### PR TITLE
Bump e-c-c to v8.9.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -925,9 +925,9 @@
     vscode-languageserver-types "^3.8.2"
 
 "@sourcegraph/extensions-client-common@^8.8.0":
-  version "8.8.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/extensions-client-common/-/extensions-client-common-8.8.0.tgz#76b25abb8413345e252adbbe944563e892454941"
-  integrity sha512-teUI4O6IXQ1HS415q+ZyaTAvgOSOlUBvrGBMUI2AKCsoWecWXDW8Fg9nG4ZoSoUHgj3Ry+TH6qPsvnw/NPUmoA==
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-8.9.0.tgz#36a8ade0ed2281e7801e08aafac669bac332f7d2"
+  integrity sha512-sLTskHYrUNupDbk+RJC9o4Rmdpc2pD4IQs6hvXx6GDjb1w/qXa1jrh+KygmDObabqDddzAPLbfGkSjkaYQJUDw==
   dependencies:
     bootstrap "^4.1.3"
     lodash-es "^4.17.10"
@@ -7082,7 +7082,7 @@ longest-streak@^2.0.1:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
   integrity sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9135,12 +9135,12 @@ react-router@^4.3.1:
     warning "^4.0.1"
 
 react-transition-group@^2.3.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
-  integrity sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
+  integrity sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==
   dependencies:
     dom-helpers "^3.3.1"
-    loose-envify "^1.3.1"
+    loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 


### PR DESCRIPTION
This includes https://github.com/sourcegraph/extensions-client-common/pull/54 which fixes client settings updates on the extension registry page.

> This PR does not need to update the CHANGELOG because this fixes a bug which wasn't released.
