### PR TITLE
enable experimentalFeatures.canonicalURLRedirect by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Updating `maxReposToSearch` site config no longer requires a server restart to take effect.
 
+### Changed
+
+- The `experimentalFeatures.canonicalURLRedirect` site config property now defaults to `enabled`. Set it to `disabled` to disable redirection to the `appURL` from other hosts.
+
 ### Removed
 
 - The experimental feature flag to disable the new repo update scheduler has been removed.

--- a/cmd/frontend/internal/cli/middleware/redirect.go
+++ b/cmd/frontend/internal/cli/middleware/redirect.go
@@ -61,9 +61,9 @@ func CanonicalURL(next http.Handler) http.Handler {
 		var canonicalURLRedirect bool
 		if conf.ExperimentalFeatures != nil {
 			switch conf.ExperimentalFeatures.CanonicalURLRedirect {
-			case "enabled":
+			case "enabled", "": // default enabled
 				canonicalURLRedirect = true
-			case "disabled", "":
+			case "disabled":
 				// noop
 			default:
 				text := "Misconfigured experimentalFeatures.canonicalURLRedirect values in site configuration."

--- a/dev/config.json
+++ b/dev/config.json
@@ -3,7 +3,6 @@
   "appURL": "http://localhost:3080",
   "experimentalFeatures": {
     "configVars": "enabled",
-    "canonicalURLRedirect": "enabled",
     "discussions": "enabled"
   },
   "disablePublicRepoRedirects": true,

--- a/doc/admin/site_config/all.md
+++ b/doc/admin/site_config/all.md
@@ -255,14 +255,14 @@ Default: `"disabled"`
 
 ### canonicalURLRedirect (string, enum)
 
-Enables or disables redirecting to the canonical URL (underneath the "appURL") for incoming HTTP requests. This experiment is intended to be enabled for all instances as of Sourcegraph 2.9.
+Enables or disables redirecting to the canonical URL (underneath the "appURL") for incoming HTTP requests. Enabled by default.
 
 This property must be one of the following enum values:
 
 - `enabled`
 - `disabled`
 
-Default: `"disabled"`
+Default: `"enabled"`
 
 ### configVars (string, enum)
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -69,7 +69,7 @@
         },
         "canonicalURLRedirect": {
           "description":
-            "Enables or disables redirecting to the canonical URL (underneath the \"appURL\") for incoming HTTP requests. Enabled by default.",
+          "Enables or disables enforcing that HTTP requests use the appURL as a prefix, by redirecting other requests to the same request URI on the appURL. For example, if the appURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Enabled by default.",
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "enabled"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -69,10 +69,10 @@
         },
         "canonicalURLRedirect": {
           "description":
-            "Enables or disables redirecting to the canonical URL (underneath the \"appURL\") for incoming HTTP requests. This experiment is intended to be enabled for all instances as of Sourcegraph 2.9.",
+            "Enables or disables redirecting to the canonical URL (underneath the \"appURL\") for incoming HTTP requests. Enabled by default.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "disabled"
+          "default": "enabled"
         },
         "configVars": {
           "description":

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -74,10 +74,10 @@ const SiteSchemaJSON = `{
         },
         "canonicalURLRedirect": {
           "description":
-            "Enables or disables redirecting to the canonical URL (underneath the \"appURL\") for incoming HTTP requests. This experiment is intended to be enabled for all instances as of Sourcegraph 2.9.",
+            "Enables or disables redirecting to the canonical URL (underneath the \"appURL\") for incoming HTTP requests. Enabled by default.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "disabled"
+          "default": "enabled"
         },
         "configVars": {
           "description":

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -74,7 +74,7 @@ const SiteSchemaJSON = `{
         },
         "canonicalURLRedirect": {
           "description":
-            "Enables or disables redirecting to the canonical URL (underneath the \"appURL\") for incoming HTTP requests. Enabled by default.",
+          "Enables or disables enforcing that HTTP requests use the appURL as a prefix, by redirecting other requests to the same request URI on the appURL. For example, if the appURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Enabled by default.",
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "enabled"


### PR DESCRIPTION
experimentalFeatures.canonicalURLRedirect was introduced in Sourcegraph 2.9 and was disabled by default. We have been running with it enabled in dev for 4 months. In 2.13 it should be enabled by default so that we can remove the feature flag in the following month and eliminate tech debt.

Also filed https://github.com/sourcegraph/sourcegraph/issues/466 to schedule the removal of this feature flag.

Fixes https://github.com/sourcegraph/enterprise/issues/12546

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
