### PR TITLE
feat: support themable decorations from extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-visibility-sensor": "^4.0.0",
     "reactstrap": "^6.2.0",
     "rxjs": "^6.3.2",
-    "sourcegraph": "^18.2.0",
+    "sourcegraph": "^18.3.0",
     "string-score": "^1.0.1",
     "textarea-caret": "3.1.0",
     "ts-key-enum": "^2.0.0",

--- a/src/repo/blob/Blob.tsx
+++ b/src/repo/blob/Blob.tsx
@@ -13,6 +13,7 @@ import * as React from 'react'
 import { Link, LinkProps } from 'react-router-dom'
 import { combineLatest, fromEvent, merge, Observable, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, share, switchMap, withLatestFrom } from 'rxjs/operators'
+import { decorationStyleForTheme } from 'sourcegraph/module/client/providers/decoration'
 import { TextDocumentDecoration } from 'sourcegraph/module/protocol/plainTypes'
 import { AbsoluteRepoFile, RenderMode } from '..'
 import { getDecorations, getHover, getJumpURL, ModeSpec } from '../../backend/features'
@@ -55,6 +56,7 @@ interface BlobProps
     className: string
     wrapCode: boolean
     renderMode: RenderMode
+    isLightTheme: boolean
 }
 
 interface BlobState extends HoverState {
@@ -281,8 +283,6 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             })
         )
 
-        // EXPERIMENTAL: DECORATIONS
-
         /** Emits when the URL's target blob (repository, revision, path, and content) changes. */
         const modelChanges: Observable<
             AbsoluteRepoFile & LSPSelector & Pick<BlobProps, 'content'>
@@ -357,20 +357,21 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                         }
                         const row = codeCell.parentElement as HTMLTableRowElement
                         let decorated = false
-                        if (decoration.backgroundColor) {
-                            row.style.backgroundColor = decoration.backgroundColor
+                        const style = decorationStyleForTheme(decoration, this.props.isLightTheme)
+                        if (style.backgroundColor) {
+                            row.style.backgroundColor = style.backgroundColor
                             decorated = true
                         }
-                        if (decoration.border) {
-                            row.style.border = decoration.border
+                        if (style.border) {
+                            row.style.border = style.border
                             decorated = true
                         }
-                        if (decoration.borderColor) {
-                            row.style.borderColor = decoration.borderColor
+                        if (style.borderColor) {
+                            row.style.borderColor = style.borderColor
                             decorated = true
                         }
-                        if (decoration.borderWidth) {
-                            row.style.borderWidth = decoration.borderWidth
+                        if (style.borderWidth) {
+                            row.style.borderWidth = style.borderWidth
                             decorated = true
                         }
                         if (decorated) {

--- a/src/repo/blob/BlobPage.tsx
+++ b/src/repo/blob/BlobPage.tsx
@@ -287,6 +287,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
                             renderMode={renderMode}
                             location={this.props.location}
                             history={this.props.history}
+                            isLightTheme={this.props.isLightTheme}
                         />
                     )}
                 {!this.state.blobOrError.richHTML &&

--- a/src/repo/blob/LineDecorationAttachment.tsx
+++ b/src/repo/blob/LineDecorationAttachment.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import ReactDOM from 'react-dom'
 import { DecorationAttachmentRenderOptions } from 'sourcegraph'
+import { decorationAttachmentStyleForTheme } from 'sourcegraph/module/client/providers/decoration'
 import { AbsoluteRepoFile } from '..'
 import { LinkOrSpan } from '../../components/LinkOrSpan'
 
@@ -8,6 +9,7 @@ interface LineDecorationAttachmentProps extends AbsoluteRepoFile {
     line: number
     portalID: string
     attachment: DecorationAttachmentRenderOptions
+    isLightTheme: boolean
 }
 
 /** Displays text after a line in Blob. */
@@ -36,6 +38,8 @@ export class LineDecorationAttachment extends React.PureComponent<LineDecoration
             return null
         }
 
+        const style = decorationAttachmentStyleForTheme(this.props.attachment, this.props.isLightTheme)
+
         return ReactDOM.createPortal(
             <LinkOrSpan
                 className="line-decoration-attachment"
@@ -55,8 +59,8 @@ export class LineDecorationAttachment extends React.PureComponent<LineDecoration
                     className="line-decoration-attachment__contents"
                     // tslint:disable-next-line:jsx-ban-props
                     style={{
-                        color: this.props.attachment.color,
-                        backgroundColor: this.props.attachment.backgroundColor,
+                        color: style.color,
+                        backgroundColor: style.backgroundColor,
                     }}
                     data-contents={this.props.attachment.contentText || ''}
                 />

--- a/yarn.lock
+++ b/yarn.lock
@@ -10048,6 +10048,14 @@ sourcegraph@^18.2.0:
     minimatch "^3.0.4"
     rxjs "^6.3.2"
 
+sourcegraph@^18.3.0:
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-18.3.0.tgz#d624b042aabf5aa5c90cefad59cc05f697ae448c"
+  integrity sha512-jTbfpcNwfSU63rU6RcpEg8NYGdqR3UyF8SlEnxe6Wg79lUa3Mocq3djTYgnf8SGVovdcHXGZQYWaLGeALgvsxw==
+  dependencies:
+    minimatch "^3.0.4"
+    rxjs "^6.3.2"
+
 sparkles@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"


### PR DESCRIPTION
Respect the theme overrides from an extension for its decorations.

Depends on https://github.com/sourcegraph/sourcegraph-extension-api/pull/110.

This enables different behavior like this:

![screenshot from 2018-10-28 17-55-20](https://user-images.githubusercontent.com/1976/47624533-f3a1e800-dada-11e8-81d9-3d4bd67fc08a.png)
![screenshot from 2018-10-28 17-55-02](https://user-images.githubusercontent.com/1976/47624534-f3a1e800-dada-11e8-9c08-9ce307653b20.png)