### PR TITLE
Remove bad metrics from prometheus

### DIFF
--- a/services/httpapi/internal_appdash.go
+++ b/services/httpapi/internal_appdash.go
@@ -5,10 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"sourcegraph.com/sourcegraph/appdash"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/httputil/httpctx"
-	"sourcegraph.com/sourcegraph/sourcegraph/pkg/statsutil"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/traceutil"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/traceutil/appdashctx"
 )
@@ -29,18 +27,8 @@ func (e PageLoadEvent) Start() time.Time { return e.S }
 // End implements the appdash.TimespanEvent interface.
 func (e PageLoadEvent) End() time.Time { return e.E }
 
-var pageLoadLabels = []string{"name"}
-var pageLoadDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "src",
-	Subsystem: "trace",
-	Name:      "browser_span_duration_seconds",
-	Help:      "Total time taken to perform a given browser operation.",
-	Buckets:   statsutil.UserLatencyBuckets,
-}, pageLoadLabels)
-
 func init() {
 	appdash.RegisterEvent(PageLoadEvent{})
-	prometheus.MustRegister(pageLoadDuration)
 }
 
 // serveInternalAppdashRecordSpan is an endpoint that records a very simple
@@ -56,13 +44,6 @@ func serveInternalAppdashRecordSpan(w http.ResponseWriter, r *http.Request) erro
 	if err := schemaDecoder.Decode(ev, r.URL.Query()); err != nil {
 		return err
 	}
-
-	// Record page load duration in Prometheus histogram.
-	labels := prometheus.Labels{
-		"name": ev.Name,
-	}
-	elapsed := ev.E.Sub(ev.S)
-	pageLoadDuration.With(labels).Observe(elapsed.Seconds())
 
 	// The `internal.appdash.record-span` span for this POST request is tiny
 	// and thus not easily accessible within the UI. We use a workaround by

--- a/services/repoupdater/repo_updater.go
+++ b/services/repoupdater/repo_updater.go
@@ -1,7 +1,6 @@
 package repoupdater
 
 import (
-	"strconv"
 	"sync"
 	"time"
 
@@ -18,19 +17,18 @@ const (
 )
 
 var (
-	enqueueCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	enqueueCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "src",
 		Subsystem: "repoupdater",
 		Name:      "enqueue",
 		Help:      "Number of requests to enqueue repos (but not necessarily accepted into queue)",
-	}, []string{"repo"})
-
-	acceptedCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	})
+	acceptedCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "src",
 		Subsystem: "repoupdater",
 		Name:      "enqueue_accepted",
 		Help:      "Number of requests to enqueue repos that were accepted / added to queue",
-	}, []string{"repo"})
+	})
 )
 
 func init() {
@@ -41,7 +39,7 @@ func init() {
 // Enqueue queues a mirror repo for refresh. If asUser is not nil, that user's
 // auth token will be used for performing the fetch from the remote host.
 func Enqueue(repo int32, asUser *sourcegraph.UserSpec) {
-	enqueueCounter.WithLabelValues(strconv.Itoa(int(repo))).Inc()
+	enqueueCounter.Inc()
 	RepoUpdater.enqueue(&repoUpdateOp{Repo: repo, AsUser: asUser})
 }
 
@@ -92,7 +90,7 @@ func (ru *repoUpdater) enqueue(op *repoUpdateOp) {
 
 	select {
 	case ru.queue <- op:
-		acceptedCounter.WithLabelValues(strconv.Itoa(int(op.Repo))).Inc()
+		acceptedCounter.Inc()
 		ru.recent[op.Repo] = now
 	default:
 		// Skip since queue is full.


### PR DESCRIPTION
This is unfortunetly an easy mistake to make since we have no tools to prevent it, nor to warn when it is happening in production (yet). This is currently causing prometheus to fail at collecting important frontend metrics.