### PR TITLE
Hotfix for graphdb update refcount slowdown

### DIFF
--- a/app/web_modules/sourcegraph/search/GlobalSearch.js
+++ b/app/web_modules/sourcegraph/search/GlobalSearch.js
@@ -65,7 +65,7 @@ class GlobalSearch extends Container {
 		this.state = {
 			query: "",
 			repo: null,
-			matchingResults: {Repos: [], Defs: [], Options: []},
+			matchingResults: {Repos: [], Defs: [], Options: [], outstandingFetches: 0},
 			className: null,
 			resultClassName: null,
 			selectionIndex: -1,
@@ -91,6 +91,7 @@ class GlobalSearch extends Container {
 			Repos: Array<Repo>,
 			Defs: Array<Def>,
 			Options: Array<Options>,
+			outstandingFetches: number,
 		};
 		selectionIndex: number;
 

--- a/services/backend/internal/localstore/defs.go
+++ b/services/backend/internal/localstore/defs.go
@@ -740,19 +740,27 @@ FROM (
 // referencing defs in the latest built revision of the specified repository
 // (repo).
 func (s *defs) UpdateRefCounts(ctx context.Context, repo string) error {
-	if err := accesscontrol.VerifyUserHasWriteAccess(ctx, "Defs.UpdateRefCounts", repo); err != nil {
-		return err
-	}
 
-	rr, err := getRepoRevLatest(graphDBH(ctx), repo)
-	if err != nil {
-		return err
-	}
-
-	if _, err := graphDBH(ctx).Exec(updateRefCountSQL, rr.ID, rr.Repo); err != nil {
-		return err
-	}
+	// TODO(sjl) per Beyang, hotfix disabling this update until we can identify a fix for deadlocks
+	// I attempted to create a ts_vector index on global_refs_new.repo, but it didn't improve performance
+	// https://app.asana.com/0/87040567695724/150990295471745
 	return nil
+
+	/*
+		if err := accesscontrol.VerifyUserHasWriteAccess(ctx, "Defs.UpdateRefCounts", repo); err != nil {
+			return err
+		}
+
+		rr, err := getRepoRevLatest(graphDBH(ctx), repo)
+		if err != nil {
+			return err
+		}
+
+		if _, err := graphDBH(ctx).Exec(updateRefCountSQL, rr.ID, rr.Repo); err != nil {
+			return err
+		}
+		return nil
+	*/
 }
 
 func getDefKey(ctx context.Context, dbh gorp.SqlExecutor, id int64) (*dbDefKey, error) {


### PR DESCRIPTION
Temporarily disabling refcount calculation in graphdb until an alternative query that doesn't perform such a large scan.  See https://app.asana.com/0/87040567695724/150990295471745 for more info. 

