### PR TITLE
Add the ability to nuke user data outright #automation

### DIFF
--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -446,9 +446,6 @@ func (u *users) HardDelete(ctx context.Context, id int32) error {
 	if _, err := tx.ExecContext(ctx, "DELETE FROM user_external_accounts WHERE user_id=$1", id); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, "DELETE FROM user_activity WHERE user_id=$1", id); err != nil {
-		return err
-	}
 	if _, err := tx.ExecContext(ctx, "DELETE FROM survey_responses WHERE user_id=$1", id); err != nil {
 		return err
 	}

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -469,6 +469,9 @@ func (u *users) HardDelete(ctx context.Context, id int32) error {
 	if _, err := tx.ExecContext(ctx, "DELETE FROM discussion_mail_reply_tokens WHERE user_id=$1", id); err != nil {
 		return err
 	}
+	if _, err := tx.ExecContext(ctx, "UPDATE discussion_threads SET target_repo_id=null WHERE author_user_id=$1", id); err != nil {
+		return err
+	}
 	if _, err := tx.ExecContext(ctx, "DELETE FROM discussion_threads_target_repo WHERE thread_id IN (SELECT id FROM discussion_threads WHERE author_user_id=$1)", id); err != nil {
 		return err
 	}

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -403,6 +403,17 @@ func (u *users) Delete(ctx context.Context, id int32) error {
 		return err
 	}
 
+	// Soft-delete discussions data.
+	if _, err := tx.ExecContext(ctx, "UPDATE discussion_mail_reply_tokens SET deleted_at=now() WHERE deleted_at IS NULL AND user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "UPDATE discussion_comments SET deleted_at=now() WHERE deleted_at IS NULL AND author_user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "UPDATE discussion_threads SET deleted_at=now() WHERE deleted_at IS NULL AND author_user_id=$1", id); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -417,6 +417,85 @@ func (u *users) Delete(ctx context.Context, id int32) error {
 	return nil
 }
 
+func (u *users) HardDelete(ctx context.Context, id int32) error {
+	// Wrap in transaction because we delete from multiple tables.
+	tx, err := dbconn.Global.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			rollErr := tx.Rollback()
+			if rollErr != nil {
+				err = multierror.Append(err, rollErr)
+			}
+			return
+		}
+		err = tx.Commit()
+	}()
+
+	if _, err := tx.ExecContext(ctx, "DELETE FROM names WHERE user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM access_tokens WHERE subject_user_id=$1 OR creator_user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM user_emails WHERE user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM user_external_accounts WHERE user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM user_activity WHERE user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM survey_responses WHERE user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM registry_extension_releases WHERE registry_extension_id IN (SELECT id FROM registry_extensions WHERE publisher_user_id=$1)", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM registry_extensions WHERE publisher_user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM org_invitations WHERE sender_user_id=$1 OR recipient_user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM org_members WHERE user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM settings WHERE user_id=$1 OR author_user_id=$1", id); err != nil {
+		return err
+	}
+
+	// Hard-delete discussions data.
+	if _, err := tx.ExecContext(ctx, "DELETE FROM discussion_mail_reply_tokens WHERE user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM discussion_threads_target_repo WHERE thread_id IN (SELECT id FROM discussion_threads WHERE author_user_id=$1)", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM discussion_comments WHERE author_user_id=$1", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM discussion_threads WHERE author_user_id=$1", id); err != nil {
+		return err
+	}
+
+	res, err := tx.ExecContext(ctx, "DELETE FROM users WHERE id=$1", id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return userNotFoundErr{args: []interface{}{id}}
+	}
+	return nil
+}
+
 func (u *users) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bool) error {
 	if Mocks.Users.SetIsSiteAdmin != nil {
 		return Mocks.Users.SetIsSiteAdmin(id, isSiteAdmin)

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -377,86 +377,97 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 }
 
 func TestUsers_Delete(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	ctx := dbtesting.TestContext(t)
+	for name, hard := range map[string]bool{"": false, "_Hard": true} {
+		t.Run("TestUsers_Delete"+name, func(t *testing.T) {
+			if testing.Short() {
+				t.Skip()
+			}
+			ctx := dbtesting.TestContext(t)
 
-	user, err := Users.Create(ctx, NewUser{
-		Email:                 "a@a.com",
-		Username:              "u",
-		Password:              "p",
-		EmailVerificationCode: "c",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			user, err := Users.Create(ctx, NewUser{
+				Email:                 "a@a.com",
+				Username:              "u",
+				Password:              "p",
+				EmailVerificationCode: "c",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Create a repository to comply with the postgres repo constraint.
-	if err := Repos.Upsert(ctx, api.InsertRepoOp{URI: "myrepo", Description: "", Fork: false, Enabled: true}); err != nil {
-		t.Fatal(err)
-	}
-	repo, err := Repos.GetByURI(ctx, "myrepo")
-	if err != nil {
-		t.Fatal(err)
-	}
+			// Create a repository to comply with the postgres repo constraint.
+			if err := Repos.Upsert(ctx, api.InsertRepoOp{URI: "myrepo", Description: "", Fork: false, Enabled: true}); err != nil {
+				t.Fatal(err)
+			}
+			repo, err := Repos.GetByURI(ctx, "myrepo")
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Create a discussion thread to confirm that deletion properly removes
-	// threads and their associated comments.
-	newThread, err := DiscussionThreads.Create(ctx, &types.DiscussionThread{
-		AuthorUserID: user.ID,
-		Title:        "Hello world",
-		TargetRepo: &types.DiscussionThreadTargetRepo{
-			RepoID:   repo.ID,
-			Path:     strPtr("foo/bar/mux.go"),
-			Branch:   strPtr("master"),
-			Revision: strPtr("0c1a96370c1a96370c1a96370c1a96370c1a9637"),
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	newComment, err := DiscussionComments.Create(ctx, &types.DiscussionComment{
-		ThreadID:     newThread.ID,
-		AuthorUserID: user.ID,
-		Contents:     "Thread contents",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			// Create a discussion thread to confirm that deletion properly removes
+			// threads and their associated comments.
+			newThread, err := DiscussionThreads.Create(ctx, &types.DiscussionThread{
+				AuthorUserID: user.ID,
+				Title:        "Hello world",
+				TargetRepo: &types.DiscussionThreadTargetRepo{
+					RepoID:   repo.ID,
+					Path:     strPtr("foo/bar/mux.go"),
+					Branch:   strPtr("master"),
+					Revision: strPtr("0c1a96370c1a96370c1a96370c1a96370c1a9637"),
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			newComment, err := DiscussionComments.Create(ctx, &types.DiscussionComment{
+				ThreadID:     newThread.ID,
+				AuthorUserID: user.ID,
+				Contents:     "Thread contents",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Delete user.
-	if err := Users.Delete(ctx, user.ID); err != nil {
-		t.Fatal(err)
-	}
+			if hard {
+				// Hard delete user.
+				if err := Users.HardDelete(ctx, user.ID); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				// Delete user.
+				if err := Users.Delete(ctx, user.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	// User no longer exists.
-	_, err = Users.GetByID(ctx, user.ID)
-	if !errcode.IsNotFound(err) {
-		t.Errorf("got error %v, want ErrUserNotFound", err)
-	}
-	users, err := Users.List(ctx, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(users) > 0 {
-		t.Errorf("got %d users, want 0", len(users))
-	}
+			// User no longer exists.
+			_, err = Users.GetByID(ctx, user.ID)
+			if !errcode.IsNotFound(err) {
+				t.Errorf("got error %v, want ErrUserNotFound", err)
+			}
+			users, err := Users.List(ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(users) > 0 {
+				t.Errorf("got %d users, want 0", len(users))
+			}
 
-	// Can't delete already-deleted user.
-	err = Users.Delete(ctx, user.ID)
-	if !errcode.IsNotFound(err) {
-		t.Errorf("got error %v, want ErrUserNotFound", err)
-	}
+			// Can't delete already-deleted user.
+			err = Users.Delete(ctx, user.ID)
+			if !errcode.IsNotFound(err) {
+				t.Errorf("got error %v, want ErrUserNotFound", err)
+			}
 
-	// Confirm discussion thread/comment no longer exists.
-	_, err = DiscussionThreads.Get(ctx, newThread.ID)
-	if _, ok := err.(*ErrThreadNotFound); !ok {
-		t.Fatal("expected ErrThreadNotFound")
-	}
-	_, err = DiscussionComments.Get(ctx, newThread.ID)
-	if _, ok := err.(*ErrCommentNotFound); !ok {
-		t.Fatal("expected ErrCommentNotFound")
+			// Confirm discussion thread/comment no longer exists.
+			_, err = DiscussionThreads.Get(ctx, newThread.ID)
+			if _, ok := err.(*ErrThreadNotFound); !ok {
+				t.Fatal("expected ErrThreadNotFound")
+			}
+			_, err = DiscussionComments.Get(ctx, newComment.ID)
+			if _, ok := err.(*ErrCommentNotFound); !ok {
+				t.Fatal("expected ErrCommentNotFound")
+			}
+		})
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -134,8 +134,7 @@ type Mutation {
     # If hard == true, a hard delete is performed. By default, deletes are
     # 'soft deletes' and could theoretically be undone with manual DB commands.
     # If a hard delete is performed, the data is truly removed from the
-    # database and deletion can NEVER be undone. This is for e.g. GDPR-style
-    # deletion.
+    # database and deletion can NEVER be undone.
     #
     # Data that is deleted as part of this operation:
     #
@@ -145,17 +144,6 @@ type Mutation {
     # - User, Organization, or Global settings authored by the user.
     # - Discussion threads and comments created by the user.
     #
-    # Data that is not currently deleted as part of this operation:
-    #
-    # - BUG(dadlerj): Redis store user activity data
-    # - BUG(dadlerj): CRM, Analytics DB, etc.
-    # - Repositories the user may have added (impossible because we don't track this).
-    # - Organizations the user may have created (impossible because we don't track this, and it would evict other members).
-    # - Extension releases the user may have made on extensions not owned by the user.
-    # - Product licenses & subscriptions the user has created (this would prevent us from having a legal record of sales).
-    #
-    # For GDPR-style deletion requests, the above user data not deleted as part
-    # of this operation must currently be performed manually.
     deleteUser(user: ID!, hard: Boolean): EmptyResponse
     # Updates the current user's password. The oldPassword arg must match the user's current password.
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -130,7 +130,33 @@ type Mutation {
     # Only site admins may perform this mutation.
     setUserEmailVerified(user: ID!, email: String!, verified: Boolean!): EmptyResponse!
     # Deletes a user account. Only site admins may perform this mutation.
-    deleteUser(user: ID!): EmptyResponse
+    #
+    # If hard == true, a hard delete is performed. By default, deletes are
+    # 'soft deletes' and could theoretically be undone with manual DB commands.
+    # If a hard delete is performed, the data is truly removed from the
+    # database and deletion can NEVER be undone. This is for e.g. GDPR-style
+    # deletion.
+    #
+    # Data that is deleted as part of this operation:
+    #
+    # - All user data (access tokens, email addresses, external account info, survey responses, etc)
+    # - Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).
+    # - Sourcegraph Extensions published by the user.
+    # - User, Organization, or Global settings authored by the user.
+    # - Discussion threads and comments created by the user.
+    #
+    # Data that is not currently deleted as part of this operation:
+    #
+    # - BUG(dadlerj): Redis store user activity data
+    # - BUG(dadlerj): CRM, Analytics DB, etc.
+    # - Repositories the user may have added (impossible because we don't track this).
+    # - Organizations the user may have created (impossible because we don't track this, and it would evict other members).
+    # - Extension releases the user may have made on extensions not owned by the user.
+    # - Product licenses & subscriptions the user has created (this would prevent us from having a legal record of sales).
+    #
+    # For GDPR-style deletion requests, the above user data not deleted as part
+    # of this operation must currently be performed manually.
+    deleteUser(user: ID!, hard: Boolean): EmptyResponse
     # Updates the current user's password. The oldPassword arg must match the user's current password.
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse
     # Creates an access token that grants the privileges of the specified user (referred to as the access token's

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -136,8 +136,7 @@ type Mutation {
     # If hard == true, a hard delete is performed. By default, deletes are
     # 'soft deletes' and could theoretically be undone with manual DB commands.
     # If a hard delete is performed, the data is truly removed from the
-    # database and deletion can NEVER be undone. This is for e.g. GDPR-style
-    # deletion.
+    # database and deletion can NEVER be undone.
     #
     # Data that is deleted as part of this operation:
     #
@@ -147,17 +146,6 @@ type Mutation {
     # - User, Organization, or Global settings authored by the user.
     # - Discussion threads and comments created by the user.
     #
-    # Data that is not currently deleted as part of this operation:
-    #
-    # - BUG(dadlerj): Redis store user activity data
-    # - BUG(dadlerj): CRM, Analytics DB, etc.
-    # - Repositories the user may have added (impossible because we don't track this).
-    # - Organizations the user may have created (impossible because we don't track this, and it would evict other members).
-    # - Extension releases the user may have made on extensions not owned by the user.
-    # - Product licenses & subscriptions the user has created (this would prevent us from having a legal record of sales).
-    #
-    # For GDPR-style deletion requests, the above user data not deleted as part
-    # of this operation must currently be performed manually.
     deleteUser(user: ID!, hard: Boolean): EmptyResponse
     # Updates the current user's password. The oldPassword arg must match the user's current password.
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -132,7 +132,33 @@ type Mutation {
     # Only site admins may perform this mutation.
     setUserEmailVerified(user: ID!, email: String!, verified: Boolean!): EmptyResponse!
     # Deletes a user account. Only site admins may perform this mutation.
-    deleteUser(user: ID!): EmptyResponse
+    #
+    # If hard == true, a hard delete is performed. By default, deletes are
+    # 'soft deletes' and could theoretically be undone with manual DB commands.
+    # If a hard delete is performed, the data is truly removed from the
+    # database and deletion can NEVER be undone. This is for e.g. GDPR-style
+    # deletion.
+    #
+    # Data that is deleted as part of this operation:
+    #
+    # - All user data (access tokens, email addresses, external account info, survey responses, etc)
+    # - Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).
+    # - Sourcegraph Extensions published by the user.
+    # - User, Organization, or Global settings authored by the user.
+    # - Discussion threads and comments created by the user.
+    #
+    # Data that is not currently deleted as part of this operation:
+    #
+    # - BUG(dadlerj): Redis store user activity data
+    # - BUG(dadlerj): CRM, Analytics DB, etc.
+    # - Repositories the user may have added (impossible because we don't track this).
+    # - Organizations the user may have created (impossible because we don't track this, and it would evict other members).
+    # - Extension releases the user may have made on extensions not owned by the user.
+    # - Product licenses & subscriptions the user has created (this would prevent us from having a legal record of sales).
+    #
+    # For GDPR-style deletion requests, the above user data not deleted as part
+    # of this operation must currently be performed manually.
+    deleteUser(user: ID!, hard: Boolean): EmptyResponse
     # Updates the current user's password. The oldPassword arg must match the user's current password.
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse
     # Creates an access token that grants the privileges of the specified user (referred to as the access token's

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -31,7 +31,7 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 		return nil, errors.New("unable to delete current user")
 	}
 
-	if args.Hard != nil || *args.Hard {
+	if args.Hard != nil && *args.Hard {
 		if err := db.Users.HardDelete(ctx, userID); err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -11,6 +11,7 @@ import (
 
 func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	User graphql.ID
+	Hard *bool
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can delete users.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
@@ -30,8 +31,14 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 		return nil, errors.New("unable to delete current user")
 	}
 
-	if err := db.Users.Delete(ctx, userID); err != nil {
-		return nil, err
+	if args.Hard != nil || *args.Hard {
+		if err := db.Users.HardDelete(ctx, userID); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := db.Users.Delete(ctx, userID); err != nil {
+			return nil, err
+		}
 	}
 	return &EmptyResponse{}, nil
 }

--- a/docs/user-data-deletion.md
+++ b/docs/user-data-deletion.md
@@ -5,7 +5,7 @@ As a site administrator, you have the ability to delete users and their associat
 On this page, you are presented two options:
 
 - Deleting a user: the user and ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
-- Nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this). For GDPR-style requests, nuking is used (but not sufficient on its own, see below).
+- Nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this).
 
 When deleting or nuking a user, the following information is removed:
 

--- a/docs/user-data-deletion.md
+++ b/docs/user-data-deletion.md
@@ -11,17 +11,6 @@ When deleting or nuking a user, the following information is removed:
 
 - All user data (access tokens, email addresses, external account info, survey responses, etc)
 - Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).
-- Sourcegraph Extensions published by the user.
+- Sourcegraph Extensions published by the user on the instance the deletion request is sent to.
 - User, Organization, or Global settings authored or modified by the user.
 - Discussion threads and comments created by the user.
-
-Data that is NOT currently removed:
-
-- BUG(@dadlerj): Redis store user activity data
-- BUG(@dadlerj): CRM, Analytics DB, etc.
-- Repositories the user may have added (impossible because we don't track this).
-- Organizations the user may have created (impossible because we don't track this, and it would evict other members).
-- Extension releases the user may have made on extensions _not created by that same user_.
-- Product licenses & subscriptions the user has created (this would prevent us from having a legal record of sales).
-
-For GDPR-style deletion requests, the above user data not deleted as part of this operation and must currently be performed manually. Contact support@sourcegraph.com for more information.

--- a/docs/user-data-deletion.md
+++ b/docs/user-data-deletion.md
@@ -1,0 +1,27 @@
+# User data deletion
+
+As a site administrator, you have the ability to delete users and their associated data on the **Admin** -> **Users** page (https://sourcegraph.example.com/site-admin/users).
+
+On this page, you are presented two options:
+
+- Deleting a user: the user and ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
+- Nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this). For GDPR-style requests, nuking is used (but not sufficient on its own, see below).
+
+When deleting or nuking a user, the following information is removed:
+
+- All user data (access tokens, email addresses, external account info, survey responses, etc)
+- Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).
+- Sourcegraph Extensions published by the user.
+- User, Organization, or Global settings authored or modified by the user.
+- Discussion threads and comments created by the user.
+
+Data that is NOT currently removed:
+
+- BUG(@dadlerj): Redis store user activity data
+- BUG(@dadlerj): CRM, Analytics DB, etc.
+- Repositories the user may have added (impossible because we don't track this).
+- Organizations the user may have created (impossible because we don't track this, and it would evict other members).
+- Extension releases the user may have made on extensions _not created by that same user_.
+- Product licenses & subscriptions the user has created (this would prevent us from having a legal record of sales).
+
+For GDPR-style deletion requests, the above user data not deleted as part of this operation and must currently be performed manually. Contact support@sourcegraph.com for more information.

--- a/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -42,8 +42,8 @@ interface UserNodeState {
 }
 
 const nukeDetails = `
-- By deleting a user, the user an ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
-- By nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this). For GDPR-style requests, nuking is used (but not sufficient on its own, see link below).
+- By deleting a user, the user and ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
+- By nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this). When deleting data at a user's request, nuking is used.
 
 Beware this includes e.g. deleting extensions authored by the user, deleting ANY settings authored or updated by the user, etc.
 

--- a/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -1,6 +1,7 @@
 import { isEqual } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import DeleteIcon from 'mdi-react/DeleteIcon'
+import RadioactiveIcon from 'mdi-react/RadioactiveIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
@@ -39,6 +40,16 @@ interface UserNodeState {
     errorDescription?: string
     resetPasswordURL?: string | null
 }
+
+const nukeDetails = `
+- By deleting a user, the user an ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
+- By nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this). For GDPR-style requests, nuking is used (but not sufficient on its own, see link below).
+
+Beware this includes e.g. deleting extensions authored by the user, deleting ANY settings authored or updated by the user, etc.
+
+For more information about what data is deleted, see https://github.com/sourcegraph/sourcegraph/blob/master/docs/user-data-deletion.md
+
+Are you ABSOLUTELY certain you wish to delete this user and all associated data?`
 
 class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
     public state: UserNodeState = {
@@ -136,6 +147,16 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                                 <DeleteIcon className="icon-inline" />
                             </button>
                         )}
+                        {this.props.node.id !== this.props.currentUser.id && (
+                            <button
+                                className="ml-1 btn btn-sm btn-danger"
+                                onClick={this.nukeUser}
+                                disabled={this.state.loading}
+                                data-tooltip="Nuke user (click for more information)"
+                            >
+                                <RadioactiveIcon className="icon-inline" />
+                            </button>
+                        )}
                     </div>
                 </div>
                 {this.state.errorDescription && (
@@ -216,8 +237,15 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
             )
     }
 
-    private deleteUser = () => {
-        if (!window.confirm(`Delete the user ${this.props.node.username}?`)) {
+    private deleteUser = () => this.doDeleteUser(false)
+    private nukeUser = () => this.doDeleteUser(true)
+
+    private doDeleteUser = (hard: boolean) => {
+        let message = `Delete the user ${this.props.node.username}?`
+        if (hard) {
+            message = `Nuke the user ${this.props.node.username}?${nukeDetails}`
+        }
+        if (!window.confirm(message)) {
             return
         }
 
@@ -227,7 +255,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
             loading: true,
         })
 
-        deleteUser(this.props.node.id)
+        deleteUser(this.props.node.id, hard)
             .toPromise()
             .then(
                 () => {

--- a/src/site-admin/backend.tsx
+++ b/src/site-admin/backend.tsx
@@ -488,16 +488,16 @@ export function randomizeUserPassword(user: GQL.ID): Observable<GQL.IRandomizeUs
     )
 }
 
-export function deleteUser(user: GQL.ID): Observable<void> {
+export function deleteUser(user: GQL.ID, hard?: boolean): Observable<void> {
     return mutateGraphQL(
         gql`
-            mutation DeleteUser($user: ID!) {
-                deleteUser(user: $user) {
+            mutation DeleteUser($user: ID!, $hard: Boolean) {
+                deleteUser(user: $user, hard: $hard) {
                     alwaysNil
                 }
             }
         `,
-        { user }
+        { user, hard }
     ).pipe(
         map(dataOrThrowErrors),
         map(data => {


### PR DESCRIPTION
How it looked before:

> @dadlerj asked: Hey @slimsag can you delete all user data for user @xyz?

How it looks now:

![image](https://user-images.githubusercontent.com/3173176/46998228-c87cc900-d0d6-11e8-9981-5675785713b0.png)

![image](https://user-images.githubusercontent.com/3173176/46998252-d92d3f00-d0d6-11e8-9c2f-a5c60bb47416.png)

https://github.com/sourcegraph/sourcegraph/blob/oss/data-deletion/docs/user-data-deletion.md

@sqs for wording review.
@dadlerj for review of BUG notes about other systems we may should integrate into this button soon.

Fixes sourcegraph/enterprise#11625
Helps sourcegraph/enterprise#13602

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
