### PR TITLE
docs: improve descriptions of extension manifest fields

### DIFF
--- a/schema/extension.schema.json
+++ b/schema/extension.schema.json
@@ -63,6 +63,7 @@
     "Contributions": {
       "description":
         "Features contributed by this extension. Extensions may also register certain types of contributions dynamically.",
+      "additionalProperties": false,
       "type": "object",
       "properties": {
         "configuration": {
@@ -88,18 +89,19 @@
               "commandArguments": {
                 "description": "The arguments to the command.",
                 "type": "array",
-                "items": { "type": "string" }
+                "items": {}
               },
               "title": {
-                "description": "The text that is shown in the UI.",
+                "description": "The templated text that is shown in the UI.",
                 "type": "string"
               },
               "category": {
-                "description": "The category of this action.",
+                "description":
+                  "The templated prefix for the title (e.g. a category of `Codecov` shows up as `Codecov: ...` in the command palette).",
                 "type": "string"
               },
               "iconURL": {
-                "description": "The icon that is shown in the UI (usually a data URI).",
+                "description": "The templated icon that is shown in the UI (usually a data URI).",
                 "type": "string"
               },
               "actionItem": {
@@ -107,15 +109,15 @@
                 "type": "object",
                 "properties": {
                   "label": {
-                    "description": "The text that is shown on the action item the UI.",
+                    "description": "The templated text that is shown on the action item the UI.",
                     "type": "string"
                   },
                   "description": {
-                    "description": "The tooltip text for an action item that is shown in the UI.",
+                    "description": "The templated tooltip text for an action item that is shown in the UI.",
                     "type": "string"
                   },
                   "iconURL": {
-                    "description": "The icon that is shown in the UI (usually a data URI).",
+                    "description": "The templated icon that is shown in the UI (usually a data URI).",
                     "type": "string"
                   }
                 }

--- a/schema/extension_stringdata.go
+++ b/schema/extension_stringdata.go
@@ -68,6 +68,7 @@ const ExtensionSchemaJSON = `{
     "Contributions": {
       "description":
         "Features contributed by this extension. Extensions may also register certain types of contributions dynamically.",
+      "additionalProperties": false,
       "type": "object",
       "properties": {
         "configuration": {
@@ -93,18 +94,19 @@ const ExtensionSchemaJSON = `{
               "commandArguments": {
                 "description": "The arguments to the command.",
                 "type": "array",
-                "items": { "type": "string" }
+                "items": {}
               },
               "title": {
-                "description": "The text that is shown in the UI.",
+                "description": "The templated text that is shown in the UI.",
                 "type": "string"
               },
               "category": {
-                "description": "The category of this action.",
+                "description":
+                  "The templated prefix for the title (e.g. a category of ` + "`" + `Codecov` + "`" + ` shows up as ` + "`" + `Codecov: ...` + "`" + ` in the command palette).",
                 "type": "string"
               },
               "iconURL": {
-                "description": "The icon that is shown in the UI (usually a data URI).",
+                "description": "The templated icon that is shown in the UI (usually a data URI).",
                 "type": "string"
               },
               "actionItem": {
@@ -112,15 +114,15 @@ const ExtensionSchemaJSON = `{
                 "type": "object",
                 "properties": {
                   "label": {
-                    "description": "The text that is shown on the action item the UI.",
+                    "description": "The templated text that is shown on the action item the UI.",
                     "type": "string"
                   },
                   "description": {
-                    "description": "The tooltip text for an action item that is shown in the UI.",
+                    "description": "The templated tooltip text for an action item that is shown in the UI.",
                     "type": "string"
                   },
                   "iconURL": {
-                    "description": "The icon that is shown in the UI (usually a data URI).",
+                    "description": "The templated icon that is shown in the UI (usually a data URI).",
                     "type": "string"
                   }
                 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,13 +17,13 @@ type AWSCodeCommitConnection struct {
 	SecretAccessKey             string `json:"secretAccessKey"`
 }
 type Action struct {
-	ActionItem       *ActionItem `json:"actionItem,omitempty"`
-	Category         string      `json:"category,omitempty"`
-	Command          string      `json:"command,omitempty"`
-	CommandArguments []string    `json:"commandArguments,omitempty"`
-	IconURL          string      `json:"iconURL,omitempty"`
-	Id               string      `json:"id,omitempty"`
-	Title            string      `json:"title,omitempty"`
+	ActionItem       *ActionItem   `json:"actionItem,omitempty"`
+	Category         string        `json:"category,omitempty"`
+	Command          string        `json:"command,omitempty"`
+	CommandArguments []interface{} `json:"commandArguments,omitempty"`
+	IconURL          string        `json:"iconURL,omitempty"`
+	Id               string        `json:"id,omitempty"`
+	Title            string        `json:"title,omitempty"`
 }
 
 // ActionItem description: The action item.


### PR DESCRIPTION
Continuation of https://github.com/sourcegraph/sourcegraph/pull/358 cc @felixfbecker 

> This PR does not need to update the CHANGELOG because it only includes small docs tweaks
