### PR TITLE
Trying to resolve SHA of custom default branch

### DIFF
--- a/services/worker/drone.go
+++ b/services/worker/drone.go
@@ -15,6 +15,6 @@ func init() {
 	// https://github.com/drone-plugins/drone-git/pull/14 and the
 	// not-yet-submitted PR based on the github.com/sqs/drone-git
 	// multiple-netrc-entries branch.
-	dronerunner.DefaultCloner = "sourcegraph/drone-git@sha256:09ddfc452b92657fcef5da70a71687f149ef2c4f0b4501fe3f4e0b9c1e91821c"
+	dronerunner.DefaultCloner = "sourcegraph/drone-git@sha256:4c52a8debb54c683a7063da3b85a862fde1279fcab10596800e28489a5aeab80"
 	droneparser.DefaultCloner = dronerunner.DefaultCloner
 }


### PR DESCRIPTION
This is my proposal how to fix https://app.asana.com/0/87040567695724/144531999537159. It includes
- trying to resolve SHA when repository contains custom default branch (for example, github.com/apache/log4j). If we were failed first time, trying to query default branch from GitHub and retry
- using updated `sourcegraph/drone-git` Docker image based on github.com/sqs/drone-git#5. Without it on my local instance I cannot start build of github.com/apache/log4j because clone fails

- [x] PERF: reviewer approves of the site perf impact of this change

Please ensure that this PR does not adds too many extra calls to GitHub