### PR TITLE
fix: restore conf.Get().AppURL but still fall back to globals.AppURL

### DIFF
--- a/cmd/frontend/registry/extensions.go
+++ b/cmd/frontend/registry/extensions.go
@@ -128,7 +128,11 @@ func GetExtensionByExtensionID(ctx context.Context, extensionID string) (local g
 
 // getLocalRegistryName returns the name of the local registry.
 func getLocalRegistryName() string {
-	return registry.Name(globals.AppURL)
+	u, err := url.Parse(conf.Get().AppURL)
+	if err != nil || u == nil || u.Host == "" {
+		return registry.Name(globals.AppURL)
+	}
+	return registry.Name(u)
 }
 
 var mockLocalRegistryExtensionIDPrefix **string


### PR DESCRIPTION
I had mistakenly removed the call to `conf.Get().AppURL` in https://github.com/sourcegraph/sourcegraph/pull/355/files#diff-46349eab2d451601271f4863de4b3cf9L129 which prevented setting `appURL` in site config from having any effect.

> This PR does not need to update the CHANGELOG because this fixes an unreleased bug.
