### PR TITLE
Replace extension drop-downs with toggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/polyfill": "^7.0.0",
     "@sourcegraph/codeintellify": "^3.9.0",
-    "@sourcegraph/extensions-client-common": "^9.0.0",
+    "@sourcegraph/extensions-client-common": "^10.0.0",
     "@sqs/jsonc-parser": "^1.0.3",
     "@types/react": "16.4.14",
     "@types/react-dom": "16.0.7",

--- a/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -1,5 +1,5 @@
 import { isExtensionAdded, isExtensionEnabled } from '@sourcegraph/extensions-client-common/lib/extensions/extension'
-import { ExtensionPrimaryActionButton } from '@sourcegraph/extensions-client-common/lib/extensions/ExtensionPrimaryActionButton'
+import { ExtensionToggle } from '@sourcegraph/extensions-client-common/lib/extensions/ExtensionToggle'
 import { ExtensionManifest } from '@sourcegraph/extensions-client-common/lib/schema/extension.schema'
 import * as React from 'react'
 import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
@@ -58,7 +58,7 @@ export const ExtensionAreaHeader: React.SFC<ExtensionAreaHeaderProps> = (props: 
                         </div>
                         <div className="d-flex align-items-center mt-3 mb-2">
                             {props.authenticatedUser && (
-                                <ExtensionPrimaryActionButton
+                                <ExtensionToggle
                                     extension={props.extension}
                                     configurationCascade={props.configurationCascade}
                                     onUpdate={props.onDidUpdateExtension}

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,10 +924,10 @@
     rxjs "^6.3.2"
     vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/extensions-client-common@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-9.0.0.tgz#c6708f895ed842e97434997bc12377121ab7026a"
-  integrity sha512-Kd7g6s+EfvZpQrA/WMhXB1sBMz5L7a+M1/VQNzpejpfD8CoW1iAXskrCO/DrPfkUcB9yLehoxv47njixMAihjQ==
+"@sourcegraph/extensions-client-common@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.0.0.tgz#bba96eaa344d3eee949a013ad88bd05231987a52"
+  integrity sha512-AHiGYYN1hAV8QuMaGufi02mP86Bg/rFwo9+hj3UOKZMO6CdgQtFeOvIoFcj0Q13K4MxueYiZId6YopfI71ZZHg==
   dependencies:
     bootstrap "^4.1.3"
     lodash-es "^4.17.10"


### PR DESCRIPTION
- Toggles instead of dropdowns + buttons
- Hover on the toggle to see where the extension is enabled/disabled
- Still asks for confirmation when enabling an extension that doesn't exist in the settings
- Pulls in @ijsnow's new and improved toggle :sparkles:

![2018-10-04 19 21 06](https://user-images.githubusercontent.com/1387653/46512810-b499b300-c80a-11e8-8848-3bf6afd645fc.gif)

> This PR does not need to update the CHANGELOG because it's not released
