### PR TITLE
ci: Remove verbose flag from go test

### DIFF
--- a/dev/circle-ci-run-tests.sh
+++ b/dev/circle-ci-run-tests.sh
@@ -33,7 +33,7 @@ for pkg in $(go list -f '{{ if or (gt (len .TestGoFiles) 0) (gt (len .XTestGoFil
 		then
 			echo "Run test with coverage for package: $pkg"
 			go install -race ./cmd/src
-			go test -race -v -timeout 5m -coverprofile=/tmp/cover.$i.out "$pkg" | tee /tmp/go-test.out
+			go test -race -timeout 5m -coverprofile=/tmp/cover.$i.out "$pkg" | tee /tmp/go-test.out
 			go-junit-report < /tmp/go-test.out >> $CIRCLE_TEST_REPORTS/junit/go-test.xml
 			covered+=("$pkg")
 		else

--- a/pkg/testutil/repo_helpers.go
+++ b/pkg/testutil/repo_helpers.go
@@ -229,10 +229,6 @@ func prepGitCommand(cmd *exec.Cmd) *exec.Cmd {
 func logCmdOutut(t *testing.T, cmd *exec.Cmd, out []byte) {
 	t.Logf(">>> START - %s", strings.Join(cmd.Args, " "))
 	t.Logf("=== ENV - %v", cmd.Env)
-	if testing.Verbose() {
-		t.Log(string(out))
-	} else {
-		t.Log(`=== (run with "go test -v" to see full command output)`)
-	}
+	t.Log(string(out))
 	t.Logf(">>> END - %s", strings.Join(cmd.Args, " "))
 }


### PR DESCRIPTION
If we have a failure it is hard to find out what it is.
Some tests also include a lot of verbose output if `-v` is specified. If we need
it, we can run the test locally.