### PR TITLE
WIP: firefox build script takes place in docker

### DIFF
--- a/client/browser-ext/.gitignore
+++ b/client/browser-ext/.gitignore
@@ -8,4 +8,5 @@ dev/
 *.zip
 *.crx
 *.pem
+*.xpi
 update.xml

--- a/client/browser-ext/README.md
+++ b/client/browser-ext/README.md
@@ -45,27 +45,13 @@ You can use [redux-devtools-extension](https://github.com/zalmoxisus/redux-devto
 $ npm run build
 ```
 
-#### Firefox
-
-To bundle the extension for Firefox, compress the *contents* of the `/build` folder (not the folder itself). Rename the file `sourcegraph.xpi`.
-
-## Compress (chrome only)
+## Create distributions
 
 ```bash
-$ npm run build
-$ npm run compress -- [options]
+$ npm run dist
 ```
 
-#### Options
-
-If you want to build a `crx` file, provide options and add an `update.xml` file url in [manifest.json](https://developer.chrome.com/extensions/autoupdate#update_url manifest.json).
-
-* --app-id: the extension id
-* --key: private key path (default: './key.pem')
-  you can use `npm run compress-keygen` to generate private key `./key.pem`
-* --codebase: the `crx` file url
-
-See [autoupdate guide](https://developer.chrome.com/extensions/autoupdate) for more information.
+The reason this process does more than just compress the build directory is to ensure that the environment that the dist is created mimics the environment for the extension submission teams. It spins up a Docker Linux image, chooses a specific version of node and npm, and runs the build process before compressing the file.
 
 ## Boilerplate
 

--- a/client/browser-ext/package.json
+++ b/client/browser-ext/package.json
@@ -7,7 +7,9 @@
     "build": "node scripts/build",
     "compress": "node scripts/compress",
     "compress-keygen": "crx keygen",
-    "clean": "rimraf build/ dev/ *.zip *.crx"
+    "clean": "rimraf build/ dev/ *.zip *.crx",
+    "build-docker": "docker build -t sourcegraph/browser-ext-build scripts/build-env",
+    "dist": "npm run build-docker && docker run -v `pwd`:/browser-ext -i -t sourcegraph/browser-ext-build /bin/bash /browser-ext/scripts/build-env/dist.sh"
   },
   "author": "John Rothfels <john@sourcegraph.com>",
   "license": "MIT",

--- a/client/browser-ext/scripts/build-env/Dockerfile
+++ b/client/browser-ext/scripts/build-env/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu
+RUN apt-get update
+RUN apt-get install -y zip
+RUN apt-get install -y curl
+RUN apt-get install -y sudo
+RUN curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
+RUN apt-get install -y nodejs

--- a/client/browser-ext/scripts/build-env/dist.sh
+++ b/client/browser-ext/scripts/build-env/dist.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /browser-ext
+npm run build
+cd /browser-ext/build
+zip -r /browser-ext/firefox-sourcegraph-dist.xpi *
+zip -r /browser-ext/chrome-sourcegraph-dist.zip *


### PR DESCRIPTION
"npm run build-docker" to build the docker image, then "npm run build-firefox"

firefox-build.zip should appear in the browser-ext directory.

##### Reviewer tasks

Naming / directory structure: I created a new folder in scripts, with the stuff specific to the firefox build. Is this reasonable?

##### Test plan

Run it on someone else's computer, does it work first try?

TODO: diff the zip file to the one created locally on the mac, and make sure they are different.