### PR TITLE
{,cmd/src}: Set import comment.

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -1,5 +1,5 @@
 // src is the Sourcegraph server and API client program.
-package main
+package main // import "sourcegraph.com/sourcegraph/sourcegraph/cmd/src"
 
 import (
 	"os"

--- a/doc.go
+++ b/doc.go
@@ -3,4 +3,4 @@
 //
 // See https://sourcegraph.com and the README.md file for more
 // information.
-package sourcegraph
+package sourcegraph // import "sourcegraph.com/sourcegraph/sourcegraph"


### PR DESCRIPTION
When people see a Go package hosted on GitHub and it doesn't have a custom import path enforced via an import comment (and it doesn't say otherwise in the README), they have no better choice but to assume the import path is simply `github.com/user/repo`.

We use a vanity import path `sourcegraph.com/sourcegraph/sourcegraph/...`, and it's already partially enforced in a few places (e.g., see
https://github.com/sourcegraph/sourcegraph/blob/12f76fdffc05bd75de7beb56495e5415c2cdfc92/pkg/vcs/doc.go#L8).

Enforce and make it clear what the import path is by adding import comments to some more prominent and visible packages.

Reference: https://golang.org/cmd/go/#hdr-Import_path_checking.

##### Reviewer tasks

- [ ] CORRECT IMPORT PATH: reviewer approves import path enforced by the import comments

##### Test plan

Need to ensure CI passes and sourcegraph builds continue to work.