### PR TITLE
limit word combinations for fulltext search to first 6 words

### DIFF
--- a/services/backend/internal/localstore/defs.go
+++ b/services/backend/internal/localstore/defs.go
@@ -666,7 +666,7 @@ func toTextSearchTokens(def *graph.Def) (aToks []string, bToks []string, cToks [
 	pathParts := delims.Split(def.Path, -1)
 	for _, w := range pathParts {
 		bToks = appendRepeated(bToks, w, 2)
-		for _, c := range allCombinations(splitCaseWords(w)) {
+		for _, c := range boundedCombinations(splitCaseWords(w), 6) {
 			if c != "" {
 				cToks = appendRepeated(cToks, c, 1)
 			}
@@ -674,7 +674,7 @@ func toTextSearchTokens(def *graph.Def) (aToks []string, bToks []string, cToks [
 	}
 	lastPathPart := pathParts[len(pathParts)-1]
 	aToks = appendRepeated(aToks, lastPathPart, 3) // mega extra points for matching the last component of the def path (typically the "name" of the def)
-	for _, c := range allCombinations(splitCaseWords(lastPathPart)) {
+	for _, c := range boundedCombinations(splitCaseWords(lastPathPart), 6) {
 		if c != "" {
 			aToks = appendRepeated(aToks, c, 1) // more points for matching last component of def path
 		}
@@ -701,6 +701,13 @@ func splitCaseWords(w string) []string {
 		return strings.Split(w, "_")
 	}
 	return camelcase.Split(w)
+}
+
+func boundedCombinations(s []string, bound int) []string {
+	if len(s) > bound {
+		return append(allCombinations(s[:bound]), s[bound:]...)
+	}
+	return allCombinations(s)
 }
 
 // allCombinations returns all strings that can be built by concatenating a subset of the given strings without reordering.

--- a/services/backend/internal/localstore/defs_test.go
+++ b/services/backend/internal/localstore/defs_test.go
@@ -11,7 +11,7 @@ func TestToTextSearchTokens(t *testing.T) {
 		DefKey: graph.DefKey{
 			Repo: "repo1/repo2",
 			Unit: "unit1/unit2",
-			Path: "path_x/pathFooBar",
+			Path: "path_x/pathFooBarHelloWorldThisIsLong",
 		},
 		File: "file1/file2",
 		Name: "name",
@@ -21,22 +21,22 @@ func TestToTextSearchTokens(t *testing.T) {
 		},
 	})
 
-	expectedAToks := []string{"pathFooBar", "pathFooBar", "pathFooBar", "pathFooBar", "FooBar", "pathBar", "Bar", "pathFoo", "Foo", "path", "name"}
-	expectedBToks := []string{"repo1", "repo2", "repo2", "repo2", "unit1", "unit2", "unit2", "unit2", "path_x", "path_x", "pathFooBar", "pathFooBar"}
-	expectedCToks := []string{"pathx", "x", "path", "pathFooBar", "FooBar", "pathBar", "Bar", "pathFoo", "Foo", "path", "file1", "file2", "file2", "file2"}
+	expectedAToks := []string{"pathFooBarHelloWorldThisIsLong", "pathFooBarHelloWorldThisIsLong", "pathFooBarHelloWorldThisIsLong", "pathFooBarHelloWorldThis", "FooBarHelloWorldThis", "pathBarHelloWorldThis", "BarHelloWorldThis", "pathFooHelloWorldThis", "FooHelloWorldThis", "pathHelloWorldThis", "HelloWorldThis", "pathFooBarWorldThis", "FooBarWorldThis", "pathBarWorldThis", "BarWorldThis", "pathFooWorldThis", "FooWorldThis", "pathWorldThis", "WorldThis", "pathFooBarHelloThis", "FooBarHelloThis", "pathBarHelloThis", "BarHelloThis", "pathFooHelloThis", "FooHelloThis", "pathHelloThis", "HelloThis", "pathFooBarThis", "FooBarThis", "pathBarThis", "BarThis", "pathFooThis", "FooThis", "pathThis", "This", "pathFooBarHelloWorld", "FooBarHelloWorld", "pathBarHelloWorld", "BarHelloWorld", "pathFooHelloWorld", "FooHelloWorld", "pathHelloWorld", "HelloWorld", "pathFooBarWorld", "FooBarWorld", "pathBarWorld", "BarWorld", "pathFooWorld", "FooWorld", "pathWorld", "World", "pathFooBarHello", "FooBarHello", "pathBarHello", "BarHello", "pathFooHello", "FooHello", "pathHello", "Hello", "pathFooBar", "FooBar", "pathBar", "Bar", "pathFoo", "Foo", "path", "Is", "Long", "name"}
+	expectedBToks := []string{"repo1", "repo2", "repo2", "repo2", "unit1", "unit2", "unit2", "unit2", "path_x", "path_x", "pathFooBarHelloWorldThisIsLong", "pathFooBarHelloWorldThisIsLong"}
+	expectedCToks := []string{"pathx", "x", "path", "pathFooBarHelloWorldThis", "FooBarHelloWorldThis", "pathBarHelloWorldThis", "BarHelloWorldThis", "pathFooHelloWorldThis", "FooHelloWorldThis", "pathHelloWorldThis", "HelloWorldThis", "pathFooBarWorldThis", "FooBarWorldThis", "pathBarWorldThis", "BarWorldThis", "pathFooWorldThis", "FooWorldThis", "pathWorldThis", "WorldThis", "pathFooBarHelloThis", "FooBarHelloThis", "pathBarHelloThis", "BarHelloThis", "pathFooHelloThis", "FooHelloThis", "pathHelloThis", "HelloThis", "pathFooBarThis", "FooBarThis", "pathBarThis", "BarThis", "pathFooThis", "FooThis", "pathThis", "This", "pathFooBarHelloWorld", "FooBarHelloWorld", "pathBarHelloWorld", "BarHelloWorld", "pathFooHelloWorld", "FooHelloWorld", "pathHelloWorld", "HelloWorld", "pathFooBarWorld", "FooBarWorld", "pathBarWorld", "BarWorld", "pathFooWorld", "FooWorld", "pathWorld", "World", "pathFooBarHello", "FooBarHello", "pathBarHello", "BarHello", "pathFooHello", "FooHello", "pathHello", "Hello", "pathFooBar", "FooBar", "pathBar", "Bar", "pathFoo", "Foo", "path", "Is", "Long", "file1", "file2", "file2", "file2"}
 	expectedDToks := []string{"foo bar", "baz"}
 
 	if !stringSliceEqual(aToks, expectedAToks) {
 		t.Errorf("wrong aToks, expected %#v, got %#v", expectedAToks, aToks)
 	}
 	if !stringSliceEqual(bToks, expectedBToks) {
-		t.Errorf("wrong aToks, expected %#v, got %#v", expectedBToks, bToks)
+		t.Errorf("wrong bToks, expected %#v, got %#v", expectedBToks, bToks)
 	}
 	if !stringSliceEqual(cToks, expectedCToks) {
-		t.Errorf("wrong aToks, expected %#v, got %#v", expectedCToks, cToks)
+		t.Errorf("wrong cToks, expected %#v, got %#v", expectedCToks, cToks)
 	}
 	if !stringSliceEqual(dToks, expectedDToks) {
-		t.Errorf("wrong aToks, expected %#v, got %#v", expectedDToks, dToks)
+		t.Errorf("wrong dToks, expected %#v, got %#v", expectedDToks, dToks)
 	}
 }
 


### PR DESCRIPTION
This is to fix the "string is too long for tsvector" error (and not waste performance).