### PR TITLE
fix: default to `localhost` for local registry prefix

### DIFF
--- a/cmd/frontend/registry/extensions.go
+++ b/cmd/frontend/registry/extensions.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+
 	"github.com/gregjones/httpcache"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -125,12 +127,8 @@ func GetExtensionByExtensionID(ctx context.Context, extensionID string) (local g
 }
 
 // getLocalRegistryName returns the name of the local registry.
-func getLocalRegistryName() (string, error) {
-	u, err := url.Parse(conf.Get().AppURL)
-	if err != nil {
-		return "", err
-	}
-	return registry.Name(u), nil
+func getLocalRegistryName() string {
+	return registry.Name(globals.AppURL)
 }
 
 var mockLocalRegistryExtensionIDPrefix **string
@@ -144,10 +142,7 @@ func GetLocalRegistryExtensionIDPrefix() *string {
 	if envvar.SourcegraphDotComMode() {
 		return nil
 	}
-	name, err := getLocalRegistryName()
-	if err != nil {
-		return nil
-	}
+	name := getLocalRegistryName()
 	return &name
 }
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -123,9 +123,6 @@ func (e httpError) Error() string { return fmt.Sprintf("HTTP error %d", e) }
 
 // Name returns the registry name given its URL.
 func Name(registry *url.URL) string {
-	if registry.Host == "" {
-		return "127.0.0.1"
-	}
 	return registry.Host
 }
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -123,6 +123,9 @@ func (e httpError) Error() string { return fmt.Sprintf("HTTP error %d", e) }
 
 // Name returns the registry name given its URL.
 func Name(registry *url.URL) string {
+	if registry.Host == "" {
+		return "localhost"
+	}
 	return registry.Host
 }
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -124,7 +124,7 @@ func (e httpError) Error() string { return fmt.Sprintf("HTTP error %d", e) }
 // Name returns the registry name given its URL.
 func Name(registry *url.URL) string {
 	if registry.Host == "" {
-		return "localhost"
+		return "127.0.0.1"
 	}
 	return registry.Host
 }


### PR DESCRIPTION
Previously, publishing an extension to an instance that didn't have `appURL` set would result in an error:

```
$ src -config=/Users/chrismwendt/src-config.dev.tmp.json extensions publish
...

GraphQL errors:
[
  {
    "message": "unable to publish remote extension \"/alice/sourcegraph-hello-world\" (publish it directly to the registry on \"\")",
    "path": [
      "extensionRegistry",
      "publishExtension"
    ]
  }
]
```

This was happening because the extension ID prefix is generated from `appURL`'s hostname, which was the empty string `""`, resulting in extension IDs of the form `/publisher/name`, which is invalid. Extension IDs are only valid if they have 2 or 3 path components.

The solution is to default to `localhost` for local extension ID prefixes when `appURL` is not set. This fixes both publishing and viewing extensions in the registry UI (viewing used to panic).

Fixes https://github.com/sourcegraph/enterprise/issues/13520

> This PR does not need to update the CHANGELOG because this isn't released
