### PR TITLE
services/worker/plan: Update srclib-go to incorporate sourcegraph/srclib-go#102.

### DIFF
--- a/services/worker/plan/srclib_images.go
+++ b/services/worker/plan/srclib_images.go
@@ -10,7 +10,7 @@ import (
 // `droneSrclibGoImage = "sourcegraph/srclib-go"`.
 var (
 	droneSrclibBashImage       = "sourcegraph/srclib-bash@sha256:c26891ddab9f7e73138927bba8dc323c0ba4c5abdb82b4a56ac4b23063e204e9"
-	droneSrclibGoImage         = "sourcegraph/srclib-go@sha256:4c91ca8b3d7fc123e9489e6751c94791776d303e21eb11e2cb14d986b78b1b06"
+	droneSrclibGoImage         = "sourcegraph/srclib-go@sha256:5d0e6892182610b86b536a3eb43044d9b960ec8c127c118243cd75b42dbf7a36"
 	droneSrclibJavaScriptImage = "sourcegraph/srclib-javascript@sha256:7cfc4ea50aaf0fea46b8704e80ef50dfa45afe82af57e653bae34ae56288a859"
 	droneSrclibJavaImage       = "sourcegraph/srclib-java@sha256:7e4ff0bc3aee6d87295dd4629fabcfbb39de115911af6d1abd1aa4e5145b5d1c"
 	droneSrclibTypeScriptImage = "sourcegraph/srclib-typescript@sha256:39adfea4bdaea50be63431fe8c85c174a6a83d34db1196ac0bb171cb79cc88d6"


### PR DESCRIPTION
Undo revert commit 78d51f514d504f9c1b491638cf28c73ee9760c5c. This time, it's built with the right Docker version and should work.

##### Reviewer tasks

- [ ] DOCKER VERSION: reviewer approves image was built using right docker version

##### Test plan

Tested on staging3.

https://staging3.sourcegraph.com/github.com/shurcooL/play/-/builds/1
https://staging3.sourcegraph.com/github.com/shurcooL/play/-/def/GoPackage/github.com/shurcooL/play/187/tictactoe/-/Player

(Compare with https://sourcegraph.com/github.com/shurcooL/play/-/builds/8.)

Worked successfully, and indexed good Go packages despite there being bad Go packages that refer to missing repos/packages. So it also shows that fix in https://github.com/sourcegraph/srclib-go/pull/102 works.