### PR TITLE
Prepended "bash " to scripts in .huskyrc.json

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,7 +1,7 @@
 {
   "hooks": {
-    "pre-commit": "dev/hooks/check-no-enterprise.sh",
-    "post-commit": "dev/hooks/check-no-enterprise.sh",
-    "pre-push": "dev/hooks/check-no-enterprise.sh ${HUSKY_GIT_PARAMS}"
+    "pre-commit": "bash dev/hooks/check-no-enterprise.sh",
+    "post-commit": "bash dev/hooks/check-no-enterprise.sh",
+    "pre-push": "bash dev/hooks/check-no-enterprise.sh ${HUSKY_GIT_PARAMS}"
   }
 }


### PR DESCRIPTION
Fixes #419

This PR does not need to update the CHANGELOG because it's only for dev tooling.