### PR TITLE
Correct URL for SVGs

### DIFF
--- a/src/search/input/MainPage.scss
+++ b/src/search/input/MainPage.scss
@@ -624,52 +624,52 @@ body.main-page {
         }
         .btn-github {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/github.png);
+                background-image: url(https://about.sourcegraph.com/integration/icons/github.png);
             }
         }
         .btn-gitlab {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/gitlab.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/gitlab.svg);
             }
         }
         .btn-phabricator {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/phabricator.png);
+                background-image: url(https://about.sourcegraph.com/integration/icons/phabricator.png);
             }
         }
         .btn-chrome {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/chrome.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/chrome.svg);
             }
         }
         .btn-firefox {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/firefox.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/firefox.svg);
             }
         }
         .btn-atom {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/atom.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/atom.svg);
             }
         }
         .btn-intellij {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/jetbrains.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/jetbrains.svg);
             }
         }
         .btn-vscode {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/vscode.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/vscode.svg);
             }
         }
         .btn-sublime {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/sublime.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/sublime.svg);
             }
         }
         .btn-vim {
             .logo-icon {
-                background-image: url(https://docs.sourcegraph.com/integration/icons/vim.svg);
+                background-image: url(https://about.sourcegraph.com/integration/icons/vim.svg);
             }
         }
     }


### PR DESCRIPTION
Revert URLs for SVGs for third party icons back to about.sourcegraph.com from docs.sourcegraph.com.