### PR TITLE
change vertical align for dropdown to realign translate button

### DIFF
--- a/app/web_modules/sourcegraph/components/styles/dropdown.css
+++ b/app/web_modules/sourcegraph/components/styles/dropdown.css
@@ -8,7 +8,7 @@
 	display: inline-block;
 	line-height: 1.45;
 	cursor: pointer;
-	vertical-align: middle;
+	vertical-align: top;
 }
 
 .wrapper-disabled {


### PR DESCRIPTION
Previously: 
![screen shot 2016-07-05 at 1 48 42 pm](https://cloud.githubusercontent.com/assets/253496/16599456/40d95d88-42b7-11e6-8443-be95739f3767.png)
Now:
![screen shot 2016-07-05 at 1 48 54 pm](https://cloud.githubusercontent.com/assets/253496/16599455/40d76d8e-42b7-11e6-83db-b602a52f5fc5.png)

##### Reviewer tasks

@chexee , mind taking a look? I checked in our code base, and I don't see the <Dropdown used anywhere else except this instance in DefInfo. 

Also, @chexee , if vertical-align isn't specified, this fixes it as well. maybe cleaner than forcing it?

##### Test plan

Tested locally, and is fixed. Checked if anyone else uses Dropdown.css, and couldn't find any users.