### PR TITLE
Makefile: use -race only for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ PRIVATE_HASH := 87ff6253d35505c92cb3190e422f64ec61cc227f
 
 SGX_OS_NAME := $(shell uname -o 2>/dev/null || uname -s)
 
-# The Go race detector (`-race`) is helpful but makes compilation take
-# longer. Setting GORACE="" will disable it.
-GORACE ?= -race
-
 ifeq "$(SGX_OS_NAME)" "Cygwin"
 	SGXOS := windows
 	CMD := cmd /C
@@ -57,7 +53,7 @@ SERVEFLAGS ?=
 serve-dev: serve-dep
 	@echo Starting server\; will recompile and restart when source files change
 	@echo
-	DEBUG=t rego -installenv=GOGC=off,GODEBUG=sbrk=1 $(GORACE) -tags="$(GOTAGS)" sourcegraph.com/sourcegraph/sourcegraph/cmd/src $(SRCFLAGS) serve --reload --app.webpack-dev-server=$(WEBPACK_DEV_SERVER_URL) --app.disable-support-services $(SERVEFLAGS)
+	DEBUG=t rego -installenv=GOGC=off,GODEBUG=sbrk=1 -tags="$(GOTAGS)" sourcegraph.com/sourcegraph/sourcegraph/cmd/src $(SRCFLAGS) serve --reload --app.webpack-dev-server=$(WEBPACK_DEV_SERVER_URL) --app.disable-support-services $(SERVEFLAGS)
 
 serve-mothership-dev:
 	@echo See docs/dev/OAuth2.md Demo configuration
@@ -123,7 +119,7 @@ test: check app/assets/bundle.js
 	$(MAKE) go-test
 
 go-test: src
-	go test $(GORACE) ${GOFLAGS} ${TESTPKGS} ${TESTFLAGS}
+	go test -race ${GOFLAGS} ${TESTPKGS} ${TESTFLAGS}
 
 smtest:
 	$(MAKE) go-test GOFLAGS=""


### PR DESCRIPTION
The race detector has a heavy impact on the performance at runtime. It makes some tasks use many GB of RAM. Only using -race for testing now.

PS: I prefer to merge myself. ;-)