### PR TITLE
frontend: do not connect to internal API via localhost

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/discussions/mailreply"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/siteid"
-	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/debugserver"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
@@ -147,15 +146,6 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-
-	// We are the frontend, so there is no need to go over the network for
-	// internal API requests.
-	u, err := url.Parse(api.InternalClient.URL)
-	if err != nil {
-		return err
-	}
-	u.Host = "127.0.0.1"
-	api.InternalClient.URL = u.String()
 
 	goroutine.Go(mailreply.StartWorker)
 	go updatecheck.Start()


### PR DESCRIPTION
In #616 it was suggested to me that we could make the frontend connect to itself
via 127.0.0.1, instead of via what is configured in `SRC_FRONTEND_INTERNAL`.

This is true, and would allow us to make requests never leave our machine (no
network involved), but this change was unfortunately incorrect.

The code assumes that the internal port can be derived from `SRC_FRONTEND_INTERNAL`
which is true in dev etc, but not true in Kubernetes cluster deployments where
`SRC_FRONTEND_INTERNAL=http://sourcegraph-frontend-internal` because there is
no port in the configured URL, but on _localhost_ the port should be `3090` because
that is the internal HTTPAPI port.

I don't see an easy / fool-proof way of solving this yet, and it has broken our
telemetry in prod snce it was deployed yesterday due to this bug. So I am reverting
this change here instead.

> This PR does not need to update the CHANGELOG because no user-facing changes.
