### PR TITLE
Update thread-loader to fix EventEmitter leak

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -281,9 +281,11 @@ github.com/sourcegraph/go-langserver v0.0.0-20180817131207-7df19dc017ef h1:3fS/i
 github.com/sourcegraph/go-langserver v0.0.0-20180817131207-7df19dc017ef/go.mod h1:bBMjfpzEHd6ijPRoQ7f+knFfw+e8R+W158/MsqAy77c=
 github.com/sourcegraph/godockerize v0.0.0-20180919081208-f4fb18a2ab18 h1:Owk1nJ1CZIhtKyiVrG65ajT834xuNhtpJWmhnNF2x3A=
 github.com/sourcegraph/godockerize v0.0.0-20180919081208-f4fb18a2ab18/go.mod h1:EnJwbnfidbH57UXewOZLIrwQVpu/spwbS/BMN0sPfCA=
+github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d h1:FxF0pen6r1WOqbm4kVDR3JV078HfPz65inWcMh1aVQI=
 github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d/go.mod h1:8HCyYaC38XwX0AOu0+fuY02Y5Z7CkITW0oVJavbna4Q=
 github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10 h1:9XH6ZJgu6KrVimEwZVXfTOvkGU1CHAvdc7mbZrMwA/U=
 github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10/go.mod h1:G6fSBYyOm5huBpPQ4qhXejeVbKeehdP7WEmwb5Si7gM=
+github.com/sourcegraph/graphql-go v0.0.0-20180929065141-c790ffc3c46a h1:quXhD1UpAyXOxkpI6uE3sLQn8+cYTPzak6us/89EkX8=
 github.com/sourcegraph/graphql-go v0.0.0-20180929065141-c790ffc3c46a/go.mod h1:VlASmqwzCjVGsAX6ZaaoPS4tulDNfI+ZuEvYeeZX4oM=
 github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe h1:JAHsmn5ixsIuTGS635/VeuVdS6RU5b4D/V1Dz/J+5R8=
 github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe/go.mod h1:0AJ8DDXVNSPaIhEfFiCg9TqPt9YgLf+umcJSUjuG9SA=
@@ -293,6 +295,7 @@ github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd h1:NPk22RvonOjkN
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
+github.com/sourcegraph/zoekt v0.0.0-20180925141536-852b3842c11d h1:82xTRg5XBKlVsvLvgcgQzcG54AFTYhS2DdMVT5U5AWw=
 github.com/sourcegraph/zoekt v0.0.0-20180925141536-852b3842c11d/go.mod h1:f1Qnbu4glSRTb9A/H7qLv4AhudFf3eStkDbpyb21KYQ=
 github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff h1:35Om/vTf7BiYaXjy+V6enYxBRzWOhoFI0g/Uzc0QL8Y=
 github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff/go.mod h1:nWz2tl1iTFolecQ3BuPG6Vgj45dmiYL0greltKiFMoU=

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "style-loader": "^0.23.0",
     "stylelint": "^9.4.0",
     "stylelint-formatter-compact": "^1.1.0",
-    "thread-loader": "sourcegraph/thread-loader#ddbb570ed8de6a44c94c248adc3486fdd3ef7a0c",
+    "thread-loader": "sourcegraph/thread-loader#6321efbc3524f18cd823dd300c1a8a7fe82ca3a5",
     "ts-loader": "^5.0.0",
     "ts-node": "^7.0.1",
     "ts-unused-exports": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10666,9 +10666,9 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-thread-loader@sourcegraph/thread-loader#ddbb570ed8de6a44c94c248adc3486fdd3ef7a0c:
+thread-loader@sourcegraph/thread-loader#6321efbc3524f18cd823dd300c1a8a7fe82ca3a5:
   version "1.2.0"
-  resolved "https://codeload.github.com/sourcegraph/thread-loader/tar.gz/ddbb570ed8de6a44c94c248adc3486fdd3ef7a0c"
+  resolved "https://codeload.github.com/sourcegraph/thread-loader/tar.gz/6321efbc3524f18cd823dd300c1a8a7fe82ca3a5"
   dependencies:
     async "^2.3.0"
     loader-runner "^2.3.0"


### PR DESCRIPTION
Fixes sourcegraph/sourcegraph#310.

<!-- delete the irrelevant line below -->

> This PR does not need to update the CHANGELOG because it's trivial.