### PR TITLE
srclib-bash: update deps and docker image hash

### DIFF
--- a/services/worker/dockerfiles/Dockerfile.srclib-bash
+++ b/services/worker/dockerfiles/Dockerfile.srclib-bash
@@ -16,7 +16,7 @@ ADD $TOOLCHAIN_URL /toolchain/t
 RUN (cd /toolchain && tar xfz t && rm t && mv * t) || true
 RUN mkdir -p $SRCLIBPATH/sourcegraph.com/sourcegraph && mv /toolchain/t $SRCLIBPATH/sourcegraph.com/sourcegraph/srclib-bash
 WORKDIR $SRCLIBPATH/sourcegraph.com/sourcegraph/srclib-bash
-RUN make
+RUN make clean && make
 
 # Install srclib binary (assumes this has been built on the Docker host)
 ADD ./srclib /bin/srclib

--- a/services/worker/plan/srclib_images.go
+++ b/services/worker/plan/srclib_images.go
@@ -9,7 +9,7 @@ import (
 // developing to make it easier to test out changes to a given toolchain. E.g.,
 // `droneSrclibGoImage = "sourcegraph/srclib-go"`.
 var (
-	droneSrclibBashImage       = "sourcegraph/srclib-bash@sha256:641dddeee4ec7db91ed59af78f2f936bdce451ea7b496b0319f20ebe6dfba255"
+	droneSrclibBashImage       = "sourcegraph/srclib-bash@sha256:1b03e7f7b30122238674bbc660e07fdaa09c8840428b8b64595f002f691595a1"
 	droneSrclibGoImage         = "sourcegraph/srclib-go@sha256:4c91ca8b3d7fc123e9489e6751c94791776d303e21eb11e2cb14d986b78b1b06"
 	droneSrclibJavaScriptImage = "sourcegraph/srclib-javascript@sha256:7cfc4ea50aaf0fea46b8704e80ef50dfa45afe82af57e653bae34ae56288a859"
 	droneSrclibJavaImage       = "sourcegraph/srclib-java@sha256:0fc9416d860193e91898534a21063cae72c1ae6f20ec62555c9756f09151a982"

--- a/vendor/github.com/mkovacs/bash/scanner/scanner.go
+++ b/vendor/github.com/mkovacs/bash/scanner/scanner.go
@@ -83,7 +83,7 @@ func (s *Scanner) transition(tf transitionFunc) {
 }
 
 func isOperator(ch rune) bool {
-	return unicode.IsSymbol(ch) || unicode.IsPunct(ch)
+	return ch != '_' && (unicode.IsSymbol(ch) || unicode.IsPunct(ch))
 }
 
 func isWordChar(ch rune) bool {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -608,10 +608,10 @@
 			"revisionTime": "2015-11-02T10:20:00-08:00"
 		},
 		{
-			"checksumSHA1": "WVRHbaY5pI2qNR633zLc2fuQRfA=",
+			"checksumSHA1": "BmsqfNtdAdosNZjuHEkfWqEercY=",
 			"path": "github.com/mkovacs/bash/scanner",
-			"revision": "c7ace111c125da28de796b78ff1fd43bd65c7576",
-			"revisionTime": "2016-06-03T19:26:47Z"
+			"revision": "af08ea6c8da57fc29900b3c54725fc3c8c4827ee",
+			"revisionTime": "2016-06-07T23:51:34Z"
 		},
 		{
 			"checksumSHA1": "dEpgq1GYh5TRRNo22ANVMK8owTA=",


### PR DESCRIPTION
Updating for changes from `srclib-bash` and `bash/scanner`.