### PR TITLE
README: add Buildkite + Apache License badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a href="https://sourcegraph.com"><img alt="Sourcegraph" src="https://storage.googleapis.com/sourcegraph-assets/sourcegraph-logo.png" height="32px" /></a>
+# <a href="https://sourcegraph.com"><img alt="Sourcegraph" src="https://storage.googleapis.com/sourcegraph-assets/sourcegraph-logo.png" height="32px" /></a> <a href="https://github.com/sourcegraph/sourcegraph/blob/master/LICENSE"><img align="right" alt="Apache license" src="https://img.shields.io/badge/license-Apache-blue.svg" /></a>  <a href="https://buildkite.com/sourcegraph/sourcegraph"><img align="right" src="https://badge.buildkite.com/00bbe6fa9986c78b8e8591cffeb0b0f2e8c4bb610d7e339ff6.svg?branch=master" /></a>
 
 [Sourcegraph](https://about.sourcegraph.com/) is a fast, open-source, fully-featured code search and navigation engine.
 


### PR DESCRIPTION
Alternative to https://github.com/sourcegraph/sourcegraph/pull/219

How it looks: https://github.com/sourcegraph/sourcegraph/blob/30c3ed37bafd15839e36756ec8d0fa21d9937b00/README.md

> This PR does not need to update the CHANGELOG because it is docs.
