### PR TITLE
docs: link to sourcegraph-extension-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Fast global code search with a hybrid backend that combines a trigram index with in-memory streaming
 - Code intelligence for many languages via the [Language Server Protocol](https://langserver.org/)
 - Enhances GitHub, GitLab, Phabricator, and other code hosts and code review tools via the [Sourcegraph browser extension](https://about.sourcegraph.com/docs/features/browser-extension/)
-- Integration with third-party developer tools via the Sourcegraph Extension API
+- Integration with third-party developer tools via the [Sourcegraph Extension API](https://github.com/sourcegraph/sourcegraph-extension-api)
 
 ## Try it
 


### PR DESCRIPTION
This makes the "Sourcegraph Extension API" text in the README a link to https://github.com/sourcegraph/sourcegraph-extension-api

> This PR does not need to update the CHANGELOG because it only affects the README
