### PR TITLE
Grouped PR for email reset token changes and password brute-forcing changes 

### DIFF
--- a/pkg/amortize/amortize_helper.go
+++ b/pkg/amortize/amortize_helper.go
@@ -1,0 +1,25 @@
+package amortize
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+// ShouldAmortize is a non-deterministic function that returns true 'a' out of
+// every 'b' times on average. ShouldAmortize panics if a > b, or if either a
+// or b is not positive.
+func ShouldAmortize(a, b int) bool {
+	if a <= 0 || b <= 0 {
+		panic("a and b must be positive")
+	}
+	if a > b {
+		panic("a must be <= b")
+	}
+
+	bigN, err := rand.Int(rand.Reader, big.NewInt(int64(b)))
+	if err != nil {
+		panic(fmt.Sprintf("error when trying to generate a random number: %s", err))
+	}
+	return bigN.Int64() < int64(a)
+}

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -1,0 +1,21 @@
+package clock
+
+import "time"
+
+// Clock is an interface that provides an abstraction over time.Now() to
+// help you control it in certain contexts, such as testing.
+type Clock interface {
+	Now() time.Time
+}
+
+type prodClock struct{}
+
+func (c prodClock) Now() time.Time {
+	return time.Now()
+}
+
+// NewProductionClock creates a Clock that simply mirrors
+// time.Now()'s original behavior, with no additional logic.
+func NewProductionClock() Clock {
+	return prodClock{}
+}

--- a/services/backend/internal/localstore/accounts.go
+++ b/services/backend/internal/localstore/accounts.go
@@ -173,11 +173,12 @@ func (s *accounts) ResetPassword(ctx context.Context, newPass *sourcegraph.NewPa
 	} else if err != nil {
 		return genericErr
 	}
+
 	// We round to the microsecond because that is the maximum resolution
 	// allowed by our DB.
 	if time.Now().Round(time.Microsecond).Before(req.ExpiresAt.Round(time.Microsecond)) {
 		log15.Info("Resetting password", "store", "Accounts", "UID", req.UID)
-		if err := (password{}).SetPassword(ctx, req.UID, newPass.Password); err != nil {
+		if err := newPassword().SetPassword(ctx, req.UID, newPass.Password); err != nil {
 			return fmt.Errorf("error changing password: %s", err)
 		}
 		// This changes the expiry date to some point in the past.

--- a/services/backend/internal/localstore/cli_config.go
+++ b/services/backend/internal/localstore/cli_config.go
@@ -23,7 +23,7 @@ func init() {
 		Defs:               &defs{},
 		GlobalDeps:         &globalDeps{},
 		GlobalRefs:         &globalRefs{},
-		Password:           &password{},
+		Password:           newPassword(),
 		Queue:              &middleware.InstrumentedQueue{Queue: &queue{}},
 		RepoConfigs:        &repoConfigs{},
 		RepoStatuses:       &repoStatuses{},

--- a/services/backend/internal/localstore/password.go
+++ b/services/backend/internal/localstore/password.go
@@ -1,22 +1,40 @@
 package localstore
 
 import (
+	"database/sql"
+	"math"
+	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
+
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/clock"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/store"
 	"sourcegraph.com/sourcegraph/sourcegraph/services/backend/accesscontrol"
 )
 
 // password is a pgsql backed implementation of the passwords store.
-type password struct{}
+// password uses the clock interface for testing purposes. Use the
+// newPassword() constructor in order to make a normal password instance
+// for production.
+type password struct {
+	clock clock.Clock
+}
+
+func newPassword() *password {
+	return &password{clock: clock.NewProductionClock()}
+}
 
 var _ store.Password = (*password)(nil)
 
 type dbPassword struct {
-	UID            int32
-	HashedPassword []byte
+	UID              int32
+	HashedPassword   []byte
+	ConsecutiveFails int32     `db:"consecutive_fails"`
+	LastFail         time.Time `db:"last_fail"`
 }
 
 var tableName = "passwords"
@@ -25,22 +43,78 @@ func init() {
 	AppSchema.Map.AddTableWithName(dbPassword{}, tableName).SetKeys(false, "UID")
 }
 
+func unmarshalPassword(ctx context.Context, UID int32) (dbPassword, error) {
+	var pass dbPassword
+	err := appDBH(ctx).SelectOne(&pass, `SELECT * FROM passwords WHERE uid=$1`, UID)
+	return pass, err
+}
+
+// calcWaitPeriod calculates how long someone should wait in between login attempts given that
+// that they have failed 'fails' time in a row previously. If "fails" is zero, the duration is
+// guaranteed to be 0 as well. Fails must be >= 0.
+// Based off of recommendations from: https://www.owasp.org/index.php/Guide_to_Authentication#Thresholds_Governor
+func calcWaitPeriod(fails int) time.Duration {
+	if fails < 0 {
+		panic("fails must be non-negative")
+	}
+	// The formula currently is: -5 + 5*3^(n/3) -> 0s, ~2s, ~5.4s, 10s, ~16.6s, ~26s, 40s, ...
+	return -5*time.Second + 5*time.Duration(math.Pow(3, float64(fails)/3))*time.Second
+}
+
+// As recommeded by: https://www.owasp.org/index.php/Authentication_Cheat_Sheet#Prevent_Brute-Force_Attacks
+const maxWaitPeriod = 20 * time.Minute
+
 // CheckUIDPassword returns an error if the password argument is not correct for
-// the user.
+// the user, or if the waiting period before the user can try logging in again
+// has expired.
 func (p password) CheckUIDPassword(ctx context.Context, UID int32, password string) error {
 	if err := accesscontrol.VerifyUserHasAdminAccess(ctx, "Password.CheckUIDPassword"); err != nil {
 		return err
 	}
-	hashed, err := appDBH(ctx).SelectStr("SELECT hashedpassword FROM passwords WHERE uid=$1;", UID)
-	if err != nil {
+	genericErr := grpc.Errorf(codes.PermissionDenied, "password login not allowed for uid %d", UID)
+
+	pass, err := unmarshalPassword(ctx, UID)
+	if err == sql.ErrNoRows {
+		return genericErr // User doesn't exist
+	} else if err != nil {
 		return err
 	}
-	if hashed == "" {
-		// Either the user has no password (and can only log in via
-		// GitHub OAuth2, etc.) or the user does not exist.
-		return grpc.Errorf(codes.PermissionDenied, "password login not allowed for uid %d", UID)
+
+	waitPeriod := calcWaitPeriod(int(pass.ConsecutiveFails))
+
+	if waitPeriod > maxWaitPeriod {
+		waitPeriod = maxWaitPeriod
+		log15.Warn("SECURITY: Maximum wait period for password attempt reached", "uid", UID, "waitPeriod", maxWaitPeriod)
 	}
-	return bcrypt.CompareHashAndPassword([]byte(hashed), []byte(password))
+
+	// Has the user waited long enough (waitPeriod) since their last failure?
+	// We round to the microsecond because that is the highest resolution that Postgres offers
+	// for the timestamp data type.
+	now := p.clock.Now().Round(1 * time.Microsecond)
+	if !pass.LastFail.Add(waitPeriod).Round(1 * time.Microsecond).Before(now) {
+		return grpc.Errorf(codes.PermissionDenied, "must wait for %s before trying again", waitPeriod.String())
+	}
+
+	if len(pass.HashedPassword) == 0 {
+		// User has no password (and can only log in via
+		// GitHub OAuth2, etc.)
+		return genericErr
+	}
+
+	cmpRes := bcrypt.CompareHashAndPassword([]byte(pass.HashedPassword), []byte(password))
+	if cmpRes == bcrypt.ErrMismatchedHashAndPassword {
+		// Wrong password - update the failure information
+		pass.ConsecutiveFails++
+		pass.LastFail = now
+	} else if cmpRes == nil {
+		// Correct password - reset the failure count
+		pass.ConsecutiveFails = 0
+	}
+	_, err = appDBH(ctx).Update(&pass)
+	if err != nil {
+		log15.Warn("Error when trying to update password failure information", "uid", UID, "error", err)
+	}
+	return cmpRes
 }
 
 func (p password) SetPassword(ctx context.Context, uid int32, password string) error {
@@ -62,9 +136,9 @@ func (p password) SetPassword(ctx context.Context, uid int32, password string) e
 
 	query := `
 WITH upsert AS (
-  UPDATE passwords SET hashedpassword=$2 WHERE uid=$1 RETURNING *
+  UPDATE passwords SET hashedpassword=$2, consecutive_fails=$3, last_fail=$4 WHERE uid=$1 RETURNING *
 )
-INSERT INTO passwords(uid, hashedpassword) SELECT $1, $2 WHERE NOT EXISTS (SELECT * FROM upsert);`
-	_, err = appDBH(ctx).Exec(query, uid, hashed)
+INSERT INTO passwords(uid, hashedpassword, consecutive_fails, last_fail) SELECT $1, $2, $3, $4 WHERE NOT EXISTS (SELECT * FROM upsert);`
+	_, err = appDBH(ctx).Exec(query, uid, hashed, 0, p.clock.Now())
 	return err
 }

--- a/services/backend/internal/localstore/password_test.go
+++ b/services/backend/internal/localstore/password_test.go
@@ -3,6 +3,7 @@ package localstore
 import (
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 var testUID int32
@@ -25,7 +26,7 @@ func TestPasswords_CheckUIDPassword_valid(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.SetPassword(ctx, uid, "p"); err != nil {
 		t.Fatal(err)
@@ -47,14 +48,31 @@ func TestPasswords_CheckUIDPassword_invalid(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.SetPassword(ctx, uid, "p"); err != nil {
+		t.Fatal(err)
+	}
+	oldDBPass, err := unmarshalPassword(ctx, uid)
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	if err := s.CheckUIDPassword(ctx, uid, "WRONG"); err == nil {
 		t.Fatal("err == nil")
+	}
+
+	newDBPass, err := unmarshalPassword(ctx, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !newDBPass.LastFail.After(oldDBPass.LastFail) {
+		t.Errorf("password's last_fail field not updated - old: %s, new: %s", oldDBPass.LastFail.String(), newDBPass.LastFail.String())
+	}
+
+	if oldDBPass.ConsecutiveFails+1 != newDBPass.ConsecutiveFails {
+		t.Errorf("password's consecutive_fails field not incremented - old: %d, new: %d", oldDBPass.ConsecutiveFails, newDBPass.ConsecutiveFails)
 	}
 }
 
@@ -69,7 +87,7 @@ func TestPasswords_CheckUIDPassword_empty(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.SetPassword(ctx, uid, "p"); err != nil {
 		t.Fatal(err)
@@ -91,7 +109,7 @@ func TestPasswords_CheckUIDPassword_noneSet(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.CheckUIDPassword(ctx, uid, "p"); err == nil {
 		t.Fatal("err == nil")
@@ -110,7 +128,7 @@ func TestPasswords_CheckUIDPassword_noneSetForUser(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.SetPassword(ctx, uid, "p"); err != nil {
 		t.Fatal(err)
@@ -132,7 +150,7 @@ func TestPasswords_SetPassword_ok(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.SetPassword(ctx, uid, "p"); err != nil {
 		t.Fatal(err)
@@ -147,8 +165,20 @@ func TestPasswords_SetPassword_ok(t *testing.T) {
 	}
 
 	// Change to p2.
+	oldPass, err := unmarshalPassword(ctx, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if err := s.SetPassword(ctx, uid, "p2"); err != nil {
 		t.Fatal(err)
+	}
+	newPass, err := unmarshalPassword(ctx, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newPass.ConsecutiveFails != 0 || !newPass.LastFail.After(oldPass.LastFail) {
+		t.Fatalf("the password should be completely reset after the password is reset - old: %+v, new: %+v", oldPass, newPass)
 	}
 	if err := s.CheckUIDPassword(ctx, uid, "p2"); err != nil {
 		t.Fatal(err)
@@ -169,7 +199,7 @@ func TestPasswords_SetPassword_empty(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.SetPassword(ctx, uid, ""); err != nil {
 		t.Fatal(err)
@@ -192,7 +222,7 @@ func TestPasswords_SetPassword_setToEmpty(t *testing.T) {
 	ctx, _, done := testContext()
 	defer done()
 
-	s := &password{}
+	s := newPassword()
 	uid := nextUID()
 	if err := s.SetPassword(ctx, uid, "p"); err != nil {
 		t.Fatal(err)
@@ -209,5 +239,86 @@ func TestPasswords_SetPassword_setToEmpty(t *testing.T) {
 	}
 	if err := s.CheckUIDPassword(ctx, uid, ""); err == nil {
 		t.Fatal("err == nil")
+	}
+}
+
+// testClock gives us the ability to inject whatever we want
+// for the next time Now() is called.
+type testClock struct {
+	nextTime time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	return c.nextTime
+}
+
+// TestPasswords_CheckUIDPassword_WaitPeriod tests to see if the waiting periods in between password
+// retries is properly enforced.
+func TestPasswords_CheckUIDPassword_WaitPeriod(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+	ctx, _, done := testContext()
+	defer done()
+
+	tc := &testClock{nextTime: time.Now()}
+	s := &password{clock: tc}
+	uid := nextUID()
+
+	// checkAndRestore is a lambda helper function with a closure containing this test's context
+	// and uid. It checks the given password 'pw' against uid's stored password
+	// with CheckUIDPassword(), and restores uid's consecutive_fails and last_fail values
+	// before returning the result of that 'pw' check.
+	var checkAndRestore = func(pw string, consecFails int, time time.Time) error {
+		checkErr := s.CheckUIDPassword(ctx, uid, pw)
+		pass, err := unmarshalPassword(ctx, uid)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		pass.ConsecutiveFails = int32(consecFails)
+		pass.LastFail = time
+		_, err = appDBH(ctx).Update(&pass)
+		if err != nil {
+			t.Fatalf("error: %v  when restoring consecutive_fails and fail_time for uid: %d: ", err, uid)
+		}
+		return checkErr
+	}
+
+	if err := s.SetPassword(ctx, uid, "p"); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 1; calcWaitPeriod(i) < maxWaitPeriod; i++ {
+		before := tc.nextTime.Add(-calcWaitPeriod(i - 1))
+		now := tc.nextTime
+		next := tc.nextTime.Add(calcWaitPeriod(i + 1))
+
+		// Before - Current system time is set to a value well before the user should be allowed a login attempt.
+		tc.nextTime = before
+		if err := checkAndRestore("WRONG", i, now); err == nil {
+			t.Fatal("should always reject an incorrect password, no matter what time it is (before)")
+		}
+		if err := checkAndRestore("p", i, now); err == nil {
+			t.Fatal("should reject even the correct password when not enough time has passed in between attempts (before)")
+		}
+		// On the nose - Current system time is set to a value that is right on the threshold, immediately after which the user should be
+		// allowed a login attempt.
+		tc.nextTime = now
+		if err := checkAndRestore("WRONG", i, now); err == nil {
+			t.Fatal("should always reject an incorrect password, no matter what time it is (on the nose)")
+		}
+		if err := checkAndRestore("p", i, now); err == nil {
+			t.Fatal("should reject even the correct password when not enough time has passed in between attempts (on the nose)")
+		}
+		// After - Current system time is set to a value well after the user should be allowed a login attempt.
+		tc.nextTime = next
+		if err := checkAndRestore("WRONG", i, now); err == nil {
+			t.Fatal("should always reject an incorrect password, no matter what time it is (after)")
+		}
+		if err := checkAndRestore("p", i+1, next); err != nil {
+			t.Fatalf("got err: %s, should accept the correct password when enough time has passed (after)", err)
+		}
 	}
 }


### PR DESCRIPTION
New SQL: 

Email Tokens
```sql
ALTER TABLE password_reset_requests ADD COLUMN expires_at timestamp;
UPDATE password_reset_requests SET expires_at = now() + '4 hours';
ALTER TABLE password_reset_requests ALTER COLUMN expires_at SET NOT NULL;
```

Password Throttling
```sql
ALTER TABLE passwords ADD COLUMN consecutive_fails int;
ALTER TABLE passwords ADD COLUMN last_fail timestamp;
UPDATE passwords SET consecutive_fails = 0, last_fail = now();
ALTER TABLE passwords ALTER COLUMN last_fail SET NOT NULL;
ALTER TABLE passwords ALTER COLUMN consecutive_fails SET NOT NULL;
```

New table for storing blacklisted session tokens
Note: As this code change is the critical path it's being pushed separate from the ddl change
          so it can be rolled back easily in the event of issues.

```sql


-- Session blacklist
CREATE TABLE blacklisted_session_token
(
    uid integer NOT NULL,
    token text NOT NULL,
    blacklist_util timestamp NOT NULL
)
WITH (
    OIDS = FALSE
);
ALTER TABLE blacklisted_session_token OWNER TO sg;

-- Index: blacklisted_session_token_idx

-- DROP INDEX blacklisted_session_token_idx;

CREATE INDEX blacklisted_session_token_idx
    ON blacklisted_session_token USING btree
    (uid DESC, token);

CREATE INDEX blacklisted_session_blacklist_until_idx
    ON blacklisted_session_token USING btree
    (blacklist_util DESC NULLS LAST);


```