### PR TITLE
discussions: add rate limiting for creating threads, comments, and @mention notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Support for multiple authentication providers is now enabled by default. To disable it, set the `experimentalFeatures.multipleAuthProviders` site config option to `"disabled"`. This only applies to Sourcegraph Enterprise.
 - When using the `http-header` auth provider, valid auth cookies (from other auth providers that are currently configured or were previously configured) are now respected and will be used for authentication. These auth cookies also take precedence over the `http-header` auth. Previously, the `http-header` auth took precedence.
 - Bitbucket Server username configuration is now used to clone repositories if the Bitbucket Server API does not set a username.
+- Code discussions: On Sourcegraph.com / when `discussions.abuseProtection` is enabled in the site config, rate limits to thread creation, comment creation, and @mentions are now applied.
 
 ### Added
 

--- a/cmd/frontend/db/discussion_comments.go
+++ b/cmd/frontend/db/discussion_comments.go
@@ -209,6 +209,11 @@ type DiscussionCommentsListOptions struct {
 
 	// Reported, when true, returns only threads that have at least one report.
 	Reported bool
+
+	// CreatedBefore, when non-nil, specifies that only comments that were
+	// created before this time should be returned.
+	CreatedBefore *time.Time
+	CreatedAfter  *time.Time
 }
 
 func (c *discussionComments) List(ctx context.Context, opts *DiscussionCommentsListOptions) ([]*types.DiscussionComment, error) {
@@ -262,6 +267,12 @@ func (*discussionComments) getListSQL(opts *DiscussionCommentsListOptions) (cond
 	}
 	if opts.Reported {
 		conds = append(conds, sqlf.Sprintf("array_length(reports,1) > 0"))
+	}
+	if opts.CreatedBefore != nil {
+		conds = append(conds, sqlf.Sprintf("created_at < %v", *opts.CreatedBefore))
+	}
+	if opts.CreatedAfter != nil {
+		conds = append(conds, sqlf.Sprintf("created_at > %v", *opts.CreatedAfter))
 	}
 	return conds
 }

--- a/cmd/frontend/graphqlbackend/discussion_comments.go
+++ b/cmd/frontend/graphqlbackend/discussion_comments.go
@@ -188,23 +188,15 @@ func (r *discussionsMutationResolver) AddCommentToThread(ctx context.Context, ar
 	if err != nil {
 		return nil, err
 	}
-	// TODO(slimsag:discussions): Unify this discussion thread creation code with the mailreply worker?
-	newComment := &types.DiscussionComment{
+
+	updatedThread, err := discussions.InsecureAddCommentToThread(ctx, &types.DiscussionComment{
 		ThreadID:     threadID,
 		AuthorUserID: currentUser.user.ID,
 		Contents:     args.Contents,
-	}
-	_, err = db.DiscussionComments.Create(ctx, newComment)
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "DiscussionComments.Create")
+		return nil, errors.Wrap(err, "AddCommentToThread")
 	}
-
-	// Fetch and return the updated thread object.
-	updatedThread, err := db.DiscussionThreads.Get(ctx, threadID)
-	if err != nil {
-		return nil, errors.Wrap(err, "DiscussionThreads.Get")
-	}
-	discussions.NotifyNewComment(updatedThread, newComment)
 	return &discussionThreadResolver{t: updatedThread}, nil
 }
 

--- a/cmd/frontend/internal/pkg/discussions/mailreply/worker.go
+++ b/cmd/frontend/internal/pkg/discussions/mailreply/worker.go
@@ -116,25 +116,15 @@ func workForever(ctx context.Context) {
 				continue // ignore empty replies
 			}
 
-			// TODO(slimsag:discussions): Unify this discussion thread creation code with the graphqlbackend?
-			newComment := &types.DiscussionComment{
+			_, err = discussions.InsecureAddCommentToThread(ctx, &types.DiscussionComment{
 				ThreadID:     threadID,
 				AuthorUserID: userID,
 				Contents:     contents,
-			}
-			_, err = db.DiscussionComments.Create(ctx, newComment)
+			})
 			if err != nil {
-				log15.Error("discussions: mailreply worker: error while creating comment", "error", err)
+				log15.Error("discussions: mailreply worker: error while adding comment to thread", "error", err)
 				continue
 			}
-
-			// Fetch and return the updated thread object.
-			updatedThread, err := db.DiscussionThreads.Get(ctx, threadID)
-			if err != nil {
-				log15.Error("discussions: mailreply worker: error while getting updated thread", "error", err)
-				continue
-			}
-			discussions.NotifyNewComment(updatedThread, newComment)
 
 			// Now that we're finished handling this message, mark it as seen
 			// and to be deleted.

--- a/cmd/frontend/internal/pkg/discussions/mentions/mentions.go
+++ b/cmd/frontend/internal/pkg/discussions/mentions/mentions.go
@@ -1,0 +1,16 @@
+package mentions
+
+import "regexp"
+
+var mentions = regexp.MustCompile(`(^|\s)@(\S*)`)
+
+// Parse parses the @mentions from the given markdown comment contents and
+// returns a list of usernames without the @ prefixes.
+func Parse(contents string) []string {
+	matches := mentions.FindAllStringSubmatch(contents, -1)
+	mentions := make([]string, 0, len(matches))
+	for _, groups := range matches {
+		mentions = append(mentions, groups[2])
+	}
+	return mentions
+}

--- a/cmd/frontend/internal/pkg/discussions/mentions/mentions_test.go
+++ b/cmd/frontend/internal/pkg/discussions/mentions/mentions_test.go
@@ -1,11 +1,11 @@
-package discussions
+package mentions
 
 import (
 	"reflect"
 	"testing"
 )
 
-func TestParseMentions(t *testing.T) {
+func TestParse(t *testing.T) {
 	tests := []struct {
 		name, input string
 		want        []string
@@ -23,7 +23,7 @@ func TestParseMentions(t *testing.T) {
 	}
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
-			got := parseMentions(tst.input)
+			got := Parse(tst.input)
 			if !reflect.DeepEqual(got, tst.want) {
 				t.Fatalf("got %q want %q", got, tst.want)
 			}

--- a/cmd/frontend/internal/pkg/discussions/ratelimit/ratelimit.go
+++ b/cmd/frontend/internal/pkg/discussions/ratelimit/ratelimit.go
@@ -1,0 +1,221 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+type limit struct {
+	// maxActions describes the maximum number of actions that can be performed
+	// within the sliding window period.
+	maxActions int
+
+	// window describes how large the sliding window of opportunity is.
+	window time.Duration
+
+	// uniquePenaltyFactor describes how many actions to subtract from
+	// maxActions when a unique action is encountered. The exact number of
+	// actions removed is calculated via:
+	//
+	// 	penalty = maxActions - min(maxActions / (uniquePenaltyFactor * uniqueActions-1), maxUniquePenalty)
+	//
+	// For example, this is used to allow creating many comments/threads within
+	// the same file (e.g. for soft real-time chat), but penalize spammers from
+	// creating many comments/threads in random files.
+	uniquePenaltyFactor float64
+
+	// maxUniquePenalty describes the maximum number of actions that can be
+	// subtracted from maxActions as a penalty when unique actions are
+	// encountered. See uniquePenaltyFactor for more information.
+	maxUniquePenalty int
+}
+
+// calculateWaitTime tells how long a user must wait to perform a single action
+// given the actions that have previously occurred in the window of oppertunity.
+func (l limit) calculateWaitTime(actions []action) time.Duration {
+	// Calculate the penalty (see uniquePenaltyFactor's documentation for
+	// information about this).
+	penalty := 0
+	uniqueActions := max(countUniqueActions(actions), 1) - 1
+	if l.uniquePenaltyFactor != 0 && uniqueActions != 0 {
+		penalty = l.maxActions - int(float64(l.maxActions)/(l.uniquePenaltyFactor*float64(uniqueActions)))
+	}
+	if penalty > l.maxUniquePenalty {
+		penalty = l.maxUniquePenalty
+	}
+
+	maxActions := max(l.maxActions-penalty, 0)
+	consumedActions := len(actions)
+	remainingActions := maxActions - consumedActions
+	if remainingActions >= 1 {
+		return 0 // they do not need to wait.
+	}
+
+	sortActionsOldestFirst(actions)
+	return l.window - time.Since(actions[0].time)
+}
+
+func countUniqueActions(actions []action) int {
+	set := map[string]struct{}{}
+	for _, a := range actions {
+		if _, ok := set[a.key]; !ok {
+			set[a.key] = struct{}{}
+		}
+	}
+	return len(set)
+}
+
+func sortActionsOldestFirst(actions []action) {
+	sort.Slice(actions, func(i, j int) bool {
+		return actions[i].time.Before(actions[j].time)
+	})
+}
+
+type action struct {
+	time time.Time // the time the action occurred at, e.g. when a thread or comment was created
+	key  string    // a unique key representing the action, e.g. the thread ID of a comment, or the repo+rev+file of a thread.
+}
+
+func (a action) String() string { return time.Since(a.time).String() }
+
+var (
+	// createThreadLimit defines the rate limit for thread creation, it is
+	// chosen based on:
+	//
+	// - We assume threads themselves are created less often than comments on
+	//   threads.
+	// - We assume each thread will take at least 30s to write and submit
+	//   end-to-end.
+	// - Some users may wish to create threads very quickly in rapid succession
+	//   _within the same file_, e.g. to quickly call out lines of code that
+	//   are not needed with "also here" comments.
+	//
+	// Examples of the limits imposed below (based on the number of unique
+	// files a thread was created on in the past 1m):
+	//
+	// 	1 unique files == 12 threads / 1m (1 every 5s)
+	// 	2 unique files == 6 threads  / 1m (1 every 10s)
+	// 	3 unique files == 3 threads  / 1m (1 every 20s)
+	// 	4 unique files == 2 threads  / 1m (1 every 30s)
+	//
+	createThreadLimit = limit{
+		maxActions:          12,
+		window:              1 * time.Minute,
+		uniquePenaltyFactor: 2,
+		maxUniquePenalty:    10,
+	}
+
+	// addCommentLimit defines the rate limit for adding comments to a thread,
+	// it is chosen based on:
+	//
+	// - The fact that comments are created more often than threads.
+	// - We want to support soft-realtime chat where e.g. you quickly respond
+	//   to someone as you would in e.g. IRC or Slack.
+	// - Comment spam is less harmful when it spans only a few threads, e.g.
+	//   60 comments in a single thread is better than 60 comments each in
+	//   random threads.
+	//
+	// Examples of the limits imposed below (based on the number of unique
+	// threads a comment was added to in the past 5m):
+	//
+	// 	1 unique threads == 20 comments / 1m (1 every 3s)
+	// 	2 unique threads == 6  comments / 1m (1 every 9s)
+	// 	3 unique threads == 3  comments / 1m (1 every 18s)
+	// 	4 unique threads == 2  comments / 1m (1 every 30s)
+	//
+	addCommentLimit = limit{
+		maxActions:          20,
+		window:              1 * time.Minute,
+		uniquePenaltyFactor: 3,
+		maxUniquePenalty:    18,
+	}
+)
+
+var one800DBError = time.Duration(18003237767) // "18.003237767s" (or "1-800-DBERROR")
+
+// TimeUntilUserCanCreateThread tells how long the user must wait until they
+// may create one new discussion thread according to rate limiting.
+//
+// This ONLY considers rate limiting, it does NOT verify the user otherwise has
+// permission to create discussion threads.
+func TimeUntilUserCanCreateThread(ctx context.Context, userID int32) (mustWait time.Duration) {
+	// Determine how many threads the user has created in the last "per"
+	// timeframe.
+	createdAfter := time.Now().Add(-createThreadLimit.window)
+	threads, err := db.DiscussionThreads.List(ctx, &db.DiscussionThreadsListOptions{
+		AuthorUserIDs: []int32{userID},
+		CreatedAfter:  &createdAfter,
+	})
+	if err != nil {
+		// It's OK to swallow the error here because showing this to the user
+		// would never be useful, and if there is an error here it is likely to
+		// be e.g. an outright database failure.
+		log15.Error("discussions: failed to determine ratelimit for thread creation", "error", err)
+		return one800DBError
+	}
+	var actions []action
+	for _, t := range threads {
+		var key string
+		if t.TargetRepo != nil {
+			key = fmt.Sprint(t.TargetRepo.RepoID, orEmpty(t.TargetRepo.Path), orEmpty(t.TargetRepo.Branch), orEmpty(t.TargetRepo.Revision))
+		} else {
+			// We don't know what this type of thread is, so we assume it does
+			// not need to be rate limited harshly.
+			key = "not-unique"
+		}
+		actions = append(actions, action{
+			time: t.CreatedAt,
+			key:  key,
+		})
+	}
+	return createThreadLimit.calculateWaitTime(actions)
+}
+
+// TimeUntilUserCanAddCommentToThread tells how long the user must wait until
+// they may add a new comment to a thread according to rate limiting.
+//
+// This ONLY considers rate limiting, it does NOT verify the user otherwise has
+// permission to create discussion threads.
+func TimeUntilUserCanAddCommentToThread(ctx context.Context, userID int32) (mustWait time.Duration) {
+	// Determine how many comments the user has created in the last "per"
+	// timeframe.
+	createdAfter := time.Now().Add(-addCommentLimit.window)
+	comments, err := db.DiscussionComments.List(ctx, &db.DiscussionCommentsListOptions{
+		AuthorUserID: &userID,
+		CreatedAfter: &createdAfter,
+	})
+	if err != nil {
+		// It's OK to swallow the error here because showing this to the user
+		// would never be useful, and if there is an error here it is likely to
+		// be e.g. an outright database failure.
+		log15.Error("discussions: failed to determine ratelimit for adding comment to thread", "error", err)
+		return one800DBError
+	}
+	var actions []action
+	for _, c := range comments {
+		actions = append(actions, action{
+			time: c.CreatedAt,
+			key:  fmt.Sprint(c.ThreadID),
+		})
+	}
+	return addCommentLimit.calculateWaitTime(actions)
+}
+
+func orEmpty(s *string) string {
+	if s != nil {
+		return *s
+	}
+	return ""
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/frontend/internal/pkg/discussions/ratelimit/ratelimit.go
+++ b/cmd/frontend/internal/pkg/discussions/ratelimit/ratelimit.go
@@ -143,7 +143,7 @@ var one800DBError = time.Duration(18003237767) // "18.003237767s" (or "1-800-DBE
 //
 // This ONLY considers rate limiting, it does NOT verify the user otherwise has
 // permission to create discussion threads.
-func TimeUntilUserCanCreateThread(ctx context.Context, userID int32) (mustWait time.Duration) {
+func TimeUntilUserCanCreateThread(ctx context.Context, userID int32, newThreadTitle, newThreadContent string) (mustWait time.Duration) {
 	// Determine how many threads the user has created in the last "per"
 	// timeframe.
 	createdAfter := time.Now().Add(-createThreadLimit.window)
@@ -181,7 +181,7 @@ func TimeUntilUserCanCreateThread(ctx context.Context, userID int32) (mustWait t
 //
 // This ONLY considers rate limiting, it does NOT verify the user otherwise has
 // permission to create discussion threads.
-func TimeUntilUserCanAddCommentToThread(ctx context.Context, userID int32) (mustWait time.Duration) {
+func TimeUntilUserCanAddCommentToThread(ctx context.Context, userID int32, newCommentContent string) (mustWait time.Duration) {
 	// Determine how many comments the user has created in the last "per"
 	// timeframe.
 	createdAfter := time.Now().Add(-addCommentLimit.window)

--- a/cmd/frontend/internal/pkg/discussions/ratelimit/ratelimit_test.go
+++ b/cmd/frontend/internal/pkg/discussions/ratelimit/ratelimit_test.go
@@ -1,0 +1,103 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLimit(t *testing.T) {
+	baseTime := time.Now()
+
+	secondsAgo := func(t time.Duration) time.Time {
+		return baseTime.Add(-t * time.Second)
+	}
+
+	testLimit := limit{
+		maxActions:          12,
+		window:              1 * time.Minute,
+		uniquePenaltyFactor: 2,
+		maxUniquePenalty:    10,
+	}
+	tests := []struct {
+		name    string
+		actions []action
+		want    time.Duration
+	}{
+		{
+			name: "under_limit_by_one",
+			actions: []action{
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(2), "a.go"},
+				action{secondsAgo(2), "a.go"},
+				action{secondsAgo(3), "a.go"},
+				action{secondsAgo(3), "a.go"},
+				action{secondsAgo(3), "a.go"},
+				action{secondsAgo(4), "a.go"},
+				action{secondsAgo(4), "a.go"},
+				action{secondsAgo(5), "a.go"},
+			},
+			want: 0 * time.Second,
+		},
+		{
+			name: "limit_hit",
+			actions: []action{
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(2), "a.go"},
+				action{secondsAgo(2), "a.go"},
+				action{secondsAgo(3), "a.go"},
+				action{secondsAgo(3), "a.go"},
+				action{secondsAgo(3), "a.go"},
+				action{secondsAgo(4), "a.go"},
+				action{secondsAgo(4), "a.go"},
+				action{secondsAgo(5), "a.go"},
+				action{secondsAgo(6), "a.go"},
+			},
+			want: 54 * time.Second,
+		},
+		{
+			name: "2_unique_files",
+			actions: []action{
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(1), "b.go"},
+				action{secondsAgo(1), "b.go"},
+				action{secondsAgo(2), "b.go"},
+				action{secondsAgo(2), "b.go"},
+				action{secondsAgo(13), "b.go"},
+			},
+			want: 47 * time.Second,
+		},
+		{
+			name: "3_unique_files",
+			actions: []action{
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(2), "b.go"},
+				action{secondsAgo(3), "c.go"},
+			},
+			want: 57 * time.Second,
+		},
+		{
+			name: "4_unique_files",
+			actions: []action{
+				action{secondsAgo(1), "a.go"},
+				action{secondsAgo(1), "b.go"},
+				action{secondsAgo(1), "c.go"},
+				action{secondsAgo(2), "d.go"},
+				action{secondsAgo(58), "d.go"},
+				action{secondsAgo(2), "d.go"},
+			},
+			want: 2 * time.Second,
+		},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got := testLimit.calculateWaitTime(tst.actions).Round(time.Second)
+			if got != tst.want {
+				t.Fatalf("got %v want %v", got, tst.want)
+			}
+		})
+	}
+}

--- a/cmd/frontend/internal/pkg/discussions/util.go
+++ b/cmd/frontend/internal/pkg/discussions/util.go
@@ -2,22 +2,33 @@ package discussions
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/discussions/ratelimit"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
 
 // InsecureAddCommentToThread handles adding a new comment to an existing
 // thread. It handles:
 //
-// 1. Creating the actual database entry.
-// 2. Notifying other users of the new comment.
-// 3. Fetching and returning the updated thread.
+// 1. Rate limiting (NOT general permission handling).
+// 2. Creating the actual database entry.
+// 3. Notifying other users of the new comment.
+// 4. Fetching and returning the updated thread.
 //
 // It does NOT verify that the user has permission to create this comment. That
 // is the responsibility of the caller.
 func InsecureAddCommentToThread(ctx context.Context, newComment *types.DiscussionComment) (*types.DiscussionThread, error) {
+	if dc := conf.Get().Discussions; dc != nil && dc.AbuseProtection {
+		if mustWait := ratelimit.TimeUntilUserCanAddCommentToThread(ctx, newComment.AuthorUserID); mustWait != 0 {
+			return nil, fmt.Errorf("You are creating comments too quickly. You may create a new one after %v", mustWait.Round(time.Second))
+		}
+	}
+
 	_, err := db.DiscussionComments.Create(ctx, newComment)
 	if err != nil {
 		return nil, err // Intentionally not wrapping the error here for cleaner error messages.

--- a/cmd/frontend/internal/pkg/discussions/util.go
+++ b/cmd/frontend/internal/pkg/discussions/util.go
@@ -1,0 +1,32 @@
+package discussions
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+)
+
+// InsecureAddCommentToThread handles adding a new comment to an existing
+// thread. It handles:
+//
+// 1. Creating the actual database entry.
+// 2. Notifying other users of the new comment.
+// 3. Fetching and returning the updated thread.
+//
+// It does NOT verify that the user has permission to create this comment. That
+// is the responsibility of the caller.
+func InsecureAddCommentToThread(ctx context.Context, newComment *types.DiscussionComment) (*types.DiscussionThread, error) {
+	_, err := db.DiscussionComments.Create(ctx, newComment)
+	if err != nil {
+		return nil, err // Intentionally not wrapping the error here for cleaner error messages.
+	}
+
+	updatedThread, err := db.DiscussionThreads.Get(ctx, newComment.ThreadID)
+	if err != nil {
+		return nil, errors.Wrap(err, "DiscussionThreads.Get")
+	}
+	NotifyNewComment(updatedThread, newComment)
+	return updatedThread, nil
+}

--- a/cmd/frontend/internal/pkg/discussions/util.go
+++ b/cmd/frontend/internal/pkg/discussions/util.go
@@ -24,7 +24,7 @@ import (
 // is the responsibility of the caller.
 func InsecureAddCommentToThread(ctx context.Context, newComment *types.DiscussionComment) (*types.DiscussionThread, error) {
 	if dc := conf.Get().Discussions; dc != nil && dc.AbuseProtection {
-		if mustWait := ratelimit.TimeUntilUserCanAddCommentToThread(ctx, newComment.AuthorUserID); mustWait != 0 {
+		if mustWait := ratelimit.TimeUntilUserCanAddCommentToThread(ctx, newComment.AuthorUserID, newComment.Contents); mustWait != 0 {
 			return nil, fmt.Errorf("You are creating comments too quickly. You may create a new one after %v", mustWait.Round(time.Second))
 		}
 	}


### PR DESCRIPTION
This PR adds rate limiting to discussions which makes it harder to spam creation of threads, comments, and @mention notifications at other users.

- The rate limiting approach for thread creation is such that you can create many 'small review' comments in a single file very quickly, but are penalized for creating a similar amount of threads across many independent files.
- The rate limiting approach for comment creation is such that you can have realtime slack/IRC-like conversations in a single discussion thread, but are penalized for posting a similar amount of comments across many independent threads.
- The rate limiting approach for @mentions is purely to prevent someone from @mentioning hundreds of users in a short timeframe.

For exact limits I have chosen, see ratelimit.go lines 88-151.

This rate limiting only applies when `discussions.abuseProtection == true` in the site config, i.e. only for public instances like Sourcegraph.com and not enabled for regular user instances by default, as with other abuse protection measures in code discussions.

Fixes sourcegraph/enterprise#13453

Note: This PR will be merged immediately after submission to prevent anyone who reads this PR description from causing harm. Any review will be followed up post-merge.

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
