### PR TITLE
web_modules/sourcegraph: improve external links UI support.

### DIFF
--- a/app/web_modules/sourcegraph/blob/BlobLine.js
+++ b/app/web_modules/sourcegraph/blob/BlobLine.js
@@ -13,6 +13,7 @@ import * as BlobActions from "sourcegraph/blob/BlobActions";
 import * as DefActions from "sourcegraph/def/DefActions";
 import {fastURLToRepoDef} from "sourcegraph/def/routes";
 import s from "sourcegraph/blob/styles/Blob.css";
+import {isExternalLink} from "sourcegraph/util/externalLink";
 import "sourcegraph/components/styles/code.css";
 
 // simpleContentsString converts [string...] (like ["a", "b", "c"]) to
@@ -95,10 +96,6 @@ class BlobLine extends Component {
 		});
 	}
 
-	_isExternalLink(url: string): bool {
-		return (/^https?:\/\/(nodejs\.org|developer\.mozilla\.org)/).test(url);
-	}
-
 	_annotate() {
 		let i = 0;
 		return fromUtf8(annotate(this.state.contents, this.state.startByte, this.state.annotations, (ann, content) => {
@@ -112,7 +109,7 @@ class BlobLine extends Component {
 
 			// If ann.URL is an absolute URL with scheme http or https, create an anchor with a link to the URL (e.g., an
 			// external URL to Mozilla's CSS reference documentation site.
-			if (annURLs && this._isExternalLink(annURLs[0])) {
+			if (annURLs && isExternalLink(annURLs[0])) {
 				let isHighlighted = this.state.highlightedDef === annURLs[0];
 				return (
 					<a

--- a/app/web_modules/sourcegraph/blob/BlobMain.js
+++ b/app/web_modules/sourcegraph/blob/BlobMain.js
@@ -24,6 +24,7 @@ import {makeRepoRev, trimRepo} from "sourcegraph/repo";
 import httpStatusCode from "sourcegraph/util/httpStatusCode";
 import Header from "sourcegraph/components/Header";
 import {createLineFromByteFunc} from "sourcegraph/blob/lineFromByte";
+import {isExternalLink} from "sourcegraph/util/externalLink";
 
 export default class BlobMain extends Container {
 	static propTypes = {
@@ -84,7 +85,7 @@ export default class BlobMain extends Container {
 
 		// Def-specific
 		state.highlightedDef = DefStore.highlightedDef;
-		if (state.highlightedDef) {
+		if (state.highlightedDef && !isExternalLink(state.highlightedDef)) {
 			let {repo, rev, def} = defRouteParams(state.highlightedDef);
 			state.highlightedDefObj = DefStore.defs.get(repo, rev, def);
 		} else {
@@ -94,7 +95,7 @@ export default class BlobMain extends Container {
 
 	onStateTransition(prevState, nextState) {
 		if (nextState.highlightedDef && prevState.highlightedDef !== nextState.highlightedDef) {
-			if (!(nextState.highlightedDef.startsWith("http:") || nextState.highlightedDef.startsWith("https:"))) { // kludge to filter out external def links
+			if (!isExternalLink(nextState.highlightedDef)) { // kludge to filter out external def links
 				let {repo, rev, def, err} = defRouteParams(nextState.highlightedDef);
 				if (err) {
 					console.err(err);

--- a/app/web_modules/sourcegraph/util/externalLink.js
+++ b/app/web_modules/sourcegraph/util/externalLink.js
@@ -1,0 +1,6 @@
+// @flow
+
+// isExternalLink returns true if given URL is considered as external link.
+export function isExternalLink(url: string): bool {
+	return (/^https?:\/\/(nodejs\.org|developer\.mozilla\.org)/).test(url);
+}


### PR DESCRIPTION
#### Description

- Issue:

This changes fixes a JS error which tries to react-router parse an annotation definition for external links (links outside sourcegraph domain, Eg. "https://developer.mozilla.org/en-US/docs/Web/CSS/padding"):

![output](https://cloud.githubusercontent.com/assets/1000404/15877941/b6f449f6-2cdc-11e6-9471-4123e4941167.gif)

- Fix:

  - [x] Add changes to ignore external links when hovering annotations:

![output](https://cloud.githubusercontent.com/assets/1000404/15878002/2b44f0f8-2cdd-11e6-9ba7-313e7a103c81.gif)


##### Reviewer tasks

n/a

##### Test plan

- Tested locally


