### PR TITLE
fixed rapid click behavior when clicking on top search examples

### DIFF
--- a/app/web_modules/sourcegraph/dashboard/DashboardContainer.js
+++ b/app/web_modules/sourcegraph/dashboard/DashboardContainer.js
@@ -31,6 +31,9 @@ class DashboardContainer extends Container {
 
 	constructor(props) {
 		super(props);
+		this.state = {
+			isTyping: false,
+		};
 		this._handleInput = this._handleInput.bind(this);
 		this._onSelectQuery = this._onSelectQuery.bind(this);
 	}
@@ -72,6 +75,7 @@ class DashboardContainer extends Container {
 		const delay = (c: string) => 20 + (25 * Math.random()) + (c === " " ? 75 : 0);
 		const simulateTyping = (v: string, i: number = 0, then: Function) => {
 			if (i >= v.length) {
+				this.setState({isTyping: false});
 				then();
 				return;
 			}
@@ -79,10 +83,11 @@ class DashboardContainer extends Container {
 			this._input.value += c;
 			setTimeout(() => simulateTyping(v, i + 1, then), delay(c));
 		};
-
-		this._input.focus();
-		this._input.value = "";
-		simulateTyping(query, 0, () => setTimeout(() => this._goToSearch(query), 300));
+		if (!this.state.isTyping) {
+			this._input.focus();
+			this._input.value = "";
+			this.setState({isTyping: true}, () => simulateTyping(query, 0, () => setTimeout(() => this._goToSearch(query), 300)));
+		}
 	}
 
 	render() {


### PR DESCRIPTION
Right now in prod, double clicking on any search example causes garbage text to be entered into the search box (although the correct term is still searched). 

You can see an example of this here: https://cl.ly/1J2j3122192v

Now, I've added checks that prevents more than one example from being typed at any given time. 

Example here: https://cl.ly/2b3u1I292v0Z
