### PR TITLE
UX: Hide search box after result is selected

### DIFF
--- a/app/web_modules/sourcegraph/app/GlobalNav.js
+++ b/app/web_modules/sourcegraph/app/GlobalNav.js
@@ -181,6 +181,10 @@ class SearchForm extends React.Component {
 			if (nextQuery && !this.state.query) this.setState({open: true});
 			this.setState({query: nextQuery});
 		}
+
+		if (!nextQuery) {
+			this.setState({open: false});
+		}
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
##### Description

Explicitly hides the search results box after a result is selected by setting open to false after `state.nextQuery` is set to null.

This is on staging4

