### PR TITLE
app: fix repeated WantFile and WantAnnotations actions (second try)

### DIFF
--- a/app/web_modules/sourcegraph/def/RefsContainer.js
+++ b/app/web_modules/sourcegraph/def/RefsContainer.js
@@ -184,12 +184,12 @@ export default class RefsContainer extends Container {
 		}
 
 		if (nextState.refs && !nextState.refs.Error && (nextState.refs !== prevState.refs || nextState.shownFiles !== prevState.shownFiles)) {
-			for (let ref of nextState.refs) {
-				let refRev = ref.Repo === nextState.repo ? nextState.commitID : ref.CommitID;
-				if (nextState.shownFiles.has(ref.File)) {
-					Dispatcher.Backends.dispatch(new BlobActions.WantFile(ref.Repo, refRev, ref.File));
-					Dispatcher.Backends.dispatch(new BlobActions.WantAnnotations(ref.Repo, ref.CommitID, ref.File));
-				}
+			let firstRef = nextState.refs[0]; // hack: assuming that all refs given to a RefsContainer are from the same repo and rev, thus using the first ref to determine which files we want to show
+			let repo = firstRef.Repo;
+			let rev = repo === nextState.repo ? nextState.commitID : firstRef.CommitID;
+			for (let file of nextState.shownFiles) {
+				Dispatcher.Backends.dispatch(new BlobActions.WantFile(repo, rev, file));
+				Dispatcher.Backends.dispatch(new BlobActions.WantAnnotations(repo, rev, file));
 			}
 		}
 	}

--- a/app/web_modules/sourcegraph/def/RefsContainer_test.js
+++ b/app/web_modules/sourcegraph/def/RefsContainer_test.js
@@ -19,6 +19,6 @@ describe("RefsContainer", () => {
 	});
 
 	it("should render if the def and refs loaded", () => {
-		render(<RefsContainer repoRefs={{Repo: "github.com/gorilla/mux", Files: []}} defObj={{}} refs={[]} />, context);
+		render(<RefsContainer repoRefs={{Repo: "github.com/gorilla/mux", Files: []}} defObj={{}} refs={[{Repo: "repo", CommitID: "commit"}]} />, context);
 	});
 });


### PR DESCRIPTION
Previously the code was iterating over the list of definition results and issuing a WantFile and WantAnnotations for each of them, although they may all be in a few or even a single file. This means that the actions were issued multiple times for the same file. The new implementation iterates over the list of files instead.

Fixes https://app.asana.com/0/87040567695724/153775463609634