### PR TITLE
chore: gomvpkg xlang/uri

### DIFF
--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -13,17 +13,17 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/go-lsp"
+	lsp "github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/pkg/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/pkg/trace"
 	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 var mockSearchSymbols func(ctx context.Context, args *search.Args, limit int) (res []*fileMatchResolver, common *searchResultsCommon, err error)
@@ -121,7 +121,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 		return nil, err
 	}
 	span.SetTag("commit", string(commitID))
-	baseURI, err := uri.Parse("git://" + string(repoRevs.Repo.URI) + "?" + url.QueryEscape(inputRev))
+	baseURI, err := gituri.Parse("git://" + string(repoRevs.Repo.URI) + "?" + url.QueryEscape(inputRev))
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func makeFileMatchURIFromSymbol(symbolResolver *symbolResolver, inputRev string)
 
 // symbolToLSPSymbolInformation converts a symbols service Symbol struct to an LSP SymbolInformation
 // baseURI is the git://repo?rev base URI for the symbol that is extended with the file path
-func symbolToLSPSymbolInformation(s protocol.Symbol, baseURI *uri.URI) lsp.SymbolInformation {
+func symbolToLSPSymbolInformation(s protocol.Symbol, baseURI *gituri.URI) lsp.SymbolInformation {
 	ch := ctagsSymbolCharacter(s)
 	return lsp.SymbolInformation{
 		Name:          s.Name + s.Signature,

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/go-lsp"
+	lsp "github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/pkg/symbols/protocol"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -65,7 +65,7 @@ func computeSymbols(ctx context.Context, commit *gitCommitResolver, query *strin
 	if query != nil {
 		searchArgs.Query = *query
 	}
-	baseURI, err := uri.Parse("git://" + string(commit.repo.repo.URI) + "?" + string(commit.oid))
+	baseURI, err := gituri.Parse("git://" + string(commit.repo.repo.URI) + "?" + string(commit.oid))
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func toSymbolResolver(symbol lsp.SymbolInformation, lang string, commitResolver 
 		symbol:   symbol,
 		language: lang,
 	}
-	uri, err := uri.Parse(string(symbol.Location.URI))
+	uri, err := gituri.Parse(string(symbol.Location.URI))
 	if err != nil {
 		log15.Warn("Omitting symbol with invalid URI from results.", "uri", symbol.Location.URI, "error", err)
 		return nil

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -12,9 +12,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/pkg/gosrc"
 	"github.com/sourcegraph/sourcegraph/pkg/httputil"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 // serveGoSymbolURL handles Go symbol URLs (e.g.,
@@ -71,7 +71,7 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 
 	if len(symbols) > 0 {
 		symbol := symbols[0]
-		uri, err := uri.Parse(string(symbol.Location.URI))
+		uri, err := gituri.Parse(string(symbol.Location.URI))
 		if err != nil {
 			return err
 		}

--- a/cmd/frontend/internal/httpapi/xlang.go
+++ b/cmd/frontend/internal/httpapi/xlang.go
@@ -23,9 +23,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/httpapi"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/pkg/honey"
 	xlang_lspext "github.com/sourcegraph/sourcegraph/xlang/lspext"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 // We need to multiplex an entire xlang connection pool on an HTTP
@@ -159,7 +159,7 @@ func serveXLang(w http.ResponseWriter, r *http.Request) (err error) {
 	if initParams.RootURI == "" {
 		return errors.New("invalid empty LSP root URI in initialize request")
 	}
-	rootURI, err := uri.Parse(string(initParams.RootURI))
+	rootURI, err := gituri.Parse(string(initParams.RootURI))
 	if err != nil {
 		return fmt.Errorf("invalid LSP root URI %q: %s", initParams.RootURI, err)
 	}
@@ -298,7 +298,7 @@ func isEmpty(v interface{}) bool {
 	}
 }
 
-func addRootURIFields(ev *libhoney.Event, u *uri.URI) {
+func addRootURIFields(ev *libhoney.Event, u *gituri.URI) {
 	// u usually looks something like git://github.com/foo/bar?commithash
 	ev.AddField("repo", u.Host+u.Path)
 	ev.AddField("commit", u.RawQuery)

--- a/enterprise/cmd/xlang-go/internal/server/bench_test.go
+++ b/enterprise/cmd/xlang-go/internal/server/bench_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/xlang/lspext"
 	"github.com/sourcegraph/sourcegraph/xlang/proxy"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 // Notable benchmark results:
@@ -106,7 +106,7 @@ func BenchmarkIntegration(b *testing.B) {
 		},
 	}
 	for rootURI, test := range tests {
-		root, err := uri.Parse(string(rootURI))
+		root, err := gituri.Parse(string(rootURI))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -247,11 +247,11 @@ func BenchmarkIntegrationShared(b *testing.B) {
 	ctx := context.Background()
 	for label, test := range tests {
 		b.Run(label, func(b *testing.B) {
-			old, err := uri.Parse(test.oldRootURI)
+			old, err := gituri.Parse(test.oldRootURI)
 			if err != nil {
 				b.Fatal(err)
 			}
-			root, err := uri.Parse(test.rootURI)
+			root, err := gituri.Parse(test.rootURI)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/enterprise/cmd/xlang-go/internal/server/environment.go
+++ b/enterprise/cmd/xlang-go/internal/server/environment.go
@@ -21,8 +21,8 @@ import (
 	"github.com/sourcegraph/go-langserver/langserver"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/jsonx"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/xlang/lspext"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 const (
@@ -317,7 +317,7 @@ func determineRootImportPath(ctx context.Context, originalRootURI lsp.DocumentUR
 	if originalRootURI == "" {
 		return "", errors.New("unable to determine Go workspace root import path without due to empty root path")
 	}
-	u, err := uri.Parse(string(originalRootURI))
+	u, err := gituri.Parse(string(originalRootURI))
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/cmd/xlang-go/internal/server/integration_test.go
+++ b/enterprise/cmd/xlang-go/internal/server/integration_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	lsext "github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/pkg/gosrc"
 	"github.com/sourcegraph/sourcegraph/xlang/lspext"
 	"github.com/sourcegraph/sourcegraph/xlang/proxy"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 	"github.com/sourcegraph/sourcegraph/xlang/vfsutil"
 )
 
@@ -193,7 +193,7 @@ func TestIntegration(t *testing.T) {
 		},
 	}
 	for rootURI, test := range tests {
-		root, err := uri.Parse(string(rootURI))
+		root, err := gituri.Parse(string(rootURI))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -245,7 +245,7 @@ func TestIntegration(t *testing.T) {
 				t.Fatal("initialize:", err)
 			}
 
-			root, err := uri.Parse(string(rootURI))
+			root, err := gituri.Parse(string(rootURI))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/cmd/xlang-go/internal/server/proxy_test.go
+++ b/enterprise/cmd/xlang-go/internal/server/proxy_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	lsext "github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/xlang"
 	"github.com/sourcegraph/sourcegraph/xlang/lspext"
 	"github.com/sourcegraph/sourcegraph/xlang/proxy"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 func init() {
@@ -617,7 +617,7 @@ func yza() {}
 			defer done()
 			c := dialProxy(t, addr, nil)
 
-			root, err := uri.Parse(string(test.rootURI))
+			root, err := gituri.Parse(string(test.rootURI))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/cmd/xlang-go/internal/server/stress_test.go
+++ b/enterprise/cmd/xlang-go/internal/server/stress_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/xlang/lspext"
 	"github.com/sourcegraph/sourcegraph/xlang/proxy"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 // BenchmarkStress benchmarks performing "textDocument/definition",
@@ -59,7 +59,7 @@ func BenchmarkStress(b *testing.B) {
 		},
 	}
 	for rootURI, test := range tests {
-		root, err := uri.Parse(rootURI)
+		root, err := gituri.Parse(rootURI)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -164,7 +164,7 @@ func BenchmarkStress(b *testing.B) {
 	}
 }
 
-func doStressTestOpForPosition(ctx context.Context, c *jsonrpc2.Conn, root *uri.URI, path string, line, character int) error {
+func doStressTestOpForPosition(ctx context.Context, c *jsonrpc2.Conn, root *gituri.URI, path string, line, character int) error {
 	params := lsp.TextDocumentPositionParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: lsp.DocumentURI(root.WithFilePath(path).String())},
 		Position:     lsp.Position{Line: line, Character: character},

--- a/enterprise/cmd/xlang-go/internal/server/vfs.go
+++ b/enterprise/cmd/xlang-go/internal/server/vfs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/xlang/vfsutil"
 )
 
@@ -28,7 +28,7 @@ func remoteFS(ctx context.Context, conn *jsonrpc2.Conn, workspaceURI lsp.Documen
 	if workspaceURI == "" || UseRemoteFS {
 		return vfsutil.RemoteFS(conn), nil
 	}
-	u, err := uri.Parse(string(workspaceURI))
+	u, err := gituri.Parse(string(workspaceURI))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse workspace URI for remotefs")
 	}

--- a/enterprise/cmd/xlang-go/internal/server/xlang_test.go
+++ b/enterprise/cmd/xlang-go/internal/server/xlang_test.go
@@ -25,9 +25,9 @@ import (
 	lsext "github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/xlang/lspext"
 	"github.com/sourcegraph/sourcegraph/xlang/proxy"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 )
 
 func init() {
@@ -37,7 +37,7 @@ func init() {
 var update = flag.Bool("update", false, "update golden files on disk")
 
 // lspTests runs all test suites for LSP functionality.
-func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *uri.URI, wantHover, wantDefinition, wantXDefinition map[string]string, wantReferences, wantSymbols map[string][]string, wantXDependencies string, wantXReferences map[*lsext.WorkspaceReferencesParams][]string, wantXPackages []string) {
+func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *gituri.URI, wantHover, wantDefinition, wantXDefinition map[string]string, wantReferences, wantSymbols map[string][]string, wantXDependencies string, wantXReferences map[*lsext.WorkspaceReferencesParams][]string, wantXPackages []string) {
 	for pos, want := range wantHover {
 		tbRun(t, fmt.Sprintf("hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
 			hoverTest(t, ctx, c, root, pos, want)
@@ -103,7 +103,7 @@ func tbRun(t testing.TB, name string, f func(testing.TB)) bool {
 	}
 }
 
-func hoverTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *uri.URI, pos, want string) {
+func hoverTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *gituri.URI, pos, want string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
@@ -124,7 +124,7 @@ func hoverTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *uri.UR
 	}
 }
 
-func definitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *uri.URI, pos, want string) {
+func definitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *gituri.URI, pos, want string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func definitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *u
 	}
 }
 
-func xdefinitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *uri.URI, pos, want string) {
+func xdefinitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *gituri.URI, pos, want string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +154,7 @@ func xdefinitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *
 	}
 }
 
-func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *uri.URI, pos string, want []string) {
+func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *gituri.URI, pos string, want []string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
@@ -173,7 +173,7 @@ func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *u
 	}
 }
 
-func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *uri.URI, query string, want []string) {
+func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, root *gituri.URI, query string, want []string) {
 	wg := sync.WaitGroup{}
 	for i := 0; i < len(query)-1; i++ {
 		wg.Add(1)
@@ -231,7 +231,7 @@ func jsonTest(t testing.TB, gotData interface{}, testName string) {
 	}
 }
 
-func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI *uri.URI, params lsext.WorkspaceReferencesParams, want []string) {
+func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI *gituri.URI, params lsext.WorkspaceReferencesParams, want []string) {
 	references, err := callWorkspaceReferences(ctx, c, params)
 	if err != nil {
 		t.Fatal(err)
@@ -241,7 +241,7 @@ func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn
 	}
 }
 
-func workspacePackagesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI *uri.URI, want []string) {
+func workspacePackagesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI *gituri.URI, want []string) {
 	packages, err := callWorkspacePackages(ctx, c)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/gituri/uri.go
+++ b/pkg/gituri/uri.go
@@ -1,4 +1,4 @@
-package uri
+package gituri
 
 import (
 	"errors"
@@ -40,7 +40,7 @@ func Parse(uriStr string) (*URI, error) {
 		return nil, err
 	}
 	if !u.IsAbs() {
-		return nil, &url.Error{Op: "uri.Parse", URL: uriStr, Err: errors.New("sourcegraph URI must be absolute")}
+		return nil, &url.Error{Op: "gituri.Parse", URL: uriStr, Err: errors.New("sourcegraph URI must be absolute")}
 	}
 	return &URI{*u}, nil
 }

--- a/pkg/gituri/uri_test.go
+++ b/pkg/gituri/uri_test.go
@@ -1,4 +1,4 @@
-package uri
+package gituri
 
 import (
 	"net/url"

--- a/xlang/proxy/client_proxy.go
+++ b/xlang/proxy/client_proxy.go
@@ -21,14 +21,14 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/go-lsp"
+	lsp "github.com/sourcegraph/go-lsp"
 	plspext "github.com/sourcegraph/go-lsp/lspext"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
 	"github.com/sourcegraph/sourcegraph/xlang/lspext"
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
 	"golang.org/x/time/rate"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -209,8 +209,8 @@ func (p *Proxy) DisconnectIdleClients(maxIdle time.Duration) error {
 // anonymous clients are accessing the same repository at the same
 // commit.
 type contextID struct {
-	rootURI uri.URI // the rootURI in the initialize request (typically the repo clone URL + "?REV")
-	mode    string  // the mode (i.e., "go" or "typescript")
+	rootURI gituri.URI // the rootURI in the initialize request (typically the repo clone URL + "?REV")
+	mode    string     // the mode (i.e., "go" or "typescript")
 
 	// session is the unique ID identifying this session, used when it
 	// shouldn't be shared by all users viewing the same rootURI and
@@ -395,7 +395,7 @@ func (c *clientProxyConn) handle(ctx context.Context, conn *jsonrpc2.Conn, req *
 		// months.
 		params.RootPath = ""
 
-		rootURI, err := uri.Parse(string(params.RootURI))
+		rootURI, err := gituri.Parse(string(params.RootURI))
 		if err != nil {
 			return nil, fmt.Errorf("invalid rootUri %q: %s", params.RootURI, err)
 		}

--- a/xlang/proxy/uris.go
+++ b/xlang/proxy/uris.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 )
 
 // relWorkspaceURI maps absolute URIs like
@@ -21,8 +21,8 @@ import (
 // (e.g., a client performs a cross-workspace go-to-definition and
 // then notifies the server that the client opened the destination
 // resource).
-func relWorkspaceURI(root uri.URI, uriStr string) (*uri.URI, error) {
-	u, err := uri.Parse(uriStr)
+func relWorkspaceURI(root gituri.URI, uriStr string) (*gituri.URI, error) {
+	u, err := gituri.Parse(uriStr)
 	if err != nil {
 		return nil, err
 	}
@@ -45,15 +45,15 @@ func relWorkspaceURI(root uri.URI, uriStr string) (*uri.URI, error) {
 		u = u.WithFilePath(strings.TrimPrefix(u.FilePath(), rootPath+string(os.PathSeparator)))
 	}
 
-	return &uri.URI{URL: url.URL{Scheme: "file", Path: "/" + u.FilePath()}}, nil
+	return &gituri.URI{URL: url.URL{Scheme: "file", Path: "/" + u.FilePath()}}, nil
 }
 
 // absWorkspaceURI is the inverse of relWorkspaceURI. It maps
 // workspace-relative URIs like "file:///dir/file.txt" to their
 // absolute URIs like
 // "git://github.com/facebook/react.git?master#dir/file.txt".
-func absWorkspaceURI(root uri.URI, uriStr string) (*uri.URI, error) {
-	uri, err := uri.Parse(uriStr)
+func absWorkspaceURI(root gituri.URI, uriStr string) (*gituri.URI, error) {
+	uri, err := gituri.Parse(uriStr)
 	if err != nil {
 		return nil, err
 	}

--- a/xlang/proxy/uris_test.go
+++ b/xlang/proxy/uris_test.go
@@ -3,11 +3,11 @@ package proxy
 import (
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/xlang/uri"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 )
 
 func TestAbsRelWorkspaceURI(t *testing.T) {
-	root, err := uri.Parse("git://a.com/b?rev=c")
+	root, err := gituri.Parse("git://a.com/b?rev=c")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestAbsRelWorkspaceURI(t *testing.T) {
 }
 
 func TestRelWorkspaceURI_rootIsSubdirectory(t *testing.T) {
-	root, err := uri.Parse("git://a.com/b?rev=c#d")
+	root, err := gituri.Parse("git://a.com/b?rev=c#d")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This will make it easier to remove the xlang code in a subsequent commit.

```
gomvpkg -from github.com/sourcegraph/sourcegraph/xlang/uri -to github.com/sourcegraph/sourcegraph/pkg/gituri
```