### PR TITLE
metrics: Measure number of running grpc requests

### DIFF
--- a/cli/internal/middleware/metric.go
+++ b/cli/internal/middleware/metric.go
@@ -1,10 +1,14 @@
 package middleware
 
 import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/oauth2"
 	"gopkg.in/inconshreveable/log15.v2"
-	"net/http"
 	"sourcegraph.com/sourcegraph/sourcegraph/api/sourcegraph"
 	appauth "sourcegraph.com/sourcegraph/sourcegraph/app/auth"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/auth/accesstoken"
@@ -13,9 +17,6 @@ import (
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/repotrackutil"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/statsutil"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/traceutil"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var metricLabels = []string{"route", "method", "code", "repo"}
@@ -90,7 +91,7 @@ func Metrics(next http.Handler) http.Handler {
 		requestDuration.With(labels).Observe(duration.Seconds())
 		requestHeartbeat.With(labels).Set(float64(time.Now().Unix()))
 
-		log15.Debug("TRACE HTTP", "method", r.Method, "URL", r.URL.String(), "routename", name, "spanID", traceutil.SpanID(r), "code", code, "RemoteAddr", r.RemoteAddr, "UserAgent", r.UserAgent(), "uid", uid, "duration", duration, "session", sessionID)
+		log15.Debug("TRACE HTTP", "method", r.Method, "URL", r.URL.String(), "routename", name, "spanID", traceutil.SpanID(r), "code", code, "RemoteAddr", r.RemoteAddr, "UserAgent", r.UserAgent(), "uid", uid, "session", sessionID, "duration", duration)
 	})
 }
 


### PR DESCRIPTION
Also removed the heartbeat, we never use it. This should help us in future when
we have a deadlock, and also help us understand long running grpc methods
better.