### PR TITLE
repo-updater: Include extra context if graphql unmarshaling fails

### DIFF
--- a/cmd/repo-updater/internal/externalservice/github/client_test.go
+++ b/cmd/repo-updater/internal/externalservice/github/client_test.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestUnmarshal(t *testing.T) {
+	type result struct {
+		FieldA string
+		FieldB string
+	}
+	cases := map[string]string{
+		// Valid
+		`[]`:                                  "",
+		`[{"FieldA": "hi"}]`:                  "",
+		`[{"FieldA": "hi", "FieldB": "bye"}]`: "",
+
+		// Error
+		`[[]]`:            `graphql: cannot unmarshal at offset 2: before "[["; after "]]": json: cannot unmarshal array into Go value of type github.result`,
+		`[{"FieldA": 1}]`: `graphql: cannot unmarshal at offset 13: before "[{\"FieldA\": 1"; after "}]": json: cannot unmarshal number into Go value of type string`,
+	}
+	// Large body
+	repeated := strings.Repeat(`{"FieldA": "hi", "FieldB": "bye"},`, 100)
+	cases[fmt.Sprintf(`[%s {"FieldA": 1}, %s]`, repeated, repeated[:len(repeated)-1])] = `graphql: cannot unmarshal at offset 3414: before ", \"FieldB\": \"bye\"},{\"FieldA\": \"hi\", \"FieldB\": \"bye\"},{\"FieldA\": \"hi\", \"FieldB\": \"bye\"}, {\"FieldA\": 1"; after "}, {\"FieldA\": \"hi\", \"FieldB\": \"bye\"},{\"FieldA\": \"hi\", \"FieldB\": \"bye\"},{\"FieldA\": \"hi\", \"FieldB\": \"b": json: cannot unmarshal number into Go value of type string`
+
+	for data, errStr := range cases {
+		var a []result
+		var b []result
+		errA := json.Unmarshal([]byte(data), &a)
+		errB := unmarshal([]byte(data), &b)
+
+		if len(data) > 50 {
+			data = data[:50] + "..."
+		}
+
+		if !reflect.DeepEqual(a, b) {
+			t.Errorf("Expected the same result unmarshalling %v\na: %v\nb: %v", data, a, b)
+		}
+		if !reflect.DeepEqual(errA, errors.Cause(errB)) {
+			t.Errorf("Expected the same underlying error unmarshalling %v\na: %v\nb: %v", data, errA, errB)
+		}
+		got := ""
+		if errB != nil {
+			got = errB.Error()
+		}
+		if got != errStr {
+			t.Errorf("Unexpected error message %v\ngot:  %s\nwant: %s", data, got, errStr)
+		}
+	}
+}


### PR DESCRIPTION
A user is reporting that the list affiliated query is failing against
github.com. I am unable to reproduce this and the error message given by go
has no context. I am unsure if it is a regression, but for some reason go is
not reporting the field it is failing to unmarshal.

The error returned by the json library includes the offset the error occurred
at. This commit uses that and the response's byte buffer to include extra
context in the error message. This should help us narrow down which field is
giving us the issue, and adjust our client / file a bug against github.

Part of https://github.com/sourcegraph/sourcegraph/issues/218