### PR TITLE
repo-updater: Remove honeycomb logging

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -37,8 +37,6 @@ func main() {
 
 	// Start up handler that frontend relies on
 	var repoupdater repoupdater.Server
-	// Log usage statistics
-	go repoupdater.RecordStats()
 	handler := nethttp.Middleware(opentracing.GlobalTracer(), repoupdater.Handler())
 	host := ""
 	if insecureDev {

--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
-	"github.com/sourcegraph/sourcegraph/pkg/honey"
 	"github.com/sourcegraph/sourcegraph/pkg/httputil"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -65,7 +64,6 @@ type repoCreateOrUpdateRequest struct {
 // a given source.
 func createEnableUpdateRepos(ctx context.Context, source string, repoChan <-chan repoCreateOrUpdateRequest) {
 	enqueued := 0
-	dequeued := 0
 	errors := 0
 	newList := make(sourceRepoList)
 
@@ -117,14 +115,7 @@ func createEnableUpdateRepos(ctx context.Context, source string, repoChan <-chan
 		do(repo)
 	}
 	if NewScheduler() {
-		enqueued, dequeued = repos.updateSource(source, newList)
-	}
-	if honey.Enabled() {
-		ev := honey.Event("repo-updater")
-		ev.AddField("source", "create-enable-update-repos")
-		ev.AddField("fetches", enqueued)
-		ev.AddField("dequeued", dequeued)
-		ev.AddField("errors", errors)
+		repos.updateSource(source, newList)
 	}
 }
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
-	"github.com/sourcegraph/sourcegraph/pkg/honey"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater/protocol"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -25,25 +24,6 @@ type Server struct {
 	fetches int
 	errors  int
 	mu      sync.Mutex
-}
-
-// RecordStats logs activity data to Honeycomb if that's enabled.
-func (s *Server) RecordStats() {
-	if !honey.Enabled() {
-		return
-	}
-	tick := time.NewTicker(10 * time.Minute)
-	for range tick.C {
-		ev := honey.Event("repo-updater")
-		ev.AddField("source", "server")
-		s.mu.Lock()
-		ev.AddField("fetches", s.fetches)
-		ev.AddField("errors", s.errors)
-		s.fetches = 0
-		s.errors = 0
-		s.mu.Unlock()
-		ev.Send()
-	}
 }
 
 // Handler returns the http.Handler that should be used to serve requests.


### PR DESCRIPTION
Honeycomb is not the best for these sort of aggregate metrics. We should
rather be logging events in repo-updater to honeycomb. In the meantime, I am
removing this since we never look at the repo-updater dataset in honeycomb.