### PR TITLE
fix: refresh list of extensions when viewing a repository

### DIFF
--- a/src/repo/RepoContainer.tsx
+++ b/src/repo/RepoContainer.tsx
@@ -16,6 +16,7 @@ import {
 } from '../extensions/ExtensionsClientCommonContext'
 import { searchQueryForRepoRev } from '../search'
 import { queryUpdates } from '../search/input/QueryInput'
+import { refreshConfiguration } from '../user/settings/backend'
 import { ErrorLike, isErrorLike } from '../util/errors'
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
 import { EREPONOTFOUND, EREPOSEEOTHER, fetchRepository, RepoSeeOtherError, ResolvedRev } from './backend'
@@ -89,6 +90,13 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
     }
 
     public componentDidMount(): void {
+        // Refresh the list of Sourcegraph extensions to use. This helps when a
+        // language server gets automatically enabled after the first repository
+        // in that language is added.
+        refreshConfiguration()
+            .toPromise()
+            .catch(err => console.error(err))
+
         const parsedRouteChanges = this.routeMatchChanges.pipe(
             map(({ repoRevAndRest }) => parseURLPath(repoRevAndRest))
         )


### PR DESCRIPTION
This mitigates a bug where when you added a repository and a language server was automatically started then navigate to a file, the corresponding language extension was not active because the webapp's list of extensions was stale.

Fixes https://github.com/sourcegraph/enterprise/issues/13654

> This PR does not need to update the CHANGELOG because this mitigates an unreleased bug.
