### PR TITLE
feat: remove default extension registry

### DIFF
--- a/pkg/conf/platform.go
+++ b/pkg/conf/platform.go
@@ -7,6 +7,10 @@ type PlatformConfiguration struct {
 	RemoteRegistryURL string
 }
 
+// DefaultRemoteRegistry is the default value for the site configuration field
+// "remoteRegistry" when unspecified.
+var DefaultRemoteRegistry string
+
 // Extensions returns the configuration for the Sourcegraph platform, or nil if it is disabled.
 func Extensions() *PlatformConfiguration {
 	cfg := Get()
@@ -24,13 +28,12 @@ func Extensions() *PlatformConfiguration {
 
 	// If the "remoteRegistry" value is a string, use that. If false, then keep it empty. Otherwise
 	// use the default.
-	const defaultRemoteRegistry = "https://sourcegraph.com/.api/registry"
 	if s, ok := x.RemoteRegistry.(string); ok {
 		pc.RemoteRegistryURL = s
 	} else if b, ok := x.RemoteRegistry.(bool); ok && !b {
 		// Nothing to do.
 	} else {
-		pc.RemoteRegistryURL = defaultRemoteRegistry
+		pc.RemoteRegistryURL = DefaultRemoteRegistry
 	}
 
 	return &pc

--- a/src/extensions/ExtensionsEmptyState.tsx
+++ b/src/extensions/ExtensionsEmptyState.tsx
@@ -10,9 +10,9 @@ export const ExtensionsEmptyState: React.SFC<{
         <h4 className="text-muted mb-3">
             Extensions add new features to Sourcegraph. Check out the{' '}
             <a href="https://about.sourcegraph.com/docs/extensions/" target="_blank">
-                docs
+                Sourcegraph Extensions documentation
             </a>{' '}
-            for adding extensions or upgrading your instance.
+            for how to publish extensions.
         </h4>
         <Link to="/extensions" className="btn btn-primary" onClick={onClick}>
             Add extensions from registry

--- a/src/extensions/ExtensionsEmptyState.tsx
+++ b/src/extensions/ExtensionsEmptyState.tsx
@@ -7,7 +7,13 @@ export const ExtensionsEmptyState: React.SFC<{
     onClick?: () => void
 }> = ({ className = 'px-3 py-4', onClick }) => (
     <div className={`${className} text-center bg-striped-secondary`}>
-        <h4 className="text-muted mb-3">Extensions add new features to Sourcegraph.</h4>
+        <h4 className="text-muted mb-3">
+            Extensions add new features to Sourcegraph. Check out the{' '}
+            <a href="https://about.sourcegraph.com/docs/extensions/" target="_blank">
+                docs
+            </a>{' '}
+            for adding extensions or upgrading your instance.
+        </h4>
         <Link to="/extensions" className="btn btn-primary" onClick={onClick}>
             Add extensions from registry
         </Link>

--- a/src/extensions/ExtensionsEmptyState.tsx
+++ b/src/extensions/ExtensionsEmptyState.tsx
@@ -6,7 +6,7 @@ export const ExtensionsEmptyState: React.SFC<{
     className?: string
     onClick?: () => void
 }> = ({ className = 'px-3 py-4', onClick }) => (
-    <div className={`${className} text-center bg-striped-secondary`}>
+    <div className={`${className} text-center`}>
         <h4 className="text-muted mb-3">
             Extensions add new features to Sourcegraph. Check out the{' '}
             <a href="https://about.sourcegraph.com/docs/extensions/" target="_blank">


### PR DESCRIPTION
Here's what the OSS extension registry looks like by default:

![image](https://user-images.githubusercontent.com/1387653/46639801-47916080-cb1d-11e8-9e68-c61ec90073e4.png)

@sqs Could you make a pass on the wording/CTA for the empty registry? Will users be expecting more information here about what extensions are and which license they need in order to get started with a private extension registry?

Resolves https://github.com/sourcegraph/enterprise/issues/13550

> This PR does not need to update the CHANGELOG because ...
