### PR TITLE
Enable gitserver tests, remove unnecessary cases

### DIFF
--- a/app/internal/gitserver/lg_test.go
+++ b/app/internal/gitserver/lg_test.go
@@ -13,34 +13,10 @@ import (
 	"sourcegraph.com/sourcegraph/sourcegraph/services/backend/testserver"
 )
 
-func TestGitServerWithAnonymousReaders(t *testing.T) {
+func TestGitServer(t *testing.T) {
 	var tests = []interface{}{
 		// Clone test.
 		gitCloneTest{false, false, []string{}, false},
-		gitCloneTest{false, true, []string{}, false},
-
-		// Shallow clone tests.
-		gitCloneTest{false, true, []string{"--depth", "1"}, false},
-
-		// Empty fetch tests.
-		gitCloneTest{false, true, []string{}, true},
-
-		// Push tests.
-		gitPushTest{true, false, true, false},
-		gitPushTest{false, true, true, false},
-
-		// Vary permissions.
-		gitPushTest{true, true, false, false},
-		gitPushTest{false, true, false, true},
-		gitPushTest{false, true, true, true},
-	}
-	testGitServer(t, tests)
-}
-
-func TestGitServerWithAuth(t *testing.T) {
-	var tests = []interface{}{
-		// Clone test.
-		gitCloneTest{true, false, []string{}, false},
 		gitCloneTest{false, true, []string{}, false},
 
 		// Shallow clone tests.

--- a/dev/circle-ci-run-tests.sh
+++ b/dev/circle-ci-run-tests.sh
@@ -26,7 +26,7 @@ echo "$changed"
 
 pkgs=()
 covered=()
-for pkg in $(go list  -f '{{ if or (gt (len .TestGoFiles) 0) (gt (len .XTestGoFiles ) 0) }}{{ .ImportPath }}{{ end }}' ./... | grep -v /vendor/ | sort); do
+for pkg in $(go list -tags 'exectest buildtest pgsqltest nettest githubtest'  -f '{{ if or (gt (len .TestGoFiles) 0) (gt (len .XTestGoFiles ) 0) }}{{ .ImportPath }}{{ end }}' ./... | grep -v /vendor/ | sort); do
 	if (( i % CIRCLE_NODE_TOTAL == CIRCLE_NODE_INDEX ))
 	then
 		if [ "$CIRCLE_BRANCH" == 'master' ] || echo "$changed" | awk -v D="$(pwd)" '{ print D "/" $2 }' | egrep "$pkg/$"


### PR DESCRIPTION
See full commit messages.

Test plan: manually check CI logs to ensure that app/internal/gitserver's tests were run.