### PR TITLE
app: rerender DashboardContainer when context.signedIn changes

### DIFF
--- a/app/web_modules/sourcegraph/dashboard/DashboardContainer.js
+++ b/app/web_modules/sourcegraph/dashboard/DashboardContainer.js
@@ -37,12 +37,13 @@ class DashboardContainer extends Container {
 
 	stores() { return [UserStore]; }
 
-	reconcileState(state, props) {
+	reconcileState(state, props, context) {
 		Object.assign(state, props);
 
 		const settings = UserStore.settings.get();
 		state.langs = settings && settings.search ? settings.search.languages : null;
 		state.scope = settings && settings.search ? settings.search.scope : null;
+		state.signedIn = context && context.signedIn;
 	}
 
 	onStateTransition(prevState, nextState) {


### PR DESCRIPTION
Without setting signedIn on the state, the sourcegraph/Component class
would return shouldComponentUpdate == false when this.context.signedIn
changed, because it wasn't reflected in state. The contract of
sourcegraph/Component states that the state must entirely reflect the
values that need to cause rerenders.

Fixes https://app.asana.com/0/87040567695724/154969378440945