### PR TITLE
Store repo clone URL in database

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -116,8 +116,8 @@ func (s *repos) Add(ctx context.Context, uri api.RepoURI) (err error) {
 		// everywhere else, require server admins to explicitly enable repositories.
 		enableAutoAddedRepos := envvar.SourcegraphDotComMode()
 		if err := s.Upsert(ctx, api.InsertRepoOp{
-			URI: result.Repo.URI,
-			// TODO(): what should URL be here?
+			URI:          result.Repo.URI,
+			URL:          result.Repo.VCS.URL,
 			Description:  result.Repo.Description,
 			Fork:         result.Repo.Fork,
 			Archived:     result.Repo.Archived,

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -116,7 +116,8 @@ func (s *repos) Add(ctx context.Context, uri api.RepoURI) (err error) {
 		// everywhere else, require server admins to explicitly enable repositories.
 		enableAutoAddedRepos := envvar.SourcegraphDotComMode()
 		if err := s.Upsert(ctx, api.InsertRepoOp{
-			URI:          result.Repo.URI,
+			URI: result.Repo.URI,
+			// TODO(): what should URL be here?
 			Description:  result.Repo.Description,
 			Fork:         result.Repo.Fork,
 			Archived:     result.Repo.Archived,

--- a/cmd/frontend/db/migrations/bindata.go
+++ b/cmd/frontend/db/migrations/bindata.go
@@ -176,6 +176,8 @@
 // ../../../../migrations/1528395555_.up.sql (710B)
 // ../../../../migrations/1528395556_.down.sql (63B)
 // ../../../../migrations/1528395556_.up.sql (64B)
+// ../../../../migrations/1528395557_.down.sql (33B)
+// ../../../../migrations/1528395557_.up.sql (37B)
 
 package migrations
 
@@ -3764,6 +3766,46 @@ func _1528395556_UpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395557_DownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x28\x4a\x2d\xc8\x57\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x2d\xca\xb1\x06\x04\x00\x00\xff\xff\x04\x24\x65\x99\x21\x00\x00\x00")
+
+func _1528395557_DownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395557_DownSql,
+		"1528395557_.down.sql",
+	)
+}
+
+func _1528395557_DownSql() (*asset, error) {
+	bytes, err := _1528395557_DownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395557_.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x65, 0x34, 0x5b, 0xd4, 0x59, 0xe, 0xf7, 0x40, 0xe6, 0xf4, 0x41, 0x93, 0x68, 0xf3, 0xf2, 0x24, 0x84, 0xc4, 0x43, 0xfe, 0xf3, 0x7a, 0xb5, 0xe8, 0x20, 0x17, 0x62, 0x46, 0xe4, 0x85, 0x22, 0x97}}
+	return a, nil
+}
+
+var __1528395557_UpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x28\x4a\x2d\xc8\x57\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x2d\xca\x51\x28\x49\xad\x28\xb1\x06\x04\x00\x00\xff\xff\xe5\x1b\x81\x71\x25\x00\x00\x00")
+
+func _1528395557_UpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395557_UpSql,
+		"1528395557_.up.sql",
+	)
+}
+
+func _1528395557_UpSql() (*asset, error) {
+	bytes, err := _1528395557_UpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395557_.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x59, 0xd, 0x99, 0xee, 0xd6, 0xad, 0x9, 0xe1, 0x20, 0x47, 0xec, 0x47, 0x4d, 0x3e, 0xaf, 0xaa, 0xc2, 0x2d, 0xdc, 0x90, 0xbf, 0xaa, 0x7b, 0x36, 0x57, 0xe, 0xb7, 0xf2, 0xba, 0x61, 0x87, 0x70}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -4206,6 +4248,10 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395556_.down.sql": _1528395556_DownSql,
 
 	"1528395556_.up.sql": _1528395556_UpSql,
+
+	"1528395557_.down.sql": _1528395557_DownSql,
+
+	"1528395557_.up.sql": _1528395557_UpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -4425,6 +4471,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395555_.up.sql":                                          &bintree{_1528395555_UpSql, map[string]*bintree{}},
 	"1528395556_.down.sql":                                        &bintree{_1528395556_DownSql, map[string]*bintree{}},
 	"1528395556_.up.sql":                                          &bintree{_1528395556_UpSql, map[string]*bintree{}},
+	"1528395557_.down.sql":                                        &bintree{_1528395557_DownSql, map[string]*bintree{}},
+	"1528395557_.up.sql":                                          &bintree{_1528395557_UpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -578,11 +578,11 @@ func (s *repos) UpdateRepositoryMetadata(ctx context.Context, uri api.RepoURI, d
 }
 
 const upsertSQL = `WITH UPSERT AS (
-	UPDATE repo SET uri=$1, description=$2, fork=$3, enabled=$4, external_id=$5, external_service_type=$6, external_service_id=$7, archived=$9 WHERE uri=$1 RETURNING uri
+	UPDATE repo SET uri=$1, description=$2, fork=$3, enabled=$4, external_id=$5, external_service_type=$6, external_service_id=$7, archived=$9, url=$10 WHERE uri=$1 RETURNING uri
 )
-INSERT INTO repo(uri, description, fork, language, enabled, external_id, external_service_type, external_service_id, archived) (
+INSERT INTO repo(uri, description, fork, language, enabled, external_id, external_service_type, external_service_id, archived, url) (
 	SELECT $1 AS uri, $2 AS description, $3 AS fork, $8 as language, $4 AS enabled,
-	       $5 AS external_id, $6 AS external_service_type, $7 AS external_service_id, $9 AS archived
+	       $5 AS external_id, $6 AS external_service_type, $7 AS external_service_id, $9 AS archived, $10 AS url
 	WHERE $1 NOT IN (SELECT uri FROM upsert)
 )`
 
@@ -624,7 +624,7 @@ func (s *repos) Upsert(ctx context.Context, op api.InsertRepoOp) error {
 	}
 
 	spec := (&dbExternalRepoSpec{}).fromAPISpec(op.ExternalRepo)
-	_, err = dbconn.Global.ExecContext(ctx, upsertSQL, op.URI, op.Description, op.Fork, enabled, spec.id, spec.serviceType, spec.serviceID, language, op.Archived)
+	_, err = dbconn.Global.ExecContext(ctx, upsertSQL, op.URI, op.Description, op.Fork, enabled, spec.id, spec.serviceType, spec.serviceID, language, op.Archived, op.URL)
 	return err
 }
 

--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -393,6 +393,7 @@ Referenced by:
  external_service_id     | text                     | 
  enabled                 | boolean                  | not null default true
  archived                | boolean                  | not null default false
+ url                     | text                     | 
 Indexes:
     "repo_pkey" PRIMARY KEY, btree (id)
     "repo_uri_unique" UNIQUE, btree (uri)

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -44,6 +44,7 @@ func serveReposCreateIfNotExists(w http.ResponseWriter, r *http.Request) error {
 	}
 	err = backend.Repos.Upsert(r.Context(), api.InsertRepoOp{
 		URI:          repo.RepoURI,
+		URL:          repo.URL,
 		Description:  repo.Description,
 		Fork:         repo.Fork,
 		Archived:     repo.Archived,

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -177,7 +177,7 @@ func awsCodeCommitRepositoryToRepoPath(conn *awsCodeCommitConnection, repo *awsc
 func updateAWSCodeCommitRepositories(ctx context.Context, conn *awsCodeCommitConnection) {
 	repos := conn.listAllRepositories(ctx)
 
-	repoChan := make(chan repoCreateOrUpdateRequest)
+	repoChan := make(chan api.RepoCreateOrUpdateRequest)
 	defer close(repoChan)
 	go createEnableUpdateRepos(ctx, fmt.Sprintf("aws:%s", conn.config.AccessKeyID), repoChan)
 	for repo := range repos {
@@ -187,14 +187,12 @@ func updateAWSCodeCommitRepositories(ctx context.Context, conn *awsCodeCommitCon
 			log15.Error("Error generating remote URL for AWS CodeCommit repository. Skipping.", "repo", repo.ARN, "error", err)
 			continue
 		}
-		repoChan <- repoCreateOrUpdateRequest{
-			RepoCreateOrUpdateRequest: api.RepoCreateOrUpdateRequest{
-				RepoURI:      awsCodeCommitRepositoryToRepoPath(conn, repo),
-				ExternalRepo: AWSCodeCommitExternalRepoSpec(repo, createAWSCodeCommitServiceID(conn.awsPartition, conn.awsRegion, repo.AccountID)),
-				Description:  repo.Description,
-				Enabled:      conn.config.InitialRepositoryEnablement,
-			},
-			URL: remoteURL,
+		repoChan <- api.RepoCreateOrUpdateRequest{
+			RepoURI:      awsCodeCommitRepositoryToRepoPath(conn, repo),
+			ExternalRepo: AWSCodeCommitExternalRepoSpec(repo, createAWSCodeCommitServiceID(conn.awsPartition, conn.awsRegion, repo.AccountID)),
+			Description:  repo.Description,
+			Enabled:      conn.config.InitialRepositoryEnablement,
+			URL:          remoteURL,
 		}
 	}
 }

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -237,7 +237,7 @@ func RunBitbucketServerRepositorySyncWorker(ctx context.Context) {
 
 // updateBitbucketServerRepos ensures that all provided repositories exist in the repository table.
 func updateBitbucketServerRepos(ctx context.Context, conn *bitbucketServerConnection) {
-	repoChan := make(chan repoCreateOrUpdateRequest)
+	repoChan := make(chan api.RepoCreateOrUpdateRequest)
 	defer close(repoChan)
 	go createEnableUpdateRepos(ctx, fmt.Sprintf("bitbucket:%s", conn.config.Username), repoChan)
 	for r := range conn.listAllRepos(ctx) {
@@ -250,15 +250,13 @@ func updateBitbucketServerRepos(ctx context.Context, conn *bitbucketServerConnec
 			continue
 		}
 
-		repoChan <- repoCreateOrUpdateRequest{
-			RepoCreateOrUpdateRequest: api.RepoCreateOrUpdateRequest{
-				RepoURI:      ri.URI,
-				ExternalRepo: ri.ExternalRepo,
-				Description:  ri.Description,
-				Fork:         ri.Fork,
-				Enabled:      conn.config.InitialRepositoryEnablement,
-			},
-			URL: ri.VCS.URL,
+		repoChan <- api.RepoCreateOrUpdateRequest{
+			RepoURI:      ri.URI,
+			ExternalRepo: ri.ExternalRepo,
+			Description:  ri.Description,
+			Fork:         ri.Fork,
+			Enabled:      conn.config.InitialRepositoryEnablement,
+			URL:          ri.VCS.URL,
 		}
 	}
 }

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -288,21 +288,19 @@ func githubRepositoryToRepoPath(conn *githubConnection, repo *github.Repository)
 func updateGitHubRepositories(ctx context.Context, conn *githubConnection) {
 	repos := conn.listAllRepositories(ctx)
 
-	repoChan := make(chan repoCreateOrUpdateRequest)
+	repoChan := make(chan api.RepoCreateOrUpdateRequest)
 	defer close(repoChan)
 	go createEnableUpdateRepos(ctx, fmt.Sprintf("github:%s", conn.config.Token), repoChan)
 	for repo := range repos {
 		// log15.Debug("github sync: create/enable/update repo", "repo", repo.NameWithOwner)
-		repoChan <- repoCreateOrUpdateRequest{
-			RepoCreateOrUpdateRequest: api.RepoCreateOrUpdateRequest{
-				RepoURI:      githubRepositoryToRepoPath(conn, repo),
-				ExternalRepo: GitHubExternalRepoSpec(repo, *conn.baseURL),
-				Description:  repo.Description,
-				Fork:         repo.IsFork,
-				Archived:     repo.IsArchived,
-				Enabled:      conn.config.InitialRepositoryEnablement,
-			},
-			URL: conn.authenticatedRemoteURL(repo),
+		repoChan <- api.RepoCreateOrUpdateRequest{
+			RepoURI:      githubRepositoryToRepoPath(conn, repo),
+			ExternalRepo: GitHubExternalRepoSpec(repo, *conn.baseURL),
+			Description:  repo.Description,
+			Fork:         repo.IsFork,
+			Archived:     repo.IsArchived,
+			Enabled:      conn.config.InitialRepositoryEnablement,
+			URL:          conn.authenticatedRemoteURL(repo),
 		}
 	}
 }

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -206,20 +206,18 @@ func gitlabProjectToRepoPath(conn *gitlabConnection, proj *gitlab.Project) api.R
 func updateGitLabProjects(ctx context.Context, conn *gitlabConnection) {
 	projs := conn.listAllProjects(ctx)
 
-	repoChan := make(chan repoCreateOrUpdateRequest)
+	repoChan := make(chan api.RepoCreateOrUpdateRequest)
 	defer close(repoChan)
 	go createEnableUpdateRepos(ctx, fmt.Sprintf("gitlab:%s", conn.config.Token), repoChan)
 	for proj := range projs {
-		repoChan <- repoCreateOrUpdateRequest{
-			RepoCreateOrUpdateRequest: api.RepoCreateOrUpdateRequest{
-				RepoURI:      gitlabProjectToRepoPath(conn, proj),
-				ExternalRepo: GitLabExternalRepoSpec(proj, *conn.baseURL),
-				Description:  proj.Description,
-				Fork:         proj.ForkedFromProject != nil,
-				Archived:     proj.Archived,
-				Enabled:      conn.config.InitialRepositoryEnablement,
-			},
-			URL: conn.authenticatedRemoteURL(proj),
+		repoChan <- api.RepoCreateOrUpdateRequest{
+			RepoURI:      gitlabProjectToRepoPath(conn, proj),
+			ExternalRepo: GitLabExternalRepoSpec(proj, *conn.baseURL),
+			Description:  proj.Description,
+			Fork:         proj.ForkedFromProject != nil,
+			Archived:     proj.Archived,
+			Enabled:      conn.config.InitialRepositoryEnablement,
+			URL:          conn.authenticatedRemoteURL(proj),
 		}
 	}
 }

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -102,7 +102,7 @@ func gitoliteUpdateRepos(ctx context.Context, gconf *schema.GitoliteConnection, 
 		return err
 	}
 
-	repoChan := make(chan repoCreateOrUpdateRequest)
+	repoChan := make(chan api.RepoCreateOrUpdateRequest)
 	defer close(repoChan)
 	go createEnableUpdateRepos(ctx, fmt.Sprintf("gitolite:%s", gconf.Prefix), repoChan)
 	if doPhabricator && gconf.PhabricatorMetadataCommand != "" {
@@ -111,12 +111,10 @@ func gitoliteUpdateRepos(ctx context.Context, gconf *schema.GitoliteConnection, 
 	for _, entry := range rlist {
 		// We don't have descriptions available for these. The old code didn't do that either.
 		url := strings.Replace(entry, gconf.Prefix, gconf.Host+":", 1)
-		repoChan <- repoCreateOrUpdateRequest{
-			RepoCreateOrUpdateRequest: api.RepoCreateOrUpdateRequest{
-				RepoURI: api.RepoURI(entry),
-				Enabled: true,
-			},
-			URL: url,
+		repoChan <- api.RepoCreateOrUpdateRequest{
+			RepoURI: api.RepoURI(entry),
+			Enabled: true,
+			URL:     url,
 		}
 	}
 	return nil

--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -50,26 +50,19 @@ func cachedTransportWithCertTrusted(cert string) (http.RoundTripper, error) {
 	}, nil
 }
 
-// A repoCreateOrUpdateRequest is a RepoCreateOrUpdateRequest, from the API,
-// plus a specific URL we'd like to use for it.
-type repoCreateOrUpdateRequest struct {
-	api.RepoCreateOrUpdateRequest
-	URL string // the repository's Git remote URL
-}
-
 // createEnableUpdateRepos receives requests on the provided channel. The
 // source argument should be a distinctive string identifying the configuration
 // being updated, so repo-updater can detect when repositories are dropped from
 // a given source.
-func createEnableUpdateRepos(ctx context.Context, source string, repoChan <-chan repoCreateOrUpdateRequest) {
+func createEnableUpdateRepos(ctx context.Context, source string, repoChan <-chan api.RepoCreateOrUpdateRequest) {
 	newList := make(sourceRepoList)
 
-	do := func(op repoCreateOrUpdateRequest) {
-		if op.RepoCreateOrUpdateRequest.RepoURI == "" {
-			log15.Warn("ignoring invalid request to create or enable repo with empty name", "source", source, "repo", op.RepoCreateOrUpdateRequest.ExternalRepo)
+	do := func(op api.RepoCreateOrUpdateRequest) {
+		if op.RepoURI == "" {
+			log15.Warn("ignoring invalid request to create or enable repo with empty name", "source", source, "repo", op.ExternalRepo)
 			return
 		}
-		createdRepo, err := api.InternalClient.ReposCreateIfNotExists(ctx, op.RepoCreateOrUpdateRequest)
+		createdRepo, err := api.InternalClient.ReposCreateIfNotExists(ctx, op)
 		if err != nil {
 			log15.Warn("Error creating or updating repository", "repo", op.RepoURI, "error", err)
 			return

--- a/migrations/1528395557_.down.sql
+++ b/migrations/1528395557_.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repo DROP COLUMN url;

--- a/migrations/1528395557_.up.sql
+++ b/migrations/1528395557_.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repo ADD COLUMN url text;

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -54,6 +54,7 @@ func (Repo) Fork() bool {
 // InsertRepoOp represents an operation to insert a repository.
 type InsertRepoOp struct {
 	URI          RepoURI
+	URL          string
 	Description  string
 	Fork         bool
 	Archived     bool

--- a/pkg/api/httpapi_schema.go
+++ b/pkg/api/httpapi_schema.go
@@ -25,6 +25,9 @@ type RepoCreateOrUpdateRequest struct {
 	// optional during the transition period.
 	ExternalRepo *ExternalRepoSpec
 
+	// URL is the clone url for the repo.
+	URL string
+
 	// RepoURI is the repository's URI.
 	//
 	// TODO(sqs): Add a way for callers to request that this repository's URI be renamed.


### PR DESCRIPTION
Add a new `url` column to the `repo` table that stores the clone url of each repo.

No readers of this field are added in this PR, but I am working on some changes that would benefit from this.

This PR moves us in the direction of the desired end state of the database being the source of truth for what repos are enabled (and with this change, how to clone them).

The URLs stored in the database _would_ have the access token stored with them (e.g. `https://token123@github.com/foo/bar`), but this would get updated any time repo-updater runs.