### PR TITLE
dev/ci: clean up deployment logic to dogfood/prod

### DIFF
--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -200,27 +200,26 @@ func main() {
 		// Only deploy pure-OSS images dogfood/prod. Images that contain some
 		// private code (server/frontend) are already deployed by the
 		// enterprise CI above.
-		deploy := branch != "master"
 
-		if deploy {
-			// Deploy to dogfood
-			pipeline.AddStep(":dog:",
-				// Protect against concurrent/out-of-order deploys
-				bk.ConcurrencyGroup("deploy"),
-				bk.Concurrency(1),
-				bk.Env("VERSION", version),
-				bk.Env("CONTEXT", "gke_sourcegraph-dev_us-central1-a_dogfood-cluster-7"),
-				bk.Env("NAMESPACE", "default"),
-				bk.Cmd("./dev/ci/deploy-dogfood.sh"))
-			pipeline.AddWait()
+		if !strings.HasPrefix(branch, "docker-images/") {
+			return
 		}
 
-		if deploy {
-			// Deploy to prod
-			pipeline.AddStep(":rocket:",
-				bk.Env("VERSION", version),
-				bk.Cmd("./dev/ci/deploy-prod.sh"))
-		}
+		// Deploy to dogfood
+		pipeline.AddStep(":dog:",
+			// Protect against concurrent/out-of-order deploys
+			bk.ConcurrencyGroup("deploy"),
+			bk.Concurrency(1),
+			bk.Env("VERSION", version),
+			bk.Env("CONTEXT", "gke_sourcegraph-dev_us-central1-a_dogfood-cluster-7"),
+			bk.Env("NAMESPACE", "default"),
+			bk.Cmd("./dev/ci/deploy-dogfood.sh"))
+		pipeline.AddWait()
+
+		// Deploy to prod
+		pipeline.AddStep(":rocket:",
+			bk.Env("VERSION", version),
+			bk.Cmd("./dev/ci/deploy-prod.sh"))
 	}
 
 	switch {

--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -242,9 +242,6 @@ func main() {
 		}
 		pipeline.AddWait()
 
-	case branch == "master":
-		addDeploySteps()
-
 	case strings.HasPrefix(branch, "docker-images-patch/"):
 		version = version + "_patch"
 		addDockerImageStep(branch[20:], false)


### PR DESCRIPTION
> This PR does not need to update the CHANGELOG because this PR has no user-facing changes

Previously, this line: https://github.com/sourcegraph/sourcegraph/blob/34bbc85e55581afcc0354fe374e4739ef07323d0/dev/ci/gen-pipeline.go#L245-L246
was a no-op since https://github.com/sourcegraph/sourcegraph/blob/34bbc85e55581afcc0354fe374e4739ef07323d0/dev/ci/gen-pipeline.go#L199-L203

is the inverse of that conditional. 

Also, the `deploy` variable + associated logic in `addDeploySteps` could be simplified by just using an early `return` statement.

This PR address both of these issues. 