### PR TITLE
Fix usages of db. UserEmails.GetPrimaryEmail that shouldn't fail if no email…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to Sourcegraph are documented in this file.
 - The experimental feature flag to disable the new repo update scheduler has been removed.
 - The `experimentalFeatures.configVars` feature flag was removed.
 
+### Fixed
+
+- Fixed an error that prevented users without emails from submitting satisfaction surveys.
+
 ## 2.12.1
 
 ### Fixed

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/siteid"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
+	"github.com/sourcegraph/sourcegraph/pkg/errcode"
 	"github.com/sourcegraph/sourcegraph/pkg/hubspot/hubspotutil"
 )
 
@@ -84,7 +85,7 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 	if actor.IsAuthenticated() {
 		uid = &actor.UID
 		e, _, err := db.UserEmails.GetPrimaryEmail(ctx, actor.UID)
-		if err != nil {
+		if err != nil && !errcode.IsNotFound(err) {
 			return nil, err
 		}
 		if e != "" {

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -59,7 +59,7 @@ func UnmarshalUserID(id graphql.ID) (userID int32, err error) {
 
 func (r *UserResolver) SourcegraphID() int32 { return r.user.ID }
 
-// Email returns the user's oldest verified email, if one exists.
+// Email returns the user's oldest email, if one exists.
 // DEPRECATED: use Emails instead.
 func (r *UserResolver) Email(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to access the email address.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -59,6 +59,8 @@ func UnmarshalUserID(id graphql.ID) (userID int32, err error) {
 
 func (r *UserResolver) SourcegraphID() int32 { return r.user.ID }
 
+// Email returns the user's oldest verified email, if one exists.
+// DEPRECATED: use Emails instead.
 func (r *UserResolver) Email(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to access the email address.
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
@@ -66,7 +68,7 @@ func (r *UserResolver) Email(ctx context.Context) (string, error) {
 	}
 
 	email, _, err := db.UserEmails.GetPrimaryEmail(ctx, r.user.ID)
-	if err != nil {
+	if err != nil && !errcode.IsNotFound(err) {
 		return "", err
 	}
 

--- a/src/tracking/eventLogger.tsx
+++ b/src/tracking/eventLogger.tsx
@@ -44,15 +44,7 @@ class EventLogger {
     /**
      * Set user-level properties in all external tracking services
      */
-    public updateUser(
-        user:
-            | GQL.IUser
-            | {
-                  sourcegraphID: number | null
-                  username: string | null
-                  email: string | null
-              }
-    ): void {
+    public updateUser(user: GQL.IUser): void {
         this.setUserIds(user.sourcegraphID, user.username)
         if (user.email) {
             this.setUserEmail(user.email)


### PR DESCRIPTION
… is found

Fixes two instances in which `db.User.GetPrimaryEmail` is called that shouldn't fail when a primary email is not found:
* Satisfaction survey submissions
* GraphQL `UserResolver.Email` handler

This reverts https://github.com/sourcegraph/sourcegraph/commit/bcb29723056edaf317d865db550ecbdfd7e94c12, and fixes the issue that caused it in the first place 

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
