### PR TITLE
fix: restore hasCodeIntelligence

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2589,6 +2589,10 @@ type Site implements ConfigurationSubject {
     noRepositoriesEnabled: Boolean!
     # Alerts to display to the viewer.
     alerts: [Alert!]!
+    # Whether the site has code intelligence. This field will be expanded in the future to describe
+    # more about the code intelligence available (languages supported, etc.). It is subject to
+    # change without notice.
+    hasCodeIntelligence: Boolean!
     # Whether we want to show built-in searches on the saved searches page
     disableBuiltInSearches: Boolean!
     # Whether the server sends emails to users to verify email addresses. If false, then site admins must manually

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2596,6 +2596,10 @@ type Site implements ConfigurationSubject {
     noRepositoriesEnabled: Boolean!
     # Alerts to display to the viewer.
     alerts: [Alert!]!
+    # Whether the site has code intelligence. This field will be expanded in the future to describe
+    # more about the code intelligence available (languages supported, etc.). It is subject to
+    # change without notice.
+    hasCodeIntelligence: Boolean!
     # Whether we want to show built-in searches on the saved searches page
     disableBuiltInSearches: Boolean!
     # Whether the server sends emails to users to verify email addresses. If false, then site admins must manually


### PR DESCRIPTION
Fixes codeintel on Sourcegraph.com

I have not verified this fixes the problem yet.

> This PR does not need to update the CHANGELOG because ...
