### PR TITLE
builds: Add JS to must succeed list

### DIFF
--- a/services/worker/plan/srclib.go
+++ b/services/worker/plan/srclib.go
@@ -91,10 +91,11 @@ const mustSucceedLangThreshold = 0.33
 // mustSucceedLangs are languages for which srclib must succeed if their
 // proportion of code bytes in a repository exceeds mustSucceedLangThreshold.
 var mustSucceedLangs = map[string]struct{}{
-	"Go":     struct{}{},
-	"Java":   struct{}{},
-	"C#":     struct{}{},
-	"Python": struct{}{},
+	"C#":         struct{}{},
+	"Go":         struct{}{},
+	"Java":       struct{}{},
+	"Javascript": struct{}{},
+	"Python":     struct{}{},
 }
 
 // 8GB


### PR DESCRIPTION
If more than a 1/3 of a repo is JS, we will mark the build as failed if the JS
step fails.

Fixes https://app.asana.com/0/146253180133821/150415241999794