### PR TITLE
rename csrf_token to sg_csrf

### DIFF
--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -12,7 +12,7 @@ import (
 func CSRFMiddleware(next http.Handler, secure bool) http.Handler {
 	return csrf.Protect(
 		[]byte("e953612ddddcdd5ec60d74e07d40218c"),
-		csrf.CookieName("csrf_token"),
+		csrf.CookieName("sg_csrf"),
 		csrf.Path("/"),
 		csrf.Secure(secure),
 	)(next)


### PR DESCRIPTION
`csrf_token` is not a sufficiently unique name when running on localhost, and appears to cause issues for a non-zero number of developers.

fixes https://github.com/sourcegraph/sourcegraph/issues/65