### PR TITLE
Update homepage modal animation

### DIFF
--- a/src/search/input/MainPage.scss
+++ b/src/search/input/MainPage.scss
@@ -456,18 +456,35 @@ body.modal-open {
             transition: all 0.325s ease-in-out;
             margin-bottom: 1rem;
         }
-        .modal-copy-row {
-            padding-bottom: 4rem;
-            * {
-                transition: all 350ms ease;
-                color: #666;
+        .search-modal-container {
+            .modal-copy-row {
+                h1,
+                h2,
+                h3,
+                h4,
+                h5,
+                p {
+                    transition: all 350ms ease;
+                    color: #666 !important;
+                }
+            }
+            .activesec {
+                h1,
+                h2,
+                h3,
+                h4,
+                h5,
+                p {
+                    transition: all 350ms ease;
+
+                    color: white !important;
+                }
             }
         }
-        .activesec * {
-            transition: all 350ms ease;
-
-            color: white;
+        .modal-copy-row {
+            padding-bottom: 4rem;
         }
+
         .main-page__container {
             width: 100%;
             max-width: 100%;

--- a/src/search/input/MainPage.tsx
+++ b/src/search/input/MainPage.tsx
@@ -616,7 +616,7 @@ export class MainPage extends React.Component<Props, State> {
                         this.state.modalSearchClosing ? 'modal-closing' : ''
                     }`}
                 >
-                    <div className="container">
+                    <div className="container search-modal-container">
                         <button className="btn-close-top" onClick={this.closeModal('search')}>
                             <CloseIcon className="material-icons" />
                         </button>
@@ -627,7 +627,7 @@ export class MainPage extends React.Component<Props, State> {
                             </div>
                         </div>
                         <div
-                            className={`search-row copy-section ${
+                            className={`search-row copy-section  ${
                                 this.state.animateModalSearch ? 'search-row-animate' : ''
                             }`}
                         >


### PR DESCRIPTION
Moved the animation class for changing the modal copy to only the search section to prevent edge case issues like https://github.com/sourcegraph/enterprise/issues/13580 where it is possible that another modal might have dimmed text.