### PR TITLE
builds: Prevent adding docker images prod does not support

### DIFF
--- a/services/worker/dockerfiles/Makefile
+++ b/services/worker/dockerfiles/Makefile
@@ -4,7 +4,7 @@
 
 TOOLCHAINS ?= srclib-go srclib-java srclib-typescript srclib-python srclib-basic srclib-javascript srclib-csharp srclib-css
 
-.PHONY: default build push pull $(TOOLCHAINS) clean
+.PHONY: default build $(TOOLCHAINS) clean
 
 default:
 	@echo "See README.md for instructions"

--- a/services/worker/plan/srclib_test.go
+++ b/services/worker/plan/srclib_test.go
@@ -1,7 +1,13 @@
 package plan
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -241,4 +247,93 @@ func config2yaml(c droneyaml.Config) string {
 		panic(err)
 	}
 	return string(b)
+}
+
+// TestImages_Version ensures we can parse all docker image names specified in
+// srclib_images.go
+func TestImages_Version(t *testing.T) {
+	for lang, b := range langSrclibConfigs {
+		image := b.Build.Container.Image
+		_, err := versionHash(image)
+		if err != nil {
+			t.Errorf("could not parse %s hash %#v: %s", lang, image, err)
+		}
+	}
+}
+
+// TestImages_Exists ensures each image specified in srclib_images.go exists
+// on the remote docker registry.
+func TestImages_Exists(t *testing.T) {
+	// We speak to an external service, so skip if we want short tests
+	if testing.Short() {
+		t.Skip("talks to external service (docker.io)")
+	}
+
+	wg := sync.WaitGroup{}
+	for lang, b := range langSrclibConfigs {
+		wg.Add(1)
+		go func(lang, image string) {
+			defer wg.Done()
+			v, err := getImageSchemaVersion(image)
+			if err != nil {
+				t.Logf("WARNING: %s - failed to get docker image version of %s: %s", lang, image, err)
+				return
+			}
+			if v == 0 {
+				t.Errorf("%s: could not find image %s", lang, image)
+			} else if v != 1 && strings.Contains(image, "@sha256:") {
+				t.Errorf("%s: docker image is specified using `sha256` tag, but image is not version 1. Image %s is using version %d. Please build the image and use a named tag, or build with docker 1.9", lang, image, v)
+			}
+		}(lang, b.Build.Container.Image)
+	}
+	wg.Wait()
+}
+
+func getImageSchemaVersion(image string) (int, error) {
+	parts := strings.SplitN(image, "@", 2)
+	if len(parts) < 2 {
+		parts = strings.SplitN(image, ":", 2)
+		if len(parts) < 2 {
+			return 0, fmt.Errorf("missing tag in image name %s", image)
+		}
+	}
+	name, tag := parts[0], parts[1]
+
+	token, err := getToken("registry.docker.io", "repository:"+name+":pull")
+	if err != nil {
+		return 0, err
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://index.docker.io/v2/%s/manifests/%s", name, tag), nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	m := struct {
+		SchemaVersion int `json:"schemaVersion"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&m)
+	return m.SchemaVersion, err
+}
+
+func getToken(service, scope string) (string, error) {
+	// We need to get a token
+	v := url.Values{}
+	v.Set("service", service)
+	v.Set("scope", scope)
+	resp, err := http.Get("https://auth.docker.io/token?" + v.Encode())
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	t := struct {
+		Token string `json:"token"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&t)
+	return t.Token, err
 }


### PR DESCRIPTION
In production we only support docker images which are v1. If you build an image
with docker v0.10 or higher, it breaks srclib in production. This commit adds a
test which speaks to the docker registry to ensure the image exists and is an
old enough version.

This was tested by using the image in ff1c35f6a9796e7117623848234ea96a10c4d4f3
which introduced a bad image. Also we manually modified a sha to be non-existant
to test 404.