### PR TITLE
builds: Ensure UI triggered/new repos have high priorities.

### DIFF
--- a/app/web_modules/sourcegraph/build/BuildBackend.js
+++ b/app/web_modules/sourcegraph/build/BuildBackend.js
@@ -67,9 +67,6 @@ const BuildBackend = {
 						body: JSON.stringify({
 							CommitID: action.commitID,
 							Branch: action.branch,
-							// HACK: this will enable builds queued through the ui
-							// to receive a higher priority.
-							Config: {Queue: true, Priority: 40},
 						}),
 					})
 						.then(checkStatus)

--- a/cli/coverage_cmd.go
+++ b/cli/coverage_cmd.go
@@ -286,7 +286,10 @@ func (c *coverageCmd) Execute(args []string) error {
 			WebhookURL: os.Getenv("SG_SLACK_GRAPH_WEBHOOK_URL"),
 		})
 
-		syncCmd := &repoSyncCmd{Force: true}
+		syncCmd := &repoSyncCmd{
+			Force:         true,
+			buildPriority: -100, // let other builds run first
+		}
 		syncCmd.Args.URIs = repos
 		err := syncCmd.Execute(nil)
 		if err != nil {

--- a/cli/repo_cmds.go
+++ b/cli/repo_cmds.go
@@ -353,6 +353,10 @@ type repoSyncCmd struct {
 	Force bool   `long:"force" short:"f" description:"force rebuild even if build exists for the latest commit"`
 	Rev   string `long:"revision" short:"r" description:"sync the specified branch or commit ID"`
 
+	// buildPriority is used to control the priority of the build. Private
+	// since we don't want to expose it to the user.
+	buildPriority int32
+
 	Args struct {
 		URIs []string `name:"REPO-URI" description:"repository URIs (e.g., host.com/myrepo)"`
 	} `positional-args:"yes" required:"yes"`
@@ -427,7 +431,10 @@ func (c *repoSyncCmd) sync(repoURI string) error {
 		b, err := cl.Builds.Create(cliContext, &sourcegraph.BuildsCreateOp{
 			Repo:     repoRevSpec.Repo,
 			CommitID: repoRevSpec.CommitID,
-			Config:   sourcegraph.BuildConfig{Queue: true},
+			Config: sourcegraph.BuildConfig{
+				Queue:    true,
+				Priority: c.buildPriority,
+			},
 		})
 		if err != nil {
 			return err

--- a/services/backend/builds.go
+++ b/services/backend/builds.go
@@ -101,6 +101,17 @@ func (s *builds) Create(ctx context.Context, op *sourcegraph.BuildsCreateOp) (*s
 		b.Priority += 20
 	}
 
+	// If this is the first ever build for a repo, give it a high priority
+	hasBuild, err := s.List(ctx, &sourcegraph.BuildListOptions{
+		Repo: repo.ID,
+		ListOptions: sourcegraph.ListOptions{
+			PerPage: 1,
+		},
+	})
+	if err == nil && len(hasBuild.Builds) == 0 {
+		b.Priority += 20
+	}
+
 	b, err = store.BuildsFromContext(ctx).Create(ctx, b)
 	if err != nil {
 		return nil, err

--- a/services/backend/mirror_repos.go
+++ b/services/backend/mirror_repos.go
@@ -131,7 +131,10 @@ func (s *mirrorRepos) cloneRepo(ctx context.Context, repo *sourcegraph.Repo, rem
 		Repo:     repo.ID,
 		CommitID: res.CommitID,
 		Branch:   repo.DefaultBranch,
-		Config:   sourcegraph.BuildConfig{Queue: true},
+		Config: sourcegraph.BuildConfig{
+			Queue:    true,
+			Priority: -50,
+		},
 	})
 	if err != nil {
 		log15.Warn("cloneRepo: failed to create build", "err", err, "repo", repo.URI, "commit", res.CommitID, "branch", repo.DefaultBranch)

--- a/services/events/listeners/git_hooks.go
+++ b/services/events/listeners/git_hooks.go
@@ -150,7 +150,10 @@ func buildHook(ctx context.Context, id events.EventID, payload events.GitPayload
 			CommitID: event.Commit,
 			Tag:      event.Tag,
 			Branch:   event.Branch,
-			Config:   sourcegraph.BuildConfig{Queue: true},
+			Config: sourcegraph.BuildConfig{
+				Queue:    true,
+				Priority: -50,
+			},
 		})
 		if err != nil {
 			log15.Warn("postPushHook: failed to create build", "err", err, "repo", repo, "commit", event.Commit, "branch", event.Branch, "tag", event.Tag)

--- a/services/httpapi/repos_builds.go
+++ b/services/httpapi/repos_builds.go
@@ -62,6 +62,12 @@ func serveRepoBuildsCreate(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return &errcode.HTTPErr{Status: http.StatusBadRequest, Err: err}
 	}
+	// Don't let the user specify the config
+	op.Config = sourcegraph.BuildConfig{
+		Queue: true,
+		// Builds triggered from the UI have a high priority
+		Priority: 100,
+	}
 
 	repo, err := handlerutil.GetRepoID(ctx, mux.Vars(r))
 	if err != nil {


### PR DESCRIPTION
We can run coverage job builds with a much lower priority such that any other
build will run first.

Fixes https://app.asana.com/0/87040567695724/140739668608789