### PR TITLE
builds: Allow worker to override AppURL

### DIFF
--- a/cli/serve_cmd.go
+++ b/cli/serve_cmd.go
@@ -448,7 +448,7 @@ func (c *ServeCmd) Execute(args []string) error {
 		log15.Info("Skip starting worker process.")
 	} else {
 		go func() {
-			if err := worker.RunWorker(idKey, endpoint.URLOrDefault(), c.WorkCmd.Parallel, c.WorkCmd.DequeueMsec); err != nil {
+			if err := worker.RunWorker(context.Background(), idKey, endpoint.URLOrDefault(), c.WorkCmd.Parallel, c.WorkCmd.DequeueMsec); err != nil {
 				log.Fatal("Worker exited with error:", err)
 			}
 		}()

--- a/pkg/conf/context.go
+++ b/pkg/conf/context.go
@@ -27,3 +27,10 @@ func AppURL(ctx context.Context) *url.URL {
 	}
 	return url
 }
+
+// AppURLOrNil returns the context's base URL that was previously configured
+// using WithURL or nil.
+func AppURLOrNil(ctx context.Context) *url.URL {
+	url, _ := ctx.Value(appURLKey).(*url.URL)
+	return url
+}

--- a/services/worker/configure.go
+++ b/services/worker/configure.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"sourcegraph.com/sourcegraph/sourcegraph/api/sourcegraph"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/conf"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/dockerutil"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/inventory"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/routevar"
@@ -197,6 +198,11 @@ func configureBuild(ctx context.Context, build *sourcegraph.BuildJob) (*builder.
 // getContainerAppURL gets the Sourcegraph server's app URL from the
 // POV of the Docker containers.
 func getAppURL(ctx context.Context) (*url.URL, error) {
+	u := conf.AppURLOrNil(ctx)
+	if u != nil {
+		return u, nil
+	}
+
 	cl, err := sourcegraph.NewClientFromContext(ctx)
 	if err != nil {
 		return nil, err

--- a/services/worker/worker.go
+++ b/services/worker/worker.go
@@ -21,8 +21,8 @@ import (
 )
 
 // RunWorker starts the worker loop with the given parameters.
-func RunWorker(key *idkey.IDKey, endpoint *url.URL, parallel int, dequeueMsec int) error {
-	ctx := sourcegraph.WithGRPCEndpoint(context.Background(), endpoint)
+func RunWorker(ctx context.Context, key *idkey.IDKey, endpoint *url.URL, parallel int, dequeueMsec int) error {
+	ctx = sourcegraph.WithGRPCEndpoint(ctx, endpoint)
 	ctx = sourcegraph.WithCredentials(ctx, sharedsecret.DefensiveReuseTokenSource(nil, sharedsecret.ShortTokenSource(key, "worker:build")))
 
 	cl, err := sourcegraph.NewClientFromContext(ctx)


### PR DESCRIPTION
We want to use a srclib import URL that is different to what the Meta.Config
service returns. We want this since we want imports to go through another
frontend.