### PR TITLE
browser-ext/chrome: enable for shell scripts

### DIFF
--- a/client/browser-ext/chrome/extension/annotations.js
+++ b/client/browser-ext/chrome/extension/annotations.js
@@ -271,7 +271,7 @@ function addPopover(el) {
 				if (json.Data) {
 					const f = json.FmtStrings;
 					const doc = json.DocHTML ? `<div>${json.DocHTML.__html}</div>` : "";
-					html = `<div><div class=${styles.popoverTitle}>${f.DefKeyword || ""}${f.DefKeyword ? " " : ""}<b style="color:#4078C0">${f.Name.Unqualified}</b>${f.NameAndTypeSeparator || ""}${f.Type.ScopeQualified === f.DefKeyword ? "" : f.Type.ScopeQualified}</div>${doc}<div class=${styles.popoverRepo}>${json.Repo}</div></div>`;
+					html = `<div><div class=${styles.popoverTitle}>${f.DefKeyword || ""}${f.DefKeyword ? " " : ""}<b style="color:#4078C0">${f.Name.Unqualified}</b>${f.NameAndTypeSeparator || ""}${f.Type.ScopeQualified === f.DefKeyword ? "" : f.Type.ScopeQualified || ""}</div>${doc}<div class=${styles.popoverRepo}>${json.Repo}</div></div>`;
 				}
 				popoverCache[url] = html;
 				cb(html, json);

--- a/client/browser-ext/chrome/extension/inject.js
+++ b/client/browser-ext/chrome/extension/inject.js
@@ -203,7 +203,7 @@ class InjectApp extends React.Component {
 		const pathParts = path.split("/");
 		let lang = pathParts[pathParts.length - 1].split(".")[1] || null;
 		lang = lang ? lang.toLowerCase() : null;
-		const supportedLang = lang === "go" || lang === "java";
+		const supportedLang = lang === "go" || lang === "java" || lang === "sh" || lang === "bash";
 		return window.location.href.split("/")[5] === "blob" && document.querySelector(".file") && supportedLang;
 	}
 


### PR DESCRIPTION
Enabling the Chrome extension for shell scripts.
Tested locally.