### PR TITLE
feat: allow extensions to contribute sections to the Explore area

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/polyfill": "^7.0.0",
     "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^3.9.0",
-    "@sourcegraph/extensions-client-common": "^10.4.2",
+    "@sourcegraph/extensions-client-common": "^10.5.0",
     "@sourcegraph/phabricator-extension": "^1.18.0",
     "@sqs/jsonc-parser": "^1.0.3",
     "@types/react": "16.4.14",

--- a/src/docSite/DocSitePage.tsx
+++ b/src/docSite/DocSitePage.tsx
@@ -14,6 +14,7 @@ import { Markdown } from '../components/Markdown'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../util/errors'
+import { createLinkClickHandler } from '../util/linkClickHandler'
 import { memoizeObservable } from '../util/memoize'
 
 const queryDocPage = memoizeObservable(
@@ -146,7 +147,7 @@ export class DocSitePage extends React.PureComponent<Props, State> {
                 ) : (
                     <div className="doc-site-page container px-0 d-flex flex-column flex-grow-1">
                         <div
-                            onClick={this.onContentClick}
+                            onClick={createLinkClickHandler(this.props.history)}
                             className="doc-site-page__page flex-grow-1 d-flex flex-wrap flex-row-reverse"
                         >
                             <PageTitle
@@ -178,42 +179,4 @@ export class DocSitePage extends React.PureComponent<Props, State> {
             </>
         )
     }
-
-    private onContentClick: React.MouseEventHandler<HTMLElement> = event => {
-        // Capture clicks on relative links and use pushState for them instead of incurring a full
-        // page reload.
-        if (
-            !event.defaultPrevented &&
-            event.button === 0 &&
-            !event.metaKey &&
-            !event.altKey &&
-            !event.ctrlKey &&
-            !event.shiftKey
-        ) {
-            // Find nearest ancestor <a>.
-            let e: HTMLElement | null = event.target as HTMLElement
-            while (e) {
-                const href = e.getAttribute('href')
-                if (isAnchor(e) && !e.target && href && !/^(https?:)?\/\//.test(href)) {
-                    event.preventDefault()
-                    const url = new URL(e.href)
-                    this.props.history.push({ pathname: url.pathname, hash: url.hash })
-
-                    // HACK: Navigate to the in-page anchor. It does not work without this. This is definitely not
-                    // the best solution. See RenderedFile for another solution (note that using RenderedFile in
-                    // this component's render method instead of Markdown does not work either).
-                    if (url.hash.startsWith('#')) {
-                        setTimeout(() => (window.location.href = url.hash))
-                    }
-
-                    return
-                }
-                e = e.parentElement
-            }
-        }
-    }
-}
-
-function isAnchor(e: HTMLElement): e is HTMLAnchorElement {
-    return e.tagName === 'A'
 }

--- a/src/explore/ExploreArea.tsx
+++ b/src/explore/ExploreArea.tsx
@@ -7,6 +7,7 @@ import H from 'history'
 import * as React from 'react'
 import { Subject, Subscription } from 'rxjs'
 import * as GQL from '../backend/graphqlschema'
+import { ExtensionsControllerProps } from '../extensions/ExtensionsClientCommonContext'
 import { ComponentDescriptor } from '../util/contributions'
 
 /** Feature flag for showing the explore link. */
@@ -15,7 +16,7 @@ export const SHOW_EXPLORE = localStorage.getItem('explore') !== null
 /**
  * Properties passed to all section components in the explore area.
  */
-export interface ExploreAreaSectionContext {
+export interface ExploreAreaSectionContext extends ExtensionsControllerProps {
     /** The currently authenticated user. */
     authenticatedUser: GQL.IUser | null
 
@@ -27,6 +28,7 @@ export interface ExploreAreaSectionContext {
 
     isLightTheme: boolean
     location: H.Location
+    history: H.History
 }
 
 /** A section shown in the explore area. */
@@ -67,11 +69,13 @@ export class ExploreArea extends React.Component<ExploreAreaProps, ExploreAreaSt
 
     public render(): JSX.Element | null {
         const context: ExploreAreaSectionContext = {
+            extensionsController: this.props.extensionsController,
             authenticatedUser: this.props.authenticatedUser,
             viewerSubject: this.props.viewerSubject,
             configurationCascade: this.props.configurationCascade,
             isLightTheme: this.props.isLightTheme,
             location: this.props.location,
+            history: this.props.history,
         }
 
         return (

--- a/src/explore/exploreSections.tsx
+++ b/src/explore/exploreSections.tsx
@@ -2,11 +2,15 @@ import React from 'react'
 import { SiteUsageExploreSection } from '../analytics/explore/SiteUsageExploreSection'
 import { isDiscussionsEnabled } from '../discussions'
 import { DiscussionsExploreSection } from '../discussions/explore/DiscussionsExploreSection'
+import { ExtensionViewsExploreSection } from '../extensions/explore/ExtensionViewsExploreSection'
 import { RepositoriesExploreSection } from '../repo/explore/RepositoriesExploreSection'
 import { SavedSearchesExploreSection } from '../search/saved-queries/explore/SavedSearchesExploreSection'
 import { ExploreSectionDescriptor } from './ExploreArea'
 
 export const exploreSections: ReadonlyArray<ExploreSectionDescriptor> = [
+    {
+        render: props => <ExtensionViewsExploreSection {...props} />,
+    },
     {
         render: props => <RepositoriesExploreSection {...props} />,
     },

--- a/src/extensions/explore/ExtensionViewsExploreSection.tsx
+++ b/src/extensions/explore/ExtensionViewsExploreSection.tsx
@@ -1,0 +1,61 @@
+import H from 'history'
+import marked from 'marked'
+import React from 'react'
+import { Subscription } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { ContributableViewContainer } from 'sourcegraph/module/protocol'
+import { PanelView } from 'sourcegraph/module/protocol/plainTypes'
+import { Markdown } from '../../components/Markdown'
+import { createLinkClickHandler } from '../../util/linkClickHandler'
+import { ExtensionsControllerProps } from '../ExtensionsClientCommonContext'
+
+interface Props extends ExtensionsControllerProps {
+    history: H.History
+}
+
+interface State {
+    /** Views contributed by extensions. */
+    views?: (PanelView & { id: string })[] | null
+}
+
+/**
+ * An explore section that shows views from extensions.
+ *
+ * TODO(sqs): This reuses panels displayed in the blob panel, which is hacky. The sourcegraph.app.createPanelView
+ * API should let you specify where the panel should live.
+ */
+export class ExtensionViewsExploreSection extends React.PureComponent<Props, State> {
+    private subscriptions = new Subscription()
+
+    public componentDidMount(): void {
+        this.subscriptions.add(
+            this.props.extensionsController.registries.views
+                .getViews(ContributableViewContainer.Panel)
+                .pipe(map(views => ({ views })))
+                .subscribe(stateUpdate => this.setState(stateUpdate))
+        )
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    public render(): JSX.Element | null {
+        if (!this.state || !this.state.views) {
+            return null
+        }
+
+        return (
+            <div className="extension-views-explore-section">
+                {this.state.views.map((view, i) => (
+                    <div key={i} className="mt-5">
+                        <h2>{view.title}</h2>
+                        <div onClick={createLinkClickHandler(this.props.history)}>
+                            <Markdown dangerousInnerHTML={marked(view.content)} />
+                        </div>
+                    </div>
+                ))}
+            </div>
+        )
+    }
+}

--- a/src/nav/NavLinks.tsx
+++ b/src/nav/NavLinks.tsx
@@ -60,6 +60,7 @@ export class NavLinks extends React.PureComponent<Props> {
                     menu={ContributableMenu.GlobalNav}
                     extensionsController={this.props.extensionsController}
                     extensions={this.props.extensions}
+                    location={this.props.location}
                 />
                 <li className="nav-item">
                     {SHOW_EXPLORE ? (

--- a/src/panel/Panel.tsx
+++ b/src/panel/Panel.tsx
@@ -12,7 +12,7 @@ import { Resizable } from '../components/Resizable'
 import { Spacer, Tab, TabsWithURLViewStatePersistence } from '../components/Tabs'
 import { ExtensionsControllerProps } from '../extensions/ExtensionsClientCommonContext'
 import { eventLogger } from '../tracking/eventLogger'
-import { isErrorLike } from '../util/errors'
+import { createLinkClickHandler } from '../util/linkClickHandler'
 import { parseHash } from '../util/url'
 
 /**
@@ -170,7 +170,7 @@ export class Panel extends React.PureComponent<Props, State> {
                             id: panelView.id,
                             priority: 0,
                             element: (
-                                <div className="p-2">
+                                <div className="p-2" onClick={createLinkClickHandler(this.props.history)}>
                                     <Markdown dangerousInnerHTML={marked(panelView.content)} />
                                 </div>
                             ),

--- a/src/repo/RepoHeader.tsx
+++ b/src/repo/RepoHeader.tsx
@@ -240,6 +240,7 @@ export class RepoHeader extends React.PureComponent<Props, State> {
                         menu={ContributableMenu.EditorTitle}
                         extensionsController={this.props.extensionsController}
                         extensions={this.props.extensions}
+                        location={this.props.location}
                     />
                     {this.props.actionButtons.map(
                         ({ condition = () => true, label, tooltip, icon: Icon, to }) =>

--- a/src/repo/TreePage.tsx
+++ b/src/repo/TreePage.tsx
@@ -326,6 +326,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                                                 className="btn btn-secondary mr-1 mb-1"
                                                 extensionsController={this.props.extensionsController}
                                                 extensions={this.props.extensions}
+                                                location={this.props.location}
                                             />
                                         ))}
                                     </section>
@@ -333,6 +334,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 empty={null}
                                 extensionsController={this.props.extensionsController}
                                 extensions={this.props.extensions}
+                                location={this.props.location}
                             />
                             <div className="tree-page__section">
                                 <h3 className="tree-page__section-header">Changes</h3>

--- a/src/util/linkClickHandler.ts
+++ b/src/util/linkClickHandler.ts
@@ -1,0 +1,47 @@
+import H from 'history'
+
+/**
+ * When used as a click handler on an element, captures clicks on relative links and navigates to their href using
+ * the router instead of incurring a full page reload.
+ *
+ * This is useful on Markdown elements where all links are rendered with <a>, not react-router-dom's <Link>.
+ */
+export function createLinkClickHandler(history: H.History): React.MouseEventHandler<HTMLElement> {
+    return (event: React.MouseEvent<HTMLElement>) => {
+        // Capture clicks on relative links and use pushState for them instead of incurring a full
+        // page reload.
+        if (
+            !event.defaultPrevented &&
+            event.button === 0 &&
+            !event.metaKey &&
+            !event.altKey &&
+            !event.ctrlKey &&
+            !event.shiftKey
+        ) {
+            // Find nearest ancestor <a>.
+            let e: HTMLElement | null = event.target as HTMLElement
+            while (e) {
+                const href = e.getAttribute('href')
+                if (isAnchor(e) && !e.target && href && !/^(https?:)?\/\//.test(href)) {
+                    event.preventDefault()
+                    const url = new URL(e.href)
+                    history.push({ pathname: url.pathname, hash: url.hash })
+
+                    // HACK: Navigate to the in-page anchor. It does not work without this. This is definitely not
+                    // the best solution. See RenderedFile for another solution (note that using RenderedFile in
+                    // this component's render method instead of Markdown does not work either).
+                    if (url.hash.startsWith('#')) {
+                        setTimeout(() => (window.location.href = url.hash))
+                    }
+
+                    return
+                }
+                e = e.parentElement
+            }
+        }
+    }
+}
+
+function isAnchor(e: HTMLElement): e is HTMLAnchorElement {
+    return e.tagName === 'A'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,14 +971,15 @@
     rxjs "^6.3.2"
     vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/extensions-client-common@^10.4.2":
-  version "10.4.2"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.4.2.tgz#f964076bf460ca1b697ebe48e9a51a5d4c3f7fa7"
-  integrity sha512-UPgOXGrDkoiOm7nPM2mdK68f1+qFEjUTAeBgDH8f5A2seMIvXVaoNAdregC7m4V/K1PTnAHort4X8j4Bpj+ZRw==
+"@sourcegraph/extensions-client-common@^10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.5.0.tgz#c78c57ab005622b53fe7678afe2d11fc05c1d541"
+  integrity sha512-1ZWWLGjGKovV3N78AUvyaPiG+eCG8awiXNcKaDxPAgizM7iCjZrQUjdfhCCMR8nvTDY/d5EI76LlAU1hbuBVJw==
   dependencies:
     "@slimsag/react-shortcuts" "^1.2.0"
     bootstrap "^4.1.3"
     lodash-es "^4.17.10"
+    marked "^0.5.1"
     react "^16.4.2"
     react-router "^4.3.1"
     react-router-dom "^4.3.1"
@@ -7094,6 +7095,11 @@ marked@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.0.tgz#9e590bad31584a48ff405b33ab1c0dd25172288e"
   integrity sha512-UhjmkCWKu1SS/BIePL2a59BMJ7V42EYtTfksodPRXzPEGEph3Inp5dylseqt+KbU9Jglsx8xcMKmlumfJMBXAA==
+
+marked@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.1.tgz#062f43b88b02ee80901e8e8d8e6a620ddb3aa752"
+  integrity sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw==
 
 matchdep@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Extensions can use `sourcegraph.app.createPanelView` to add a section to the Explore area. This is experimental.