### PR TITLE
langserver: Use docker events instead of aggressive polling

### DIFF
--- a/cmd/frontend/internal/pkg/langservers/langservers.go
+++ b/cmd/frontend/internal/pkg/langservers/langservers.go
@@ -753,12 +753,6 @@ func validate(language string) error {
 		return err
 	}
 
-	return canManageDocker()
-}
-
-// canManageDocker returns an error if running in Data Center mode, or if the
-// Docker socket is not present.
-func canManageDocker() error {
 	if reason, ok := conf.SupportsManagingLanguageServers(); !ok {
 		return errors.New(reason)
 	}
@@ -893,12 +887,6 @@ func dockerEventNotify(c chan<- struct{}, filter ...string) {
 	}
 
 	for {
-		if canManageDocker() != nil {
-			// We don't need to run events, so check again soon
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
 		err := notifyNewLine(exec.Command("docker", args...), c)
 		if err != nil {
 			// If we failed with error, wait a bit longer to prevent fast


### PR DESCRIPTION
Previously we would poll every second every docker container to find out the
status. This lead to a surprisingly high amount of resource usage. Instead we
can use `docker events` to be notified when a container state changes.

We don't parse the docker events output, instead when an event happens we
recheck all state. This does mean that if a docker daemon has a constantly
changing state on a container it will trigger often. As such we also never
consume from the event channel faster than 1 event per second.

Supersedes https://github.com/sourcegraph/sourcegraph/pull/388

Fixes https://github.com/sourcegraph/enterprise#13646