### PR TITLE
show nicer message for unauthed users who try to use extensions

### DIFF
--- a/cmd/frontend/graphqlbackend/configuration.go
+++ b/cmd/frontend/graphqlbackend/configuration.go
@@ -55,12 +55,6 @@ func (r *schemaResolver) ConfigurationMutation(ctx context.Context, args *struct
 	if canAdmin, err := subject.ViewerCanAdminister(ctx); err != nil {
 		return nil, err
 	} else if !canAdmin {
-		if !actor.FromContext(ctx).IsAuthenticated() {
-			// TODO(sqs): Quick hack to show a less confusing error message when an anon user
-			// toggles code coverage on Sourcegraph.com. Make the extension actually show a friendly
-			// message and/or implement anon user settings on Sourcegraph.com.
-			return nil, errors.New("to toggle coverage or edit settings, you must sign in or sign up")
-		}
 		return nil, errors.New("viewer is not allowed to edit these settings")
 	}
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/polyfill": "^7.0.0",
     "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^3.9.0",
-    "@sourcegraph/extensions-client-common": "^10.4.1",
+    "@sourcegraph/extensions-client-common": "^10.4.2",
     "@sourcegraph/phabricator-extension": "^1.18.0",
     "@sqs/jsonc-parser": "^1.0.3",
     "@types/react": "16.4.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,10 +971,10 @@
     rxjs "^6.3.2"
     vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/extensions-client-common@^10.4.1":
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.4.1.tgz#2f40925509e9c6ce2d177e3a329a530290f79a69"
-  integrity sha512-K8T4vfmhV6y/4QVcKyLahuBBOC15/YXzO9y/ggxekw/EDnqF2tXjMxQHg62EM8sM2p+F28pvs2aDZAI0QOMEyw==
+"@sourcegraph/extensions-client-common@^10.4.2":
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.4.2.tgz#f964076bf460ca1b697ebe48e9a51a5d4c3f7fa7"
+  integrity sha512-UPgOXGrDkoiOm7nPM2mdK68f1+qFEjUTAeBgDH8f5A2seMIvXVaoNAdregC7m4V/K1PTnAHort4X8j4Bpj+ZRw==
   dependencies:
     "@slimsag/react-shortcuts" "^1.2.0"
     bootstrap "^4.1.3"


### PR DESCRIPTION
**Depends on** https://github.com/sourcegraph/extensions-client-common/pull/65.

Previously, users would see a terse message like "to toggle coverage or edit settings, you must sign in". This was not very helpful, especially when the user was on GitHub (sign in where? GitHub? I am signed in!).

Now it reads as follows:

> Unable to update user setting git.blame.lineDecorations because you are not signed in.
>
> Sign into Sourcegraph on localhost:3080

![screenshot from 2018-10-28 22-44-04](https://user-images.githubusercontent.com/1976/47631749-79865900-db04-11e8-92b0-c7c88a135104.png)

I added the setting key to make it sound less like spam and more like a real necessity (which it is).