### PR TITLE
Make dark theme the default

### DIFF
--- a/src/SourcegraphWebApp.tsx
+++ b/src/SourcegraphWebApp.tsx
@@ -112,7 +112,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
         const clientConnection = connectAsPage()
         const extensions = createExtensionsContextController(clientConnection)
         this.state = {
-            isLightTheme: localStorage.getItem(LIGHT_THEME_LOCAL_STORAGE_KEY) !== 'false',
+            isLightTheme: localStorage.getItem(LIGHT_THEME_LOCAL_STORAGE_KEY) === 'false',
             navbarSearchQuery: '',
             showHelpPopover: false,
             configurationCascade: { subjects: null, merged: null },


### PR DESCRIPTION
<!-- delete the irrelevant line below -->

> This PR updates the CHANGELOG.md file to describe any user-facing changes.

This makes dark theme the default for the Sourcegraph web application. I was digging through the repository using Sourcegraph and found the initialization for the theme [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@9f467018d92c6e2b046f9950015eddb592da7e88/-/blob/src/SourcegraphWebApp.tsx#L115:13=)

I'm doing this because dark mode is amazing, feel free to close :stuck_out_tongue: 