### PR TITLE
fix change-password page visibility logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to Sourcegraph are documented in this file.
 - Updating `maxReposToSearch` site config no longer requires a server restart to take effect.
 - The update check page no longer shows an error if you are using an insiders build. Insiders builds will now notify site administrators that updates are available 40 days after the release date of the installed build.
 
+### Fixed
+
+- The user account sidebar "Password" link (to the change-password form) is now shown correctly.
+
 ### Removed
 
 - The experimental feature flag to disable the new repo update scheduler has been removed.

--- a/cmd/frontend/graphqlbackend/auth_providers.go
+++ b/cmd/frontend/graphqlbackend/auth_providers.go
@@ -3,38 +3,22 @@ package graphqlbackend
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth"
 )
 
 func (r *siteResolver) AuthProviders(ctx context.Context) (*authProviderConnectionResolver, error) {
-	// 🚨 SECURITY: Only site admins can list auth providers.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
-	}
-
 	return &authProviderConnectionResolver{
 		authProviders: auth.Providers(),
 	}, nil
 }
 
 // authProviderConnectionResolver resolves a list of auth providers.
-//
-// 🚨 SECURITY: When instantiating an authProviderConnectionResolver value, the caller MUST check
-// permissions.
 type authProviderConnectionResolver struct {
 	authProviders []auth.Provider
 }
 
 func (r *authProviderConnectionResolver) Nodes(ctx context.Context) ([]*authProviderResolver, error) {
-	// 🚨 SECURITY: Only site admins can list auth providers. This check is intentionally redundant
-	// (with the check in (*siteResolver).AuthProviders), to reduce the likelihood of a bug causing
-	// this information to leak.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
-	}
-
 	var rs []*authProviderResolver
 	for _, authProvider := range r.authProviders {
 		rs = append(rs, &authProviderResolver{

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2158,8 +2158,8 @@ type AuthProviderConnection {
     pageInfo: PageInfo!
 }
 
-# A provider of user authentication, such as an external single-sign-on service (e.g., using OpenID
-# Connect or SAML).
+# A provider of user authentication, such as an external single-sign-on service (e.g., using OpenID Connect or
+# SAML). The provider information in this type is visible to all viewers and does not contain any secret values.
 type AuthProvider {
     # The type of the auth provider.
     serviceType: String!
@@ -2702,7 +2702,8 @@ type Site implements ConfigurationSubject {
         # Returns the first n access tokens from the list.
         first: Int
     ): AccessTokenConnection!
-    # A list of all authentication providers.
+    # A list of all authentication providers. This information is visible to all viewers and does not contain any
+    # secret information.
     authProviders: AuthProviderConnection!
     # A list of all user external accounts on this site.
     externalAccounts(
@@ -2734,8 +2735,6 @@ type Site implements ConfigurationSubject {
     # more about the code intelligence available (languages supported, etc.). It is subject to
     # change without notice.
     hasCodeIntelligence: Boolean!
-    # Whether the site is using an external authentication service such as OIDC or SAML.
-    externalAuthEnabled: Boolean!
     # Whether we want to show built-in searches on the saved searches page
     disableBuiltInSearches: Boolean!
     # Whether the server sends emails to users to verify email addresses. If false, then site admins must manually

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2165,8 +2165,8 @@ type AuthProviderConnection {
     pageInfo: PageInfo!
 }
 
-# A provider of user authentication, such as an external single-sign-on service (e.g., using OpenID
-# Connect or SAML).
+# A provider of user authentication, such as an external single-sign-on service (e.g., using OpenID Connect or
+# SAML). The provider information in this type is visible to all viewers and does not contain any secret values.
 type AuthProvider {
     # The type of the auth provider.
     serviceType: String!
@@ -2709,7 +2709,8 @@ type Site implements ConfigurationSubject {
         # Returns the first n access tokens from the list.
         first: Int
     ): AccessTokenConnection!
-    # A list of all authentication providers.
+    # A list of all authentication providers. This information is visible to all viewers and does not contain any
+    # secret information.
     authProviders: AuthProviderConnection!
     # A list of all user external accounts on this site.
     externalAccounts(
@@ -2741,8 +2742,6 @@ type Site implements ConfigurationSubject {
     # more about the code intelligence available (languages supported, etc.). It is subject to
     # change without notice.
     hasCodeIntelligence: Boolean!
-    # Whether the site is using an external authentication service such as OIDC or SAML.
-    externalAuthEnabled: Boolean!
     # Whether we want to show built-in searches on the saved searches page
     disableBuiltInSearches: Boolean!
     # Whether the server sends emails to users to verify email addresses. If false, then site admins must manually

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -56,15 +56,6 @@ func noRepositoriesEnabled(ctx context.Context) (bool, error) {
 	return len(repos) == 0, nil
 }
 
-func (*siteResolver) ExternalAuthEnabled() bool {
-	for _, p := range conf.AuthProviders() {
-		if p.Builtin == nil {
-			return true // has a non-builtin auth provider
-		}
-	}
-	return false
-}
-
 func (*siteResolver) DisableBuiltInSearches() bool {
 	return conf.Get().DisableBuiltInSearches
 }

--- a/src/site/backend.tsx
+++ b/src/site/backend.tsx
@@ -30,7 +30,16 @@ export function refreshSiteFlags(): Observable<never> {
                             isDismissibleWithKey
                         }
                         hasCodeIntelligence
-                        externalAuthEnabled
+                        authProviders {
+                            nodes {
+                                serviceType
+                                serviceID
+                                clientID
+                                displayName
+                                isBuiltin
+                                authenticationURL
+                            }
+                        }
                         disableBuiltInSearches
                         sendsEmailVerificationEmails
                         updateCheck {

--- a/src/site/index.ts
+++ b/src/site/index.ts
@@ -6,7 +6,7 @@ export type SiteFlags = Pick<
     | 'noRepositoriesEnabled'
     | 'alerts'
     | 'hasCodeIntelligence'
-    | 'externalAuthEnabled'
+    | 'authProviders'
     | 'disableBuiltInSearches'
     | 'sendsEmailVerificationEmails'
     | 'updateCheck'

--- a/src/user/account/UserAccountArea.tsx
+++ b/src/user/account/UserAccountArea.tsx
@@ -29,15 +29,14 @@ export interface UserAccountAreaRouteContext extends UserAccountAreaProps {
      * is viewing another user's account page).
      */
     user: GQL.IUser
-
-    externalAuthEnabled: boolean
+    authProviders: GQL.IAuthProvider[]
     newToken?: GQL.ICreateAccessTokenResult
     onDidCreateAccessToken: (value?: GQL.ICreateAccessTokenResult) => void
     onDidPresentNewToken: (value?: GQL.ICreateAccessTokenResult) => void
 }
 
 interface UserAccountAreaState {
-    externalAuthEnabled: boolean
+    authProviders: GQL.IAuthProvider[]
 
     /**
      * Holds the newly created access token (from UserAccountCreateAccessTokenPage), if any. After
@@ -51,13 +50,13 @@ interface UserAccountAreaState {
  */
 export const UserAccountArea = withAuthenticatedUser(
     class UserAccountArea extends React.Component<UserAccountAreaProps, UserAccountAreaState> {
-        public state: UserAccountAreaState = { externalAuthEnabled: false }
+        public state: UserAccountAreaState = { authProviders: [] }
         private subscriptions = new Subscription()
 
         public componentDidMount(): void {
             this.subscriptions.add(
-                siteFlags.pipe(map(({ externalAuthEnabled }) => externalAuthEnabled)).subscribe(externalAuthEnabled => {
-                    this.setState({ externalAuthEnabled })
+                siteFlags.pipe(map(({ authProviders }) => authProviders)).subscribe(({ nodes }) => {
+                    this.setState({ authProviders: nodes })
                 })
             )
         }
@@ -92,14 +91,14 @@ export const UserAccountArea = withAuthenticatedUser(
                 user: this.props.user,
                 onDidCreateAccessToken: this.setNewToken,
                 onDidPresentNewToken: this.setNewToken,
-                externalAuthEnabled: this.state.externalAuthEnabled,
+                authProviders: this.state.authProviders,
             }
 
             return (
                 <div className="user-settings-area area">
                     <UserAccountSidebar
-                        externalAuthEnabled={this.state.externalAuthEnabled}
                         items={this.props.sideBarItems}
+                        authProviders={this.state.authProviders}
                         {...this.props}
                         className="area__sidebar"
                     />

--- a/src/user/account/UserAccountPasswordPage.tsx
+++ b/src/user/account/UserAccountPasswordPage.tsx
@@ -2,6 +2,7 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
+import { Link } from 'react-router-dom'
 import { Subject, Subscription } from 'rxjs'
 import { catchError, filter, mergeMap, tap } from 'rxjs/operators'
 import { PasswordInput } from '../../auth/SignInSignUpCommon'
@@ -13,6 +14,7 @@ import { updatePassword } from './backend'
 
 interface Props extends RouteComponentProps<any> {
     user: GQL.IUser
+    authenticatedUser: GQL.IUser
 }
 
 interface State {
@@ -83,65 +85,78 @@ export class UserAccountPasswordPage extends React.Component<Props, State> {
             <div className="user-account-password-page">
                 <PageTitle title="Change password" />
                 <h2>Change password</h2>
-                {this.state.error && <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>}
-                {this.state.saved && <p className="alert alert-success">Password changed!</p>}
-                <Form onSubmit={this.handleSubmit}>
-                    {/* Include a username field as a hint for password managers to update the saved password. */}
-                    <input
-                        type="text"
-                        value={this.props.user.username}
-                        name="username"
-                        autoComplete="username"
-                        readOnly={true}
-                        hidden={true}
-                    />
-                    <div className="form-group">
-                        <label>Old password</label>
-                        <PasswordInput
-                            value={this.state.oldPassword}
-                            onChange={this.onOldPasswordFieldChange}
-                            disabled={this.state.loading}
-                            name="oldPassword"
-                            placeholder=" "
-                            autoComplete="current-password"
-                        />
+                {this.props.authenticatedUser.id !== this.props.user.id ? (
+                    <div className="alert alert-danger">
+                        Only the user may change their password. Site admins may{' '}
+                        <Link to={`/site-admin/users?query=${encodeURIComponent(this.props.user.username)}`}>
+                            reset a user's password
+                        </Link>.
                     </div>
-                    <div className="form-group">
-                        <label>New password</label>
-                        <PasswordInput
-                            value={this.state.newPassword}
-                            onChange={this.onNewPasswordFieldChange}
-                            disabled={this.state.loading}
-                            name="newPassword"
-                            placeholder=" "
-                            autoComplete="new-password"
-                        />
-                    </div>
-                    <div className="form-group">
-                        <label>Confirm new password</label>
-                        <PasswordInput
-                            value={this.state.newPasswordConfirmation}
-                            onChange={this.onNewPasswordConfirmationFieldChange}
-                            disabled={this.state.loading}
-                            name="newPasswordConfirmation"
-                            placeholder=" "
-                            inputRef={this.setNewPasswordConfirmationField}
-                            autoComplete="new-password"
-                        />
-                    </div>
-                    <button
-                        className="btn btn-primary user-account-password-page__button"
-                        type="submit"
-                        disabled={this.state.loading}
-                    >
-                        Update password
-                    </button>
-                    {this.state.loading && (
-                        <div className="icon-inline">
-                            <LoadingSpinner className="icon-inline" />
-                        </div>
-                    )}
-                </Form>
+                ) : (
+                    <>
+                        {this.state.error && (
+                            <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>
+                        )}
+                        {this.state.saved && <p className="alert alert-success">Password changed!</p>}
+                        <Form onSubmit={this.handleSubmit}>
+                            {/* Include a username field as a hint for password managers to update the saved password. */}
+                            <input
+                                type="text"
+                                value={this.props.user.username}
+                                name="username"
+                                autoComplete="username"
+                                readOnly={true}
+                                hidden={true}
+                            />
+                            <div className="form-group">
+                                <label>Old password</label>
+                                <PasswordInput
+                                    value={this.state.oldPassword}
+                                    onChange={this.onOldPasswordFieldChange}
+                                    disabled={this.state.loading}
+                                    name="oldPassword"
+                                    placeholder=" "
+                                    autoComplete="current-password"
+                                />
+                            </div>
+                            <div className="form-group">
+                                <label>New password</label>
+                                <PasswordInput
+                                    value={this.state.newPassword}
+                                    onChange={this.onNewPasswordFieldChange}
+                                    disabled={this.state.loading}
+                                    name="newPassword"
+                                    placeholder=" "
+                                    autoComplete="new-password"
+                                />
+                            </div>
+                            <div className="form-group">
+                                <label>Confirm new password</label>
+                                <PasswordInput
+                                    value={this.state.newPasswordConfirmation}
+                                    onChange={this.onNewPasswordConfirmationFieldChange}
+                                    disabled={this.state.loading}
+                                    name="newPasswordConfirmation"
+                                    placeholder=" "
+                                    inputRef={this.setNewPasswordConfirmationField}
+                                    autoComplete="new-password"
+                                />
+                            </div>
+                            <button
+                                className="btn btn-primary user-account-password-page__button"
+                                type="submit"
+                                disabled={this.state.loading}
+                            >
+                                Update password
+                            </button>
+                            {this.state.loading && (
+                                <div className="icon-inline">
+                                    <LoadingSpinner className="icon-inline" />
+                                </div>
+                            )}
+                        </Form>
+                    </>
+                )}
             </div>
         )
     }

--- a/src/user/account/UserAccountSidebar.tsx
+++ b/src/user/account/UserAccountSidebar.tsx
@@ -3,6 +3,7 @@ import ConsoleIcon from 'mdi-react/ConsoleIcon'
 import LogoutIcon from 'mdi-react/LogoutIcon'
 import * as React from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
+import * as GQL from '../../backend/graphqlschema'
 import {
     SIDEBAR_BUTTON_CLASS,
     SidebarGroup,
@@ -17,9 +18,7 @@ import { NavItemDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
 
 export interface UserAccountSidebarItemConditionContext {
-    /** True if the site admin is viewing another user's account */
-    siteAdminViewingOtherUser: boolean
-    externalAuthEnabled: boolean
+    authProviders: GQL.IAuthProvider[]
 }
 
 export type UserAccountSidebarItems = Record<
@@ -29,8 +28,8 @@ export type UserAccountSidebarItems = Record<
 
 export interface UserAccountSidebarProps extends UserAreaRouteContext, RouteComponentProps<{}> {
     items: UserAccountSidebarItems
+    authProviders: GQL.IAuthProvider[]
     className?: string
-    externalAuthEnabled: boolean
 }
 
 /** Sidebar for user account pages. */
@@ -56,10 +55,7 @@ export const UserAccountSidebar: React.SFC<UserAccountSidebarProps> = props => {
                 <SidebarGroupItems>
                     {props.items.account.map(
                         ({ label, to, exact, condition = () => true }) =>
-                            condition({
-                                siteAdminViewingOtherUser,
-                                externalAuthEnabled: props.externalAuthEnabled,
-                            }) && (
+                            condition({ authProviders: props.authProviders }) && (
                                 <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
                                     {label}
                                 </SidebarNavItem>

--- a/src/user/account/routes.tsx
+++ b/src/user/account/routes.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { UserAccountAccountPage } from './UserAccountAccountPage'
 import { UserAccountAreaRoute } from './UserAccountArea'
 import { UserAccountCreateAccessTokenPage } from './UserAccountCreateAccessTokenPage'
 import { UserAccountEmailsPage } from './UserAccountEmailsPage'
+import { UserAccountPasswordPage } from './UserAccountPasswordPage'
 import { UserAccountProfilePage } from './UserAccountProfilePage'
 import { UserAccountTokensPage } from './UserAccountTokensPage'
 
@@ -15,10 +15,10 @@ export const userAccountAreaRoutes: ReadonlyArray<UserAccountAreaRoute> = [
         render: props => <UserAccountProfilePage {...props} />,
     },
     {
-        path: '/account',
+        path: '/password',
         exact: true,
         // tslint:disable-next-line:jsx-no-lambda
-        render: props => <UserAccountAccountPage {...props} />,
+        render: props => <UserAccountPasswordPage {...props} />,
         condition: ({ externalAuthEnabled }) => externalAuthEnabled,
     },
     {

--- a/src/user/account/routes.tsx
+++ b/src/user/account/routes.tsx
@@ -19,7 +19,6 @@ export const userAccountAreaRoutes: ReadonlyArray<UserAccountAreaRoute> = [
         exact: true,
         // tslint:disable-next-line:jsx-no-lambda
         render: props => <UserAccountPasswordPage {...props} />,
-        condition: ({ externalAuthEnabled }) => externalAuthEnabled,
     },
     {
         path: '/emails',

--- a/src/user/account/sidebaritems.ts
+++ b/src/user/account/sidebaritems.ts
@@ -11,8 +11,8 @@ export const userAccountSideBarItems: UserAccountSidebarItems = {
             label: 'Password',
             to: `/password`,
             exact: true,
-            condition: ({ siteAdminViewingOtherUser, externalAuthEnabled }) =>
-                siteAdminViewingOtherUser && !externalAuthEnabled,
+            // Only the builtin auth provider has a password.
+            condition: ({ authProviders }) => authProviders.some(({ isBuiltin }) => isBuiltin),
         },
         {
             label: 'Emails',

--- a/src/user/account/sidebaritems.ts
+++ b/src/user/account/sidebaritems.ts
@@ -9,7 +9,7 @@ export const userAccountSideBarItems: UserAccountSidebarItems = {
         },
         {
             label: 'Password',
-            to: `/account`,
+            to: `/password`,
             exact: true,
             condition: ({ siteAdminViewingOtherUser, externalAuthEnabled }) =>
                 siteAdminViewingOtherUser && !externalAuthEnabled,


### PR DESCRIPTION
Previously, the logic for whether to show the change-password page was wrong. It also did not have the correct values in the condition context to determine whether to show it.

So, this commit exposes authProviders to all viewers in GraphQL, and makes them available in siteFlags to UI components. This is OK because the AuthProvider GraphQL type only exposes the same information about auth providers that users could see if they logged into them (e.g., the client ID, which is by definition a non-secret value).

A more limited set of authProvider info was already made available on `window.context` to construct the sign-in page on instances with multiple auth providers and `auth.public == false`. It is not possible to make that use the GraphQL authProviders result because viewers of that page are not yet authenticated and are therefore prevented from accessing the GraphQL API entirely. It may be possible for the UserAccountPasswordPage to use those window.context values, but it instead uses them from GraphQL to avoid more dependencies on window.context values (which operate outside of the React data flow model).

fix https://github.com/sourcegraph/enterprise/issues/12077


> This PR updates the CHANGELOG.md file to describe any user-facing changes.