### PR TITLE
Prevent unauthorized repo api access from leaking info. 401 -> 404

### DIFF
--- a/services/backend/internal/localstore/repos.go
+++ b/services/backend/internal/localstore/repos.go
@@ -194,6 +194,10 @@ func verifyAccessAndSetAllFields(ctx context.Context, repo *sourcegraph.Repo) (*
 	// accesscontrol.VerifyUserHasReadAccess calls (*repos).Get).
 	if strings.HasPrefix(strings.ToLower(repo.URI), "github.com/") {
 		if err := accesscontrol.VerifyActorHasGitHubRepoAccess(ctx, auth.ActorFromContext(ctx), "Repos.Get", repo.ID, repo.URI); err != nil {
+			thrown := grpc.Code(err)
+			if codes.Code(thrown) == codes.Unauthenticated {
+				return nil, grpc.Errorf(codes.NotFound, "Not Found")
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Small change to swallow errors that would indicate that a valid repo exists at a URL, preventing repo enumeration attacks.  We simply always return a 404 externally in the case of 404 or 401 Unauthorized. 
