### PR TITLE
New repo-updater scheduler

### DIFF
--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -53,6 +53,12 @@ func (s *Server) handleRepoInfo(w http.ResponseWriter, r *http.Request) {
 		} else {
 			resp.CloneTime = &cloneTime
 		}
+
+		if lastChanged, err := repoLastChanged(dir); err != nil {
+			log15.Warn("error getting last changed", "repo", req.Repo, "err", err)
+		} else {
+			resp.LastChanged = &lastChanged
+		}
 	}
 
 	if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/cmd/gitserver/server/repo_info_test.go
+++ b/cmd/gitserver/server/repo_info_test.go
@@ -69,11 +69,16 @@ func TestServer_handleRepoInfo(t *testing.T) {
 		repoLastFetched = func(dir string) (time.Time, error) { return lastFetched, nil }
 		defer func() { repoLastFetched = origRepoLastFetched }()
 
+		lastChanged := time.Date(1987, 1, 2, 3, 4, 5, 6, time.UTC)
+		origRepoLastChanged := repoLastChanged
+		repoLastChanged = func(dir string) (time.Time, error) { return lastChanged, nil }
+		defer func() { repoLastChanged = origRepoLastChanged }()
+
 		origRepoRemoteURL := repoRemoteURL
 		repoRemoteURL = func(context.Context, string) (string, error) { return "u", nil }
 		defer func() { repoRemoteURL = origRepoRemoteURL }()
 
-		if got, want := getRepoInfo(t, "x"), (protocol.RepoInfoResponse{Cloned: true, LastFetched: &lastFetched, URL: "u"}); !reflect.DeepEqual(got, want) {
+		if got, want := getRepoInfo(t, "x"), (protocol.RepoInfoResponse{Cloned: true, LastFetched: &lastFetched, LastChanged: &lastChanged, URL: "u"}); !reflect.DeepEqual(got, want) {
 			t.Errorf("got %+v, want %+v", got, want)
 		}
 	})

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -204,8 +204,12 @@ func (s *Server) Handler() http.Handler {
 	s.repoUpdateLocks = make(map[api.RepoName]*locks)
 
 	// GitMaxConcurrentClones controls the maximum number of clones that
-	// can happen at once. Used to prevent throttle limits from a code
-	// host. Defaults to 5.
+	// can happen at once on a single gitserver.
+	// Used to prevent throttle limits from a code host. Defaults to 5.
+	//
+	// The new repo-updater scheduler enforces the rate limit across all gitserver,
+	// so ideally this logic could be removed here; however, ensureRevision can also
+	// cause an update to happen and it is called on every exec command.
 	maxConcurrentClones := conf.Get().GitMaxConcurrentClones
 	if maxConcurrentClones == 0 {
 		maxConcurrentClones = 5

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"log"
 	"net"
 	"net/http"
@@ -35,6 +36,11 @@ func main() {
 		Name: "Repo Updater State",
 		Path: "/repo-updater-state",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if conf.UpdateScheduler2Enabled() {
+				http.Error(w, "The new update scheduler exposes information in the mirroring tab of the repository settings page.", http.StatusBadRequest)
+				return
+			}
+
 			d, err := json.MarshalIndent(repos.QueueSnapshot(), "", "  ")
 			if err != nil {
 				http.Error(w, "failed to marshal snapshot: "+err.Error(), http.StatusInternalServerError)

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -1,0 +1,502 @@
+package repos
+
+import (
+	"container/heap"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
+	gitserverprotocol "github.com/sourcegraph/sourcegraph/pkg/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/pkg/mutablelimiter"
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+const (
+	// minDelay is the minimum amount of time between scheduled updates for a single repository.
+	minDelay = 45 * time.Second
+
+	// maxDelay is the maximum amount of time between scheduled updates for a single repository.
+	maxDelay = 8 * time.Hour
+)
+
+// updateScheduler schedules repo update (or clone) requests to gitserver.
+//
+// Repository metadata is synced from configured code hosts and added to the scheduler.
+//
+// Updates are scheduled based on the time that has elapsed since the last commit
+// divided by a constant factor of 2. For example, if a repo's last commit was 8 hours ago
+// then the next update will be scheduled 4 hours from now. If there are still no new commits,
+// then the next update will be scheduled 6 hours from then.
+// This heuristic is simple to compute and has nice backoff properties.
+//
+// When it is time for a repo to update, the scheduler inserts the repo into a queue.
+//
+// A worker continuously dequeues repos and sends updates to gitserver, but its concurrency
+// is limited by the gitMaxConcurrentClones site configuration.
+type updateScheduler struct {
+	mu sync.Mutex
+
+	// sourceRepos stores the last known list of repos from each source
+	// so we can compute which repos have been added/removed/enabled/disabled.
+	sourceRepos map[string]sourceRepoMap
+
+	updateQueue *updateQueue
+	schedule    *schedule
+}
+
+// sourceRepoMap is the set of repositories associated with a specific configuration source.
+type sourceRepoMap map[api.RepoName]*configuredRepo
+
+// notifyChanBuffer controls the buffer size of notification channels.
+// It is important that this value is 1 so that we can perform lossless
+// non-blocking sends.
+const notifyChanBuffer = 1
+
+// newUpdateScheduler returns a new scheduler.
+func newUpdateScheduler() *updateScheduler {
+	return &updateScheduler{
+		sourceRepos: make(map[string]sourceRepoMap),
+		updateQueue: &updateQueue{
+			index:         make(map[api.RepoName]*repoUpdate),
+			notifyEnqueue: make(chan struct{}, notifyChanBuffer),
+		},
+		schedule: &schedule{
+			index:  make(map[api.RepoName]*scheduledRepoUpdate),
+			wakeup: make(chan struct{}, notifyChanBuffer),
+		},
+	}
+}
+
+// run starts scheduled repo updates.
+func (s *updateScheduler) run(ctx context.Context) {
+	go s.runScheduleLoop(ctx)
+	go s.runUpdateLoop(ctx)
+}
+
+// runScheduleLoop starts the loop that schedules updates by enqueuing them into the updateQueue.
+func (s *updateScheduler) runScheduleLoop(ctx context.Context) {
+	for {
+		select {
+		case <-s.schedule.wakeup:
+		case <-ctx.Done():
+			return
+		}
+
+		s.schedule.mu.Lock()
+
+		for {
+			if len(s.schedule.heap) == 0 {
+				break
+			}
+
+			repoUpdate := s.schedule.heap[0]
+			if !repoUpdate.due.Before(timeNow().Add(time.Millisecond)) {
+				break
+			}
+
+			s.updateQueue.enqueue(repoUpdate.repo, priorityLow)
+			repoUpdate.due = timeNow().Add(repoUpdate.interval)
+			heap.Fix(s.schedule, 0)
+		}
+
+		s.schedule.rescheduleTimer()
+		s.schedule.mu.Unlock()
+	}
+}
+
+// runUpdateLoop sends repo update requests to gitserver.
+func (s *updateScheduler) runUpdateLoop(ctx context.Context) {
+	limiter := configuredLimiter()
+
+	for {
+		select {
+		case <-s.updateQueue.notifyEnqueue:
+		case <-ctx.Done():
+			return
+		}
+
+		for {
+			ctx, cancel, err := limiter.Acquire(ctx)
+			if err != nil {
+				// context is canceled; shutdown
+				return
+			}
+
+			repo := s.updateQueue.acquireNext()
+			if repo == nil {
+				cancel()
+				break
+			}
+
+			go func(ctx context.Context, repo *configuredRepo, cancel context.CancelFunc) {
+				defer cancel()
+				defer s.updateQueue.remove(repo, true)
+
+				resp, err := requestRepoUpdate(ctx, repo, 1*time.Second)
+				if err != nil {
+					log15.Warn("error requesting repo update", "uri", repo.name, "err", err)
+				}
+				if resp != nil && resp.LastFetched != nil && resp.LastChanged != nil {
+					// This is the heuristic that is described in the updateScheduler documentation.
+					// Update that documentation if you update this logic.
+					interval := resp.LastFetched.Sub(*resp.LastChanged) / 2
+					s.schedule.updateInterval(repo, interval)
+				}
+			}(ctx, repo, cancel)
+		}
+	}
+}
+
+// requestRepoUpdate sends a request to gitserver to request an update.
+var requestRepoUpdate = func(ctx context.Context, repo *configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
+	return gitserver.DefaultClient.RequestRepoUpdate(ctx, gitserver.Repo{Name: repo.name, URL: repo.url}, since)
+}
+
+// configuredLimiter returns a mutable limiter that is
+// configured with the maximum number of concurrent update
+// requests that repo-updater should send to gitserver.
+var configuredLimiter = func() *mutablelimiter.Limiter {
+	limiter := mutablelimiter.New(1)
+	conf.Watch(func() {
+		limit := conf.Get().GitMaxConcurrentClones
+		if limit == 0 {
+			limit = 5
+		}
+		limiter.SetLimit(limit)
+	})
+	return limiter
+}
+
+// updateSource updates the list of configured repos associated with the given source.
+// This is the source of truth for what repos exist in the schedule.
+func (s *updateScheduler) updateSource(source string, newList sourceRepoMap) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	log15.Debug("updating configured repos", "source", source, "count", len(newList))
+	if s.sourceRepos[source] == nil {
+		s.sourceRepos[source] = sourceRepoMap{}
+	}
+
+	// Remove repos that don't exist in the new list or are disabled in the new list.
+	oldList := s.sourceRepos[source]
+	for key, repo := range oldList {
+		if updatedRepo, ok := newList[key]; !ok || !updatedRepo.enabled {
+			s.schedule.remove(repo)
+			updating := false // don't immediately remove repos that are already updating; they will automatically get removed when the update finishes
+			s.updateQueue.remove(repo, updating)
+		}
+	}
+
+	// Schedule enabled repos.
+	for key, updatedRepo := range newList {
+		if !updatedRepo.enabled {
+			continue
+		}
+
+		oldRepo := oldList[key]
+		if oldRepo == nil || !oldRepo.enabled {
+			s.schedule.add(updatedRepo)
+			s.updateQueue.enqueue(updatedRepo, priorityLow)
+		} else {
+			s.schedule.update(updatedRepo)
+			s.updateQueue.update(updatedRepo)
+		}
+	}
+
+	s.sourceRepos[source] = newList
+}
+
+// UpdateOnce causes a single update of the given repository.
+// It neither adds nor removes the repo from the schedule.
+func (s *updateScheduler) UpdateOnce(name api.RepoName, url string) {
+	repo := &configuredRepo{
+		name: name,
+		url:  url,
+	}
+	s.updateQueue.enqueue(repo, priorityHigh)
+}
+
+// updateQueue is a priority queue of repos to update.
+// A repo can't have more than one location in the queue.
+type updateQueue struct {
+	mu sync.Mutex
+
+	heap  []*repoUpdate
+	index map[api.RepoName]*repoUpdate
+
+	seq uint64
+
+	// The queue performs a non-blocking send on this channel
+	// when a new value is enqueued so that the update loop
+	// can wake up if it is idle.
+	notifyEnqueue chan struct{}
+}
+
+type priority int
+
+const (
+	priorityLow priority = iota
+	priorityHigh
+)
+
+// repoUpdate is a repository that has been queued for an update.
+type repoUpdate struct {
+	repo     *configuredRepo
+	priority priority
+	seq      uint64 // the sequence number of the update
+	updating bool   // whether the repo has been acquired for update
+	index    int    // the index in the heap
+}
+
+// enqueue add the repo to the queue with the given priority.
+func (q *updateQueue) enqueue(repo *configuredRepo, p priority) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	update := q.index[repo.name]
+	if update == nil {
+		heap.Push(q, &repoUpdate{
+			repo:     repo,
+			priority: p,
+		})
+		notify(q.notifyEnqueue)
+		return
+	}
+
+	if p <= update.priority {
+		// Repo is already in the queue with at least as good priority.
+		return
+	}
+
+	// Repo is in the queue at a lower priority.
+	update.priority = p      // bump the priority
+	update.seq = q.nextSeq() // put it after all existing updates with this priority
+	heap.Fix(q, update.index)
+	notify(q.notifyEnqueue)
+}
+
+// nextSeq increments and returns the next sequence number.
+// The caller must hold the lock on q.mu.
+func (q *updateQueue) nextSeq() uint64 {
+	q.seq++
+	return q.seq
+}
+
+// update updates the repo data in the queue.
+// It does nothing if the repo is not in the queue or if the repo is already updating.
+func (q *updateQueue) update(repo *configuredRepo) {
+	q.mu.Lock()
+	if update := q.index[repo.name]; update != nil && !update.updating {
+		update.repo = repo
+	}
+	q.mu.Unlock()
+}
+
+// remove removes the repo from the queue if the repo.updating matches the updating argument.
+func (q *updateQueue) remove(repo *configuredRepo, updating bool) {
+	q.mu.Lock()
+	if update := q.index[repo.name]; update != nil && update.updating == updating {
+		heap.Remove(q, update.index)
+	}
+	q.mu.Unlock()
+}
+
+// acquireNext acquires the next repo for update.
+// The acquired repo must be removed from the queue
+// when the update finishes (independent of success or failure).
+func (q *updateQueue) acquireNext() *configuredRepo {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.heap) == 0 {
+		return nil
+	}
+	update := q.heap[0]
+	if update.updating {
+		// Everything in the queue is already updating.
+		return nil
+	}
+	update.updating = true
+	heap.Fix(q, update.index)
+	return update.repo
+}
+
+// The following methods implement heap.Interface based on the priority queue example:
+// https://golang.org/pkg/container/heap/#example__priorityQueue
+
+func (q *updateQueue) Len() int { return len(q.heap) }
+func (q *updateQueue) Less(i, j int) bool {
+	qi := q.heap[i]
+	qj := q.heap[j]
+	if qi.updating != qj.updating {
+		// Repos that are already updating are sorted last.
+		return qj.updating
+	}
+	if qi.priority != qj.priority {
+		// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+		return qi.priority > qj.priority
+	}
+	// Queue semantics for items with the same priority.
+	return qi.seq < qj.seq
+}
+func (q *updateQueue) Swap(i, j int) {
+	q.heap[i], q.heap[j] = q.heap[j], q.heap[i]
+	q.heap[i].index = i
+	q.heap[j].index = j
+}
+func (q *updateQueue) Push(x interface{}) {
+	n := len(q.heap)
+	item := x.(*repoUpdate)
+	item.index = n
+	item.seq = q.nextSeq()
+	q.heap = append(q.heap, item)
+	q.index[item.repo.name] = item
+}
+func (q *updateQueue) Pop() interface{} {
+	n := len(q.heap)
+	item := q.heap[n-1]
+	item.index = -1 // for safety
+	q.heap = q.heap[0 : n-1]
+	delete(q.index, item.repo.name)
+	return item
+}
+
+// schedule is the schedule of when repos get enqueued into the updateQueue.
+type schedule struct {
+	mu sync.Mutex
+
+	heap  []*scheduledRepoUpdate // min heap of scheduledRepoUpdates based on their due time.
+	index map[api.RepoName]*scheduledRepoUpdate
+
+	// timer sends a value on the wakeup channel when it is time
+	timer  *time.Timer
+	wakeup chan struct{}
+}
+
+// scheduledRepoUpdate is the update schedule for a single repo.
+type scheduledRepoUpdate struct {
+	repo     *configuredRepo // the repo to update
+	interval time.Duration   // how regularly the repo is updated
+	due      time.Time       // the next time that the repo will be enqueued for a update
+	index    int             // the index in the heap
+}
+
+// add adds a repo to the schedule.
+// It does nothing if the repo already exists in the schedule.
+func (s *schedule) add(repo *configuredRepo) {
+	s.mu.Lock()
+	if s.index[repo.name] == nil {
+		heap.Push(s, &scheduledRepoUpdate{
+			repo:     repo,
+			interval: minDelay,
+			due:      timeNow().Add(minDelay),
+		})
+		s.rescheduleTimer()
+	}
+	s.mu.Unlock()
+}
+
+// update updates the repo data in the schedule.
+// It does nothing if the repo is not in the schedule.
+func (s *schedule) update(repo *configuredRepo) {
+	s.mu.Lock()
+	if update := s.index[repo.name]; update != nil {
+		update.repo = repo
+	}
+	s.mu.Unlock()
+}
+
+// updateInterval updates the update interval of a repo in the schedule.
+// It does nothing if the repo is not in the schedule.
+func (s *schedule) updateInterval(repo *configuredRepo, interval time.Duration) {
+	s.mu.Lock()
+	if update := s.index[repo.name]; update != nil {
+		switch {
+		case interval > maxDelay:
+			update.interval = maxDelay
+		case interval < minDelay:
+			update.interval = minDelay
+		default:
+			update.interval = interval
+		}
+		update.due = timeNow().Add(update.interval)
+		log15.Debug("updated repo", "repo", repo.name, "due", update.due.Sub(timeNow()))
+		heap.Fix(s, update.index)
+		s.rescheduleTimer()
+	}
+	s.mu.Unlock()
+}
+
+// remove removes a repo from the schedule.
+func (s *schedule) remove(repo *configuredRepo) {
+	s.mu.Lock()
+	if update := s.index[repo.name]; update != nil {
+		reschedule := update.index == 0
+		heap.Remove(s, update.index)
+		if reschedule {
+			s.rescheduleTimer()
+		}
+	}
+	s.mu.Unlock()
+}
+
+// rescheduleTimer schedules the scheduler to wakeup
+// at the time that the next repo is due for an update.
+// The caller must hold the lock on s.mu.
+func (s *schedule) rescheduleTimer() {
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
+	}
+	if len(s.heap) > 0 {
+		delay := s.heap[0].due.Sub(timeNow())
+		s.timer = timeAfterFunc(delay, func() {
+			notify(s.wakeup)
+		})
+	}
+}
+
+// The following methods implement heap.Interface based on the priority queue example:
+// https://golang.org/pkg/container/heap/#example__priorityQueue
+
+func (s *schedule) Len() int { return len(s.heap) }
+func (s *schedule) Less(i, j int) bool {
+	return s.heap[i].due.Before(s.heap[j].due)
+}
+func (s *schedule) Swap(i, j int) {
+	s.heap[i], s.heap[j] = s.heap[j], s.heap[i]
+	s.heap[i].index = i
+	s.heap[j].index = j
+}
+func (s *schedule) Push(x interface{}) {
+	n := len(s.heap)
+	item := x.(*scheduledRepoUpdate)
+	item.index = n
+	s.heap = append(s.heap, item)
+	s.index[item.repo.name] = item
+}
+func (s *schedule) Pop() interface{} {
+	n := len(s.heap)
+	item := s.heap[n-1]
+	item.index = -1 // for safety
+	s.heap = s.heap[0 : n-1]
+	delete(s.index, item.repo.name)
+	return item
+}
+
+// notify performs a non-blocking send on the channel.
+// The channel should be buffered.
+var notify = func(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+// Mockable time functions for testing.
+var (
+	timeNow       = time.Now
+	timeAfterFunc = time.AfterFunc
+)

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -1,0 +1,1590 @@
+package repos
+
+import (
+	"container/heap"
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	gitserverprotocol "github.com/sourcegraph/sourcegraph/pkg/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/pkg/mutablelimiter"
+)
+
+var defaultTime = time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
+
+func init() {
+	timeNow = nil
+	notify = nil
+	timeAfterFunc = nil
+}
+
+func mockTime(t time.Time) {
+	timeNow = func() time.Time {
+		return t
+	}
+}
+
+type recording struct {
+	notifications       []chan struct{}
+	timeAfterFuncDelays []time.Duration
+}
+
+func startRecording() (*recording, func()) {
+	var r recording
+
+	mockTime(defaultTime)
+
+	notify = func(ch chan struct{}) {
+		r.notifications = append(r.notifications, ch)
+	}
+
+	timeAfterFunc = func(delay time.Duration, f func()) *time.Timer {
+		r.timeAfterFuncDelays = append(r.timeAfterFuncDelays, delay)
+		f()
+		return nil
+	}
+
+	return &r, func() {
+		timeNow = nil
+		notify = nil
+		timeAfterFunc = nil
+	}
+}
+
+func TestUpdateQueue_enqueue(t *testing.T) {
+	a := configuredRepo{name: "a", url: "a.com"}
+	b := configuredRepo{name: "b", url: "b.com"}
+	c := configuredRepo{name: "c", url: "c.com"}
+	d := configuredRepo{name: "d", url: "d.com"}
+	e := configuredRepo{name: "e", url: "e.com"}
+
+	type enqueueCall struct {
+		repo     configuredRepo
+		priority priority
+	}
+
+	tests := []struct {
+		name                  string
+		calls                 []*enqueueCall
+		expectedUpdates       []*repoUpdate
+		expectedNotifications int
+	}{
+		{
+			name: "enqueue low priority",
+			calls: []*enqueueCall{
+				{repo: a, priority: priorityLow},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityLow,
+					seq:      1,
+				},
+			},
+			expectedNotifications: 1,
+		},
+		{
+			name: "enqueue high priority",
+			calls: []*enqueueCall{
+				{repo: a, priority: priorityHigh},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityHigh,
+					seq:      1,
+				},
+			},
+			expectedNotifications: 1,
+		},
+		{
+			name: "enqueue low b then high a",
+			calls: []*enqueueCall{
+				{repo: b, priority: priorityLow},
+				{repo: a, priority: priorityHigh},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityHigh,
+					seq:      2,
+				},
+				{
+					repo:     &b,
+					priority: priorityLow,
+					seq:      1,
+				},
+			},
+			expectedNotifications: 2,
+		},
+		{
+			name: "enqueue high a then low b",
+			calls: []*enqueueCall{
+				{repo: a, priority: priorityHigh},
+				{repo: b, priority: priorityLow},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityHigh,
+					seq:      1,
+				},
+				{
+					repo:     &b,
+					priority: priorityLow,
+					seq:      2,
+				},
+			},
+			expectedNotifications: 2,
+		},
+		{
+			name: "enqueue low a then low a",
+			calls: []*enqueueCall{
+				{repo: a, priority: priorityLow},
+				{repo: a, priority: priorityLow},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityLow,
+					seq:      1,
+				},
+			},
+			expectedNotifications: 1,
+		},
+		{
+			name: "enqueue high a then low a",
+			calls: []*enqueueCall{
+				{repo: a, priority: priorityHigh},
+				{repo: a, priority: priorityLow},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityHigh,
+					seq:      1,
+				},
+			},
+			expectedNotifications: 1,
+		},
+		{
+			name: "enqueue low a then high a",
+			calls: []*enqueueCall{
+				{repo: a, priority: priorityLow},
+				{repo: a, priority: priorityHigh},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityHigh,
+					seq:      2,
+				},
+			},
+			expectedNotifications: 2,
+		},
+		{
+			name: "heap is fixed when priority is bumped",
+			calls: []*enqueueCall{
+				{repo: c, priority: priorityLow},
+				{repo: d, priority: priorityLow},
+				{repo: a, priority: priorityLow},
+				{repo: e, priority: priorityLow},
+				{repo: b, priority: priorityLow},
+
+				{repo: a, priority: priorityHigh},
+				{repo: b, priority: priorityHigh},
+				{repo: c, priority: priorityHigh},
+				{repo: d, priority: priorityHigh},
+				{repo: e, priority: priorityHigh},
+			},
+			expectedUpdates: []*repoUpdate{
+				{
+					repo:     &a,
+					priority: priorityHigh,
+					seq:      6,
+				},
+				{
+					repo:     &b,
+					priority: priorityHigh,
+					seq:      7,
+				},
+				{
+					repo:     &c,
+					priority: priorityHigh,
+					seq:      8,
+				},
+				{
+					repo:     &d,
+					priority: priorityHigh,
+					seq:      9,
+				},
+				{
+					repo:     &e,
+					priority: priorityHigh,
+					seq:      10,
+				},
+			},
+			expectedNotifications: 10,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+
+			for _, call := range test.calls {
+				s.updateQueue.enqueue(&call.repo, call.priority)
+			}
+
+			verifyQueue(t, s, test.expectedUpdates)
+
+			// Verify notifications.
+			expectedRecording := &recording{}
+			for i := 0; i < test.expectedNotifications; i++ {
+				expectedRecording.notifications = append(expectedRecording.notifications, s.updateQueue.notifyEnqueue)
+			}
+			if !reflect.DeepEqual(expectedRecording, r) {
+				t.Fatalf("\nexpected\n%s\ngot\n%s", spew.Sdump(expectedRecording), spew.Sdump(r))
+			}
+		})
+	}
+}
+
+func TestUpdateQueue_remove(t *testing.T) {
+	a := &configuredRepo{name: "a", url: "a.com"}
+	b := &configuredRepo{name: "b", url: "b.com"}
+	c := &configuredRepo{name: "c", url: "c.com"}
+
+	type removeCall struct {
+		repo     *configuredRepo
+		updating bool
+	}
+
+	tests := []struct {
+		name         string
+		initialQueue []*repoUpdate
+		removeCalls  []*removeCall
+		finalQueue   []*repoUpdate
+	}{
+		{
+			name: "remove only",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+			},
+			removeCalls: []*removeCall{
+				{repo: a},
+			},
+		},
+		{
+			name: "remove front",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 2},
+			},
+			removeCalls: []*removeCall{
+				{repo: a},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: b, seq: 2},
+			},
+		},
+		{
+			name: "remove back",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 2},
+			},
+			removeCalls: []*removeCall{
+				{repo: b},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+			},
+		},
+		{
+			name: "remove middle",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 2},
+				{repo: c, seq: 3},
+			},
+			removeCalls: []*removeCall{
+				{repo: c},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 2},
+			},
+		},
+		{
+			name: "remove not present",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+			},
+			removeCalls: []*removeCall{
+				{repo: b},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+			},
+		},
+		{
+			name: "remove from empty queue",
+			removeCalls: []*removeCall{
+				{repo: a},
+			},
+		},
+		{
+			name: "remove all",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 2},
+				{repo: c, seq: 3},
+			},
+			removeCalls: []*removeCall{
+				{repo: a},
+				{repo: b},
+				{repo: c},
+			},
+		},
+		{
+			name: "remove all reverse",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 2},
+				{repo: c, seq: 3},
+			},
+			removeCalls: []*removeCall{
+				{repo: c},
+				{repo: b},
+				{repo: a},
+			},
+		},
+		{
+			name: "don't remove updating",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1, updating: true},
+			},
+			removeCalls: []*removeCall{
+				{repo: a, updating: false},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, seq: 1, updating: true},
+			},
+		},
+		{
+			name: "don't remove not updating",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1, updating: false},
+			},
+			removeCalls: []*removeCall{
+				{repo: a, updating: true},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, seq: 1, updating: false},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+			setupInitialQueue(s, test.initialQueue)
+
+			// Perform the removals.
+			for _, call := range test.removeCalls {
+				s.updateQueue.remove(call.repo, call.updating)
+			}
+
+			verifyQueue(t, s, test.finalQueue)
+
+			// Verify no notifications.
+			expectedRecording := &recording{}
+			if !reflect.DeepEqual(expectedRecording, r) {
+				t.Fatalf("\nexpected\n%s\ngot\n%s", spew.Sdump(expectedRecording), spew.Sdump(r))
+			}
+		})
+	}
+}
+
+func TestUpdateQueue_acquireNext(t *testing.T) {
+	a := &configuredRepo{name: "a", url: "a.com"}
+	b := &configuredRepo{name: "b", url: "b.com"}
+
+	tests := []struct {
+		name           string
+		initialQueue   []*repoUpdate
+		acquireResults []*configuredRepo
+		finalQueue     []*repoUpdate
+	}{
+		{
+			name:           "acquire from empty queue returns nil",
+			acquireResults: []*configuredRepo{nil},
+		},
+		{
+			name: "acquire sets updating to true",
+			initialQueue: []*repoUpdate{
+				{repo: a, updating: false, seq: 1},
+			},
+			acquireResults: []*configuredRepo{a},
+			finalQueue: []*repoUpdate{
+				{repo: a, updating: true, seq: 1},
+			},
+		},
+		{
+			name: "acquire sends update to back of queue",
+			initialQueue: []*repoUpdate{
+				{repo: a, updating: false, seq: 1},
+				{repo: b, updating: false, seq: 2},
+			},
+			acquireResults: []*configuredRepo{a},
+			finalQueue: []*repoUpdate{
+				{repo: b, updating: false, seq: 2},
+				{repo: a, updating: true, seq: 1},
+			},
+		},
+		{
+			name: "acquire does not return repos that are already updating",
+			initialQueue: []*repoUpdate{
+				{repo: a, updating: true, seq: 1},
+			},
+			acquireResults: []*configuredRepo{nil},
+			finalQueue: []*repoUpdate{
+				{repo: a, updating: true, seq: 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+			setupInitialQueue(s, test.initialQueue)
+
+			// Test aquireNext.
+			for i, expected := range test.acquireResults {
+				if actual := s.updateQueue.acquireNext(); !reflect.DeepEqual(expected, actual) {
+					t.Fatalf("\nacquireNext expected %d\n%s\ngot\n%s", i, spew.Sdump(expected), spew.Sdump(actual))
+				}
+			}
+
+			verifyQueue(t, s, test.finalQueue)
+
+			// Verify no notifications.
+			expectedRecording := &recording{}
+			if !reflect.DeepEqual(expectedRecording, r) {
+				t.Fatalf("\nexpected\n%s\ngot\n%s", spew.Sdump(expectedRecording), spew.Sdump(r))
+			}
+		})
+	}
+}
+
+func setupInitialQueue(s *updateScheduler, initialQueue []*repoUpdate) {
+	for _, update := range initialQueue {
+		heap.Push(s.updateQueue, update)
+	}
+}
+
+func verifyQueue(t *testing.T, s *updateScheduler, expected []*repoUpdate) {
+	t.Helper()
+
+	var actualQueue []*repoUpdate
+	for len(s.updateQueue.heap) > 0 {
+		update := heap.Pop(s.updateQueue).(*repoUpdate)
+		update.index = 0 // this will always be -1, but easier to set it to 0 to avoid boilerplate in test cases
+		actualQueue = append(actualQueue, update)
+	}
+
+	if !reflect.DeepEqual(expected, actualQueue) {
+		t.Fatalf("\nexpected final queue\n%s\ngot\n%s", spew.Sdump(expected), spew.Sdump(actualQueue))
+	}
+}
+
+func TestSchedule_add(t *testing.T) {
+	a := &configuredRepo{name: "a", url: "a.com"}
+	b := &configuredRepo{name: "b", url: "b.com"}
+
+	type addCall struct {
+		time time.Time
+		repo *configuredRepo
+	}
+
+	tests := []struct {
+		name                string
+		initialSchedule     []*scheduledRepoUpdate
+		addCalls            []*addCall
+		finalSchedule       []*scheduledRepoUpdate
+		timeAfterFuncDelays []time.Duration
+		wakeupNotifications int
+	}{
+		{
+			name: "add to empty schedule",
+			addCalls: []*addCall{
+				{repo: a, time: defaultTime},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					interval: minDelay,
+					due:      defaultTime.Add(minDelay),
+					repo:     a,
+				},
+			},
+			timeAfterFuncDelays: []time.Duration{minDelay},
+			wakeupNotifications: 1,
+		},
+		{
+			name: "add duplicate is no-op",
+			initialSchedule: []*scheduledRepoUpdate{
+				{
+					interval: minDelay,
+					due:      defaultTime,
+					repo:     a,
+				},
+			},
+			addCalls: []*addCall{
+				{repo: a, time: defaultTime.Add(time.Minute)},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					interval: minDelay,
+					due:      defaultTime,
+					repo:     a,
+				},
+			},
+		},
+		{
+			name: "add later",
+			initialSchedule: []*scheduledRepoUpdate{
+				{
+					interval: minDelay,
+					due:      defaultTime.Add(30 * time.Second),
+					repo:     a,
+				},
+			},
+			addCalls: []*addCall{
+				{repo: b, time: defaultTime.Add(time.Second)},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					interval: minDelay,
+					due:      defaultTime.Add(30 * time.Second),
+					repo:     a,
+				},
+				{
+					interval: minDelay,
+					due:      defaultTime.Add(time.Second + minDelay),
+					repo:     b,
+				},
+			},
+			timeAfterFuncDelays: []time.Duration{29 * time.Second},
+			wakeupNotifications: 1,
+		},
+		{
+			name: "add before",
+			initialSchedule: []*scheduledRepoUpdate{
+				{
+					interval: minDelay,
+					due:      defaultTime.Add(time.Minute),
+					repo:     a,
+				},
+			},
+			addCalls: []*addCall{
+				{repo: b, time: defaultTime.Add(time.Second)},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					interval: minDelay,
+					due:      defaultTime.Add(time.Second + minDelay),
+					repo:     b,
+				},
+				{
+					interval: minDelay,
+					due:      defaultTime.Add(time.Minute),
+					repo:     a,
+				},
+			},
+			timeAfterFuncDelays: []time.Duration{minDelay},
+			wakeupNotifications: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+			setupInitialSchedule(s, test.initialSchedule)
+
+			for _, call := range test.addCalls {
+				mockTime(call.time)
+				s.schedule.add(call.repo)
+			}
+
+			verifySchedule(t, s, test.finalSchedule)
+			verifyScheduleRecording(t, s, test.timeAfterFuncDelays, test.wakeupNotifications, r)
+		})
+	}
+}
+
+func TestSchedule_updateInterval(t *testing.T) {
+	a := &configuredRepo{name: "a", url: "a.com"}
+	b := &configuredRepo{name: "b", url: "b.com"}
+	c := &configuredRepo{name: "c", url: "c.com"}
+	d := &configuredRepo{name: "d", url: "d.com"}
+	e := &configuredRepo{name: "e", url: "e.com"}
+
+	type updateCall struct {
+		time     time.Time
+		repo     *configuredRepo
+		interval time.Duration
+	}
+
+	tests := []struct {
+		name                string
+		initialSchedule     []*scheduledRepoUpdate
+		updateCalls         []*updateCall
+		finalSchedule       []*scheduledRepoUpdate
+		timeAfterFuncDelays []time.Duration
+		wakeupNotifications int
+	}{
+		{
+			name: "update has no effect if repo isn't in schedule",
+			updateCalls: []*updateCall{
+				{repo: a, time: defaultTime},
+			},
+		},
+		{
+			name: "update earlier",
+			initialSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: minDelay,
+					due:      defaultTime.Add(time.Hour),
+				},
+			},
+			updateCalls: []*updateCall{
+				{
+					repo:     a,
+					time:     defaultTime.Add(time.Second),
+					interval: 123 * time.Second,
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: 123 * time.Second,
+					due:      defaultTime.Add(124 * time.Second),
+				},
+			},
+			timeAfterFuncDelays: []time.Duration{123 * time.Second},
+			wakeupNotifications: 1,
+		},
+		{
+			name: "minimum interval",
+			initialSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: maxDelay,
+					due:      defaultTime.Add(maxDelay),
+				},
+			},
+			updateCalls: []*updateCall{
+				{
+					repo:     a,
+					time:     defaultTime,
+					interval: time.Second,
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: minDelay,
+					due:      defaultTime.Add(minDelay),
+				},
+			},
+			timeAfterFuncDelays: []time.Duration{minDelay},
+			wakeupNotifications: 1,
+		},
+		{
+			name: "maximum interval",
+			initialSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: minDelay,
+					due:      defaultTime.Add(minDelay),
+				},
+			},
+			updateCalls: []*updateCall{
+				{
+					repo:     a,
+					time:     defaultTime,
+					interval: 365 * 25 * time.Hour,
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: maxDelay,
+					due:      defaultTime.Add(maxDelay),
+				},
+			},
+			timeAfterFuncDelays: []time.Duration{maxDelay},
+			wakeupNotifications: 1,
+		},
+		{
+			name: "update later",
+			initialSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: minDelay,
+					due:      defaultTime.Add(time.Hour),
+				},
+			},
+			updateCalls: []*updateCall{
+				{
+					repo:     a,
+					time:     defaultTime.Add(time.Second),
+					interval: 123 * time.Minute,
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{
+					repo:     a,
+					interval: 123 * time.Minute,
+					due:      defaultTime.Add(time.Second + 123*time.Minute),
+				},
+			},
+			timeAfterFuncDelays: []time.Duration{123 * time.Minute},
+			wakeupNotifications: 1,
+		},
+		{
+			name: "heap reorders correctly",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: c, interval: minDelay, due: defaultTime.Add(1 * time.Minute)},
+				{repo: d, interval: minDelay, due: defaultTime.Add(2 * time.Minute)},
+				{repo: a, interval: minDelay, due: defaultTime.Add(3 * time.Minute)},
+				{repo: e, interval: minDelay, due: defaultTime.Add(4 * time.Minute)},
+				{repo: b, interval: minDelay, due: defaultTime.Add(5 * time.Minute)},
+			},
+			updateCalls: []*updateCall{
+				{repo: a, time: defaultTime, interval: 1 * time.Minute},
+				{repo: b, time: defaultTime, interval: 2 * time.Minute},
+				{repo: c, time: defaultTime, interval: 3 * time.Minute},
+				{repo: d, time: defaultTime, interval: 4 * time.Minute},
+				{repo: e, time: defaultTime, interval: 5 * time.Minute},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: 1 * time.Minute, due: defaultTime.Add(1 * time.Minute)},
+				{repo: b, interval: 2 * time.Minute, due: defaultTime.Add(2 * time.Minute)},
+				{repo: c, interval: 3 * time.Minute, due: defaultTime.Add(3 * time.Minute)},
+				{repo: d, interval: 4 * time.Minute, due: defaultTime.Add(4 * time.Minute)},
+				{repo: e, interval: 5 * time.Minute, due: defaultTime.Add(5 * time.Minute)},
+			},
+			timeAfterFuncDelays: []time.Duration{time.Minute, time.Minute, time.Minute, time.Minute, time.Minute},
+			wakeupNotifications: 5,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+			setupInitialSchedule(s, test.initialSchedule)
+
+			for _, call := range test.updateCalls {
+				mockTime(call.time)
+				s.schedule.updateInterval(call.repo, call.interval)
+			}
+
+			verifySchedule(t, s, test.finalSchedule)
+			verifyScheduleRecording(t, s, test.timeAfterFuncDelays, test.wakeupNotifications, r)
+		})
+	}
+}
+
+func TestSchedule_remove(t *testing.T) {
+	a := &configuredRepo{name: "a", url: "a.com"}
+	b := &configuredRepo{name: "b", url: "b.com"}
+	c := &configuredRepo{name: "c", url: "c.com"}
+
+	type removeCall struct {
+		time time.Time
+		repo *configuredRepo
+	}
+
+	tests := []struct {
+		name                string
+		initialSchedule     []*scheduledRepoUpdate
+		removeCalls         []*removeCall
+		finalSchedule       []*scheduledRepoUpdate
+		timeAfterFuncDelays []time.Duration
+		wakeupNotifications int
+	}{
+		{
+			name: "remove on empty schedule",
+			removeCalls: []*removeCall{
+				{repo: a, time: defaultTime},
+			},
+		},
+		{
+			name: "remove has no effect if repo isn't in schedule",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a},
+			},
+			removeCalls: []*removeCall{
+				{repo: b},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: a},
+			},
+		},
+		{
+			name: "remove last scheduled doesn't reschedule timer",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a},
+			},
+			removeCalls: []*removeCall{
+				{repo: a},
+			},
+		},
+		{
+			name: "remove next reschedules timer",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: minDelay, due: defaultTime},
+				{repo: b, interval: minDelay, due: defaultTime.Add(minDelay)},
+				{repo: c, interval: maxDelay, due: defaultTime.Add(maxDelay)},
+			},
+			removeCalls: []*removeCall{
+				{repo: a, time: defaultTime},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: b, interval: minDelay, due: defaultTime.Add(minDelay)},
+				{repo: c, interval: maxDelay, due: defaultTime.Add(maxDelay)},
+			},
+			timeAfterFuncDelays: []time.Duration{minDelay},
+			wakeupNotifications: 1,
+		},
+		{
+			name: "remove not-next doesn't reschedule timer",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: minDelay, due: defaultTime},
+				{repo: b, interval: minDelay, due: defaultTime.Add(minDelay)},
+				{repo: c, interval: maxDelay, due: defaultTime.Add(maxDelay)},
+			},
+			removeCalls: []*removeCall{
+				{repo: b, time: defaultTime},
+				{repo: c, time: defaultTime},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: minDelay, due: defaultTime},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+			setupInitialSchedule(s, test.initialSchedule)
+
+			for _, call := range test.removeCalls {
+				mockTime(call.time)
+				s.schedule.remove(call.repo)
+			}
+
+			verifySchedule(t, s, test.finalSchedule)
+			verifyScheduleRecording(t, s, test.timeAfterFuncDelays, test.wakeupNotifications, r)
+		})
+	}
+}
+
+func setupInitialSchedule(s *updateScheduler, initialSchedule []*scheduledRepoUpdate) {
+	for _, update := range initialSchedule {
+		heap.Push(s.schedule, update)
+	}
+}
+
+func verifySchedule(t *testing.T, s *updateScheduler, expected []*scheduledRepoUpdate) {
+	t.Helper()
+
+	var actualSchedule []*scheduledRepoUpdate
+	for len(s.schedule.heap) > 0 {
+		update := heap.Pop(s.schedule).(*scheduledRepoUpdate)
+		update.index = 0 // this will always be -1, but easier to set it to 0 to avoid boilerplate in test cases
+		actualSchedule = append(actualSchedule, update)
+	}
+
+	if !reflect.DeepEqual(expected, actualSchedule) {
+		t.Fatalf("\nexpected final schedule\n%s\ngot\n%s", spew.Sdump(expected), spew.Sdump(actualSchedule))
+	}
+}
+
+func verifyScheduleRecording(t *testing.T, s *updateScheduler, timeAfterFuncDelays []time.Duration, wakeupNotifications int, r *recording) {
+	t.Helper()
+
+	if !reflect.DeepEqual(timeAfterFuncDelays, r.timeAfterFuncDelays) {
+		t.Fatalf("\nexpected timeAfterFuncDelays\n%s\ngot\n%s", spew.Sdump(timeAfterFuncDelays), spew.Sdump(r.timeAfterFuncDelays))
+	}
+
+	if l := len(r.notifications); l != wakeupNotifications {
+		t.Fatalf("expected %d notifications; got %d", wakeupNotifications, l)
+	}
+
+	for _, n := range r.notifications {
+		if n != s.schedule.wakeup {
+			t.Fatalf("received notification on wrong channel")
+		}
+	}
+}
+
+func TestUpdateScheduler_runScheduleLoop(t *testing.T) {
+	a := &configuredRepo{name: "a", url: "a.com"}
+	b := &configuredRepo{name: "b", url: "b.com"}
+	c := &configuredRepo{name: "c", url: "c.com"}
+	d := &configuredRepo{name: "d", url: "d.com"}
+	e := &configuredRepo{name: "e", url: "e.com"}
+
+	tests := []struct {
+		name                  string
+		initialSchedule       []*scheduledRepoUpdate
+		finalSchedule         []*scheduledRepoUpdate
+		finalQueue            []*repoUpdate
+		timeAfterFuncDelays   []time.Duration
+		expectedNotifications func(s *updateScheduler) []chan struct{}
+	}{
+		{
+			name: "empty schedule",
+		},
+		{
+			name: "no updates due",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: 11 * time.Second, due: defaultTime.Add(time.Minute)},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: 11 * time.Second, due: defaultTime.Add(time.Minute)},
+			},
+			timeAfterFuncDelays: []time.Duration{time.Minute},
+			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+				return []chan struct{}{s.schedule.wakeup}
+			},
+		},
+		{
+			name: "one update due, rescheduled to front",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: 11 * time.Second, due: defaultTime.Add(1 * time.Microsecond)},
+				{repo: b, interval: 22 * time.Second, due: defaultTime.Add(time.Minute)},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: 11 * time.Second, due: defaultTime.Add(11 * time.Second)},
+				{repo: b, interval: 22 * time.Second, due: defaultTime.Add(time.Minute)},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, priority: priorityLow, seq: 1},
+			},
+			timeAfterFuncDelays: []time.Duration{11 * time.Second},
+			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+				return []chan struct{}{s.updateQueue.notifyEnqueue, s.schedule.wakeup}
+			},
+		},
+		{
+			name: "one update due, rescheduled to back",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: 11 * time.Minute, due: defaultTime},
+				{repo: b, interval: 22 * time.Second, due: defaultTime.Add(time.Minute)},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: b, interval: 22 * time.Second, due: defaultTime.Add(time.Minute)},
+				{repo: a, interval: 11 * time.Minute, due: defaultTime.Add(11 * time.Minute)},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, priority: priorityLow, seq: 1},
+			},
+			timeAfterFuncDelays: []time.Duration{time.Minute},
+			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+				return []chan struct{}{s.updateQueue.notifyEnqueue, s.schedule.wakeup}
+			},
+		},
+		{
+			name: "all updates due",
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: c, interval: 3 * time.Minute, due: defaultTime.Add(-5 * time.Minute)},
+				{repo: d, interval: 4 * time.Minute, due: defaultTime.Add(-4 * time.Minute)},
+				{repo: a, interval: 1 * time.Minute, due: defaultTime.Add(-3 * time.Minute)},
+				{repo: e, interval: 5 * time.Minute, due: defaultTime.Add(-2 * time.Minute)},
+				{repo: b, interval: 2 * time.Minute, due: defaultTime.Add(-1 * time.Minute)},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: 1 * time.Minute, due: defaultTime.Add(1 * time.Minute)},
+				{repo: b, interval: 2 * time.Minute, due: defaultTime.Add(2 * time.Minute)},
+				{repo: c, interval: 3 * time.Minute, due: defaultTime.Add(3 * time.Minute)},
+				{repo: d, interval: 4 * time.Minute, due: defaultTime.Add(4 * time.Minute)},
+				{repo: e, interval: 5 * time.Minute, due: defaultTime.Add(5 * time.Minute)},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: c, priority: priorityLow, seq: 1},
+				{repo: d, priority: priorityLow, seq: 2},
+				{repo: a, priority: priorityLow, seq: 3},
+				{repo: e, priority: priorityLow, seq: 4},
+				{repo: b, priority: priorityLow, seq: 5},
+			},
+			timeAfterFuncDelays: []time.Duration{1 * time.Minute},
+			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+				return []chan struct{}{
+					s.updateQueue.notifyEnqueue,
+					s.updateQueue.notifyEnqueue,
+					s.updateQueue.notifyEnqueue,
+					s.updateQueue.notifyEnqueue,
+					s.updateQueue.notifyEnqueue,
+					s.schedule.wakeup,
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+
+			// unbuffer the wakeup channel
+			s.schedule.wakeup = make(chan struct{})
+
+			setupInitialSchedule(s, test.initialSchedule)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				s.runScheduleLoop(ctx)
+				close(done)
+			}()
+
+			// Let the goroutine do a single loop.
+			s.schedule.wakeup <- struct{}{}
+
+			// Cancel after the first loop.
+			// This doesn't race with the wakeup notification because the channel is not buffered.
+			cancel()
+
+			// Wait for the goroutine to exit so we can verify the final state.
+			<-done
+
+			verifySchedule(t, s, test.finalSchedule)
+			verifyQueue(t, s, test.finalQueue)
+			verifyRecording(t, s, test.timeAfterFuncDelays, test.expectedNotifications, r)
+		})
+	}
+}
+
+func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
+	a := &configuredRepo{name: "a", url: "a.com"}
+	b := &configuredRepo{name: "b", url: "b.com"}
+	c := &configuredRepo{name: "c", url: "c.com"}
+
+	type mockRequestRepoUpdate struct {
+		repo *configuredRepo
+		resp *gitserverprotocol.RepoUpdateResponse
+		err  error
+	}
+
+	tests := []struct {
+		name                   string
+		gitMaxConcurrentClones int
+		initialSchedule        []*scheduledRepoUpdate
+		initialQueue           []*repoUpdate
+		mockRequestRepoUpdates []*mockRequestRepoUpdate
+		finalSchedule          []*scheduledRepoUpdate
+		finalQueue             []*repoUpdate
+		timeAfterFuncDelays    []time.Duration
+		expectedNotifications  func(s *updateScheduler) []chan struct{}
+	}{
+		{
+			name: "empty queue",
+		},
+		{
+			name: "non-empty queue at clone limit",
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+			},
+		},
+		{
+			name:                   "queue drains",
+			gitMaxConcurrentClones: 1,
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 2},
+				{repo: c, seq: 3},
+			},
+			mockRequestRepoUpdates: []*mockRequestRepoUpdate{
+				{repo: a},
+				{repo: b},
+				{repo: c},
+			},
+		},
+		{
+			name:                   "schedule updated",
+			gitMaxConcurrentClones: 1,
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: time.Hour, due: defaultTime.Add(time.Hour)},
+			},
+			initialQueue: []*repoUpdate{
+				{repo: a, seq: 1},
+				{repo: b, seq: 1},
+			},
+			mockRequestRepoUpdates: []*mockRequestRepoUpdate{
+				{
+					repo: a,
+					resp: &gitserverprotocol.RepoUpdateResponse{
+						LastFetched: timePtr(defaultTime.Add(2 * time.Minute)),
+						LastChanged: timePtr(defaultTime),
+					},
+				},
+				{
+					repo: b,
+					resp: &gitserverprotocol.RepoUpdateResponse{
+						LastFetched: timePtr(defaultTime.Add(2 * time.Minute)),
+						LastChanged: timePtr(defaultTime),
+					},
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: a, interval: time.Minute, due: defaultTime.Add(time.Minute)},
+			},
+			timeAfterFuncDelays: []time.Duration{time.Minute},
+			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+				return []chan struct{}{s.schedule.wakeup}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			configuredLimiter = func() *mutablelimiter.Limiter {
+				return mutablelimiter.New(test.gitMaxConcurrentClones)
+			}
+			defer func() {
+				configuredLimiter = nil
+			}()
+
+			expectedRequestCount := len(test.mockRequestRepoUpdates)
+			mockRequestRepoUpdates := make(chan *mockRequestRepoUpdate, expectedRequestCount)
+			for _, m := range test.mockRequestRepoUpdates {
+				mockRequestRepoUpdates <- m
+			}
+			// intentionally don't close the channel so any futher receives just block
+
+			contexts := make(chan context.Context, expectedRequestCount)
+			requestRepoUpdate = func(ctx context.Context, repo *configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
+				select {
+				case mock := <-mockRequestRepoUpdates:
+					if !reflect.DeepEqual(mock.repo, repo) {
+						t.Errorf("\nexpected requestRepoUpdate\n%s\ngot\n%s", spew.Sdump(mock.repo), spew.Sdump(repo))
+					}
+					contexts <- ctx // Intercept all contexts so we can wait for spawned goroutines to finish.
+					return mock.resp, mock.err
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			defer func() { requestRepoUpdate = nil }()
+
+			s := newUpdateScheduler()
+
+			// unbuffer the channel
+			s.updateQueue.notifyEnqueue = make(chan struct{})
+
+			setupInitialSchedule(s, test.initialSchedule)
+			setupInitialQueue(s, test.initialQueue)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				s.runUpdateLoop(ctx)
+				close(done)
+			}()
+
+			// Let the goroutine do a single loop.
+			s.updateQueue.notifyEnqueue <- struct{}{}
+
+			// Wait for all goroutines that have a mock request to finish.
+			// There may be additional goroutines which don't have a mock request
+			// and will block until the context is canceled.
+			for i := 0; i < expectedRequestCount; i++ {
+				ctx := <-contexts
+				<-ctx.Done()
+			}
+
+			verifySchedule(t, s, test.finalSchedule)
+			verifyQueue(t, s, test.finalQueue)
+			verifyRecording(t, s, test.timeAfterFuncDelays, test.expectedNotifications, r)
+
+			// Cancel the context.
+			cancel()
+
+			// Wait for the goroutine to exit.
+			<-done
+		})
+	}
+}
+
+func verifyRecording(t *testing.T, s *updateScheduler, timeAfterFuncDelays []time.Duration, expectedNotifications func(s *updateScheduler) []chan struct{}, r *recording) {
+	if !reflect.DeepEqual(timeAfterFuncDelays, r.timeAfterFuncDelays) {
+		t.Fatalf("\nexpected timeAfterFuncDelays\n%s\ngot\n%s", spew.Sdump(timeAfterFuncDelays), spew.Sdump(r.timeAfterFuncDelays))
+	}
+
+	if expectedNotifications == nil {
+		expectedNotifications = func(s *updateScheduler) []chan struct{} {
+			return nil
+		}
+	}
+
+	if expected := expectedNotifications(s); !reflect.DeepEqual(expected, r.notifications) {
+		t.Fatalf("\nexpected notifications\n%s\ngot\n%s", spew.Sdump(expected), spew.Sdump(r.notifications))
+	}
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+func TestUpdateScheduler_updateSource(t *testing.T) {
+	type updateSourceCall struct {
+		source  string
+		newList sourceRepoMap
+	}
+
+	tests := []struct {
+		name                  string
+		initialSourceRepos    map[string]sourceRepoMap
+		initialSchedule       []*scheduledRepoUpdate
+		initialQueue          []*repoUpdate
+		updateSourceCalls     []*updateSourceCall
+		finalSourceRepos      map[string]sourceRepoMap
+		finalSchedule         []*scheduledRepoUpdate
+		finalQueue            []*repoUpdate
+		timeAfterFuncDelays   []time.Duration
+		expectedNotifications func(s *updateScheduler) []chan struct{}
+	}{
+		{
+			name:               "add disabled repo",
+			initialSourceRepos: map[string]sourceRepoMap{},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: false},
+					},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: false},
+				},
+			},
+		},
+		{
+			name:               "add enabled repo",
+			initialSourceRepos: map[string]sourceRepoMap{},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+					},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, interval: minDelay, due: defaultTime.Add(minDelay)},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, seq: 1, updating: false},
+			},
+			timeAfterFuncDelays: []time.Duration{minDelay},
+			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+				return []chan struct{}{s.schedule.wakeup, s.updateQueue.notifyEnqueue}
+			},
+		},
+		{
+			name: "update disabled repo",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: false},
+				},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: true},
+					},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: true},
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "aa.com", enabled: true}, interval: minDelay, due: defaultTime.Add(minDelay)},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "aa.com", enabled: true}, seq: 1, updating: false},
+			},
+			timeAfterFuncDelays: []time.Duration{minDelay},
+			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+				return []chan struct{}{s.schedule.wakeup, s.updateQueue.notifyEnqueue}
+			},
+		},
+		{
+			name: "disabled repo removed from schedule and queue",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+				},
+			},
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, interval: minDelay, due: defaultTime},
+			},
+			initialQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: false}, updating: false},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: false},
+					},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: false},
+				},
+			},
+		},
+		{
+			name: "missing repo removed from schedule and queue",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+				},
+			},
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, interval: minDelay, due: defaultTime},
+			},
+			initialQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true /* enabled state doesn't get updated once in the queue because concurrency nightmare */}, updating: false},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source:  "a",
+					newList: sourceRepoMap{},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{},
+			},
+		},
+		{
+			name: "disabled repo not removed from queue when updating",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+				},
+			},
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, interval: minDelay, due: defaultTime},
+			},
+			initialQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, updating: true},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: false},
+					},
+				},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, seq: 1, updating: true},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: false},
+				},
+			},
+		},
+		{
+			name: "missing repo not removed from queue when updating",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+				},
+			},
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, interval: minDelay, due: defaultTime},
+			},
+			initialQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, updating: true},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source:  "a",
+					newList: sourceRepoMap{},
+				},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, seq: 1, updating: true},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{},
+			},
+		},
+		{
+			name: "enabled repo updated",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+				},
+			},
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, interval: minDelay, due: defaultTime.Add(minDelay)},
+			},
+			initialQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, seq: 1, updating: false},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: true},
+					},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: true},
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "aa.com", enabled: true}, interval: minDelay, due: defaultTime.Add(minDelay)},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "aa.com", enabled: true}, seq: 1, updating: false},
+			},
+		},
+		{
+			name: "disabled repo updated",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: false},
+				},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: false},
+					},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: false},
+				},
+			},
+		},
+		{
+			name: "update enabled repo while updating",
+			initialSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "a.com", enabled: true},
+				},
+			},
+			initialSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, interval: minDelay, due: defaultTime.Add(minDelay)},
+			},
+			initialQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, seq: 1, updating: true},
+			},
+			updateSourceCalls: []*updateSourceCall{
+				{
+					source: "a",
+					newList: sourceRepoMap{
+						api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: true},
+					},
+				},
+			},
+			finalSourceRepos: map[string]sourceRepoMap{
+				"a": sourceRepoMap{
+					api.RepoName("a/a"): &configuredRepo{name: "a", url: "aa.com", enabled: true},
+				},
+			},
+			finalSchedule: []*scheduledRepoUpdate{
+				{repo: &configuredRepo{name: "a", url: "aa.com", enabled: true}, interval: minDelay, due: defaultTime.Add(minDelay)},
+			},
+			finalQueue: []*repoUpdate{
+				{repo: &configuredRepo{name: "a", url: "a.com", enabled: true}, seq: 1, updating: true},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, stop := startRecording()
+			defer stop()
+
+			s := newUpdateScheduler()
+			s.sourceRepos = test.initialSourceRepos
+			setupInitialSchedule(s, test.initialSchedule)
+			setupInitialQueue(s, test.initialQueue)
+
+			for _, call := range test.updateSourceCalls {
+				s.updateSource(call.source, call.newList)
+			}
+
+			if !reflect.DeepEqual(s.sourceRepos, test.finalSourceRepos) {
+				t.Fatalf("\nexpected source repos\n%s\ngot\n%s", spew.Sdump(test.finalSourceRepos), spew.Sdump(s.sourceRepos))
+			}
+
+			verifySchedule(t, s, test.finalSchedule)
+			verifyQueue(t, s, test.finalQueue)
+			verifyRecording(t, s, test.timeAfterFuncDelays, test.expectedNotifications, r)
+		})
+	}
+}
+
+// TODO: update enabled state and url once in the queue?

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -43,6 +43,13 @@ func JumpToDefOSSIndexEnabled() bool {
 	return p == "enabled"
 }
 
+// UpdateScheduler2Enabled returns true if UpdateScheduler2 experiment is enabled.
+func UpdateScheduler2Enabled() bool {
+	p := Get().ExperimentalFeatures.UpdateScheduler2
+	// default is disabled
+	return p == "enabled"
+}
+
 type AccessTokAllow string
 
 const (

--- a/pkg/gitserver/protocol/gitserver.go
+++ b/pkg/gitserver/protocol/gitserver.go
@@ -111,6 +111,7 @@ type RepoInfoResponse struct {
 	CloneProgress   string     // a progress message from the running clone command.
 	Cloned          bool       // whether the repository has been cloned successfully
 	LastFetched     *time.Time // when the last `git remote update` or `git fetch` occurred
+	LastChanged     *time.Time // timestamp of the most recent ref in the git repository
 
 	// CloneTime is the time the clone occurred. Note: Repositories may be
 	// recloned automatically, so this time is likely to move forward

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -138,6 +138,7 @@ type ExperimentalFeatures struct {
 	CanonicalURLRedirect string `json:"canonicalURLRedirect,omitempty"`
 	Discussions          string `json:"discussions,omitempty"`
 	JumpToDefOSSIndex    string `json:"jumpToDefOSSIndex,omitempty"`
+	UpdateScheduler2     string `json:"updateScheduler2,omitempty"`
 }
 
 // ExtensionRepository description: The location of the version control repository for this extension.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -85,6 +85,12 @@
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
+        },
+        "updateScheduler2": {
+          "description": "Enables a new update scheduler algorithm",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
         }
       }
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -90,6 +90,12 @@ const SiteSchemaJSON = `{
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
+        },
+        "updateScheduler2": {
+          "description": "Enables a new update scheduler algorithm",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
         }
       }
     },


### PR DESCRIPTION
This PR implements a new scheduling algorithm for repo updater. The existing logic in reposlist.go is complicated and hard to follow. The proposed code in this PR is about 2/3s the size of the previous scheduler and I think is much easier to follow since it splits the system into two parts: a scheduler and an updater.

I did not make any attempt to solve other known problems (i.e. supporting repo renames), but I don't think I made any of these problems worse.

GitHub helpfully collapses the most interesting file in this diff: scheduler.go.

This is feature flagged and off by default, so I would like to merge this as-is.

I will open a followup PR to address observability.

