### PR TITLE
Remove the word 'Really' from prompts.

### DIFF
--- a/src/org/area/OrgMembersPage.tsx
+++ b/src/org/area/OrgMembersPage.tsx
@@ -52,9 +52,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                 .pipe(
                     filter(() =>
                         window.confirm(
-                            this.isSelf
-                                ? 'Really leave the organization?'
-                                : `Really remove the user ${this.props.node.username}?`
+                            this.isSelf ? 'Leave the organization?' : `Remove the user ${this.props.node.username}?`
                         )
                     ),
                     switchMap(() =>

--- a/src/repo/settings/index.ts
+++ b/src/repo/settings/index.ts
@@ -1,2 +1,2 @@
 export const REPO_DELETE_CONFIRMATION_MESSAGE =
-    'Really delete this repository from Sourcegraph? This cannot be undone. The original repository on the code host is not affected. If this repository was added by a configured code host, it will be re-added during the next sync.'
+    'Delete this repository from Sourcegraph? This cannot be undone. The original repository on the code host is not affected. If this repository was added by a configured code host, it will be re-added during the next sync.'

--- a/src/search/saved-queries/SavedQuery.tsx
+++ b/src/search/saved-queries/SavedQuery.tsx
@@ -168,7 +168,7 @@ export class SavedQuery extends React.PureComponent<Props, State> {
     private confirmDelete = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation()
         e.preventDefault()
-        if (window.confirm('Really delete this saved query?')) {
+        if (window.confirm('Delete this saved query?')) {
             eventLogger.log('SavedQueryDeleted')
             this.deleteRequested.next()
         } else {

--- a/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -168,7 +168,7 @@ export class DynamicallyImportedMonacoSettingsEditor extends React.PureComponent
         if (
             this.state.value === undefined ||
             this.props.value === this.state.value ||
-            window.confirm('Really discard edits?')
+            window.confirm('Discard edits?')
         ) {
             this.setState({ value: undefined })
         }

--- a/src/settings/SettingsFile.tsx
+++ b/src/settings/SettingsFile.tsx
@@ -269,7 +269,10 @@ export class SettingsFile extends React.PureComponent<Props, State> {
     }
 
     private discard = () => {
-        if (this.getPropsSettingsContentsOrEmpty() === this.state.contents || window.confirm('Really discard edits?')) {
+        if (
+            this.getPropsSettingsContentsOrEmpty() === this.state.contents ||
+            window.confirm('Discard settings edits?')
+        ) {
             eventLogger.log('SettingsFileDiscard')
             this.setState({
                 contents: undefined,

--- a/src/settings/tokens/AccessTokenNode.tsx
+++ b/src/settings/tokens/AccessTokenNode.tsx
@@ -78,7 +78,7 @@ export class AccessTokenNode extends React.PureComponent<AccessTokenNodeProps, A
                 .pipe(
                     filter(() =>
                         window.confirm(
-                            'Really delete and revoke this token? Any clients using it will no longer be able to access the Sourcegraph API.'
+                            'Delete and revoke this token? Any clients using it will no longer be able to access the Sourcegraph API.'
                         )
                     ),
                     switchMap(() =>

--- a/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -161,8 +161,8 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
         if (
             !window.confirm(
                 siteAdmin
-                    ? `Really promote user ${this.props.node.username} to site admin?`
-                    : `Really revoke site admin status from user ${this.props.node.username}?`
+                    ? `Promote user ${this.props.node.username} to site admin?`
+                    : `Revoke site admin status from user ${this.props.node.username}?`
             )
         ) {
             return
@@ -189,7 +189,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
     private randomizePassword = () => {
         if (
             !window.confirm(
-                `Really reset the password for ${
+                `Reset the password for ${
                     this.props.node.username
                 } to a random password? The user must reset their password to sign in again.`
             )
@@ -217,7 +217,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
     }
 
     private deleteUser = () => {
-        if (!window.confirm(`Really delete the user ${this.props.node.username}?`)) {
+        if (!window.confirm(`Delete the user ${this.props.node.username}?`)) {
             return
         }
 

--- a/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/src/site-admin/SiteAdminOrgsPage.tsx
@@ -86,7 +86,7 @@ class OrgNode extends React.PureComponent<OrgNodeProps, OrgNodeState> {
     }
 
     private deleteOrg = () => {
-        if (!window.confirm(`Really delete the organization ${this.props.node.name}?`)) {
+        if (!window.confirm(`Delete the organization ${this.props.node.name}?`)) {
             return
         }
 

--- a/src/user/account/UserAccountEmailsPage.tsx
+++ b/src/user/account/UserAccountEmailsPage.tsx
@@ -75,7 +75,7 @@ class UserEmailNode extends React.PureComponent<UserEmailNodeProps, UserEmailNod
     }
 
     private remove = () => {
-        if (!window.confirm(`Really remove the email address ${this.props.node.email}?`)) {
+        if (!window.confirm(`Remove the email address ${this.props.node.email}?`)) {
             return
         }
 


### PR DESCRIPTION
This PR removes the word 'Really' from all prompts and asks the user directly if they want to preform an action. We should not use words like 'really', or 'please', to confirm users actions. Instead, just be straight forward.