### PR TITLE
Fix Go code intelligence

### DIFF
--- a/cmd/frontend/internal/pkg/langservers/langservers.go
+++ b/cmd/frontend/internal/pkg/langservers/langservers.go
@@ -477,9 +477,12 @@ func start(language string) error {
 	return err
 }
 
+// GoLangserverSrcGitServersHost is the address where gitserver is accessbile from the Go language server.
+var GoLangserverSrcGitServersHost = "host.docker.internal"
+
 func startDebugArgs(language string) (args []string) {
 	if language == "go" {
-		args = append(args, []string{"-e", "SRC_GIT_SERVERS=host.docker.internal:3178"}...)
+		args = append(args, []string{"-e", fmt.Sprintf("SRC_GIT_SERVERS=%s:3178", GoLangserverSrcGitServersHost)}...)
 	}
 
 	p := debugContainerPorts[language]

--- a/cmd/frontend/internal/pkg/langservers/langservers.go
+++ b/cmd/frontend/internal/pkg/langservers/langservers.go
@@ -479,7 +479,7 @@ func start(language string) error {
 
 func startDebugArgs(language string) (args []string) {
 	if language == "go" {
-		args = append(args, []string{"-e", "SRC_GIT_SERVERS=localhost:3178"}...)
+		args = append(args, []string{"-e", "SRC_GIT_SERVERS=host.docker.internal:3178"}...)
 	}
 
 	p := debugContainerPorts[language]

--- a/cmd/frontend/internal/pkg/langservers/langservers.go
+++ b/cmd/frontend/internal/pkg/langservers/langservers.go
@@ -477,7 +477,7 @@ func start(language string) error {
 	return err
 }
 
-// GoLangserverSrcGitServersHost is the address where gitserver is accessbile from the Go language server.
+// GoLangserverSrcGitServersHost is the address where gitserver is accessible from the Go language server.
 var GoLangserverSrcGitServersHost = "host.docker.internal"
 
 func startDebugArgs(language string) (args []string) {

--- a/cmd/frontend/internal/pkg/langservers/langservers.go
+++ b/cmd/frontend/internal/pkg/langservers/langservers.go
@@ -477,12 +477,14 @@ func start(language string) error {
 	return err
 }
 
-// GoLangserverSrcGitServersHost is the address where gitserver is accessible from the Go language server.
-var GoLangserverSrcGitServersHost = "host.docker.internal"
-
 func startDebugArgs(language string) (args []string) {
 	if language == "go" {
-		args = append(args, []string{"-e", fmt.Sprintf("SRC_GIT_SERVERS=%s:3178", GoLangserverSrcGitServersHost)}...)
+		// The address where gitserver is accessible from the Go language server.
+		host := os.Getenv("GOLANGSERVER_SRC_GIT_SERVERS")
+		if host == "" {
+			host = "localhost:3178"
+		}
+		args = append(args, []string{"-e", fmt.Sprintf("SRC_GIT_SERVERS=%s", host)}...)
 	}
 
 	p := debugContainerPorts[language]

--- a/dev/launch.sh
+++ b/dev/launch.sh
@@ -42,6 +42,7 @@ export GITHUB_BASE_URL=http://127.0.0.1:3180
 export SRC_REPOS_DIR=$HOME/.sourcegraph/repos
 export INSECURE_DEV=1
 export SRC_GIT_SERVERS=127.0.0.1:3178
+export GOLANGSERVER_SRC_GIT_SERVERS=host.docker.internal:3178
 export SEARCHER_URL=http://127.0.0.1:3181
 export REPO_UPDATER_URL=http://127.0.0.1:3182
 export LSP_PROXY=127.0.0.1:4388


### PR DESCRIPTION
In OSS, we run Go code intelligence in a docker container. Inside the container 127.0.0.1 does not map to the localhost of the container. host.docker.internal does though (on Docker for Mac and Windows, but [not Linux](https://github.com/docker/for-linux/issues/264)). It doesn't seem like there is a universal solution that works for both Mac and Linux (https://dev.to/bufferings/access-host-from-a-docker-container-4099).

In enterprise, we run Go code intelligence in process per https://github.com/sourcegraph/sourcegraph/issues/177#issuecomment-426144313 so it does need to be 127.0.0.1 there.

fix https://github.com/sourcegraph/sourcegraph/issues/177