### PR TITLE
Analytics: Filter out E2E and other bots from analytics based on user agent

### DIFF
--- a/app/web_modules/sourcegraph/util/EventLogger.js
+++ b/app/web_modules/sourcegraph/util/EventLogger.js
@@ -86,6 +86,11 @@ export class EventLogger {
 		}
 
 		this.userAgentIsBot = Boolean(context.userAgentIsBot);
+
+		// Opt out of Amplitude events if the user agent is a bot.
+		if (this.userAgentIsBot) {
+			this._amplitude.setOptOut(true);
+		}
 	}
 
 	// User data from the previous call to _updateUser.
@@ -158,10 +163,6 @@ export class EventLogger {
 
 	// records events for the current user, if user agent is not bot
 	logEvent(eventName, eventProperties) {
-		if (this.userAgentIsBot) {
-			// Filter out bot or test user agents.
-			return;
-		}
 		if (typeof window !== "undefined" && window.localStorage["event-log"]) {
 			console.debug("%cEVENT %s", "color: #aaa", eventName, eventProperties);
 		}
@@ -183,7 +184,7 @@ export class EventLogger {
 
 	// records intercom events for the current user
 	logIntercomEvent(eventName, eventProperties) {
-		if (this._intercom) this._intercom("trackEvent", eventName, eventProperties);
+		if (this._intercom && !this.userAgentIsBot) this._intercom("trackEvent", eventName, eventProperties);
 	}
 
 	__onDispatch(action) {


### PR DESCRIPTION
##### Description

It looks like we only implemented checks for `userAgentIsBot` when calling `logEvent` to Amplitude instead of performing that check at logEvent we can set a flag up front that tells amplitude not to send the events. We also shouldn't be logging any events to intercom for e2e tests as well, but intercom looks like it doesn't have a flag for this so we will have to opt out manually. 

@slimsag could you look this over to see if this would affect the e2e tests at all?