### PR TITLE
fix: calculate and show accurate count of max users per license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Site and user usage statistics are now visible to all users. Previously only site admins (and users, for their own usage statistics) could view this information. The information consists of aggregate counts of actions such as searches, page views, etc.
 - The Git blame information shown at the end of a line is now provided by the [Git extras extension](https://sourcegraph.com/extensions/sourcegraph/git-extras). You must add that extension to continue using this feature.
+### Fixed
+
+- Fixed an issue where the site admin License page showed a count of current users, rather than the max number of users over the life of the license.
+
+### Removed
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/product_subscription_status.go
+++ b/cmd/frontend/graphqlbackend/product_subscription_status.go
@@ -16,6 +16,12 @@ var ActualUserCount = func(ctx context.Context) (int32, error) {
 	return 0, nil
 }
 
+// ActualUserCountDate is called to obtain the timestamp when the actual maximum number of user accounts
+// that have been active on this Sourcegraph instance for the current license was reached.
+var ActualUserCountDate = func(ctx context.Context) (string, error) {
+	return "", nil
+}
+
 // productSubscriptionStatus implements the GraphQL type ProductSubscriptionStatus.
 type productSubscriptionStatus struct{}
 
@@ -34,6 +40,10 @@ func (productSubscriptionStatus) ProductNameWithBrand() (string, error) {
 
 func (productSubscriptionStatus) ActualUserCount(ctx context.Context) (int32, error) {
 	return ActualUserCount(ctx)
+}
+
+func (productSubscriptionStatus) ActualUserCountDate(ctx context.Context) (string, error) {
+	return ActualUserCountDate(ctx)
 }
 
 func (r productSubscriptionStatus) License() (*ProductLicenseInfo, error) {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2775,6 +2775,9 @@ type ProductSubscriptionStatus {
     # The max number of user accounts that have been active on this Sourcegraph site for the current license.
     # If no license is in use, returns zero.
     actualUserCount: Int!
+    # The date and time when the max number of user accounts that have been active on this Sourcegraph site for
+    # the current license was reached. If no license is in use, returns an empty string.
+    actualUserCountDate: String!
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2782,6 +2782,9 @@ type ProductSubscriptionStatus {
     # The max number of user accounts that have been active on this Sourcegraph site for the current license.
     # If no license is in use, returns zero.
     actualUserCount: Int!
+    # The date and time when the max number of user accounts that have been active on this Sourcegraph site for
+    # the current license was reached. If no license is in use, returns an empty string.
+    actualUserCountDate: String!
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo
 }

--- a/enterprise/cmd/frontend/auth/httpheader/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/httpheader/middleware_test.go
@@ -20,8 +20,8 @@ import (
 // SEE ALSO FOR MANUAL TESTING: See the Middleware docstring for information about the testproxy
 // helper program, which helps with manual testing of the HTTP auth proxy behavior.
 func TestMiddleware(t *testing.T) {
-	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, error) {
-		return &license.Info{Tags: licensing.EnterpriseTags}, nil
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
 	}
 	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 

--- a/enterprise/cmd/frontend/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/middleware_test.go
@@ -117,8 +117,8 @@ func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
 
-	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, error) {
-		return &license.Info{Tags: licensing.EnterpriseTags}, nil
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
 	}
 	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 
@@ -297,8 +297,8 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
 
-	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, error) {
-		return &license.Info{Tags: licensing.EnterpriseTags}, nil
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
 	}
 	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 

--- a/enterprise/cmd/frontend/auth/saml/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/saml/middleware_test.go
@@ -169,8 +169,8 @@ func TestMiddleware(t *testing.T) {
 	idpHTTPServer, idpServer := newSAMLIDPServer(t)
 	defer idpHTTPServer.Close()
 
-	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, error) {
-		return &license.Info{Tags: licensing.EnterpriseTags}, nil
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
 	}
 	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -76,7 +76,7 @@ func (r *productLicense) Subscription(ctx context.Context) (graphqlbackend.Produ
 func (r *productLicense) Info() (*graphqlbackend.ProductLicenseInfo, error) {
 	// Call this instead of licensing.ParseProductLicenseKey so that license info can be read from
 	// license keys generated using the test license generation private key.
-	info, err := licensing.ParseProductLicenseKeyWithBuiltinOrGenerationKey(r.v.LicenseKey)
+	info, _, err := licensing.ParseProductLicenseKeyWithBuiltinOrGenerationKey(r.v.LicenseKey)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement_test.go
@@ -68,8 +68,8 @@ func TestEnforcementPreCreateUser(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("license %s with %d active users", test.license, test.activeUserCount), func(t *testing.T) {
-			MockGetConfiguredProductLicenseInfo = func() (*license.Info, error) {
-				return test.license, nil
+			MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+				return test.license, "test-signature", nil
 			}
 			defer func() { MockGetConfiguredProductLicenseInfo = nil }()
 			db.Mocks.Users.Count = func(context.Context, *db.UsersListOptions) (int, error) {

--- a/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
+++ b/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
@@ -25,7 +25,7 @@ var (
 func init() {
 	// Start counting max users on the instance on launch.
 	hooks.AfterDBInit = func() {
-		go StartMaxUserCount()
+		go startMaxUserCount()
 	}
 	// Make the Site.productSubscription.actualUserCount and Site.productSubscription.actualUserCountDate
 	// GraphQL fields return the proper max user count and timestamp on the current license.
@@ -138,8 +138,8 @@ func actualUserCountDate(ctx context.Context) (string, error) {
 	return date, err
 }
 
-// StartMaxUserCount starts checking for a new count of max user accounts periodically.
-func StartMaxUserCount() {
+// startMaxUserCount starts checking for a new count of max user accounts periodically.
+func startMaxUserCount() {
 	if started {
 		panic("already started")
 	}
@@ -150,7 +150,7 @@ func StartMaxUserCount() {
 	for {
 		_, signature, err := GetConfiguredProductLicenseInfoWithSignature()
 		if err != nil {
-			log15.Error("licensing.StartMaxUserCount: error getting configured license info")
+			log15.Error("licensing.startMaxUserCount: error getting configured license info")
 		} else if signature != "" {
 			ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			_ = checkMaxUsers(ctx, signature) // updates global state on its own, can safely ignore return value

--- a/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
+++ b/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
@@ -1,0 +1,163 @@
+package licensing
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
+	"github.com/sourcegraph/sourcegraph/pkg/redispool"
+
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+var (
+	fetchOnce sync.Once
+	pool      = redispool.Store
+	keyPrefix = "license_user_count:"
+
+	started bool
+)
+
+func init() {
+	// Start counting max users on the instance on launch.
+	hooks.AfterDBInit = func() {
+		go StartMaxUserCount()
+	}
+	// Make the Site.productSubscription.actualUserCount and Site.productSubscription.actualUserCountDate
+	// GraphQL fields return the proper max user count and timestamp on the current license.
+	graphqlbackend.ActualUserCount = actualUserCount
+	graphqlbackend.ActualUserCountDate = actualUserCountDate
+}
+
+// setMaxUsers sets the max users associated with a license key if the new max count is greater than the previous max.
+func setMaxUsers(key string, count int) error {
+	c := pool.Get()
+	defer c.Close()
+
+	lastMax, _, err := getMaxUsers(c, key)
+	if err != nil {
+		return err
+	}
+
+	if count > lastMax {
+		err = c.Send("HSET", maxUsersKey(), key, count)
+		if err != nil {
+			return err
+		}
+		return c.Send("HSET", maxUsersTimeKey(), key, time.Now().Format("2006-01-02 15:04:05 UTC"))
+	}
+	return nil
+}
+
+// GetMaxUsers gets the max users associated with a license key.
+func GetMaxUsers(signature string) (int, string, error) {
+	c := pool.Get()
+	defer c.Close()
+
+	if signature == "" {
+		// No license key is in use.
+		return 0, "", nil
+	}
+
+	return getMaxUsers(c, signature)
+}
+
+func getMaxUsers(c redis.Conn, key string) (int, string, error) {
+	lastMax, err := redis.String(c.Do("HGET", maxUsersKey(), key))
+	if err != nil && err != redis.ErrNil {
+		return 0, "", err
+	}
+	lastMaxInt := 0
+	if lastMax != "" {
+		lastMaxInt, err = strconv.Atoi(lastMax)
+		if err != nil {
+			return 0, "", err
+		}
+	}
+	lastMaxDate, err := redis.String(c.Do("HGET", maxUsersTimeKey(), key))
+	if err != nil && err != redis.ErrNil {
+		return 0, "", err
+	}
+	return lastMaxInt, lastMaxDate, nil
+}
+
+// checkMaxUsers runs periodically, and if a license key is in use, updates the
+// record of maximum count of user accounts in use.
+func checkMaxUsers(ctx context.Context, signature string) error {
+	if signature == "" {
+		// No license key is in use.
+		return nil
+	}
+
+	count, err := db.Users.Count(ctx, nil)
+	if err != nil {
+		log15.Error("licensing.checkMaxUsers: error getting user count", "error", err)
+		return err
+	}
+	err = setMaxUsers(signature, int(count))
+	if err != nil {
+		log15.Error("licensing.checkMaxUsers: error setting new max users", "error", err)
+		return err
+	}
+	return nil
+}
+
+func maxUsersKey() string {
+	return keyPrefix + "max"
+}
+
+func maxUsersTimeKey() string {
+	return keyPrefix + "max_time"
+}
+
+// actualUserCount returns the actual max number of users that have had accounts on the
+// Sourcegraph instance, under the current license.
+func actualUserCount(ctx context.Context) (int32, error) {
+	_, signature, err := GetConfiguredProductLicenseInfoWithSignature()
+	if err != nil || signature == "" {
+		return 0, err
+	}
+
+	count, _, err := GetMaxUsers(signature)
+	return int32(count), err
+}
+
+// actualUserCountDate returns the timestamp when the actual max number of users that have
+// had accounts on the Sourcegraph instance, under the current license, was reached.
+func actualUserCountDate(ctx context.Context) (string, error) {
+	_, signature, err := GetConfiguredProductLicenseInfoWithSignature()
+	if err != nil || signature == "" {
+		return "", err
+	}
+
+	_, date, err := GetMaxUsers(signature)
+	return date, err
+}
+
+// StartMaxUserCount starts checking for a new count of max user accounts periodically.
+func StartMaxUserCount() {
+	if started {
+		panic("already started")
+	}
+	started = true
+
+	ctx := context.Background()
+	const delay = 360 * time.Minute
+	for {
+		_, signature, err := GetConfiguredProductLicenseInfoWithSignature()
+		if err != nil {
+			log15.Error("licensing.StartMaxUserCount: error getting configured license info")
+		} else if signature != "" {
+			ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			_ = checkMaxUsers(ctx, signature) // updates global state on its own, can safely ignore return value
+			cancel()
+		}
+		time.Sleep(delay)
+	}
+}

--- a/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
+++ b/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	fetchOnce sync.Once
 	pool      = redispool.Store
 	keyPrefix = "license_user_count:"
 

--- a/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
+++ b/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
@@ -3,7 +3,6 @@ package licensing
 import (
 	"context"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/garyburd/redigo/redis"

--- a/enterprise/cmd/frontend/internal/registry/allow_test.go
+++ b/enterprise/cmd/frontend/internal/registry/allow_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestIsRemoteExtensionAllowed(t *testing.T) {
-	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, error) {
-		return &license.Info{Tags: licensing.EnterpriseTags}, nil
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
 	}
 	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 	defer conf.Mock(nil)
@@ -58,8 +58,8 @@ func sameElements(a, b []string) bool {
 }
 
 func TestFilterRemoteExtensions(t *testing.T) {
-	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, error) {
-		return &license.Info{Tags: licensing.EnterpriseTags}, nil
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
 	}
 	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 

--- a/enterprise/pkg/license/license.go
+++ b/enterprise/pkg/license/license.go
@@ -127,7 +127,7 @@ func GenerateSignedKey(info Info, privateKey ssh.Signer) (string, error) {
 
 // ParseSignedKey parses and verifies the signed license key. If parsing or verification fails, a
 // non-nil error is returned.
-func ParseSignedKey(text string, publicKey ssh.PublicKey) (info *Info, err error) {
+func ParseSignedKey(text string, publicKey ssh.PublicKey) (info *Info, signature string, err error) {
 	// Ignore whitespace, in case the license key was (e.g.) wrapped in an email message.
 	text = strings.Map(func(c rune) rune {
 		if unicode.IsSpace(c) {
@@ -138,14 +138,14 @@ func ParseSignedKey(text string, publicKey ssh.PublicKey) (info *Info, err error
 
 	signedKeyData, err := base64.RawURLEncoding.DecodeString(text)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	var signedKey signedKey
 	if err := json.Unmarshal(signedKeyData, &signedKey); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if err := json.Unmarshal(signedKey.EncodedInfo, &info); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return info, publicKey.Verify(signedKey.EncodedInfo, signedKey.Signature)
+	return info, string(signedKey.Signature.Blob), publicKey.Verify(signedKey.EncodedInfo, signedKey.Signature)
 }

--- a/enterprise/pkg/license/license_test.go
+++ b/enterprise/pkg/license/license_test.go
@@ -109,7 +109,7 @@ func TestGenerateParseSignedKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		got, err := ParseSignedKey(text, publicKey)
+		got, _, err := ParseSignedKey(text, publicKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,7 +129,7 @@ func TestGenerateParseSignedKey(t *testing.T) {
 		// Add some whitespace.
 		text = text[:20] + " \n \t" + text[20:40] + " " + text[40:]
 
-		got, err := ParseSignedKey(text, publicKey)
+		got, _, err := ParseSignedKey(text, publicKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -143,7 +143,7 @@ func TestGenerateParseSignedKey(t *testing.T) {
 
 func TestParseSignedKey(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
-		if _, err := ParseSignedKey("invalid", publicKey); err == nil {
+		if _, _, err := ParseSignedKey("invalid", publicKey); err == nil {
 			t.Fatal("want error")
 		}
 	})

--- a/enterprise/src/productSubscription/TrueUpStatusSummary.tsx
+++ b/enterprise/src/productSubscription/TrueUpStatusSummary.tsx
@@ -6,12 +6,13 @@ import { formatUserCount } from '../productSubscription/helpers'
 
 interface Props {
     actualUserCount: number
+    actualUserCountDate: string | null
     license: GQL.IProductLicenseInfo
 }
 /**
  * Displays a summary of the site's true-up pricing status.
  */
-export const TrueUpStatusSummary: React.SFC<Props> = ({ actualUserCount, license }) => (
+export const TrueUpStatusSummary: React.SFC<Props> = ({ actualUserCount, actualUserCountDate, license }) => (
     <>
         <div className="true-up-status-summary mb-2 mt-4">
             <div className="true-up-status-summary__container">
@@ -25,13 +26,17 @@ export const TrueUpStatusSummary: React.SFC<Props> = ({ actualUserCount, license
                 <SingleValueCard
                     className="true-up-status-summary__item"
                     value={numberWithCommas(actualUserCount)}
-                    valueTooltip={`${numberWithCommas(actualUserCount)} total users`}
+                    valueTooltip={`${numberWithCommas(actualUserCount)} total users${actualUserCountDate !== '' &&
+                        `(reached on ${actualUserCountDate})`}`}
                     title="Maximum users"
                     subText="This is the highest peak of users on your installation since the license started, and this is the minimum number you need to purchase when you renew your license."
                 />
                 <SingleValueCard
                     className="true-up-status-summary__item"
                     value={numberWithCommas(Math.max(0, actualUserCount - license.userCount))}
+                    valueTooltip={`${numberWithCommas(
+                        Math.max(0, actualUserCount - license.userCount)
+                    )} users over${actualUserCountDate !== '' && `(on ${actualUserCountDate})`}`}
                     title="Users over license"
                     subText="The true-up model has a retroactive charge for these users at the next renewal. If you want to update your license sooner to prevent this, please contact sales@sourcegraph.com."
                     valueClassName={license.userCount - actualUserCount < 0 ? 'text-danger' : ''}

--- a/enterprise/src/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/enterprise/src/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -63,7 +63,7 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
             )
         }
 
-        const { productNameWithBrand, actualUserCount, license } = this.state.statusOrError
+        const { productNameWithBrand, actualUserCount, actualUserCountDate, license } = this.state.statusOrError
 
         // No license means Sourcegraph Core. For that, show the user that they can use this for free
         // forever, and show them how to upgrade.
@@ -131,7 +131,11 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
                 />
                 {license &&
                     (this.props.showTrueUpStatus ? (
-                        <TrueUpStatusSummary actualUserCount={actualUserCount} license={license} />
+                        <TrueUpStatusSummary
+                            actualUserCount={actualUserCount}
+                            actualUserCountDate={actualUserCountDate}
+                            license={license}
+                        />
                     ) : (
                         license.userCount - actualUserCount < 0 && (
                             <div className="alert alert-warning">
@@ -155,6 +159,7 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
                     productSubscription {
                         productNameWithBrand
                         actualUserCount
+                        actualUserCountDate
                         license {
                             tags
                             userCount

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,6 @@ github.com/beevik/etree v0.0.0-20180609182452-90dafc1e1f11 h1:C2jA9xWe9gk/WFMzvR
 github.com/beevik/etree v0.0.0-20180609182452-90dafc1e1f11/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
-github.com/beyang/vfsgen v0.0.0-20180926055532-04927b934b6e/go.mod h1:gxuhoRMrB2MpVzi2lRON+0PBvxvx8Pks8BnqxO2Fqs0=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boj/redistore v0.0.0-20160128113310-fc113767cd6b h1:PfxLkkgJYE095CKZji++BNwZjxWfoAF21WFPzkzOZEs=
@@ -301,8 +300,6 @@ github.com/sourcegraph/go-lsp v0.0.0-20181009131510-4631ffd93a18 h1:XOwy8S85zGn+
 github.com/sourcegraph/go-lsp v0.0.0-20181009131510-4631ffd93a18/go.mod h1:tpps84QRlOVVLYk5QpKYX8Tr289D1v/UTWDLqeguiqM=
 github.com/sourcegraph/go-vcsurl v0.0.0-20131114132947-6b12603ea6fd h1:wxP7dU7tNtU03+Z4GIuYGV17AO1i3HfCBArGu0igaro=
 github.com/sourcegraph/go-vcsurl v0.0.0-20131114132947-6b12603ea6fd/go.mod h1:Dl+4tLnKopzymgEhEZCi6/KSIZPFBe1rvoKMxCGh0Ms=
-github.com/sourcegraph/godockerize v0.0.0-20181029061954-5cf4e6d81720 h1:OkqHsJCzy3ZorBLAxbmnnx1NTpIG/+prvCZ50CLdgNw=
-github.com/sourcegraph/godockerize v0.0.0-20181029061954-5cf4e6d81720/go.mod h1:EnJwbnfidbH57UXewOZLIrwQVpu/spwbS/BMN0sPfCA=
 github.com/sourcegraph/godockerize v0.0.0-20181102001209-f9c9d82c8d1c h1:0D6Kdy5X2sdLmGSrg6sOgA9xuWLBi4pa6f55Igu6fmA=
 github.com/sourcegraph/godockerize v0.0.0-20181102001209-f9c9d82c8d1c/go.mod h1:EnJwbnfidbH57UXewOZLIrwQVpu/spwbS/BMN0sPfCA=
 github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d h1:FxF0pen6r1WOqbm4kVDR3JV078HfPz65inWcMh1aVQI=


### PR DESCRIPTION
> This PR updates the CHANGELOG.md file to describe any user-facing changes.

This fix makes it so that:

* We now show the correct number of max user accounts on an instance via the GraphQL field `Site.productSubscription.actualUserCount`
* We expose a new GraphQL field `Site.productSubscription.actualUserCountTime` indicating the time when the max count of users was hit. This now appears on the site-admin license page, when you hover over that number.
* We run a background routine every 6 hours that calculates the number of active user accounts. I chose to have this happen in the background, rather than continuously when new users are added, because (1) it simplified things a bit (e.g. made it so I didn't have to call the enterprise-only `licensing` package from `db`), and (2) it also gives admins a bit of slack — they get a bit of time to delete rogue accounts if they go above their license.
