### PR TITLE
build: get auth override secret from env

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "graphql-lint": "graphql-schema-linter --old-implements-syntax --comment-descriptions cmd/frontend/graphqlbackend/schema.graphql",
     "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --require ts-node/register --require src/util/long-stack-traces.ts --timeout 10000 'src/**/*.test.ts?(x)'",
     "cover": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --require ts-node/register mocha --timeout 10000 './src/**/*.test.ts?(x)'",
-    "test-e2e": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --require ts-node/register --require ./src/util/long-stack-traces.ts --timeout 60000 --slow 5000 --exit './src/**/*.test.e2e.ts?(x)'",
+    "test-e2e": "env OVERRIDE_AUTH_SECRET=sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --require ts-node/register --require ./src/util/long-stack-traces.ts --timeout 60000 --slow 5000 --exit './src/**/*.test.e2e.ts?(x)'",
     "build": "NODE_OPTIONS=\"--max_old_space_size=4096\" gulp build",
     "watch": "NODE_OPTIONS=\"--max_old_space_size=4096\" gulp watch",
     "watch-webpack": "NODE_OPTIONS=\"--max_old_space_size=4096\" gulp watchWebpack",

--- a/src/e2e/index.test.e2e.tsx
+++ b/src/e2e/index.test.e2e.tsx
@@ -10,15 +10,16 @@ const SCREENSHOT_DIRECTORY = path.resolve(__dirname, '..', '..', 'puppeteer')
 describe('e2e test suite', () => {
     let authenticate: (page: puppeteer.Page) => Promise<void>
     let baseURL: string
-    let overrideAuthSecret: string
+
+    const overrideAuthSecret = process.env.OVERRIDE_AUTH_SECRET
+    if (!overrideAuthSecret) {
+        throw new Error('Auth secret not set - unable to execute tests')
+    }
+
     if (process.env.SOURCEGRAPH_BASE_URL && process.env.SOURCEGRAPH_BASE_URL !== 'http://localhost:3080') {
         baseURL = process.env.SOURCEGRAPH_BASE_URL
-        // Assume that the dogfood (sourcegraph.sgdev.org) override token works.
-        overrideAuthSecret = '2qzNBYQmUigCFdVVjDGyFfp'
     } else {
         baseURL = 'http://localhost:3080'
-        // Use OVERRIDE_AUTH_SECRET env var from dev/launch.sh.
-        overrideAuthSecret = 'sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ'
     }
     console.log('Using base URL', baseURL)
     authenticate = page => page.setExtraHTTPHeaders({ 'X-Override-Auth-Secret': overrideAuthSecret })


### PR DESCRIPTION
This PR removes secrets from the e2e tests. Running tests against localhost or against _sgdev in CI_ does not change however one regression is that we can't run tests locally against sgdev as easily. It is still possible but a bit harder. I will open up an issue for this.

<!-- delete the irrelevant line below -->

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
