### PR TITLE
cmd/frontend: make createdb error readable

### DIFF
--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -23,7 +23,7 @@ func main() {
 	const dbname = "schemadoc-gen-temp"
 	_ = exec.Command("dropdb", dbname).Run()
 	if out, err := exec.Command("createdb", dbname).CombinedOutput(); err != nil {
-		log.Fatal("createdb", out, err)
+		log.Fatalf("createdb: %s, %v", out, err)
 	}
 	defer exec.Command("dropdb", dbname).Run()
 


### PR DESCRIPTION
As it was, since exec.Command output is a []byte, the call to log.Fatal
on it was just spewing the bytes, instead of their string
representation, which made the log message near useless.

> This PR does not need to update the CHANGELOG because it is a just dev workflow detail.

