### PR TITLE
e2etest: send failure alerts to OpsGenie + minor fixes

### DIFF
--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -153,7 +153,9 @@ func (t *T) WaitForElement(by, value string, filters ...ElementFilter) selenium.
 			if err != nil {
 				return false
 			}
-			t.Logf("WaitForElement: %d matches for (%s, %q)", len(elements), by, value)
+			if *verboseFlag {
+				t.Logf("WaitForElement: %d matches for (%s, %q)", len(elements), by, value)
+			}
 			f := And(filters...)
 			for _, e := range elements {
 				if f(e) {
@@ -161,7 +163,9 @@ func (t *T) WaitForElement(by, value string, filters ...ElementFilter) selenium.
 					return true
 				}
 			}
-			t.Logf("WaitForElement: failed to find filter match")
+			if *verboseFlag {
+				t.Logf("WaitForElement: failed to find filter match")
+			}
 			return false
 		},
 		fmt.Sprintf("Wait for element to appear: %s %q", by, value),
@@ -663,6 +667,7 @@ var tr = &testRunner{
 var (
 	runOnce     = flag.Bool("once", true, "run the tests only once (true) or forever (false)")
 	runFlag     = flag.String("run", "", "specify an exact test name to run (e.g. 'login_flow', 'register_flow')")
+	verboseFlag = flag.Bool("v", false, "verbosely log selenium actions (useful when debugging selenium)")
 	retriesFlag = flag.Int("retries", 3, "maximum number of times to retry a test before considering it failed")
 )
 
@@ -819,6 +824,9 @@ Flags:
 	flag.Parse()
 
 	// Prepare logging.
+	if !*verboseFlag {
+		selenium.Log = log.New(ioutil.Discard, "", 0)
+	}
 	tr.log = log.New(io.MultiWriter(os.Stderr, tr.slackLogBuffer), "", 0)
 
 	err := parseEnv()

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -78,9 +78,14 @@ func (e *internalError) Error() string {
 
 // Fatalf implements the TestingT and the selenium.TestingT interface.
 func (t *T) Fatalf(fmtStr string, v ...interface{}) {
-	currentURL, _ := t.WebDriver.CurrentURL()
-	fmtStr = fmtStr + " (on page %s)"
-	v = append(v, currentURL)
+	// We only need to append "(on page ...)" if we're being run by 'go test'
+	// because otherwise (*testRunner).runTest handles it in a more general
+	// purpose way (includes panics etc).
+	if t.testingT != nil {
+		currentURL, _ := t.WebDriver.CurrentURL()
+		fmtStr = fmtStr + " (on page %s)"
+		v = append(v, currentURL)
+	}
 	t.testingT.Fatalf(fmtStr, v...)
 }
 

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -456,16 +456,16 @@ func (t *testRunner) runTests(logSuccess bool) bool {
 						failuresMu.Unlock()
 					}
 
-					if t.slack != nil {
-						t.log.Printf("[failure] [%v] [%v]: %v\n", test.Name, unitTime, err)
-					}
 					testCounter.WithLabelValues(test.Name, "failure").Inc()
 
 					if err := t.slackFileUpload(failureType, screenshot, test.Name+".png"); err != nil {
 						t.log.Println("could not upload screenshot to Slack", test.Name, err)
 					}
 
-					if t.slack == nil {
+					if t.slack != nil {
+						t.log.Printf("[failure] [%v] [%v]: %v\n", test.Name, unitTime, err)
+					} else {
+						// Include the screenshot location when running without slack.
 						t.log.Printf("[failure] [%v] [%v]: %v (see ./%s.png)\n", test.Name, unitTime, err, test.Name)
 					}
 					return

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -513,6 +513,10 @@ func (t *testRunner) runTests(logSuccess bool) bool {
 	return failures == 0
 }
 
+var opsGenieClient = &http.Client{
+	Timeout: 5 * time.Second,
+}
+
 func (t *testRunner) alertOpsGenie(msg string) error {
 	key := os.Getenv("OPSGENIE_KEY")
 	if key == "" {
@@ -536,7 +540,7 @@ func (t *testRunner) alertOpsGenie(msg string) error {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := opsGenieClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -508,40 +508,9 @@ func (t *testRunner) runTests(logSuccess bool) bool {
 		if err != nil {
 			t.log.Printf("[WARNING] error while sending alert to opsgenie %s\n", err)
 		}
-
-		// emit the alert to monitoring-bot
-		err = t.sendAlert()
-		if err != nil {
-			t.log.Printf("[WARNING] error while sending alert to monitoring-bot %s\n", err)
-		}
 	}
 	t.slackLogBuffer.Reset()
 	return failures == 0
-}
-
-func (t *testRunner) sendAlert() error {
-	username := os.Getenv("MONITORING_BOT_USERNAME")
-	if username == "" {
-		return nil
-	}
-
-	u, err := url.Parse("https://monitoring-bot.sourcegraph.com/alert?source=e2etest")
-	if err != nil {
-		return err
-	}
-
-	u.User = url.UserPassword(username, os.Getenv("MONITORING_BOT_PASSWORD"))
-
-	resp, err := http.Get(u.String())
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("monitoring bot returned non-200 status code: %d", resp.StatusCode)
-	}
-	return nil
 }
 
 func (t *testRunner) alertOpsGenie(msg string) error {

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -451,11 +451,17 @@ func (t *testRunner) runTests(logSuccess bool) bool {
 						failuresMu.Unlock()
 					}
 
-					t.log.Printf("[failure] [%v] [%v]: %v\n", test.Name, unitTime, err)
+					if t.slack != nil {
+						t.log.Printf("[failure] [%v] [%v]: %v\n", test.Name, unitTime, err)
+					}
 					testCounter.WithLabelValues(test.Name, "failure").Inc()
 
 					if err := t.slackFileUpload(failureType, screenshot, test.Name+".png"); err != nil {
 						t.log.Println("could not upload screenshot to Slack", test.Name, err)
+					}
+
+					if t.slack == nil {
+						t.log.Printf("[failure] [%v] [%v]: %v (see ./%s.png)\n", test.Name, unitTime, err, test.Name)
 					}
 					return
 				}

--- a/test/e2e/e2etest_test.go
+++ b/test/e2e/e2etest_test.go
@@ -4,8 +4,6 @@ import (
 	"flag"
 	"os"
 	"testing"
-
-	"sourcegraph.com/sourcegraph/go-selenium"
 )
 
 func TestDefFlow(t *testing.T) {
@@ -40,9 +38,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		skipMsg = "parseEnv: " + err.Error()
 	}
-	if !testing.Verbose() {
-		selenium.Log = nil
-	}
+	*verboseFlag = testing.Verbose()
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This change effectively sends failure alerts (if any test has failed) top OpsGenie (only one alert will be created).

Additionally, a few minor bug fixes which make working with e2etest locally are also included.

##### Test plan

Tested manually. I will deploy directly to prod once merged.

