### PR TITLE
use relative URIs for JSON Schemas

### DIFF
--- a/pkg/conf/validate.go
+++ b/pkg/conf/validate.go
@@ -131,9 +131,9 @@ type jsonLoaderFactory struct{}
 
 func (f jsonLoaderFactory) New(source string) gojsonschema.JSONLoader {
 	switch source {
-	case "https://sourcegraph.com/v1/settings.schema.json":
+	case "settings.schema.json":
 		return gojsonschema.NewStringLoader(schema.SettingsSchemaJSON)
-	case "https://sourcegraph.com/v1/site.schema.json":
+	case "site.schema.json":
 		return gojsonschema.NewStringLoader(schema.SiteSchemaJSON)
 	}
 	return nil

--- a/schema/extension.schema.json
+++ b/schema/extension.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sourcegraph.com/v1/extension.schema.json#",
+  "$id": "extension.schema.json#",
   "title": "Sourcegraph extension manifest",
   "description": "The Sourcegraph extension manifest describes the extension and the features it provides.",
   "type": "object",

--- a/schema/extension_stringdata.go
+++ b/schema/extension_stringdata.go
@@ -5,7 +5,7 @@ package schema
 // ExtensionSchemaJSON is the content of the file "extension.schema.json".
 const ExtensionSchemaJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sourcegraph.com/v1/extension.schema.json#",
+  "$id": "extension.schema.json#",
   "title": "Sourcegraph extension manifest",
   "description": "The Sourcegraph extension manifest describes the extension and the features it provides.",
   "type": "object",

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sourcegraph.com/v1/settings.schema.json#",
+  "$id": "settings.schema.json#",
   "title": "Settings",
   "description": "Configuration settings for users and organizations on Sourcegraph.",
   "type": "object",
@@ -44,7 +44,7 @@
       "description": "Predefined search scopes",
       "type": "array",
       "items": {
-        "$ref": "https://sourcegraph.com/v1/settings.schema.json#/definitions/SearchScope"
+        "$ref": "#/definitions/SearchScope"
       }
     },
     "search.repositoryGroups": {
@@ -57,7 +57,7 @@
       }
     },
     "notifications.slack": {
-      "$ref": "https://sourcegraph.com/v1/settings.schema.json#/definitions/SlackNotificationsConfig"
+      "$ref": "#/definitions/SlackNotificationsConfig"
     },
     "motd": {
       "description":

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -5,7 +5,7 @@ package schema
 // SettingsSchemaJSON is the content of the file "settings.schema.json".
 const SettingsSchemaJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sourcegraph.com/v1/settings.schema.json#",
+  "$id": "settings.schema.json#",
   "title": "Settings",
   "description": "Configuration settings for users and organizations on Sourcegraph.",
   "type": "object",
@@ -49,7 +49,7 @@ const SettingsSchemaJSON = `{
       "description": "Predefined search scopes",
       "type": "array",
       "items": {
-        "$ref": "https://sourcegraph.com/v1/settings.schema.json#/definitions/SearchScope"
+        "$ref": "#/definitions/SearchScope"
       }
     },
     "search.repositoryGroups": {
@@ -62,7 +62,7 @@ const SettingsSchemaJSON = `{
       }
     },
     "notifications.slack": {
-      "$ref": "https://sourcegraph.com/v1/settings.schema.json#/definitions/SlackNotificationsConfig"
+      "$ref": "#/definitions/SlackNotificationsConfig"
     },
     "motd": {
       "description":

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sourcegraph.com/v1/site.schema.json#",
+  "$id": "site.schema.json#",
   "title": "Site configuration",
   "description": "Configuration for a Sourcegraph site.",
   "type": "object",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -5,7 +5,7 @@ package schema
 // SiteSchemaJSON is the content of the file "site.schema.json".
 const SiteSchemaJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sourcegraph.com/v1/site.schema.json#",
+  "$id": "site.schema.json#",
   "title": "Site configuration",
   "description": "Configuration for a Sourcegraph site.",
   "type": "object",

--- a/src/settings/MonacoSettingsEditor.tsx
+++ b/src/settings/MonacoSettingsEditor.tsx
@@ -155,7 +155,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
                     schema: jsonSchemaMetaSchema,
                 },
                 {
-                    uri: 'https://sourcegraph.com/v1/settings.schema.json#',
+                    uri: 'settings.schema.json#',
                     schema: settingsSchema,
                 },
                 {
@@ -165,7 +165,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
                     schema: contributionSchema,
                 },
                 {
-                    // This is the absolute URI of the contributions JSON Schema.
+                    // This is the absolute URI of the contributions JSON Schema used in extension.schema.json.
                     uri: 'https://sourcegraph.com/v1/contribution.schema.json#',
                     schema: contributionSchema,
                 },


### PR DESCRIPTION
The absolute URIs we were previously using were fake. Using relative URIs is supported by all of the tooling related to JSON Schema that we use, and it's simpler.

fix #506 (there are some remaining absolute JSON Schema URIs in extensions-client-common)