### PR TITLE
Language server support

### DIFF
--- a/lang/sample/README.md
+++ b/lang/sample/README.md
@@ -1,0 +1,20 @@
+# Running your own language server
+
+This describes how to run your own language server with the Visual Studio Code
+extension in `../vscode-client`.  For instructions on running the sample
+language server, see
+[`../vscode-client/README.md`](../vscode-client/README.md).
+
+To run your own language server:
+
+1.  In the extension code (`../vscode-client/src/extension.ts`), in the
+    `activate` function, change the `run` and `debug` field commands from
+    `sample_server` to `${your_server}`.
+1.  Open ../lang/vscode-client/package.json and under `"activationEvents"` add
+    `"onCommand:${your_language}"`
+1.  Build your server program in the `$PATH` that visual studio sees (e.g.
+    `go build -o /usr/local/bin/${your_server} ${your_server}.go`.)
+1.  Follow the instructions in the
+    [Node.js example language server tutorial](https://code.visualstudio.com/docs/extensions/example-language-server)
+    under "To test the language server do the following:" to build and run the
+    vscode-client sample extension.

--- a/lang/sample/sample_server.go
+++ b/lang/sample/sample_server.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/jsonrpc2"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/lsp"
+)
+
+var (
+	mode    = flag.String("mode", "stdio", "communication mode (stdio|tcp)")
+	addr    = flag.String("addr", ":2088", "server listen address (tcp)")
+	logfile = flag.String("log", "/tmp/sample_server.log", "write log output to this file (and stderr)")
+)
+
+func main() {
+	flag.Parse()
+	log.SetFlags(0)
+
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if *logfile != "" {
+		f, err := os.Create(*logfile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		log.SetOutput(io.MultiWriter(os.Stderr, f))
+	}
+
+	h := &jsonrpc2.LoggingHandler{handler{}}
+
+	switch *mode {
+	case "tcp":
+		lis, err := net.Listen("tcp", *addr)
+		if err != nil {
+			return err
+		}
+		defer lis.Close()
+		log.Println("listening on", *addr)
+		return jsonrpc2.Serve(lis, h)
+
+	case "stdio":
+		log.Println("reading on stdin, writing on stdout")
+		jsonrpc2.NewServerConn(os.Stdin, os.Stdout, h)
+		select {}
+
+	default:
+		return fmt.Errorf("invalid mode %q", *mode)
+	}
+}
+
+type handler struct{}
+
+func (handler) Handle(req *jsonrpc2.Request) (resp *jsonrpc2.Response) {
+	if !req.Notification {
+		resp = &jsonrpc2.Response{ID: req.ID}
+	}
+
+	switch req.Method {
+	case "initialize":
+		resp.SetResult(lsp.InitializeResult{
+			Capabilities: lsp.ServerCapabilities{
+				HoverProvider:      true,
+				DefinitionProvider: true,
+				ReferencesProvider: true,
+			},
+		})
+
+	case "shutdown":
+		// Result is undefined, per
+		// https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#shutdown-request.
+		resp.SetResult(true)
+
+	case "textDocument/hover":
+		var params lsp.TextDocumentPositionParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			resp.Error = &jsonrpc2.Error{Code: 123, Message: "error!"}
+			return
+		}
+
+		pos := params.Position
+		resp.SetResult(lsp.Hover{
+			Contents: []lsp.MarkedString{{Language: "markdown", Value: "Hello over LSP!"}},
+			Range: lsp.Range{
+				Start: lsp.Position{Line: pos.Line, Character: pos.Character - 3},
+				End:   lsp.Position{Line: pos.Line, Character: pos.Character + 3},
+			},
+		})
+	case "textDocument/definition":
+		var params lsp.TextDocumentPositionParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			resp.Error = &jsonrpc2.Error{Code: 123, Message: "error!"}
+			return
+		}
+		resp.SetResult(lsp.Location{
+			URI: params.TextDocument.URI,
+			Range: lsp.Range{
+				Start: lsp.Position{Line: 0, Character: 0},
+				End:   lsp.Position{Line: 0, Character: 0},
+			},
+		})
+	case "textDocument/references":
+		var params lsp.ReferenceParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			resp.Error = &jsonrpc2.Error{Code: 123, Message: "error!"}
+			return
+		}
+		resp.SetResult([]lsp.Location{lsp.Location{
+			URI: params.TextDocument.URI,
+			Range: lsp.Range{
+				Start: lsp.Position{Line: 0, Character: 0},
+				End:   lsp.Position{Line: 0, Character: 3},
+			},
+		}, lsp.Location{
+			URI: params.TextDocument.URI,
+			Range: lsp.Range{
+				Start: lsp.Position{Line: 0, Character: 4},
+				End:   lsp.Position{Line: 0, Character: 6},
+			},
+		}})
+	}
+
+	return
+}

--- a/lang/vscode-client/.gitignore
+++ b/lang/vscode-client/.gitignore
@@ -1,0 +1,3 @@
+out
+server
+node_modules

--- a/lang/vscode-client/.vscode/launch.json
+++ b/lang/vscode-client/.vscode/launch.json
@@ -1,0 +1,28 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+	"version": "0.1.0",
+	"configurations": [
+		{
+			"name": "Launch Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outDir": "${workspaceRoot}/out/src",
+			"preLaunchTask": "npm"
+		},
+		{
+			"name": "Launch Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outDir": "${workspaceRoot}/out/test",
+			"preLaunchTask": "npm"
+		}
+	]
+}

--- a/lang/vscode-client/.vscode/settings.json
+++ b/lang/vscode-client/.vscode/settings.json
@@ -1,0 +1,10 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+	"files.exclude": {
+		"out": false // set this to true to hide the "out" folder with the compiled JS files
+	},
+	"search.exclude": {
+		"out": true // set this to false to include "out" folder in search results
+	},
+	"typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
+}

--- a/lang/vscode-client/.vscode/tasks.json
+++ b/lang/vscode-client/.vscode/tasks.json
@@ -1,0 +1,30 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+
+// A task runner that calls a custom npm script that compiles the extension.
+{
+	"version": "0.1.0",
+
+	// we want to run npm
+	"command": "npm",
+
+	// the command is a shell script
+	"isShellCommand": true,
+
+	// show the output window only if unrecognized errors occur.
+	"showOutput": "silent",
+
+	// we run the custom script "compile" as defined in package.json
+	"args": ["run", "compile", "--loglevel", "silent"],
+
+	// The tsc compiler is started in watching mode
+	"isWatching": true,
+
+	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
+	"problemMatcher": "$tsc-watch"
+}

--- a/lang/vscode-client/.vscodeignore
+++ b/lang/vscode-client/.vscodeignore
@@ -1,0 +1,9 @@
+.vscode/**
+typings/**
+out/test/**
+test/**
+src/**
+**/*.map
+.gitignore
+tsconfig.json
+vsc-extension-quickstart.md

--- a/lang/vscode-client/License.txt
+++ b/lang/vscode-client/License.txt
@@ -1,0 +1,11 @@
+Copyright (c) Microsoft Corporation
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lang/vscode-client/README.md
+++ b/lang/vscode-client/README.md
@@ -1,0 +1,33 @@
+# Running the sample language server via a Visual Studio code extension
+
+This describes how to run the sample language server in `../sample`
+in Visual Studio Code via the Visual Studio Code extension in this directory.
+
+To run the sample language server and extension:
+
+1.  Run `npm install` in this directory (`vscode-client`).
+1.  Open this directory by itself in Visual Studio Code.
+1.  `cd ../sample`. Build the the `sample_server` program and
+    ensure it is in the `$PATH` that Visual Studio Code sees
+    (e.g., `go build -o /usr/local/bin/sample_server sample_server.go`).
+1.  Follow the instructions in the
+    [Node.js example language server tutorial](https://code.visualstudio.com/docs/extensions/example-language-server)
+    under "To test the language server do the following:" to build and
+    run the vscode-client sample extension.
+1.  When the new Visual Studio Code window opens with the extension,
+    create a new text file and type some text. Move your mouse cursor
+    over the text, and you should see "Hello over LSP!" in a tooltip.
+    Right click on any text and click "Go to Definition", and you'll
+    be taken to the beginning of the file. Right click on any text and
+    click "Find All References", and if your text is longer than 6
+    characters, you'll be shown two references in the first line of your
+    file.
+
+Debug tips if extension throws an error:
+
+1.  Open the debug pane (Cmd+Shift+D) to see the call stack.
+1.  Open the debug console (Cmd+Shift+Y) and press the green
+    "play"/triangle button to see the error logs.
+1.  Commonly seen error is the server is not in a `$PATH` that VSCode sees.
+
+To run your own language server with this extension, see [`../sample/README.md`](../sample/README.md).

--- a/lang/vscode-client/ThirdPartyNotices.txt
+++ b/lang/vscode-client/ThirdPartyNotices.txt
@@ -1,0 +1,31 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+For Microsoft vscode-languageserver-node-example
+ 
+This project incorporates material from the project(s) listed below (collectively, “Third Party Code”).
+Microsoft is not the original author of the Third Party Code.  The original copyright notice and license 
+under which Microsoft received such Third Party Code are set out below. This Third Party Code is licensed 
+to you under their original license terms set forth below.  Microsoft reserves all other rights not expressly 
+granted, whether by implication, estoppel or otherwise.
+ 
+1.       DefinitelyTyped version 0.0.1 (https://github.com/borisyankov/DefinitelyTyped)
+ 
+This project is licensed under the MIT license.
+Copyrights are respective of each contributor listed at the beginning of each definition file.
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lang/vscode-client/package.json
+++ b/lang/vscode-client/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "language-client-example",
+	"description": "VSCode part of a language server",
+	"author": "Microsoft Corporation",
+	"license": "MIT",
+	"version": "0.0.1",
+	"publisher": "vscode",
+	"engines": {
+		"vscode": "^0.10.10"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"onLanguage:plaintext"
+	],
+	"main": "./out/src/extension",
+	"scripts": {
+		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install"
+
+	},
+	"devDependencies": {
+		"typescript": "^1.8.9",
+		"vscode": "^0.11.0"
+	},
+	"dependencies": {
+		"vscode-languageclient": "^2.2.1"
+	}
+}

--- a/lang/vscode-client/src/extension.ts
+++ b/lang/vscode-client/src/extension.ts
@@ -1,0 +1,43 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import * as path from 'path';
+
+import { workspace, Disposable, ExtensionContext } from 'vscode';
+import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, ErrorAction, CloseAction, TransportKind } from 'vscode-languageclient';
+
+export function activate(context: ExtensionContext) {
+	let serverOptions: ServerOptions = {
+		run : { command: "sample_server" },
+		debug : { command: "sample_server" },
+	}
+
+	// Options to control the language client
+	let clientOptions: LanguageClientOptions = {
+		// Register the server for plain text documents
+		documentSelector: ['plaintext'],
+		synchronize: {
+			// Synchronize the setting section 'languageServerExample' to the server
+			configurationSection: 'languageServerExample',
+		},
+		errorHandler: {
+			error(error: Error, message, count: number): ErrorAction {
+				console.log("ERR", error, message, count);
+				return ErrorAction.Shutdown;
+			},
+    		closed(): CloseAction {
+				return CloseAction.Restart;
+			},
+		},
+	}
+
+	// Create the language client and start the client.
+	let disposable = new LanguageClient('Language Server Example', serverOptions, clientOptions).start();
+
+	// Push the disposable to the context's subscriptions so that the
+	// client can be deactivated on extension deactivation
+	context.subscriptions.push(disposable);
+}

--- a/lang/vscode-client/test/index.ts
+++ b/lang/vscode-client/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+var testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+	ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+	useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/lang/vscode-client/tsconfig.json
+++ b/lang/vscode-client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"outDir": "out",
+		"noLib": true,
+		"sourceMap": true
+	},
+	"exclude": [
+		"node_modules",
+		"server"
+	]
+}

--- a/lang/vscode-client/typings/node.d.ts
+++ b/lang/vscode-client/typings/node.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/lang/vscode-client/typings/vscode-typings.d.ts
+++ b/lang/vscode-client/typings/vscode-typings.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/vscode/typings/index.d.ts" />

--- a/pkg/jsonrpc2/jsonrpc2.go
+++ b/pkg/jsonrpc2/jsonrpc2.go
@@ -1,0 +1,660 @@
+// Package jsonrpc2 provides a client and server implementation of
+// [JSON-RPC 2.0](http://www.jsonrpc.org/specification).
+package jsonrpc2
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const jsonrpcVersion = "2.0"
+
+// Request represents a JSON-RPC request or
+// notification. See
+// http://www.jsonrpc.org/specification#request_object and
+// http://www.jsonrpc.org/specification#notification.
+type Request struct {
+	Method       string
+	Params       *json.RawMessage
+	ID           string
+	Notification bool
+	JSONRPC      string // "2.0"
+}
+
+func (r *Request) MarshalJSON() ([]byte, error) {
+	// Override to omit ID if Notification.
+	m := map[string]interface{}{
+		"method":  r.Method,
+		"params":  r.Params,
+		"jsonrpc": r.JSONRPC,
+	}
+	if !r.Notification {
+		m["id"] = r.ID
+	}
+	return json.Marshal(m)
+}
+
+func (r *Request) UnmarshalJSON(data []byte) error {
+	var m struct {
+		Method  string           `json:"method"`
+		Params  *json.RawMessage `json:"params"`
+		ID      *string          `json:"id,omitempty"`
+		JSONRPC string           `json:"jsonrpc"` // "2.0"
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	*r = Request{
+		Method:  m.Method,
+		Params:  m.Params,
+		JSONRPC: m.JSONRPC,
+	}
+	if m.ID != nil {
+		(*r).ID = *m.ID
+	} else {
+		(*r).Notification = true
+	}
+	return nil
+}
+
+// SetParams sets r.Params to the JSON representation of v. If JSON
+// marshaling fails, it panics.
+func (r *Request) SetParams(v interface{}) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("Response.SetParams: " + err.Error())
+	}
+	r.Params = (*json.RawMessage)(&b)
+}
+
+// Response represents a JSON-RPC response. See
+// http://www.jsonrpc.org/specification#response_object.
+type Response struct {
+	Result  *json.RawMessage `json:"result,omitempty"`
+	Error   *Error           `json:"error,omitempty"`
+	ID      string           `json:"id"`
+	JSONRPC string           `json:"jsonrpc"` // "2.0"
+
+	// SPEC NOTE: The spec says "If there was an error in detecting
+	// the id in the Request object (e.g. Parse error/Invalid
+	// Request), it MUST be Null." If we made the ID field nullable,
+	// then we'd have to make it a pointer type. For simplicity, we're
+	// ignoring the case where there was an error in detecting the ID
+	// in the Request object.
+}
+
+// SetResult sets r.Result to the JSON representation of v. If JSON
+// marshaling fails, it panics.
+func (r *Response) SetResult(v interface{}) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("Response.SetResult: " + err.Error())
+	}
+	r.Result = (*json.RawMessage)(&b)
+}
+
+// Error represents a JSON-RPC response error.
+type Error struct {
+	Code    int64  `json:"code"`
+	Message string `json:"message"`
+	Data    *json.RawMessage
+}
+
+// SetError sets e.Error to the JSON representation of v. If JSON
+// marshaling fails, it panics.
+func (e *Error) SetError(v interface{}) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("Error.SetData: " + err.Error())
+	}
+	e.Data = (*json.RawMessage)(&b)
+}
+
+const (
+	// Errors defined in the JSON-RPC spec. See http://www.jsonrpc.org/specification#error_object.
+	CodeParseError       = -32700
+	CodeInvalidRequest   = -32600
+	CodeMethodNotFound   = -32601
+	CodeInvalidParams    = -32602
+	CodeInternalError    = -32603
+	codeServerErrorStart = -32099
+	codeServerErrorEnd   = -32000
+)
+
+// Client is a JSON-RPC client.
+type Client struct {
+	conn io.ReadWriteCloser
+
+	mu    sync.Mutex
+	resps chan Response // only set if someone is in a RequestAndWaitForResponse call
+}
+
+// NewClient creates a new JSON-RPC client using the given ReadWriteCloser
+// (typically a TCP connection or stdio).
+//
+// NewClient consumes conn, you should call Close on the returned client not
+// on the given conn.
+func NewClient(conn io.ReadWriteCloser) *Client {
+	c := &Client{conn: conn}
+	go c.readResponses()
+	return c
+}
+
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+func (c *Client) readResponses() {
+	r := bufio.NewReader(c.conn)
+	for {
+		var resp responseOrResponseBatch
+
+		n, err := readHeaderContentLength(r)
+		if err == nil {
+			err = json.NewDecoder(io.LimitReader(r, int64(n))).Decode(&resp)
+		}
+		if err != nil {
+			if isFatalConnError(err) {
+				if err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
+					log.Println("jsonrpc2 client:", err)
+				}
+				c.conn.Close()
+				break
+			}
+			log.Println("jsonrpc2 client:", err)
+			continue
+		}
+
+		c.mu.Lock()
+		if c.resps != nil {
+			if resp.single != nil {
+				c.resps <- *resp.single
+			} else {
+				for _, resp := range resp.batch {
+					c.resps <- resp
+				}
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+func (c *Client) send(body interface{}) error {
+	w := bufio.NewWriter(c.conn)
+	if err := marshalHeadersAndBody(w, body); err != nil {
+		w.Flush()
+		return err
+	}
+	return w.Flush()
+}
+
+// Request sends req to the server. It does not wait for the server to
+// send the corresponding JSON-RPC response object. An error is
+// returned if the request is unable to be sent. To wait for the
+// corresponding response, use RequestAndWaitForResponse.
+func (c *Client) Request(req Request) error {
+	req.JSONRPC = jsonrpcVersion
+	return c.send(req)
+}
+
+// RequestAndWaitForResponse sends req to the server and waits for the
+// corresponding response (where resp.ID == req.ID). If req is a
+// notification, call Request instead, since the server will never
+// respond to notifications, and this method would block forever.
+//
+// It is NOT safe to call this method from more than one goroutine
+// concurrently.
+func (c *Client) RequestAndWaitForResponse(req Request) (*Response, error) {
+	if req.Notification {
+		panic("jsonrpc2: Request ID must be set (if req is a notification, call Request to avoid a futile wait for a response)")
+	}
+
+	// Open this channel until we receive the response we're looking
+	// for. readResponses will send us the responses on the channel if
+	// it's non-nil.
+	c.mu.Lock()
+	c.resps = make(chan Response)
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		close(c.resps)
+		c.resps = nil
+		c.mu.Unlock()
+	}()
+
+	if err := c.Request(req); err != nil {
+		return nil, err
+	}
+
+	for resp := range c.resps {
+		if resp.ID == req.ID {
+			return &resp, nil
+		}
+	}
+	panic("unreachable") // above loop is infinite until condition is met
+}
+
+// RequestBatch is the batched version of Request.
+func (c *Client) RequestBatch(reqs ...Request) error {
+	for _, req := range reqs {
+		req.JSONRPC = jsonrpcVersion
+	}
+	return c.send(reqs)
+}
+
+// RequestBatchAndWaitForAllResponses is the batched version of
+// RequestAndWaitForResponse.
+func (c *Client) RequestBatchAndWaitForAllResponses(reqs ...Request) (map[string]*Response, error) {
+	wantResps := make(map[string]*Response, len(reqs)) // overallocation if reqs has notifs, but that's fine
+	for _, req := range reqs {
+		if !req.Notification {
+			wantResps[req.ID] = nil
+		}
+	}
+
+	// Open this channel until we receive the response we're looking
+	// for. readResponses will send us the responses on the channel if
+	// it's non-nil.
+	c.mu.Lock()
+	c.resps = make(chan Response)
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		close(c.resps)
+		c.resps = nil
+		c.mu.Unlock()
+	}()
+
+	if err := c.RequestBatch(reqs...); err != nil {
+		return nil, err
+	}
+
+	remaining := len(wantResps)
+	for resp := range c.resps {
+		if existing, present := wantResps[resp.ID]; present {
+			if existing != nil {
+				return nil, fmt.Errorf("jsonrpc2: duplicate response received with ID %s", resp.ID)
+			}
+			tmp := resp
+			wantResps[resp.ID] = &tmp
+			remaining--
+		}
+		if remaining == 0 {
+			return wantResps, nil
+		}
+	}
+	panic("unreachable") // above loop is infinite until
+}
+
+// Handler handles JSON-RPC requests and notifications.
+type Handler interface {
+	// Handle handles a request (if !Request.Notification) or notification
+	// (if Request.Notification). If the argument is a request, it must
+	// return a non-nil response. If the argument is a notification,
+	// it must return a nil response.
+	//
+	// If the client sent a batch request, and the handler doesn't
+	// also implement BatchHandler, Handle will be called once for
+	// each element of the batch, in the same order the requests
+	// appeared in the batch.
+	Handle(*Request) *Response
+}
+
+// BatchHandler is like Handler, but it also operates on entire
+// batches at once.  Like Handler, it returns a nil response for
+// notifications.
+type BatchHandler interface {
+	Handler
+	HandleBatch([]*Request) []*Response
+}
+
+// Server is a JSON-RPC server.
+type Server struct{}
+
+// Serve starts a new JSON-RPC server.
+func Serve(lis net.Listener, h Handler) error {
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			return err
+		}
+		NewServerConn(conn, conn, h)
+	}
+}
+
+// NewServerConn creates a server for a single client. It can also be
+// used to create an interactive program that uses standard
+// input/output, if os.Stdin and os.Stdout are passed.
+func NewServerConn(r io.ReadCloser, w io.WriteCloser, h Handler) {
+	sc := &serverConn{r: r, w: w, h: h}
+	sc.serveConn()
+}
+
+const serverConnBufSize = 20
+
+type serverConn struct {
+	r io.ReadCloser
+	w io.WriteCloser
+	h Handler
+
+	reqs chan requestOrRequestBatch // batches or 1-element slices of single requests
+}
+
+func (sc *serverConn) serveConn() {
+	sc.reqs = make(chan requestOrRequestBatch, serverConnBufSize)
+
+	go sc.readRequests()
+	go sc.handleRequests()
+
+	// TODO(sqs) clean up reqs, conn on exit
+}
+
+func (sc *serverConn) readRequests() {
+	r := bufio.NewReader(sc.r)
+	for {
+		var req requestOrRequestBatch
+
+		n, err := readHeaderContentLength(r)
+		if err == nil {
+			err = json.NewDecoder(io.LimitReader(r, int64(n))).Decode(&req)
+		}
+		if err != nil {
+			if isFatalConnError(err) {
+				if err != io.EOF {
+					log.Println("jsonrpc2 server:", err)
+				}
+				close(sc.reqs)
+				sc.r.Close()
+				sc.w.Close()
+				break
+			}
+			log.Println("jsonrpc2 server:", err)
+			// TODO(sqs): return server error to client
+			continue
+		}
+
+		sc.reqs <- req
+	}
+}
+
+func checkResponse(req *Request, resp *Response) {
+	if req.Notification {
+		if resp != nil {
+			panic("jsonrpc2: Handle returned non-nil response for notification (must be nil)")
+		}
+	} else {
+		if resp.ID != req.ID {
+			panic(fmt.Sprintf("jsonrpc2: Handle set an invalid response ID %s", resp.ID))
+		}
+		if resp.Result != nil && resp.Error != nil {
+			panic("jsonrpc2: Handle returned non-nil result and error (exactly 1 must be non-nil)")
+		}
+		if resp.Result == nil && resp.Error == nil {
+			panic("jsonrpc2: Handle returned nil result and error (exactly 1 must be non-nil)")
+		}
+
+		resp.JSONRPC = jsonrpcVersion
+	}
+}
+
+// mapRespsToReq returns a slice whose i'th element reports the index
+// in reqs of the i'th response in resps.
+//
+// It returns an error if a response's ID does not refer to that of a
+// request in reqs, or if two responses have the same ID, or if there
+// is a request (non-notification) that does not have a corresponding
+// response.
+func mapRespsToReq(reqs []*Request, resps []*Response) ([]int, error) {
+	reqIndexByID := make(map[string]int, len(reqs))
+	for i, req := range reqs {
+		if !req.Notification {
+			reqIndexByID[req.ID] = i
+		}
+	}
+
+	if len(resps) != len(reqIndexByID) {
+		return nil, fmt.Errorf("jsonrpc2: response batch too small: %d responses for %d non-notification requests", len(resps), len(reqIndexByID))
+	}
+
+	m := make([]int, len(resps))
+	seenIDs := make(map[string]struct{}, len(resps))
+	for i, resp := range resps {
+		reqIndex, present := reqIndexByID[resp.ID]
+		if !present {
+			return nil, fmt.Errorf("jsonrpc2: response batch contains response with ID %s that doesn't match any IDs in request batch", resp.ID)
+		}
+		m[i] = reqIndex
+
+		if _, seen := seenIDs[resp.ID]; seen {
+			return nil, fmt.Errorf("jsonrpc2: response batch contains multiple responses with same ID %s", resp.ID)
+		}
+		seenIDs[resp.ID] = struct{}{}
+	}
+
+	return m, nil
+}
+
+func (sc *serverConn) handleRequests() {
+	w := bufio.NewWriter(sc.w)
+reqLoop:
+	for reqSingleOrBatch := range sc.reqs {
+		var body interface{}
+		if req := reqSingleOrBatch.single; req != nil {
+			// Single (non-batch)
+			resp := sc.h.Handle(req)
+			checkResponse(req, resp)
+			if req.Notification {
+				continue
+			}
+			body = resp
+		} else {
+			// Batch
+			reqs := reqSingleOrBatch.batch
+
+			{
+				// Validate that there aren't any duplicate request IDs.
+				reqID := make(map[string]struct{}, len(reqs))
+				for _, req := range reqs {
+					if req.Notification {
+						continue
+					}
+					if _, present := reqID[req.ID]; present {
+						// TODO(sqs): return error Response object(s) instead?
+						log.Printf("jsonrpc2: ignoring invalid request batch containing multiple requests with same ID %s", req.ID)
+						continue reqLoop
+					}
+					reqID[req.ID] = struct{}{}
+				}
+			}
+
+			bh, ok := sc.h.(BatchHandler)
+			if !ok {
+				bh = batchHandlerWrapper{sc.h}
+			}
+			resps := bh.HandleBatch(reqs)
+
+			respIndexToReqIndex, err := mapRespsToReq(reqs, resps)
+			if err != nil {
+				// All errors are due to certain bugs in the Handler
+				// and are not able to be triggered by clients when
+				// the Handler is correct, so panicking is acceptable.
+				panic(err)
+			}
+			for i, resp := range resps {
+				req := reqs[respIndexToReqIndex[i]]
+				checkResponse(req, resp)
+			}
+
+			body = resps
+		}
+		if err := marshalHeadersAndBody(w, body); err != nil {
+			w.Flush()
+			// TODO(sqs): return server error
+			log.Println("jsonrpc2 server:", err)
+			continue
+		}
+		if err := w.Flush(); err != nil {
+			// TODO(sqs): return server error
+			log.Println("jsonrpc2 server:", err)
+			continue
+		}
+	}
+}
+
+// batchHandlerWrapper makes any Handler implement BatchHandler by
+// just calling its Handle method for each request in the
+// batch. Handlers can implement BatchHandler on their own to provide
+// optimized batch handling or batch handling with different behavior
+// than this wrapper's serial handling.
+type batchHandlerWrapper struct{ Handler }
+
+func (h batchHandlerWrapper) HandleBatch(reqs []*Request) []*Response {
+	resps := make([]*Response, 0, len(reqs))
+	for _, req := range reqs {
+		resp := h.Handler.Handle(req)
+		if resp != nil {
+			checkResponse(req, resp)
+			resps = append(resps, resp)
+		}
+	}
+
+	return resps
+}
+
+type requestOrRequestBatch struct {
+	batch  []*Request
+	single *Request
+}
+
+func (v *requestOrRequestBatch) MarshalJSON() ([]byte, error) {
+	if v.single != nil {
+		return json.Marshal(v.single)
+	}
+	return json.Marshal(v.batch)
+}
+
+func (v *requestOrRequestBatch) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimLeft(data, " \t\n\r")
+	if len(data) == 0 {
+		return errInvalidRequestJSON
+	}
+	switch data[0] {
+	case '[':
+		*v = requestOrRequestBatch{}
+		if err := json.Unmarshal(data, &v.batch); err != nil {
+			return err
+		}
+		return nil
+
+	case '{':
+		*v = requestOrRequestBatch{}
+		if err := json.Unmarshal(data, &v.single); err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return errInvalidRequestJSON
+	}
+}
+
+type responseOrResponseBatch struct {
+	batch  []Response
+	single *Response
+}
+
+func (v *responseOrResponseBatch) MarshalJSON() ([]byte, error) {
+	if v.single != nil {
+		return json.Marshal(v.single)
+	}
+	return json.Marshal(v.batch)
+}
+
+func (v *responseOrResponseBatch) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimLeft(data, " \t\n\r")
+	if len(data) == 0 {
+		return errInvalidResponseJSON
+	}
+	switch data[0] {
+	case '[':
+		*v = responseOrResponseBatch{}
+		if err := json.Unmarshal(data, &v.batch); err != nil {
+			return err
+		}
+		return nil
+
+	case '{':
+		*v = responseOrResponseBatch{}
+		if err := json.Unmarshal(data, &v.single); err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return errInvalidResponseJSON
+	}
+}
+
+func readHeaderContentLength(r *bufio.Reader) (contentLength uint32, err error) {
+	for {
+		line, err := r.ReadString('\r')
+		if err != nil {
+			return 0, err
+		}
+		b, err := r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		if b != '\n' {
+			return 0, fmt.Errorf(`jsonrpc2: line endings must be \r\n`)
+		}
+		if line == "\r" {
+			break
+		}
+		if strings.HasPrefix(line, "Content-Length: ") {
+			line = strings.TrimPrefix(line, "Content-Length: ")
+			line = strings.TrimSpace(line)
+			n, err := strconv.ParseUint(line, 10, 32)
+			if err != nil {
+				return 0, err
+			}
+			contentLength = uint32(n)
+		}
+	}
+	if contentLength == 0 {
+		err = fmt.Errorf("jsonrpc2: no Content-Length header found")
+	}
+	return
+}
+
+func marshalHeadersAndBody(w io.Writer, v interface{}) error {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Content-Length: %d\r\n", len(body))
+	fmt.Fprint(w, "Content-Type: application/vscode-jsonrpc; charset=utf8\r\n\r\n")
+	_, err = w.Write(body)
+	return err
+}
+
+var (
+	errInvalidRequestJSON  = errors.New("jsonrpc2: request must be either a JSON object or JSON array")
+	errInvalidResponseJSON = errors.New("jsonrpc2: response must be either a JSON object or JSON array")
+)
+
+func isFatalConnError(err error) bool {
+	if err, ok := err.(net.Error); ok && !err.Temporary() {
+		return true
+	}
+	return err == io.EOF
+}

--- a/pkg/jsonrpc2/jsonrpc2_test.go
+++ b/pkg/jsonrpc2/jsonrpc2_test.go
@@ -1,0 +1,221 @@
+package jsonrpc2
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestResponseMarshalJSON_JSONRPC(t *testing.T) {
+	var r Response
+	r.JSONRPC = jsonrpcVersion
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := `"jsonrpc":"2.0"`; !strings.Contains(string(b), want) {
+		t.Errorf("got %s, want it to include the string %s", b, want)
+	}
+}
+
+func TestResponseMarshalJSON_Notification(t *testing.T) {
+	tests := map[string]bool{
+		`{"id":"0"}`:        false,
+		`{"id":"1"}`:        false,
+		`{"id":"foo"}`:      false,
+		`{}`:                true,
+		`{"jsonrpc":"2.0"}`: true,
+	}
+	for s, want := range tests {
+		var r Request
+		if err := json.Unmarshal([]byte(s), &r); err != nil {
+			t.Fatal(err)
+		}
+		if r.Notification != want {
+			t.Errorf("%s: got %v, want %v", s, r.Notification, want)
+		}
+	}
+}
+
+type testHandler struct{}
+
+func (testHandler) Handle(req *Request) *Response {
+	if req.Notification {
+		return nil // notification
+	}
+	return &Response{ID: req.ID, Result: toRaw(fmt.Sprintf("hello, #%s: %s", req.ID, *req.Params))}
+}
+
+func TestClientServer(t *testing.T) {
+	var h testHandler
+
+	done := make(chan struct{})
+	lis, err := net.Listen("tcp", "127.0.0.1:0") // any available address
+	if err != nil {
+		t.Fatal("Listen:", err)
+	}
+	defer func() {
+		if lis == nil {
+			return // already closed
+		}
+		if err := lis.Close(); err != nil {
+			if !strings.HasSuffix(err.Error(), "use of closed network connection") {
+				t.Fatal(err)
+			}
+		}
+	}()
+	go func() {
+		if err := Serve(lis, h); err != nil {
+			if !strings.HasSuffix(err.Error(), "use of closed network connection") {
+				t.Error(err)
+			}
+		}
+		close(done)
+	}()
+
+	conn, err := net.Dial("tcp", lis.Addr().String())
+	if err != nil {
+		t.Fatal("Dial:", err)
+	}
+	cl := NewClient(conn)
+	defer func() {
+		if err := cl.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Simple
+	for i := 1; i <= 100; i++ {
+		resp, err := cl.RequestAndWaitForResponse(Request{ID: strconv.Itoa(i), Notification: false, Params: toRaw([]int32{1, 2, 3})})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got string
+		if err := json.Unmarshal(*resp.Result, &got); err != nil {
+			t.Fatal(err)
+		}
+		if want := fmt.Sprintf("hello, #%d: [1,2,3]", i); !reflect.DeepEqual(got, want) {
+			t.Errorf("got result %q, want %q", got, want)
+		}
+	}
+
+	// Batch
+	resps, err := cl.RequestBatchAndWaitForAllResponses(
+		Request{ID: "1", Notification: false, Params: toRaw([]int32{1})},
+		Request{ID: "0", Notification: true, Params: toRaw([]string{"x"})}, // notification
+		Request{ID: "2", Notification: false, Params: toRaw([]int32{2})},
+		Request{ID: "foo", Notification: false, Params: toRaw([]int32{3})},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]*Response{
+		"1":   &Response{ID: "1", Result: toRaw("hello, #1: [1]"), JSONRPC: jsonrpcVersion},
+		"2":   &Response{ID: "2", Result: toRaw("hello, #2: [2]"), JSONRPC: jsonrpcVersion},
+		"foo": &Response{ID: "foo", Result: toRaw("hello, #foo: [3]"), JSONRPC: jsonrpcVersion},
+	}
+	if !reflect.DeepEqual(resps, want) {
+		t.Errorf("got responses %s, want %s", toString(resps), toString(want))
+	}
+
+	lis.Close()
+	<-done // ensure Serve's error return (if any) is caught by this test
+}
+
+func TestMessageCodec(t *testing.T) {
+	tests := []struct {
+		v, vempty interface{}
+	}{
+		{
+			v:      &requestOrRequestBatch{single: &Request{ID: "123", Notification: false}},
+			vempty: &requestOrRequestBatch{single: &Request{ID: "123", Notification: false}},
+		},
+		{
+			v:      &responseOrResponseBatch{single: &Response{ID: "123"}},
+			vempty: &responseOrResponseBatch{},
+		},
+	}
+	for _, test := range tests {
+		b, err := json.Marshal(test.v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := json.Unmarshal(b, test.vempty); err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(test.vempty, test.v) {
+			t.Errorf("got %+v, want %+v", test.vempty, test.v)
+		}
+	}
+}
+
+func TestMapRespsToReq(t *testing.T) {
+	tests := []struct {
+		reqs      []*Request
+		resps     []*Response
+		want      []int
+		wantError bool
+	}{
+		{
+			reqs: nil, resps: nil, want: []int{}, wantError: false,
+		},
+		{
+			reqs: []*Request{{ID: "1"}}, resps: []*Response{{ID: "1"}}, want: []int{0},
+		},
+		{
+			reqs: []*Request{{ID: "foo"}}, resps: []*Response{{ID: "foo"}}, want: []int{0},
+		},
+		{
+			reqs: []*Request{{ID: "2"}}, resps: []*Response{}, wantError: true,
+		},
+		{
+			reqs: []*Request{}, resps: []*Response{{ID: "3"}}, wantError: true,
+		},
+		{
+			reqs: []*Request{{ID: "4"}}, resps: []*Response{{ID: "4"}, {ID: "4"}}, wantError: true,
+		},
+	}
+	for _, test := range tests {
+		m, err := mapRespsToReq(test.reqs, test.resps)
+		if (err != nil) != test.wantError {
+			t.Errorf("got error %v, wantError %v", err, test.wantError)
+			continue
+		}
+		if test.wantError {
+			continue
+		}
+		if !reflect.DeepEqual(m, test.want) {
+			t.Errorf("got %v, want %v", m, test.want)
+		}
+	}
+}
+
+func TestReadHeaderContentLength(t *testing.T) {
+	s := "Content-Type: foo\r\nContent-Length: 123\r\n\r\n{}"
+	n, err := readHeaderContentLength(bufio.NewReader(strings.NewReader(s)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := uint32(123); n != want {
+		t.Errorf("got %d, want %d", n, want)
+	}
+}
+
+func toString(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func toRaw(v interface{}) *json.RawMessage {
+	b, _ := json.Marshal(v)
+	m := json.RawMessage(b)
+	return &m
+}

--- a/pkg/jsonrpc2/logging.go
+++ b/pkg/jsonrpc2/logging.go
@@ -1,0 +1,35 @@
+package jsonrpc2
+
+import (
+	"encoding/json"
+	"log"
+)
+
+// LoggingHandler wraps a Handler and logs requests, notifications,
+// and responses (using the log.Printf).
+type LoggingHandler struct {
+	Handler
+}
+
+func (h *LoggingHandler) Handle(req *Request) *Response {
+	logRequest(*req)
+	resp := h.Handler.Handle(req)
+	if resp != nil {
+		logResponse(req.ID, req.Method, *resp)
+	}
+	return resp
+}
+
+func logRequest(req Request) {
+	params, _ := json.Marshal(req.Params)
+	if !req.Notification {
+		log.Printf("REQUEST[%s]: %s: %s", req.ID, req.Method, params)
+	} else {
+		log.Printf("NOTIFY: %s: %s", req.Method, params)
+	}
+}
+
+func logResponse(id string, method string, resp Response) {
+	result, _ := json.Marshal(resp.Result)
+	log.Printf("RESPONSE[%s]: %s: %s", id, method, result)
+}

--- a/pkg/lsp/jsonrpc.go
+++ b/pkg/lsp/jsonrpc.go
@@ -1,0 +1,27 @@
+package lsp
+
+import "fmt"
+
+// Refer to https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md for documentation.
+
+type ResponseError struct {
+	Code    int
+	Message string
+	Data    interface{}
+}
+
+type ErrorCode int
+
+const (
+	ParseError       ErrorCode = -32700
+	InvalidRequest             = -32600
+	MethodNotFound             = -32601
+	InvalidParams              = -32602
+	InternalError              = -32603
+	serverErrorStart           = -3209
+	serverErrorEnd             = -32000
+)
+
+func (e *ResponseError) Error() string {
+	return fmt.Sprintf("ResponseError{Code: %v, Message: %v, Data: %v}", e.Code, e.Message, e.Data)
+}

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -1,0 +1,320 @@
+package lsp
+
+// Refer to https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md for documentation.
+
+type None struct{}
+
+type InitializeParams struct {
+	ProcessID    int                `json:"processId"`
+	RootPath     string             `json:"rootPath"`
+	Capabilities ClientCapabilities `json:"capabilities"`
+}
+
+type ClientCapabilities struct{}
+
+type InitializeResult struct {
+	Capabilities ServerCapabilities `json:"capabilities"`
+}
+
+type InitializeError struct {
+	Retry bool `json:"retry"`
+}
+
+type TextDocumentSyncKind int
+
+const (
+	TDSKNone        TextDocumentSyncKind = 0
+	TDSKFull                             = 1
+	TDSKIncremental                      = 2
+)
+
+type ServerCapabilities struct {
+	TextDocumentSync                 int                              `json:"textDocumentSync,omitempty"`
+	HoverProvider                    bool                             `json:"hoverProvider,omitempty"`
+	CompletionProvider               *CompletionOptions               `json:"completionProvider,omitempty"`
+	SignatureHelpProvider            *SignatureHelpOptions            `json:"signatureHelpProvider,omitempty"`
+	DefinitionProvider               bool                             `json:"definitionProvider,omitempty"`
+	ReferencesProvider               bool                             `json:"referencesProvider,omitempty"`
+	DocumentHighlightProvider        bool                             `json:"documentHighlightProvider,omitempty"`
+	DocumentSymbolProvider           bool                             `json:"documentSymbolProvider,omitempty"`
+	WorkspaceSymbolProvider          bool                             `json:"workspaceSymbolProvider,omitempty"`
+	CodeActionProvider               bool                             `json:"codeActionProvider,omitempty"`
+	CodeLensProvider                 *CodeLensOptions                 `json:"codeLensProvider,omitempty"`
+	DocumentFormattingProvider       bool                             `json:"documentFormattingProvider,omitempty"`
+	DocumentRangeFormattingProvider  bool                             `json:"documentRangeFormattingProvider,omitempty"`
+	DocumentOnTypeFormattingProvider *DocumentOnTypeFormattingOptions `json:"documentOnTypeFormattingProvider,omitempty"`
+	RenameProvider                   bool                             `json:"renameProvider,omitempty"`
+}
+
+type CompletionOptions struct {
+	ResolveProvider   bool     `json:"resolveProvider,omitempty"`
+	TriggerCharacters []string `json:"triggerCharacters,omitempty"`
+}
+
+type DocumentOnTypeFormattingOptions struct {
+	FirstTriggerCharacter string   `json:"firstTriggerCharacter"`
+	MoreTriggerCharacter  []string `json:"moreTriggerCharacter,omitempty"`
+}
+
+type CodeLensOptions struct {
+	ResolveProvider bool `json:"resolveProvider,omitempty"`
+}
+
+type SignatureHelpOptions struct {
+	TriggerCharacters []string `json:"triggerCharacters,omitempty"`
+}
+
+type CompletionItemKind int
+
+const (
+	CIKText        CompletionItemKind = 1
+	CIKMethod                         = 2
+	CIKFunction                       = 3
+	CIKConstructor                    = 4
+	CIKField                          = 5
+	CIKVariable                       = 6
+	CIKClass                          = 7
+	CIKInterface                      = 8
+	CIKModule                         = 9
+	CIKProperty                       = 10
+	CIKUnit                           = 11
+	CIKValue                          = 12
+	CIKEnum                           = 13
+	CIKKeyword                        = 14
+	CIKSnippet                        = 15
+	CIKColor                          = 16
+	CIKFile                           = 17
+	CIKReference                      = 18
+)
+
+type CompletionItem struct {
+	Label         string      `json:"label"`
+	Kind          int         `json:"kind,omitempty"`
+	Detail        string      `json:"detail,omitempty"`
+	Documentation string      `json:"documentation,omitempty"`
+	SortText      string      `json:"sortText,omitempty"`
+	FilterText    string      `json:"filterText,omitempty"`
+	InsertText    string      `json:"insertText,omitempty"`
+	TextEdit      TextEdit    `json:"textEdit,omitempty"`
+	Data          interface{} `json:"data,omitempty"`
+}
+
+type CompletionList struct {
+	IsIncomplete bool             `json:"isIncomplete"`
+	Items        []CompletionItem `json:"items"`
+}
+
+type Hover struct {
+	Contents []MarkedString `json:"contents,omitempty"`
+	Range    Range          `json:"range"`
+}
+
+type MarkedString struct {
+	Language string `json:"language"`
+	Value    string `json:"value"`
+}
+
+type SignatureHelp struct {
+	Signatures      []SignatureInformation `json:"signatures"`
+	ActiveSignature int                    `json:"activeSignature,omitempty"`
+	ActiveParameter int                    `json:"activeParameter,omitempty"`
+}
+
+type SignatureInformation struct {
+	Label         string                 `json:"label"`
+	Documentation string                 `json:"documentation,omitempty"`
+	Paramaters    []ParameterInformation `json:"paramaters,omitempty"`
+}
+
+type ParameterInformation struct {
+	Label         string `json:"label"`
+	Documentation string `json:"documentation,omitempty"`
+}
+
+type ReferenceContext struct {
+	IncludeDeclaration bool `json:"IncludeDeclaration"`
+}
+
+type ReferenceParams struct {
+	TextDocumentPositionParams
+	Context ReferenceContext `json:"context"`
+}
+
+type DocumentHighlightKind int
+
+const (
+	Text  DocumentHighlightKind = 1
+	Read                        = 2
+	Write                       = 3
+)
+
+type DocumentHighlight struct {
+	Range Range `json:"range"`
+	Kind  int   `json:"kind,omitempty"`
+}
+
+type DocumentSymbolParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+type SymbolKind int
+
+const (
+	SKFile        SymbolKind = 1
+	SKModule                 = 2
+	SKNamespace              = 3
+	SKPackage                = 4
+	SKClass                  = 5
+	SKMethod                 = 6
+	SKProperty               = 7
+	SKField                  = 8
+	SKConstructor            = 9
+	SKEnum                   = 10
+	SKInterface              = 11
+	SKFunction               = 12
+	SKVariable               = 13
+	SKConstant               = 14
+	SKString                 = 15
+	SKNumber                 = 16
+	SKBoolean                = 17
+	SKArray                  = 18
+)
+
+type SymbolInformation struct {
+	Name          string   `json:"name"`
+	Kind          int      `json:"kind"`
+	Location      Location `json:"location"`
+	ContainerName string   `json:"containerName,omitempty"`
+}
+
+type WorkspaceSymbolParams struct {
+	Query string `json:"query"`
+}
+
+type CodeActionContext struct {
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+type CodeActionParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Range        Range                  `json:"range"`
+	Context      CodeActionContext      `json:"context"`
+}
+
+type CodeLensParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+type CodeLens struct {
+	Range   Range       `json:"range"`
+	Command Command     `json:"command,omitempty"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+type DocumentFormattingParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Options      FormattingOptions      `json:"options"`
+}
+
+type FormattingOptions struct {
+	TabSize      int    `json:"tabSize"`
+	InsertSpaces bool   `json:"insertSpaces"`
+	Key          string `json:"key"`
+}
+
+type RenameParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Position     Position               `json:"position"`
+	NewName      string                 `json:"newName"`
+}
+
+type DidOpenTextDocumentParams struct {
+	TextDocument TextDocumentItem `json:"textDocument"`
+}
+
+type DidChangeTextDocumentParams struct {
+	TextDocument   VersionedTextDocumentIdentifier  `json:"textDocument"`
+	ContentChanges []TextDocumentContentChangeEvent `json:"contentChanges"`
+}
+
+type TextDocumentContentChangeEvent struct {
+	Range       *Range `json:"range,omitEmpty"`
+	RangeLength uint   `json:"rangeLength,omitEmpty"`
+	Text        string `json:"text"`
+}
+
+type DidCloseTextDocumentParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+type DidSaveTextDocumentParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+type MessageType int
+
+const (
+	MTError   MessageType = 1
+	MTWarning             = 2
+	Info                  = 3
+	Log                   = 4
+)
+
+type ShowMessageParams struct {
+	Type    int    `json:"type"`
+	Message string `json:"message"`
+}
+
+type MessageActionItem struct {
+	Title string `json:"title"`
+}
+
+type ShowMessageRequestParams struct {
+	Type    int                 `json:"type"`
+	Message string              `json:"message"`
+	Actions []MessageActionItem `json:"actions"`
+}
+
+type LogMessageParams struct {
+	Type    int    `json:"type"`
+	Message string `json:"message"`
+}
+
+type DidChangeConfigurationParams struct {
+	Settings interface{} `json:"settings"`
+}
+
+type FileChangeType int
+
+const (
+	Created FileChangeType = 1
+	Changed                = 2
+	Deleted                = 3
+)
+
+type FileEvent struct {
+	URI  string `json:"uri"`
+	Type int    `json:"type"`
+}
+
+type DidChangeWatchedFilesParams struct {
+	Changes []FileEvent `json:"changes"`
+}
+
+type PublishDiagnosticsParams struct {
+	URI         string       `json:"uri"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+type DocumentRangeFormattingParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Range        Range                  `json:"range"`
+	Options      FormattingOptions      `json:"options"`
+}
+
+type DocumentOnTypeFormattingParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Position     Position               `json:"position"`
+	Ch           string                 `json:"ch"`
+	Options      FormattingOptions      `json:"formattingOptions"`
+}

--- a/pkg/lsp/structures.go
+++ b/pkg/lsp/structures.go
@@ -1,0 +1,155 @@
+package lsp
+
+type Position struct {
+	/**
+	 * Line position in a document (zero-based).
+	 */
+	Line int `json:"line"`
+
+	/**
+	 * Character offset on a line in a document (zero-based).
+	 */
+	Character int `json:"character"`
+}
+
+type Range struct {
+	/**
+	 * The range's start position.
+	 */
+	Start Position `json:"start"`
+
+	/**
+	 * The range's end position.
+	 */
+	End Position `json:"end"`
+}
+
+type Location struct {
+	URI   string `json:"uri"`
+	Range Range  `json:"range"`
+}
+
+type Diagnostic struct {
+	/**
+	 * The range at which the message applies.
+	 */
+	Range Range `json:"range"`
+
+	/**
+	 * The diagnostic's severity. Can be omitted. If omitted it is up to the
+	 * client to interpret diagnostics as error, warning, info or hint.
+	 */
+	Severity int `json:"severity"`
+
+	/**
+	 * The diagnostic's code. Can be omitted.
+	 */
+	Code string `json:"code"`
+
+	/**
+	 * A human-readable string describing the source of this
+	 * diagnostic, e.g. 'typescript' or 'super lint'.
+	 */
+	Source string `json:"source"`
+
+	/**
+	 * The diagnostic's message.
+	 */
+	Message string `json:"message"`
+}
+
+type DiagnosticSeverity int
+
+const (
+	Error       DiagnosticSeverity = 1
+	Warning                        = 2
+	Information                    = 3
+	Hint                           = 4
+)
+
+type Command struct {
+	/**
+	 * Title of the command, like `save`.
+	 */
+	Title string `json:"title"`
+	/**
+	 * The identifier of the actual command handler.
+	 */
+	Command string `json:"command"`
+	/**
+	 * Arguments that the command handler should be
+	 * invoked with.
+	 */
+	Arguments []interface{} `json:"arguments"`
+}
+
+type TextEdit struct {
+	/**
+	 * The range of the text document to be manipulated. To insert
+	 * text into a document create a range where start === end.
+	 */
+	Range Range `json:"range"`
+
+	/**
+	 * The string to be inserted. For delete operations use an
+	 * empty string.
+	 */
+	NewText string `json:"newText"`
+}
+
+type WorkspaceEdit struct {
+	/**
+	 * Holds changes to existing resources.
+	 */
+	Changes map[string][]TextEdit `json:"changes"`
+}
+
+type TextDocumentIdentifier struct {
+	/**
+	 * The text document's URI.
+	 */
+	URI string `json:"uri"`
+}
+
+type TextDocumentItem struct {
+	/**
+	 * The text document's URI.
+	 */
+	URI string `json:"uri"`
+
+	/**
+	 * The text document's language identifier.
+	 */
+	LanguageID string `json:"languageId"`
+
+	/**
+	 * The version number of this document (it will strictly increase after each
+	 * change, including undo/redo).
+	 */
+	Version int `json:"version"`
+
+	/**
+	 * The content of the opened text document.
+	 */
+	Text string `json:"text"`
+}
+
+type VersionedTextDocumentIdentifier struct {
+	TextDocumentIdentifier
+	/**
+	 * The version number of this document.
+	 */
+	Version int `json:"version"`
+}
+
+type TextDocumentPositionParams struct {
+	/**
+	 * The text document.
+	 */
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+
+	/**
+	 * The position inside the text document.
+	 */
+	Position Position `json:"position"`
+}


### PR DESCRIPTION
This change adds support for language servers.  In this change is a JSON-RPC implementation in `pkg/jsonrpc2`, language server protocol types in `pkg/lsp`, and a sample language server and Visual Studio Code extension for using the language server in `lang/server` and `lang/vscode-client` respectively.  

##### Reviewer tasks

- [ ] HACKS: reviewer approves hacks introduced by this change
- [ ] DOCS: reviewer approves the docstrings (or the justified omission thereof)
- [ ] UNIT-TEST: reviewer approves the unit tests (or the justified omission thereof)

