### PR TITLE
frontend: Use an uncommon name for csrf cookie

### DIFF
--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -12,7 +12,10 @@ import (
 func CSRFMiddleware(next http.Handler, secure bool) http.Handler {
 	return csrf.Protect(
 		[]byte("e953612ddddcdd5ec60d74e07d40218c"),
-		csrf.CookieName("csrf_token"),
+		// We do not use the name csrf_token since it is a common name. This
+		// leads to conflicts between apps on localhost. See
+		// https://github.com/sourcegraph/sourcegraph/issues/65
+		csrf.CookieName("sg_csrf_token"),
 		csrf.Path("/"),
 		csrf.Secure(secure),
 	)(next)


### PR DESCRIPTION
The name `csrf_token` seems to be use by other applications. When a user views
Sourcegraph on localhost it is not uncommon for a csrf_token to be set by
another app the user uses on localhost. This has lead to csrf errors, making the
site unuseable for the user. The proposed solution is to just use a different
name.

This does mean when this rolls out users will not have `sg_csrf_token` set. I
suspect they will run into a not authorized error, but will work on the next
page refresh.

Fixes https://github.com/sourcegraph/sourcegraph/issues/65