### PR TITLE
Fix non-determinism in search results

### DIFF
--- a/services/backend/internal/localstore/defs.go
+++ b/services/backend/internal/localstore/defs.go
@@ -332,31 +332,26 @@ func (s *defs) Search(ctx context.Context, op store.DefSearchOp) (*sourcegraph.S
 	var results []*sourcegraph.DefSearchResult
 	for _, d := range dbSearchResults {
 		// convert dbDef to Def
-		var def sourcegraph.Def
-		{
-			dk, err := getDefKey(ctx, graphDBH(ctx), d.DefKey)
-			if err != nil {
-				return nil, fmt.Errorf("error getting def key: %s", err)
-			}
-
-			rv, err := getRepoRev(ctx, graphDBH(ctx), d.Rev)
-			if err != nil {
-				return nil, fmt.Errorf("error getting repo revision repo_rev.id %d: %s", d.Rev, err)
-			}
-
-			def = sourcegraph.Def{
-				Def: graph.Def{
-					DefKey: graph.DefKey{
-						Repo:     dk.Repo,
-						CommitID: rv.Commit,
-						UnitType: dk.UnitType,
-						Unit:     dk.Unit,
-						Path:     dk.Path,
-					},
-					Name: d.Name,
-					Kind: d.Kind,
+		dk, err := getDefKey(ctx, graphDBH(ctx), d.DefKey)
+		if err != nil {
+			return nil, fmt.Errorf("error getting def key: %s", err)
+		}
+		rv, err := getRepoRev(ctx, graphDBH(ctx), d.Rev)
+		if err != nil {
+			return nil, fmt.Errorf("error getting repo revision repo_rev.id %d: %s", d.Rev, err)
+		}
+		def := sourcegraph.Def{
+			Def: graph.Def{
+				DefKey: graph.DefKey{
+					Repo:     dk.Repo,
+					CommitID: rv.Commit,
+					UnitType: dk.UnitType,
+					Unit:     dk.Unit,
+					Path:     dk.Path,
 				},
-			}
+				Name: d.Name,
+				Kind: d.Kind,
+			},
 		}
 
 		// Critical permissions check. DO NOT REMOVE.

--- a/services/backend/search_test.go
+++ b/services/backend/search_test.go
@@ -1,0 +1,109 @@
+package backend
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"sourcegraph.com/sourcegraph/sourcegraph/api/sourcegraph"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/store"
+	"sourcegraph.com/sourcegraph/srclib/graph"
+)
+
+// TestSearch tests the search endpoint with mocks for store.Defs (used to get
+// the definition IDs to return in search results) and Graph.Defs (used to fill
+// in the definition metadata for each result).
+func TestSearch(t *testing.T) {
+	const (
+		repoURI = "r1"
+		repoID  = 1
+	)
+
+	var s search
+	ctx, mock := testContext()
+
+	// Mock data
+	wantDefsKeys := []graph.DefKey{
+		{Repo: repoURI, CommitID: "c1", UnitType: "t1", Unit: "u1", Path: "p1"},
+		{Repo: repoURI, CommitID: "c1", UnitType: "t1", Unit: "u1", Path: "p2"},
+		{Repo: repoURI, CommitID: "c2", UnitType: "t2", Unit: "u2", Path: "p3"},
+	}
+	wantDefs := make([]*sourcegraph.Def, len(wantDefsKeys))
+	var (
+		calledDefGetMu sync.Mutex
+		calledDefGet   = make(map[graph.DefKey]bool)
+	)
+	for i, dk := range wantDefsKeys {
+		wantDefs[i] = &sourcegraph.Def{Def: graph.Def{DefKey: dk}}
+		calledDefGet[dk] = false
+	}
+	wantDefResults := make([]*sourcegraph.DefSearchResult, len(wantDefs))
+	for i, d := range wantDefs {
+		wantDefResults[i] = &sourcegraph.DefSearchResult{Def: *d, Score: 0, RefCount: 0}
+	}
+	wantResults := &sourcegraph.SearchResultsList{
+		DefResults:         wantDefResults,
+		SearchQueryOptions: []*sourcegraph.SearchOptions{{ListOptions: sourcegraph.ListOptions{}}},
+	}
+
+	query := "this is the test query"
+	expTokQuery := strings.Fields(query)
+
+	// Declare mocks
+	mock.servers.Defs.Get_ = func(ctx context.Context, op *sourcegraph.DefsGetOp) (*sourcegraph.Def, error) {
+		calledDefGetMu.Lock()
+		defer calledDefGetMu.Unlock()
+
+		if op.Def.Repo != repoID {
+			t.Fatalf("expected request for def from repo %d, got %d", repoID, op.Def.Repo)
+		}
+		// Mock fetch of defs (should be called to hydrate each def result)
+		for _, d := range wantDefs {
+			if d.CommitID == op.Def.CommitID && d.Unit == op.Def.Unit && d.UnitType == op.Def.UnitType && d.Path == op.Def.Path {
+				calledDefGet[graph.DefKey{Repo: repoURI, CommitID: d.CommitID, Unit: d.Unit, UnitType: d.UnitType, Path: d.Path}] = true
+				return d, nil
+			}
+		}
+		t.Fatalf("attempted to request unmocked def: %+v", op)
+		return nil, nil
+	}
+	mock.stores.Repos.GetByURI_ = func(ctx context.Context, repo string) (*sourcegraph.Repo, error) {
+		return &sourcegraph.Repo{URI: repo, ID: repoID}, nil
+	}
+
+	calledDefsSearch := false
+	mock.stores.Defs.Search_ = func(ctx context.Context, op store.DefSearchOp) (*sourcegraph.SearchResultsList, error) {
+		calledDefsSearch = true
+		if !reflect.DeepEqual(expTokQuery, op.TokQuery) {
+			t.Fatalf("expected op.TokQuery %+v, got %+v", expTokQuery, op.TokQuery)
+		}
+		return &sourcegraph.SearchResultsList{DefResults: wantDefResults}, nil
+	}
+
+	// Test that search endpoint works.
+	results, err := s.Search(ctx, &sourcegraph.SearchOp{
+		Query: query,
+		Opt:   &sourcegraph.SearchOptions{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from search.Search: %s", err)
+	}
+
+	// Test that backend stores were called
+	if !reflect.DeepEqual(wantResults, results) {
+		t.Errorf("wanted\n%+v, got\n%+v", wantResults, results)
+	}
+
+	if !calledDefsSearch {
+		t.Errorf("!calledDefsSearch")
+	}
+
+	for dk, calledGet := range calledDefGet {
+		if !calledGet {
+			t.Errorf("failed to call Graph.Defs.Get on def %+v", dk)
+		}
+	}
+}


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph-issues/issues/35.
Adds a unit test to the search service.

The issue before was that the srclib store `Defs.List` behavior was not as expected (it would list all definitions in the specified repository revisions, instead of fetching only the definitions that corresponded to the provided def keys). This switches the def "hydration" operation to use `Defs.Get` in parallel on all definition search results.