### PR TITLE
Add 'from' keyword to javascript list of keywords

### DIFF
--- a/pkg/coverageutil/javascript.go
+++ b/pkg/coverageutil/javascript.go
@@ -241,7 +241,7 @@ var javascriptKeywords = map[string]bool{
 	"true":         true,
 	"false":        true,
 	"undefined":    true,
-        "from" :        true,
+	"from":         true,
 }
 
 // Initializes text scanner that extracts only idents

--- a/pkg/coverageutil/javascript.go
+++ b/pkg/coverageutil/javascript.go
@@ -241,6 +241,7 @@ var javascriptKeywords = map[string]bool{
 	"true":         true,
 	"false":        true,
 	"undefined":    true,
+        "from" :        true,
 }
 
 // Initializes text scanner that extracts only idents


### PR DESCRIPTION
In construction 'import' ... 'from' ... from plays role of keyword, was not previously included in the list of javascript keywords


