### PR TITLE
repo-updater: Use username if set in bitbucket config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code intelligence is now provided by [Sourcegraph extensions](https://github.com/sourcegraph/sourcegraph-extension-api). The extension for each language in the site configuration `langservers` property is automatically enabled. TODO BEFORE RELEASE: Make the previous sentence true. See https://github.com/sourcegraph/sourcegraph/issues/13125.
 - Support for multiple authentication providers is now enabled by default. To disable it, set the `experimentalFeatures.multipleAuthProviders` site config option to `"disabled"`. This only applies to Sourcegraph Enterprise.
 - When using the `http-header` auth provider, valid auth cookies (from other auth providers that are currently configured or were previously configured) are now respected and will be used for authentication. These auth cookies also take precedence over the `http-header` auth. Previously, the `http-header` auth took precedence.
+- Bitbucket Server username configuration is now used to clone repositories if the Bitbucket Server API does not set a username.
 
 ### Added
 

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -100,15 +100,13 @@ func bitbucketServerRepoInfo(config *schema.BitbucketServerConnection, repo *bit
 			break
 		}
 		if l.Name == "http" {
-			// l.Href already contains the username in the URL userinfo, so just add the token or
-			// password.
 			var password string
 			if config.Token != "" {
 				password = config.Token // prefer personal access token
 			} else {
 				password = config.Password
 			}
-			cloneURL = addPasswordBestEffort(l.Href, password)
+			cloneURL = setUserinfoBestEffort(l.Href, config.Username, password)
 			// No break, so that we fallback to http in case of ssh missing
 			// with GitURLType == "ssh"
 		}

--- a/cmd/repo-updater/repos/util_test.go
+++ b/cmd/repo-updater/repos/util_test.go
@@ -1,0 +1,43 @@
+package repos
+
+import "testing"
+
+func TestSetUserinfoBestEffort(t *testing.T) {
+	cases := []struct {
+		rawurl   string
+		username string
+		password string
+		want     string
+	}{
+		// no-op
+		{"https://foo.com/foo/bar", "", "", "https://foo.com/foo/bar"},
+		// invalid URI is returned as is
+		{":/foo.com/foo/bar", "u", "p", ":/foo.com/foo/bar"},
+
+		// no user details in rawurl
+		{"https://foo.com/foo/bar", "u", "p", "https://u:p@foo.com/foo/bar"},
+		{"https://foo.com/foo/bar", "u", "", "https://u@foo.com/foo/bar"},
+		{"https://foo.com/foo/bar", "", "p", "https://foo.com/foo/bar"},
+
+		// user set already
+		{"https://x@foo.com/foo/bar", "u", "p", "https://x:p@foo.com/foo/bar"},
+		{"https://x@foo.com/foo/bar", "u", "", "https://x@foo.com/foo/bar"},
+		{"https://x@foo.com/foo/bar", "", "p", "https://x:p@foo.com/foo/bar"},
+
+		// user and password set already
+		{"https://x:y@foo.com/foo/bar", "u", "p", "https://x:y@foo.com/foo/bar"},
+		{"https://x:y@foo.com/foo/bar", "u", "", "https://x:y@foo.com/foo/bar"},
+		{"https://x:y@foo.com/foo/bar", "", "p", "https://x:y@foo.com/foo/bar"},
+
+		// empty password
+		{"https://x:@foo.com/foo/bar", "u", "p", "https://x:@foo.com/foo/bar"},
+		{"https://x:@foo.com/foo/bar", "u", "", "https://x:@foo.com/foo/bar"},
+		{"https://x:@foo.com/foo/bar", "", "p", "https://x:@foo.com/foo/bar"},
+	}
+	for _, c := range cases {
+		got := setUserinfoBestEffort(c.rawurl, c.username, c.password)
+		if got != c.want {
+			t.Errorf("setUserinfoBestEffort(%q, %q, %q): got %q want %q", c.rawurl, c.username, c.password, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Some bitbucket servers do not set the username in the URLs returned from the
API. To work around this we can use the username field specified in the
bitbucket configuration.

Fixes https://github.com/sourcegraph/sourcegraph/issues/221