### PR TITLE
Add hook for enterprise services started at launch, remove unused (in…

### DIFF
--- a/cmd/frontend/graphqlbackend/product_subscription_status.go
+++ b/cmd/frontend/graphqlbackend/product_subscription_status.go
@@ -2,14 +2,18 @@ package graphqlbackend
 
 import (
 	"context"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 )
 
 // GetProductNameWithBrand is called to obtain the full product name (e.g., "Sourcegraph OSS") from a
 // product license.
 var GetProductNameWithBrand = func(hasLicense bool, licenseTags []string) string {
 	return "Sourcegraph OSS"
+}
+
+// ActualUserCount is called to obtain the actual maximum number of user accounts that have been active
+// on this Sourcegraph instance for the current license.
+var ActualUserCount = func(ctx context.Context) (int32, error) {
+	return 0, nil
 }
 
 // productSubscriptionStatus implements the GraphQL type ProductSubscriptionStatus.
@@ -29,8 +33,7 @@ func (productSubscriptionStatus) ProductNameWithBrand() (string, error) {
 }
 
 func (productSubscriptionStatus) ActualUserCount(ctx context.Context) (int32, error) {
-	count, err := db.Users.Count(ctx, nil)
-	return int32(count), err
+	return ActualUserCount(ctx)
 }
 
 func (r productSubscriptionStatus) License() (*ProductLicenseInfo, error) {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3114,7 +3114,8 @@ type SurveyResponse {
 type ProductSubscriptionStatus {
     # The full name of the product in use, such as "Sourcegraph Enterprise".
     productNameWithBrand: String!
-    # The actual total number of users on this Sourcegraph site.
+    # The max number of user accounts that have been active on this Sourcegraph site for the current license.
+    # If no license is in use, return zero.
     actualUserCount: Int!
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3115,7 +3115,7 @@ type ProductSubscriptionStatus {
     # The full name of the product in use, such as "Sourcegraph Enterprise".
     productNameWithBrand: String!
     # The max number of user accounts that have been active on this Sourcegraph site for the current license.
-    # If no license is in use, return zero.
+    # If no license is in use, returns zero.
     actualUserCount: Int!
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3121,7 +3121,8 @@ type SurveyResponse {
 type ProductSubscriptionStatus {
     # The full name of the product in use, such as "Sourcegraph Enterprise".
     productNameWithBrand: String!
-    # The actual total number of users on this Sourcegraph site.
+    # The max number of user accounts that have been active on this Sourcegraph site for the current license.
+    # If no license is in use, return zero.
     actualUserCount: Int!
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3122,7 +3122,7 @@ type ProductSubscriptionStatus {
     # The full name of the product in use, such as "Sourcegraph Enterprise".
     productNameWithBrand: String!
     # The max number of user accounts that have been active on this Sourcegraph site for the current license.
-    # If no license is in use, return zero.
+    # If no license is in use, returns zero.
     actualUserCount: Int!
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -6,6 +6,6 @@ import "net/http"
 // middleware. The client is not yet authenticated when PreAuthMiddleware is called.
 var PreAuthMiddleware func(http.Handler) http.Handler
 
-// EnterpriseLaunch is run as a goroutine on product launch, providing a hook for Enterprise
-// background services.
-var EnterpriseLaunch func()
+// AfterDBInit is called after the database is initialized, and can be used to
+// e.g. launch background services that depend on the database.
+var AfterDBInit func()

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -5,3 +5,7 @@ import "net/http"
 // PreAuthMiddleware is an HTTP handler middleware that, if set, runs just before auth-related
 // middleware. The client is not yet authenticated when PreAuthMiddleware is called.
 var PreAuthMiddleware func(http.Handler) http.Handler
+
+// EnterpriseLaunch is run as a goroutine on product launch, providing a hook for Enterprise
+// background services.
+var EnterpriseLaunch func()

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -157,7 +157,7 @@ func Main() error {
 	goroutine.Go(mailreply.StartWorker)
 	go updatecheck.Start()
 	if hooks.EnterpriseLaunch != nil {
-		go hooks.EnterpriseLaunch()
+		goroutine.Go(hooks.EnterpriseLaunch())
 	}
 
 	tlsCertAndKey := tlsCert != "" && tlsKey != ""

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -156,8 +156,8 @@ func Main() error {
 	})
 	goroutine.Go(mailreply.StartWorker)
 	go updatecheck.Start()
-	if hooks.EnterpriseLaunch != nil {
-		goroutine.Go(hooks.EnterpriseLaunch())
+	if hooks.AfterDBInit != nil {
+		hooks.AfterDBInit()
 	}
 
 	tlsCertAndKey := tlsCert != "" && tlsKey != ""

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/pkg/updatecheck"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/loghandlers"
@@ -155,6 +156,9 @@ func Main() error {
 	})
 	goroutine.Go(mailreply.StartWorker)
 	go updatecheck.Start()
+	if hooks.EnterpriseLaunch != nil {
+		go hooks.EnterpriseLaunch()
+	}
 
 	tlsCertAndKey := tlsCert != "" && tlsKey != ""
 	useTLS := httpsAddr != "" && (tlsCertAndKey || (globals.AppURL.Scheme == "https" && conf.GetTODO().TlsLetsencrypt != "off"))


### PR DESCRIPTION
… OSS) and incorrect max user count reporting

> This PR does not need to update the CHANGELOG because there are no user-facing changes
