### PR TITLE
Fix location change on search submit

### DIFF
--- a/app/web_modules/sourcegraph/app/GlobalNav.js
+++ b/app/web_modules/sourcegraph/app/GlobalNav.js
@@ -226,7 +226,7 @@ class SearchForm extends React.Component {
 
 	_handleSubmit(ev: Event) {
 		ev.preventDefault();
-		this.props.router.push(locationForSearch(this.props.location, this.state.query, true, true));
+		this.props.router.push(locationForSearch(this.props.location, this.state.query, false, true));
 	}
 
 	_handleKeyDown(ev: KeyboardEvent) {


### PR DESCRIPTION
Fixes this bug: https://cl.ly/3v1q1I2K2l2m, where pressing enter on an empty search when on a repo page changes the search scope to global and takes you away from the repo. 

##### Reviewer tasks

*AUTHOR: Add other outstanding tasks for the reviewer. Remove irrelevant items below.*

- [ ] HACKS: reviewer approves hacks introduced by this change
^^ Is there a reason the `updatePath` param was set to `true` previously?
