### PR TITLE
ui: Use correct duration in appdash initial load

### DIFF
--- a/app/web_modules/sourcegraph/app/appdash.js
+++ b/app/web_modules/sourcegraph/app/appdash.js
@@ -90,7 +90,7 @@ export function withAppdashRouteStateRecording(ChildComponent: Object): Object {
 			// document, and when the document.readyState was changed to "complete".
 			// i.e., the time it took to load the page.
 			const startTime = window.performance.timing.fetchStart;
-			const endTime = window.performance.timing.domComplete;
+			const endTime = window.performance.timing.domComplete > 0 ? window.performance.timing.domComplete : new Date().getTime();
 			const routeName = getRouteName(this.state.routes);
 			recordSpan({
 				name: `load page ${routeName}`,


### PR DESCRIPTION
The DOM may have not fully loaded, which leads to `domComplete=0`. ie we show
`-unixtime` as the duration. Instead we can just rely on the current time.

Fixes https://app.asana.com/0/87040567695724/151870203669931