### PR TITLE
enable multipleAuthProviders by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Sourcegraph Server and Data Center are documented in this
 
 - Reduced the size of in-memory data structured used for storing search results. This shdould reduce the backend memory usage of large result sets.
 - Code intelligence is now provided by [Sourcegraph extensions](https://github.com/sourcegraph/sourcegraph-extension-api). The extension for each language in the site configuration `langservers` property is automatically enabled. TODO BEFORE RELEASE: Make the previous sentence true. See https://github.com/sourcegraph/sourcegraph/issues/13125.
+- Support for multiple authentication providers is now enabled by default. To disable it, set the `experimentalFeatures.multipleAuthProviders` site config option to `"disabled"`. This only applies to Sourcegraph Enterprise.
 
 ### Added
 

--- a/cmd/frontend/internal/auth/config_test.go
+++ b/cmd/frontend/internal/auth/config_test.go
@@ -31,8 +31,38 @@ func TestValidateCustom(t *testing.T) {
 			},
 			wantProblems: []string{"auth.providers takes precedence"},
 		},
-		"multiple auth providers without experimentalFeature.multipleAuthProviders": {
+		"multiple auth providers with experimentalFeatures == nil": {
 			input: schema.SiteConfiguration{
+				AuthProviders: []schema.AuthProviders{
+					{Builtin: &schema.BuiltinAuthProvider{Type: "a"}},
+					{Builtin: &schema.BuiltinAuthProvider{Type: "b"}},
+				},
+			},
+			wantProblems: nil,
+		},
+		"multiple auth providers with experimentalFeatures.multipleAuthProviders unset": {
+			input: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{},
+				AuthProviders: []schema.AuthProviders{
+					{Builtin: &schema.BuiltinAuthProvider{Type: "a"}},
+					{Builtin: &schema.BuiltinAuthProvider{Type: "b"}},
+				},
+			},
+			wantProblems: nil,
+		},
+		"multiple auth providers with experimentalFeatures.multipleAuthProviders == enabled": {
+			input: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{MultipleAuthProviders: "enabled"},
+				AuthProviders: []schema.AuthProviders{
+					{Builtin: &schema.BuiltinAuthProvider{Type: "a"}},
+					{Builtin: &schema.BuiltinAuthProvider{Type: "b"}},
+				},
+			},
+			wantProblems: nil,
+		},
+		"multiple auth providers with experimentalFeatures.multipleAuthProviders == disabled": {
+			input: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{MultipleAuthProviders: "disabled"},
 				AuthProviders: []schema.AuthProviders{
 					{Builtin: &schema.BuiltinAuthProvider{Type: "a"}},
 					{Builtin: &schema.BuiltinAuthProvider{Type: "b"}},

--- a/dev/config.json
+++ b/dev/config.json
@@ -4,7 +4,6 @@
   "experimentalFeatures": {
     "configVars": "enabled",
     "canonicalURLRedirect": "enabled",
-    "multipleAuthProviders": "enabled",
     "updateScheduler": "enabled",
     "discussions": "enabled"
   },

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -40,8 +40,8 @@ func MultipleAuthProvidersEnabled() bool { return MultipleAuthProvidersEnabledFr
 // MultipleAuthProvidersEnabledFromConfig is like MultipleAuthProvidersEnabled, except it accepts a
 // site configuration input value instead of using the current global value.
 func MultipleAuthProvidersEnabledFromConfig(c *schema.SiteConfiguration) bool {
-	// default is disabled
-	return c.ExperimentalFeatures != nil && c.ExperimentalFeatures.MultipleAuthProviders == "enabled"
+	// default is enabled
+	return c.ExperimentalFeatures == nil || c.ExperimentalFeatures.MultipleAuthProviders != "disabled"
 }
 
 type AccessTokAllow string

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -90,10 +90,10 @@
         },
         "multipleAuthProviders": {
           "description":
-            "Enables or disables the use of multiple authentication providers and a publicly accessible web page displaying authentication options for unauthenticated users. (WARNING: Do not use this unless you know what you're doing.)",
+            "Enables or disables the use of multiple authentication providers and a publicly accessible web page displaying authentication options for unauthenticated users.\n\nOnly applies to Sourcegraph Enterprise Starter and Sourcegraph Enterprise.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "disabled"
+          "default": "enabled"
         },
         "discussions": {
           "description": "Enables the code discussions experiment.",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -372,7 +372,7 @@
     },
     "auth.providers": {
       "description":
-        "The authentication providers to use for identifying and signing in users.\n\nOnly one authentication provider is supported. If you set the deprecated field \"auth.provider\", then that value is used as the authentication provider, and you can't set another one here.",
+        "The authentication providers to use for identifying and signing in users.\n\nOnly one authentication provider is officially supported at the moment. Multiple providers can be specified, but the support is experimental. If you set the deprecated field \"auth.provider\", then that value is used as the authentication provider, and you can't set another one here.",
       "type": "array",
       "items": {
         "required": ["type"],

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -95,10 +95,10 @@ const SiteSchemaJSON = `{
         },
         "multipleAuthProviders": {
           "description":
-            "Enables or disables the use of multiple authentication providers and a publicly accessible web page displaying authentication options for unauthenticated users. (WARNING: Do not use this unless you know what you're doing.)",
+            "Enables or disables the use of multiple authentication providers and a publicly accessible web page displaying authentication options for unauthenticated users.\n\nOnly applies to Sourcegraph Enterprise Starter and Sourcegraph Enterprise.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "disabled"
+          "default": "enabled"
         },
         "discussions": {
           "description": "Enables the code discussions experiment.",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -377,7 +377,7 @@ const SiteSchemaJSON = `{
     },
     "auth.providers": {
       "description":
-        "The authentication providers to use for identifying and signing in users.\n\nOnly one authentication provider is supported. If you set the deprecated field \"auth.provider\", then that value is used as the authentication provider, and you can't set another one here.",
+        "The authentication providers to use for identifying and signing in users.\n\nOnly one authentication provider is officially supported at the moment. Multiple providers can be specified, but the support is experimental. If you set the deprecated field \"auth.provider\", then that value is used as the authentication provider, and you can't set another one here.",
       "type": "array",
       "items": {
         "required": ["type"],


### PR DESCRIPTION
This feature flag shipped default disabled 3 releases ago. No issues have been reported. It is now changed to default enabled. In the following major release, the feature flag will be removed and multipleAuthProviders will always be enabled.

The goal is to reduce complexity of auth code by removing cases. The special-case of 1 auth provider doesn't add much complexity, but it's still good to remove one case.

This only applies to Enterprise.

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
