### PR TITLE
srclib_support: use basic_formatter for Bash

### DIFF
--- a/pkg/srclib_support/basic_formatter.go
+++ b/pkg/srclib_support/basic_formatter.go
@@ -11,6 +11,7 @@ import (
 func init() {
 	graph.RegisterMakeDefFormatter("PipPackage", newBasicFormatter("Python"))
 	graph.RegisterMakeDefFormatter("DjangoApp", newBasicFormatter("Python"))
+	graph.RegisterMakeDefFormatter("BashDirectory", newBasicFormatter("Bash"))
 	graph.RegisterMakeDefFormatter("basic-css", newBasicFormatter("CSS"))
 	graph.RegisterMakeDefFormatter("basic-php", newBasicFormatter("PHP"))
 	graph.RegisterMakeDefFormatter("basic-objc", newBasicFormatter("Objective-C"))


### PR DESCRIPTION
This is needed so that Bash definitions are rendered correctly.