### PR TITLE
tree: add loader to directory component

### DIFF
--- a/src/tree/Directory.tsx
+++ b/src/tree/Directory.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { ChevronDownIcon } from 'mdi-react'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import * as React from 'react'
@@ -8,6 +9,7 @@ import { treePadding } from './util'
 interface TreeChildProps extends TreeLayerProps {
     className: string
     maxEntries: number
+    loading: boolean
     handleTreeClick: () => void
     noopRowClick: (e: React.MouseEvent<HTMLAnchorElement>) => void
     linkRowClick: (e: React.MouseEvent<HTMLAnchorElement>) => void
@@ -51,6 +53,11 @@ export const Directory: React.SFC<TreeChildProps> = (props: TreeChildProps): JSX
                         {props.entryInfo.name}
                     </Link>
                 </div>
+                {props.loading && (
+                    <div className="tree__row-loader">
+                        <LoadingSpinner className="icon-inline tree-page__entries-loader" />
+                    </div>
+                )}
             </div>
             {props.index === props.maxEntries - 1 && (
                 <div

--- a/src/tree/SingleChildTreeLayer.tsx
+++ b/src/tree/SingleChildTreeLayer.tsx
@@ -126,6 +126,7 @@ export class SingleChildTreeLayer extends React.Component<SingleChildTreeLayerPr
                             {...this.props}
                             className={className}
                             maxEntries={maxEntries}
+                            loading={false}
                             handleTreeClick={this.handleTreeClick}
                             noopRowClick={this.noopRowClick}
                             linkRowClick={this.linkRowClick}

--- a/src/tree/TreeLayer.tsx
+++ b/src/tree/TreeLayer.tsx
@@ -263,6 +263,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                     {...this.props}
                                     className={className}
                                     maxEntries={maxEntries}
+                                    loading={treeOrError === LOADING}
                                     handleTreeClick={this.handleTreeClick}
                                     noopRowClick={this.noopRowClick}
                                     linkRowClick={this.linkRowClick}


### PR DESCRIPTION
Directories in the tree component should show a loading indicator if it hasn't received a network response. This got removed in recent updates to the tree, so this PR adds it back.
