### PR TITLE
services/ext/github: Style changes to improve readability.

### DIFF
--- a/services/ext/github/repos_test.go
+++ b/services/ext/github/repos_test.go
@@ -179,7 +179,7 @@ func TestRepos_Get_publicnotfound(t *testing.T) {
 		t.Fatal(err)
 	}
 	if calledGetMissing {
-		t.Fatal("should of hit cache")
+		t.Fatal("should have hit cache")
 	}
 
 	// Now if we call as an authed user, we will hit the cache but not use
@@ -203,7 +203,7 @@ func TestRepos_Get_publicnotfound(t *testing.T) {
 		t.Fatal(err)
 	}
 	if calledGetMissing {
-		t.Fatal("should of hit cache")
+		t.Fatal("should have hit cache")
 	}
 
 	// authed user + 404 == never cache. Do twice to ensure we do not


### PR DESCRIPTION
Followup to #84 comments left by me. This should be a refactor that does not change behavior. These are suggestions, so @keegancsmith feel free to accept/reject them depending on if you agree.

Make `getFromCache` and `getFromAPI` signatures more traditional. They now both return (*Resource, error) where Resource can/should only be used if and only if error is nil. This behavior is also now documented.

---

Also, perform `githubutil.SplitRepoURI` first thing in github.Repos.Get, before even hitting the cache.

The cache is redis and may be a network call, etc., so the assumption is that `githubutil.SplitRepoURI` is a much cheaper/quicker operation. If the local parsing of `githubutil.SplitRepoURI` fails, there's no way it's a valid repo that would be cached.

This is a minor optimization that can help in a situation where an invalid repo URL is requested at a high rate.

##### Reviewer tasks

- [ ] STYLE: reviewer accepts style changes introduced by this change (and considers them an improvement)

##### Test plan

Tests pass locally.