### PR TITLE
wfeat: remove Repository.listTotalRefs from GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1106,8 +1106,6 @@ type Repository implements Node {
         # Return dependencies matching the query.
         query: String
     ): DependencyConnection!
-    # The total ref list.
-    listTotalRefs: TotalRefList!
     # Link to another Sourcegraph instance location where this repository is located.
     redirectURL: String
     # Whether the viewer has admin privileges on this repository.
@@ -1527,14 +1525,6 @@ type PhabricatorRepo {
     callsign: String!
     # The URL to the phabricator instance (e.g. http://phabricator.sgdev.org)
     url: String!
-}
-
-# A total ref list.
-type TotalRefList {
-    # The repositories.
-    repositories: [Repository!]!
-    # The total.
-    total: Int!
 }
 
 # Pagination information. See https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1113,8 +1113,6 @@ type Repository implements Node {
         # Return dependencies matching the query.
         query: String
     ): DependencyConnection!
-    # The total ref list.
-    listTotalRefs: TotalRefList!
     # Link to another Sourcegraph instance location where this repository is located.
     redirectURL: String
     # Whether the viewer has admin privileges on this repository.
@@ -1534,14 +1532,6 @@ type PhabricatorRepo {
     callsign: String!
     # The URL to the phabricator instance (e.g. http://phabricator.sgdev.org)
     url: String!
-}
-
-# A total ref list.
-type TotalRefList {
-    # The repositories.
-    repositories: [Repository!]!
-    # The total.
-    total: Int!
 }
 
 # Pagination information. See https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo.


### PR DESCRIPTION
This field returned a list of all repositories that refer to this repository. It has not been used in several months (since the count badge on the references panel tab was removed).

This does NOT remove the TotalRefs API used by the badges endpoint. That is an internal (not GraphQL) API.

BREAKING CHANGE: No known API clients use this resolver.