### PR TITLE
build: call gulp through yarn

### DIFF
--- a/dev/Procfile
+++ b/dev/Procfile
@@ -9,7 +9,7 @@ github-proxy: ./dev/delve-hook github-proxy
 lsp-proxy: ./dev/delve-hook lsp-proxy
 frontend: ./dev/delve-hook .bin/frontend
 watch: ./dev/changewatch.sh
-web: ./node_modules/.bin/gulp --color watch
+web: yarn gulp --color watch
 syntect_server: ./dev/syntect_server
 zoekt-indexserver: ./dev/zoekt-wrapper zoekt-sourcegraph-indexserver -sourcegraph_url http://localhost:3090 -index $HOME/.sourcegraph/zoekt/index -interval 1m -listen :6072
 zoekt-webserver: ./dev/zoekt-wrapper zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc


### PR DESCRIPTION
This PR changes the build script to call gulp through yarn rather than directly from the .bin directory. This may solve https://github.com/sourcegraph/sourcegraph/issues/186, but should be tested by others before closing the issue.