### PR TITLE
fix external ref fetches

### DIFF
--- a/services/httpapi/def_refs.go
+++ b/services/httpapi/def_refs.go
@@ -1,7 +1,6 @@
 package httpapi
 
 import (
-	"encoding/json"
 	"net/http"
 	"sort"
 
@@ -84,7 +83,7 @@ func serveDefRefs(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	return json.NewEncoder(w).Encode(refs.Refs)
+	return writeJSON(w, refs.Refs)
 }
 
 func serveDefRefLocations(w http.ResponseWriter, r *http.Request) error {
@@ -169,7 +168,7 @@ func serveDefRefLocations(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return json.NewEncoder(w).Encode(refLocations)
+	return writeJSON(w, refLocations)
 }
 
 type fileList []*sourcegraph.DefFileRef

--- a/services/httpapi/def_refs.go
+++ b/services/httpapi/def_refs.go
@@ -60,13 +60,13 @@ func serveDefRefs(w http.ResponseWriter, r *http.Request) error {
 			path = opt.Files[0]
 		}
 
-		res, err := cl.Repos.ResolveRev(ctx, &sourcegraph.ReposResolveRevOp{Repo: repo.ID, Rev: ""})
+		res, err := cl.Repos.ResolveRev(ctx, &sourcegraph.ReposResolveRevOp{Repo: opt.Repo, Rev: ""})
 		if err != nil {
 			return err
 		}
 
 		dataVersion, err := cl.Repos.GetSrclibDataVersionForPath(ctx, &sourcegraph.TreeEntrySpec{
-			RepoRev: sourcegraph.RepoRevSpec{Repo: repo.ID, CommitID: res.CommitID},
+			RepoRev: sourcegraph.RepoRevSpec{Repo: opt.Repo, CommitID: res.CommitID},
 			Path:    path,
 		})
 		if err != nil {


### PR DESCRIPTION
Fixes the issue where pages like https://sourcegraph.com/github.com/aws/aws-sdk-go/-/info/GoPackage/github.com/aws/aws-sdk-go/private/util/-/GoFmt do not load external ref snippets.