### PR TITLE
github: Use an HTTP cache backed by Redis

### DIFF
--- a/pkg/httputil/cache.go
+++ b/pkg/httputil/cache.go
@@ -3,14 +3,16 @@ package httputil
 import (
 	"net/http"
 
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/rcache"
+
 	"github.com/sourcegraph/httpcache"
 )
 
 var (
-	// Cache is an in-memory HTTP cache.
-	Cache = httpcache.NewMemoryCache()
+	// Cache is a HTTP cache backed by Redis
+	Cache = rcache.NewByteCache("http")
 
-	// CachingClient is an HTTP client that caches responses in memory
-	// (using Cache).
+	// CachingClient is an HTTP client that caches responses backed by
+	// Redis (using Cache).
 	CachingClient = &http.Client{Transport: httpcache.NewTransport(Cache)}
 )

--- a/pkg/rcache/rcache.go
+++ b/pkg/rcache/rcache.go
@@ -92,7 +92,7 @@ var ErrNotFound = errors.New("Redis key not found")
 // Get fetches the cached value for the given key into the
 // destination. If the key does not exist, it will return ErrNotFound.
 func (r *Redis) Get(key string, dst interface{}) error {
-	rkey := fmt.Sprintf("%s:%s:%s", globalPrefix, r.keyPrefix, key)
+	rkey := r.rkey(key)
 
 	conn, cleanup, err := getConn()
 	if err != nil {
@@ -121,7 +121,7 @@ func (r *Redis) Get(key string, dst interface{}) error {
 // Add adds a value to the Redis-backed cache with the specified key.
 // If ttlSeconds =< 0, then a TTL will not be set.
 func (r *Redis) Add(key string, val interface{}, ttlSeconds int) error {
-	rkey := fmt.Sprintf("%s:%s:%s", globalPrefix, r.keyPrefix, key)
+	rkey := r.rkey(key)
 
 	conn, cleanup, err := getConn()
 	if err != nil {
@@ -146,6 +146,11 @@ func (r *Redis) Add(key string, val interface{}, ttlSeconds int) error {
 		}
 	}
 	return nil
+}
+
+// rkey generates the actual key we use on redis.
+func (r *Redis) rkey(key string) string {
+	return fmt.Sprintf("%s:%s:%s", globalPrefix, r.keyPrefix, key)
 }
 
 // ClearAllForTest clears all of the entries with a given prefix. This

--- a/pkg/rcache/rcache_test.go
+++ b/pkg/rcache/rcache_test.go
@@ -11,9 +11,9 @@ func clearAll(t *testing.T, prefix string) {
 	}
 }
 
-func TestRedis(t *testing.T) {
+func TestCache(t *testing.T) {
+	globalPrefix = "__test__TestCache"
 	clearAll(t, globalPrefix)
-	globalPrefix = "__test__TestRedis"
 	defer clearAll(t, globalPrefix)
 
 	type kvTTL struct {
@@ -47,7 +47,7 @@ func TestRedis(t *testing.T) {
 		}},
 	}
 
-	caches := make([]*Redis, len(cases))
+	caches := make([]*Cache, len(cases))
 	for i, test := range cases {
 		caches[i] = New(test.prefix)
 		for _, entry := range test.entries {
@@ -77,9 +77,9 @@ func TestRedis(t *testing.T) {
 	}
 }
 
-func TestRedis_values(t *testing.T) {
+func TestCache_values(t *testing.T) {
+	globalPrefix = "__test__TestCache_values"
 	clearAll(t, globalPrefix)
-	globalPrefix = "__test__TestRedis_values"
 	defer clearAll(t, globalPrefix)
 
 	cache := New("some_prefix")

--- a/pkg/rcache/rcache_test.go
+++ b/pkg/rcache/rcache_test.go
@@ -144,3 +144,30 @@ func TestCache_values(t *testing.T) {
 		}
 	}
 }
+
+func TestByteCache(t *testing.T) {
+	globalPrefix = "__test__TestByteCache"
+	clearAll(t, globalPrefix)
+	defer clearAll(t, globalPrefix)
+
+	c := NewByteCache("some_prefix")
+	_, ok := c.Get("a")
+	if ok {
+		t.Fatal("Initial Get should of found nothing")
+	}
+
+	c.Set("a", []byte("b"))
+	b, ok := c.Get("a")
+	if !ok {
+		t.Fatal("Expect to get a after setting")
+	}
+	if string(b) != "b" {
+		t.Fatalf("got %v, want %v", string(b), "b")
+	}
+
+	c.Delete("a")
+	_, ok = c.Get("a")
+	if ok {
+		t.Fatal("Get after delete should of found nothing")
+	}
+}


### PR DESCRIPTION
Previously we used an in-memory cache for caching at the HTTP Transport
layer in the Github Client. This lead to large amount of uncached requests
to the Github API on startup (eg when deploying). This started to cause us
to get uncomfortably close to getting rate limited to no requests.

This change switches us from an in-memory cache to Redis. This will also
have the advantage of all instances sharing the same cache, further
reducing the hits we do against the GitHub API. A new type of Redis cache
is introduced called
`rcache.ByteCache` which matches the interface used by `httpcache`.

Note that `httputil.Cache` and `httputil.CachingClient` is currently only
used by GitHub.

Fixes https://app.asana.com/0/87040567695724/154090028181702