### PR TITLE
sfye fix for repos hosted on sourcegraph.com

### DIFF
--- a/app/web_modules/sourcegraph/misc/golang.js
+++ b/app/web_modules/sourcegraph/misc/golang.js
@@ -33,7 +33,7 @@ export const route: Route = {
 				.then((data) => {
 					// TODO(matt): remove once sourcegraph.com resolving bug is fixed
 					let path = data.Path;
-					if (path.startsWith("/github.com/sourcegraph/")) {
+					if (path.startsWith("/github.com/sourcegraph/sourcegraph")) {
 						path = path.replace("GoPackage/github.com", "GoPackage/sourcegraph.com");
 					}
 					replace({


### PR DESCRIPTION
simple fix, it turns out that only the sourcegraph.com/sourcegraph/sourcgraph was creating invalid urls in sourcegraph for your editor. Making the corrective behavior we are taking just operate on this repo, not all sourcegraph repos.