### PR TITLE
Dealing with ports forwarding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ app-dep:
 	cd app && $(NPM_RUN_DEP)
 
 WEBPACK_DEV_SERVER_URL ?= http://localhost:8080
+PUBLIC_WEBPACK_DEV_SERVER_URL ?= $(WEBPACK_DEV_SERVER_URL)
+WEBPACK_DEV_SERVER_ADDR ?= 127.0.0.1
 SERVEFLAGS ?=
 serve-dev: serve-dep
 	@echo Starting server\; will recompile and restart when source files change
@@ -74,7 +76,7 @@ serve-dep:
 # the app itself).
 	@[ "$(SGXOS)" = "windows" ] || [ `ulimit -n` -ge 10000 ] || (echo "Error: Please increase the open file limit by running\n\n  ulimit -n 10000\n" 1>&2; exit 1)
 
-	@[ -n "$(WEBPACK_DEV_SERVER_URL)" ] && [ "$(WEBPACK_DEV_SERVER_URL)" != " " ] && (curl -Ss -o /dev/null "$(WEBPACK_DEV_SERVER_URL)" || (cd app && WEBPACK_DEV_SERVER_URL="$(WEBPACK_DEV_SERVER_URL)" npm start &)) || echo Serving bundled assets, not using Webpack.
+	@[ -n "$(WEBPACK_DEV_SERVER_URL)" ] && [ "$(WEBPACK_DEV_SERVER_URL)" != " " ] && (curl -Ss -o /dev/null "$(WEBPACK_DEV_SERVER_URL)" || (cd app && WEBPACK_DEV_SERVER_URL="$(WEBPACK_DEV_SERVER_URL)" PUBLIC_WEBPACK_DEV_SERVER_URL="$(PUBLIC_WEBPACK_DEV_SERVER_URL)" WEBPACK_DEV_SERVER_ADDR="$(WEBPACK_DEV_SERVER_ADDR)" npm start &)) || echo Serving bundled assets, not using Webpack.
 
 smoke: src
 	dropdb --if-exists src-smoke

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -62,10 +62,20 @@ if (useHot) {
 	);
 }
 
-const webpackDevServerPort = 8080;
+// port to listen
+var webpackDevServerPort = 8080;
 if (process.env.WEBPACK_DEV_SERVER_URL) {
 	webpackDevServerPort = url.parse(process.env.WEBPACK_DEV_SERVER_URL).port;
 }
+// address to listen on
+const webpackDevServerAddr = process.env.WEBPACK_DEV_SERVER_ADDR || "127.0.0.1";
+// public address of webpack dev server
+var publicWebpackDevServer = "localhost:8080";
+if (process.env.PUBLIC_WEBPACK_DEV_SERVER_URL) {
+	var uStruct = url.parse(process.env.PUBLIC_WEBPACK_DEV_SERVER_URL);
+	publicWebpackDevServer = uStruct.host;
+}
+
 
 module.exports = {
 	name: "browser",
@@ -102,6 +112,8 @@ module.exports = {
 	},
 	postcss: [require("postcss-modules-values"), autoprefixer({remove: false})],
 	devServer: {
+		host: webpackDevServerAddr,
+		public: publicWebpackDevServer,
 		port: webpackDevServerPort,
 		headers: {"Access-Control-Allow-Origin": "*"},
 		noInfo: true,
@@ -115,5 +127,5 @@ if (useHot) {
 	module.exports.entry.unshift("react-hot-loader/patch");
 }
 if (process.env.NODE_ENV !== "production") {
-	module.exports.entry.unshift(`webpack-dev-server/client?http://localhost:${webpackDevServerPort}`);
+	module.exports.entry.unshift(`webpack-dev-server/client?http://${publicWebpackDevServer}`);
 }


### PR DESCRIPTION
Introduced two optional environment variables:
-  `PUBLIC_WEBPACK_DEV_SERVER_URL` points to public address of webpack dev server (IP/HOST:PORT). If set, webpack server will still listen on address extracted from `WEBPACK_DEV_SERVER_URL` but will use `PUBLIC_WEBPACK_DEV_SERVER_URL` as a public one. If not set, webpack dev server will listen on `localhost:8080`
- `WEBPACK_DEV_SERVER_ADDR` webpack dev server bind IP address. If set, webpack dev server will bind to given IP, if not, default `127.0.0.1` will be used.

Default behavior is to leave them unset, however in the case when virtual box container maps public address `PUBLIC-NAME:PUBLIC-PORT` to virtual box's `LOCAL-IP:LOCAL-PORT` we may set:
- `PUBLIC_WEBPACK_DEV_SERVER_URL` to `PUBLIC-NAME:PUBLIC-PORT`
- `WEBPACK_DEV_SERVER_ADDR` to `0.0.0.0`

##### Reviewer tasks

@sqs Could you please run the app with my changes but without extra environment variables set  (default developer's config where server is running on `localhost:3080` with webpack dev server on `localhost:8080` ? I'd like to make sure I didn't break things.

