### PR TITLE
{cmd/repo-updater,cmd/gitserver}: aggresively remove log details that could contain sensitive info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph Server and Data Center are documented in this
 
 - Files with the gitattribute `export-ignore` are no longer excluded for language analysis and search.
 - "Discard changes?" confirmation popup doesn't pop up every single time you try to navigate to a new page after editting something in the site settings page anymore.
+- Fixed an issue where Git repository URLs would sometimes be logged, potentially containing e.g. basic auth tokens.
 
 ### Removed
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -814,7 +814,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoURI, url string, op
 		tmpPath = filepath.Join(tmpPath, ".git")
 
 		cmd := exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", url, tmpPath)
-		log15.Info("cloning repo", "repo", repo, "url", url, "tmp", tmpPath, "dst", dstPath)
+		log15.Info("cloning repo", "repo", repo, "tmp", tmpPath, "dst", dstPath)
 
 		pr, pw := io.Pipe()
 		defer pw.Close()
@@ -1257,7 +1257,7 @@ func (s *Server) doRepoUpdate2(repo api.RepoURI, url string) error {
 		var err error
 		url, err = repoRemoteURL(ctx, dir)
 		if err != nil || url == "" {
-			log15.Error("Failed to determine Git remote URL", "repo", repo, "error", err, "url", url)
+			log15.Error("Failed to determine Git remote URL", "repo", repo, "error", err)
 			return errors.Wrap(err, "failed to determine Git remote URL")
 		}
 		urlIsGitRemote = true
@@ -1273,13 +1273,13 @@ func (s *Server) doRepoUpdate2(repo api.RepoURI, url string) error {
 		if current, _ := repoRemoteURL(ctx, dir); current == "" {
 			cmd = exec.Command("git", "remote", "add", "origin", url)
 		} else if current != url {
-			log15.Debug("repository remote URL changed", "repo", repo, "old", current, "new", url)
+			log15.Debug("repository remote URL changed", "repo", repo)
 			cmd = exec.Command("git", "remote", "set-url", "origin", "--", url)
 		}
 		if cmd != nil {
 			cmd.Dir = dir
 			if err, _ := runCommand(ctx, cmd); err != nil {
-				log15.Error("Failed to update repository's Git remote URL.", "repo", repo, "url", url, "error", err)
+				log15.Error("Failed to update repository's Git remote URL.", "repo", repo, "error", err)
 			}
 		}
 	}
@@ -1310,7 +1310,7 @@ func (s *Server) doRepoUpdate2(repo api.RepoURI, url string) error {
 	cmd.Dir = path.Join(s.ReposDir, string(repo))
 	output, err := s.runWithRemoteOpts(ctx, cmd, nil)
 	if err != nil {
-		log15.Error("Failed to fetch remote info", "repo", repo, "url", url, "error", err, "output", string(output))
+		log15.Error("Failed to fetch remote info", "repo", repo, "error", err, "output", string(output))
 		return errors.Wrap(err, "failed to fetch remote info")
 	}
 	submatches := headBranchPattern.FindSubmatch(output)

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -50,7 +50,7 @@ func init() {
 			for _, c := range conf.Get().AwsCodeCommit {
 				conn, err := newAWSCodeCommitConnection(c)
 				if err != nil {
-					log15.Error("Error processing configured AWS CodeCommit connection. Skipping it.", "region", c.Region, "accessKeyID", c.AccessKeyID, "error", err)
+					log15.Error("Error processing configured AWS CodeCommit connection. Skipping it.", "region", c.Region, "error", err)
 					continue
 				}
 				conns = append(conns, conn)
@@ -141,7 +141,7 @@ var awsCodeCommitRepositorySyncWorker = &worker{
 					if err == nil {
 						break
 					}
-					log15.Error("Unable to reach AWS CodeCommit API to determine AWS account ID.", "region", c.config.Region, "accessKeyID", c.config.AccessKeyID, "error", err, "retryInterval", retryInterval)
+					log15.Error("Unable to reach AWS CodeCommit API to determine AWS account ID.", "region", c.config.Region, "error", err, "retryInterval", retryInterval)
 					select {
 					case <-shutdown:
 						return

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -433,7 +433,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) <-chan *gith
 					log15.Debug("github sync: ListViewerRepositories", "repos", len(repos), "rateLimitCost", rateLimitCost, "rateLimitRemaining", rateLimitRemaining, "rateLimitReset", rateLimitReset)
 					for _, r := range repos {
 						if c.githubDotCom && r.IsFork && r.ViewerPermission == "READ" {
-							log15.Debug("not syncing readonly fork", "url", r.URL)
+							log15.Debug("not syncing readonly fork", "repo", r.NameWithOwner)
 							continue
 						}
 						// log15.Debug("github sync: ListViewerRepositories: repo", "repo", r.NameWithOwner)

--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -101,7 +101,7 @@ func createEnableUpdateRepos(ctx context.Context, source string, repoChan <-chan
 				errors++
 				return
 			}
-			log15.Debug("fetching repo", "repo", createdRepo.URI, "url", op.URL, "cloned", isCloned)
+			log15.Debug("fetching repo", "repo", createdRepo.URI, "cloned", isCloned)
 			err = gitserver.DefaultClient.EnqueueRepoUpdateDeprecated(ctx, gitserver.Repo{Name: createdRepo.URI, URL: op.URL})
 			enqueued++
 			if err != nil {


### PR DESCRIPTION
I have reviewed (briefly) every existing `log15.` statement in `cmd/repo-update` and `cmd/gitserver` to formulate this change. It is possible that I have removed e.g. printing of some URLs which cannot contain sensitive information (I do not think this is important however, and we can fix going forward).

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
