### PR TITLE
resize phabricator icon

### DIFF
--- a/src/util/icons.tsx
+++ b/src/util/icons.tsx
@@ -84,7 +84,7 @@ export const PhabricatorIcon: React.SFC<Props> = props => (
         className={`mdi-icon${props.className ? ' ' + props.className : ''}`}
         width="24"
         height="24"
-        viewBox="0 0 24 24"
+        viewBox="0 0 64 64"
     >
         <g>
             <g id="Oval">


### PR DESCRIPTION
Resize the Phabricator icon
![image](https://user-images.githubusercontent.com/9110008/46639034-bf10c100-cb18-11e8-89c3-d850279dc825.png)
vs
![image](https://user-images.githubusercontent.com/9110008/46639046-cf28a080-cb18-11e8-8f7e-6474266c76fa.png)

> This PR does not need to update the CHANGELOG because it is a minor UI fix.
