### PR TITLE
app: make nav and body fixed width (except for blob)

### DIFF
--- a/app/web_modules/sourcegraph/app/App.js
+++ b/app/web_modules/sourcegraph/app/App.js
@@ -33,7 +33,9 @@ function App(props, {signedIn}) {
 			<Helmet titleTemplate="%s · Sourcegraph" defaultTitle="Sourcegraph" />
 			<GlobalNav location={props.location} channelStatusCode={props.channelStatusCode}/>
 			<div styleName="main-content">
-				{props.navContext && <div styleName="breadcrumb">{props.navContext}</div>}
+				{props.navContext && <nav styleName="nav-context">
+					<div styleName="nav-context-inner">{props.navContext}</div>
+				</nav>}
 				{props.main}
 			</div>
 			{!signedIn && <Footer />}

--- a/app/web_modules/sourcegraph/app/GlobalNav.js
+++ b/app/web_modules/sourcegraph/app/GlobalNav.js
@@ -39,7 +39,7 @@ function GlobalNav({navContext, location, channelStatusCode}, {user, siteConfig,
 					</div>
 				</LocationStateModal>
 			}
-			<div styleName="flex flex-fill flex-center tl" className={base.bn}>
+			<div styleName="navbar-inner flex flex-fill flex-center tl" className={base.bn}>
 				<Link to="/">
 					<Logo styleName={`logo flex-fixed ${signedIn ? "logomark" : ""}`}
 						width={signedIn ? "24px" : "200px"}

--- a/app/web_modules/sourcegraph/app/styles/App.css
+++ b/app/web_modules/sourcegraph/app/styles/App.css
@@ -1,10 +1,12 @@
 @value colors "sourcegraph/components/styles/_colors.css";
 @value vars "sourcegraph/components/styles/_vars.css";
 @value base "sourcegraph/components/styles/_base.css";
+@value layout "sourcegraph/components/styles/_layout.css";
 @value modal "sourcegraph/components/styles/modal.css";
 
 @value desktop-base-size, mobile-base-size, media-sm from vars;
 @value c_cool-gray from colors;
+@value media-sm from vars;
 
 /*
 Stick footer at bottom even if the page content doesn't take up
@@ -24,8 +26,14 @@ the entire viewport height.
 }
 
 .breadcrumb {
-	composes: bb ph3 pv2 from base;
+	composes: bb pv2 from base;
 	composes: b--cool-gray-2 bg-cool-pale-gray-2 from colors;
+}
+.nav-context {
+	composes: breadcrumb;
+}
+.nav-context-inner {
+	composes: navbar-fixed from layout;
 }
 
 /*

--- a/app/web_modules/sourcegraph/app/styles/GlobalNav.css
+++ b/app/web_modules/sourcegraph/app/styles/GlobalNav.css
@@ -55,7 +55,11 @@
 	padding-top: navbarHeight;
 }
 
-.logo { composes: mt2 mh3 from base; }
+.navbar-inner {
+	composes: navbar-fixed from layout;
+}
+
+.logo { composes: mt2 mr3 from base; }
 .logomark:hover {
 	animation: spin 0.5s ease-in-out 1;
 }

--- a/app/web_modules/sourcegraph/blob/BlobMain.js
+++ b/app/web_modules/sourcegraph/blob/BlobMain.js
@@ -58,11 +58,13 @@ export default class BlobMain extends Container {
 	componentDidMount() {
 		if (super.componentDidMount) super.componentDidMount();
 		this._dispatcherToken = Dispatcher.Stores.register(this.__onDispatch.bind(this));
+		if (typeof document !== "undefined") this._setFullWidthPage(true);
 	}
 
 	componentWillUnmount() {
 		if (super.componentWillUnmount) super.componentWillUnmount();
 		Dispatcher.Stores.unregister(this._dispatcherToken);
+		if (typeof document !== "undefined") this._setFullWidthPage(false);
 	}
 
 	_dispatcherToken: string;
@@ -125,6 +127,12 @@ export default class BlobMain extends Container {
 		} else if (action instanceof BlobActions.SelectCharRange) {
 			let hash = action.startLine ? `L${lineRange(lineCol(action.startLine, action.startCol), action.endLine && lineCol(action.endLine, action.endCol))}` : null;
 			this._navigate(action.repo, action.rev, action.path, hash);
+		}
+	}
+
+	_setFullWidthPage(fullWidth) {
+		if (typeof document !== "undefined") {
+			document.body.classList.toggle("full-width", fullWidth);
 		}
 	}
 

--- a/app/web_modules/sourcegraph/components/styles/_layout.css
+++ b/app/web_modules/sourcegraph/components/styles/_layout.css
@@ -2,6 +2,14 @@
 
 .containerFixed {
 	composes: center from base;
+	composes: ph3 from base;
 	width: 100%;
 	max-width: 940px;
+}
+:global .full-width :local .containerFixed {
+	max-width: none;
+}
+.navbar-fixed {
+	composes: containerFixed;
+	composes: ph3 from base;
 }

--- a/app/web_modules/sourcegraph/def/styles/DefInfo.css
+++ b/app/web_modules/sourcegraph/def/styles/DefInfo.css
@@ -1,12 +1,11 @@
 @value base "sourcegraph/components/styles/_base.css";
 @value grid "sourcegraph/components/styles/_grid.css";
+@value layout "sourcegraph/components/styles/_layout.css";
 @value colors "sourcegraph/components/styles/_colors.css";
 @value typography "sourcegraph/components/styles/_typography.css";
 
 .container {
-	composes: center from base;
-	composes: col-11-ns from grid;
-	max-width: 68rem;
+	composes: containerFixed from layout;
 	min-height: 50vh;
 }
 

--- a/app/web_modules/sourcegraph/repo/styles/Repo.css
+++ b/app/web_modules/sourcegraph/repo/styles/Repo.css
@@ -1,7 +1,7 @@
 @value vars "sourcegraph/components/styles/_vars.css";
 @value base "sourcegraph/components/styles/_base.css";
 @value colors "sourcegraph/components/styles/_colors.css";
-@value grid "sourcegraph/components/styles/_grid.css";
+@value layout "sourcegraph/components/styles/_layout.css";
 @value typography "sourcegraph/components/styles/_typography.css";
 @value GlobalNav "sourcegraph/app/styles/GlobalNav.css";
 
@@ -27,6 +27,7 @@
 
 .container {
 	composes: pt6 from base;
+	composes: containerFixed from layout;
 }
 
 .cloning-title {
@@ -41,6 +42,5 @@
 /* Repo Main */
 .tree-search-modal {
 	composes: f4 from typography;
-	composes: col-9 from grid;
 	composes: modal from "sourcegraph/components/styles/modal.css";
 }

--- a/app/web_modules/sourcegraph/tree/styles/Tree.css
+++ b/app/web_modules/sourcegraph/tree/styles/Tree.css
@@ -1,15 +1,15 @@
 @value base "sourcegraph/components/styles/_base.css";
 @value colors "sourcegraph/components/styles/_colors.css";
 @value typography "sourcegraph/components/styles/_typography.css";
-@value grid "sourcegraph/components/styles/_grid.css";
+@value layout "sourcegraph/components/styles/_layout.css";
 @value tooltips "sourcegraph/components/styles/tooltips.css";
 @value breadcrumb "sourcegraph/components/styles/breadcrumb.css";
 @value animation "sourcegraph/components/styles/animation.css";
 
 .tree-container {
 	composes: cf from base;
-	composes: col-9 from grid;
-	margin: 0 auto;
+	composes: containerFixed from layout;
+	composes: mt4 from base;
 }
 
 .tree-common {
@@ -19,7 +19,7 @@
 }
 
 .input-container {
-	composes: ma3 from base;
+	composes: mb3 from base;
 	display: flex;
 }
 
@@ -27,7 +27,7 @@
 .list-header {
 	display: flex;
 	align-items: center;
-	composes: mh3 pb1 from base;
+	composes: pb1 from base;
 	composes: ftracked f6 from typography;
 	composes: gray from colors;
 }
@@ -39,7 +39,7 @@
 .list-item {
 	display: flex;
 	align-items: center;
-	composes: pa3 mh3 bt from base;
+	composes: pa3 bt from base;
 	composes: blue b--black-20 from colors;
 	word-wrap: break-word;
 	overflow: hidden;


### PR DESCRIPTION
Prior to this PR, the top nav would always span the full screen width,
even if the main body container was fixed. This meant that the
DefInfo, Repo, and Tree pages (and static pages) looked a bit weird,
with the nav taking up full width and the content only taking up
partial width in the center.

@chexee Your call on whether to merge this. I was going to do some other demo changes where it'd make a bigger difference.

#### Before
![screenshot from 2016-06-09 23-02-12](https://cloud.githubusercontent.com/assets/1976/15955467/54b7a272-2e96-11e6-85a0-9e73da65cd2d.png)

#### After
![screenshot from 2016-06-09 23-01-59](https://cloud.githubusercontent.com/assets/1976/15955468/54b8e97a-2e96-11e6-9fba-578557c44a96.png)
