### PR TITLE
fix: don't unauthenticate cookie users who use tokens 

### DIFF
--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -264,9 +264,10 @@ func CookieMiddlewareWithCSRFSafety(next http.Handler, corsAllowHeader string, i
 }
 
 func authenticateByCookie(r *http.Request, w http.ResponseWriter) context.Context {
-	// If the request is already authenticated, then do not clobber the request's existing
+	fmt.Println("AUTH_BY_COOKIE")
+	// If the request is already authenticated from a cookie (and not a token), then do not clobber the request's existing
 	// authenticated actor with the actor (if any) derived from the session cookie.
-	if actor.FromContext(r.Context()).IsAuthenticated() {
+	if a := actor.FromContext(r.Context()); a.IsAuthenticated() && a.FromSessionCookie {
 		if hasSessionCookie(r) {
 			// Delete the session cookie to avoid confusion. (This occurs most often when switching
 			// the auth provider to http-header; in that case, we want to rely on the http-header

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -264,7 +264,6 @@ func CookieMiddlewareWithCSRFSafety(next http.Handler, corsAllowHeader string, i
 }
 
 func authenticateByCookie(r *http.Request, w http.ResponseWriter) context.Context {
-	fmt.Println("AUTH_BY_COOKIE")
 	// If the request is already authenticated from a cookie (and not a token), then do not clobber the request's existing
 	// authenticated actor with the actor (if any) derived from the session cookie.
 	if a := actor.FromContext(r.Context()); a.IsAuthenticated() && a.FromSessionCookie {


### PR DESCRIPTION
Don't un-authenticate users who are making a request with a token.

<!-- delete the irrelevant line below -->

> This PR does not need to update the CHANGELOG because it currently doesn't affect users. This change is simply required for an incoming change to the browser extension.
