### PR TITLE
e2etest: make `go test` first-class citizen and other improvements

### DIFF
--- a/test/e2e/channel_flow.go
+++ b/test/e2e/channel_flow.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"os"
 
 	"sourcegraph.com/sourcegraph/go-selenium"
 )
@@ -27,7 +26,7 @@ func testChannelFlow(t *T) error {
 		return err
 	}
 
-	grpcEnv := os.Getenv("TARGET_GRPC")
+	grpcEnv := t.TargetGRPC().String()
 	if grpcEnv == "" {
 		return errors.New("TARGET_GRPC environment variable not set")
 	}

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -135,7 +135,7 @@ func (t *T) GRPCClient() (context.Context, *sourcegraph.Client) {
 		var err error
 		endpoint, err = url.Parse(grpc)
 		if err != nil {
-			t.Fatalf("could not parge TARGET_GRPC as url: %s", err)
+			t.Fatalf("could not parse TARGET_GRPC as url: %s", err)
 		}
 	}
 

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -705,7 +705,7 @@ func parseEnv() error {
 	serverAddr := os.Getenv("SELENIUM_SERVER_IP")
 	serverPort := os.Getenv("SELENIUM_SERVER_PORT")
 	if serverAddr == "" {
-		return errors.New("unable to get SELENIUM_SERVER_IP from environment")
+		serverAddr = "localhost" // default to localhost
 	}
 	if serverPort == "" {
 		serverPort = "4444" // default to standard Selenium port
@@ -829,10 +829,10 @@ func Main() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, `
 Environment:
-  SELENIUM_SERVER_IP (required)
-      IP address of the Selenium server (run 'docker-machine ls' on OS X and Windows; use 'localhost' on Linux)
   TARGET (required)
       target Sourcegraph server to test against (e.g. 'http://192.168.1.1:3080', use LAN IP due to Docker!)
+  SELENIUM_SERVER_IP = "localhost"
+      IP address of the Selenium server (consider consulting 'docker-machine ls' on certain Docker versions)
   SELENIUM_SERVER_PORT = "4444"
       port of the Selenium server
   ID_KEY_DATA (optional)

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -108,9 +108,8 @@ func (t *T) Endpoint(e string) string {
 	return u + e
 }
 
-// GRPCClient returns a new authenticated Sourcegraph gRPC client. It uses the
-// server's ID key, and thus has 100% unrestricted access. Use with caution!
-func (t *T) GRPCClient() (context.Context, *sourcegraph.Client) {
+// TargetGRPC returns the final gRPC target URL, e.g. https://grpc.sourcegraph.com.
+func (t *T) TargetGRPC() *url.URL {
 	cpy := *t.Target
 	endpoint := &cpy
 
@@ -138,10 +137,15 @@ func (t *T) GRPCClient() (context.Context, *sourcegraph.Client) {
 			t.Fatalf("could not parse TARGET_GRPC as url: %s", err)
 		}
 	}
+	return endpoint
+}
 
+// GRPCClient returns a new authenticated Sourcegraph gRPC client. It uses the
+// server's ID key, and thus has 100% unrestricted access. Use with caution!
+func (t *T) GRPCClient() (context.Context, *sourcegraph.Client) {
 	// Create context with gRPC endpoint and idKey credentials.
 	ctx := context.Background()
-	ctx = sourcegraph.WithGRPCEndpoint(ctx, endpoint)
+	ctx = sourcegraph.WithGRPCEndpoint(ctx, t.TargetGRPC())
 	ctx = sourcegraph.WithCredentials(ctx, sharedsecret.TokenSource(t.tr.idKey, "internal:e2etest"))
 
 	// Create client.

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -111,7 +111,8 @@ func (t *T) Endpoint(e string) string {
 // GRPCClient returns a new authenticated Sourcegraph gRPC client. It uses the
 // server's ID key, and thus has 100% unrestricted access. Use with caution!
 func (t *T) GRPCClient() (context.Context, *sourcegraph.Client) {
-	endpoint := t.Target
+	cpy := *t.Target
+	endpoint := &cpy
 
 	// HACK: Because there is no gRPC service discovery system set up in
 	//       Sourcegraph, we hard-code gRPC endpoints here so that we don't

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -112,6 +112,24 @@ func (t *T) Endpoint(e string) string {
 // server's ID key, and thus has 100% unrestricted access. Use with caution!
 func (t *T) GRPCClient() (context.Context, *sourcegraph.Client) {
 	endpoint := t.Target
+
+	// HACK: Because there is no gRPC service discovery system set up in
+	//       Sourcegraph, we hard-code gRPC endpoints here so that we don't
+	//       have to specify TARGET_GRPC every single time (one less thing
+	//       to think about).
+	switch endpoint.Host {
+	case "sourcegraph.com":
+		endpoint.Host = "grpc.sourcegraph.com"
+	case "staging.sourcegraph.com":
+		endpoint.Host = "grpc-staging.sourcegraph.com"
+	case "staging2.sourcegraph.com":
+		endpoint.Host = "grpc-staging2.sourcegraph.com"
+	case "staging3.sourcegraph.com":
+		endpoint.Host = "grpc-staging3.sourcegraph.com"
+	case "staging4.sourcegraph.com":
+		endpoint.Host = "grpc-staging4.sourcegraph.com"
+	}
+
 	if grpc := os.Getenv("TARGET_GRPC"); grpc != "" {
 		var err error
 		endpoint, err = url.Parse(grpc)

--- a/test/e2e/e2etest.go
+++ b/test/e2e/e2etest.go
@@ -719,7 +719,7 @@ var tr = &testRunner{
 var (
 	runOnce     = flag.Bool("once", true, "run the tests only once (true) or forever (false)")
 	runFlag     = flag.String("run", "", "specify an exact test name to run (e.g. 'login_flow', 'register_flow')")
-	retriesFlag = flag.Int("retries", 3, "maximum number of times to retry a test before considering it failed")
+	retriesFlag = flag.Int("retries", 1, "maximum number of times to retry a test before considering it failed")
 
 	seleniumTrace = os.Getenv("SELENIUM_TRACE") != ""
 )

--- a/test/e2e/e2etest_test.go
+++ b/test/e2e/e2etest_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		fatalMsg = "parseEnv: " + err.Error()
 	}
-	*verboseFlag = testing.Verbose()
+	seleniumTrace = testing.Verbose()
 	os.Exit(m.Run())
 }
 

--- a/test/e2e/e2etest_test.go
+++ b/test/e2e/e2etest_test.go
@@ -1,9 +1,16 @@
 package e2e
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"hash/crc32"
+	"log"
+	"net"
 	"os"
 	"testing"
+
+	"sourcegraph.com/sourcegraph/sourcegraph/test/e2e/e2etestuser"
 )
 
 func TestDefFlow(t *testing.T) {
@@ -38,8 +45,33 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		fatalMsg = "parseEnv: " + err.Error()
 	}
+
+	// Prevent collision between multiple people running e2etest at the same
+	// time against the same target instance. Otherwise, we may hit race
+	// conditions / etc.
+	hwid, err := HardwareID()
+	if err != nil {
+		log.Fatal(err)
+	}
+	e2etestuser.Prefix = e2etestuser.Prefix + hwid
+
 	seleniumTrace = testing.Verbose()
 	os.Exit(m.Run())
+}
+
+// HardwareID returns a CRC32 checksum of the first network adapter with an
+// hardware address.
+func HardwareID() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	for _, iface := range ifaces {
+		if addr := iface.HardwareAddr.String(); addr != "" {
+			return fmt.Sprint(crc32.ChecksumIEEE([]byte(addr))), nil
+		}
+	}
+	return "", errors.New("could not find a hardware address")
 }
 
 func runE2E(t *testing.T, name string) {

--- a/test/e2e/e2etest_test.go
+++ b/test/e2e/e2etest_test.go
@@ -30,13 +30,13 @@ func TestChannelFlow(t *testing.T) {
 	runE2E(t, "channel_flow")
 }
 
-var skipMsg string
+var fatalMsg string
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	err := parseEnv()
 	if err != nil {
-		skipMsg = "parseEnv: " + err.Error()
+		fatalMsg = "parseEnv: " + err.Error()
 	}
 	*verboseFlag = testing.Verbose()
 	os.Exit(m.Run())
@@ -52,8 +52,8 @@ func runE2E(t *testing.T, name string) {
 	if test == nil {
 		t.Fatal("Could not find test")
 	}
-	if skipMsg != "" {
-		t.Skip(skipMsg)
+	if fatalMsg != "" {
+		t.Fatal(fatalMsg)
 	}
 	wd, err := tr.newWebDriver()
 	if err != nil {

--- a/test/e2e/e2etest_test.go
+++ b/test/e2e/e2etest_test.go
@@ -29,8 +29,24 @@ func TestRepoFlow(t *testing.T) {
 	runE2E(t, "repo_flow")
 }
 
-func TestSearchFlow(t *testing.T) {
-	runE2E(t, "search_flow")
+func TestSearchFlow0(t *testing.T) {
+	runE2E(t, "search_flow_0")
+}
+
+func TestSearchFlow1(t *testing.T) {
+	runE2E(t, "search_flow_1")
+}
+
+func TestSearchFlow2(t *testing.T) {
+	runE2E(t, "search_flow_2")
+}
+
+func TestSearchFlow3(t *testing.T) {
+	runE2E(t, "search_flow_3")
+}
+
+func TestSearchFlow4(t *testing.T) {
+	runE2E(t, "search_flow_4")
 }
 
 func TestChannelFlow(t *testing.T) {

--- a/test/e2e/e2etest_test.go
+++ b/test/e2e/e2etest_test.go
@@ -43,6 +43,7 @@ func TestMain(m *testing.M) {
 }
 
 func runE2E(t *testing.T, name string) {
+	t.Parallel()
 	var test *Test
 	for _, tst := range tr.tests {
 		if tst.Name == name {

--- a/test/e2e/e2etestuser/prefix.go
+++ b/test/e2e/e2etestuser/prefix.go
@@ -3,7 +3,7 @@ package e2etestuser
 // Prefix is prefixed to all e2etest user account logins to ensure they can be
 // filtered out of different systems easily and do not conflict with real user
 // accounts.
-const Prefix = "e2etestuserx4FF3"
+var Prefix = "e2etestuserx4FF3"
 
 // UserAgent is explicitly filtered out on several metrics/monitoring systems.
 const UserAgent = "Sourcegraph e2etest-bot"

--- a/test/e2e/search_flow.go
+++ b/test/e2e/search_flow.go
@@ -3,19 +3,29 @@ package e2e
 import "sourcegraph.com/sourcegraph/go-selenium"
 
 func init() {
-	Register(&Test{
-		Name:        "search_flow",
-		Description: "fetch every search item on sourcegraph.com for Go, ensure each first listing has usage examples",
-		Func:        testSearchFlow,
-	})
+	registerTest := func(name, q string) {
+		Register(&Test{
+			Name:        name,
+			Description: "fetch every search item on sourcegraph.com for Go, ensure each first listing has usage examples",
+			Func: func(t *T) error {
+				return runSearchFlow(t, q)
+			},
+		})
+	}
+
+	registerTest("search_flow_0", "new http request")
+	registerTest("search_flow_1", "read file")
+	registerTest("search_flow_2", "json encoder")
+	registerTest("search_flow_3", "sql query")
+	registerTest("search_flow_4", "indent json")
 }
 
-func runSearchFlow(t *T, query string) {
+func runSearchFlow(t *T, query string) error {
 	wd := t.WebDriver
 
 	err := wd.Get(t.Endpoint("/search"))
 	if err != nil {
-		t.Fatalf("TestSearchFlow: %s ", err)
+		return err
 	}
 
 	searchInput := t.WaitForElement(selenium.ById, "e2etest-search-input")
@@ -27,20 +37,5 @@ func runSearchFlow(t *T, query string) {
 
 	// The usage examples are in `table` elements
 	t.WaitForElement(selenium.ByTagName, "table")
-}
-
-func testSearchFlow(t *T) error {
-	wd := t.WebDriver
-
-	err := wd.Get(t.Endpoint("/search"))
-	if err != nil {
-		t.Fatalf("TestSearchFlow: %s", err)
-	}
-
-	queries := [5]string{"new http request", "read file", "json encoder", "sql query", "indent json"}
-	for _, q := range queries {
-		runSearchFlow(t, q)
-	}
-
 	return nil
 }


### PR DESCRIPTION
This PR effectively makes using e2etest much easier for new developers (and people who haven't used it before in general), so that nobody should have an excuse not to use e2etest.

- Basically deprecate all mention of the `e2etest` binary and instead use `go test` (`e2etest` binary only lives for prod now).
- Make several general improvements to the `go test` user experience.
- Improve and simplify the documentation for e2etest significantly.
- Improve overall runtime from 30s -> 9s.

##### Test plan

I have tested locally -> after review I will deploy to prod (and confirm it is working okay).