### PR TITLE
fix: bump sourcegraph to 18.0.1 and e-c-c

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -894,6 +894,13 @@
     "@shellscape/koa-send" "^4.1.0"
     debug "^2.6.8"
 
+"@shopify/react-shortcuts@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@shopify/react-shortcuts/-/react-shortcuts-1.0.2.tgz#01d9f6979ff5cce1d70474e1452fb750f7bbe819"
+  integrity sha512-KEQd0IKSE/IRmPn5MfboeBxJzh5KGb7OLvpfoxjhcbijj/YsU117H62PKsjBuPMc0fi0f8jTIeg938w2y0U5xg==
+  dependencies:
+    prop-types "^15.6.2"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -925,10 +932,11 @@
     vscode-languageserver-types "^3.8.2"
 
 "@sourcegraph/extensions-client-common@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.0.0.tgz#bba96eaa344d3eee949a013ad88bd05231987a52"
-  integrity sha512-AHiGYYN1hAV8QuMaGufi02mP86Bg/rFwo9+hj3UOKZMO6CdgQtFeOvIoFcj0Q13K4MxueYiZId6YopfI71ZZHg==
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.2.1.tgz#a9ba194996d5936e59c9f2158d3e6bc7202956fd"
+  integrity sha512-JjdSqBG2XrDWzEl8SIzb7ALu/Q6mxSmaPYHAugDh9NxtI/obFwDTiapGf+GIEipV8BARSoBBZbxlHUl/eQHi+g==
   dependencies:
+    "@shopify/react-shortcuts" "^1.0.2"
     bootstrap "^4.1.3"
     lodash-es "^4.17.10"
     react "^16.4.2"
@@ -9193,10 +9201,24 @@ react@^16.4.2:
     prop-types "^15.6.2"
     schedule "^0.4.0"
 
-reactstrap@^6.2.0, reactstrap@^6.4.0:
+reactstrap@^6.2.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-6.4.0.tgz#891252a284710180cd3d746dd236ee61d28a1c66"
   integrity sha512-+O0pnbsheW4i6wE96KlSpIhbnZM9EJv0XUYVuFbzLElRp33WrMKvX9YTgGgJQEqHLCJYYdJBi+fGm/hTwTfsCQ==
+  dependencies:
+    classnames "^2.2.3"
+    lodash.isfunction "^3.0.9"
+    lodash.isobject "^3.0.2"
+    lodash.tonumber "^4.0.3"
+    prop-types "^15.5.8"
+    react-lifecycles-compat "^3.0.4"
+    react-popper "^0.10.4"
+    react-transition-group "^2.3.1"
+
+reactstrap@^6.4.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-6.5.0.tgz#ba655e32646e2621829f61faa033e607ec6624e5"
+  integrity sha512-dWb3fB/wBAiQloteKlf+j9Nl2VLe6BMZgTEt6hpeTt0t9TwtkeU+2v2NBYONZaF4FZATfMiIKozhWpc2HmLW1g==
   dependencies:
     classnames "^2.2.3"
     lodash.isfunction "^3.0.9"
@@ -10126,9 +10148,9 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 sourcegraph@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-18.0.0.tgz#bbb61f7ab03ed169138d12dd258b1195198fe851"
-  integrity sha512-0bhjDK5gMMX/O7TkBMU49XDgHD3YOki/aqzdz+MoQd94aGrD1OxsAugINUHH+Kq3zGWZZPBmZiPTqM9iIkBkXw==
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-18.0.1.tgz#7e741c1521337cb799fc0f8f1ecc6dd8158aa504"
+  integrity sha512-fhrbx6v0s0sAcdiO5VoxI/es0bhTy5npksT+EHENUj94L2KcRj39qlH4RYwutZgn7K/dirnX7tso/H9K9+c0Lw==
   dependencies:
     minimatch "^3.0.4"
     rxjs "^6.3.2"


### PR DESCRIPTION
This suppresses an unnecessary console error when disabling Sourcegraph extensions.

> This PR does not need to update the CHANGELOG because it's a tiny bug fix.
