### PR TITLE
temporary fix while sourcegraph.com resolving is returning github.com

### DIFF
--- a/app/web_modules/sourcegraph/misc/golang.js
+++ b/app/web_modules/sourcegraph/misc/golang.js
@@ -31,9 +31,14 @@ export const route: Route = {
 			defaultFetch(`/.api/resolve-custom-import/info?def=${def}&pkg=${pkg}&repo=${repo}`)
 				.then((resp) => resp.json())
 				.then((data) => {
+					// TODO(matt): remove once sourcegraph.com resolving bug is fixed
+					let path = data.Path;
+					if (path.startsWith("/github.com/sourcegraph/")) {
+						path = path.replace("GoPackage/github.com", "GoPackage/sourcegraph.com");
+					}
 					replace({
 						...nextRouterState.location,
-						pathname: data.Path,
+						pathname: path,
 						query: {
 							utm_source: "sourcegraph-editor",
 							editor_type: editor_type,


### PR DESCRIPTION
There is an Asana bug for this, but basically URLs are getting resolved as:
https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/info/GoPackage/github.com/sourcegraph/sourcegraph/pkg/csp/-/Policy?editor_type=sublime&utm_source=sourcegraph-editor

Instead of:
https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/info/GoPackage/sourcegraph.com/sourcegraph/sourcegraph/pkg/csp/-/Policy?editor_type=sublime&utm_source=sourcegraph-editor

And there are 404s using SFYE. This appears to be specific to sourecgraph.com libraries.

##### Reviewer tasks

*AUTHOR: Add other outstanding tasks for the reviewer. Remove irrelevant items below.*

- [ ] HACKS: reviewer approves hacks introduced by this change

##### Test plan

will put on a staging instance, and verifiy that SFYE works.

