### PR TITLE
Rig logout so the desktop app can detect it by looking at the URL

### DIFF
--- a/app/web_modules/sourcegraph/user/UserBackend.js
+++ b/app/web_modules/sourcegraph/user/UserBackend.js
@@ -102,7 +102,13 @@ const UserBackend = {
 					.then(checkStatus)
 					.then((resp) => resp.json())
 					.catch((err) => ({Error: err}))
-					.then((data) => Dispatcher.Stores.dispatch(new UserActions.LoginCompleted(data)))
+					.then((data) => {
+						Dispatcher.Stores.dispatch(new UserActions.LoginCompleted(data));
+						// Redirect on login.
+						if (data.Success) {
+							window.location.href = "/";
+						}
+					})
 			);
 			break;
 		case UserActions.SubmitLogout:
@@ -118,7 +124,7 @@ const UserBackend = {
 						Dispatcher.Stores.dispatch(new UserActions.LogoutCompleted(data));
 						// Redirect on logout.
 						if (data.Success) {
-							window.location.href = "/";
+							window.location.href = "/#loggedout";
 						}
 					})
 			);


### PR DESCRIPTION
Change the redirect URL after logout from `/` to `/#logout` so the desktop app can detect it.
Also redirect to `/` after login to clear any leftover `#logout` from a previous logout which would look confusing.

Tested locally. Deploying to `staging3`...