### PR TITLE
Clarify instructions

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -19,9 +19,21 @@ The sections below describe the the dependencies that you need to have to be abl
 
 Run this command to get the Sourcegraph source code on your local machine:
 
+Using GitHub:
+
+```
+git clone https://github.com/sourcegraph/sourcegraph.git
+// or via ssh if configured
+git clone git@github.com:sourcegraph/sourcegraph.git
+```
+
+Using Go:
+
 ```
 go get github.com/sourcegraph/sourcegraph
 ```
+> Install [Go](https://golang.org/doc/install) (v1.11 or higher)
+
 
 This is your "Sourcegraph repository directory".
 
@@ -45,8 +57,15 @@ You have two options for installing these dependencies.
 
 This is a streamlined setup for Mac machines.
 
-1.  Install [Docker for Mac](https://docs.docker.com/docker-for-mac/).
-2.  Install [Homebrew](https://brew.sh).
+1.  Install [Homebrew](https://brew.sh).
+2.  Install [Docker for Mac](https://docs.docker.com/docker-for-mac/).
+    
+    optionally via `brew`
+    
+    ```
+    brew cask install docker
+    ```
+    
 3.  Install Go, Node, PostgreSQL 9, Redis, Git with the following command:
 
     ```
@@ -111,7 +130,7 @@ commands under `sudo`.
 Run the following command to install Yarn, a package manager for Node.js.
 
 ```
-npm install -g yarn
+brew install yarn
 ```
 
 ## Step 4: Initialize your database
@@ -121,16 +140,11 @@ of that database.
 
 ### I. Create a database for the current Unix user
 
-If you are running on Linux, you may need to become the `postgres` user to
-administer Postgres.
-
-```bash
-# Linux only
-sudo su - postgres
-```
-
-After that, create the database - `createdb` with no arguments creates
+Create the database - `createdb` with no arguments creates
 a database with a name matching the current user.
+
+> If you are running on Linux, you may need to become the `postgres` user to
+  administer Postgres. Run `sudo su - postgres` first then continue.
 
 ```bash
 createdb

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -19,14 +19,6 @@ The sections below describe the the dependencies that you need to have to be abl
 
 Run this command to get the Sourcegraph source code on your local machine:
 
-Using GitHub:
-
-```
-git clone https://github.com/sourcegraph/sourcegraph.git
-// or via ssh if configured
-git clone git@github.com:sourcegraph/sourcegraph.git
-```
-
 Using Go:
 
 ```

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -24,6 +24,7 @@ Using Go:
 ```
 go get github.com/sourcegraph/sourcegraph
 ```
+
 > Install [Go](https://golang.org/doc/install) (v1.11 or higher)
 
 
@@ -122,7 +123,7 @@ commands under `sudo`.
 Run the following command to install Yarn, a package manager for Node.js.
 
 ```
-brew install yarn
+npm install -g yarn
 ```
 
 ## Step 4: Initialize your database


### PR DESCRIPTION
Made edits to instructions order and some commands to make things hopefully easier. These are just what helped me. Open to suggestions

- provide standard git instructions to get repo as `Go` isn't installed everywhere
- use `brew` for `yarn` as recommended by [yarn](https://yarnpkg.com/en/docs/install#mac-stable)
- add `Go` install instructions as well as how to install `docker` via `brew cask`
- tighten up some steps order and verbiage

<!-- delete the irrelevant line below -->

> This PR does not need to update the CHANGELOG because it's current instructions tightened up a bit.
