### PR TITLE
rcache: Simplify implementation

### DIFF
--- a/pkg/httputil/cache.go
+++ b/pkg/httputil/cache.go
@@ -9,8 +9,10 @@ import (
 )
 
 var (
-	// Cache is a HTTP cache backed by Redis
-	Cache = rcache.NewByteCache("http")
+	// Cache is a HTTP cache backed by Redis. The TTL of a week is a
+	// balance between caching values for a useful amount of time versus
+	// growing the cache too large.
+	Cache = rcache.NewByteCache("http", 604800)
 
 	// CachingClient is an HTTP client that caches responses backed by
 	// Redis (using Cache).

--- a/pkg/httputil/cache.go
+++ b/pkg/httputil/cache.go
@@ -12,7 +12,7 @@ var (
 	// Cache is a HTTP cache backed by Redis. The TTL of a week is a
 	// balance between caching values for a useful amount of time versus
 	// growing the cache too large.
-	Cache = rcache.NewByteCache("http", 604800)
+	Cache = rcache.New("http", 604800)
 
 	// CachingClient is an HTTP client that caches responses backed by
 	// Redis (using Cache).

--- a/pkg/rcache/rcache.go
+++ b/pkg/rcache/rcache.go
@@ -199,12 +199,10 @@ type ByteCache struct {
 }
 
 // NewByteCache creates a ByteCache
-func NewByteCache(keyPrefix string) *ByteCache {
-	// We always set the TTL just in case a user of the cache forgets to
-	// delete an entry.
+func NewByteCache(keyPrefix string, ttlSeconds int) *ByteCache {
 	return &ByteCache{
 		r:          &Redis{keyPrefix: keyPrefix},
-		ttlSeconds: 604800, // Hardcode 1 week
+		ttlSeconds: ttlSeconds,
 	}
 }
 

--- a/pkg/rcache/rcache.go
+++ b/pkg/rcache/rcache.go
@@ -1,6 +1,7 @@
 package rcache
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -40,8 +41,8 @@ func New(keyPrefix string, ttlSeconds int) *Cache {
 
 // Get implements httpcache.Cache.Get
 func (r *Cache) Get(key string) ([]byte, bool) {
-	resp, err := cmd("GET", r.rkey(key))
-	if err != nil || resp.IsType(redis.Nil) {
+	resp := cmd("GET", r.rkey(key))
+	if resp == nil || resp.IsType(redis.Nil) {
 		return nil, false
 	}
 
@@ -54,12 +55,12 @@ func (r *Cache) Get(key string) ([]byte, bool) {
 
 // Delete implements httpcache.Cache.Set
 func (r *Cache) Set(key string, b []byte) {
-	_, _ = cmd("SETEX", r.rkey(key), r.ttlSeconds, b)
+	_ = cmd("SETEX", r.rkey(key), r.ttlSeconds, b)
 }
 
 // Delete implements httpcache.Cache.Delete
 func (r *Cache) Delete(key string) {
-	_, _ = cmd("DEL", r.rkey(key))
+	_ = cmd("DEL", r.rkey(key))
 }
 
 // rkey generates the actual key we use on redis.
@@ -70,14 +71,14 @@ func (r *Cache) rkey(key string) string {
 // ClearAllForTest clears all of the entries with a given prefix. This
 // is an O(n) operation and should only be used in tests.
 func ClearAllForTest(prefix string) error {
-	_, err := cmd("EVAL", `local keys = redis.call('keys', ARGV[1])
+	resp := cmd("EVAL", `local keys = redis.call('keys', ARGV[1])
 if #keys > 0 then
 	return redis.call('del', unpack(keys))
 else
 	return ''
 end`, 0, fmt.Sprintf("%s:*", fmt.Sprintf("%s:%s", globalPrefix, prefix)))
-	if err != nil {
-		return fmt.Errorf("error clearing Redis test data: %s", err)
+	if resp == nil {
+		return errors.New("error clearing Redis test data")
 	}
 	return nil
 }
@@ -115,25 +116,25 @@ func redisPool() (*pool.Pool, error) {
 	return connPool_, nil
 }
 
-// cmd is a helper around redis.(*Client).Cmd. As a convenience it returns
-// Resp.Err as err if we get a response. This reduces the number of error
-// checks needed.
-func cmd(cmd string, args ...interface{}) (*redis.Resp, error) {
+// cmd is a helper around redis.(*Client).Cmd. If any error happens (including
+// resp.Err) cmd will log it and return nil.
+func cmd(cmd string, args ...interface{}) *redis.Resp {
 	connPool, err := redisPool()
 	if err != nil {
 		log15.Warn("failed to connect to redis pool", "error", err)
-		return nil, err
+		return nil
 	}
 	conn, err := connPool.Get()
 	if err != nil {
 		log15.Warn("failed to get a connection from the redis pool", "error", err)
-		return nil, err
+		return nil
 	}
 	defer connPool.Put(conn)
 
 	resp := conn.Cmd(cmd, args...)
 	if resp.Err != nil {
 		log15.Warn("failed to execute redis command", "cmd", cmd, "args", args, "error", resp.Err)
+		return nil
 	}
-	return resp, resp.Err
+	return resp
 }

--- a/pkg/rcache/rcache.go
+++ b/pkg/rcache/rcache.go
@@ -1,7 +1,6 @@
 package rcache
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -150,46 +149,6 @@ func (r *Redis) SetEx(key string, val []byte, ttlSeconds int) error {
 // rkey generates the actual key we use on redis.
 func (r *Redis) rkey(key string) string {
 	return fmt.Sprintf("%s:%s:%s", globalPrefix, r.keyPrefix, key)
-}
-
-func New(keyPrefix string) *Cache {
-	return &Cache{
-		r: &Redis{keyPrefix: keyPrefix},
-	}
-}
-
-// Cache is a cache implemented on top of a Redis client. It is designed to
-// mimick the API of cache.Cache to make it easy to switch instances of
-// cache.Cache to Redis.
-type Cache struct {
-	r *Redis
-}
-
-// Get fetches the cached value for the given key into the
-// destination. If the key does not exist, it will return ErrNotFound.
-func (r *Cache) Get(key string, dst interface{}) error {
-	b, err := r.r.Get(key)
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(b, dst); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Add adds a value to the Redis-backed cache with the specified key.
-// If ttlSeconds =< 0, then a TTL will not be set.
-func (r *Cache) Add(key string, val interface{}, ttlSeconds int) error {
-	vjson, err := json.Marshal(val)
-	if err != nil {
-		return err
-	}
-
-	if ttlSeconds > 0 {
-		return r.r.SetEx(key, vjson, ttlSeconds)
-	}
-	return r.r.Set(key, vjson)
 }
 
 // ByteCache implements httpcache.Cache

--- a/pkg/rcache/rcache.go
+++ b/pkg/rcache/rcache.go
@@ -151,33 +151,33 @@ func (r *Redis) rkey(key string) string {
 	return fmt.Sprintf("%s:%s:%s", globalPrefix, r.keyPrefix, key)
 }
 
-// ByteCache implements httpcache.Cache
-type ByteCache struct {
+// Cache implements httpcache.Cache
+type Cache struct {
 	r          *Redis
 	ttlSeconds int
 }
 
-// NewByteCache creates a ByteCache
-func NewByteCache(keyPrefix string, ttlSeconds int) *ByteCache {
-	return &ByteCache{
+// New creates a redis backed Cache
+func New(keyPrefix string, ttlSeconds int) *Cache {
+	return &Cache{
 		r:          &Redis{keyPrefix: keyPrefix},
 		ttlSeconds: ttlSeconds,
 	}
 }
 
 // Get implements httpcache.Cache.Get
-func (r *ByteCache) Get(key string) ([]byte, bool) {
+func (r *Cache) Get(key string) ([]byte, bool) {
 	b, err := r.r.Get(key)
 	return b, err == nil
 }
 
 // Delete implements httpcache.Cache.Set
-func (r *ByteCache) Set(key string, responseBytes []byte) {
+func (r *Cache) Set(key string, responseBytes []byte) {
 	_ = r.r.SetEx(key, responseBytes, r.ttlSeconds)
 }
 
 // Delete implements httpcache.Cache.Delete
-func (r *ByteCache) Delete(key string) {
+func (r *Cache) Delete(key string) {
 	_ = r.r.Del(key)
 }
 

--- a/pkg/rcache/rcache_test.go
+++ b/pkg/rcache/rcache_test.go
@@ -150,7 +150,7 @@ func TestByteCache(t *testing.T) {
 	clearAll(t, globalPrefix)
 	defer clearAll(t, globalPrefix)
 
-	c := NewByteCache("some_prefix")
+	c := NewByteCache("some_prefix", 123)
 	_, ok := c.Get("a")
 	if ok {
 		t.Fatal("Initial Get should of found nothing")

--- a/pkg/rcache/rcache_test.go
+++ b/pkg/rcache/rcache_test.go
@@ -8,8 +8,8 @@ func clearAll(t *testing.T, prefix string) {
 	}
 }
 
-func TestCache(t *testing.T) {
-	globalPrefix = "__test__TestCache"
+func TestCache_namespace(t *testing.T) {
+	globalPrefix = "__test__TestCache_namespace"
 	clearAll(t, globalPrefix)
 	defer clearAll(t, globalPrefix)
 
@@ -44,9 +44,9 @@ func TestCache(t *testing.T) {
 		}},
 	}
 
-	caches := make([]*ByteCache, len(cases))
+	caches := make([]*Cache, len(cases))
 	for i, test := range cases {
-		caches[i] = NewByteCache(test.prefix, 123)
+		caches[i] = New(test.prefix, 123)
 		for _, entry := range test.entries {
 			caches[i].Set(entry.k, []byte(entry.v))
 		}
@@ -70,12 +70,12 @@ func TestCache(t *testing.T) {
 	}
 }
 
-func TestByteCache(t *testing.T) {
-	globalPrefix = "__test__TestByteCache"
+func TestCache_simple(t *testing.T) {
+	globalPrefix = "__test__TestCache_simple"
 	clearAll(t, globalPrefix)
 	defer clearAll(t, globalPrefix)
 
-	c := NewByteCache("some_prefix", 123)
+	c := New("some_prefix", 123)
 	_, ok := c.Get("a")
 	if ok {
 		t.Fatal("Initial Get should of found nothing")

--- a/services/ext/github/repos.go
+++ b/services/ext/github/repos.go
@@ -8,8 +8,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"gopkg.in/inconshreveable/log15.v2"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/go-github/github"
 	"golang.org/x/net/context"
@@ -68,7 +66,7 @@ func (s *repos) Get(ctx context.Context, repo string) (*sourcegraph.Repo, error)
 		return nil, grpc.Errorf(codes.NotFound, "github repo not found: %s", repo)
 	}
 
-	if cached, err := getFromCache(ctx, repo); err == nil {
+	if cached := getFromCache(ctx, repo); cached != nil {
 		reposGithubPublicCacheCounter.WithLabelValues("hit").Inc()
 		if cached.PublicNotFound {
 			return nil, grpc.Errorf(codes.NotFound, "github repo not found: %s", repo)
@@ -80,7 +78,7 @@ func (s *repos) Get(ctx context.Context, repo string) (*sourcegraph.Repo, error)
 	if grpc.Code(err) == codes.NotFound {
 		// Before we do anything, ensure we cache NotFound responses.
 		// Do this if client is unauthed or authed, it's okay since we're only caching not found responses here.
-		_ = reposGithubPublicCache.Add(repo, cachedRepo{PublicNotFound: true}, reposGithubPublicCacheTTL)
+		addToCache(repo, &cachedRepo{PublicNotFound: true})
 		reposGithubPublicCacheCounter.WithLabelValues("public-notfound").Inc()
 	}
 	if err != nil {
@@ -90,7 +88,7 @@ func (s *repos) Get(ctx context.Context, repo string) (*sourcegraph.Repo, error)
 
 	// We are allowed to cache public repos
 	if !remoteRepo.Private {
-		_ = reposGithubPublicCache.Add(repo, remoteRepo, reposGithubPublicCacheTTL)
+		addToCache(repo, &cachedRepo{Repo: *remoteRepo})
 		reposGithubPublicCacheCounter.WithLabelValues("miss").Inc()
 	} else {
 		reposGithubPublicCacheCounter.WithLabelValues("private").Inc()
@@ -110,23 +108,25 @@ var errInapplicableCache = errors.New("cached value cannot be used in this scena
 
 // getFromCache attempts to get a response from the redis cache.
 // It returns nil error for cache-hit condition and non-nil error for cache-miss.
-func getFromCache(ctx context.Context, repo string) (*cachedRepo, error) {
+func getFromCache(ctx context.Context, repo string) *cachedRepo {
 	var cached cachedRepo
 	err := reposGithubPublicCache.Get(repo, &cached)
 	if err != nil {
-		if err != rcache.ErrNotFound {
-			log15.Error("github cache-get error", "repo", repo, "err", err)
-		}
-		return nil, err
+		return nil
 	}
 
 	// Do not use a cached NotFound if we are an authed user, since it may
 	// exist as a private repo for the user.
 	if client(ctx).isAuthedUser && cached.PublicNotFound {
-		return nil, errInapplicableCache
+		return nil
 	}
 
-	return &cached, nil
+	return &cached
+}
+
+// addToCache will cache the value for repo.
+func addToCache(repo string, c *cachedRepo) {
+	_ = reposGithubPublicCache.Add(repo, c, reposGithubPublicCacheTTL)
 }
 
 // getFromAPI attempts to get a response from the GitHub API without use of

--- a/services/ext/github/repos.go
+++ b/services/ext/github/repos.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	reposGithubPublicCache        = rcache.NewByteCache("gh_pub", conf.GetenvIntOrDefault("SG_REPOS_GITHUB_PUBLIC_CACHE_TTL_SECONDS", 600))
+	reposGithubPublicCache        = rcache.New("gh_pub", conf.GetenvIntOrDefault("SG_REPOS_GITHUB_PUBLIC_CACHE_TTL_SECONDS", 600))
 	reposGithubPublicCacheCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "src",
 		Subsystem: "repos",

--- a/services/ext/github/repos_test.go
+++ b/services/ext/github/repos_test.go
@@ -20,7 +20,7 @@ func resetCache(t *testing.T) {
 	if err := rcache.ClearAllForTest(testGHCachePrefix); err != nil {
 		t.Fatal(err)
 	}
-	reposGithubPublicCache = rcache.New(testGHCachePrefix)
+	reposGithubPublicCache = rcache.NewByteCache(testGHCachePrefix, 1000)
 }
 
 // TestRepos_Get_existing_public tests the behavior of Repos.Get when called on a

--- a/services/ext/github/repos_test.go
+++ b/services/ext/github/repos_test.go
@@ -20,7 +20,7 @@ func resetCache(t *testing.T) {
 	if err := rcache.ClearAllForTest(testGHCachePrefix); err != nil {
 		t.Fatal(err)
 	}
-	reposGithubPublicCache = rcache.NewByteCache(testGHCachePrefix, 1000)
+	reposGithubPublicCache = rcache.New(testGHCachePrefix, 1000)
 }
 
 // TestRepos_Get_existing_public tests the behavior of Repos.Get when called on a


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/sourcegraph/pull/261

We greatly simplify the implementation and uses of the API. There are plenty of commits, but they are all small and do one thing. Easiest way to review is each commit independently.