### PR TITLE
{lang/golang, pkg/lputil}: add langprocessor-go which implements the intermediate REST protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ eb-bundle.zip
 /deploy/sourcegraph.com/src
 /deploy/sourcegraph/src
 /lang/golang/cmd/langserver-go/langserver-go
+/lang/golang/cmd/langprocessor-go/langprocessor-go
 
 # Sublime
 *.sublime-project

--- a/lang/golang/cmd/langprocessor-go/Dockerfile
+++ b/lang/golang/cmd/langprocessor-go/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.4
+
+ADD langprocessor-go /langprocessor-go
+
+ENTRYPOINT ["/langprocessor-go"]

--- a/lang/golang/cmd/langprocessor-go/build.sh
+++ b/lang/golang/cmd/langprocessor-go/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+GOOS=linux GOARCH=amd64 go build -o langprocessor-go .
+
+docker build -t us.gcr.io/sourcegraph-dev/langprocessor-go .
+gcloud docker push us.gcr.io/sourcegraph-dev/langprocessor-go

--- a/lang/golang/cmd/langprocessor-go/langprocessor-go.go
+++ b/lang/golang/cmd/langprocessor-go/langprocessor-go.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/lputil"
+)
+
+var (
+	httpAddr = flag.String("http", ":4141", "HTTP address to listen on")
+	lspAddr  = flag.String("lsp", ":2088", "LSP server address")
+)
+
+func main() {
+	flag.Parse()
+
+	gopath := os.Getenv("GOPATH")
+	rootPath := func(repo, commit string) string {
+		return filepath.Join(gopath, "src", repo)
+	}
+
+	log.Println("Translating HTTP", *httpAddr, "to LSP", *lspAddr)
+	http.Handle("/", &lputil.Translator{
+		Addr:     *lspAddr,
+		RootPath: rootPath,
+	})
+	http.ListenAndServe(*httpAddr, nil)
+}

--- a/pkg/lputil/lputil.go
+++ b/pkg/lputil/lputil.go
@@ -1,0 +1,141 @@
+// Package lputil implements Language Processor utilities.
+package lputil
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/jsonrpc2"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/lsp"
+)
+
+// Translator is an HTTP handler which translates from the Language Processor
+// REST API (defined in proto.go) directly to Sourcegraph LSP batch requests.
+type Translator struct {
+	// Addr is the address of the LSP server which translation should occur
+	// against.
+	Addr string
+
+	// RootPath is invoked to determine the workspace directly at which all
+	// file requests are relative to.
+	RootPath func(repo, commit string) string
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (t *Translator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// TODO: use a mux in the future.
+	err := t.serveHover(w, r)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		err2 := json.NewEncoder(w).Encode(&Error{
+			Error: err.Error(),
+		})
+		if err2 != nil {
+			// TODO: configurable logging
+			log.Println(err2)
+		}
+	}
+}
+
+func (t *Translator) serveHover(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != "POST" || r.URL.Path != "/hover" || len(r.URL.Query()) > 0 {
+		w.WriteHeader(http.StatusNotFound)
+		return nil
+	}
+
+	// TODO(slimsag): We don't need to create a new JSON RPC 2 connection every
+	// time, but we will need reconnection logic and a non-dumb jsonrpc2.Client
+	// which can handle concurrency (according to Sourcegraph LSP spec we can
+	// and should use one connection for all requests).
+	conn, err := net.Dial("tcp", t.Addr)
+	if err != nil {
+		return err
+	}
+	cl := jsonrpc2.NewClient(conn)
+	defer func() {
+		if err := cl.Close(); err != nil {
+			// TODO: configurable logging
+			log.Println(err)
+		}
+	}()
+
+	// Decode the user request.
+	var pos Position
+	if err := json.NewDecoder(r.Body).Decode(&pos); err != nil {
+		return err
+	}
+	if pos.Repo == "" {
+		return fmt.Errorf("Repo field must be set")
+	}
+	if pos.Commit == "" {
+		return fmt.Errorf("Commit field must be set")
+	}
+	if pos.File == "" {
+		return fmt.Errorf("File field must be set")
+	}
+
+	// Build the LSP requests.
+	reqInit := jsonrpc2.Request{
+		ID:     "0",
+		Method: "initialize",
+	}
+	rootPath := t.RootPath(pos.Repo, pos.Commit)
+	log.Println("hover", rootPath)
+	reqInit.SetParams(&lsp.InitializeParams{
+		RootPath: rootPath,
+	})
+	// TODO: should probably check server capabilities before invoking hover,
+	// but good enough for now.
+	reqHoverID := "1"
+	reqHover := jsonrpc2.Request{
+		ID:     reqHoverID,
+		Method: "textDocument/hover",
+	}
+	reqHover.SetParams(&lsp.TextDocumentPositionParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: pos.File},
+		Position: lsp.Position{
+			Line:      pos.Line,
+			Character: pos.Character,
+		},
+	})
+	reqShutdown := jsonrpc2.Request{ID: "2", Method: "shutdown"}
+
+	// Make the batched LSP request.
+	resps, err := cl.RequestBatchAndWaitForAllResponses(
+		reqInit,
+		reqHover,
+		reqShutdown,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal the LSP responses.
+	hoverResp, ok := resps[reqHoverID]
+	if !ok {
+		return fmt.Errorf("response to hover request from LSP server not found")
+	}
+	var respHover lsp.Hover
+	if hoverResp.Result != nil {
+		if err := json.Unmarshal(*hoverResp.Result, &respHover); err != nil {
+			return err
+		}
+	}
+
+	// Encode our response.
+	final := &Hover{
+		Contents: make([]HoverContent, len(respHover.Contents)),
+	}
+	for _, marked := range respHover.Contents {
+		final.Contents = append(final.Contents, HoverContent{
+			Type:  marked.Language,
+			Value: marked.Value,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(final)
+}

--- a/pkg/lputil/proto.go
+++ b/pkg/lputil/proto.go
@@ -1,0 +1,51 @@
+package lputil
+
+// Error is returned in the event of any request error, in addition to the HTTP
+// status 400 Bad Request.
+type Error struct {
+	// Error, if any, specifies that there was an error serving the request.
+	Error string
+}
+
+// Position represents a single specific position within a file located in a
+// repository at a given revision.
+type Position struct {
+	// Repo is the repository URI in which the file is located.
+	Repo string
+
+	// Commit is the Git commit ID (not branch) of the repository.
+	Commit string
+
+	// File is the file which the user is viewing, relative to the repository root.
+	File string
+
+	// Line is the line number in the file (zero based), e.g. where a user's cursor
+	// is located within the file.
+	Line int
+
+	// Character is the character offset on a line in the file (zero based), e.g.
+	// where a user's cursor is located within the file.
+	Character int
+}
+
+// HoverContent represents a subset of the content for when a user “hovers”
+// over a definition.
+//
+// For example, one HoverContent object may represent the comments of a
+// function, while the another HoverContent object may represent the function
+// signature. In the future we may abuse this field to carry more data, and
+// thus we use “type” instead of “language” like in LSP. In practice at this
+// point, it always maps to a language (Go, Java, etc).
+type HoverContent struct {
+	// Type is the type of content (e.g. "Go").
+	Type string
+
+	// Value is the value of the content (e.g. "func NewRequest() *Request").
+	Value string
+}
+
+// Hover represents a message for when a user "hovers" over a definition. It is
+// a human-readable description of a definition.
+type Hover struct {
+	Contents []HoverContent
+}


### PR DESCRIPTION
This change adds a langprocessor-go binary which implements the intermediate Language Processor REST protocol (via the new `pkg/lputil`). It simply translates from LSP into the REST protocol in an effort to serve hover requests.

It can be tested via:

```
curl -H "Content-Type: application/json" -X POST -d '{"Repo": "github.com/gorilla/mux", "Commit": "d391bea3118c9fc17a88d62c9189bb791255e0ef", "File": "mux.go", "Line": 17, "Character": 5}' http://localhost:4141/hover
```

After starting it:

```
go install ./lang/golang/cmd/langprocessor-go/ && langprocessor-go
```

And the LSP server which it connects to:

```
go install ./lang/golang/cmd/langserver-go/ && langserver-go
```

Which ultimately produces the response:

```
{"Contents":[{"Type":"","Value":""},{"Type":"go","Value":"func github.com/gorilla/mux.NewRouter() *github.com/gorilla/mux.Router"}]}
```