### PR TITLE
app: display upvote/downvote buttons on Usage Examples for admin users

### DIFF
--- a/app/web_modules/sourcegraph/components/Icons.js
+++ b/app/web_modules/sourcegraph/components/Icons.js
@@ -23,6 +23,8 @@ export const FaAngleRight = iconWrapper(require("react-icons/lib/fa/angle-right"
 export const FaChevronDown = iconWrapper(require("react-icons/lib/fa/chevron-down"));
 export const PlayIcon = iconWrapper(require("react-icons/lib/fa/play-circle"));
 export const ToolsIcon = iconWrapper(require("react-icons/lib/go/tools"));
+export const FaThumbsUp = iconWrapper(require("react-icons/lib/fa/thumbs-up"));
+export const FaThumbsDown = iconWrapper(require("react-icons/lib/fa/thumbs-down"));
 
 // iconWrapper lets you pass a style directly to any of the exported components, e.g.
 // <RepoIcon styleName="foo" />

--- a/app/web_modules/sourcegraph/def/ExamplesContainer.js
+++ b/app/web_modules/sourcegraph/def/ExamplesContainer.js
@@ -57,6 +57,7 @@ class ExamplesContainer extends Container {
 						{refLocs && !refLocs.RepoRefs && <i>No examples found</i>}
 						{refLocs && refLocs.RepoRefs && refLocs.RepoRefs.map((repoRefs, i) => <RefsContainer
 							key={i}
+							refIndex={i}
 							repo={this.props.repo}
 							rev={this.props.rev}
 							commitID={this.props.commitID}

--- a/app/web_modules/sourcegraph/def/RefsContainer.js
+++ b/app/web_modules/sourcegraph/def/RefsContainer.js
@@ -27,6 +27,7 @@ import base from "sourcegraph/components/styles/_base.css";
 import colors from "sourcegraph/components/styles/_colors.css";
 import * as AnalyticsConstants from "sourcegraph/util/constants/AnalyticsConstants";
 import {urlToRepo} from "sourcegraph/repo/routes";
+import {FaThumbsUp, FaThumbsDown} from "sourcegraph/components/Icons";
 
 const SNIPPET_REF_CONTEXT_LINES = 4; // Number of additional lines to show above/below a ref
 
@@ -46,11 +47,13 @@ export default class RefsContainer extends Container {
 		fileCollapseThreshold: React.PropTypes.number, // number of files to show before "and X more..."-style paginator
 		rangeLimit: React.PropTypes.number,
 		showRepoTitle: React.PropTypes.bool,
+		refIndex: React.PropTypes.number,
 	};
 
 	static contextTypes = {
 		router: React.PropTypes.object.isRequired,
 		eventLogger: React.PropTypes.object.isRequired,
+		user: React.PropTypes.object,
 	};
 
 	constructor(props) {
@@ -66,6 +69,7 @@ export default class RefsContainer extends Container {
 		this.ranges = {};
 		this.anns = {};
 		this._toggleFile = this._toggleFile.bind(this);
+		this._vote = this._vote.bind(this);
 	}
 
 	shouldComponentUpdate(nextProps, nextState, nextContext) {
@@ -240,6 +244,16 @@ export default class RefsContainer extends Container {
 		this.setState({shownFiles: newOpenFiles});
 	}
 
+	_vote(upvote, repo, path) {
+		this.context.eventLogger.logEventForCategory(AnalyticsConstants.CATEGORY_INTERNAL, AnalyticsConstants.ACTION_CLICK, "UsageExampleVote", {
+			page: window.location.href,
+			upvote: upvote,
+			repo: repo,
+			path: path,
+		});
+		this.setState({voteDone: true});
+	}
+
 	render() {
 		if (this.state.fileLocations && this.state.fileLocations.length === 0) return null;
 
@@ -316,6 +330,10 @@ export default class RefsContainer extends Container {
 
 								return (
 									<div key={i}>
+										{this.context.user && this.context.user.Admin && <span className={`${this.state.voteDone ? styles.voteDone : styles.vote}`}>
+											<a className={`${styles.upvote}`} onClick={() => { this._vote(true, this.state.refRepo, loc.Path); }}><FaThumbsUp /></a>
+											<a className={`${styles.downvote}`} onClick={() => { this._vote(false, this.state.refRepo, loc.Path); }}><FaThumbsDown /></a>
+										</span>}
 										<Blob
 											repo={this.state.refRepo}
 											rev={this.state.refRev}

--- a/app/web_modules/sourcegraph/def/RefsContainer.js
+++ b/app/web_modules/sourcegraph/def/RefsContainer.js
@@ -250,6 +250,7 @@ export default class RefsContainer extends Container {
 			upvote: upvote,
 			repo: repo,
 			path: path,
+			index: this.props.refIndex,
 		});
 		this.setState({voteDone: true});
 	}
@@ -331,8 +332,8 @@ export default class RefsContainer extends Container {
 								return (
 									<div key={i}>
 										{this.context.user && this.context.user.Admin && <span className={`${this.state.voteDone ? styles.voteDone : styles.vote}`}>
-											<a className={`${styles.upvote}`} onClick={() => { this._vote(true, this.state.refRepo, loc.Path); }}><FaThumbsUp /></a>
-											<a className={`${styles.downvote}`} onClick={() => { this._vote(false, this.state.refRepo, loc.Path); }}><FaThumbsDown /></a>
+											<a className={styles.upvote} onClick={() => this._vote(true, this.state.refRepo, loc.Path)}><FaThumbsUp /></a>
+											<a className={styles.downvote} onClick={() => this._vote(false, this.state.refRepo, loc.Path)}><FaThumbsDown /></a>
 										</span>}
 										<Blob
 											repo={this.state.refRepo}

--- a/app/web_modules/sourcegraph/def/RefsContainer_test.js
+++ b/app/web_modules/sourcegraph/def/RefsContainer_test.js
@@ -6,6 +6,7 @@ import {render} from "sourcegraph/util/renderTestUtils";
 
 const context = {
 	eventLogger: {logEvent: () => null},
+	user: null,
 };
 
 describe("RefsContainer", () => {

--- a/app/web_modules/sourcegraph/def/styles/Refs.css
+++ b/app/web_modules/sourcegraph/def/styles/Refs.css
@@ -7,6 +7,30 @@
 @value c_dark-blue from colors;
 @value media-sm from vars;
 
+
+.vote {
+	display: span;
+	float: left;
+	position: relative;
+	left: -23px;
+	width: 0;
+}
+
+.voteDone {
+	display: span;
+	float: left;
+	position: relative;
+	left: -23px;
+	width: 0;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s 0.25s, opacity 0.25s linear;
+}
+
+.upvote, .downvote {
+	display: block;
+}
+
 .f7 { composes: f7 from typography; }
 
 .container {

--- a/app/web_modules/sourcegraph/user/index.js
+++ b/app/web_modules/sourcegraph/user/index.js
@@ -33,6 +33,7 @@ export function betaPending(u: ?User): boolean {
 export type AuthInfo = {
 	UID?: number;
 	Login?: string;
+	Admin?: boolean;
 };
 
 export type EmailAddr = {

--- a/app/web_modules/sourcegraph/util/constants/AnalyticsConstants.js
+++ b/app/web_modules/sourcegraph/util/constants/AnalyticsConstants.js
@@ -15,6 +15,7 @@ export const CATEGORY_REFERENCES = "References";
 export const CATEGORY_PRICING = "Pricing";
 export const CATEGORY_GLOBAL_SEARCH = "GlobalSearch";
 export const CATEGORY_EXTERNAL = "External";
+export const CATEGORY_INTERNAL = "Internal";
 export const CATEGORY_ENGAGEMENT = "ReEngagement";
 export const CATEGORY_UNKNOWN = "Unknown";
 


### PR DESCRIPTION
This change adds simple upvote/downvote buttons for admin users which directly
submit data to Amplitude including four identifying datapoints:

1. Whether it was an upvote or a downvote.
2. Which page (`window.location.href`) the user was on.
3. Which repository the usage example definition comes from.
4. Which file the usage example definition comes from.
5. Which index the usage example has (zero-based number which shows us where on
   the page the usage example was located, not good for concretely identifying
   the usage example hence the repo/file fields above).

When the upvote/downvote button is clicked, we simply fade out the buttons.

![gif](http://g.recordit.co/8xS70lTUdJ.gif)

##### Reviewer tasks

- [ ] UNIT-TEST: reviewer approves the unit tests (or the justified omission thereof)

##### Test plan

Tested manually.