### PR TITLE
Analytics: Set isEmployee flag

### DIFF
--- a/app/web_modules/sourcegraph/util/EventLogger.js
+++ b/app/web_modules/sourcegraph/util/EventLogger.js
@@ -88,9 +88,7 @@ export class EventLogger {
 		this.userAgentIsBot = Boolean(context.userAgentIsBot);
 
 		// Opt out of Amplitude events if the user agent is a bot.
-		if (this.userAgentIsBot) {
-			this._amplitude.setOptOut(true);
-		}
+		this._amplitude.setOptOut(this.userAgentIsBot);
 	}
 
 	// User data from the previous call to _updateUser.
@@ -198,6 +196,9 @@ export class EventLogger {
 				this.setUserProperty("orgs", Object.keys(orgs));
 				this.setUserProperty("num_github_repos", action.data.RemoteRepos.length);
 				this.setIntercomProperty("companies", Object.keys(orgs).map(org => ({id: `github_${org}`, name: org})));
+				if (orgs["sourcegraph"]) {
+					this.setUserProperty("is_sg_employee", "true");
+				}
 			}
 			break;
 


### PR DESCRIPTION
##### Description

Setting isEmployee flag and resetting analytics opt out based on the user. It is not absolutely necessary, but if a user was marked as a bot it persists until explicitly set to false. This could be problematic when debugging analytics. For example, if you were marked as a bot while running CI and then wanted to check dev analytics at a later date to confirm everything was firing correctly it would not be immediately obvious why your user isn't firing events.