### PR TITLE
Fix text-ellipses and text alignment at small sizes.

### DIFF
--- a/app/web_modules/sourcegraph/repo/styles/Repo.css
+++ b/app/web_modules/sourcegraph/repo/styles/Repo.css
@@ -11,6 +11,8 @@
 	display: inline-block;
 	flex: 0 0 auto;
 }
+
+.nav { display: flex; }
 .repoName {
 	composes: b db mr3 from base;
 }
@@ -22,6 +24,7 @@
 	.repo-nav-context {
 		overflow: hidden;
 		text-overflow: ellipsis;
+		flex: 1;
 	}
 }
 

--- a/app/web_modules/sourcegraph/repo/styles/RevSwitcher.css
+++ b/app/web_modules/sourcegraph/repo/styles/RevSwitcher.css
@@ -2,7 +2,9 @@
 @value colors "sourcegraph/components/styles/_colors.css";
 @value grid "sourcegraph/components/styles/_grid.css";
 @value typography "sourcegraph/components/styles/_typography.css";
+@value vars "sourcegraph/components/styles/_vars.css";
 @value c_cool-gray from colors;
+@value media-sm from vars;
 
 .wrapper {
 	position: relative;
@@ -54,4 +56,9 @@
 .icon-hidden {
 	composes: icon;
 	opacity: 0;
+}
+
+@media screen and media-sm {
+	.wrapper { margin-top: 0; }
+	.dropdown-menu { right: 0; }
 }


### PR DESCRIPTION
The ellipses truncation broke at some point (possibly after adding the RevSwitcher).

This adds back ellipses truncation and fixes text and RevSwitcher menu misalignment on mobile.