### PR TITLE
vendor: Update gorilla/sessions to master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/gorilla/mux v1.6.2
 	github.com/gorilla/schema v1.0.2
 	github.com/gorilla/securecookie v1.1.1
-	github.com/gorilla/sessions v1.1.2
+	github.com/gorilla/sessions v1.1.4-0.20181015005113-68d1edeb366b
 	github.com/gorilla/websocket v1.4.0
 	github.com/graph-gophers/graphql-go v0.0.0-20180806175703-94da0f0031f9
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.1.2 h1:4esMHhwKLQ9Odtku/p+onvH+eRJFWjV4y3iTDVWrZNU=
 github.com/gorilla/sessions v1.1.2/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
+github.com/gorilla/sessions v1.1.4-0.20181015005113-68d1edeb366b h1:f7hwT2OyqHpOYXLrYcIU++OAWPdJQV36OS05+q+TN/g=
+github.com/gorilla/sessions v1.1.4-0.20181015005113-68d1edeb366b/go.mod h1:Ieo8HYsV0qN9WIJeic1HRzDxX9UY5BkplHncRmmZPwU=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/graph-gophers/graphql-go v0.0.0-20180806175703-94da0f0031f9 h1:szkPl6mglONCUK9VrQxlzuALNb/JVF5vS/98r+kCDCg=

--- a/vendor/github.com/gorilla/sessions/README.md
+++ b/vendor/github.com/gorilla/sessions/README.md
@@ -1,23 +1,22 @@
-sessions
-========
+# sessions
+
 [![GoDoc](https://godoc.org/github.com/gorilla/sessions?status.svg)](https://godoc.org/github.com/gorilla/sessions) [![Build Status](https://travis-ci.org/gorilla/sessions.svg?branch=master)](https://travis-ci.org/gorilla/sessions)
 [![Sourcegraph](https://sourcegraph.com/github.com/gorilla/sessions/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/sessions?badge)
-
 
 gorilla/sessions provides cookie and filesystem sessions and infrastructure for
 custom session backends.
 
 The key features are:
 
-* Simple API: use it as an easy way to set signed (and optionally
+- Simple API: use it as an easy way to set signed (and optionally
   encrypted) cookies.
-* Built-in backends to store sessions in cookies or the filesystem.
-* Flash messages: session values that last until read.
-* Convenient way to switch session persistency (aka "remember me") and set
+- Built-in backends to store sessions in cookies or the filesystem.
+- Flash messages: session values that last until read.
+- Convenient way to switch session persistency (aka "remember me") and set
   other attributes.
-* Mechanism to rotate authentication and encryption keys.
-* Multiple sessions per request, even using different backends.
-* Interfaces and infrastructure for custom session backends: sessions from
+- Mechanism to rotate authentication and encryption keys.
+- Multiple sessions per request, even using different backends.
+- Interfaces and infrastructure for custom session backends: sessions from
   different stores can be retrieved and batch-saved using a common API.
 
 Let's start with an example that shows the sessions API in a nutshell:
@@ -28,7 +27,11 @@ Let's start with an example that shows the sessions API in a nutshell:
 		"github.com/gorilla/sessions"
 	)
 
-	var store = sessions.NewCookieStore([]byte("something-very-secret"))
+	// Note: Don't store your key in your source code. Pass it via an
+	// environmental variable, or flag (or both), and don't accidentally commit it
+	// alongside your code. Ensure your key is sufficiently random - i.e. use Go's
+	// crypto/rand or securecookie.GenerateRandomKey(32) and persist the result.
+	var store = sessions.NewCookieStore(os.Getenv("SESSION_KEY"))
 
 	func MyHandler(w http.ResponseWriter, r *http.Request) {
 		// Get a session. We're ignoring the error resulted from decoding an
@@ -50,7 +53,7 @@ And finally we call `session.Save()` to save the session in the response.
 
 Important Note: If you aren't using gorilla/mux, you need to wrap your handlers
 with
-[`context.ClearHandler`](http://www.gorillatoolkit.org/pkg/context#ClearHandler)
+[`context.ClearHandler`](https://www.gorillatoolkit.org/pkg/context#ClearHandler)
 or else you will leak memory! An easy way to do this is to wrap the top-level
 mux when calling http.ListenAndServe:
 
@@ -61,31 +64,31 @@ mux when calling http.ListenAndServe:
 The ClearHandler function is provided by the gorilla/context package.
 
 More examples are available [on the Gorilla
-website](http://www.gorillatoolkit.org/pkg/sessions).
+website](https://www.gorillatoolkit.org/pkg/sessions).
 
 ## Store Implementations
 
 Other implementations of the `sessions.Store` interface:
 
-* [github.com/starJammer/gorilla-sessions-arangodb](https://github.com/starJammer/gorilla-sessions-arangodb) - ArangoDB
-* [github.com/yosssi/boltstore](https://github.com/yosssi/boltstore) - Bolt
-* [github.com/srinathgs/couchbasestore](https://github.com/srinathgs/couchbasestore) - Couchbase
-* [github.com/denizeren/dynamostore](https://github.com/denizeren/dynamostore) - Dynamodb on AWS
-* [github.com/savaki/dynastore](https://github.com/savaki/dynastore) - DynamoDB on AWS (Official AWS library)
-* [github.com/bradleypeabody/gorilla-sessions-memcache](https://github.com/bradleypeabody/gorilla-sessions-memcache) - Memcache
-* [github.com/dsoprea/go-appengine-sessioncascade](https://github.com/dsoprea/go-appengine-sessioncascade) - Memcache/Datastore/Context in AppEngine
-* [github.com/kidstuff/mongostore](https://github.com/kidstuff/mongostore) - MongoDB
-* [github.com/srinathgs/mysqlstore](https://github.com/srinathgs/mysqlstore) - MySQL
-* [github.com/EnumApps/clustersqlstore](https://github.com/EnumApps/clustersqlstore) - MySQL Cluster
-* [github.com/antonlindstrom/pgstore](https://github.com/antonlindstrom/pgstore) - PostgreSQL
-* [github.com/boj/redistore](https://github.com/boj/redistore) - Redis
-* [github.com/boj/rethinkstore](https://github.com/boj/rethinkstore) - RethinkDB
-* [github.com/boj/riakstore](https://github.com/boj/riakstore) - Riak
-* [github.com/michaeljs1990/sqlitestore](https://github.com/michaeljs1990/sqlitestore) - SQLite
-* [github.com/wader/gormstore](https://github.com/wader/gormstore) - GORM (MySQL, PostgreSQL, SQLite)
-* [github.com/gernest/qlstore](https://github.com/gernest/qlstore) - ql
-* [github.com/quasoft/memstore](https://github.com/quasoft/memstore) - In-memory implementation for use in unit tests
-* [github.com/lafriks/xormstore](https://github.com/lafriks/xormstore) - XORM (MySQL, PostgreSQL, SQLite, Microsoft SQL Server, TiDB)
+- [github.com/starJammer/gorilla-sessions-arangodb](https://github.com/starJammer/gorilla-sessions-arangodb) - ArangoDB
+- [github.com/yosssi/boltstore](https://github.com/yosssi/boltstore) - Bolt
+- [github.com/srinathgs/couchbasestore](https://github.com/srinathgs/couchbasestore) - Couchbase
+- [github.com/denizeren/dynamostore](https://github.com/denizeren/dynamostore) - Dynamodb on AWS
+- [github.com/savaki/dynastore](https://github.com/savaki/dynastore) - DynamoDB on AWS (Official AWS library)
+- [github.com/bradleypeabody/gorilla-sessions-memcache](https://github.com/bradleypeabody/gorilla-sessions-memcache) - Memcache
+- [github.com/dsoprea/go-appengine-sessioncascade](https://github.com/dsoprea/go-appengine-sessioncascade) - Memcache/Datastore/Context in AppEngine
+- [github.com/kidstuff/mongostore](https://github.com/kidstuff/mongostore) - MongoDB
+- [github.com/srinathgs/mysqlstore](https://github.com/srinathgs/mysqlstore) - MySQL
+- [github.com/EnumApps/clustersqlstore](https://github.com/EnumApps/clustersqlstore) - MySQL Cluster
+- [github.com/antonlindstrom/pgstore](https://github.com/antonlindstrom/pgstore) - PostgreSQL
+- [github.com/boj/redistore](https://github.com/boj/redistore) - Redis
+- [github.com/boj/rethinkstore](https://github.com/boj/rethinkstore) - RethinkDB
+- [github.com/boj/riakstore](https://github.com/boj/riakstore) - Riak
+- [github.com/michaeljs1990/sqlitestore](https://github.com/michaeljs1990/sqlitestore) - SQLite
+- [github.com/wader/gormstore](https://github.com/wader/gormstore) - GORM (MySQL, PostgreSQL, SQLite)
+- [github.com/gernest/qlstore](https://github.com/gernest/qlstore) - ql
+- [github.com/quasoft/memstore](https://github.com/quasoft/memstore) - In-memory implementation for use in unit tests
+- [github.com/lafriks/xormstore](https://github.com/lafriks/xormstore) - XORM (MySQL, PostgreSQL, SQLite, Microsoft SQL Server, TiDB)
 
 ## License
 

--- a/vendor/github.com/gorilla/sessions/cookie.go
+++ b/vendor/github.com/gorilla/sessions/cookie.go
@@ -1,0 +1,19 @@
+// +build !go1.11
+
+package sessions
+
+import "net/http"
+
+// newCookieFromOptions returns an http.Cookie with the options set.
+func newCookieFromOptions(name, value string, options *Options) *http.Cookie {
+	return &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+	}
+
+}

--- a/vendor/github.com/gorilla/sessions/cookie_go111.go
+++ b/vendor/github.com/gorilla/sessions/cookie_go111.go
@@ -1,0 +1,20 @@
+// +build go1.11
+
+package sessions
+
+import "net/http"
+
+// newCookieFromOptions returns an http.Cookie with the options set.
+func newCookieFromOptions(name, value string, options *Options) *http.Cookie {
+	return &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+		SameSite: options.SameSite,
+	}
+
+}

--- a/vendor/github.com/gorilla/sessions/doc.go
+++ b/vendor/github.com/gorilla/sessions/doc.go
@@ -26,7 +26,11 @@ Let's start with an example that shows the sessions API in a nutshell:
 		"github.com/gorilla/sessions"
 	)
 
-	var store = sessions.NewCookieStore([]byte("something-very-secret"))
+	// Note: Don't store your key in your source code. Pass it via an
+	// environmental variable, or flag (or both), and don't accidentally commit it
+	// alongside your code. Ensure your key is sufficiently random - i.e. use Go's
+	// crypto/rand or securecookie.GenerateRandomKey(32) and persist the result.
+	var store = sessions.NewCookieStore(os.Getenv("SESSION_KEY"))
 
 	func MyHandler(w http.ResponseWriter, r *http.Request) {
 		// Get a session. Get() always returns a session, even if empty.

--- a/vendor/github.com/gorilla/sessions/go.mod
+++ b/vendor/github.com/gorilla/sessions/go.mod
@@ -1,6 +1,6 @@
-module "github.com/gorilla/sessions"
+module github.com/gorilla/sessions
 
 require (
-	"github.com/gorilla/context" v1.1.1
-	"github.com/gorilla/securecookie" v1.1.1
+	github.com/gorilla/context v1.1.1
+	github.com/gorilla/securecookie v1.1.1
 )

--- a/vendor/github.com/gorilla/sessions/sessions.go
+++ b/vendor/github.com/gorilla/sessions/sessions.go
@@ -178,15 +178,7 @@ func Save(r *http.Request, w http.ResponseWriter) error {
 // the Expires field calculated based on the MaxAge value, for Internet
 // Explorer compatibility.
 func NewCookie(name, value string, options *Options) *http.Cookie {
-	cookie := &http.Cookie{
-		Name:     name,
-		Value:    value,
-		Path:     options.Path,
-		Domain:   options.Domain,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-	}
+	cookie := newCookieFromOptions(name, value, options)
 	if options.MaxAge > 0 {
 		d := time.Duration(options.MaxAge) * time.Second
 		cookie.Expires = time.Now().Add(d)

--- a/vendor/github.com/gorilla/sessions/store.go
+++ b/vendor/github.com/gorilla/sessions/store.go
@@ -47,9 +47,6 @@ type Store interface {
 // It is recommended to use an authentication key with 32 or 64 bytes.
 // The encryption key, if set, must be either 16, 24, or 32 bytes to select
 // AES-128, AES-192, or AES-256 modes.
-//
-// Use the convenience function securecookie.GenerateRandomKey() to create
-// strong keys.
 func NewCookieStore(keyPairs ...[]byte) *CookieStore {
 	cs := &CookieStore{
 		Codecs: securecookie.CodecsFromPairs(keyPairs...),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -130,7 +130,7 @@ github.com/gorilla/mux
 github.com/gorilla/schema
 # github.com/gorilla/securecookie v1.1.1
 github.com/gorilla/securecookie
-# github.com/gorilla/sessions v1.1.2
+# github.com/gorilla/sessions v1.1.4-0.20181015005113-68d1edeb366b
 github.com/gorilla/sessions
 # github.com/gorilla/websocket v1.4.0
 github.com/gorilla/websocket


### PR DESCRIPTION
In CI go mod would sometimes rewrite the vendored gorilla/sessions go.mod file.
This lead to CI failing. I submitted a fix to upstream go.mod which was merged
into master, so updating to master.