### PR TITLE
builds: Include Go as supported language

### DIFF
--- a/services/worker/plan/infer.go
+++ b/services/worker/plan/infer.go
@@ -49,6 +49,7 @@ var langConfigs = map[string]struct {
 	build  droneyaml.BuildItem
 	matrix map[string][]string
 }{
+	"Go": {},
 	"JavaScript": {
 		build: droneyaml.BuildItem{
 			Key: "JavaScript deps (node v$$NODE_VERSION)",

--- a/services/worker/plan/infer.go
+++ b/services/worker/plan/infer.go
@@ -22,7 +22,10 @@ func inferConfig(inv *inventory.Inventory) (*droneyaml.Config, []matrix.Axis, er
 	for _, lang := range inv.Languages {
 		c, ok := langConfigs[lang.Name]
 		if !ok {
-			unsupported = append(unsupported, lang.Name)
+			// Only warn about languages which are possible to build.
+			if lang.Type == "programming" {
+				unsupported = append(unsupported, lang.Name)
+			}
 		} else {
 			config.Build = append(config.Build, c.build)
 		}


### PR DESCRIPTION
Example output from `Detect projects` now

```
Detected 1 programming languages in use by this repository:
 - Go

Found 2 non-programming languages in use by this repository that will not be analysed:
 - Markdown
 - YAML
```

Before it would of been

```
Detected 3 programming languages in use by this repository:
 - Go
 - Markdown
 - YAML
```

but then it would of warned about not being able to build all 3 languages (but
would still analyse Go).

Fixes https://app.asana.com/0/87040567695724/142418359113253