### PR TITLE
golang: Add debug HTTP endpoints to cmds

### DIFF
--- a/cli/git_server_cmd.go
+++ b/cli/git_server_cmd.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 
+	log15 "gopkg.in/inconshreveable/log15.v2"
+
 	"sourcegraph.com/sourcegraph/sourcegraph/cli/cli"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/debugserver"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/gitserver"
@@ -45,7 +47,8 @@ func (c *gitServerCmd) Execute(args []string) error {
 	}
 
 	if c.ProfBindAddr != "" {
-		debugserver.Start(c.ProfBindAddr)
+		go debugserver.Start(c.ProfBindAddr)
+		log15.Debug("Profiler available", "on", fmt.Sprintf("%s/pprof", c.ProfBindAddr))
 	}
 
 	if c.Addr != "" {

--- a/cli/git_server_cmd.go
+++ b/cli/git_server_cmd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"sourcegraph.com/sourcegraph/sourcegraph/cli/cli"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/debugserver"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/gitserver"
 )
 
@@ -44,7 +45,7 @@ func (c *gitServerCmd) Execute(args []string) error {
 	}
 
 	if c.ProfBindAddr != "" {
-		startDebugServer(c.ProfBindAddr)
+		debugserver.Start(c.ProfBindAddr)
 	}
 
 	if c.Addr != "" {

--- a/cli/serve_cmd.go
+++ b/cli/serve_cmd.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"gopkg.in/inconshreveable/log15.v2"
 	"io"
 	"io/ioutil"
 	"log"
@@ -20,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/gorilla/mux"
@@ -42,6 +43,7 @@ import (
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/auth/idkey"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/auth/sharedsecret"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/conf"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/debugserver"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/eventsutil"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/handlerutil"
@@ -240,7 +242,7 @@ func (c *ServeCmd) Execute(args []string) error {
 	}
 
 	if c.ProfBindAddr != "" {
-		startDebugServer(c.ProfBindAddr)
+		debugserver.Start(c.ProfBindAddr)
 	}
 
 	app.Init()

--- a/cli/serve_cmd.go
+++ b/cli/serve_cmd.go
@@ -242,7 +242,8 @@ func (c *ServeCmd) Execute(args []string) error {
 	}
 
 	if c.ProfBindAddr != "" {
-		debugserver.Start(c.ProfBindAddr)
+		go debugserver.Start(c.ProfBindAddr)
+		log15.Debug("Profiler available", "on", fmt.Sprintf("%s/pprof", c.ProfBindAddr))
 	}
 
 	app.Init()

--- a/lang/golang/cmd/langprocessor-go/langprocessor-go.go
+++ b/lang/golang/cmd/langprocessor-go/langprocessor-go.go
@@ -7,16 +7,22 @@ import (
 	"os"
 	"path/filepath"
 
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/debugserver"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/lputil"
 )
 
 var (
 	httpAddr = flag.String("http", ":4141", "HTTP address to listen on")
 	lspAddr  = flag.String("lsp", ":2088", "LSP server address")
+	profbind = flag.String("prof-http", "", "net/http/pprof http bind address")
 )
 
 func main() {
 	flag.Parse()
+
+	if *profbind != "" {
+		go debugserver.Start(*profbind)
+	}
 
 	gopath := os.Getenv("GOPATH")
 	rootPath := func(repo, commit string) string {

--- a/lang/golang/cmd/langprocessor-go/langprocessor-go.go
+++ b/lang/golang/cmd/langprocessor-go/langprocessor-go.go
@@ -14,7 +14,7 @@ import (
 var (
 	httpAddr = flag.String("http", ":4141", "HTTP address to listen on")
 	lspAddr  = flag.String("lsp", ":2088", "LSP server address")
-	profbind = flag.String("prof-http", "", "net/http/pprof http bind address")
+	profbind = flag.String("prof-http", ":6060", "net/http/pprof http bind address")
 )
 
 func main() {

--- a/lang/golang/cmd/langserver-go/langserver-go.go
+++ b/lang/golang/cmd/langserver-go/langserver-go.go
@@ -9,13 +9,15 @@ import (
 	"os"
 
 	"sourcegraph.com/sourcegraph/sourcegraph/lang/golang"
+	"sourcegraph.com/sourcegraph/sourcegraph/pkg/debugserver"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/jsonrpc2"
 )
 
 var (
-	mode    = flag.String("mode", "stdio", "communication mode (stdio|tcp)")
-	addr    = flag.String("addr", ":2088", "server listen address (tcp)")
-	logfile = flag.String("log", "/tmp/langserver-golang.log", "write log output to this file (and stderr)")
+	mode     = flag.String("mode", "stdio", "communication mode (stdio|tcp)")
+	addr     = flag.String("addr", ":2088", "server listen address (tcp)")
+	profbind = flag.String("prof-http", "", "net/http/pprof http bind address")
+	logfile  = flag.String("log", "/tmp/langserver-golang.log", "write log output to this file (and stderr)")
 )
 
 func main() {
@@ -36,6 +38,10 @@ func run() error {
 		}
 		defer f.Close()
 		log.SetOutput(io.MultiWriter(os.Stderr, f))
+	}
+
+	if *profbind != "" {
+		go debugserver.Start(*profbind)
 	}
 
 	h := &jsonrpc2.LoggingHandler{&golang.Handler{}}

--- a/lang/golang/cmd/langserver-go/langserver-go.go
+++ b/lang/golang/cmd/langserver-go/langserver-go.go
@@ -16,7 +16,7 @@ import (
 var (
 	mode     = flag.String("mode", "stdio", "communication mode (stdio|tcp)")
 	addr     = flag.String("addr", ":2088", "server listen address (tcp)")
-	profbind = flag.String("prof-http", "", "net/http/pprof http bind address")
+	profbind = flag.String("prof-http", ":6060", "net/http/pprof http bind address")
 	logfile  = flag.String("log", "/tmp/langserver-golang.log", "write log output to this file (and stderr)")
 )
 

--- a/pkg/debugserver/debug.go
+++ b/pkg/debugserver/debug.go
@@ -1,8 +1,7 @@
-package cli
+package debugserver
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/pprof"
 
@@ -13,7 +12,8 @@ import (
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/expvarutil"
 )
 
-func startDebugServer(addr string) {
+// Start runs a debug server (pprof, prometheus, etc) on addr.
+func Start(addr string) {
 	// Starts a pprof server by default, but this is OK, because only
 	// whitelisted ports on the web server machines should be publicly
 	// accessible anyway.
@@ -42,7 +42,7 @@ func startDebugServer(addr string) {
 		pp.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 		pp.Handle("/depprof", depprof.NewHandler("sourcegraph.com/sourcegraph/sourcegraph"))
 		pp.Handle("/metrics", prometheus.Handler())
-		log.Println("warning: could not start pprof HTTP server:", http.ListenAndServe(addr, pp))
+		log15.Warn("could not start debug HTTP server:", "error", http.ListenAndServe(addr, pp))
 	}()
 	log15.Debug("Profiler available", "on", fmt.Sprintf("%s/pprof", addr))
 }

--- a/pkg/debugserver/debug.go
+++ b/pkg/debugserver/debug.go
@@ -1,26 +1,20 @@
 package debugserver
 
 import (
-	"fmt"
+	"log"
 	"net/http"
 	"net/http/pprof"
-
-	"gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/neelance/depprof"
 	"github.com/prometheus/client_golang/prometheus"
 	"sourcegraph.com/sourcegraph/sourcegraph/pkg/expvarutil"
 )
 
-// Start runs a debug server (pprof, prometheus, etc) on addr.
+// Start runs a debug server (pprof, prometheus, etc) on addr. It is blocking.
 func Start(addr string) {
-	// Starts a pprof server by default, but this is OK, because only
-	// whitelisted ports on the web server machines should be publicly
-	// accessible anyway.
-	go func() {
-		pp := http.NewServeMux()
-		index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte(`
+	pp := http.NewServeMux()
+	index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`
 				<a href="/vars">Vars</a><br>
 				<a href="/debug/pprof">PProf</a><br>
 				<a href="/depprof">DepProf</a><br>
@@ -29,20 +23,18 @@ func Start(addr string) {
 				<form method="post" action="/gc" style="display: inline;"><input type="submit" value="GC"></form>
 				<form method="post" action="/freeosmemory" style="display: inline;"><input type="submit" value="Free OS Memory"></form>
 			`))
-		})
-		pp.Handle("/", index)
-		pp.Handle("/debug", index)
-		pp.Handle("/vars", http.HandlerFunc(expvarutil.ExpvarHandler))
-		pp.Handle("/gc", http.HandlerFunc(expvarutil.GCHandler))
-		pp.Handle("/freeosmemory", http.HandlerFunc(expvarutil.FreeOSMemoryHandler))
-		pp.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-		pp.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-		pp.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-		pp.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-		pp.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-		pp.Handle("/depprof", depprof.NewHandler("sourcegraph.com/sourcegraph/sourcegraph"))
-		pp.Handle("/metrics", prometheus.Handler())
-		log15.Warn("could not start debug HTTP server:", "error", http.ListenAndServe(addr, pp))
-	}()
-	log15.Debug("Profiler available", "on", fmt.Sprintf("%s/pprof", addr))
+	})
+	pp.Handle("/", index)
+	pp.Handle("/debug", index)
+	pp.Handle("/vars", http.HandlerFunc(expvarutil.ExpvarHandler))
+	pp.Handle("/gc", http.HandlerFunc(expvarutil.GCHandler))
+	pp.Handle("/freeosmemory", http.HandlerFunc(expvarutil.FreeOSMemoryHandler))
+	pp.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	pp.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	pp.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	pp.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	pp.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	pp.Handle("/depprof", depprof.NewHandler("sourcegraph.com/sourcegraph/sourcegraph"))
+	pp.Handle("/metrics", prometheus.Handler())
+	log.Println("warning: could not start debug HTTP server:", http.ListenAndServe(addr, pp))
 }


### PR DESCRIPTION
Factored out the code we use in `src serve` so we can re-use it.