### PR TITLE
reduce parallelism of symbols result parsing

### DIFF
--- a/cmd/symbols/internal/symbols/parse.go
+++ b/cmd/symbols/internal/symbols/parse.go
@@ -74,7 +74,7 @@ func (s *Service) parseUncached(ctx context.Context, repo api.RepoURI, commitID 
 	var (
 		mu  sync.Mutex // protects symbols and err
 		wg  sync.WaitGroup
-		sem = make(chan struct{}, 1000) // TODO: this is a super aggressive number, should we lower it further?
+		sem = make(chan struct{}, runtime.NumCPU())
 	)
 	tr.LazyPrintf("parse")
 	totalParseRequests := 0


### PR DESCRIPTION
Previously there were up to 1000 goroutines allowed to wait on ctags parser processes to become ready, and to perform some post-processing on the output simultaneously. Now there are at most runtime.NumCPU() such goroutines allowed at once. Note that the number of active ctags processes was already limited to well under 1000.

This is an attempt to fix an issue where symbol parsing fails with:

```
runtime: failed to create new OS thread (have 52 already; errno=12)
```

The hypothesis is that this is due to heavy system load caused by the ctags parsers. New goroutines were not able to be spawned and mapped to an OS thread due to the overall high system load. 

address https://github.com/sourcegraph/enterprise/issues/12796