### PR TITLE
commit UI

### DIFF
--- a/app/web_modules/sourcegraph/Error.js
+++ b/app/web_modules/sourcegraph/Error.js
@@ -1,0 +1,6 @@
+// @flow
+
+// Error is a type that describes errors returned by XyzBackends if a network
+// request fails. Generally you will use Error in a union like `MyType | Error`,
+// so that you force callers to handle errors.
+export type Error = {Error: any};

--- a/app/web_modules/sourcegraph/app/routePatterns.js
+++ b/app/web_modules/sourcegraph/app/routePatterns.js
@@ -9,6 +9,7 @@ export type RouteName = "styleguide" |
 	"tools" |
 	"myRepos" |
 	"tour" |
+	"commit" |
 	"def" |
 	"defInfo" |
 	"repo" |
@@ -51,6 +52,7 @@ export const rel: {[key: RouteName]: string} = {
 	forgot: "forgot",
 	reset: "reset",
 	admin: "-/",
+	commit: "commit",
 	def: "def/*",
 	defInfo: "info/*",
 	repo: "*", // matches both "repo" and "repo@rev"
@@ -81,6 +83,7 @@ export const abs: {[key: RouteName]: string} = {
 	admin: rel.admin,
 	adminBuilds: `${rel.admin}${rel.builds}`,
 	adminCoverage: `${rel.admin}${rel.coverage}`,
+	commit: `${rel.repo}/-/${rel.commit}`,
 	def: `${rel.repo}/-/${rel.def}`,
 	defInfo: `${rel.repo}/-/${rel.defInfo}`,
 	repo: rel.repo,

--- a/app/web_modules/sourcegraph/blob/BlobLine.js
+++ b/app/web_modules/sourcegraph/blob/BlobLine.js
@@ -172,7 +172,7 @@ class BlobLine extends Component {
 		let isDiff = this.state.oldLineNumber || this.state.newLineNumber;
 
 		return (
-			<tr className={s.line}
+			<tr className={`${s.line} ${this.state.className || ""}`}
 				data-line={this.state.lineNumber}>
 				{this.state.lineNumber &&
 					<td className={s.lineNumberCell} onClick={(event) => {
@@ -185,8 +185,8 @@ class BlobLine extends Component {
 						<Link className={this.state.selected ? s.selectedLineNumber : s.lineNumber}
 							to={`${urlToBlob(this.state.repo, this.state.rev, this.state.path)}#L${this.state.lineNumber}`} data-line={this.state.lineNumber} />
 					</td>}
-				{isDiff && <td className="line-number" data-line={this.state.oldLineNumber || ""}></td>}
-				{isDiff && <td className="line-number" data-line={this.state.newLineNumber || ""}></td>}
+				{isDiff && <td className={s.lineNumberCell} data-line={this.state.oldLineNumber || ""}><span className={s.lineNumber} data-line={this.state.oldLineNumber} /></td>}
+				{isDiff && <td className={s.lineNumberCell} data-line={this.state.newLineNumber || ""}><span className={s.lineNumber} data-line={this.state.newLineNumber} /></td>}
 
 				<td className={`code ${this.state.selected ? s.selectedLineContent : s.lineContent}`}>
 					{contents}

--- a/app/web_modules/sourcegraph/blob/testdata/BlobLine-contents.json
+++ b/app/web_modules/sourcegraph/blob/testdata/BlobLine-contents.json
@@ -2,6 +2,7 @@
 	"renderOutput": {
 		"type": "tr",
 		"props": {
+			"className": "undefined ",
 			"children": [
 				{
 					"type": "td",

--- a/app/web_modules/sourcegraph/blob/testdata/BlobLine-empty.json
+++ b/app/web_modules/sourcegraph/blob/testdata/BlobLine-empty.json
@@ -2,6 +2,7 @@
 	"renderOutput": {
 		"type": "tr",
 		"props": {
+			"className": "undefined ",
 			"children": [
 				{
 					"type": "td",

--- a/app/web_modules/sourcegraph/blob/testdata/BlobLine-lineNumber.json
+++ b/app/web_modules/sourcegraph/blob/testdata/BlobLine-lineNumber.json
@@ -2,6 +2,7 @@
 	"renderOutput": {
 		"type": "tr",
 		"props": {
+			"className": "undefined ",
 			"data-line": 42,
 			"children": [
 				{

--- a/app/web_modules/sourcegraph/blob/testdata/BlobLine-selection.json
+++ b/app/web_modules/sourcegraph/blob/testdata/BlobLine-selection.json
@@ -2,6 +2,7 @@
 	"renderOutput": {
 		"type": "tr",
 		"props": {
+			"className": "undefined ",
 			"children": [
 				{
 					"type": "td",

--- a/app/web_modules/sourcegraph/build/BuildContainer.js
+++ b/app/web_modules/sourcegraph/build/BuildContainer.js
@@ -99,7 +99,7 @@ class BuildContainer extends Container {
 					}}>Rebuild</Button>}
 				</div>
 				<BuildHeader build={this.state.build} commit={this.state.commit} />
-				{this.state.commit && <span styleName="commit"><Commit commit={this.state.commit} repo={this.state.repo}/></span>}
+				{this.state.commit && <div styleName="commit"><Commit commit={this.state.commit} repo={this.state.repo} full={false} /></div>}
 				{this.state.tasks && this.state.tasks.BuildTasks && <BuildTasks tasks={this.state.tasks.BuildTasks} logs={this.state.logs} />}
 			</div>
 		);

--- a/app/web_modules/sourcegraph/build/styles/Build.css
+++ b/app/web_modules/sourcegraph/build/styles/Build.css
@@ -32,8 +32,8 @@
 }
 
 .header {
-	composes: col-6 col-3-ns from grid;
-	composes: pa3 mh3 ba from base;
+	composes: col-4 col-3-ns from grid;
+	composes: pv3 mr3 ba from base;
 	composes: b--black-20 from base;
 	text-align: center;
 }
@@ -53,7 +53,7 @@
 }
 
 .commit {
-	composes: pa4 from base;
+	composes: pv3 from base;
 }
 
 .tasks {

--- a/app/web_modules/sourcegraph/components/Avatar.js
+++ b/app/web_modules/sourcegraph/components/Avatar.js
@@ -1,28 +1,14 @@
 import React from "react";
-
-import Component from "sourcegraph/Component";
-
 import CSSModules from "react-css-modules";
 import styles from "./styles/avatar.css";
 
 const PLACEHOLDER_IMAGE = "https://secure.gravatar.com/avatar?d=mm&f=y&s=128";
 
-class Avatar extends Component {
-	constructor(props) {
-		super(props);
-	}
-
-	reconcileState(state, props) {
-		Object.assign(state, props);
-	}
-
-	render() {
-		return (
-			<img className={this.props.className} styleName={this.state.size ? this.state.size : "small"} src={this.state.img || PLACEHOLDER_IMAGE} />
-		);
-	}
+function Avatar({className, size, img}) {
+	return (
+		<img className={className || ""} styleName={size || "small"} src={img || PLACEHOLDER_IMAGE} />
+	);
 }
-
 Avatar.propTypes = {
 	img: React.PropTypes.string,
 	size: React.PropTypes.string,

--- a/app/web_modules/sourcegraph/components/Menu.js
+++ b/app/web_modules/sourcegraph/components/Menu.js
@@ -8,6 +8,7 @@ import styles from "./styles/menu.css";
 class Menu extends React.Component {
 	static propTypes = {
 		children: React.PropTypes.any,
+		className: React.PropTypes.string,
 	};
 
 	renderMenuItems() {
@@ -17,7 +18,7 @@ class Menu extends React.Component {
 	}
 
 	render() {
-		return <div styleName="container">{this.renderMenuItems()}</div>;
+		return <div className={this.props.className} styleName="container">{this.renderMenuItems()}</div>;
 	}
 }
 

--- a/app/web_modules/sourcegraph/components/Popover.js
+++ b/app/web_modules/sourcegraph/components/Popover.js
@@ -49,7 +49,7 @@ class Popover extends Component {
 			<div styleName="container" ref="container">
 				{this.state.children[0]}
 				{this.state.visible &&
-					<div ref="content" styleName={`popover-${this.state.left ? "left" : "right"}`}>
+					<div ref="content" styleName={`popover-${this.state.left ? "left" : "right"}`} className={this.state.popoverClassName}>
 						{this.state.children[1]}
 					</div>}
 			</div>
@@ -67,6 +67,7 @@ Popover.propTypes = {
 		}
 	},
 	left: React.PropTypes.bool, // position popover content to the left (default: right)
+	popoverClassName: React.PropTypes.string,
 };
 
 export default CSSModules(Popover, styles);

--- a/app/web_modules/sourcegraph/components/styles/icon.css
+++ b/app/web_modules/sourcegraph/components/styles/icon.css
@@ -4,4 +4,5 @@
 	composes: v-txt-top from typography;
 	display: inline-flex;
 	align-items: center;
+	pointer-events: none;
 }

--- a/app/web_modules/sourcegraph/delta/DeltaActions.js
+++ b/app/web_modules/sourcegraph/delta/DeltaActions.js
@@ -1,0 +1,34 @@
+// @flow
+
+import type {Error} from "sourcegraph/Error";
+import type {DeltaFiles} from "sourcegraph/delta";
+
+export class WantFiles {
+	baseRepo: number;
+	baseRev: string;
+	headRepo: number;
+	headRev: string;
+
+	constructor(baseRepo: number, baseRev: string, headRepo: number, headRev: string) {
+		this.baseRepo = baseRepo;
+		this.baseRev = baseRev;
+		this.headRepo = headRepo;
+		this.headRev = headRev;
+	}
+}
+
+export class FetchedFiles {
+	baseRepo: number;
+	baseRev: string;
+	headRepo: number;
+	headRev: string;
+	data: DeltaFiles | Error;
+
+	constructor(baseRepo: number, baseRev: string, headRepo: number, headRev: string, data: DeltaFiles | Error) {
+		this.baseRepo = baseRepo;
+		this.baseRev = baseRev;
+		this.headRepo = headRepo;
+		this.headRev = headRev;
+		this.data = data;
+	}
+}

--- a/app/web_modules/sourcegraph/delta/DeltaBackend.js
+++ b/app/web_modules/sourcegraph/delta/DeltaBackend.js
@@ -1,0 +1,31 @@
+// @flow weak
+
+import * as DeltaActions from "sourcegraph/delta/DeltaActions";
+import DeltaStore from "sourcegraph/delta/DeltaStore";
+import Dispatcher from "sourcegraph/Dispatcher";
+import {defaultFetch, checkStatus} from "sourcegraph/util/xhr";
+import {singleflightFetch} from "sourcegraph/util/singleflightFetch";
+
+const DeltaBackend = {
+	fetch: singleflightFetch(defaultFetch),
+
+	__onDispatch(action) {
+		if (action instanceof DeltaActions.WantFiles) {
+			let commit = DeltaStore.files.get(action.baseRepo, action.baseRev, action.headRepo, action.headRev);
+			if (commit === null) {
+				DeltaBackend.fetch(`/.api/repos/${action.headRepo}@${action.headRev}/-/delta/${action.baseRev}/-/files`)
+					.then(checkStatus)
+					.then((resp) => resp.json())
+					.catch((err) => ({Error: err}))
+					.then((data) => {
+						Dispatcher.Stores.dispatch(new DeltaActions.FetchedFiles(action.baseRepo, action.baseRev, action.headRepo, action.headRev, data));
+					});
+			}
+			return;
+		}
+	},
+};
+
+Dispatcher.Backends.register(DeltaBackend.__onDispatch);
+
+export default DeltaBackend;

--- a/app/web_modules/sourcegraph/delta/DeltaBackend_test.js
+++ b/app/web_modules/sourcegraph/delta/DeltaBackend_test.js
@@ -1,0 +1,22 @@
+// @flow
+
+import expect from "expect.js";
+
+import Dispatcher from "sourcegraph/Dispatcher";
+import DeltaBackend from "sourcegraph/delta/DeltaBackend";
+import * as DeltaActions from "sourcegraph/delta/DeltaActions";
+import immediateSyncPromise from "sourcegraph/util/immediateSyncPromise";
+
+const d = {Base: {Repo: 1, CommitID: "cbase"}, Head: {Repo: 1, CommitID: "chead"}};
+
+describe("DeltaBackend", () => {
+	it("should handle WantFiles", () => {
+		DeltaBackend.fetch = function(url, options) {
+			expect(url).to.be("/.api/repos/1@chead/-/delta/cbase/-/files");
+			return immediateSyncPromise({status: 200, json: () => ({Ds: d})});
+		};
+		expect(Dispatcher.Stores.catchDispatched(() => {
+			DeltaBackend.__onDispatch(new DeltaActions.WantFiles(d.Base.Repo, d.Base.CommitID, d.Head.Repo, d.Head.CommitID));
+		})).to.eql([new DeltaActions.FetchedFiles(d.Base.Repo, d.Base.CommitID, d.Head.Repo, d.Head.CommitID, {Ds: d})]);
+	});
+});

--- a/app/web_modules/sourcegraph/delta/DeltaStore.js
+++ b/app/web_modules/sourcegraph/delta/DeltaStore.js
@@ -1,0 +1,43 @@
+// @flow weak
+
+import Store from "sourcegraph/Store";
+import Dispatcher from "sourcegraph/Dispatcher";
+import deepFreeze from "sourcegraph/util/deepFreeze";
+import * as DeltaActions from "sourcegraph/delta/DeltaActions";
+import "sourcegraph/delta/DeltaBackend";
+import type {DeltaFiles} from "sourcegraph/delta";
+
+function keyFor(baseRepo: number, baseRev: string, headRepo: number, headRev: string): string {
+	return `${baseRepo}#${baseRev}#${headRepo}#${headRev}`;
+}
+
+export class DeltaStore extends Store {
+	reset(data?: {files: {content: DeltaFiles}}) {
+		this.files = deepFreeze({
+			content: data && data.files ? data.files.content : {},
+			get(baseRepo: number, baseRev: string, headRepo: number, headRev: string) {
+				return this.content[keyFor(baseRepo, baseRev, headRepo, headRev)] || null;
+			},
+		});
+	}
+
+	toJSON(): any {
+		return {
+			files: this.files,
+		};
+	}
+
+	__onDispatch(action) {
+		if (action instanceof DeltaActions.FetchedFiles) {
+			this.files = deepFreeze({...this.files,
+				content: {...this.files.content,
+					[keyFor(action.baseRepo, action.baseRev, action.headRepo, action.headRev)]: action.data,
+				},
+			});
+			this.__emitChange();
+			return;
+		}
+	}
+}
+
+export default new DeltaStore(Dispatcher.Stores);

--- a/app/web_modules/sourcegraph/delta/DeltaStore_test.js
+++ b/app/web_modules/sourcegraph/delta/DeltaStore_test.js
@@ -1,0 +1,15 @@
+// @flow
+
+import expect from "expect.js";
+
+import DeltaStore from "sourcegraph/delta/DeltaStore";
+import * as DeltaActions from "sourcegraph/delta/DeltaActions";
+
+const d = {Base: {Repo: 1, CommitID: "cbase"}, Head: {Repo: 2, CommitID: "chead"}};
+
+describe("DeltaStore", () => {
+	it("should handle FetchedCommit", () => {
+		DeltaStore.directDispatch(new DeltaActions.FetchedFiles(d.Base.Repo, d.Base.CommitID, d.Head.Repo, d.Head.CommitID, {Ds: d}));
+		expect(DeltaStore.files.get(d.Base.Repo, d.Base.CommitID, d.Head.Repo, d.Head.CommitID)).to.eql({Ds: d});
+	});
+});

--- a/app/web_modules/sourcegraph/delta/DiffFileList.js
+++ b/app/web_modules/sourcegraph/delta/DiffFileList.js
@@ -1,59 +1,57 @@
 import React from "react";
-
-import classNames from "classnames";
 import DiffStatScale from "sourcegraph/delta/DiffStatScale";
 import {isDevNull} from "sourcegraph/delta/util";
+import styles from "sourcegraph/delta/styles/DiffFileList.css";
+import CSSModules from "react-css-modules";
+import {TriangleDownIcon} from "sourcegraph/components/Icons";
+import {Panel, Menu, Popover} from "sourcegraph/components";
 
 class DiffFileList extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {closed: false};
-	}
+	static propTypes = {
+		files: React.PropTypes.arrayOf(React.PropTypes.object),
+		stats: React.PropTypes.object.isRequired,
+	};
+
+	state = {closed: false};
 
 	render() {
 		return (
-			<div className={classNames({
-				"file-list": true,
-				"closed": Boolean(this.state.closed),
-			})}>
-				<a className="file-list-header" onClick={() => this.setState({closed: !this.state.closed})}>
-					<i className={this.state.closed ? "fa fa-icon fa-plus-square-o" : "fa fa-icon fa-minus-square-o"} />
-					<b>Files</b> <span className="count">( {this.props.files.length} )</span>
-					<span className="pull-right stats">
-						<span className="additions-color">+{this.props.stats.Added}</span>
-						<span className="deletions-color">-{this.props.stats.Deleted}</span>
-					</span>
-				</a>
-
-				<ul className="file-list-items">
-					{this.props.files.map((fd, i) => (
-						<li key={fd.OrigName + fd.NewName} className="file-list-item">
-							<a href={`#F${i}`}>
-								{isDevNull(fd.OrigName) ? <code className="change-type additions-color">+</code> : null}
-								{isDevNull(fd.NewName) ? <code className="change-type deletions-color">&minus;</code> : null}
-								{!isDevNull(fd.OrigName) && !isDevNull(fd.NewName) ? <code className="change-type changes-color">&bull;</code> : null}
-
-								{!isDevNull(fd.OrigName) && !isDevNull(fd.NewName) && fd.OrigName !== fd.NewName ? (
-									<span>{fd.OrigName} <i className="fa fa-icon fa-long-arrow-right" />&nbsp;</span>
-								) : null}
-
-								{isDevNull(fd.NewName) ? fd.OrigName : fd.NewName}
-
-								<div className="pull-right stats">
-									<span className="additions-color">+{this.props.stats.Added}</span>
-									<span className="deletions-color">-{this.props.stats.Deleted}</span>
-									<DiffStatScale Stat={this.props.stats} />
+			<Panel styleName="container">
+				<div styleName="header">
+				<Popover popoverClassName={styles.popover}>
+						<div styleName="label">
+							<DiffStatScale Stat={this.props.stats} />
+							<span styleName="count">{this.props.files.length}</span> changed files
+							<span styleName="overall-stats">
+								<span styleName="stat added">+{this.props.stats.Added}</span>
+								<span styleName="stat deleted">&ndash;{this.props.stats.Deleted}</span>
+							</span>
+							&nbsp;<TriangleDownIcon />
+						</div>
+						<Menu className={styles["popover-menu"]}>
+							{this.props.files.map((fd, i) => (
+								<div key={fd.OrigName + fd.NewName} styleName="file-item">
+									<a href={`#F${i}`} styleName="file">
+										{isDevNull(fd.OrigName) ? <code styleName="change-type added">+</code> : null}
+										{isDevNull(fd.NewName) ? <code styleName="change-type deleted">&ndash;</code> : null}
+										{!isDevNull(fd.OrigName) && !isDevNull(fd.NewName) ? <code styleName="change-type changed">&bull;</code> : null}
+										{!isDevNull(fd.OrigName) && !isDevNull(fd.NewName) && fd.OrigName !== fd.NewName ? (
+											<span>{fd.OrigName} &rarr;&nbsp;</span>
+										) : null}
+										{isDevNull(fd.NewName) ? fd.OrigName : fd.NewName}
+									</a>
+									<span styleName="file-stats">
+										<span styleName="stat added">+{fd.Stats.Added}</span>
+										<span styleName="stat deleted">&ndash;{fd.Stats.Deleted}</span>
+									</span>
 								</div>
-							</a>
-						</li>
-					))}
-				</ul>
-			</div>
+							))}
+						</Menu>
+					</Popover>
+				</div>
+			</Panel>
 		);
 	}
 }
-DiffFileList.propTypes = {
-	files: React.PropTypes.arrayOf(React.PropTypes.object),
-	stats: React.PropTypes.object.isRequired,
-};
-export default DiffFileList;
+
+export default CSSModules(DiffFileList, styles, {allowMultiple: true});

--- a/app/web_modules/sourcegraph/delta/DiffFileList_test.js
+++ b/app/web_modules/sourcegraph/delta/DiffFileList_test.js
@@ -6,26 +6,29 @@ import DiffFileList from "sourcegraph/delta/DiffFileList";
 
 import testdataInitial from "sourcegraph/delta/testdata/DiffFileList-initial.json";
 
-const sampleFiles = [
-	{
-		OrigName: "a",
-		NewName: "b",
-	},
-	{
-		OrigName: "/dev/null",
-		NewName: "b",
-	},
-	{
-		OrigName: "a",
-		NewName: "/dev/null",
-	},
-];
-
 const sampleStats = {
 	Added: 5,
 	Changed: 6,
 	Deleted: 7,
 };
+
+const sampleFiles = [
+	{
+		OrigName: "a",
+		NewName: "b",
+		Stats: sampleStats,
+	},
+	{
+		OrigName: "/dev/null",
+		NewName: "b",
+		Stats: sampleStats,
+	},
+	{
+		OrigName: "a",
+		NewName: "/dev/null",
+		Stats: sampleStats,
+	},
+];
 
 describe("DiffFileList", () => {
 	it("should render", () => {

--- a/app/web_modules/sourcegraph/delta/DiffStatScale.js
+++ b/app/web_modules/sourcegraph/delta/DiffStatScale.js
@@ -1,4 +1,6 @@
 import React from "react";
+import styles from "sourcegraph/delta/styles/DiffStatScale.css";
+import CSSModules from "react-css-modules";
 
 class DiffStatScale extends React.Component {
 	render() {
@@ -48,12 +50,12 @@ class DiffStatScale extends React.Component {
 		}
 
 		return (
-			<span className="diff-stat-scale">
-				<span className="stat-added">{bar(sds.ScaledAdded)}</span>
-				<span className="stat-changed">{bar(sds.ScaledChanged)}</span>
-				<span className="stat-deleted">{bar(sds.ScaledDeleted)}</span>
+			<span styleName="diff-stat-scale">
+				<span styleName="stat-added">{bar(sds.ScaledAdded)}</span>
+				<span styleName="stat-changed">{bar(sds.ScaledChanged)}</span>
+				<span styleName="stat-deleted">{bar(sds.ScaledDeleted)}</span>
 				{filler > 0 ? (
-					<span className="stat-filler">{bar(filler)}</span>
+					<span styleName="stat-filler">{bar(filler)}</span>
 				) : null}
 			</span>
 		);
@@ -67,4 +69,4 @@ DiffStatScale.propTypes = {
 	}).isRequired,
 	Size: React.PropTypes.number,
 };
-export default DiffStatScale;
+export default CSSModules(DiffStatScale, styles);

--- a/app/web_modules/sourcegraph/delta/FileDiffs.js
+++ b/app/web_modules/sourcegraph/delta/FileDiffs.js
@@ -1,5 +1,6 @@
 import React from "react";
-
+import styles from "sourcegraph/delta/styles/FileDiffs.css";
+import CSSModules from "react-css-modules";
 import BlobStore from "sourcegraph/blob/BlobStore";
 import Container from "sourcegraph/Container";
 import * as DefActions from "sourcegraph/def/DefActions";
@@ -8,12 +9,8 @@ import DefTooltip from "sourcegraph/def/DefTooltip";
 import DiffFileList from "sourcegraph/delta/DiffFileList";
 import Dispatcher from "sourcegraph/Dispatcher";
 import FileDiff from "sourcegraph/delta/FileDiff";
-
-// TODO(sqs): FileDiffs does not yet support multiple-defs (when a single
-// ref links to multiple defs, like Go embedded fields linking to both the
-// type and the field). We could copy over the implementation from
-// BlobMain, but that is going to be factored out soon, and let's
-// keep it clean.
+import {isExternalLink} from "sourcegraph/util/externalLink";
+import {routeParams as defRouteParams} from "sourcegraph/def";
 
 class FileDiffs extends Container {
 	reconcileState(state, props) {
@@ -22,11 +19,25 @@ class FileDiffs extends Container {
 
 		state.defs = DefStore.defs;
 		state.highlightedDef = DefStore.highlightedDef || null;
+
+		if (state.highlightedDef && !isExternalLink(state.highlightedDef)) {
+			let {repo, rev, def} = defRouteParams(state.highlightedDef);
+			state.highlightedDefObj = DefStore.defs.get(repo, rev, def);
+		} else {
+			state.highlightedDefObj = null;
+		}
 	}
 
 	onStateTransition(prevState, nextState) {
 		if (nextState.highlightedDef && prevState.highlightedDef !== nextState.highlightedDef) {
-			Dispatcher.Backends.dispatch(new DefActions.WantDef(nextState.highlightedDef));
+			if (!isExternalLink(nextState.highlightedDef)) { // kludge to filter out external def links
+				let {repo, rev, def, err} = defRouteParams(nextState.highlightedDef);
+				if (err) {
+					console.err(err);
+				} else {
+					Dispatcher.Backends.dispatch(new DefActions.WantDef(repo, rev, def));
+				}
+			}
 		}
 	}
 
@@ -35,24 +46,23 @@ class FileDiffs extends Container {
 	}
 
 	render() {
-		const highlightedDefData = this.state.highlightedDef && this.state.defs.get(this.state.highlightedDef);
-
 		return (
-			<div>
+			<div styleName="container">
 				<DiffFileList files={this.props.files} stats={this.props.stats} />
 				{this.props.files.map((fd, i) => (
-					<FileDiff
-						key={fd.OrigName + fd.NewName}
+					<div styleName="file-diff" key={fd.OrigName + fd.NewName}><FileDiff
 						id={`F${i}`}
 						diff={fd}
 						baseRepo={this.props.baseRepo}
 						baseRev={this.props.baseRev}
 						headRepo={this.props.headRepo}
 						headRev={this.props.headRev}
+						highlightedDef={this.state.highlightedDef}
+						highlightedDefObj={this.state.highlightedDefObj}
 						annotations={this.state.annotations}
-						defs={this.state.defs} />
+						defs={this.state.defs} /></div>
 				))}
-				{highlightedDefData && !highlightedDefData.Error && <DefTooltip def={highlightedDefData} />}
+				{this.state.highlightedDefObj && !this.state.highlightedDefObj.Error && <DefTooltip currentRepo={this.state.baseRepo} def={this.state.highlightedDefObj} />}
 			</div>
 		);
 	}
@@ -65,4 +75,4 @@ FileDiffs.propTypes = {
 	headRepo: React.PropTypes.string.isRequired,
 	headRev: React.PropTypes.string.isRequired,
 };
-export default FileDiffs;
+export default CSSModules(FileDiffs, styles);

--- a/app/web_modules/sourcegraph/delta/Hunk.js
+++ b/app/web_modules/sourcegraph/delta/Hunk.js
@@ -1,7 +1,7 @@
 import React from "react";
-
+import styles from "sourcegraph/delta/styles/Hunk.css";
+import CSSModules from "react-css-modules";
 import {atob} from "abab";
-import classNames from "classnames";
 import BlobLine from "sourcegraph/blob/BlobLine";
 import fileLines from "sourcegraph/util/fileLines";
 
@@ -11,18 +11,18 @@ class Hunk extends React.Component {
 
 		let lines = fileLines(atob(hunk.Body));
 
-		let origLine = hunk.OrigStartLine;
-		let newLine = hunk.NewStartLine;
+		let origLine = hunk.OrigStartLine || 0;
+		let newLine = hunk.NewStartLine || 0;
 
 		let lineStartByte = 0;
 
 		return (
-			<table className="line-numbered-code theme-default file-diff-hunk">
+			<table styleName="lines">
 				<tbody>
-					<tr className="line hunk-header">
-						<td className="line-number">...</td>
-						<td className="line-number">...</td>
-						<td className="line-content">
+					<tr styleName="line">
+						<td styleName="line-number-cell"><span styleName="line-number">...</span></td>
+						<td styleName="line-number-cell"><span styleName="line-number">...</span></td>
+						<td styleName="line-content">
 							@@ -{hunk.OrigStartLine},{hunk.OrigLines} +{hunk.NewStartLine},{hunk.NewLines} @@ {hunk.Section}
 						</td>
 					</tr>
@@ -32,13 +32,16 @@ class Hunk extends React.Component {
 						lineStartByte += line.length + 1; // account for 1-char newline
 
 						const prefix = line[0];
+						let styleName;
 						if (i > 0) {
 							switch (prefix) {
 							case "+":
 								newLine++;
+								styleName = styles["new-line"];
 								break;
 							case "-":
 								origLine++;
+								styleName = styles["old-line"];
 								break;
 							case " ":
 								origLine++;
@@ -54,14 +57,13 @@ class Hunk extends React.Component {
 						return (
 							<BlobLine
 								key={i}
-								className={classNames({
-									"new-line": prefix === "+",
-									"old-line": prefix === "-",
-								})}
+								className={styleName || null}
 								oldLineNumber={prefix === "+" ? null : origLine}
 								newLineNumber={prefix === "-" ? null : newLine}
 								contents={line}
 								startByte={thisLineStartByte}
+								highlightedDef={this.props.highlightedDef}
+								highlightedDefObj={this.props.highlightedDefObj}
 								annotations={anns} />
 						);
 					})}
@@ -73,5 +75,8 @@ class Hunk extends React.Component {
 Hunk.propTypes = {
 	hunk: React.PropTypes.object.isRequired,
 	annotations: React.PropTypes.array,
+
+	highlightedDef: React.PropTypes.string,
+	highlightedDefObj: React.PropTypes.object,
 };
-export default Hunk;
+export default CSSModules(Hunk, styles);

--- a/app/web_modules/sourcegraph/delta/index.js
+++ b/app/web_modules/sourcegraph/delta/index.js
@@ -1,0 +1,13 @@
+// @flow
+
+import type {RepoRevSpec} from "sourcegraph/repo";
+
+export type DeltaSpec = {
+	Base: RepoRevSpec;
+	Head: RepoRevSpec;
+};
+
+export type DeltaFiles = {
+	Ds: DeltaSpec;
+	Opt?: ?Object;
+};

--- a/app/web_modules/sourcegraph/delta/styles/DiffFileList.css
+++ b/app/web_modules/sourcegraph/delta/styles/DiffFileList.css
@@ -1,0 +1,81 @@
+@value vars "sourcegraph/components/styles/_vars.css";
+@value base "sourcegraph/components/styles/_base.css";
+@value colors "sourcegraph/components/styles/_colors.css";
+@value layout "sourcegraph/components/styles/_layout.css";
+@value typography "sourcegraph/components/styles/_typography.css";
+@value GlobalNav "sourcegraph/app/styles/GlobalNav.css";
+
+.container {
+	composes: pv4 from base;
+	min-width: 400px;
+}
+.header {
+	display: flex;
+	justify-content: space-between;
+	composes: cool-gray from colors;
+	user-select: none;
+}
+.stats {
+	font-weight: bold;
+}
+.overall-stats {
+	composes: ph1 from base;
+}
+.label {
+	font-weight: bold;
+	composes: f4 from typography;
+	display: block;
+	cursor: pointer;
+}
+.count {
+
+}
+
+/* make the popover caret align with the down caret */
+.popover {
+	width: calc(100% + 20px);
+}
+.popover-menu {
+	width: 100%;
+}
+
+.files {
+	list-style-type: none;
+	composes: pl0 mv0 from base;
+}
+.closed {
+	display: none;
+}
+.file-item {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.file {
+	composes: cool-gray from colors;
+	user-select: none;
+	white-space: nowrap;
+}
+.file-stats {
+	composes: stats;
+	display: inline-block;
+	float: right;
+}
+.change-type {
+	display: inline-block;
+	font-weight: bold;
+	composes: pr2 from base;
+}
+
+.stat {
+	composes: pl2 from base;
+}
+.added {
+	color: green;
+}
+.deleted {
+	color: red;
+}
+.changed {
+	color: orange;
+}

--- a/app/web_modules/sourcegraph/delta/styles/DiffStatScale.css
+++ b/app/web_modules/sourcegraph/delta/styles/DiffStatScale.css
@@ -5,7 +5,18 @@
 @value typography "sourcegraph/components/styles/_typography.css";
 @value GlobalNav "sourcegraph/app/styles/GlobalNav.css";
 
-.container {
-	composes: containerFixed from layout;
-	composes: pa3 from base;
+.diff-stat-scale {
+	display: inline-block;
+}
+.stat-added {
+	color: green;
+}
+.stat-deleted {
+	color: red;
+}
+.stat-changed {
+	color: orange;
+}
+.stat-filler {
+	color: transparent;
 }

--- a/app/web_modules/sourcegraph/delta/styles/FileDiff.css
+++ b/app/web_modules/sourcegraph/delta/styles/FileDiff.css
@@ -6,6 +6,25 @@
 @value GlobalNav "sourcegraph/app/styles/GlobalNav.css";
 
 .container {
-	composes: containerFixed from layout;
-	composes: pa3 from base;
+
+}
+
+.header {
+	display: flex;
+	composes: bg-light-gray from colors;
+	composes: pv2 ph3 br2 from base;
+}
+.info {
+	flex: 1 0;
+}
+.name {
+	font-weight: bold;
+}
+.actions {
+	flex: 0 1;
+}
+.action {
+	composes: pl2 from base;
+}
+.hunk {
 }

--- a/app/web_modules/sourcegraph/delta/styles/FileDiffs.css
+++ b/app/web_modules/sourcegraph/delta/styles/FileDiffs.css
@@ -5,7 +5,8 @@
 @value typography "sourcegraph/components/styles/_typography.css";
 @value GlobalNav "sourcegraph/app/styles/GlobalNav.css";
 
-.container {
-	composes: containerFixed from layout;
-	composes: pa3 from base;
+.container {}
+
+.file-diff {
+	composes: mb5 from base;
 }

--- a/app/web_modules/sourcegraph/delta/styles/Hunk.css
+++ b/app/web_modules/sourcegraph/delta/styles/Hunk.css
@@ -1,0 +1,31 @@
+@value vars "sourcegraph/components/styles/_vars.css";
+@value base "sourcegraph/components/styles/_base.css";
+@value colors "sourcegraph/components/styles/_colors.css";
+@value layout "sourcegraph/components/styles/_layout.css";
+@value typography "sourcegraph/components/styles/_typography.css";
+@value GlobalNav "sourcegraph/app/styles/GlobalNav.css";
+@value Blob "sourcegraph/blob/styles/Blob.css";
+
+.container {}
+
+.lines {
+	composes: lines from Blob;
+}
+.line {
+	composes: line from Blob;
+}
+.line-number-cell {
+	composes: lineNumberCell from Blob;
+}
+.line-number {
+	composes: lineNumber from Blob;
+}
+.line-content {
+	composes: lineContent from Blob;
+}
+.new-line {
+	composes: bg-green-2 from colors;
+}
+.old-line {
+	composes: bg-red-2 from colors;
+}

--- a/app/web_modules/sourcegraph/delta/testdata/DiffFileList-initial.json
+++ b/app/web_modules/sourcegraph/delta/testdata/DiffFileList-initial.json
@@ -1,117 +1,57 @@
 {
 	"renderOutput": {
-		"type": "div",
+		"type": "WrappedComponent",
 		"props": {
-			"className": "file-list",
+			"styleName": "container",
 			"children": [
 				{
-					"type": "a",
+					"type": "div",
 					"props": {
-						"className": "file-list-header",
+						"styleName": "header",
 						"children": [
 							{
-								"type": "i",
+								"type": "WrappedComponent",
 								"props": {
-									"className": "fa fa-icon fa-minus-square-o"
-								}
-							},
-							{
-								"type": "b",
-								"props": {
-									"children": [
-										"Files"
-									]
-								}
-							},
-							" ",
-							{
-								"type": "span",
-								"props": {
-									"className": "count",
-									"children": [
-										"( 3 )"
-									]
-								}
-							},
-							{
-								"type": "span",
-								"props": {
-									"className": "pull-right stats",
 									"children": [
 										{
-											"type": "span",
+											"type": "div",
+											"key": ".0",
 											"props": {
-												"className": "additions-color",
-												"children": [
-													"+5"
-												]
-											}
-										},
-										{
-											"type": "span",
-											"props": {
-												"className": "deletions-color",
-												"children": [
-													"-7"
-												]
-											}
-										}
-									]
-								}
-							}
-						]
-					}
-				},
-				{
-					"type": "ul",
-					"props": {
-						"className": "file-list-items",
-						"children": [
-							{
-								"type": "li",
-								"key": "ab",
-								"props": {
-									"className": "file-list-item",
-									"children": [
-										{
-											"type": "a",
-											"props": {
-												"href": "#F0",
+												"styleName": "label",
 												"children": [
 													{
-														"type": "code",
+														"type": "WrappedComponent",
+														"key": ".0",
 														"props": {
-															"className": "change-type changes-color",
-															"children": [
-																"•"
-															]
+															"Stat": {
+																"Added": 5,
+																"Changed": 6,
+																"Deleted": 7
+															}
 														}
 													},
 													{
 														"type": "span",
+														"key": ".1",
 														"props": {
+															"styleName": "count",
 															"children": [
-																"a ",
-																{
-																	"type": "i",
-																	"props": {
-																		"className": "fa fa-icon fa-long-arrow-right"
-																	}
-																},
-																" "
+																"3"
 															]
 														}
 													},
-													"b",
+													" changed files",
 													{
-														"type": "div",
+														"type": "span",
+														"key": ".3",
 														"props": {
-															"className": "pull-right stats",
+															"styleName": "overall-stats",
 															"children": [
 																{
 																	"type": "span",
+																	"key": ".0",
 																	"props": {
-																		"className": "additions-color",
+																		"styleName": "stat added",
 																		"children": [
 																			"+5"
 																		]
@@ -119,147 +59,212 @@
 																},
 																{
 																	"type": "span",
+																	"key": ".1",
 																	"props": {
-																		"className": "deletions-color",
+																		"styleName": "stat deleted",
 																		"children": [
-																			"-7"
+																			"–7"
 																		]
-																	}
-																},
-																{
-																	"type": "DiffStatScale",
-																	"props": {
-																		"Stat": {
-																			"Added": 5,
-																			"Changed": 6,
-																			"Deleted": 7
-																		}
 																	}
 																}
 															]
 														}
+													},
+													" ",
+													{
+														"type": "WrappedComponent",
+														"key": ".5",
+														"props": {}
 													}
 												]
 											}
-										}
-									]
-								}
-							},
-							{
-								"type": "li",
-								"key": "/dev/nullb",
-								"props": {
-									"className": "file-list-item",
-									"children": [
+										},
 										{
-											"type": "a",
+											"type": "WrappedComponent",
+											"key": ".1",
 											"props": {
-												"href": "#F1",
 												"children": [
 													{
-														"type": "code",
-														"props": {
-															"className": "change-type additions-color",
-															"children": [
-																"+"
-															]
-														}
-													},
-													"b",
-													{
 														"type": "div",
+														"key": ".$ab",
 														"props": {
-															"className": "pull-right stats",
+															"styleName": "file-item",
 															"children": [
 																{
-																	"type": "span",
+																	"type": "a",
+																	"key": ".0",
 																	"props": {
-																		"className": "additions-color",
+																		"href": "#F0",
+																		"styleName": "file",
 																		"children": [
-																			"+5"
+																			{
+																				"type": "code",
+																				"key": ".2",
+																				"props": {
+																					"styleName": "change-type changed",
+																					"children": [
+																						"•"
+																					]
+																				}
+																			},
+																			{
+																				"type": "span",
+																				"key": ".3",
+																				"props": {
+																					"children": [
+																						"a → "
+																					]
+																				}
+																			},
+																			"b"
 																		]
 																	}
 																},
 																{
 																	"type": "span",
+																	"key": ".1",
 																	"props": {
-																		"className": "deletions-color",
+																		"styleName": "file-stats",
 																		"children": [
-																			"-7"
+																			{
+																				"type": "span",
+																				"key": ".0",
+																				"props": {
+																					"styleName": "stat added",
+																					"children": [
+																						"+5"
+																					]
+																				}
+																			},
+																			{
+																				"type": "span",
+																				"key": ".1",
+																				"props": {
+																					"styleName": "stat deleted",
+																					"children": [
+																						"–7"
+																					]
+																				}
+																			}
 																		]
-																	}
-																},
-																{
-																	"type": "DiffStatScale",
-																	"props": {
-																		"Stat": {
-																			"Added": 5,
-																			"Changed": 6,
-																			"Deleted": 7
-																		}
 																	}
 																}
 															]
 														}
-													}
-												]
-											}
-										}
-									]
-								}
-							},
-							{
-								"type": "li",
-								"key": "a/dev/null",
-								"props": {
-									"className": "file-list-item",
-									"children": [
-										{
-											"type": "a",
-											"props": {
-												"href": "#F2",
-												"children": [
+													},
 													{
-														"type": "code",
+														"type": "div",
+														"key": ".$/dev/nullb",
 														"props": {
-															"className": "change-type deletions-color",
+															"styleName": "file-item",
 															"children": [
-																"−"
+																{
+																	"type": "a",
+																	"key": ".0",
+																	"props": {
+																		"href": "#F1",
+																		"styleName": "file",
+																		"children": [
+																			{
+																				"type": "code",
+																				"key": ".0",
+																				"props": {
+																					"styleName": "change-type added",
+																					"children": [
+																						"+"
+																					]
+																				}
+																			},
+																			"b"
+																		]
+																	}
+																},
+																{
+																	"type": "span",
+																	"key": ".1",
+																	"props": {
+																		"styleName": "file-stats",
+																		"children": [
+																			{
+																				"type": "span",
+																				"key": ".0",
+																				"props": {
+																					"styleName": "stat added",
+																					"children": [
+																						"+5"
+																					]
+																				}
+																			},
+																			{
+																				"type": "span",
+																				"key": ".1",
+																				"props": {
+																					"styleName": "stat deleted",
+																					"children": [
+																						"–7"
+																					]
+																				}
+																			}
+																		]
+																	}
+																}
 															]
 														}
 													},
-													"a",
 													{
 														"type": "div",
+														"key": ".$a/dev/null",
 														"props": {
-															"className": "pull-right stats",
+															"styleName": "file-item",
 															"children": [
 																{
-																	"type": "span",
+																	"type": "a",
+																	"key": ".0",
 																	"props": {
-																		"className": "additions-color",
+																		"href": "#F2",
+																		"styleName": "file",
 																		"children": [
-																			"+5"
+																			{
+																				"type": "code",
+																				"key": ".1",
+																				"props": {
+																					"styleName": "change-type deleted",
+																					"children": [
+																						"–"
+																					]
+																				}
+																			},
+																			"a"
 																		]
 																	}
 																},
 																{
 																	"type": "span",
+																	"key": ".1",
 																	"props": {
-																		"className": "deletions-color",
+																		"styleName": "file-stats",
 																		"children": [
-																			"-7"
+																			{
+																				"type": "span",
+																				"key": ".0",
+																				"props": {
+																					"styleName": "stat added",
+																					"children": [
+																						"+5"
+																					]
+																				}
+																			},
+																			{
+																				"type": "span",
+																				"key": ".1",
+																				"props": {
+																					"styleName": "stat deleted",
+																					"children": [
+																						"–7"
+																					]
+																				}
+																			}
 																		]
-																	}
-																},
-																{
-																	"type": "DiffStatScale",
-																	"props": {
-																		"Stat": {
-																			"Added": 5,
-																			"Changed": 6,
-																			"Deleted": 7
-																		}
 																	}
 																}
 															]
@@ -274,7 +279,8 @@
 						]
 					}
 				}
-			]
+			],
+			"hover": false
 		}
 	}
 }

--- a/app/web_modules/sourcegraph/delta/testdata/DiffStatScale-initial.json
+++ b/app/web_modules/sourcegraph/delta/testdata/DiffStatScale-initial.json
@@ -2,12 +2,13 @@
 	"renderOutput": {
 		"type": "span",
 		"props": {
-			"className": "diff-stat-scale",
+			"styleName": "diff-stat-scale",
 			"children": [
 				{
 					"type": "span",
+					"key": ".0",
 					"props": {
-						"className": "stat-added",
+						"styleName": "stat-added",
 						"children": [
 							"■"
 						]
@@ -15,8 +16,9 @@
 				},
 				{
 					"type": "span",
+					"key": ".1",
 					"props": {
-						"className": "stat-changed",
+						"styleName": "stat-changed",
 						"children": [
 							"■"
 						]
@@ -24,8 +26,9 @@
 				},
 				{
 					"type": "span",
+					"key": ".2",
 					"props": {
-						"className": "stat-deleted",
+						"styleName": "stat-deleted",
 						"children": [
 							"■"
 						]
@@ -33,8 +36,9 @@
 				},
 				{
 					"type": "span",
+					"key": ".3",
 					"props": {
-						"className": "stat-filler",
+						"styleName": "stat-filler",
 						"children": [
 							"■■"
 						]

--- a/app/web_modules/sourcegraph/delta/testdata/FileDiff-added.json
+++ b/app/web_modules/sourcegraph/delta/testdata/FileDiff-added.json
@@ -2,40 +2,64 @@
 	"renderOutput": {
 		"type": "div",
 		"props": {
-			"className": "file-diff",
+			"styleName": "container",
 			"id": "myid",
 			"children": [
 				{
 					"type": "header",
+					"key": ".0",
 					"props": {
+						"styleName": "header",
 						"children": [
 							{
-								"type": "DiffStatScale",
+								"type": "div",
+								"key": ".0",
 								"props": {
-									"Stat": {
-										"Added": 5,
-										"Changed": 6,
-										"Deleted": 7
-									}
-								}
-							},
-							{
-								"type": "span",
-								"props": {
+									"styleName": "info",
 									"children": [
-										"b"
+										{
+											"type": "WrappedComponent",
+											"key": ".0",
+											"props": {
+												"Stat": {
+													"Added": 5,
+													"Changed": 6,
+													"Deleted": 7
+												}
+											}
+										},
+										{
+											"type": "span",
+											"key": ".1",
+											"props": {
+												"styleName": "name",
+												"children": [
+													{
+														"type": "span",
+														"key": ".0",
+														"props": {
+															"children": [
+																"b"
+															]
+														}
+													}
+												]
+											}
+										}
 									]
 								}
 							},
 							{
 								"type": "div",
+								"key": ".1",
 								"props": {
-									"className": "btn-group pull-right",
+									"styleName": "actions",
 									"children": [
 										{
 											"type": "a",
+											"key": ".1",
 											"props": {
-												"className": "button btn btn-default btn-xs",
+												"styleName": "action",
 												"href": "/hr@hv/-/blob/b",
 												"children": [
 													"New"
@@ -49,8 +73,8 @@
 					}
 				},
 				{
-					"type": "Hunk",
-					"key": "0",
+					"type": "WrappedComponent",
+					"key": ".1:$0",
 					"props": {
 						"hunk": {
 							"Body": "a\nb"
@@ -72,8 +96,7 @@
 			"$constructor": "WantAnnotations",
 			"repo": "hr",
 			"commitID": "hv",
-			"path": "",
-			"startByte": "b"
+			"path": "b"
 		}
 	]
 }

--- a/app/web_modules/sourcegraph/delta/testdata/FileDiff-changed.json
+++ b/app/web_modules/sourcegraph/delta/testdata/FileDiff-changed.json
@@ -2,55 +2,73 @@
 	"renderOutput": {
 		"type": "div",
 		"props": {
-			"className": "file-diff",
+			"styleName": "container",
 			"id": "myid",
 			"children": [
 				{
 					"type": "header",
+					"key": ".0",
 					"props": {
+						"styleName": "header",
 						"children": [
 							{
-								"type": "DiffStatScale",
+								"type": "div",
+								"key": ".0",
 								"props": {
-									"Stat": {
-										"Added": 5,
-										"Changed": 6,
-										"Deleted": 7
-									}
-								}
-							},
-							{
-								"type": "span",
-								"props": {
+									"styleName": "info",
 									"children": [
-										"a"
-									]
-								}
-							},
-							{
-								"type": "span",
-								"props": {
-									"children": [
-										" ",
 										{
-											"type": "i",
+											"type": "WrappedComponent",
+											"key": ".0",
 											"props": {
-												"className": "fa fa-long-arrow-right"
+												"Stat": {
+													"Added": 5,
+													"Changed": 6,
+													"Deleted": 7
+												}
 											}
 										},
-										" b"
+										{
+											"type": "span",
+											"key": ".1",
+											"props": {
+												"styleName": "name",
+												"children": [
+													{
+														"type": "span",
+														"key": ".0",
+														"props": {
+															"children": [
+																"a"
+															]
+														}
+													},
+													{
+														"type": "span",
+														"key": ".1",
+														"props": {
+															"children": [
+																" → b"
+															]
+														}
+													}
+												]
+											}
+										}
 									]
 								}
 							},
 							{
 								"type": "div",
+								"key": ".1",
 								"props": {
-									"className": "btn-group pull-right",
+									"styleName": "actions",
 									"children": [
 										{
 											"type": "a",
+											"key": ".0",
 											"props": {
-												"className": "button btn btn-default btn-xs",
+												"styleName": "action",
 												"href": "/br@bv/-/blob/a",
 												"children": [
 													"Original"
@@ -59,8 +77,9 @@
 										},
 										{
 											"type": "a",
+											"key": ".1",
 											"props": {
-												"className": "button btn btn-default btn-xs",
+												"styleName": "action",
 												"href": "/hr@hv/-/blob/b",
 												"children": [
 													"New"
@@ -74,8 +93,8 @@
 					}
 				},
 				{
-					"type": "Hunk",
-					"key": "0",
+					"type": "WrappedComponent",
+					"key": ".1:$0",
 					"props": {
 						"hunk": {
 							"Body": "a\nb"
@@ -90,8 +109,8 @@
 					}
 				},
 				{
-					"type": "Hunk",
-					"key": "1",
+					"type": "WrappedComponent",
+					"key": ".1:$1",
 					"props": {
 						"hunk": {
 							"Body": "a\nb"
@@ -113,15 +132,13 @@
 			"$constructor": "WantAnnotations",
 			"repo": "br",
 			"commitID": "bv",
-			"path": "",
-			"startByte": "a"
+			"path": "a"
 		},
 		{
 			"$constructor": "WantAnnotations",
 			"repo": "hr",
 			"commitID": "hv",
-			"path": "",
-			"startByte": "b"
+			"path": "b"
 		}
 	]
 }

--- a/app/web_modules/sourcegraph/delta/testdata/FileDiff-deleted.json
+++ b/app/web_modules/sourcegraph/delta/testdata/FileDiff-deleted.json
@@ -2,40 +2,64 @@
 	"renderOutput": {
 		"type": "div",
 		"props": {
-			"className": "file-diff",
+			"styleName": "container",
 			"id": "myid",
 			"children": [
 				{
 					"type": "header",
+					"key": ".0",
 					"props": {
+						"styleName": "header",
 						"children": [
 							{
-								"type": "DiffStatScale",
+								"type": "div",
+								"key": ".0",
 								"props": {
-									"Stat": {
-										"Added": 5,
-										"Changed": 6,
-										"Deleted": 7
-									}
-								}
-							},
-							{
-								"type": "span",
-								"props": {
+									"styleName": "info",
 									"children": [
-										"a"
+										{
+											"type": "WrappedComponent",
+											"key": ".0",
+											"props": {
+												"Stat": {
+													"Added": 5,
+													"Changed": 6,
+													"Deleted": 7
+												}
+											}
+										},
+										{
+											"type": "span",
+											"key": ".1",
+											"props": {
+												"styleName": "name",
+												"children": [
+													{
+														"type": "span",
+														"key": ".0",
+														"props": {
+															"children": [
+																"a"
+															]
+														}
+													}
+												]
+											}
+										}
 									]
 								}
 							},
 							{
 								"type": "div",
+								"key": ".1",
 								"props": {
-									"className": "btn-group pull-right",
+									"styleName": "actions",
 									"children": [
 										{
 											"type": "a",
+											"key": ".0",
 											"props": {
-												"className": "button btn btn-default btn-xs",
+												"styleName": "action",
 												"href": "/br@bv/-/blob/a",
 												"children": [
 													"Original"
@@ -49,8 +73,8 @@
 					}
 				},
 				{
-					"type": "Hunk",
-					"key": "0",
+					"type": "WrappedComponent",
+					"key": ".1:$0",
 					"props": {
 						"hunk": {
 							"Body": "a\nb"
@@ -72,8 +96,7 @@
 			"$constructor": "WantAnnotations",
 			"repo": "br",
 			"commitID": "bv",
-			"path": "",
-			"startByte": "a"
+			"path": "a"
 		}
 	]
 }

--- a/app/web_modules/sourcegraph/delta/testdata/FileDiff-renamed.json
+++ b/app/web_modules/sourcegraph/delta/testdata/FileDiff-renamed.json
@@ -2,55 +2,73 @@
 	"renderOutput": {
 		"type": "div",
 		"props": {
-			"className": "file-diff",
+			"styleName": "container",
 			"id": "myid",
 			"children": [
 				{
 					"type": "header",
+					"key": ".0",
 					"props": {
+						"styleName": "header",
 						"children": [
 							{
-								"type": "DiffStatScale",
+								"type": "div",
+								"key": ".0",
 								"props": {
-									"Stat": {
-										"Added": 5,
-										"Changed": 6,
-										"Deleted": 7
-									}
-								}
-							},
-							{
-								"type": "span",
-								"props": {
+									"styleName": "info",
 									"children": [
-										"a"
-									]
-								}
-							},
-							{
-								"type": "span",
-								"props": {
-									"children": [
-										" ",
 										{
-											"type": "i",
+											"type": "WrappedComponent",
+											"key": ".0",
 											"props": {
-												"className": "fa fa-long-arrow-right"
+												"Stat": {
+													"Added": 5,
+													"Changed": 6,
+													"Deleted": 7
+												}
 											}
 										},
-										" b"
+										{
+											"type": "span",
+											"key": ".1",
+											"props": {
+												"styleName": "name",
+												"children": [
+													{
+														"type": "span",
+														"key": ".0",
+														"props": {
+															"children": [
+																"a"
+															]
+														}
+													},
+													{
+														"type": "span",
+														"key": ".1",
+														"props": {
+															"children": [
+																" → b"
+															]
+														}
+													}
+												]
+											}
+										}
 									]
 								}
 							},
 							{
 								"type": "div",
+								"key": ".1",
 								"props": {
-									"className": "btn-group pull-right",
+									"styleName": "actions",
 									"children": [
 										{
 											"type": "a",
+											"key": ".0",
 											"props": {
-												"className": "button btn btn-default btn-xs",
+												"styleName": "action",
 												"href": "/br@bv/-/blob/a",
 												"children": [
 													"Original"
@@ -59,8 +77,9 @@
 										},
 										{
 											"type": "a",
+											"key": ".1",
 											"props": {
-												"className": "button btn btn-default btn-xs",
+												"styleName": "action",
 												"href": "/hr@hv/-/blob/b",
 												"children": [
 													"New"
@@ -74,8 +93,8 @@
 					}
 				},
 				{
-					"type": "Hunk",
-					"key": "0",
+					"type": "WrappedComponent",
+					"key": ".1:$0",
 					"props": {
 						"hunk": {
 							"Body": "a\nb"
@@ -97,15 +116,13 @@
 			"$constructor": "WantAnnotations",
 			"repo": "br",
 			"commitID": "bv",
-			"path": "",
-			"startByte": "a"
+			"path": "a"
 		},
 		{
 			"$constructor": "WantAnnotations",
 			"repo": "hr",
 			"commitID": "hv",
-			"path": "",
-			"startByte": "b"
+			"path": "b"
 		}
 	]
 }

--- a/app/web_modules/sourcegraph/delta/testdata/FileDiffs-initial.json
+++ b/app/web_modules/sourcegraph/delta/testdata/FileDiffs-initial.json
@@ -2,9 +2,11 @@
 	"renderOutput": {
 		"type": "div",
 		"props": {
+			"styleName": "container",
 			"children": [
 				{
-					"type": "DiffFileList",
+					"type": "WrappedComponent",
+					"key": ".0",
 					"props": {
 						"files": [
 							{
@@ -20,47 +22,63 @@
 					}
 				},
 				{
-					"type": "FileDiff",
-					"key": "ab",
+					"type": "div",
+					"key": ".1:$ab",
 					"props": {
-						"id": "F0",
-						"diff": {
-							"OrigName": "a",
-							"NewName": "b"
-						},
-						"baseRepo": "br",
-						"baseRev": "bv",
-						"headRepo": "hr",
-						"headRev": "hv",
-						"annotations": {
-							"content": {}
-						},
-						"defs": {
-							"content": {},
-							"pos": {}
-						}
+						"styleName": "file-diff",
+						"children": [
+							{
+								"type": "WrappedComponent",
+								"props": {
+									"id": "F0",
+									"diff": {
+										"OrigName": "a",
+										"NewName": "b"
+									},
+									"baseRepo": "br",
+									"baseRev": "bv",
+									"headRepo": "hr",
+									"headRev": "hv",
+									"annotations": {
+										"content": {}
+									},
+									"defs": {
+										"content": {},
+										"pos": {}
+									}
+								}
+							}
+						]
 					}
 				},
 				{
-					"type": "FileDiff",
-					"key": "cd",
+					"type": "div",
+					"key": ".1:$cd",
 					"props": {
-						"id": "F1",
-						"diff": {
-							"OrigName": "c",
-							"NewName": "d"
-						},
-						"baseRepo": "br",
-						"baseRev": "bv",
-						"headRepo": "hr",
-						"headRev": "hv",
-						"annotations": {
-							"content": {}
-						},
-						"defs": {
-							"content": {},
-							"pos": {}
-						}
+						"styleName": "file-diff",
+						"children": [
+							{
+								"type": "WrappedComponent",
+								"props": {
+									"id": "F1",
+									"diff": {
+										"OrigName": "c",
+										"NewName": "d"
+									},
+									"baseRepo": "br",
+									"baseRev": "bv",
+									"headRepo": "hr",
+									"headRev": "hv",
+									"annotations": {
+										"content": {}
+									},
+									"defs": {
+										"content": {},
+										"pos": {}
+									}
+								}
+							}
+						]
 					}
 				}
 			]

--- a/app/web_modules/sourcegraph/delta/testdata/Hunk-initial.json
+++ b/app/web_modules/sourcegraph/delta/testdata/Hunk-initial.json
@@ -2,7 +2,7 @@
 	"renderOutput": {
 		"type": "table",
 		"props": {
-			"className": "line-numbered-code theme-default file-diff-hunk",
+			"styleName": "lines",
 			"children": [
 				{
 					"type": "tbody",
@@ -10,31 +10,51 @@
 						"children": [
 							{
 								"type": "tr",
+								"key": ".0",
 								"props": {
-									"className": "line hunk-header",
+									"styleName": "line",
 									"children": [
 										{
 											"type": "td",
+											"key": ".0",
 											"props": {
-												"className": "line-number",
+												"styleName": "line-number-cell",
 												"children": [
-													"..."
+													{
+														"type": "span",
+														"props": {
+															"styleName": "line-number",
+															"children": [
+																"..."
+															]
+														}
+													}
 												]
 											}
 										},
 										{
 											"type": "td",
+											"key": ".1",
 											"props": {
-												"className": "line-number",
+												"styleName": "line-number-cell",
 												"children": [
-													"..."
+													{
+														"type": "span",
+														"props": {
+															"styleName": "line-number",
+															"children": [
+																"..."
+															]
+														}
+													}
 												]
 											}
 										},
 										{
 											"type": "td",
+											"key": ".2",
 											"props": {
-												"className": "line-content",
+												"styleName": "line-content",
 												"children": [
 													"@@ -5,20 +5,20 @@ mysection"
 												]
@@ -45,9 +65,8 @@
 							},
 							{
 								"type": "BlobLine",
-								"key": "0",
+								"key": ".1:$0",
 								"props": {
-									"className": "new-line",
 									"newLineNumber": 5,
 									"contents": "+ a",
 									"startByte": 0
@@ -55,9 +74,8 @@
 							},
 							{
 								"type": "BlobLine",
-								"key": "1",
+								"key": ".1:$1",
 								"props": {
-									"className": "old-line",
 									"oldLineNumber": 6,
 									"contents": "- b",
 									"startByte": 4
@@ -65,9 +83,8 @@
 							},
 							{
 								"type": "BlobLine",
-								"key": "2",
+								"key": ".1:$2",
 								"props": {
-									"className": "",
 									"oldLineNumber": 7,
 									"newLineNumber": 6,
 									"contents": " c",
@@ -76,9 +93,8 @@
 							},
 							{
 								"type": "BlobLine",
-								"key": "3",
+								"key": ".1:$3",
 								"props": {
-									"className": "old-line",
 									"oldLineNumber": 8,
 									"contents": "- d",
 									"startByte": 11
@@ -86,9 +102,8 @@
 							},
 							{
 								"type": "BlobLine",
-								"key": "4",
+								"key": ".1:$4",
 								"props": {
-									"className": "old-line",
 									"oldLineNumber": 9,
 									"contents": "- e",
 									"startByte": 15

--- a/app/web_modules/sourcegraph/repo/RepoActions.js
+++ b/app/web_modules/sourcegraph/repo/RepoActions.js
@@ -27,6 +27,21 @@ export class ResolvedRev {
 	}
 }
 
+export class WantCommit {
+	constructor(repo, rev) {
+		this.repo = repo;
+		this.rev = rev;
+	}
+}
+
+export class FetchedCommit {
+	constructor(repo, rev, commit) {
+		this.repo = repo;
+		this.rev = rev;
+		this.commit = commit;
+	}
+}
+
 export class WantInventory {
 	constructor(repo, commitID) {
 		this.repo = repo;

--- a/app/web_modules/sourcegraph/repo/RepoBackend.js
+++ b/app/web_modules/sourcegraph/repo/RepoBackend.js
@@ -14,6 +14,20 @@ const RepoBackend = {
 	fetch: singleflightFetch(defaultFetch),
 
 	__onDispatch(action) {
+		if (action instanceof RepoActions.WantCommit) {
+			let commit = RepoStore.commits.get(action.repo, action.rev);
+			if (commit === null) {
+				RepoBackend.fetch(`/.api/repos/${action.repo}${action.rev ? `@${action.rev}` : ""}/-/commit`)
+					.then(checkStatus)
+					.then((resp) => resp.json())
+					.catch((err) => ({Error: err}))
+					.then((data) => {
+						Dispatcher.Stores.dispatch(new RepoActions.FetchedCommit(action.repo, action.rev, data));
+					});
+			}
+			return;
+		}
+
 		switch (action.constructor) {
 
 		case RepoActions.WantRepo:

--- a/app/web_modules/sourcegraph/repo/RepoBackend_test.js
+++ b/app/web_modules/sourcegraph/repo/RepoBackend_test.js
@@ -1,0 +1,18 @@
+import expect from "expect.js";
+
+import Dispatcher from "sourcegraph/Dispatcher";
+import RepoBackend from "sourcegraph/repo/RepoBackend";
+import * as RepoActions from "sourcegraph/repo/RepoActions";
+import immediateSyncPromise from "sourcegraph/util/immediateSyncPromise";
+
+describe("RepoBackend", () => {
+	it("should handle WantCommit", () => {
+		RepoBackend.fetch = function(url, options) {
+			expect(url).to.be("/.api/repos/r@v/-/commit");
+			return immediateSyncPromise({status: 200, json: () => ({ID: "c"})});
+		};
+		expect(Dispatcher.Stores.catchDispatched(() => {
+			RepoBackend.__onDispatch(new RepoActions.WantCommit("r", "v"));
+		})).to.eql([new RepoActions.FetchedCommit("r", "v", {ID: "c"})]);
+	});
+});

--- a/app/web_modules/sourcegraph/repo/RepoStore.js
+++ b/app/web_modules/sourcegraph/repo/RepoStore.js
@@ -7,7 +7,7 @@ import * as RepoActions from "sourcegraph/repo/RepoActions";
 import "sourcegraph/repo/RepoBackend";
 
 function keyFor(repo, rev) {
-	return `${repo}@${rev}`;
+	return `${repo}@${rev || ""}`;
 }
 
 export class RepoStore extends Store {
@@ -32,6 +32,12 @@ export class RepoStore extends Store {
 			content: data && data.resolutions ? data.resolutions.content : {},
 			get(repo) {
 				return this.content[keyFor(repo)] || null;
+			},
+		});
+		this.commits = deepFreeze({
+			content: data && data.commits ? data.commits.content : {},
+			get(repo: string, rev: string) {
+				return this.content[keyFor(repo, rev)] || null;
 			},
 		});
 		this.inventory = deepFreeze({
@@ -78,7 +84,16 @@ export class RepoStore extends Store {
 			});
 			this.__emitChange();
 			return;
+		} else if (action instanceof RepoActions.FetchedCommit) {
+			this.commits = deepFreeze({...this.commits,
+				content: {...this.commits.content,
+					[keyFor(action.repo, action.rev)]: action.commit,
+				},
+			});
+			this.__emitChange();
+			return;
 		}
+
 
 		switch (action.constructor) {
 

--- a/app/web_modules/sourcegraph/repo/RepoStore_test.js
+++ b/app/web_modules/sourcegraph/repo/RepoStore_test.js
@@ -1,0 +1,11 @@
+import expect from "expect.js";
+
+import RepoStore from "sourcegraph/repo/RepoStore";
+import * as RepoActions from "sourcegraph/repo/RepoActions";
+
+describe("RepoStore", () => {
+	it("should handle FetchedCommit", () => {
+		RepoStore.directDispatch(new RepoActions.FetchedCommit("r", "v", {ID: "c"}));
+		expect(RepoStore.commits.get("r", "v")).to.eql({ID: "c"});
+	});
+});

--- a/app/web_modules/sourcegraph/repo/commit/CommitMain.css
+++ b/app/web_modules/sourcegraph/repo/commit/CommitMain.css
@@ -1,0 +1,10 @@
+@value vars "sourcegraph/components/styles/_vars.css";
+@value base "sourcegraph/components/styles/_base.css";
+@value colors "sourcegraph/components/styles/_colors.css";
+@value layout "sourcegraph/components/styles/_layout.css";
+@value typography "sourcegraph/components/styles/_typography.css";
+@value GlobalNav "sourcegraph/app/styles/GlobalNav.css";
+
+.container {
+	composes: containerFixed from layout;
+}

--- a/app/web_modules/sourcegraph/repo/commit/CommitMain.js
+++ b/app/web_modules/sourcegraph/repo/commit/CommitMain.js
@@ -5,33 +5,47 @@ import Helmet from "react-helmet";
 import Container from "sourcegraph/Container";
 import CSSModules from "react-css-modules";
 import styles from "./CommitMain.css";
-import * as BuildActions from "sourcegraph/build/BuildActions";
-import BuildStore from "sourcegraph/build/BuildStore";
-import "sourcegraph/build/BuildBackend";
+import DeltaStore from "sourcegraph/delta/DeltaStore";
+import * as DeltaActions from "sourcegraph/delta/DeltaActions";
+import "sourcegraph/delta/DeltaBackend";
+import BlobStore from "sourcegraph/blob/BlobStore";
+import "sourcegraph/blob/BlobBackend";
 import RepoStore from "sourcegraph/repo/RepoStore";
 import * as RepoActions from "sourcegraph/repo/RepoActions";
 import "sourcegraph/repo/RepoBackend";
 import Commit from "sourcegraph/vcs/Commit";
 import Dispatcher from "sourcegraph/Dispatcher";
+import FileDiffs from "sourcegraph/delta/FileDiffs";
 
 class CommitMain extends Container {
 	static propTypes = {
 		repo: React.PropTypes.string,
+		repoID: React.PropTypes.number,
 		rev: React.PropTypes.string,
 		commitID: React.PropTypes.string,
 	};
 
-	stores() { return [BuildStore, RepoStore]; }
+	stores() { return [DeltaStore, RepoStore, BlobStore]; }
 
 	reconcileState(state, props) {
 		Object.assign(state, props);
 
 		state.commit = RepoStore.commits.get(state.repo, state.rev);
+		state.parentCommitID = state.commit && !state.commit.Error && state.commit.Parents ? state.commit.Parents[0] : null;
+
+		state.files = state.repo && state.commitID && state.parentCommitID ? DeltaStore.files.get(state.repo, state.parentCommitID, state.repo, state.commitID) : null;
+
+		state.annotations = BlobStore.annotations;
 	}
 
 	onStateTransition(prevState, nextState) {
-		if (prevState.commitID !== nextState.commitID || prevState.repo !== nextState.repo || prevState.rev !== nextState.rev) {
+		if (prevState.repo !== nextState.repo || prevState.rev !== nextState.rev) {
 			Dispatcher.Backends.dispatch(new RepoActions.WantCommit(nextState.repo, nextState.rev));
+		}
+		if (prevState.repoID !== nextState.repoID || prevState.repo !== nextState.repo || prevState.commitID !== nextState.commitID || prevState.parentCommitID !== nextState.parentCommitID) {
+			if (nextState.repo && nextState.commitID && nextState.parentCommitID) {
+				Dispatcher.Backends.dispatch(new DeltaActions.WantFiles(nextState.repo, nextState.parentCommitID, nextState.repo, nextState.commitID));
+			}
 		}
 	}
 
@@ -40,7 +54,14 @@ class CommitMain extends Container {
 		return (
 			<div styleName="container">
 				<Helmet title={`@${this.state.commitID.slice(0, 6)}`} />
-				{this.state.commit && !this.state.commit.Error && <Commit repo={this.state.repo} commit={this.state.commit} />}
+				{this.state.commit && !this.state.commit.Error && <Commit repo={this.state.repo} commit={this.state.commit} full={true} />}
+				{this.state.files && !this.state.files.Error &&
+				<FileDiffs files={this.state.files.FileDiffs}
+					stats={this.state.files.Stats}
+					baseRepo={this.state.repo}
+					baseRev={this.state.parentCommitID}
+					headRepo={this.state.repo}
+					headRev={this.state.commitID} />}
 			</div>
 		);
 	}

--- a/app/web_modules/sourcegraph/repo/commit/CommitMain.js
+++ b/app/web_modules/sourcegraph/repo/commit/CommitMain.js
@@ -1,0 +1,49 @@
+// @flow weak
+
+import React from "react";
+import Helmet from "react-helmet";
+import Container from "sourcegraph/Container";
+import CSSModules from "react-css-modules";
+import styles from "./CommitMain.css";
+import * as BuildActions from "sourcegraph/build/BuildActions";
+import BuildStore from "sourcegraph/build/BuildStore";
+import "sourcegraph/build/BuildBackend";
+import RepoStore from "sourcegraph/repo/RepoStore";
+import * as RepoActions from "sourcegraph/repo/RepoActions";
+import "sourcegraph/repo/RepoBackend";
+import Commit from "sourcegraph/vcs/Commit";
+import Dispatcher from "sourcegraph/Dispatcher";
+
+class CommitMain extends Container {
+	static propTypes = {
+		repo: React.PropTypes.string,
+		rev: React.PropTypes.string,
+		commitID: React.PropTypes.string,
+	};
+
+	stores() { return [BuildStore, RepoStore]; }
+
+	reconcileState(state, props) {
+		Object.assign(state, props);
+
+		state.commit = RepoStore.commits.get(state.repo, state.rev);
+	}
+
+	onStateTransition(prevState, nextState) {
+		if (prevState.commitID !== nextState.commitID || prevState.repo !== nextState.repo || prevState.rev !== nextState.rev) {
+			Dispatcher.Backends.dispatch(new RepoActions.WantCommit(nextState.repo, nextState.rev));
+		}
+	}
+
+	render() {
+		if (!this.state.commitID) return null;
+		return (
+			<div styleName="container">
+				<Helmet title={`@${this.state.commitID.slice(0, 6)}`} />
+				{this.state.commit && !this.state.commit.Error && <Commit repo={this.state.repo} commit={this.state.commit} />}
+			</div>
+		);
+	}
+}
+
+export default CSSModules(CommitMain, styles);

--- a/app/web_modules/sourcegraph/repo/commit/routes.js
+++ b/app/web_modules/sourcegraph/repo/commit/routes.js
@@ -1,0 +1,27 @@
+// @flow
+
+import {rel} from "sourcegraph/app/routePatterns";
+import urlTo from "sourcegraph/util/urlTo";
+import {makeRepoRev} from "sourcegraph/repo";
+import type {Route} from "react-router";
+
+let _commitMain;
+
+export const routes: Route = [
+	{
+		path: rel.commit,
+		getComponents: (location, callback) => {
+			require.ensure([], (require) => {
+				if (!_commitMain) {
+					const withResolvedRepoRev = require("sourcegraph/repo/withResolvedRepoRev").default;
+					_commitMain = withResolvedRepoRev(require("sourcegraph/repo/commit/CommitMain").default, true);
+				}
+				callback(null, {main: _commitMain});
+			});
+		},
+	},
+];
+
+export function urlToRepoCommit(repo: string, rev: string): string {
+	return urlTo("commit", {splat: makeRepoRev(repo, rev)});
+}

--- a/app/web_modules/sourcegraph/repo/index.js
+++ b/app/web_modules/sourcegraph/repo/index.js
@@ -1,5 +1,15 @@
 // @flow
 
+export type RepoRev = {
+	Repo: string;
+	Rev: ?string;
+};
+
+export type RepoRevSpec = {
+	Repo: number;
+	CommitID: ?string;
+};
+
 // repoPath returns the path portion of a repo route var match.
 export function repoPath(repoRevRouteVar: string): string {
 	const at = repoRevRouteVar.indexOf("@");

--- a/app/web_modules/sourcegraph/repo/routes.js
+++ b/app/web_modules/sourcegraph/repo/routes.js
@@ -34,6 +34,7 @@ export const routes: Array<Route> = [
 		getChildRoutes: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, [
+					...require("sourcegraph/repo/commit/routes").routes,
 					...require("sourcegraph/blob/routes").routes,
 					...require("sourcegraph/build/routes").routes,
 					...require("sourcegraph/def/routes").routes,

--- a/app/web_modules/sourcegraph/vcs/Commit.js
+++ b/app/web_modules/sourcegraph/vcs/Commit.js
@@ -1,47 +1,77 @@
 import React from "react";
-
-import Component from "sourcegraph/Component";
 import TimeAgo from "sourcegraph/util/TimeAgo";
-
 import {Avatar} from "sourcegraph/components";
-
+import {urlToRepoCommit} from "sourcegraph/repo/commit/routes";
 import CSSModules from "react-css-modules";
 import styles from "./styles/Commit.css";
 
-class Commit extends Component {
-	reconcileState(state, props) {
-		if (state.commit !== props.commit) {
-			state.commit = props.commit;
-		}
-		if (state.repo !== props.repo) {
-			state.repo = props.repo;
-		}
+function showBothSigs(a, b) {
+	return a && b && (a.Name !== b.Name || a.Email !== b.Email);
+}
+
+function username(email) {
+	if (!email) return "(unknown)";
+	const i = email.indexOf("@");
+	if (i === -1) return email;
+	return `${email.slice(0, i)}@…`;
+}
+
+function sigName(sig) {
+	if (!sig) return null;
+	if (sig.Name) {
+		return (
+			<span styleName="sig-name">
+				{sig.Name ? <span styleName="name">{sig.Name}&nbsp;</span> : null}
+				<span styleName="name-secondary">({username(sig.Email)})</span>
+			</span>
+		);
+	}
+	return (
+		<span styleName="sig-name">
+			<span styleName="name">{username(sig.Email)}</span>
+		</span>
+	);
+}
+
+function Commit({repo, commit, full}) {
+	const parts = commit.Message ? commit.Message.split("\n") : null;
+	let title = parts ? parts[0] : "(no commit message)";
+	let rest = parts ? parts.slice(1).join("\n") : null;
+	rest = rest.trim();
+
+	const maxTitleSize = 120;
+	if (title.length > maxTitleSize) {
+		rest = `…${title.slice(maxTitleSize)}\n${rest}`;
+		title = `${title.slice(0, maxTitleSize)}…`;
 	}
 
-	render() {
-		return (
-			<div styleName="container">
-				<div styleName="avatar">
-					<Avatar img={this.state.commit.AuthorPerson ? this.state.commit.AuthorPerson.AvatarURL : ""} size="large" />
-				</div>
-				<div styleName="body">
-					<div styleName="title">
-						<code styleName="sha">{this.state.commit.ID.substring(0, 6)}</code>
-						{this.state.commit.Message.slice(0, 70)}
+	return (
+		<div styleName="container">
+			<div styleName="main">
+				<a styleName="title" href={urlToRepoCommit(repo, commit.ID)}>{title}</a>
+				<div styleName="meta">
+					<Avatar className={styles.avatar} img={commit.AuthorPerson ? commit.AuthorPerson.AvatarURL : ""} size="small" />
+					<div styleName="signature">
+						<span styleName="sig">{sigName(commit.Author)} authored <TimeAgo time={commit.Author.Date} /></span><wbr/>
+						{commit.Committer && showBothSigs(commit.Author, commit.Committer) ? <span styleName="sig">{sigName(commit.Committer)} committed <TimeAgo time={commit.Committer.Date} /></span> : null}
 					</div>
-					<div styleName="text">
-						<span>authored <TimeAgo time={this.state.commit.Author.Date} /></span>
-						{this.state.commit.Committer ? <span>, committed <TimeAgo time={this.state.commit.Committer.Date} /></span> : null}
+					<div styleName="commit-id">
+						<a href={urlToRepoCommit(repo, commit.ID)}>
+							<code styleName="sha">{commit.ID.substring(0, 8)}</code>
+						</a>
 					</div>
 				</div>
 			</div>
-		);
-	}
+			{full && rest && <div styleName="rest">{rest}</div>}
+		</div>
+	);
 }
-
 Commit.propTypes = {
 	commit: React.PropTypes.object.isRequired,
 	repo: React.PropTypes.string.isRequired,
+
+	// full is whether to show the full commit message (beyond the first line).
+	full: React.PropTypes.bool.isRequired,
 };
 
 export default CSSModules(Commit, styles);

--- a/app/web_modules/sourcegraph/vcs/Commit_test.js
+++ b/app/web_modules/sourcegraph/vcs/Commit_test.js
@@ -20,19 +20,19 @@ const sampleRepo = "sourcegraph.com/sourcegraph";
 describe("Commit", () => {
 	it("should initially render empty", () => {
 		autotest(testdataInitial, `${__dirname}/testdata/Commit-initial.json`,
-			<Commit commit={sampleCommit} repo={sampleRepo} />
+			<Commit commit={sampleCommit} repo={sampleRepo} full={false} />
 		);
 	});
 
 	it("should render commit", () => {
 		autotest(testdataAvailable, `${__dirname}/testdata/Commit-available.json`,
-			<Commit	commit={sampleCommit} repo={sampleRepo} />
+			<Commit commit={sampleCommit} repo={sampleRepo} full={false} />
 		);
 	});
 
 	it("should render commit without author information", () => {
 		autotest(testdataNoAuthorPerson, `${__dirname}/testdata/Commit-noAuthorPerson.json`,
-			<Commit	commit={{ID: "abc", Message: "msg", Author: {Date: ""}, AuthorPerson: null}} repo={sampleRepo} />
+			<Commit commit={{ID: "abc", Message: "msg", Author: {Date: ""}, AuthorPerson: null}} repo={sampleRepo} full={false} />
 		);
 	});
 });

--- a/app/web_modules/sourcegraph/vcs/styles/Commit.css
+++ b/app/web_modules/sourcegraph/vcs/styles/Commit.css
@@ -1,27 +1,58 @@
 @value base "sourcegraph/components/styles/_base.css";
 @value typography "sourcegraph/components/styles/_typography.css";
+@value colors "sourcegraph/components/styles/_colors.css";
 
 .container {
+}
+
+.main {
+}
+
+.title {
+	display: block;
+	font-weight: bold;
+	composes: pv2 from base;
+	composes: f4 from typography;
+	composes: cool-gray from colors;
+}
+
+.meta {
 	display: flex;
 	align-items: center;
 }
 
+.signature {
+	flex: 1 1;
+}
 .avatar {
-	composes: ma3 from base;
+	vertical-align: bottom;
+	composes: pr2 from base;
 }
-
-.body {
-	flex: 1 1 auto;
+.sig {
+	white-space: nowrap;
+	composes: pr3 from base;
 }
+.sig-name {}
+.name {
+	font-weight: bold;
+}
+.name-secondary {}
+.username {}
 
-.title {
-	composes: f3 b from typography;
+.commit-id {
+	flex: 0;
+	text-align: right;
+	composes: pl4 from base;
 }
 
 .sha {
-	composes: pr3 from base;
+	composes: code from typography;
+	composes: cool-gray from colors;
 }
 
-.text {
-	composes: normal-text from typography;
+.rest {
+	white-space: pre-wrap;
+	composes: pt3 pb2 from base;
+	composes: code from typography;
+	composes: cool-gray from colors;
 }

--- a/app/web_modules/sourcegraph/vcs/testdata/Commit-available.json
+++ b/app/web_modules/sourcegraph/vcs/testdata/Commit-available.json
@@ -8,40 +8,15 @@
 					"type": "div",
 					"key": ".0",
 					"props": {
-						"styleName": "avatar",
+						"styleName": "main",
 						"children": [
 							{
-								"type": "WrappedComponent",
-								"props": {
-									"img": "http://example.com/avatar.png",
-									"size": "large"
-								}
-							}
-						]
-					}
-				},
-				{
-					"type": "div",
-					"key": ".1",
-					"props": {
-						"styleName": "body",
-						"children": [
-							{
-								"type": "div",
+								"type": "a",
 								"key": ".0",
 								"props": {
 									"styleName": "title",
+									"href": "/sourcegraph.com/sourcegraph@abc/-/commit",
 									"children": [
-										{
-											"type": "code",
-											"key": ".0",
-											"props": {
-												"styleName": "sha",
-												"children": [
-													"abc"
-												]
-											}
-										},
 										"msg"
 									]
 								}
@@ -50,19 +25,86 @@
 								"type": "div",
 								"key": ".1",
 								"props": {
-									"styleName": "text",
+									"styleName": "meta",
 									"children": [
 										{
-											"type": "span",
+											"type": "WrappedComponent",
 											"key": ".0",
 											"props": {
+												"img": "http://example.com/avatar.png",
+												"size": "small"
+											}
+										},
+										{
+											"type": "div",
+											"key": ".1",
+											"props": {
+												"styleName": "signature",
 												"children": [
-													"authored ",
 													{
-														"type": "TimeAgo",
-														"key": ".1",
+														"type": "span",
+														"key": ".0",
 														"props": {
-															"time": ""
+															"styleName": "sig",
+															"children": [
+																{
+																	"type": "span",
+																	"key": ".0",
+																	"props": {
+																		"styleName": "sig-name",
+																		"children": [
+																			{
+																				"type": "span",
+																				"props": {
+																					"styleName": "name",
+																					"children": [
+																						"(unknown)"
+																					]
+																				}
+																			}
+																		]
+																	}
+																},
+																" authored ",
+																{
+																	"type": "TimeAgo",
+																	"key": ".2",
+																	"props": {
+																		"time": ""
+																	}
+																}
+															]
+														}
+													},
+													{
+														"type": "wbr",
+														"key": ".1",
+														"props": {}
+													}
+												]
+											}
+										},
+										{
+											"type": "div",
+											"key": ".2",
+											"props": {
+												"styleName": "commit-id",
+												"children": [
+													{
+														"type": "a",
+														"props": {
+															"href": "/sourcegraph.com/sourcegraph@abc/-/commit",
+															"children": [
+																{
+																	"type": "code",
+																	"props": {
+																		"styleName": "sha",
+																		"children": [
+																			"abc"
+																		]
+																	}
+																}
+															]
 														}
 													}
 												]

--- a/app/web_modules/sourcegraph/vcs/testdata/Commit-initial.json
+++ b/app/web_modules/sourcegraph/vcs/testdata/Commit-initial.json
@@ -8,40 +8,15 @@
 					"type": "div",
 					"key": ".0",
 					"props": {
-						"styleName": "avatar",
+						"styleName": "main",
 						"children": [
 							{
-								"type": "WrappedComponent",
-								"props": {
-									"img": "http://example.com/avatar.png",
-									"size": "large"
-								}
-							}
-						]
-					}
-				},
-				{
-					"type": "div",
-					"key": ".1",
-					"props": {
-						"styleName": "body",
-						"children": [
-							{
-								"type": "div",
+								"type": "a",
 								"key": ".0",
 								"props": {
 									"styleName": "title",
+									"href": "/sourcegraph.com/sourcegraph@abc/-/commit",
 									"children": [
-										{
-											"type": "code",
-											"key": ".0",
-											"props": {
-												"styleName": "sha",
-												"children": [
-													"abc"
-												]
-											}
-										},
 										"msg"
 									]
 								}
@@ -50,19 +25,86 @@
 								"type": "div",
 								"key": ".1",
 								"props": {
-									"styleName": "text",
+									"styleName": "meta",
 									"children": [
 										{
-											"type": "span",
+											"type": "WrappedComponent",
 											"key": ".0",
 											"props": {
+												"img": "http://example.com/avatar.png",
+												"size": "small"
+											}
+										},
+										{
+											"type": "div",
+											"key": ".1",
+											"props": {
+												"styleName": "signature",
 												"children": [
-													"authored ",
 													{
-														"type": "TimeAgo",
-														"key": ".1",
+														"type": "span",
+														"key": ".0",
 														"props": {
-															"time": ""
+															"styleName": "sig",
+															"children": [
+																{
+																	"type": "span",
+																	"key": ".0",
+																	"props": {
+																		"styleName": "sig-name",
+																		"children": [
+																			{
+																				"type": "span",
+																				"props": {
+																					"styleName": "name",
+																					"children": [
+																						"(unknown)"
+																					]
+																				}
+																			}
+																		]
+																	}
+																},
+																" authored ",
+																{
+																	"type": "TimeAgo",
+																	"key": ".2",
+																	"props": {
+																		"time": ""
+																	}
+																}
+															]
+														}
+													},
+													{
+														"type": "wbr",
+														"key": ".1",
+														"props": {}
+													}
+												]
+											}
+										},
+										{
+											"type": "div",
+											"key": ".2",
+											"props": {
+												"styleName": "commit-id",
+												"children": [
+													{
+														"type": "a",
+														"props": {
+															"href": "/sourcegraph.com/sourcegraph@abc/-/commit",
+															"children": [
+																{
+																	"type": "code",
+																	"props": {
+																		"styleName": "sha",
+																		"children": [
+																			"abc"
+																		]
+																	}
+																}
+															]
 														}
 													}
 												]

--- a/app/web_modules/sourcegraph/vcs/testdata/Commit-noAuthorPerson.json
+++ b/app/web_modules/sourcegraph/vcs/testdata/Commit-noAuthorPerson.json
@@ -8,40 +8,15 @@
 					"type": "div",
 					"key": ".0",
 					"props": {
-						"styleName": "avatar",
+						"styleName": "main",
 						"children": [
 							{
-								"type": "WrappedComponent",
-								"props": {
-									"img": "",
-									"size": "large"
-								}
-							}
-						]
-					}
-				},
-				{
-					"type": "div",
-					"key": ".1",
-					"props": {
-						"styleName": "body",
-						"children": [
-							{
-								"type": "div",
+								"type": "a",
 								"key": ".0",
 								"props": {
 									"styleName": "title",
+									"href": "/sourcegraph.com/sourcegraph@abc/-/commit",
 									"children": [
-										{
-											"type": "code",
-											"key": ".0",
-											"props": {
-												"styleName": "sha",
-												"children": [
-													"abc"
-												]
-											}
-										},
 										"msg"
 									]
 								}
@@ -50,19 +25,86 @@
 								"type": "div",
 								"key": ".1",
 								"props": {
-									"styleName": "text",
+									"styleName": "meta",
 									"children": [
 										{
-											"type": "span",
+											"type": "WrappedComponent",
 											"key": ".0",
 											"props": {
+												"img": "",
+												"size": "small"
+											}
+										},
+										{
+											"type": "div",
+											"key": ".1",
+											"props": {
+												"styleName": "signature",
 												"children": [
-													"authored ",
 													{
-														"type": "TimeAgo",
-														"key": ".1",
+														"type": "span",
+														"key": ".0",
 														"props": {
-															"time": ""
+															"styleName": "sig",
+															"children": [
+																{
+																	"type": "span",
+																	"key": ".0",
+																	"props": {
+																		"styleName": "sig-name",
+																		"children": [
+																			{
+																				"type": "span",
+																				"props": {
+																					"styleName": "name",
+																					"children": [
+																						"(unknown)"
+																					]
+																				}
+																			}
+																		]
+																	}
+																},
+																" authored ",
+																{
+																	"type": "TimeAgo",
+																	"key": ".2",
+																	"props": {
+																		"time": ""
+																	}
+																}
+															]
+														}
+													},
+													{
+														"type": "wbr",
+														"key": ".1",
+														"props": {}
+													}
+												]
+											}
+										},
+										{
+											"type": "div",
+											"key": ".2",
+											"props": {
+												"styleName": "commit-id",
+												"children": [
+													{
+														"type": "a",
+														"props": {
+															"href": "/sourcegraph.com/sourcegraph@abc/-/commit",
+															"children": [
+																{
+																	"type": "code",
+																	"props": {
+																		"styleName": "sha",
+																		"children": [
+																			"abc"
+																		]
+																	}
+																}
+															]
 														}
 													}
 												]

--- a/pkg/routevar/delta.go
+++ b/pkg/routevar/delta.go
@@ -12,8 +12,8 @@ type Delta struct {
 // DeltaRouteVars returns the route variables for generating URLs to
 // the delta specified by this Delta.
 func DeltaRouteVars(s Delta) map[string]string {
-	m := RepoRevRouteVars(s.Base)
-	m["DeltaHeadRev"] = "@" + s.Head.Rev
+	m := RepoRevRouteVars(s.Head)
+	m["DeltaBaseRev"] = "@" + s.Base.Rev
 	return m
 }
 
@@ -22,10 +22,10 @@ func DeltaRouteVars(s Delta) map[string]string {
 func ToDelta(routeVars map[string]string) Delta {
 	repoRev := ToRepoRev(routeVars)
 	return Delta{
-		Base: repoRev,
-		Head: RepoRev{
+		Base: RepoRev{
 			Repo: repoRev.Repo,
-			Rev:  strings.TrimPrefix(routeVars["DeltaHeadRev"], "@"),
+			Rev:  strings.TrimPrefix(routeVars["DeltaBaseRev"], "@"),
 		},
+		Head: repoRev,
 	}
 }

--- a/pkg/routevar/delta_test.go
+++ b/pkg/routevar/delta_test.go
@@ -20,8 +20,8 @@ func TestDeltas(t *testing.T) {
 			},
 			wantRouteVars: map[string]string{
 				"Repo":         "samerepo",
-				"Rev":          "@base-rev",
-				"DeltaHeadRev": "@head-rev",
+				"Rev":          "@head-rev",
+				"DeltaBaseRev": "@base-rev",
 			},
 		},
 	}

--- a/services/httpapi/delta.go
+++ b/services/httpapi/delta.go
@@ -1,0 +1,40 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"sourcegraph.com/sourcegraph/sourcegraph/api/sourcegraph"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/handlerutil"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/routevar"
+)
+
+func serveDeltaFiles(w http.ResponseWriter, r *http.Request) error {
+	ctx, cl := handlerutil.Client(r)
+
+	var opt sourcegraph.DeltaListFilesOptions
+	if err := schemaDecoder.Decode(&opt, r.URL.Query()); err != nil {
+		return err
+	}
+
+	delta := routevar.ToDelta(mux.Vars(r))
+	baseRepoRev, err := resolveLocalRepoRev(ctx, delta.Base)
+	if err != nil {
+		return err
+	}
+	headRepoRev, err := resolveLocalRepoRev(ctx, delta.Head)
+	if err != nil {
+		return err
+	}
+
+	files, err := cl.Deltas.ListFiles(ctx, &sourcegraph.DeltasListFilesOp{
+		Ds:  sourcegraph.DeltaSpec{Base: *baseRepoRev, Head: *headRepoRev},
+		Opt: &opt,
+	})
+	if err != nil {
+		return err
+	}
+
+	return writeJSON(w, files)
+}

--- a/services/httpapi/delta_test.go
+++ b/services/httpapi/delta_test.go
@@ -1,0 +1,71 @@
+package httpapi
+
+import (
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"sourcegraph.com/sourcegraph/go-diff/diff"
+	"sourcegraph.com/sourcegraph/sourcegraph/api/sourcegraph"
+)
+
+func TestDeltaFiles_ok(t *testing.T) {
+	c, mock := newTest()
+
+	want := &sourcegraph.DeltaFiles{Stats: diff.Stat{Added: 1}}
+
+	calledReposResolve := mock.Repos.MockResolve_Local(t, "r", 1)
+	var calledReposResolveRevBase, calledReposResolveRevHead bool
+	mock.Repos.ResolveRev_ = func(ctx context.Context, op *sourcegraph.ReposResolveRevOp) (*sourcegraph.ResolvedRev, error) {
+		if want := int32(1); op.Repo != want {
+			t.Errorf("got repo %d, want %d", op.Repo, want)
+		}
+		switch op.Rev {
+		case "vbase":
+			calledReposResolveRevBase = true
+			return &sourcegraph.ResolvedRev{CommitID: "cbase"}, nil
+		case "vhead":
+			calledReposResolveRevHead = true
+			return &sourcegraph.ResolvedRev{CommitID: "chead"}, nil
+		default:
+			t.Fatalf("got rev %q, want \"vbase\" or \"vhead\"", op.Rev)
+			panic("unreachable")
+		}
+	}
+	var calledDeltasListFiles bool
+	mock.Deltas.ListFiles_ = func(ctx context.Context, op *sourcegraph.DeltasListFilesOp) (*sourcegraph.DeltaFiles, error) {
+		calledDeltasListFiles = true
+		wantOp := sourcegraph.DeltasListFilesOp{
+			Ds: sourcegraph.DeltaSpec{
+				Base: sourcegraph.RepoRevSpec{Repo: 1, CommitID: "cbase"},
+				Head: sourcegraph.RepoRevSpec{Repo: 1, CommitID: "chead"},
+			},
+			Opt: &sourcegraph.DeltaListFilesOptions{Filter: "f"},
+		}
+		if !reflect.DeepEqual(*op, wantOp) {
+			t.Fatalf("got op %#v, want %#v", *op, wantOp)
+		}
+		return want, nil
+	}
+
+	var files *sourcegraph.DeltaFiles
+	if err := c.GetJSON("/repos/r@vhead/-/delta/vbase/-/files?Filter=f", &files); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf("got %+v, want %+v", files, want)
+	}
+	if !*calledReposResolve {
+		t.Error("!calledReposResolve")
+	}
+	if !calledReposResolveRevBase {
+		t.Error("!calledReposResolveRevBase")
+	}
+	if !calledReposResolveRevHead {
+		t.Error("!calledReposResolveRevHead")
+	}
+	if !calledDeltasListFiles {
+		t.Error("!calledDeltasListFiles")
+	}
+}

--- a/services/httpapi/httpapi.go
+++ b/services/httpapi/httpapi.go
@@ -75,6 +75,7 @@ func NewHandler(m *mux.Router) http.Handler {
 	m.Get(apirouter.DefRefLocations).Handler(handler(serveDefRefLocations))
 	m.Get(apirouter.DefExamples).Handler(handler(serveDefExamples))
 	m.Get(apirouter.Defs).Handler(handler(serveDefs))
+	m.Get(apirouter.DeltaFiles).Handler(handler(serveDeltaFiles))
 	m.Get(apirouter.GlobalSearch).Handler(handler(serveGlobalSearch))
 	m.Get(apirouter.Repo).Handler(handler(serveRepo))
 	m.Get(apirouter.RepoResolve).Handler(handler(serveRepoResolve))

--- a/services/httpapi/httpapi.go
+++ b/services/httpapi/httpapi.go
@@ -67,6 +67,7 @@ func NewHandler(m *mux.Router) http.Handler {
 	m.Get(apirouter.BuildTaskLog).Handler(handler(serveBuildTaskLog))
 	m.Get(apirouter.ChannelListen).HandlerFunc(serveChannelListen)
 	m.Get(apirouter.ChannelSend).Handler(handler(serveChannelSend))
+	m.Get(apirouter.Commit).Handler(handler(serveCommit))
 	m.Get(apirouter.Coverage).Handler(handler(serveCoverage))
 	m.Get(apirouter.Def).Handler(handler(serveDef))
 	m.Get(apirouter.DefAuthors).Handler(handler(serveDefAuthors))

--- a/services/httpapi/repo_vcs_test.go
+++ b/services/httpapi/repo_vcs_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"sourcegraph.com/sourcegraph/sourcegraph/api/sourcegraph"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/vcs"
 )
 
 func TestRepoResolveRev_ok(t *testing.T) {
@@ -57,5 +58,32 @@ func TestRepoResolveRev_notFound(t *testing.T) {
 	}
 	if !calledResolveRev {
 		t.Error("!calledReposResolveRev")
+	}
+}
+
+func TestCommit_ok(t *testing.T) {
+	c, mock := newTest()
+
+	want := &vcs.Commit{ID: "c"}
+
+	calledReposResolve := mock.Repos.MockResolve_Local(t, "r", 1)
+	calledResolveRev := mock.Repos.MockResolveRev_NoCheck(t, "c")
+	calledReposGetCommit := mock.Repos.MockGetCommit_Return_NoCheck(t, want)
+
+	var commit *vcs.Commit
+	if err := c.GetJSON("/repos/r@v/-/commit", &commit); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(commit, want) {
+		t.Errorf("got %+v, want %+v", commit, want)
+	}
+	if !*calledReposResolve {
+		t.Error("!calledReposResolve")
+	}
+	if !*calledResolveRev {
+		t.Error("!calledReposResolveRev")
+	}
+	if !*calledReposGetCommit {
+		t.Error("!calledReposGetCommit")
 	}
 }

--- a/services/httpapi/repos.go
+++ b/services/httpapi/repos.go
@@ -225,15 +225,7 @@ func getRepoLastBuildTime(r *http.Request, repoPath string, commitID string) (ti
 }
 
 func resolveLocalRepo(ctx context.Context, repoPath string) (int32, error) {
-	cl, err := sourcegraph.NewClientFromContext(ctx)
-	if err != nil {
-		return 0, err
-	}
-	res, err := cl.Repos.Resolve(ctx, &sourcegraph.RepoResolveOp{Path: repoPath})
-	if err != nil {
-		return 0, err
-	}
-	return res.Repo, nil
+	return handlerutil.GetRepoID(ctx, map[string]string{"Repo": repoPath})
 }
 
 func resolveLocalRepoRev(ctx context.Context, repoRev routevar.RepoRev) (*sourcegraph.RepoRevSpec, error) {

--- a/services/httpapi/router/router.go
+++ b/services/httpapi/router/router.go
@@ -26,6 +26,7 @@ const (
 	BuildTaskLog             = "build.task.log"
 	ChannelListen            = "channel.listen"
 	ChannelSend              = "channel.send"
+	Commit                   = "commit"
 	Coverage                 = "coverage"
 	Def                      = "def"
 	DefRefs                  = "def.refs"
@@ -107,6 +108,7 @@ func New(base *mux.Router) *mux.Router {
 	repo.Path("/commits").Methods("GET").Name(RepoCommits) // uses Head/Base query params, not {Rev} route var
 	repoRev.Path("/tree-list").Methods("GET").Name(RepoTreeList)
 	repoRev.Path("/rev").Methods("GET").Name(RepoResolveRev)
+	repoRev.Path("/commit").Methods("GET").Name(Commit)
 	repoRev.Path("/inventory").Methods("GET").Name(RepoInventory)
 	repoRev.Path("/tree-search").Methods("GET").Name(RepoTreeSearch)
 	repoRev.Path("/tree{Path:.*}").Name(RepoTree)

--- a/services/httpapi/router/router.go
+++ b/services/httpapi/router/router.go
@@ -34,6 +34,7 @@ const (
 	DefExamples              = "def.examples"
 	DefAuthors               = "def.authors"
 	Defs                     = "defs"
+	DeltaFiles               = "delta.files"
 	GlobalSearch             = "global.search"
 	Repo                     = "repo"
 	RepoResolve              = "repo.resolve"
@@ -109,6 +110,7 @@ func New(base *mux.Router) *mux.Router {
 	repoRev.Path("/tree-list").Methods("GET").Name(RepoTreeList)
 	repoRev.Path("/rev").Methods("GET").Name(RepoResolveRev)
 	repoRev.Path("/commit").Methods("GET").Name(Commit)
+	repoRev.Path("/delta/{DeltaBaseRev}/-/files").Methods("GET").Name(DeltaFiles)
 	repoRev.Path("/inventory").Methods("GET").Name(RepoInventory)
 	repoRev.Path("/tree-search").Methods("GET").Name(RepoTreeSearch)
 	repoRev.Path("/tree{Path:.*}").Name(RepoTree)


### PR DESCRIPTION
Adds a commit page that shows highlighted red/green diffs. Also improves the commit component (which was only used on the build page).

This is not totally perfect, but it's pretty hidden from the masses, so let's get this out there soon. We can test it internally first.

<img width="848" alt="screen shot 2016-06-12 at 9 59 42 pm" src="https://cloud.githubusercontent.com/assets/1976/15996068/469d1d48-30e9-11e6-8866-72707cfa2551.png">
<img width="408" alt="screen shot 2016-06-12 at 9 59 29 pm" src="https://cloud.githubusercontent.com/assets/1976/15996069/46aa14c6-30e9-11e6-9f8b-23d9c5e41c05.png">
![image](https://cloud.githubusercontent.com/assets/1976/15996079/5bd1c420-30e9-11e6-901f-7f26fadd912b.png)
