### PR TITLE
srclib_support: use basic_formatter for man page defs

### DIFF
--- a/pkg/srclib_support/basic_formatter.go
+++ b/pkg/srclib_support/basic_formatter.go
@@ -18,6 +18,7 @@ func init() {
 	graph.RegisterMakeDefFormatter("TypeScriptModule", newBasicFormatter("TypeScript"))
 	graph.RegisterMakeDefFormatter("CommonJSPackage", newBasicFormatter("JavaScript"))
 	graph.RegisterMakeDefFormatter("myunittype", newBasicFormatter("Generic")) // for quick lang prototypes
+	graph.RegisterMakeDefFormatter("ManPages", newBasicFormatter("Man"))
 }
 
 // DefData should be kept in sync with the def 'Data' field emitted by the


### PR DESCRIPTION
Needed to render man page defs correctly.