### PR TITLE
add primary workflow UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed an issue where GraphQL field `elapsedMilliseconds` returned invalid value on empty searches
 - Editor extensions now properly search the selection as a literal string, instead of incorrectly using regexp.
 - Fixed a bug where editing and deleting global saved searches was not possible.
+- Fixed editing and deleting options for global saved queries by site admin, and limit these options for non-site-admins.
+- In index search, if the search regex produces multiline matches, search results are still processed per line and highlighted correctly.
+- Go-To-GitHub and Go-To-Gitlab buttons now link to the right branch, line and commit range.
+- Go-to-Github button links to default branch when no rev is given.
+- The close button in the panel header stays located on the top.
+- The Phabricator icon is now displayed correctly.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed an issue where GraphQL field `elapsedMilliseconds` returned invalid value on empty searches
 - Editor extensions now properly search the selection as a literal string, instead of incorrectly using regexp.
 - Fixed a bug where editing and deleting global saved searches was not possible.
-- Fixed editing and deleting options for global saved queries by site admin, and limit these options for non-site-admins.
-- Fixed editing and deleting options for global saved searches by site admin, and limit these options for non-site-admins.
 - In index search, if the search regex produces multiline matches, search results are still processed per line and highlighted correctly.
 - Go-To-GitHub and Go-To-Gitlab buttons now link to the right branch, line and commit range.
 - Go-to-Github button links to default branch when no rev is given.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Editor extensions now properly search the selection as a literal string, instead of incorrectly using regexp.
 - Fixed a bug where editing and deleting global saved searches was not possible.
 - In index search, if the search regex produces multiline matches, search results are still processed per line and highlighted correctly.
-- Go-To-GitHub and Go-To-Gitlab buttons now link to the right branch, line and commit range.
-- Go-to-Github button links to default branch when no rev is given.
+- Go-To-GitHub and Go-To-GitLab buttons now link to the right branch, line and commit range.
+- Go-to-GitHub button links to default branch when no rev is given.
 - The close button in the panel header stays located on the top.
 - The Phabricator icon is now displayed correctly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Editor extensions now properly search the selection as a literal string, instead of incorrectly using regexp.
 - Fixed a bug where editing and deleting global saved searches was not possible.
 - Fixed editing and deleting options for global saved queries by site admin, and limit these options for non-site-admins.
+- Fixed editing and deleting options for global saved searches by site admin, and limit these options for non-site-admins.
 - In index search, if the search regex produces multiline matches, search results are still processed per line and highlighted correctly.
 - Go-To-GitHub and Go-To-Gitlab buttons now link to the right branch, line and commit range.
 - Go-to-Github button links to default branch when no rev is given.


### PR DESCRIPTION
Add primary workflow UX improvements to CHANGELOG

> This PR does not need to update the CHANGELOG because it's a change to the CHANGELOG itself.
