### PR TITLE
fix: use v3 in baseURL when fetching GHE repos

### DIFF
--- a/cmd/repo-updater/internal/externalservice/github/repos.go
+++ b/cmd/repo-updater/internal/externalservice/github/repos.go
@@ -301,9 +301,14 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 // ListViewerRepositories lists GitHub repositories affiliated with the viewer
 // (the currently authenticated user). page is the page of results to
 // return. Pages are 1-indexed (so the first call should be for page 1).
-func (c *Client) ListViewerRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+func (c *Client) ListViewerRepositories(ctx context.Context, page int, gitHubDotCom bool) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	var restRepos []restRepository
-	path := fmt.Sprintf("user/repos?sort=pushed&page=%d", page)
+	var path string
+	if gitHubDotCom {
+		path = fmt.Sprintf("user/repos?sort=pushed&page=%d", page)
+	} else {
+		path = fmt.Sprintf("v3/user/repos?sort=pushed&page=%d", page)
+	}
 	if err := c.requestGet(ctx, path, &restRepos); err != nil {
 		return nil, false, 1, err
 	}

--- a/cmd/repo-updater/internal/externalservice/github/repos.go
+++ b/cmd/repo-updater/internal/externalservice/github/repos.go
@@ -1,12 +1,11 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"context"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -301,10 +300,10 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 // ListViewerRepositories lists GitHub repositories affiliated with the viewer
 // (the currently authenticated user). page is the page of results to
 // return. Pages are 1-indexed (so the first call should be for page 1).
-func (c *Client) ListViewerRepositories(ctx context.Context, page int, gitHubDotCom bool) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+func (c *Client) ListViewerRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	var restRepos []restRepository
 	var path string
-	if gitHubDotCom {
+	if c.githubDotCom {
 		path = fmt.Sprintf("user/repos?sort=pushed&page=%d", page)
 	} else {
 		path = fmt.Sprintf("v3/user/repos?sort=pushed&page=%d", page)

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -10,14 +10,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/pkg/atomicvalue"
-	"github.com/sourcegraph/sourcegraph/pkg/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
-
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/internal/externalservice/github"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/atomicvalue"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
@@ -55,8 +54,8 @@ func init() {
 				// Add a GitHub.com entry by default, to support navigating to URL paths like
 				// /github.com/foo/bar to auto-add that repository.
 				githubConf = append(githubConf, &schema.GitHubConnection{
-					RepositoryQuery: []string{"none"}, // don't try to list all repositories during syncs
-					Url:             "https://github.com",
+					RepositoryQuery:             []string{"none"}, // don't try to list all repositories during syncs
+					Url:                         "https://github.com",
 					InitialRepositoryEnablement: true,
 				})
 			}
@@ -424,7 +423,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) <-chan *gith
 					var repos []*github.Repository
 					var rateLimitCost int
 					var err error
-					repos, hasNextPage, rateLimitCost, err = c.client.ListViewerRepositories(ctx, page, c.githubDotCom)
+					repos, hasNextPage, rateLimitCost, err = c.client.ListViewerRepositories(ctx, page)
 					if err != nil {
 						log15.Error("Error listing viewer's affiliated GitHub repositories", "page", page, "error", err)
 						break

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -55,8 +55,8 @@ func init() {
 				// Add a GitHub.com entry by default, to support navigating to URL paths like
 				// /github.com/foo/bar to auto-add that repository.
 				githubConf = append(githubConf, &schema.GitHubConnection{
-					RepositoryQuery:             []string{"none"}, // don't try to list all repositories during syncs
-					Url:                         "https://github.com",
+					RepositoryQuery: []string{"none"}, // don't try to list all repositories during syncs
+					Url:             "https://github.com",
 					InitialRepositoryEnablement: true,
 				})
 			}
@@ -424,7 +424,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) <-chan *gith
 					var repos []*github.Repository
 					var rateLimitCost int
 					var err error
-					repos, hasNextPage, rateLimitCost, err = c.client.ListViewerRepositories(ctx, page)
+					repos, hasNextPage, rateLimitCost, err = c.client.ListViewerRepositories(ctx, page, c.githubDotCom)
 					if err != nil {
 						log15.Error("Error listing viewer's affiliated GitHub repositories", "page", page, "error", err)
 						break


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/440 by checking if we are fetching from GitHub Enterprise or GitHub and updating the baseURL accordingly.