### PR TITLE
Improve global refs update

### DIFF
--- a/services/backend/search.go
+++ b/services/backend/search.go
@@ -1,8 +1,9 @@
 package backend
 
 import (
-	"gopkg.in/inconshreveable/log15.v2"
 	"strings"
+
+	"gopkg.in/inconshreveable/log15.v2"
 
 	srch "sourcegraph.com/sourcegraph/sourcegraph/pkg/search"
 	"sourcegraph.com/sourcegraph/sourcegraph/services/svc"

--- a/services/httpapi/srclib_import.go
+++ b/services/httpapi/srclib_import.go
@@ -106,7 +106,7 @@ func serveSrclibImport(w http.ResponseWriter, r *http.Request) (err error) {
 	}
 
 	// global * reindex, doesn't block import
-	cl.Async.RefreshIndexes(ctx, &sourcegraph.AsyncRefreshIndexesOp{Repo: repoRev.Repo})
+	cl.Async.RefreshIndexes(ctx, &sourcegraph.AsyncRefreshIndexesOp{Repo: repoRev.Repo, Force: true})
 
 	return nil
 }

--- a/services/httpapi/srclib_import_test.go
+++ b/services/httpapi/srclib_import_test.go
@@ -37,7 +37,7 @@ func TestSrclibImport(t *testing.T) {
 		URI: wantRepo,
 	})
 	calledReposResolveRev := mock.Repos.MockResolveRev_NoCheck(t, wantCommitID)
-	calledRefreshIndexes := mock.Async.MockRefreshIndexes(t, &sourcegraph.AsyncRefreshIndexesOp{Repo: wantRepoID})
+	calledRefreshIndexes := mock.Async.MockRefreshIndexes(t, &sourcegraph.AsyncRefreshIndexesOp{Repo: wantRepoID, Force: true})
 
 	// Mock the srclib store interface (and replace the old
 	// newSrclibStoreClient value when done).


### PR DESCRIPTION
This minimizes the transaction zone of the global refs update step, which should hopefully improve perf.

It also forces a global_refs reindex on every successful srclib import. This will make `src repo sync -f $REPO` work as expected (previously, this wouldn't actually force a rebuild of the global_refs index, which was confusing when debugging).