### PR TITLE
browser-ext: fix "<"  and ">" in code bug

### DIFF
--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -145,6 +145,9 @@ function isStartOfSpanTag(childNodeChars, idx) {
 // next is a helper method for traverseDOM which transforms a character
 // into itself or wraps the character in a starting/ending anchor tag
 function next(c, byteCount, annsByStartByte, annsByEndByte) {
+	if (c === "<" || c === ">") {
+		c = _.escape(c);
+	}
 	let matchDetails = annsByStartByte[byteCount];
 	// if there is a match
 	if (!annotating && matchDetails) {

--- a/client/browser-ext/chrome/manifest.prod.json
+++ b/client/browser-ext/chrome/manifest.prod.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.14",
+  "version": "1.1.15",
   "name": "Sourcegraph for GitHub",
   "manifest_version": 2,
   "description": "Browse and search code on GitHub like an IDE, with jump-to-definition, doc tooltips, and semantic search.",


### PR DESCRIPTION
This fixes a bug where "<" and ">" characters are not properly handled if they appear in the code.  I thought my previous change had fixed this but I've just found that it hadn't handled all cases.  It seems that for generic types in Java,  "<" and ">" characters are not escaped by default.  

Go to this link: https://github.com/square/retrofit/blob/master/retrofit/src/main/java/retrofit2/Callback.java#L31 and see that Callback<T> becomes just Callback as the <T> disappears.  This is because it's read as an HTML tag because <T> shows up as a single element, whereas in other cases in the same file, each character (<, T, >), is separated by span tags.  This will fix that by special casing if < or > appear in the code and escaping HTML.  This should not affect other occurrences of these characters appearing that behave properly.

##### Reviewer tasks

- [ ] HACKS: reviewer approves hacks introduced by this change

##### Test plan

Take a look at some Java other files with generics and see that these characters don't disappear <T>.  Also take a look at some other Go and Java files to ensure there is no odd behavior with ">" or "<" characters.


