### PR TITLE
Dealing with C# preprocessor directives

### DIFF
--- a/pkg/coverageutil/csharp.go
+++ b/pkg/coverageutil/csharp.go
@@ -10,7 +10,9 @@ import (
 // It's based on scanner.Scanner with adjustments to handle C#-specific
 // things such as:
 // - strings can be multiline
-// numeric literals may have a suffix
+// - numeric literals may have a suffix
+// - verbatim strings
+// - preprocessor directives
 type csharpScanner struct {
 	*scanner.Scanner
 }
@@ -52,6 +54,13 @@ func (s *csharpScanner) scan() rune {
 				s.consumeVerbatimString()
 				return s.scan()
 			}
+		}
+	case ch == '#':
+		{
+			for ch >= 0 && ch != '\n' {
+				ch = s.Next()
+			}
+			return s.scan()
 		}
 	case unicode.IsSpace(ch):
 		{

--- a/pkg/coverageutil/csharp_test.go
+++ b/pkg/coverageutil/csharp_test.go
@@ -28,5 +28,10 @@ func TestCsharp(testing *testing.T) {
 				"@\"a\"\" b\" c",
 				[]Token{{9, 1, "c"}},
 			},
+			{
+				"preprocessor directives",
+				"#ifdef A\nfoo\n#endif\n#region License Information (GPL v3)",
+				[]Token{{9, 2, "foo"}},
+			},
 		})
 }


### PR DESCRIPTION
Ignoring preprocessor directives in C# code when extracting identifiers to reduce number of uncovered idents in C# code (spotted by @ildarisaev)

##### Test plan

Covered by unit test