### PR TITLE
remove fbjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "d3-selection": "^1.2.0",
     "d3-shape": "^1.2.0",
     "date-fns": "^2.0.0-alpha.7",
-    "fbjs": "^0.8.17",
     "get-stream": "^4.0.0",
     "graphiql": "^0.11.11",
     "graphql": "14.0.2",

--- a/src/repo/RepoHeaderContributionPortal.tsx
+++ b/src/repo/RepoHeaderContributionPortal.tsx
@@ -1,4 +1,4 @@
-import shallowEqual from 'fbjs/lib/shallowEqual'
+import { isEqual } from 'lodash'
 import * as React from 'react'
 import { RepoHeaderContribution, RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 
@@ -26,14 +26,11 @@ export class RepoHeaderContributionPortal extends React.Component<Props> {
     public shouldComponentUpdate(nextProps: Props): boolean {
         // This "smart" comparison lets us skip ~75% of the updates that extending React.PureComponent (and not
         // implementing shouldComponentUpdate) or always returning true here would yield.
-        //
-        // We use fbjs/lib/shallowEqual because it's what React uses, so it avoids bringing in another dep and
-        // avoids implementation disparities (and is faster than a deep comparison).
         return (
             this.props.repoHeaderContributionsLifecycleProps !== nextProps.repoHeaderContributionsLifecycleProps ||
             this.props.position !== nextProps.position ||
             this.props.priority !== nextProps.priority ||
-            !shallowEqual(this.props.element.props, nextProps.element.props)
+            !isEqual(this.props.element.props, nextProps.element.props)
         )
     }
 

--- a/src/types/fbjs/index.d.ts
+++ b/src/types/fbjs/index.d.ts
@@ -1,5 +1,0 @@
-declare module 'fbjs/lib/shallowEqual' {
-    function shallowEqual(objA: any, objB: any): boolean
-
-    export = shallowEqual
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4647,7 +4647,7 @@ fastparse@^1.1.1:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
   integrity sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=
 
-fbjs@^0.8.17, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=


### PR DESCRIPTION
Its shallowEqual offers no meaningful benefits over lodash's isEqual for us.

fixes https://github.com/sourcegraph/enterprise/issues/13159