### PR TITLE
Add platform to event properties

### DIFF
--- a/app/web_modules/sourcegraph/util/EventLogger.js
+++ b/app/web_modules/sourcegraph/util/EventLogger.js
@@ -43,17 +43,15 @@ export class EventLogger {
 		// with the relevant event properties.
 		this._dispatcherToken = Dispatcher.Stores.register(this.__onDispatch.bind(this));
 
-		document.addEventListener("sourcegraph:platform:initalization", this._initializeForSourcegraphPlatform.bind(this));
+		if (typeof document !== "undefined") {
+			document.addEventListener("sourcegraph:platform:initalization", this._initializeForSourcegraphPlatform.bind(this));
+		}
 	}
 
 	_initializeForSourcegraphPlatform(event) {
 		if (event && event.detail && event.detail.currentPlatform) {
-			this.setCurrentPlatformForEvent(event.detail.currentPlatform);
+			this._currentPlatform = event.detail.currentPlatform;
 		}
-	}
-
-	setCurrentPlatformForEvent(platform) {
-		this._currentPlatform = platform;
 	}
 
 	setSiteConfig(siteConfig: SiteConfig) {

--- a/app/web_modules/sourcegraph/util/EventLogger.js
+++ b/app/web_modules/sourcegraph/util/EventLogger.js
@@ -30,6 +30,7 @@ export class EventLogger {
 	userAgentIsBot: bool;
 	_dispatcherToken: any;
 	_siteConfig: ?SiteConfig;
+	_currentPlatform: string = "Web";
 
 	constructor() {
 		this._intercomSettings = null;
@@ -41,6 +42,18 @@ export class EventLogger {
 		// You must separately log "frontend" actions of interest,
 		// with the relevant event properties.
 		this._dispatcherToken = Dispatcher.Stores.register(this.__onDispatch.bind(this));
+
+		document.addEventListener("sourcegraph:platform:initalization", this._initializeForSourcegraphPlatform.bind(this));
+	}
+
+	_initializeForSourcegraphPlatform(event) {
+		if (event && event.detail && event.detail.currentPlatform) {
+			this.setCurrentPlatformForEvent(event.detail.currentPlatform);
+		}
+	}
+
+	setCurrentPlatformForEvent(platform) {
+		this._currentPlatform = platform;
 	}
 
 	setSiteConfig(siteConfig: SiteConfig) {
@@ -179,7 +192,7 @@ export class EventLogger {
 		}
 
 		// Log Amplitude "View" event
-		this._amplitude.logEvent(title, eventProperties);
+		this._amplitude.logEvent(title, {...eventProperties, Platform: this._currentPlatform});
 
 		// Log GA "pageview" event without props.
 		window.ga("send", {
@@ -198,7 +211,7 @@ export class EventLogger {
 			return;
 		}
 
-		this._amplitude.logEvent(eventLabel, {...eventProperties, eventCategory: eventCategory, eventAction: eventAction, is_authed: this._user ? "true" : "false"});
+		this._amplitude.logEvent(eventLabel, {...eventProperties, eventCategory: eventCategory, eventAction: eventAction, is_authed: this._user ? "true" : "false", Platform: this._currentPlatform});
 
 		window.ga("send", {
 			hitType: "event",


### PR DESCRIPTION
##### Description

Adds a platform for analytics calls that matches Platform for ChromeExtension. This also means event properties can be Web, Chrome ext, integration and also pass in additional props that let us know how the integration was kicked off i.e Platform: Desktop that came from Sublime.