### PR TITLE
fix: sync langservers and extensions on any site config change

### DIFF
--- a/cmd/frontend/internal/bg/langservers.go
+++ b/cmd/frontend/internal/bg/langservers.go
@@ -5,9 +5,75 @@ import (
 
 	log15 "gopkg.in/inconshreveable/log15.v2"
 
+	"github.com/sourcegraph/jsonx"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/langservers"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
+
+// KeepLangServersAndGlobalSettingsInSync watches for configuration changes and
+// updates global settings to reflect the enablement state of languages in the
+// `langservers` array.
+func KeepLangServersAndGlobalSettingsInSync(ctx context.Context) {
+	conf.Watch(func() {
+		config := conf.Get()
+		if config == nil {
+			return
+		}
+
+		settings, err := db.Settings.GetLatest(context.Background(), api.ConfigurationSubject{Site: true})
+		if err != nil {
+			log15.Warn("error getting existing global settings", "error", err)
+			return
+		}
+		var contents string
+		var id *int32
+		var authorUserID int32
+		if settings == nil {
+			contents = "{}"
+			// HACK: Global settings are nil (probably because this is a brand new
+			// instance), so there's no existing author user ID to reuse. Just take
+			// any user's ID. The author isn't shown anywhere, anyway.
+			users, err := db.Users.List(ctx, &db.UsersListOptions{
+				LimitOffset: &db.LimitOffset{Limit: 1},
+			})
+			if err != nil {
+				log15.Warn("error listing users in order to enable/disable a language extension", "error", err)
+				return
+			}
+			if len(users) == 0 {
+				log15.Warn("unable to obtain a user ID to enable/disable a language extension because there are no users in the database")
+				return
+			}
+			authorUserID = users[0].ID
+		} else {
+			contents = settings.Contents
+			authorUserID = settings.AuthorUserID
+			id = &settings.ID
+		}
+
+		for _, language := range config.Langservers {
+			edits, _, err := jsonx.ComputePropertyEdit(contents, jsonx.PropertyPath("extensions", "langserver/"+language.Language), !language.Disabled, nil, conf.FormatOptions)
+			if err != nil {
+				log15.Warn("error updating global settings to enable/disable a language extension", "error", err)
+				return
+			}
+
+			contents, err = jsonx.ApplyEdits(contents, edits...)
+			if err != nil {
+				log15.Warn("error applying edits to global settings to enable/disable a language extension", "error", err)
+				return
+			}
+		}
+
+		_, err = db.Settings.CreateIfUpToDate(context.Background(), api.ConfigurationSubject{Site: true}, id, authorUserID, contents)
+		if err != nil {
+			log15.Warn("error updating global settings to enable/disable a language extension", "error", err)
+			return
+		}
+	})
+}
 
 // RespectLangServersConfigUpdate is invoked inside of conf.Watch, but also
 // sometimes manually when the caller needs to block untill the latest config

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -155,6 +155,9 @@ func Main() error {
 	goroutine.Go(func() {
 		bg.StartLangServers(context.Background())
 	})
+	goroutine.Go(func() {
+		bg.KeepLangServersAndGlobalSettingsInSync(context.Background())
+	})
 	goroutine.Go(func() { bg.MigrateExternalAccounts(context.Background()) })
 	goroutine.Go(mailreply.StartWorker)
 	go updatecheck.Start()


### PR DESCRIPTION
This ensures that language Sourcegraph extensions are enabled/disabled to match global settings whenever the `langservers` array in site config changes.

Not much of the logic around updating settings actually changed. All that changed was the call site and the place where the code lives.

Fixes https://github.com/sourcegraph/sourcegraph/issues/363

> This PR does not need to update the CHANGELOG because it fixes an unreleased bug.
