### PR TITLE
Fix for stuck repository breadcrumb 

### DIFF
--- a/app/web_modules/sourcegraph/home/index.js
+++ b/app/web_modules/sourcegraph/home/index.js
@@ -5,6 +5,7 @@ export const tools = {
 	getComponent: (location, callback) => {
 		require.ensure([], (require) => {
 			callback(null, {
+				navContext: null,
 				main: require("sourcegraph/home/ToolsContainer").default,
 			});
 		});
@@ -15,6 +16,7 @@ export const tool = {
 	getComponent: (location, callback) => {
 		require.ensure([], (require) => {
 			callback(null, {
+				navContext: null,
 				main: require("sourcegraph/home/ToolsContainer").default,
 			});
 		});

--- a/app/web_modules/sourcegraph/page/index.js
+++ b/app/web_modules/sourcegraph/page/index.js
@@ -21,6 +21,7 @@ export const routes: Array<Route> = [
 		getComponents: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, {
+					navContext: null,
 					main: require("sourcegraph/page/AboutPage").default,
 				});
 			});
@@ -31,6 +32,7 @@ export const routes: Array<Route> = [
 		getComponents: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, {
+					navContext: null,
 					main: require("sourcegraph/page/BetaPage").default,
 				});
 			});
@@ -41,6 +43,7 @@ export const routes: Array<Route> = [
 		getComponents: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, {
+					navContext: null,
 					main: require("sourcegraph/page/ContactPage").default,
 				});
 			});
@@ -51,6 +54,7 @@ export const routes: Array<Route> = [
 		getComponents: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, {
+					navContext: null,
 					main: require("sourcegraph/page/SecurityPage").default,
 				});
 			});
@@ -61,6 +65,7 @@ export const routes: Array<Route> = [
 		getComponents: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, {
+					navContext: null,
 					main: require("sourcegraph/page/PricingPage").default,
 				});
 			});
@@ -71,6 +76,7 @@ export const routes: Array<Route> = [
 		getComponents: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, {
+					navContext: null,
 					main: require("sourcegraph/page/TermsPage").default,
 				});
 			});
@@ -81,6 +87,7 @@ export const routes: Array<Route> = [
 		getComponents: (location, callback) => {
 			require.ensure([], (require) => {
 				callback(null, {
+					navContext: null,
 					main: require("sourcegraph/page/PrivacyPage").default,
 				});
 			});

--- a/app/web_modules/sourcegraph/user/settings/routes.js
+++ b/app/web_modules/sourcegraph/user/settings/routes.js
@@ -8,13 +8,13 @@ export const routes: Array<Route> = [
 		path: rel.settings,
 		getComponent: (location, callback) =>
 			System.import("sourcegraph/user/settings/SettingsMain")
-				.then(m => callback(null, {main: m.default})),
+			.then(m => callback(null, {navContext: null, main: m.default})),
 		childRoutes: [
 			{
 				path: rel.settingsRepos,
 				getComponent: (location, callback) =>
 					System.import("sourcegraph/user/settings/UserSettingsReposMain")
-						.then(m => callback(null, {main: m.default})),
+					.then(m => callback(null, {navContext: null, main: m.default})),
 			},
 		],
 	},


### PR DESCRIPTION
Added `navContext: null` for `home` routes, `page` routes, and `settings` routes. 