### PR TITLE
add special case for the import path of the Kubernetes repo

### DIFF
--- a/services/worker/configure.go
+++ b/services/worker/configure.go
@@ -51,6 +51,12 @@ func configureBuild(ctx context.Context, build *sourcegraph.BuildJob) (*builder.
 		b.DroneYMLFileExists = true
 	}
 
+	// Virtual .drone.yml for Kubernetes repo
+	if repo.URI == "github.com/kubernetes/kubernetes" {
+		b.Payload.Yaml = "clone:\n  path: k8s.io/kubernetes"
+		b.DroneYMLFileExists = true
+	}
+
 	// Drone build
 	b.Payload.Build = &plugin.Build{
 		Commit: build.CommitID,


### PR DESCRIPTION
There is no information in the K8s repository to automatically derive the correct import path. This is why a manual special case is required.