### PR TITLE
Corrected refname => revision resolution

### DIFF
--- a/services/backend/mirror_repos.go
+++ b/services/backend/mirror_repos.go
@@ -187,7 +187,7 @@ func (s *mirrorRepos) updateRepo(ctx context.Context, repo *sourcegraph.Repo, vc
 			}
 
 			// Determine the new branch head revision.
-			head, err := vcsRepo.ResolveRevision(change.Branch)
+			head, err := vcsRepo.ResolveRevision("refs/heads/" + change.Branch)
 			if err != nil {
 				return err
 			}
@@ -217,7 +217,7 @@ func (s *mirrorRepos) updateRepo(ctx context.Context, repo *sourcegraph.Repo, vc
 		}
 
 		// Determine new branch head revision.
-		head, err := vcsRepo.ResolveRevision(oldBranch.Name)
+		head, err := vcsRepo.ResolveRevision("refs/heads/" + oldBranch.Name)
 		if err == vcs.ErrRevisionNotFound {
 			// Branch was deleted.
 			// TODO: what about GitPayload.ContentEncoding field?


### PR DESCRIPTION
Fixes https://app.asana.com/0/87040567695724/140099827375686
The reason was the following: there may be multiple refnames ending with the same suffix, for example
```
$ git show-ref --heads | grep 1.0.2
...
f6c1ff038cd9ff067e344a1194cfb4c8ad194090 refs/heads/1.0.2
901b3948ffc5f4ea7ad0c5e7d68ecdeb86d4461d refs/heads/rr/146/1.0.2
...
```

then

```
$ git rev-parse 1.0.2
warning: refname '1.0.2' is ambiguous.
e5fd456075b3318eb7092ff0169a30d1298086d6
$ git rev-parse refs/heads/1.0.2
f6c1ff038cd9ff067e344a1194cfb4c8ad194090

```

When we are looking for changes, there may be false positive change detected because the results of `git show-ref` and `git rev-parse` may differ.
I propose to fix it by adding "refs/heads/" prefix because refnames there are relative to "refs/heads/" anyway