### PR TITLE
app/web_modules: Fix ineffective signed in check on about page.

### DIFF
--- a/app/web_modules/sourcegraph/page/AboutPage.js
+++ b/app/web_modules/sourcegraph/page/AboutPage.js
@@ -67,5 +67,8 @@ function AboutPage(props, {signedIn}): React$Element {
 		</div>
 	);
 }
+AboutPage.contextTypes = {
+	signedIn: React.PropTypes.bool,
+};
 
 export default CSSModules(AboutPage, styles);


### PR DESCRIPTION
This change enables `signedIn` to be set when rendering the about page. That page uses it to not display "Sign up with GitHub" buttons when the user is already signed in.

Currently, the about page always displays those because those `signedIn` is always `undefined`, no matter if the user is logged in or not:

![image](https://cloud.githubusercontent.com/assets/1924134/16354783/d427ee10-3a56-11e6-9944-5e14dfc5a18b.png)

![image](https://cloud.githubusercontent.com/assets/1924134/16354784/d67c32a2-3a56-11e6-81f2-acc91187f7a7.png)

Setting `AboutPage.contextTypes` seems to fix that. I got the idea from [the code for pricing page](https://github.com/sourcegraph/sourcegraph/blob/47f606ac15d644cc93623ffef9eb2e930b8952cd/app/web_modules/sourcegraph/page/PricingPage.js#L109-L112). However, I am not familiar with React's details enough to know if this is the best way.

##### Reviewer tasks

I am not familiar with React's details enough to know if this is the best and most correct fix, or if the issue should be resolved in another way.

- [x] REACT: reviewer approves this is the proper React way to fix this issue

##### Test plan

I tested this change locally while working on a feature branch. It resolved the bug. I've recreated this change from memory, however.


