### PR TITLE
Link to default branch when no rev is given

### DIFF
--- a/src/repo/RepoContainer.tsx
+++ b/src/repo/RepoContainer.tsx
@@ -236,8 +236,14 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                         <GoToCodeHostAction
                             key="go-to-code-host"
                             repo={this.state.repoOrError}
-                            // We need a rev to generate code host URLs, since we don't have a default use HEAD.
-                            rev={this.state.rev || 'HEAD'}
+                            // We need a rev to generate code host URLs, if rev isn't available, we use the default branch or HEAD.
+                            rev={
+                                this.state.rev ||
+                                (!isErrorLike(this.state.repoOrError) &&
+                                    this.state.repoOrError.defaultBranch &&
+                                    this.state.repoOrError.defaultBranch.displayName) ||
+                                'HEAD'
+                            }
                             filePath={filePath}
                             commitRange={commitRange}
                             position={position}

--- a/src/repo/actions/GoToCodeHostAction.tsx
+++ b/src/repo/actions/GoToCodeHostAction.tsx
@@ -71,6 +71,13 @@ export class GoToCodeHostAction extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
+        // If the default branch is undefined, set to HEAD
+        const defaultBranch =
+            (!isErrorLike(this.props.repo) &&
+                this.props.repo &&
+                this.props.repo.defaultBranch &&
+                this.props.repo.defaultBranch.displayName) ||
+            'HEAD'
         // If neither repo or file can be loaded, return null, which will hide all code host icons
         if (!this.props.repo || isErrorLike(this.state.fileExternalLinksOrError)) {
             return null
@@ -105,7 +112,7 @@ export class GoToCodeHostAction extends React.PureComponent<Props, State> {
         let url = externalURL.url
         if (externalURL.serviceType === 'github') {
             // If in a branch, add branch path to the GitHub URL.
-            if (this.props.rev && this.props.rev !== 'HEAD' && !this.state.fileExternalLinksOrError) {
+            if (this.props.rev && this.props.rev !== defaultBranch && !this.state.fileExternalLinksOrError) {
                 url += `/tree/${this.props.rev}`
             }
             // If showing a comparison, add comparison specifier to the GitHub URL.

--- a/src/repo/backend.tsx
+++ b/src/repo/backend.tsx
@@ -59,6 +59,9 @@ export const fetchRepository = memoizeObservable(
                         enabled
                         viewerCanAdminister
                         redirectURL
+                        defaultBranch {
+                            displayName
+                        }
                     }
                 }
             `,


### PR DESCRIPTION
Link to default branch when no rev is given. Fixes #407 .

Originally, if no rev was given, the Go-To-Github Url would link to "HEAD", which in Github would be the latest commit SHA instead of the master/default branch. This meant an additional step of switching to the default branch if one wanted to edit the file. 

Instead of linking to "HEAD", this PR makes it that we link to the default branch.

> This PR updates the CHANGELOG.md file to describe any user-facing changes.

