### PR TITLE
services/backend/internal/localstore: fix GlobalDefs.Search with Repos / NotRepos queries

### DIFF
--- a/services/backend/internal/localstore/repos_db_test.go
+++ b/services/backend/internal/localstore/repos_db_test.go
@@ -23,7 +23,7 @@ import (
 	"sourcegraph.com/sqs/pbtypes"
 )
 
-func repoURIs(repos []*sourcegraph.Repo) []string {
+func sortedRepoURIs(repos []*sourcegraph.Repo) []string {
 	var uris []string
 	for _, repo := range repos {
 		uris = append(uris, repo.URI)
@@ -135,7 +135,7 @@ func TestRepos_List_query(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := repoURIs(repos); !reflect.DeepEqual(got, test.want) {
+		if got := sortedRepoURIs(repos); !reflect.DeepEqual(got, test.want) {
 			t.Errorf("%q: got repos %v, want %v", test.query, got, test.want)
 		}
 	}
@@ -175,7 +175,7 @@ func TestRepos_List_URIs(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := repoURIs(repos); !reflect.DeepEqual(got, test.want) {
+		if got := sortedRepoURIs(repos); !reflect.DeepEqual(got, test.want) {
 			t.Errorf("%v: got repos %v, want %v", test.uris, got, test.want)
 		}
 	}
@@ -225,7 +225,7 @@ func TestRepos_List_GitHubURIs_PublicRepo(t *testing.T) {
 	}
 
 	want := []string{"a/b"}
-	if got := repoURIs(repoList); !reflect.DeepEqual(got, want) {
+	if got := sortedRepoURIs(repoList); !reflect.DeepEqual(got, want) {
 		t.Fatalf("got repos: %v, want %v", got, want)
 	}
 
@@ -235,7 +235,7 @@ func TestRepos_List_GitHubURIs_PublicRepo(t *testing.T) {
 	}
 
 	want = []string{"a/b", "github.com/public"}
-	if got := repoURIs(repoList); !reflect.DeepEqual(got, want) {
+	if got := sortedRepoURIs(repoList); !reflect.DeepEqual(got, want) {
 		t.Fatalf("got repos: %v, want %v", got, want)
 	}
 }
@@ -261,7 +261,7 @@ func TestRepos_List_GitHubURIs_PrivateRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := repoURIs(repoList); len(got) != 0 {
+	if got := sortedRepoURIs(repoList); len(got) != 0 {
 		t.Fatal("List should not have returned any repos, got:", got)
 	}
 }
@@ -287,7 +287,7 @@ func TestRepos_List_GithubURIs_UnauthenticatedRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := repoURIs(repoList); len(got) != 0 {
+	if got := sortedRepoURIs(repoList); len(got) != 0 {
 		t.Fatal("List should not have returned any repos, got:", got)
 	}
 
@@ -373,7 +373,7 @@ func TestRepos_Search(t *testing.T) {
 		for _, r := range results {
 			repos = append(repos, r.Repo)
 		}
-		if got := repoURIs(repos); !reflect.DeepEqual(got, test.want) {
+		if got := sortedRepoURIs(repos); !reflect.DeepEqual(got, test.want) {
 			t.Errorf("%q: got repos %v, want %v", test.query, got, test.want)
 		}
 	}
@@ -427,7 +427,7 @@ func TestRepos_Search_PrivateRepo(t *testing.T) {
 		for _, r := range results {
 			repos = append(repos, r.Repo)
 		}
-		if got := repoURIs(repos); !reflect.DeepEqual(got, test.want) {
+		if got := sortedRepoURIs(repos); !reflect.DeepEqual(got, test.want) {
 			t.Errorf("%q: got repos %v, want %v", test.query, got, test.want)
 		}
 	}


### PR DESCRIPTION
One thing missed in Quinn's [PR #26](https://github.com/sourcegraph/sourcegraph/pull/26) was the `GlobalDefs.Search` method which allows filtering by `Repos` and `NotRepos` fields. These fields were change to `int32` repo ID types, but because our `arg` SQL pattern takes `interface{}` it blindly worked without a compiler error. Thus, when you attempt to search by `Repos` `[1, 2, 3]` it compares against _repo URIs_ 1,2,3 NOT repo IDs 1,2,3 like it should.

Comparing against repo IDs requires a DB migration, which this PR does not perform. Instead, we just resolve the `Repos` and `NotRepos` repo URIs upon a call to `GlobalDefs.Search` and then run the query using repo URIs per usual. This is a stop-gap solution for a different PR I am working on, and we can switch to storing repo IDs in the `global_defs` table at a later date.

##### Reviewer tasks

- [x] HACKS: reviewer approves hacks introduced by this change
  - Not really a hack, just a stopgap solution. But please confirm this is OK.
- [x] UNIT-TEST: reviewer approves the unit tests (or the justified omission thereof)
  - Not sure investing in a test at this point is entirely valuable, this code could break in many more ways than can be tested easily / in a timely mannor.

##### Test plan

Locally tested. To my knowledge, nobody currently uses the `Repos` / `NotRepos` filters yet (I am with my future PR, though).