### PR TITLE
fix invalid elapsedMilliseconds value for empty search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The user account sidebar "Password" link (to the change-password form) is now shown correctly.
 - Fixed an issue where GitHub rate limits were underutilized if the remaining
   rate limit dropped below 150.
+- Fixed an issue where GraphQL field `elapsedMilliseconds` returned invalid value on empty searches
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -643,14 +643,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		if err != nil {
 			return nil, err
 		}
-		return &searchResultsResolver{alert: alert}, nil
+		return &searchResultsResolver{alert: alert, start: start}, nil
 	}
 	if overLimit {
 		alert, err := r.alertForOverRepoLimit(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return &searchResultsResolver{alert: alert}, nil
+		return &searchResultsResolver{alert: alert, start: start}, nil
 	}
 
 	p, err := r.getPatternInfo()


### PR DESCRIPTION
> This PR updates the CHANGELOG.md file to describe any user-facing changes.

# Overview

See #405 for full bug description. Empty search results coming back with a value of `2077252342` for `elapsedMilliseconds`.

# Fix

This wacky value is caused by returning structs (see: https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/graphqlbackend/search_results.go#L646) with a default Time value for `start`. When the date math gets done in `ElapsedMilliseconds`, it's basically calculating time elapsed since Epoch.