### PR TITLE
Updating srclib-java Docker image

### DIFF
--- a/services/worker/dockerfiles/Dockerfile.srclib-java
+++ b/services/worker/dockerfiles/Dockerfile.srclib-java
@@ -14,7 +14,7 @@ RUN apt-get install -qq git make -y lib32z1 lib32ncurses5 lib32stdc++6
 ENV SRCLIBPATH /srclib/toolchains
 
 # Gradle
-ENV GRADLE_VERSION 2.10
+ENV GRADLE_VERSION 2.13
 WORKDIR /usr/lib
 RUN wget -q https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && unzip "gradle-${GRADLE_VERSION}-bin.zip" && ln -s "/usr/lib/gradle-${GRADLE_VERSION}/bin/gradle" /usr/bin/gradle && rm "gradle-${GRADLE_VERSION}-bin.zip"
 

--- a/services/worker/plan/srclib_images.go
+++ b/services/worker/plan/srclib_images.go
@@ -12,7 +12,7 @@ var (
 	droneSrclibBashImage       = "sourcegraph/srclib-bash@sha256:641dddeee4ec7db91ed59af78f2f936bdce451ea7b496b0319f20ebe6dfba255"
 	droneSrclibGoImage         = "sourcegraph/srclib-go@sha256:4c91ca8b3d7fc123e9489e6751c94791776d303e21eb11e2cb14d986b78b1b06"
 	droneSrclibJavaScriptImage = "sourcegraph/srclib-javascript@sha256:7cfc4ea50aaf0fea46b8704e80ef50dfa45afe82af57e653bae34ae56288a859"
-	droneSrclibJavaImage       = "sourcegraph/srclib-java@sha256:0fc9416d860193e91898534a21063cae72c1ae6f20ec62555c9756f09151a982"
+	droneSrclibJavaImage       = "sourcegraph/srclib-java@sha256:7e4ff0bc3aee6d87295dd4629fabcfbb39de115911af6d1abd1aa4e5145b5d1c"
 	droneSrclibTypeScriptImage = "sourcegraph/srclib-typescript@sha256:39adfea4bdaea50be63431fe8c85c174a6a83d34db1196ac0bb171cb79cc88d6"
 	droneSrclibCSharpImage     = "sourcegraph/srclib-csharp@sha256:faa3c210e22693dc33954fb9d6714c7a735372e3a90a4cebc19c64be42551177"
 	droneSrclibCSSImage        = "sourcegraph/srclib-css@sha256:fb756d7443c72350c65f2141675efddbeb611603b77ee11f0ebaf03150e979a5"


### PR DESCRIPTION
- Docker image now contains latest Gradle 2.13
- Docker image rebuilt based on sourcegraph/srclib-java@49819eb6eec4cc8abec7d4b7a5ea0e7b58cfa0b2

##### Test plan

Please make sure that Java projects indexing goes well after merge


