### PR TITLE
app: link to the line of the ref when viewing an example

### DIFF
--- a/app/web_modules/sourcegraph/dashboard/DashboardContainer.js
+++ b/app/web_modules/sourcegraph/dashboard/DashboardContainer.js
@@ -37,12 +37,13 @@ class DashboardContainer extends Container {
 
 	stores() { return [UserStore]; }
 
-	reconcileState(state, props) {
+	reconcileState(state, props, context) {
 		Object.assign(state, props);
 
 		const settings = UserStore.settings.get();
 		state.langs = settings && settings.search ? settings.search.languages : null;
 		state.scope = settings && settings.search ? settings.search.scope : null;
+		state.signedIn = context && context.signedIn;
 	}
 
 	onStateTransition(prevState, nextState) {

--- a/app/web_modules/sourcegraph/def/styles/Refs.css
+++ b/app/web_modules/sourcegraph/def/styles/Refs.css
@@ -8,10 +8,12 @@
 @value media-sm from vars;
 
 
+.single-ref-container {
+	position: relative;
+}
 .vote {
 	display: inline-block;
-	float: left;
-	position: relative;
+	position: absolute;
 	left: -23px;
 	width: 20px;
 }
@@ -34,8 +36,6 @@
 .f7 { composes: f7 from typography; }
 
 .container {
-	composes: br2 ba bw1 from base;
-	composes: b--cool-pale-gray from colors;
 	display: flex;
 	flex-direction: column;
 }
@@ -66,6 +66,7 @@
 
 .refs {
 	composes: b--cool-pale-gray from colors;
+	composes: br2 ba bw1 from base;
 	flex: 1 1 auto;
 }
 


### PR DESCRIPTION
Previously, the "Used in REPO" link just linked to the repo homepage, which
was not very helpful.

This change makes it so that it now says "From REPO" and it links to the file
and line number that the ref came from. This is not perfect, but it's a big
improvement.