### PR TITLE
limit length of matching characters to length of line minus offset

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -1,6 +1,7 @@
 package graphqlbackend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -521,6 +522,10 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 				}
 				offsets := make([][2]int32, len(l.LineFragments))
 				for k, m := range l.LineFragments {
+					l.Line = bytes.Split(l.Line, []byte{'\n'})[0]
+					if m.LineOffset+m.MatchLength > len(l.Line) {
+						m.MatchLength = len(l.Line) - m.LineOffset
+					}
 					offset := utf8.RuneCount(l.Line[:m.LineOffset])
 					length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 					offsets[k] = [2]int32{int32(offset), int32(length)}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -560,10 +560,10 @@ func queryToZoektQuery(query *search.PatternInfo) (zoektquery.Q, error) {
 	parseRe := func(pattern string, filenameOnly bool) (zoektquery.Q, error) {
 		// these are the flags used by zoekt, which differ to searcher.
 		re, err := syntax.Parse(pattern, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
-		noOpAnyChar(re)
 		if err != nil {
 			return nil, err
 		}
+		noOpAnyChar(re)
 		// zoekt decides to use its literal optimization at the query parser
 		// level, so we check if our regex can just be a literal.
 		if re.Op == syntax.OpLiteral {


### PR DESCRIPTION
Issue https://github.com/sourcegraph/enterprise/issues/11960 revealed that using a quantifier combined with regex that takes any character and line breaks (e.g. `test(.|\s)*`) will lead to a wrong number of matched characters per line when using indexed search.

Example: searching for `repo:sourcegraph test(.|\s)*` shows these results with no highlighting:
![image](https://user-images.githubusercontent.com/9110008/47478290-cf45c300-d7dd-11e8-94ba-92f2707272b3.png)

When using indexed search, the length (number of matching characters per line) with the above mentioned search actually returns the number of matching characters from the offset to the end of the file, leading to this condition in `dom.tsx` to return and cancel the highlighting.
``` // return if length is invalid/longer than remaining characters between start and end
    if (length > node.textContent!.length - start) {
        return
    }
```

`length` can be traced down to `textsearch.go`. If the search is conducted with index search, printing offset, length and l.Line, show that l.Line is in fact a combination off all lines separated by `\n` starting from the offset.

```
...,"lineMatches":[{"preview":"group :development, :test do\n  gem 'byebug'\n  gem 'annotate'\nend\n","lineNumber":31,"offsetAndLengths":[[21,44]]}]}],"alert":null,"elapsedMilliseconds":14}}}}
```

The same search using graphQL however returns the correct line and thus length.
```
...,"lineMatches":[{"preview":"group :development, :test do","lineNumber":31,"offsetAndLengths":[[21,7]]}]}],"alert":null,"elapsedMilliseconds":63}}}}
```

This current solution is a workaround, as the source of the problem most likely is located in zoekt, where `MatchLength` does not seem to be limited to matching text within a line when a search is performed with e.g. `test(.|\s)*`:
https://sourcegraph.com/github.com/sourcegraph/zoekt/-/blob/api.go#L80-90
@keegancsmith would you want to investigate this?

The workaround splits the lines by `\n` and limits the length of `m.MatchLength` by `len(l.Line)-m.LineOffset`

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
