### PR TITLE
use @slimsag/react-shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@babel/core": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/polyfill": "^7.0.0",
-    "@shopify/react-shortcuts": "^1.0.2",
+    "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^3.9.0",
     "@sourcegraph/extensions-client-common": "^10.2.0",
     "@sqs/jsonc-parser": "^1.0.3",

--- a/src/SourcegraphWebApp.tsx
+++ b/src/SourcegraphWebApp.tsx
@@ -1,4 +1,4 @@
-import { ShortcutProvider } from '@shopify/react-shortcuts'
+import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import { Notifications } from '@sourcegraph/extensions-client-common/lib/app/notifications/Notifications'
 import { createController as createExtensionsController } from '@sourcegraph/extensions-client-common/lib/client/controller'
 import { ConfiguredExtension } from '@sourcegraph/extensions-client-common/lib/extensions/extension'

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -1,4 +1,4 @@
-import { Key, ModifierKey } from '@shopify/react-shortcuts'
+import { Key, ModifierKey } from '@slimsag/react-shortcuts'
 
 /**
  * A map of action names to the keys that trigger them. The actions are their own namespace for now, but it will be

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,6 +906,13 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@slimsag/react-shortcuts@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@slimsag/react-shortcuts/-/react-shortcuts-1.2.1.tgz#a3ea054a057137de8636bc9fabac61369103e597"
+  integrity sha512-dUTQjBX1yjnHbqkTL5ditqtx5R6QhcXI3lCnjOy8e5XUOr5LOtVpol1mufU2lAb7DtEYrSVRQpUeNmZrTEgLcg==
+  dependencies:
+    prop-types "^15.6.2"
+
 "@sourcegraph/codeintellify@^3.9.0":
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/@sourcegraph/codeintellify/-/codeintellify-3.9.0.tgz#1e3f002558cc367e8c5ee9b0a54e0c47c6ee8761"


### PR DESCRIPTION
See https://github.com/sourcegraph/browser-extensions/pull/263 for motivation

> This PR does not need to update the CHANGELOG because no user-facing changes.
