### PR TITLE
Include Logic to Throttle Password Attempts

### DIFF
--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -10,12 +10,12 @@ type Clock interface {
 
 type prodClock struct{}
 
-func (c *prodClock) Now() time.Time {
+func (c prodClock) Now() time.Time {
 	return time.Now()
 }
 
 // NewProductionClock creates a Clock that simply mirrors
 // time.Now()'s original behavior, with no additional logic.
 func NewProductionClock() Clock {
-	return &prodClock{}
+	return prodClock{}
 }

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -1,0 +1,21 @@
+package clock
+
+import "time"
+
+// Clock is an interface that provides an abstraction over time.Now() to
+// help you control it in certain contexts, such as testing.
+type Clock interface {
+	Now() time.Time
+}
+
+type prodClock struct{}
+
+func (c *prodClock) Now() time.Time {
+	return time.Now()
+}
+
+// NewProductionClock creates a Clock that simply mirrors
+// time.Now()'s original behavior, with no additional logic.
+func NewProductionClock() Clock {
+	return &prodClock{}
+}

--- a/services/backend/internal/localstore/accounts.go
+++ b/services/backend/internal/localstore/accounts.go
@@ -156,7 +156,7 @@ func (s *accounts) ResetPassword(ctx context.Context, newPass *sourcegraph.NewPa
 		return genericErr
 	}
 	log15.Info("Resetting password", "store", "Accounts", "UID", req.UID)
-	if err := (password{}).SetPassword(ctx, req.UID, newPass.Password); err != nil {
+	if err := newPassword().SetPassword(ctx, req.UID, newPass.Password); err != nil {
 		return fmt.Errorf("Error changing password: %s", err)
 	}
 

--- a/services/backend/internal/localstore/cli_config.go
+++ b/services/backend/internal/localstore/cli_config.go
@@ -23,7 +23,7 @@ func init() {
 		Defs:               &defs{},
 		GlobalDeps:         &globalDeps{},
 		GlobalRefs:         &globalRefs{},
-		Password:           &password{},
+		Password:           newPassword(),
 		Queue:              &middleware.InstrumentedQueue{Queue: &queue{}},
 		RepoConfigs:        &repoConfigs{},
 		RepoStatuses:       &repoStatuses{},

--- a/services/backend/internal/localstore/password.go
+++ b/services/backend/internal/localstore/password.go
@@ -45,7 +45,7 @@ func marshalPassword(ctx context.Context, UID int32) (dbPassword, error) {
 	return pass, appDBH(ctx).SelectOne(&pass, `SELECT * FROM passwords WHERE uid=$1`, UID)
 }
 
-// 5 - 5*3^n 0, 10, 40, ...
+// -5 + 5*3^n -> 0, 10, 40, ...
 func calcWaitPeriod(fails int) time.Duration {
 	return -5*time.Second + 5*time.Duration(math.Pow(3, float64(fails)))*time.Second
 }
@@ -53,7 +53,8 @@ func calcWaitPeriod(fails int) time.Duration {
 const maxWaitPeriod = 20 * time.Minute
 
 // CheckUIDPassword returns an error if the password argument is not correct for
-// the user.
+// the user, or if the waiting period before the user can try logging in again
+// has expired.
 func (p *password) CheckUIDPassword(ctx context.Context, UID int32, password string) error {
 	if err := accesscontrol.VerifyUserHasAdminAccess(ctx, "Password.CheckUIDPassword"); err != nil {
 		return err

--- a/services/backend/internal/localstore/password.go
+++ b/services/backend/internal/localstore/password.go
@@ -17,6 +17,9 @@ import (
 )
 
 // password is a pgsql backed implementation of the passwords store.
+// password uses the clock interface for testing purposes. Use the
+// newPassword() constructor in order to make a normal password instance
+// for production.
 type password struct {
 	clock clock.Clock
 }

--- a/services/backend/internal/localstore/password.go
+++ b/services/backend/internal/localstore/password.go
@@ -43,7 +43,7 @@ func init() {
 	AppSchema.Map.AddTableWithName(dbPassword{}, tableName).SetKeys(false, "UID")
 }
 
-func marshalPassword(ctx context.Context, UID int32) (dbPassword, error) {
+func unmarshalPassword(ctx context.Context, UID int32) (dbPassword, error) {
 	var pass dbPassword
 	err := appDBH(ctx).SelectOne(&pass, `SELECT * FROM passwords WHERE uid=$1`, UID)
 	return pass, err
@@ -73,7 +73,7 @@ func (p password) CheckUIDPassword(ctx context.Context, UID int32, password stri
 	}
 	genericErr := grpc.Errorf(codes.PermissionDenied, "password login not allowed for uid %d", UID)
 
-	pass, err := marshalPassword(ctx, UID)
+	pass, err := unmarshalPassword(ctx, UID)
 	if err == sql.ErrNoRows {
 		return genericErr // User doesn't exist
 	} else if err != nil {

--- a/services/backend/internal/localstore/password.go
+++ b/services/backend/internal/localstore/password.go
@@ -1,22 +1,37 @@
 package localstore
 
 import (
+	"database/sql"
+	"math"
+	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
+
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/clock"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/store"
 	"sourcegraph.com/sourcegraph/sourcegraph/services/backend/accesscontrol"
 )
 
 // password is a pgsql backed implementation of the passwords store.
-type password struct{}
+type password struct {
+	clock clock.Clock
+}
+
+func newPassword() *password {
+	return &password{clock: clock.NewProductionClock()}
+}
 
 var _ store.Password = (*password)(nil)
 
 type dbPassword struct {
-	UID            int32
-	HashedPassword []byte
+	UID              int32
+	HashedPassword   []byte
+	ConsecutiveFails int32     `db:"consecutive_fails"`
+	LastFail         time.Time `db:"last_fail"`
 }
 
 var tableName = "passwords"
@@ -25,25 +40,65 @@ func init() {
 	AppSchema.Map.AddTableWithName(dbPassword{}, tableName).SetKeys(false, "UID")
 }
 
+func marshalPassword(ctx context.Context, UID int32) (dbPassword, error) {
+	var pass dbPassword
+	return pass, appDBH(ctx).SelectOne(&pass, `SELECT * FROM passwords WHERE uid=$1`, UID)
+}
+
+// 5 - 5*3^n 0, 10, 40, ...
+func calcWaitPeriod(fails int) time.Duration {
+	return -5*time.Second + 5*time.Duration(math.Pow(3, float64(fails)))*time.Second
+}
+
+const maxWaitPeriod = 20 * time.Minute
+
 // CheckUIDPassword returns an error if the password argument is not correct for
 // the user.
-func (p password) CheckUIDPassword(ctx context.Context, UID int32, password string) error {
+func (p *password) CheckUIDPassword(ctx context.Context, UID int32, password string) error {
 	if err := accesscontrol.VerifyUserHasAdminAccess(ctx, "Password.CheckUIDPassword"); err != nil {
 		return err
 	}
-	hashed, err := appDBH(ctx).SelectStr("SELECT hashedpassword FROM passwords WHERE uid=$1;", UID)
-	if err != nil {
+	genericErr := grpc.Errorf(codes.PermissionDenied, "password login not allowed for uid %d", UID)
+
+	pass, err := marshalPassword(ctx, UID)
+	if err == sql.ErrNoRows {
+		return genericErr // User doesn't exist
+	} else if err != nil {
 		return err
 	}
-	if hashed == "" {
-		// Either the user has no password (and can only log in via
-		// GitHub OAuth2, etc.) or the user does not exist.
-		return grpc.Errorf(codes.PermissionDenied, "password login not allowed for uid %d", UID)
+
+	waitPeriod := calcWaitPeriod(int(pass.ConsecutiveFails))
+
+	if waitPeriod > maxWaitPeriod {
+		waitPeriod = maxWaitPeriod
+		log15.Warn("SECURITY: Maximum wait period for password attempt reached", "uid", UID, "waitPeriod", maxWaitPeriod)
 	}
-	return bcrypt.CompareHashAndPassword([]byte(hashed), []byte(password))
+	// Has it been over waitPeriod since their last failure?
+	if pass.LastFail.Add(waitPeriod).After(p.clock.Now()) {
+		return grpc.Errorf(codes.PermissionDenied, "must wait for %s before trying again", waitPeriod.String())
+	}
+
+	if len(pass.HashedPassword) == 0 {
+		// User has no password (and can only log in via
+		// GitHub OAuth2, etc.)
+		return genericErr
+	}
+
+	cmpRes := bcrypt.CompareHashAndPassword([]byte(pass.HashedPassword), []byte(password))
+	if cmpRes == bcrypt.ErrMismatchedHashAndPassword {
+		pass.ConsecutiveFails++
+		pass.LastFail = p.clock.Now()
+	} else if cmpRes == nil {
+		pass.ConsecutiveFails = 0
+	}
+	_, err = appDBH(ctx).Update(&pass)
+	if err != nil {
+		log15.Warn("Error when trying to update password failure information", "uid", UID, "error", err)
+	}
+	return cmpRes
 }
 
-func (p password) SetPassword(ctx context.Context, uid int32, password string) error {
+func (p *password) SetPassword(ctx context.Context, uid int32, password string) error {
 	if err := accesscontrol.VerifyUserSelfOrAdmin(ctx, "Password.SetPassword", uid); err != nil {
 		return err
 	}
@@ -62,9 +117,9 @@ func (p password) SetPassword(ctx context.Context, uid int32, password string) e
 
 	query := `
 WITH upsert AS (
-  UPDATE passwords SET hashedpassword=$2 WHERE uid=$1 RETURNING *
+  UPDATE passwords SET hashedpassword=$2, consecutive_fails=$3, last_fail=$4 WHERE uid=$1 RETURNING *
 )
-INSERT INTO passwords(uid, hashedpassword) SELECT $1, $2 WHERE NOT EXISTS (SELECT * FROM upsert);`
-	_, err = appDBH(ctx).Exec(query, uid, hashed)
+INSERT INTO passwords(uid, hashedpassword, consecutive_fails, last_fail) SELECT $1, $2, $3, $4 WHERE NOT EXISTS (SELECT * FROM upsert);`
+	_, err = appDBH(ctx).Exec(query, uid, hashed, 0, p.clock.Now())
 	return err
 }

--- a/services/backend/internal/localstore/password_test.go
+++ b/services/backend/internal/localstore/password_test.go
@@ -53,7 +53,7 @@ func TestPasswords_CheckUIDPassword_invalid(t *testing.T) {
 	if err := s.SetPassword(ctx, uid, "p"); err != nil {
 		t.Fatal(err)
 	}
-	oldDBPass, err := marshalPassword(ctx, uid)
+	oldDBPass, err := unmarshalPassword(ctx, uid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestPasswords_CheckUIDPassword_invalid(t *testing.T) {
 		t.Fatal("err == nil")
 	}
 
-	newDBPass, err := marshalPassword(ctx, uid)
+	newDBPass, err := unmarshalPassword(ctx, uid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestPasswords_SetPassword_ok(t *testing.T) {
 	}
 
 	// Change to p2.
-	oldPass, err := marshalPassword(ctx, uid)
+	oldPass, err := unmarshalPassword(ctx, uid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestPasswords_SetPassword_ok(t *testing.T) {
 	if err := s.SetPassword(ctx, uid, "p2"); err != nil {
 		t.Fatal(err)
 	}
-	newPass, err := marshalPassword(ctx, uid)
+	newPass, err := unmarshalPassword(ctx, uid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +273,7 @@ func TestPasswords_CheckUIDPassword_WaitPeriod(t *testing.T) {
 	// before returning the result of that 'pw' check.
 	var checkAndRestore = func(pw string, consecFails int, time time.Time) error {
 		checkErr := s.CheckUIDPassword(ctx, uid, pw)
-		pass, err := marshalPassword(ctx, uid)
+		pass, err := unmarshalPassword(ctx, uid)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/services/backend/internal/localstore/password_test.go
+++ b/services/backend/internal/localstore/password_test.go
@@ -1,7 +1,6 @@
 package localstore
 
 import (
-	"log"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -168,7 +167,7 @@ func TestPasswords_SetPassword_ok(t *testing.T) {
 	// Change to p2.
 	oldPass, err := marshalPassword(ctx, uid)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	if err := s.SetPassword(ctx, uid, "p2"); err != nil {
@@ -176,10 +175,10 @@ func TestPasswords_SetPassword_ok(t *testing.T) {
 	}
 	newPass, err := marshalPassword(ctx, uid)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	if newPass.ConsecutiveFails != 0 || !newPass.LastFail.After(oldPass.LastFail) {
-		log.Fatalf("the password should be completely reset after the password is reset - old: %+v, new: %+v", oldPass, newPass)
+		t.Fatalf("the password should be completely reset after the password is reset - old: %+v, new: %+v", oldPass, newPass)
 	}
 	if err := s.CheckUIDPassword(ctx, uid, "p2"); err != nil {
 		t.Fatal(err)

--- a/services/backend/internal/localstore/password_test.go
+++ b/services/backend/internal/localstore/password_test.go
@@ -276,7 +276,7 @@ func TestPasswords_CheckUIDPassword_WaitPeriod(t *testing.T) {
 		pass.LastFail = time
 		_, err = appDBH(ctx).Update(&pass)
 		if err != nil {
-			t.Fatalf("Error when restoring time: ", err)
+			t.Fatalf("error when restoring time: ", err)
 		}
 		return checkErr
 	}
@@ -298,7 +298,6 @@ func TestPasswords_CheckUIDPassword_WaitPeriod(t *testing.T) {
 		if err := checkAndRestore("p", i, now); err == nil {
 			t.Fatal("should reject even the correct password when not enough time has passed in between attempts (before)")
 		}
-
 		// ON THE NOSE
 		tc.nextTime = now
 		if err := checkAndRestore("WRONG", i, now); err == nil {
@@ -307,15 +306,13 @@ func TestPasswords_CheckUIDPassword_WaitPeriod(t *testing.T) {
 		if err := checkAndRestore("p", i, now); err == nil {
 			t.Fatal("should reject even the correct password when not enough time has passed in between attempts (on the nose)")
 		}
-
 		// AFTER
 		tc.nextTime = next
 		if err := checkAndRestore("WRONG", i, now); err == nil {
 			t.Fatal("should always reject an incorrect password, no matter what time it is (after)")
 		}
 		if err := checkAndRestore("p", i+1, next); err != nil {
-			t.Fatalf("should accept the correct password when enough time has passed (after), err: ", err)
+			t.Fatalf("got err: %s, should accept the correct password when enough time has passed (after)", err)
 		}
 	}
-
 }


### PR DESCRIPTION
New SQL, don't merge until this is applied: 

```sql
ALTER TABLE passwords ADD COLUMN consecutive_fails int;
ALTER TABLE passwords ADD COLUMN last_fail timestamp;
UPDATE passwords SET consecutive_fails = 0, last_fail = now();
ALTER TABLE passwords ALTER COLUMN last_fail SET NOT NULL;
ALTER TABLE passwords ALTER COLUMN consecutive_fails SET NOT NULL;
```

I will squash merge. 