### PR TITLE
search: Ensure we have defs when indexing a commit

### DIFF
--- a/services/backend/internal/localstore/defs.go
+++ b/services/backend/internal/localstore/defs.go
@@ -448,6 +448,10 @@ func (s *defs) UpdateFromSrclibStore(ctx context.Context, op store.DefUpdateOp) 
 		}
 	}
 
+	if len(chosenDefs) == 0 {
+		return fmt.Errorf("no indexable defs for %s %s", repo.URI, op.CommitID)
+	}
+
 	dbh := graphDBH(ctx)
 
 	// Update def_keys


### PR DESCRIPTION
This has lead to all search results for `github.com/golang/go` disappearing. The
theory of why is a few possibilities:
* Flakiness from srclib-store
* Bad import
* Race condition between importing and new commits
* Race condition in how we gc old data (there can be concurrent updates for a
  repo)

This commit should guard against all of those points expept the last. Another
commit will address that issue.

Note: It may be completely valid for a repo to have no exported symbols. In such
case we will just record the error on the async queue, but the error won't have
any other effect on the user.