### PR TITLE
app: fix fatal flaw in Beta signup page (languages and editors fields flipped)

### DIFF
--- a/app/web_modules/sourcegraph/home/BetaInterestForm.js
+++ b/app/web_modules/sourcegraph/home/BetaInterestForm.js
@@ -75,8 +75,8 @@ class BetaInterestForm extends React.Component {
 			this._email["value"].trim(),
 			firstName || "",
 			lastName || "",
-			this._editors.selected(),
 			this._languages.selected(),
+			this._editors.selected(),
 			this._message["value"].trim(),
 		));
 


### PR DESCRIPTION
Prior to this change the Language and Editor fields were accidentally swapped (only for the `/beta` page, which AFAIK nobody has yet signed up through /cc @uforic).

##### Reviewer tasks

Not much, mostly sent for posterity.

##### Test plan

Manually tested and confirmed in Mailchimp:

![image](https://cloud.githubusercontent.com/assets/3173176/16531991/0de4bdae-3f84-11e6-8bcd-efec26e3ae80.png)
