### PR TITLE
fix repository deletion by ensuring discussion threads/comments are also removed

### DIFF
--- a/cmd/frontend/db/discussion_comments.go
+++ b/cmd/frontend/db/discussion_comments.go
@@ -88,6 +88,13 @@ type DiscussionCommentsUpdateOptions struct {
 	// operation cannot be undone.
 	Delete bool
 
+	// HardDelete, when true, indicates that the comment should be deleted
+	// entirely from the DB (not just marked as deleted / a soft delete).
+	//
+	// In general, this should only occur when e.g. deleting repositories. NOT
+	// when a user or admin requests to delete something.
+	HardDelete bool
+
 	// Report, when non-nil, specifies that the report message string should be
 	// added to the list of reports on this comment.
 	Report *string
@@ -120,11 +127,12 @@ func (c *discussionComments) Update(ctx context.Context, commentID int64, opts *
 			return nil, err
 		}
 	}
-	if opts.Delete {
+	var deletingFirstComment bool
+	if opts.Delete || opts.HardDelete {
 		// Deleting the first comment in a thread implicitly means deleting the thread itself.
 		var (
-			isFirstComment bool
-			threadID       int64
+			deletingFirstComment bool
+			threadID             int64
 		)
 		if !opts.noThreadDelete {
 			comment, err := c.Get(ctx, commentID)
@@ -137,19 +145,27 @@ func (c *discussionComments) Update(ctx context.Context, commentID int64, opts *
 			if err != nil {
 				return nil, err
 			}
-			isFirstComment = comment.ID == comments[0].ID
+			deletingFirstComment = comment.ID == comments[0].ID
 			threadID = comment.ThreadID
 		}
-		if isFirstComment {
+		if deletingFirstComment {
 			_, err := DiscussionThreads.Update(ctx, threadID, &DiscussionThreadsUpdateOptions{Delete: true})
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			anyUpdate = true
-			if _, err := dbconn.Global.ExecContext(ctx, "UPDATE discussion_comments SET deleted_at=$1 WHERE id=$2 AND deleted_at IS NULL", now, commentID); err != nil {
-				return nil, err
-			}
+		}
+	}
+	if !deletingFirstComment && opts.Delete {
+		anyUpdate = true
+		if _, err := dbconn.Global.ExecContext(ctx, "UPDATE discussion_comments SET deleted_at=$1 WHERE id=$2 AND deleted_at IS NULL", now, commentID); err != nil {
+			return nil, err
+		}
+	}
+	if !deletingFirstComment && opts.HardDelete {
+		// Intentionally not setting anyUpdate=true here, it would cause us to
+		// try to update updated_at below which would fail.
+		if _, err := dbconn.Global.ExecContext(ctx, "DELETE FROM discussion_comments WHERE id=$1", commentID); err != nil {
+			return nil, err
 		}
 	}
 	if opts.Report != nil {
@@ -169,7 +185,7 @@ func (c *discussionComments) Update(ctx context.Context, commentID int64, opts *
 			return nil, err
 		}
 	}
-	if opts.Delete {
+	if opts.Delete || opts.HardDelete {
 		return nil, nil
 	}
 	return c.Get(ctx, commentID)

--- a/cmd/frontend/db/discussion_comments.go
+++ b/cmd/frontend/db/discussion_comments.go
@@ -88,12 +88,12 @@ type DiscussionCommentsUpdateOptions struct {
 	// operation cannot be undone.
 	Delete bool
 
-	// HardDelete, when true, indicates that the comment should be deleted
+	// hardDelete, when true, indicates that the comment should be deleted
 	// entirely from the DB (not just marked as deleted / a soft delete).
 	//
 	// In general, this should only occur when e.g. deleting repositories. NOT
 	// when a user or admin requests to delete something.
-	HardDelete bool
+	hardDelete bool
 
 	// Report, when non-nil, specifies that the report message string should be
 	// added to the list of reports on this comment.
@@ -128,7 +128,7 @@ func (c *discussionComments) Update(ctx context.Context, commentID int64, opts *
 		}
 	}
 	var deletingFirstComment bool
-	if opts.Delete || opts.HardDelete {
+	if opts.Delete || opts.hardDelete {
 		// Deleting the first comment in a thread implicitly means deleting the thread itself.
 		var (
 			deletingFirstComment bool
@@ -161,7 +161,7 @@ func (c *discussionComments) Update(ctx context.Context, commentID int64, opts *
 			return nil, err
 		}
 	}
-	if !deletingFirstComment && opts.HardDelete {
+	if !deletingFirstComment && opts.hardDelete {
 		// Intentionally not setting anyUpdate=true here, it would cause us to
 		// try to update updated_at below which would fail.
 		if _, err := dbconn.Global.ExecContext(ctx, "DELETE FROM discussion_comments WHERE id=$1", commentID); err != nil {
@@ -185,7 +185,7 @@ func (c *discussionComments) Update(ctx context.Context, commentID int64, opts *
 			return nil, err
 		}
 	}
-	if opts.Delete || opts.HardDelete {
+	if opts.Delete || opts.hardDelete {
 		return nil, nil
 	}
 	return c.Get(ctx, commentID)

--- a/cmd/frontend/db/discussion_threads.go
+++ b/cmd/frontend/db/discussion_threads.go
@@ -143,9 +143,17 @@ type DiscussionThreadsUpdateOptions struct {
 	// Archive, when non-nil, specifies whether the thread is archived or not.
 	Archive *bool
 
-	// Delete, when true, specifies that the comment should be deleted. This
+	// Delete, when true, specifies that the thread should be deleted. This
 	// operation cannot be undone.
 	Delete bool
+
+	// HardDelete, when true, indicates that the discussion thread should be
+	// deleted entirely from the DB (not just marked as deleted / a soft
+	// delete).
+	//
+	// In general, this should only occur when e.g. deleting repositories. NOT
+	// when a user or admin requests to delete something.
+	HardDelete bool
 }
 
 func (t *discussionThreads) Update(ctx context.Context, threadID int64, opts *DiscussionThreadsUpdateOptions) (*types.DiscussionThread, error) {
@@ -190,12 +198,48 @@ func (t *discussionThreads) Update(ctx context.Context, threadID int64, opts *Di
 			}
 		}
 	}
+	if opts.HardDelete {
+		// Intentionally not setting anyUpdate=true here, it would cause us to
+		// try to update updated_at below which would fail.
+
+		// Hard delete the mail reply tokens.
+		if _, err := dbconn.Global.ExecContext(ctx, "DELETE FROM discussion_mail_reply_tokens WHERE thread_id=$1", threadID); err != nil {
+			return nil, err
+		}
+
+		// Unlink and hard delete discussion thread targets.
+		if _, err := dbconn.Global.ExecContext(ctx, "UPDATE discussion_threads SET target_repo_id=null WHERE id=$1", threadID); err != nil {
+			return nil, err
+		}
+		if _, err := dbconn.Global.ExecContext(ctx, "DELETE FROM discussion_threads_target_repo WHERE thread_id=$1", threadID); err != nil {
+			return nil, err
+		}
+
+		// Hard delete all comments in the thread.
+		comments, err := DiscussionComments.List(ctx, &DiscussionCommentsListOptions{
+			ThreadID: &threadID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, comment := range comments {
+			_, err := DiscussionComments.Update(ctx, comment.ID, &DiscussionCommentsUpdateOptions{HardDelete: true, noThreadDelete: true})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Finally, hard delete the discussion thread itself.
+		if _, err := dbconn.Global.ExecContext(ctx, "DELETE FROM discussion_threads WHERE id=$1", threadID); err != nil {
+			return nil, err
+		}
+	}
 	if anyUpdate {
 		if _, err := dbconn.Global.ExecContext(ctx, "UPDATE discussion_threads SET updated_at=$1 WHERE id=$2 AND deleted_at IS NULL", now, threadID); err != nil {
 			return nil, err
 		}
 	}
-	if opts.Delete {
+	if opts.Delete || opts.HardDelete {
 		return nil, nil
 	}
 	return t.Get(ctx, threadID)

--- a/cmd/frontend/db/discussion_threads.go
+++ b/cmd/frontend/db/discussion_threads.go
@@ -147,13 +147,13 @@ type DiscussionThreadsUpdateOptions struct {
 	// operation cannot be undone.
 	Delete bool
 
-	// HardDelete, when true, indicates that the discussion thread should be
+	// hardDelete, when true, indicates that the discussion thread should be
 	// deleted entirely from the DB (not just marked as deleted / a soft
 	// delete).
 	//
 	// In general, this should only occur when e.g. deleting repositories. NOT
 	// when a user or admin requests to delete something.
-	HardDelete bool
+	hardDelete bool
 }
 
 func (t *discussionThreads) Update(ctx context.Context, threadID int64, opts *DiscussionThreadsUpdateOptions) (*types.DiscussionThread, error) {
@@ -198,7 +198,7 @@ func (t *discussionThreads) Update(ctx context.Context, threadID int64, opts *Di
 			}
 		}
 	}
-	if opts.HardDelete {
+	if opts.hardDelete {
 		// Intentionally not setting anyUpdate=true here, it would cause us to
 		// try to update updated_at below which would fail.
 
@@ -223,7 +223,7 @@ func (t *discussionThreads) Update(ctx context.Context, threadID int64, opts *Di
 			return nil, err
 		}
 		for _, comment := range comments {
-			_, err := DiscussionComments.Update(ctx, comment.ID, &DiscussionCommentsUpdateOptions{HardDelete: true, noThreadDelete: true})
+			_, err := DiscussionComments.Update(ctx, comment.ID, &DiscussionCommentsUpdateOptions{hardDelete: true, noThreadDelete: true})
 			if err != nil {
 				return nil, err
 			}
@@ -239,7 +239,7 @@ func (t *discussionThreads) Update(ctx context.Context, threadID int64, opts *Di
 			return nil, err
 		}
 	}
-	if opts.Delete || opts.HardDelete {
+	if opts.Delete || opts.hardDelete {
 		return nil, nil
 	}
 	return t.Get(ctx, threadID)

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -515,8 +515,22 @@ func (s *repos) Delete(ctx context.Context, repo api.RepoID) error {
 		return err
 	}
 
+	// Hard delete entries in the discussions tables that correspond to the repo.
+	threads, err := DiscussionThreads.List(ctx, &DiscussionThreadsListOptions{
+		TargetRepoID: &repo,
+	})
+	if err != nil {
+		return err
+	}
+	for _, thread := range threads {
+		_, err := DiscussionThreads.Update(ctx, thread.ID, &DiscussionThreadsUpdateOptions{HardDelete: true})
+		if err != nil {
+			return err
+		}
+	}
+
 	q := sqlf.Sprintf("DELETE FROM REPO WHERE id=%d", repo)
-	_, err := dbconn.Global.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	_, err = dbconn.Global.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	return err
 }
 

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -523,7 +523,7 @@ func (s *repos) Delete(ctx context.Context, repo api.RepoID) error {
 		return err
 	}
 	for _, thread := range threads {
-		_, err := DiscussionThreads.Update(ctx, thread.ID, &DiscussionThreadsUpdateOptions{HardDelete: true})
+		_, err := DiscussionThreads.Update(ctx, thread.ID, &DiscussionThreadsUpdateOptions{hardDelete: true})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Otherwise we will violate DB constraints.

Fixes https://github.com/sourcegraph/enterprise/issues/13413

Note: This does not handle a more general issue of us not using transactions
(both throughout this deletion code and the code discussions code in general.)

> This PR does not need to update the CHANGELOG because it was not broken in the prior release.
