### PR TITLE
Use true-up pricing in dev mode

### DIFF
--- a/enterprise/cmd/frontend/internal/licensing/enforcement.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement.go
@@ -113,7 +113,7 @@ func init() {
 		// licenses with UserCount == 0, but that might result from a bug in license decoding, and
 		// we don't want that to immediately disable Sourcegraph instances.
 		if info.UserCount > 0 && userCount >= int(info.UserCount) {
-			if info.HasTag(TrueUpUserCountTag) {
+			if info.HasTag(TrueUpUserCountTag) || info.HasTag(DevModeTag) {
 				log15.Info("Licensed user count exceeded, but license supports true-up and will not block creation of new user. The new user will be retroactively charged for in the next billing period. Contact sales@sourcegraph.com for help.", "activeUserCount", userCount, "licensedUserCount", info.UserCount)
 			} else {
 				return errcode.NewPresentationError("Unable to create user account: the Sourcegraph license's maximum user count has been reached. A site admin must upgrade the Sourcegraph subscription to allow for more users.")

--- a/enterprise/cmd/frontend/internal/licensing/tags.go
+++ b/enterprise/cmd/frontend/internal/licensing/tags.go
@@ -20,6 +20,10 @@ const (
 	// TrueUpUserCountTag is the license tag that indicates that the licensed user count can be
 	// exceeded and will be charged later.
 	TrueUpUserCountTag = "true-up"
+
+	// DevModeTag is the license tag that indicates that the license is in use for Sourcegraph
+	// internal development only.
+	DevModeTag = "dev"
 )
 
 var (
@@ -56,7 +60,7 @@ func productNameWithBrand(hasLicense bool, licenseTags []string) string {
 	if hasTag("trial") {
 		misc = append(misc, "trial")
 	}
-	if hasTag("dev") {
+	if hasTag(DevModeTag) {
 		misc = append(misc, "dev use only")
 	}
 	if len(misc) > 0 {


### PR DESCRIPTION
This was helpful for testing

> This PR does not need to update the CHANGELOG because it only affects dev mode
