### PR TITLE
Tokenize camelCase and snake_case global search results

### DIFF
--- a/pkg/search/search_tok.go
+++ b/pkg/search/search_tok.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"github.com/fatih/camelcase"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -36,7 +37,26 @@ func BagOfWords(def *graph.Def) map[string]int {
 		words[w] += 2
 		if len(defParts)-1 == i {
 			words[w] += 30 // mega extra points for matching the last component of the def path (typically the "name" of the def)
+
+			if snakeSplit := snakeCaseSplit(w); len(snakeSplit) > 1 {
+				snakeSplit := snakeCaseSplit(w)
+				for _, tokPart := range snakeSplit {
+					words[tokPart] += 10 // more points for matching last component of def path
+				}
+			} else {
+				camelSplit := camelcase.Split(w)
+				for _, tokPart := range camelSplit {
+					words[tokPart] += 10 // more points for matching last component of def path
+				}
+			}
 		}
+	}
+	camelCaseWords, snakeCaseWords := splitCaseWords(defParts)
+	for _, w := range camelCaseWords {
+		words[w]++ // add each individual word of camel cased tokens
+	}
+	for _, w := range snakeCaseWords {
+		words[w]++ // add each individual word of snake cased tokens
 	}
 	for i, w := range fileParts {
 		words[w]++
@@ -49,6 +69,27 @@ func BagOfWords(def *graph.Def) map[string]int {
 	words[def.Kind] += 1
 
 	return words
+}
+
+func splitCaseWords(defParts []string) ([]string, []string) {
+	var camelCaseWords []string
+	var snakeCaseWords []string
+
+	for _, w := range defParts {
+		if len(snakeCaseSplit(w)) > 1 {
+			snakeCaseWords = append(snakeCaseWords, snakeCaseSplit(w)...)
+		} else {
+			camelCaseWords = append(camelCaseWords, camelcase.Split(w)...)
+		}
+	}
+	return camelCaseWords, snakeCaseWords
+}
+
+func snakeCaseSplit(src string) (entries []string) {
+	if strings.Split(src, "_")[0] != src {
+		entries = strings.Split(src, "_")
+	}
+	return entries
 }
 
 func UserQueryToksToTSQuery(toks []string) string {

--- a/pkg/search/search_tok_test.go
+++ b/pkg/search/search_tok_test.go
@@ -1,0 +1,88 @@
+package search
+
+import (
+	"reflect"
+	"sourcegraph.com/sourcegraph/srclib/graph"
+	"testing"
+)
+
+func TestBagOfWords(t *testing.T) {
+	type testCase struct {
+		def      graph.Def
+		expected map[string]int
+	}
+	cases := []testCase{
+		{
+			def: graph.Def{
+				DefKey: graph.DefKey{
+					Path: "testOne/testNumberOne",
+					Repo: "github.com/firstCase/caseNumOne",
+				},
+			},
+			expected: map[string]int{
+				"Number":        11,
+				"One":           12,
+				"testOne":       2,
+				"testNumberOne": 32,
+				"test":          12,
+				"":              17,
+				"firstCase":     1,
+				"caseNumOne":    3,
+			},
+		},
+		{
+			def: graph.Def{
+				DefKey: graph.DefKey{
+					Path: "test_two/test_number_two",
+					Repo: "github.com/secondCase/caseNumTwo",
+				},
+			},
+			expected: map[string]int{
+				"test_two":        2,
+				"test_number_two": 32,
+				"test":            12,
+				"number":          11,
+				"two":             12,
+				"":                17,
+				"secondCase":      1,
+				"caseNumTwo":      3,
+			},
+		},
+		{
+			def: graph.Def{
+				DefKey: graph.DefKey{
+					Path: "test/three",
+					Repo: "github.com/thirdCase/caseNumThree",
+				},
+			},
+			expected: map[string]int{
+				"three":        43,
+				"test":         3,
+				"":             17,
+				"thirdCase":    1,
+				"caseNumThree": 3,
+			},
+		},
+		{
+			def: graph.Def{
+				DefKey: graph.DefKey{
+					Path: "test/test",
+					Repo: "github.com/fourthCase/caseNumFour",
+				},
+			},
+			expected: map[string]int{
+				"test":        46,
+				"":            17,
+				"fourthCase":  1,
+				"caseNumFour": 3,
+			},
+		},
+	}
+
+	for i, c := range cases {
+		eq := reflect.DeepEqual(BagOfWords(&c.def), c.expected)
+		if !eq {
+			t.Error("Miscalculated bag of words scoring for test case at index ", i)
+		}
+	}
+}

--- a/vendor/github.com/fatih/camelcase/LICENSE.md
+++ b/vendor/github.com/fatih/camelcase/LICENSE.md
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/fatih/camelcase/README.md
+++ b/vendor/github.com/fatih/camelcase/README.md
@@ -1,0 +1,58 @@
+# CamelCase [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/camelcase) [![Build Status](http://img.shields.io/travis/fatih/camelcase.svg?style=flat-square)](https://travis-ci.org/fatih/camelcase)
+
+CamelCase is a Golang (Go) package to split the words of a camelcase type
+string into a slice of words. It can be used to convert a camelcase word (lower
+or upper case) into any type of word.
+
+## Splitting rules:
+
+1. If string is not valid UTF-8, return it without splitting as
+   single item array.
+2. Assign all unicode characters into one of 4 sets: lower case
+   letters, upper case letters, numbers, and all other characters.
+3. Iterate through characters of string, introducing splits
+   between adjacent characters that belong to different sets.
+4. Iterate through array of split strings, and if a given string
+   is upper case:
+   * if subsequent string is lower case:
+     * move last character of upper case string to beginning of
+       lower case string
+
+## Install
+
+```bash
+go get github.com/fatih/camelcase
+```
+
+## Usage and examples
+
+```go
+splitted := camelcase.Split("GolangPackage")
+
+fmt.Println(splitted[0], splitted[1]) // prints: "Golang", "Package"
+```
+
+Both lower camel case and upper camel case are supported. For more info please
+check: [http://en.wikipedia.org/wiki/CamelCase](http://en.wikipedia.org/wiki/CamelCase)
+
+Below are some example cases:
+
+```
+"" =>                     []
+"lowercase" =>            ["lowercase"]
+"Class" =>                ["Class"]
+"MyClass" =>              ["My", "Class"]
+"MyC" =>                  ["My", "C"]
+"HTML" =>                 ["HTML"]
+"PDFLoader" =>            ["PDF", "Loader"]
+"AString" =>              ["A", "String"]
+"SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+"vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+"GL11Version" =>          ["GL", "11", "Version"]
+"99Bottles" =>            ["99", "Bottles"]
+"May5" =>                 ["May", "5"]
+"BFG9000" =>              ["BFG", "9000"]
+"BöseÜberraschung" =>     ["Böse", "Überraschung"]
+"Two  spaces" =>          ["Two", "  ", "spaces"]
+"BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+```

--- a/vendor/github.com/fatih/camelcase/camelcase.go
+++ b/vendor/github.com/fatih/camelcase/camelcase.go
@@ -1,0 +1,90 @@
+// Package camelcase is a micro package to split the words of a camelcase type
+// string into a slice of words.
+package camelcase
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Split splits the camelcase word and returns a list of words. It also
+// supports digits. Both lower camel case and upper camel case are supported.
+// For more info please check: http://en.wikipedia.org/wiki/CamelCase
+//
+// Examples
+//
+//   "" =>                     [""]
+//   "lowercase" =>            ["lowercase"]
+//   "Class" =>                ["Class"]
+//   "MyClass" =>              ["My", "Class"]
+//   "MyC" =>                  ["My", "C"]
+//   "HTML" =>                 ["HTML"]
+//   "PDFLoader" =>            ["PDF", "Loader"]
+//   "AString" =>              ["A", "String"]
+//   "SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+//   "vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+//   "GL11Version" =>          ["GL", "11", "Version"]
+//   "99Bottles" =>            ["99", "Bottles"]
+//   "May5" =>                 ["May", "5"]
+//   "BFG9000" =>              ["BFG", "9000"]
+//   "BöseÜberraschung" =>     ["Böse", "Überraschung"]
+//   "Two  spaces" =>          ["Two", "  ", "spaces"]
+//   "BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+//
+// Splitting rules
+//
+//  1) If string is not valid UTF-8, return it without splitting as
+//     single item array.
+//  2) Assign all unicode characters into one of 4 sets: lower case
+//     letters, upper case letters, numbers, and all other characters.
+//  3) Iterate through characters of string, introducing splits
+//     between adjacent characters that belong to different sets.
+//  4) Iterate through array of split strings, and if a given string
+//     is upper case:
+//       if subsequent string is lower case:
+//         move last character of upper case string to beginning of
+//         lower case string
+func Split(src string) (entries []string) {
+	// don't split invalid utf8
+	if !utf8.ValidString(src) {
+		return []string{src}
+	}
+	entries = []string{}
+	var runes [][]rune
+	lastClass := 0
+	class := 0
+	// split into fields based on class of unicode character
+	for _, r := range src {
+		switch true {
+		case unicode.IsLower(r):
+			class = 1
+		case unicode.IsUpper(r):
+			class = 2
+		case unicode.IsDigit(r):
+			class = 3
+		default:
+			class = 4
+		}
+		if class == lastClass {
+			runes[len(runes)-1] = append(runes[len(runes)-1], r)
+		} else {
+			runes = append(runes, []rune{r})
+		}
+		lastClass = class
+	}
+	// handle upper case -> lower case sequences, e.g.
+	// "PDFL", "oader" -> "PDF", "Loader"
+	for i := 0; i < len(runes)-1; i++ {
+		if unicode.IsUpper(runes[i][0]) && unicode.IsLower(runes[i+1][0]) {
+			runes[i+1] = append([]rune{runes[i][len(runes[i])-1]}, runes[i+1]...)
+			runes[i] = runes[i][:len(runes[i])-1]
+		}
+	}
+	// construct []string from results
+	for _, s := range runes {
+		if len(s) > 0 {
+			entries = append(entries, string(s))
+		}
+	}
+	return
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -176,6 +176,12 @@
 			"revisionTime": "2016-05-10T05:46:03Z"
 		},
 		{
+			"checksumSHA1": "kR64D1QzAOSM9LHOnTPdbigC8q0=",
+			"path": "github.com/fatih/camelcase",
+			"revision": "f6a740d52f961c60348ebb109adde9f4635d7540",
+			"revisionTime": "2016-03-18T18:15:35Z"
+		},
+		{
 			"checksumSHA1": "VdXZPcDRHK1T7XjBu2KW8Mb8S6w=",
 			"path": "github.com/flynn/go-shlex",
 			"revision": "3f9db97f856818214da2e1057f8ad84803971cff",


### PR DESCRIPTION
This change tokenizes camelCased and snake_cased paths in global search results by splitting out the individual words and adding them to the bag of words representations for the results.  This improves search results, since we can now match based on parts of words in the path instead of only full words.  Right now, all separated words from camelCased and snake_cased words are given a score of 1, while an additional 10 points are given for words that are separated from the last part of the path (typically the "name" of the result).

##### Reviewer tasks
- [ ] HACKS: reviewer approves hacks introduced by this change
- [ ] METRICS: reviewer verified correct usage metric tracking was added
- [ ] DOCS: reviewer approves the docstrings (or the justified omission thereof)

