### PR TITLE
fix logic for showing loading spinner on "Repository disabled" page

### DIFF
--- a/src/repo/RepositoryErrorPage.tsx
+++ b/src/repo/RepositoryErrorPage.tsx
@@ -294,7 +294,7 @@ export class RepositoryErrorPage extends React.PureComponent<Props, State> {
                                             onClick={this.enableRepository}
                                             disabled={this.state.enabledOrError === 'loading'}
                                         >
-                                            {this.state.enabledOrError !== 'loading' ? (
+                                            {this.state.enabledOrError === 'loading' ? (
                                                 <LoadingSpinner className="icon-inline" />
                                             ) : (
                                                 <CheckCircleIcon className="icon-inline" />


### PR DESCRIPTION
fix #474

