### PR TITLE
fix for amplitude tracking on first sfye pageload

### DIFF
--- a/app/web_modules/sourcegraph/channel/withChannelListener.js
+++ b/app/web_modules/sourcegraph/channel/withChannelListener.js
@@ -156,7 +156,7 @@ export default function withChannelListener(Component) {
 				let def = action.Def ? action.Def : "";
 				this.context.router.replace({
 					pathname: "/-/golang",
-					search: `?def=${def}&pkg=${action.Package}&repo=${action.Repo}&editor_type=${action.EditorType}`,
+					search: `?def=${def}&pkg=${action.Package}&repo=${action.Repo}&editor_type=${action.EditorType}&utm_source=sourcegraph-editor`,
 					state: {
 						...this.props.location.state,
 						error: null,


### PR DESCRIPTION
I noticed that on the first pageloads from sfye, the utm source was not being listed. Digging into it, it wasn't being set in one place.

##### Reviewer tasks

- [ ] HACKS: reviewer approves hacks introduced by this change

I'd love to know if there is a better way to do this URL assembly at this point, tacking on &X=A&Y=B seems error prone.

##### Test plan

Run locally, I verified that it works by stepping through with the JS debugger.


