### PR TITLE
doc/admin: add documentation links to deploy-sourcegraph-docker

### DIFF
--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -4,7 +4,7 @@ Site administrators are the admins responsible for deploying, managing, and conf
 
 - [Install Sourcegraph](install.md)
   - [Install Sourcegraph with Docker](install/docker.md)
-  - [Install Sourcegraph on Kubernetes](install/kubernetes_cluster.md)
+  - [Install Sourcegraph on a cluster](install/cluster.md)
 - Management, deployment, and configuration:
   - [Site configuration](site_config/index.md)
   - [User authentication](auth.md)

--- a/doc/admin/install/cluster.md
+++ b/doc/admin/install/cluster.md
@@ -1,0 +1,5 @@
+# Installing Sourcegraph on a cluster
+
+For cluster deployments, we recommend installing Sourcegraph on Kubernetes. See the [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph) for more information.
+
+If you cannot use Kubernetes or prefer using your own container infrastructure, check out our [pure-Docker deployment reference](https://github.com/sourcegraph/deploy-sourcegraph-docker).

--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -1,4 +1,4 @@
 # Installing Sourcegraph
 
 - [Install Sourcegraph with Docker](docker.md)
-- [Install Sourcegraph on Kubernetes](kubernetes_cluster.md)
+- [Install Sourcegraph on a cluster](cluster.md)

--- a/doc/admin/install/kubernetes_cluster.md
+++ b/doc/admin/install/kubernetes_cluster.md
@@ -1,3 +1,3 @@
 # Installing Sourcegraph on a Kubernetes cluster
 
-The Kubernetes cluster installation documentation has moved to the [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph).
+This page has moved [here](cluster.md).


### PR DESCRIPTION
This PR updates our documentation to also mention non-Kubernetes cluster deployment options.

Fixes sourcegraph/deploy-sourcegraph-docker#16

> This PR does not need to update the CHANGELOG because it is only documentation changes.

