### PR TITLE
Improve chromeext annotations

### DIFF
--- a/client/browser-ext/app/actions/index.js
+++ b/client/browser-ext/app/actions/index.js
@@ -27,9 +27,6 @@ export function setQuery(query) {
 function fetchSrclibDataVersion(dispatch, currJson, repo, rev, path) {
 	let promise;
 	// TODO: handle inflight / errored fetches of srclibDataVersion.
-	// TODO: This doesn't make sense.  If currJson.CommitID is true, i.e. we have a valid
-	// srclibDataVersion even if it is outdated, we will never check and fetch to see if it has
-	// been updated in Sourcegraph.
 	if (currJson) {
 		if (currJson.CommitID) {
 			promise = Promise.resolve(currJson);

--- a/client/browser-ext/app/actions/index.js
+++ b/client/browser-ext/app/actions/index.js
@@ -27,6 +27,9 @@ export function setQuery(query) {
 function fetchSrclibDataVersion(dispatch, currJson, repo, rev, path) {
 	let promise;
 	// TODO: handle inflight / errored fetches of srclibDataVersion.
+	// TODO: This doesn't make sense.  If currJson.CommitID is true, i.e. we have a valid
+	// srclibDataVersion even if it is outdated, we will never check and fetch to see if it has
+	// been updated in Sourcegraph.
 	if (currJson) {
 		if (currJson.CommitID) {
 			promise = Promise.resolve(currJson);

--- a/client/browser-ext/app/containers/App.js
+++ b/client/browser-ext/app/containers/App.js
@@ -110,7 +110,7 @@ export default class App extends Component {
 							<h3 styleName="list-item-empty">Searching...</h3>
 						}
 						{srclibDataVersionFetch && srclibDataVersionFetch.response && srclibDataVersionFetch.response.status === 404 &&
-							<h3 styleName="list-item-empty">404 Not Found: This repository has not been indexed by Sourcegraph.<br/><a href={`https://sourcegraph.com/${this.props.repo}`}>Let Sourcegraph index this repository.</a></h3>
+							<h3 styleName="list-item-empty">404 Not Found: This repository has not been indexed by Sourcegraph.<br/><a href={`https://sourcegraph.com/${this.props.repo}@${this.props.rev}`}>Let Sourcegraph index this repository.</a></h3>
 						}
 						{srclibDataVersionFetch && srclibDataVersionFetch.response && srclibDataVersionFetch.response.status === 401 &&
 							<h3 styleName="list-item-empty">401 Unauthorized: Log in to Sourcegraph to search private code</h3>

--- a/client/browser-ext/app/containers/App.js
+++ b/client/browser-ext/app/containers/App.js
@@ -110,7 +110,7 @@ export default class App extends Component {
 							<h3 styleName="list-item-empty">Searching...</h3>
 						}
 						{srclibDataVersionFetch && srclibDataVersionFetch.response && srclibDataVersionFetch.response.status === 404 &&
-							<h3 styleName="list-item-empty">404 Not Found: This repository has not been indexed by Sourcegraph.<br/><a href={`https://sourcegraph.com/${this.props.repo}@${this.props.rev}`}>Let Sourcegraph index this repository.</a></h3>
+							<h3 styleName="list-item-empty">404 Not Found: This repository (or revision) has not been indexed by Sourcegraph.<br/><a href={`https://sourcegraph.com/${this.props.repo}@${this.props.rev}`}>Let Sourcegraph index this repository.</a></h3>
 						}
 						{srclibDataVersionFetch && srclibDataVersionFetch.response && srclibDataVersionFetch.response.status === 401 &&
 							<h3 styleName="list-item-empty">401 Unauthorized: Log in to Sourcegraph to search private code</h3>

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -74,8 +74,23 @@ function traverseDOM(annsByStartByte, annsByEndByte){
 			if (children[j].nodeType === Node.TEXT_NODE){
 				childNodeChars = children[j].nodeValue.split("");
 			} else {
-				if (children[j].children.length > 1 && children[j].children[0].className === "pl-pds") {
-					children[j].innerHTML = _.escape(children[j].innerText);
+				// Quotation marks on GitHub are given their own span tags.
+				// This messes up anns for go imports. We handle this
+				// by combining all the child span tags when we see child spans
+				// with "pl-pds", the class for quotes, and there aren't any other
+				// tags between them (tags in between needed for highlighting).
+				if (children[j].children.length > 1) {
+					let goImport = true;
+					for (let k = 0; k < children[j].children.length; k++) {
+						if(children[j].children[k].className !== "pl-pds") {
+
+							goImport = false
+							break;
+						}
+					}
+					if (goImport) {
+						children[j].innerHTML = _.escape(children[j].innerText);
+					}
 				}
 				childNodeChars = (children[j].outerHTML).split("");
 			}

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -75,24 +75,23 @@ function traverseDOM(annsByStartByte, annsByEndByte){
 				childNodeChars = children[j].nodeValue.split("");
 			} else {
 				// Quotation marks on GitHub are given their own span tags.
-				// This messes up anns for go imports. We handle this
-				// by combining all the child span tags when we see child spans
-				// with "pl-pds", the class for quotes, and there aren't any other
+				// This messes up anns for go imports and other strings with quote marks.
+				// We handle this by combining all the child span tags when we see child
+				// spans with "pl-pds", the class for quotes, and there aren't any other
 				// tags between them (tags in between needed for highlighting).
 				if (children[j].children.length > 1) {
-					let goImport = true;
+					let stringWithQuotes = true;
 					for (let k = 0; k < children[j].children.length; k++) {
-						if(children[j].children[k].className !== "pl-pds") {
-
-							goImport = false
+						if (children[j].children[k].className !== "pl-pds") {
+							stringWithQuotes = false
 							break;
 						}
 					}
-					if (goImport) {
+					if (stringWithQuotes) {
 						children[j].innerHTML = _.escape(children[j].innerText);
 					}
 				}
-				childNodeChars = (children[j].outerHTML).split("");
+				childNodeChars = children[j].outerHTML.split("");
 			}
 
 			let consumingSpan = false;

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -70,16 +70,14 @@ function traverseDOM(annsByStartByte, annsByEndByte){
 
 		for (let j = 0; j < children.length; j++) {
 			let childNodeChars; // the "inner-stuff" of the code cell
-
+			if (children[j].className) {
+				if (annsByStartByte[startByte]) {
+					annsByStartByte[startByte].className = children[j].className;
+				}
+			}
 			if (children[j].nodeType === Node.TEXT_NODE){
 				childNodeChars = children[j].nodeValue.split("");
 			} else {
-				if (children[j].children.length > 1) {
-					// HACK: combine children spans, e.g. for a quoted token
-					// there may be 3 spans, one for each quote and one
-					// for the token iteself
-					children[j].innerHTML = _.escape(children[j].innerText);
-				}
 				childNodeChars = _.unescape(children[j].outerHTML).split("");
 			}
 
@@ -134,10 +132,14 @@ function next(c, byteCount, annsByStartByte, annsByEndByte) {
 		const url = defIsOnGitHub ? urlToDef(matchDetails.URL) : `https://sourcegraph.com${matchDetails.URL}`;
 		if (!url) return c;
 
-		const insert = `<a href="${url}" ${defIsOnGitHub ? "data-sourcegraph-ref" : "target=tab"} data-src="https://sourcegraph.com${matchDetails.URL}" class=${styles.sgdef}>${c}`;
+		const insert = annsByStartByte[byteCount].className ? `<a href="${url}" ${defIsOnGitHub ? "data-sourcegraph-ref" : "target=tab"} data-src="https://sourcegraph.com${matchDetails.URL}" class=${styles.sgdef}><span class="${annsByStartByte[byteCount].className}">${c}`
+		: `<a href="${url}" ${defIsOnGitHub ? "data-sourcegraph-ref" : "target=tab"} data-src="https://sourcegraph.com${matchDetails.URL}" class=${styles.sgdef}>${c}`;
 
 		// off-by-one case
 		if (annsByStartByte[byteCount].EndByte - annsByStartByte[byteCount].StartByte === 1) {
+			if annsByStartByte[byteCount].className {
+				return `${insert}</span></a>`
+			}
 			return `${insert}</a>`;
 		}
 

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -132,14 +132,10 @@ function next(c, byteCount, annsByStartByte, annsByEndByte) {
 		const url = defIsOnGitHub ? urlToDef(matchDetails.URL) : `https://sourcegraph.com${matchDetails.URL}`;
 		if (!url) return c;
 
-		const insert = annsByStartByte[byteCount].className ? `<a href="${url}" ${defIsOnGitHub ? "data-sourcegraph-ref" : "target=tab"} data-src="https://sourcegraph.com${matchDetails.URL}" class=${styles.sgdef}><span class="${annsByStartByte[byteCount].className}">${c}`
-		: `<a href="${url}" ${defIsOnGitHub ? "data-sourcegraph-ref" : "target=tab"} data-src="https://sourcegraph.com${matchDetails.URL}" class=${styles.sgdef}>${c}`;
+		const insert = `<a href="${url}" ${defIsOnGitHub ? "data-sourcegraph-ref" : "target=tab"} data-src="https://sourcegraph.com${matchDetails.URL}" class=${styles.sgdef}>${c}`;
 
 		// off-by-one case
 		if (annsByStartByte[byteCount].EndByte - annsByStartByte[byteCount].StartByte === 1) {
-			if annsByStartByte[byteCount].className {
-				return `${insert}</span></a>`
-			}
 			return `${insert}</a>`;
 		}
 

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -172,16 +172,18 @@ function next(c, byteCount, annsByStartByte, annsByEndByte) {
 }
 
 export const defaultBranchCache = {};
+export const fetchingDefaultBranchCache = {};
 function cacheDefaultBranch(annURL) {
 	let annURLsplit = [annURL.split("/")[1], annURL.split("/")[2], annURL.split("/")[3]];
 	let repo = annURLsplit.join("/");
-	if (defaultBranchCache[repo]) {
-		console.log("CACHED")
+	if (fetchingDefaultBranchCache[repo]) {
 		return;
 	}
+	fetchingDefaultBranchCache[repo] = true;
 	fetch(`https://sourcegraph.com/.api/repos/${repo}`)
 		.then((response) => {
 			defaultBranchCache[repo] = response.DefaultBranch;
+			fetchingDefaultBranchCache[repo] = false;
 		})
 		.catch((err) => console.log("Error getting default branch"));
 }

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -105,7 +105,7 @@ function traverseDOM(annsByStartByte, annsByEndByte){
 				if (!consumingSpan){
 					// Case to handle if < or > appears, so that we don't "consume" or make span tags in the code disappear
 					// This will not break if "&lt;" or "&gt;" appear because chars are escaped.
-					if (childNodeChars[k] === "&" && (((childNodeChars.slice(k, k+4).join("")) === ("&gt;")) || (childNodeChars.slice(k, k+4).join("") === ("&lt;")))) {
+					if (isSpanTagString(childNodeChars, k)) {
 						output += next(childNodeChars.slice(k, k+4).join(""), startByte, annsByStartByte, annsByEndByte);
 						k += childNodeChars.slice(k, k+4).join("").length-1;
 						startByte += utf8.encode(childNodeChars[k]).length;
@@ -137,6 +137,9 @@ function traverseDOM(annsByStartByte, annsByEndByte){
 	}
 }
 
+function isSpanTagString(childNodeChars, k) {
+	return (childNodeChars[k] === "&" && (((childNodeChars.slice(k, k+4).join("")) === ("&gt;")) || (childNodeChars.slice(k, k+4).join("") === ("&lt;"))))
+}
 // next is a helper method for traverseDOM which transforms a character
 // into itself or wraps the character in a starting/ending anchor tag
 function next(c, byteCount, annsByStartByte, annsByEndByte) {

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -105,7 +105,7 @@ function traverseDOM(annsByStartByte, annsByEndByte){
 				if (!consumingSpan){
 					// Case to handle if < or > appears, so that we don't "consume" or make span tags in the code disappear
 					// This will not break if "&lt;" or "&gt;" appear because chars are escaped.
-					if (isSpanTagString(childNodeChars, k)) {
+					if (isStartOfSpanTag(childNodeChars, k)) {
 						output += next(childNodeChars.slice(k, k+4).join(""), startByte, annsByStartByte, annsByEndByte);
 						k += childNodeChars.slice(k, k+4).join("").length-1;
 						startByte += utf8.encode(childNodeChars[k]).length;
@@ -137,8 +137,8 @@ function traverseDOM(annsByStartByte, annsByEndByte){
 	}
 }
 
-function isSpanTagString(childNodeChars, k) {
-	return (childNodeChars[k] === "&" && (((childNodeChars.slice(k, k+4).join("")) === ("&gt;")) || (childNodeChars.slice(k, k+4).join("") === ("&lt;"))))
+function isStartOfSpanTag(childNodeChars, idx) {
+	return (childNodeChars[idx] === "&" && (((childNodeChars.slice(idx, idx+4).join("")) === ("&gt;")) || (childNodeChars.slice(idx, idx+4).join("") === ("&lt;"))))
 }
 
 // next is a helper method for traverseDOM which transforms a character
@@ -172,20 +172,31 @@ function next(c, byteCount, annsByStartByte, annsByEndByte) {
 }
 
 export const defaultBranchCache = {};
+// fetchingDefaultBranchCache ensures we only make one API call per repo to get default branch.
 export const fetchingDefaultBranchCache = {};
 function cacheDefaultBranch(annURL) {
-	let annURLsplit = [annURL.split("/")[1], annURL.split("/")[2], annURL.split("/")[3]];
-	let repo = annURLsplit.join("/");
+	// Assumes annURL has the form github.com/user/repo. If we can't fetch the default branch, we default to master.
+	let annURLsplit = annURL.split("/");
+	let annRepo = [annURLsplit[1], annURLsplit[2], annURLsplit[3]]
+	let repo = annRepo.join("/");
 	if (fetchingDefaultBranchCache[repo]) {
 		return;
 	}
-	fetchingDefaultBranchCache[repo] = true;
-	fetch(`https://sourcegraph.com/.api/repos/${repo}`)
-		.then((response) => {
-			defaultBranchCache[repo] = response.DefaultBranch;
-			fetchingDefaultBranchCache[repo] = false;
-		})
-		.catch((err) => console.log("Error getting default branch"));
+	if (!defaultBranchCache[repo]) {
+		fetchingDefaultBranchCache[repo] = true;
+		fetch(`https://sourcegraph.com/.api/repos/${repo}`)
+			.then((response) => {
+				if (response.ok) {
+					defaultBranchCache[repo] = response.DefaultBranch;
+					fetchingDefaultBranchCache[repo] = false;
+				} else {
+					// Fall back onto master if we can't get the default branch
+					defaultBranchCache[repo] = "master";
+					fetchingDefaultBranchCache[repo] = false;
+				}
+			})
+			.catch((err) => console.log("Error getting default branch"))
+	}
 }
 
 function urlToDef(origURL) {

--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -186,14 +186,8 @@ function cacheDefaultBranch(annURL) {
 		fetchingDefaultBranchCache[repo] = true;
 		fetch(`https://sourcegraph.com/.api/repos/${repo}`)
 			.then((response) => {
-				if (response.ok) {
-					defaultBranchCache[repo] = response.DefaultBranch;
-					fetchingDefaultBranchCache[repo] = false;
-				} else {
-					// Fall back onto master if we can't get the default branch
-					defaultBranchCache[repo] = "master";
-					fetchingDefaultBranchCache[repo] = false;
-				}
+				defaultBranchCache[repo] = response.ok ? response.DefaultBranch : "master";
+				fetchingDefaultBranchCache[repo] = false;
 			})
 			.catch((err) => console.log("Error getting default branch"))
 	}

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -133,8 +133,7 @@ class InjectApp extends React.Component {
 		let user = urlsplit[0];
 		let repo = urlsplit[1]
 		// We scrape the current branch and set rev to it so we stay on the same branch when doing jump-to-def
-		let branchSelectorButton = document.getElementsByClassName("select-menu-button js-menu-target css-truncate")[0]
-		let currBranch = branchSelectorButton ? branchSelectorButton.title : "master";
+		let currBranch = this.branchSelectorButton() ? this.branchSelectorButton().title : "master";
 		let rev = currBranch;
 		if (urlsplit[3] !== null && (urlsplit[2] === "tree" || urlsplit[2] === "blob")) { // what about "commit"
 			rev = urlsplit[3];
@@ -158,6 +157,9 @@ class InjectApp extends React.Component {
 		return info;
 	}
 
+	branchSelectorButton() {
+		return document.getElementsByClassName("select-menu-button js-menu-target css-truncate")[0]
+	}
 	supportsAnnotatingFile(path) {
 		if (!path) return false;
 
@@ -181,8 +183,7 @@ class InjectApp extends React.Component {
 		// refresh endpoint will update the version and the annotations will be up to date once the new build succeeds
 		let latestRev = document.getElementsByClassName("js-permalink-shortcut")[0] ? document.getElementsByClassName("js-permalink-shortcut")[0].href.split("/")[6] : rev
 		// TODO: Branches that are not built on Sourcegraph will not get annotations, need to trigger
-		let branchSelectorButton = document.getElementsByClassName("select-menu-button js-menu-target css-truncate")[0];
-		let currBranch = branchSelectorButton ? branchSelectorButton.title : rev;
+		let currBranch = this.branchSelectorButton() ? this.branchSelectorButton().title : rev;
 		if (rev !== latestRev) rev = latestRev;
 		if (currBranch !== "master") rev = currBranch;
 		const repoName = repo;

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -386,7 +386,7 @@ class InjectApp extends React.Component {
 			e.appendChild(a);
 		}
 
-		a.href = `https://sourcegraph.com/${props.repo}/-/info/${props.defPath}`;
+		a.href = `https://sourcegraph.com/${props.repo}@${props.rev}/-/info/${props.defPath}`;
 		a.dataset.content = "Find Usages";
 		a.target = "tab";
 		a.title = `Sourcegraph: View cross-references to ${def.Name}`;

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -132,7 +132,9 @@ class InjectApp extends React.Component {
 		const urlsplit = loc.pathname.slice(1).split("/");
 		let user = urlsplit[0];
 		let repo = urlsplit[1]
-		let rev = "master"
+		// We scrape the current branch and set rev to it so we stay on the same branch when doing jump-to-def
+		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title
+		let rev = currBranch
 		if (urlsplit[3] !== null && (urlsplit[2] === "tree" || urlsplit[2] === "blob")) { // what about "commit"
 			rev = urlsplit[3];
 		}
@@ -174,10 +176,13 @@ class InjectApp extends React.Component {
 
 		let {user, repo, rev, path, defPath} = this.parseURL();
 		// This scrapes the latest commit ID and updates rev to the latest commit so we are never injecting
-		// outdated annotations.
+		// outdated annotations.  If there is a new commit, srclib-data-version will return a 404, but the
+		// refresh endpoint will update the version and the annotations will be up to date once the new build succeeds
 		let latestRev = document.getElementsByClassName("js-permalink-shortcut")[0].href.split("/")[6]
+		// TODO: Branches that are not built on Sourcegraph will not get annotations, need to trigger
+		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title
 		if (rev !== latestRev) rev = latestRev;
-
+		if (currBranch !== "master") rev = currBranch;
 		const repoName = repo;
 		if (repo) {
 			repo = `github.com/${user}/${repo}`;

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -133,7 +133,7 @@ class InjectApp extends React.Component {
 		let user = urlsplit[0];
 		let repo = urlsplit[1]
 		// We scrape the current branch and set rev to it so we stay on the same branch when doing jump-to-def
-		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title
+		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0] ? document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title : "master"
 		let rev = currBranch
 		if (urlsplit[3] !== null && (urlsplit[2] === "tree" || urlsplit[2] === "blob")) { // what about "commit"
 			rev = urlsplit[3];
@@ -178,9 +178,9 @@ class InjectApp extends React.Component {
 		// This scrapes the latest commit ID and updates rev to the latest commit so we are never injecting
 		// outdated annotations.  If there is a new commit, srclib-data-version will return a 404, but the
 		// refresh endpoint will update the version and the annotations will be up to date once the new build succeeds
-		let latestRev = document.getElementsByClassName("js-permalink-shortcut")[0].href.split("/")[6]
+		let latestRev = document.getElementsByClassName("js-permalink-shortcut")[0] ? document.getElementsByClassName("js-permalink-shortcut")[0].href.split("/")[6] : rev
 		// TODO: Branches that are not built on Sourcegraph will not get annotations, need to trigger
-		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title
+		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0] ? document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title : "master"
 		if (rev !== latestRev) rev = latestRev;
 		if (currBranch !== "master") rev = currBranch;
 		const repoName = repo;

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -232,7 +232,7 @@ class InjectApp extends React.Component {
 				pjaxGoTo(`${pathname}${hash}`, repo === this.props.repo);
 			}
 		}
-	}l
+	}
 
 	_directURLToDef({repo, rev, defPath, def}) {
 		const defObj = def ? def.content[keyFor(repo, rev, defPath)] : null;

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -108,7 +108,7 @@ class InjectApp extends React.Component {
 	}
 
 	_clickRef(ev) {
-		if (typeof ev.target.dataset.sourcegraphRef !== "undefined") {
+		if (typeof ev.target.dataset.sourcegraphRef !== "undefined" || (ev.target.parentNode && typeof ev.target.parentNode.dataset.sourcegraphRef !== "undefined")) {
 			let urlProps = this.parseURL({pathname: ev.target.pathname, hash: ev.target.hash});
 			urlProps.repo = `github.com/${urlProps.user}/${urlProps.repo}`;
 

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -133,7 +133,7 @@ class InjectApp extends React.Component {
 		let user = urlsplit[0];
 		let repo = urlsplit[1]
 		// We scrape the current branch and set rev to it so we stay on the same branch when doing jump-to-def
-		let branchSelectorButton = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0]
+		let branchSelectorButton = document.getElementsByClassName("select-menu-button js-menu-target css-truncate")[0]
 		let currBranch = branchSelectorButton ? branchSelectorButton.title : "master";
 		let rev = currBranch;
 		if (urlsplit[3] !== null && (urlsplit[2] === "tree" || urlsplit[2] === "blob")) { // what about "commit"
@@ -181,7 +181,7 @@ class InjectApp extends React.Component {
 		// refresh endpoint will update the version and the annotations will be up to date once the new build succeeds
 		let latestRev = document.getElementsByClassName("js-permalink-shortcut")[0] ? document.getElementsByClassName("js-permalink-shortcut")[0].href.split("/")[6] : rev
 		// TODO: Branches that are not built on Sourcegraph will not get annotations, need to trigger
-		let branchSelectorButton = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0];
+		let branchSelectorButton = document.getElementsByClassName("select-menu-button js-menu-target css-truncate")[0];
 		let currBranch = branchSelectorButton ? branchSelectorButton.title : rev;
 		if (rev !== latestRev) rev = latestRev;
 		if (currBranch !== "master") rev = currBranch;

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -108,7 +108,7 @@ class InjectApp extends React.Component {
 	}
 
 	_clickRef(ev) {
-		if (typeof ev.target.dataset.sourcegraphRef !== "undefined" || (ev.target.parentNode && typeof ev.target.parentNode.dataset.sourcegraphRef !== "undefined")) {
+		if (typeof ev.target.dataset.sourcegraphRef !== "undefined") {
 			let urlProps = this.parseURL({pathname: ev.target.pathname, hash: ev.target.hash});
 			urlProps.repo = `github.com/${urlProps.user}/${urlProps.repo}`;
 

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -133,8 +133,9 @@ class InjectApp extends React.Component {
 		let user = urlsplit[0];
 		let repo = urlsplit[1]
 		// We scrape the current branch and set rev to it so we stay on the same branch when doing jump-to-def
-		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0] ? document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title : "master"
-		let rev = currBranch
+		let branchSelectorButton = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0]
+		let currBranch = branchSelectorButton ? branchSelectorButton.title : "master";
+		let rev = currBranch;
 		if (urlsplit[3] !== null && (urlsplit[2] === "tree" || urlsplit[2] === "blob")) { // what about "commit"
 			rev = urlsplit[3];
 		}
@@ -180,7 +181,8 @@ class InjectApp extends React.Component {
 		// refresh endpoint will update the version and the annotations will be up to date once the new build succeeds
 		let latestRev = document.getElementsByClassName("js-permalink-shortcut")[0] ? document.getElementsByClassName("js-permalink-shortcut")[0].href.split("/")[6] : rev
 		// TODO: Branches that are not built on Sourcegraph will not get annotations, need to trigger
-		let currBranch = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0] ? document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0].title : "master"
+		let branchSelectorButton = document.getElementsByClassName('select-menu-button js-menu-target css-truncate')[0];
+		let currBranch = branchSelectorButton ? branchSelectorButton.title : rev;
 		if (rev !== latestRev) rev = latestRev;
 		if (currBranch !== "master") rev = currBranch;
 		const repoName = repo;

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -173,8 +173,16 @@ class InjectApp extends React.Component {
 		this.addSearchButton();
 
 		let {user, repo, rev, path, defPath} = this.parseURL();
+		// This scrapes the latest commit ID and updates rev to the latest commit so we are never injecting
+		// outdated annotations.
+		let latestRev = document.getElementsByClassName("js-permalink-shortcut")[0].href.split("/")[6]
+		if (rev !== latestRev) rev = latestRev;
+
 		const repoName = repo;
-		if (repo) repo = `github.com/${user}/${repo}`;
+		if (repo) {
+			repo = `github.com/${user}/${repo}`;
+			this.props.actions.refreshVCS(repo);
+		}
 		if (path) {
 			// Strip hash (e.g. line location) from path.
 			const hashLoc = path.indexOf("#");

--- a/client/browser-ext/chrome/manifest.prod.json
+++ b/client/browser-ext/chrome/manifest.prod.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.12",
+  "version": "1.1.13",
   "name": "Sourcegraph for GitHub",
   "manifest_version": 2,
   "description": "Browse and search code on GitHub like an IDE, with jump-to-definition, doc tooltips, and semantic search.",


### PR DESCRIPTION
WIP. Fix bugs related to chrome extension annotations.  

Implemented: 
- Adds refreshVCS and automatically getting the latest annotations.  
- Fixes bug where jump-to-def will automatically revert to master branch.  Jump-to-def will now stay within the currently selected branch. 
- Adds revision to the link to trigger builds when search 404s
- Adds checks to fix syntax highlighting issues when trying to solve the split up annotations in go imports because of quote mark span tags.
- Adds checks to ensure '<span>' appearing anywhere in comments or in the code won't break annotations. 

##### Reviewer tasks
- [ ] HACKS: reviewer approves hacks introduced by this change

##### Test plan
Build this locally and test the refresh and annotations update by pushing to a repo and seeing that broken annotations are not added.  Once the build on Sourcegraph is finished, see that correct annotations are added. 

Try jump-to-def on a branch that isn't master. https://github.com/alexo/wro4j/blob/1.7.x/wro4j-core/src/main/java/ro/isdc/wro/http/WroFilter.java#sourcegraph&def=JavaArtifact/ro.isdc.wro4j/wro4j-core/-/ro/isdc/wro/http/WroFilter:type/createConfiguration&L135-143 

View code that has <span> comments and see that anns don't break. https://github.com/attfarhan/mux/blob/master/route.go (build for this is queued, but should work when it's finished).  

Click on an external def from a branch that isn't master and make sure we don't 404, and we get to the def on the default branch of the repository. 


