### PR TITLE
e2e: Add convenience function Click

### DIFF
--- a/test/e2e/def_flow.go
+++ b/test/e2e/def_flow.go
@@ -19,15 +19,9 @@ func testDefFlow(t *T) error {
 	}
 
 	// Check that the def link appears
-	defLink := t.WaitForElement(selenium.ByLinkText, "View definition", MatchAttribute("href", `/github\.com/golang/go/-/def/GoPackage/net/http/-/Header/Get`))
-	if err = defLink.Click(); err != nil {
-		return err
-	}
+	t.Click(selenium.ByLinkText, "View definition", MatchAttribute("href", `/github\.com/golang/go/-/def/GoPackage/net/http/-/Header/Get`))
 
-	defLink = t.WaitForElement(selenium.ByLinkText, "View all references", MatchAttribute("href", `/github\.com/golang/go/-/info/GoPackage/net/http/-/Header/Get`))
-	if err = defLink.Click(); err != nil {
-		return err
-	}
+	t.Click(selenium.ByLinkText, "View all references", MatchAttribute("href", `/github\.com/golang/go/-/info/GoPackage/net/http/-/Header/Get`))
 
 	return nil
 }

--- a/test/e2e/login_flow.go
+++ b/test/e2e/login_flow.go
@@ -81,8 +81,7 @@ func testLoginFlow(t *T) error {
 	password.SendKeys(testPassword)
 
 	// Click the submit button.
-	submit := t.FindElement(selenium.ById, "e2etest-login-button")
-	submit.Click()
+	t.Click(selenium.ById, "e2etest-login-button")
 
 	t.WaitForRedirect(t.Endpoint("/"), "wait for redirect to home after sign-in")
 	return nil

--- a/test/e2e/register_flow.go
+++ b/test/e2e/register_flow.go
@@ -99,8 +99,7 @@ func testRegisterFlow(t *T) error {
 	email.SendKeys(t.TestEmail)
 
 	// Click the submit button.
-	submit := t.FindElement(selenium.ById, "e2etest-register-button")
-	submit.Click()
+	t.Click(selenium.ById, "e2etest-register-button")
 
 	// Wait for redirect to Sourcegraph homepage.
 	t.WaitForRedirect(t.Endpoint("/"), "wait for redirect to home after register")

--- a/test/e2e/search_flow.go
+++ b/test/e2e/search_flow.go
@@ -23,8 +23,7 @@ func runSearchFlow(t *T, query string) {
 
 	// Since the search results are listed in `code` tags,
 	// this will find the first search result (so it can be clicked)
-	searchResult := t.WaitForElement(selenium.ByTagName, "code")
-	searchResult.Click()
+	t.Click(selenium.ByTagName, "code")
 
 	// The usage examples are in `table` elements
 	t.WaitForElement(selenium.ByTagName, "table")
@@ -39,8 +38,7 @@ func testSearchFlow(t *T) error {
 	}
 
 	// set go as the language in the browser
-	selectLang := t.WaitForElement(selenium.ById, "e2etest-search-lang-select-golang")
-	selectLang.Click()
+	t.Click(selenium.ById, "e2etest-search-lang-select-golang")
 
 	queries := [5]string{"new http request", "read file", "json encoder", "sql query", "indent json"}
 	for _, q := range queries {


### PR DESCRIPTION
We add the convenience function so that we can add a work-around on an issue
that affects ChromeDriver. Our assumption is that ChromeDriver will try to click
on an element, but between the time it gets the element and clicks on it, the
element moves. This happens a lot on the Usage Examples page, since we
asynchronously load in some extra annotations that appear above the `View all
references` button. This lead to internal errors from selenium, with selenium
logs like the following:

```
org.openqa.selenium.WebDriverException: unknown error:
Element is not clickable at point (810, 295).
Other element would receive the click: <div class="Blob__margin___2uZsC" style="position: relative;">...</div>
```

More information at https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/2766