### PR TITLE
Don't require go mod tidy

### DIFF
--- a/dev/check/go-generate.sh
+++ b/dev/check/go-generate.sh
@@ -10,12 +10,11 @@ main() {
 
     go install github.com/sourcegraph/sourcegraph/vendor/golang.org/x/tools/cmd/stringer
     go install github.com/sourcegraph/sourcegraph/vendor/github.com/sourcegraph/go-jsonschema/cmd/go-jsonschema-compiler
-    go install github.com/sourcegraph/sourcegraph/vendor/github.com/kevinburke/differ
 
     # Runs generate.sh and ensures no files changed. This relies on the go
     # generation that ran are idempotent.
-
-    differ ./dev/generate.sh
+    ./dev/generate.sh
+    git diff --exit-code -- . ':!go.sum'
 }
 
 main "$@"

--- a/dev/check/go-mod.sh
+++ b/dev/check/go-mod.sh
@@ -8,18 +8,8 @@ main() {
     export GOBIN="$PWD/vendor/.bin"
     export PATH=$GOBIN:$PATH
 
-    go install github.com/sourcegraph/sourcegraph/vendor/github.com/kevinburke/differ
-    # Run any non-side-effecting command to ensure there's no Git diff present,
-    # before running the "go mod" command below this one.
-    #
-    # We are seeing some nondeterministic build behavior and want to ensure the
-    # problem is in "go mod" and not present before the tool even starts
-    # running.
-    #
-    # https://buildkite.com/sourcegraph/sourcegraph/builds/20904#f00ca1a3-b30c-41fe-8896-f2e9e6473b61
-    # https://github.com/sourcegraph/enterprise/issues/13416
-    differ git fsck
-    GO111MODULE=on differ bash -c 'go mod vendor && go mod tidy -v'
+    GO111MODULE=on go mod vendor
+    git diff --exit-code -- . ':!go.sum'
 }
 
 main "$@"


### PR DESCRIPTION
According to the Go modules FAQ it is intentional and beneficial that old entries are kept around: https://github.com/golang/go/wiki/Modules#is-gosum-a-lock-file-why-does-gosum-include-information-for-module-versions-i-am-no-longer-using

Renovate does not run `go mod tidy` after updating, at least not until https://github.com/renovatebot/renovate/issues/2594 adds an option, so this currently blocks us from using Renovate.

We can add it back later if we want once Renovate has the option, or decide the Go team knows best 🤷‍♂️ 