### PR TITLE
use tags for versioning of srclib toolchain images

### DIFF
--- a/services/worker/dockerfiles/Makefile
+++ b/services/worker/dockerfiles/Makefile
@@ -11,15 +11,11 @@ default:
 
 build: $(TOOLCHAINS)
 
-push:
-	for t in $(TOOLCHAINS); do docker push sourcegraph/$$t; done;
-
-pull:
-	for t in $(TOOLCHAINS); do docker pull sourcegraph/$$t; done;
-
 $(TOOLCHAINS): srclib
 	@$(eval COMMIT = $(shell git ls-remote https://github.com/sourcegraph/$@ master | awk '{ print $$1 }'))
-	docker build --build-arg TOOLCHAIN_URL=https://github.com/sourcegraph/$@/tarball/${COMMIT} -t sourcegraph/$@ -f ./Dockerfile.$@ .
+	docker build --build-arg TOOLCHAIN_URL=https://github.com/sourcegraph/$@/tarball/${COMMIT} -t sourcegraph/$@:${COMMIT} -f ./Dockerfile.$@ .
+	docker push sourcegraph/$@:${COMMIT}
+	@echo Update the image in ../plan/srclib_images.go to sourcegraph/$@:${COMMIT}
 
 # Generates srclib binary
 srclib:

--- a/services/worker/dockerfiles/README.md
+++ b/services/worker/dockerfiles/README.md
@@ -12,13 +12,13 @@ Instructions for deploying srclib updates to Sourcegraph.com
 
 ```
 make clean && make srclib
-make build && make push
+make build
 ```
 
 If updating a single toolchain, run:
 
 ```
-TOOLCHAINS=$TOOLCHAIN_NAME make build && TOOLCHAINS=$TOOLCHAIN_NAME make push
+TOOLCHAINS=$TOOLCHAIN_NAME make build
 ```
 
 0. Update `srclib_images.go`.


### PR DESCRIPTION
This is to avoid a breaking change in docker that makes pulling images by digest fail in production, see https://docs.docker.com/engine/breaking_changes/.