### PR TITLE
fix: reduce CPU usage by refreshing langserver info less frequently

### DIFF
--- a/cmd/frontend/internal/pkg/langservers/langservers.go
+++ b/cmd/frontend/internal/pkg/langservers/langservers.go
@@ -594,7 +594,7 @@ func queryContainerInfoWorker() {
 		// Prevent running _too_ quickly, but still run quickly enough that
 		// this info is always up-to-date and just as accurate as e.g. going
 		// to a terminal and checking yourself.
-		time.Sleep(1 * time.Second)
+		time.Sleep(5 * time.Second)
 
 		for _, language := range Languages {
 			updateInfoCache(language)


### PR DESCRIPTION
This mitigates https://github.com/sourcegraph/enterprise/issues/13646 by refreshing language server info once every 5s instead of 1s. This makes language server info a bit more stale but reduces CPU usage by a lot (this was a hot spot while idle).

Fixes https://github.com/sourcegraph/enterprise/issues/13646

> This PR does not need to update the CHANGELOG because it has a negligible effect on UX.
