### PR TITLE
support dismissing repository config and enable alerts

### DIFF
--- a/src/site/NeedsRepositoryConfigurationAlert.tsx
+++ b/src/site/NeedsRepositoryConfigurationAlert.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Link } from 'react-router-dom'
+import { DismissibleAlert } from '../components/DismissibleAlert'
 import { eventLogger } from '../tracking/eventLogger'
 import { CircleChevronRightIcon } from '../util/icons' // TODO: Switch to mdi icon
 
@@ -12,11 +13,14 @@ const onClickCTA = () => {
  * on this site.
  */
 export const NeedsRepositoryConfigurationAlert: React.SFC<{ className?: string }> = ({ className = '' }) => (
-    <div className={`alert alert-success alert-animated-bg d-flex align-items-center ${className}`}>
+    <DismissibleAlert
+        partialStorageKey="needsRepositoryConfiguration"
+        className={`alert alert-success alert-animated-bg d-flex align-items-center ${className}`}
+    >
         <Link className="site-alert__link" to="/site-admin/configuration" onClick={onClickCTA}>
             <CircleChevronRightIcon className="icon-inline site-alert__link-icon" />{' '}
             <span className="underline">Configure repositories and code hosts</span>
         </Link>
         &nbsp;to add to Sourcegraph.
-    </div>
+    </DismissibleAlert>
 )

--- a/src/site/NoRepositoriesEnabledAlert.tsx
+++ b/src/site/NoRepositoriesEnabledAlert.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Link } from 'react-router-dom'
+import { DismissibleAlert } from '../components/DismissibleAlert'
 import { eventLogger } from '../tracking/eventLogger'
 import { CircleChevronRightIcon } from '../util/icons' // TODO: Switch to mdi icon
 
@@ -12,11 +13,14 @@ const onClickCTA = () => {
  * on this site.
  */
 export const NoRepositoriesEnabledAlert: React.SFC<{ className?: string }> = ({ className = '' }) => (
-    <div className={`alert alert-success alert-animated-bg d-flex align-items-center ${className}`}>
+    <DismissibleAlert
+        partialStorageKey="noRepositoriesEnabled"
+        className={`alert alert-success alert-animated-bg d-flex align-items-center ${className}`}
+    >
         <Link className="site-alert__link" to="/site-admin/repositories" onClick={onClickCTA}>
             <CircleChevronRightIcon className="icon-inline site-alert__link-icon" />{' '}
             <span className="underline"> Select repositories to enable</span>
         </Link>
         &nbsp;to start searching and browsing
-    </div>
+    </DismissibleAlert>
 )


### PR DESCRIPTION
Dismissal state is stored in localStorage. This is convenient for local dev, where dev/config.json has no repo config and you don't want to add any (lest you accidentally commit it), but you want to dismiss the alert.