### PR TITLE
feat: require explicit revision for repository symbols

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1074,16 +1074,6 @@ type Repository implements Node {
         # Returns the first n contributors from the list.
         first: Int
     ): RepositoryContributorConnection!
-    # The repository's symbols (e.g., functions, variables, types, classes, etc.) on the default branch.
-    #
-    # The result may be stale if a new commit was just pushed to this repository's default branch and it has not
-    # yet been processed. Use Repository.commit.tree.symbols to retrieve symbols for a specific revision.
-    symbols(
-        # Returns the first n symbols from the list.
-        first: Int
-        # Return symbols matching the query.
-        query: String
-    ): SymbolConnection!
     # Packages defined in this repository, as returned by LSP workspace/xpackages requests to this repository's
     # language servers (running against a recent commit on its default branch).
     #

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1081,16 +1081,6 @@ type Repository implements Node {
         # Returns the first n contributors from the list.
         first: Int
     ): RepositoryContributorConnection!
-    # The repository's symbols (e.g., functions, variables, types, classes, etc.) on the default branch.
-    #
-    # The result may be stale if a new commit was just pushed to this repository's default branch and it has not
-    # yet been processed. Use Repository.commit.tree.symbols to retrieve symbols for a specific revision.
-    symbols(
-        # Returns the first n symbols from the list.
-        first: Int
-        # Return symbols matching the query.
-        query: String
-    ): SymbolConnection!
     # Packages defined in this repository, as returned by LSP workspace/xpackages requests to this repository's
     # language servers (running against a recent commit on its default branch).
     #

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -20,22 +20,6 @@ type symbolsArgs struct {
 	Query *string
 }
 
-func (r *repositoryResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
-	var rev string
-	if r.repo.IndexedRevision != nil {
-		rev = string(*r.repo.IndexedRevision)
-	}
-	commit, err := r.Commit(ctx, &repositoryCommitArgs{Rev: rev})
-	if err != nil {
-		return nil, err
-	}
-	symbols, err := computeSymbols(ctx, commit, args.Query, args.First)
-	if err != nil && len(symbols) == 0 {
-		return nil, err
-	}
-	return &symbolConnectionResolver{symbols: symbols, first: args.First}, nil
-}
-
 func (r *gitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
 	symbols, err := computeSymbols(ctx, r.commit, args.Query, args.First)
 	if err != nil && len(symbols) == 0 {


### PR DESCRIPTION
This removes the convenience GraphQL API resolver Repository.symbols that returned symbols on the repository's default branch. It is better to require API clients to be explicit and specify a revision to fetch symbols for.

BREAKING CHANGE: No known API clients use this resolver.