### PR TITLE
refactor: move code from extensions-client-common here when this repo was the only consumer of it

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/polyfill": "^7.0.0",
     "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^3.9.0",
-    "@sourcegraph/extensions-client-common": "^10.5.0",
+    "@sourcegraph/extensions-client-common": "^12.0.0",
     "@sourcegraph/phabricator-extension": "^1.18.0",
     "@sqs/jsonc-parser": "^1.0.3",
     "@types/react": "16.4.14",

--- a/src/extensions/ExtensionCard.scss
+++ b/src/extensions/ExtensionCard.scss
@@ -1,0 +1,35 @@
+.extension-card {
+    min-height: 9rem;
+    background-color: var(--extension-card-bg);
+    flex: 1;
+
+    &__body-title {
+        color: var(--body-color) !important;
+    }
+
+    &__icon {
+        width: 6rem;
+        height: 6rem;
+    }
+
+    &__spacer {
+        flex: 1;
+    }
+
+    &__footer {
+        background: unset;
+    }
+
+    &__body:hover {
+        text-decoration: none;
+    }
+    &__body:hover &__body-title,
+    &__body:focus &__body-title {
+        text-decoration: underline;
+        color: var(--link-hover-color);
+    }
+
+    .btn-link {
+        text-decoration: none !important;
+    }
+}

--- a/src/extensions/ExtensionCard.tsx
+++ b/src/extensions/ExtensionCard.tsx
@@ -1,0 +1,110 @@
+import { ConfiguredExtension, isExtensionEnabled } from '@sourcegraph/extensions-client-common/lib/extensions/extension'
+import { ExtensionManifest } from '@sourcegraph/extensions-client-common/lib/schema/extension.schema'
+import WarningIcon from 'mdi-react/WarningIcon'
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+import { ConfigurationSubject } from '../backend/graphqlschema'
+import { LinkOrSpan } from '../components/LinkOrSpan'
+import { Settings } from '../schema/settings.schema'
+import { isErrorLike } from '../util/errors'
+import { ExtensionConfigurationState } from './extension/ExtensionConfigurationState'
+import { ConfigurationCascadeProps, ExtensionsProps, isExtensionAdded } from './ExtensionsClientCommonContext'
+import { ExtensionToggle } from './ExtensionToggle'
+
+interface Props<S extends ConfigurationSubject, C extends Settings> extends ConfigurationCascadeProps, ExtensionsProps {
+    node: ConfiguredExtension
+    subject: Pick<ConfigurationSubject, 'id' | 'viewerCanAdminister'>
+    onDidUpdate: () => void
+}
+
+/** Displays an extension as a card. */
+export class ExtensionCard<S extends ConfigurationSubject, C extends Settings> extends React.PureComponent<
+    Props<S, C>
+> {
+    public render(): JSX.Element | null {
+        const { node, ...props } = this.props
+        const manifest: ExtensionManifest | undefined =
+            node.manifest && !isErrorLike(node.manifest) ? node.manifest : undefined
+        let iconURL: URL | undefined
+        try {
+            if (manifest && manifest.icon) {
+                iconURL = new URL(manifest.icon)
+            }
+        } catch (e) {
+            // noop
+        }
+
+        return (
+            <div className="d-flex col-sm-6 col-md-6 col-lg-4 pb-4">
+                <div className="extension-card card">
+                    <LinkOrSpan
+                        to={node.registryExtension && node.registryExtension.url}
+                        className="card-body extension-card__body d-flex flex-column"
+                    >
+                        <div className="d-flex">
+                            {manifest &&
+                                manifest.icon &&
+                                iconURL &&
+                                iconURL.protocol === 'data:' &&
+                                /^data:image\/png(;base64)?,/.test(manifest.icon) && (
+                                    <img className="extension-card__icon mr-2" src={manifest.icon} />
+                                )}
+                            <div>
+                                <h4 className="card-title extension-card__body-title mb-0">
+                                    {manifest && manifest.title ? manifest.title : node.id}
+                                </h4>
+                                <div className="extension-card__body-text d-inline-block mt-1">
+                                    {node.manifest ? (
+                                        isErrorLike(node.manifest) ? (
+                                            <span className="text-danger small" title={node.manifest.message}>
+                                                <WarningIcon className="icon-inline" /> Invalid manifest
+                                            </span>
+                                        ) : (
+                                            node.manifest.description && (
+                                                <span className="text-muted">{node.manifest.description}</span>
+                                            )
+                                        )
+                                    ) : (
+                                        <span className="text-warning small">
+                                            <WarningIcon className="icon-inline" /> No manifest
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </LinkOrSpan>
+                    <div className="card-footer extension-card__footer py-0 pl-0">
+                        <ul className="nav align-items-center">
+                            {node.registryExtension &&
+                                node.registryExtension.url && (
+                                    <li className="nav-item">
+                                        <Link to={node.registryExtension.url} className="nav-link px-2" tabIndex={-1}>
+                                            Details
+                                        </Link>
+                                    </li>
+                                )}
+                            <li className="extension-card__spacer" />
+                            {props.subject &&
+                                (props.subject.viewerCanAdminister ? (
+                                    <ExtensionToggle
+                                        extension={node}
+                                        configurationCascade={this.props.configurationCascade}
+                                        onUpdate={props.onDidUpdate}
+                                        className="btn-sm btn-secondary"
+                                        extensions={this.props.extensions}
+                                    />
+                                ) : (
+                                    <li className="nav-item">
+                                        <ExtensionConfigurationState
+                                            isAdded={isExtensionAdded(props.configurationCascade.merged, node.id)}
+                                            isEnabled={isExtensionEnabled(props.configurationCascade.merged, node.id)}
+                                        />
+                                    </li>
+                                ))}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/extensions/ExtensionToggle.tsx
+++ b/src/extensions/ExtensionToggle.tsx
@@ -1,0 +1,142 @@
+import { ConfiguredExtension, isExtensionEnabled } from '@sourcegraph/extensions-client-common/lib/extensions/extension'
+import {
+    ConfigurationCascade,
+    ConfigurationCascadeOrError,
+    ConfigurationSubject,
+} from '@sourcegraph/extensions-client-common/lib/settings'
+import { Toggle } from '@sourcegraph/extensions-client-common/lib/ui/generic/Toggle'
+import { last } from 'lodash'
+import * as React from 'react'
+import { EMPTY, from, Subject, Subscription } from 'rxjs'
+import { switchMap } from 'rxjs/operators'
+import { Settings } from '../schema/settings.schema'
+import { ErrorLike, isErrorLike } from '../util/errors'
+import { ConfigurationCascadeProps, ExtensionsProps, isExtensionAdded } from './ExtensionsClientCommonContext'
+
+interface Props<S extends ConfigurationSubject, C extends Settings> extends ConfigurationCascadeProps, ExtensionsProps {
+    /** The extension that this element is for. */
+    extension: ConfiguredExtension
+
+    disabled?: boolean
+
+    /** Class name applied to this element. */
+    className?: string
+
+    /** Class name applied to this element when it is an "Add" button. */
+    addClassName?: string
+
+    /** Called when the component performs an update that requires the parent component to refresh data. */
+    onUpdate: () => void
+}
+
+/**
+ * Displays a toggle button for an extension.
+ */
+export class ExtensionToggle<S extends ConfigurationSubject, C extends Settings> extends React.PureComponent<
+    Props<S, C>
+> {
+    private toggles = new Subject<boolean>()
+    private subscriptions = new Subscription()
+
+    public componentDidMount(): void {
+        this.subscriptions.add(
+            this.toggles
+                .pipe(
+                    switchMap(enabled => {
+                        if (this.props.configurationCascade.subjects === null) {
+                            return EMPTY
+                        }
+                        if (isErrorLike(this.props.configurationCascade.subjects)) {
+                            // TODO: Show error.
+                            return EMPTY
+                        }
+
+                        // Only operate on the highest precedence settings, for simplicity.
+                        const subjects = this.props.configurationCascade.subjects
+                        if (subjects.length === 0) {
+                            return EMPTY
+                        }
+                        const highestPrecedenceSubject = subjects[subjects.length - 1]
+                        if (!highestPrecedenceSubject || !highestPrecedenceSubject.subject.viewerCanAdminister) {
+                            return EMPTY
+                        }
+
+                        if (
+                            !isExtensionAdded(this.props.configurationCascade.merged, this.props.extension.id) &&
+                            !confirmAddExtension(this.props.extension.id, this.props.extension.manifest)
+                        ) {
+                            return EMPTY
+                        }
+
+                        return from(
+                            this.props.extensions.context.updateExtensionSettings(highestPrecedenceSubject.subject.id, {
+                                extensionID: this.props.extension.id,
+                                enabled,
+                            })
+                        )
+                    })
+                )
+                .subscribe()
+        )
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    public render(): JSX.Element | null {
+        const cascade = extractErrors(this.props.configurationCascade)
+        const subject = isErrorLike(cascade)
+            ? undefined
+            : last(cascade.subjects.filter(subject => isExtensionAdded(subject.settings, this.props.extension.id)))
+        const state = subject && {
+            state: subject.settings.extensions ? subject.settings.extensions[this.props.extension.id] : false,
+            name: subject.subject.__typename,
+        }
+
+        const onToggle = (enabled: boolean) => {
+            this.toggles.next(enabled)
+        }
+
+        return (
+            <Toggle
+                value={isExtensionEnabled(this.props.configurationCascade.merged, this.props.extension.id)}
+                onToggle={onToggle}
+                title={state ? `${state.state ? 'Enabled' : 'Disabled'} in ${state.name} settings` : 'Click to enable'}
+            />
+        )
+    }
+}
+
+/**
+ * Shows a modal confirmation prompt to the user confirming whether to add an extension.
+ */
+function confirmAddExtension(extensionID: string, extensionManifest?: ConfiguredExtension['manifest']): boolean {
+    // Either `"title" (id)` (if there is a title in the manifest) or else just `id`. It is
+    // important to show the ID because it indicates who the publisher is and allows
+    // disambiguation from other similarly titled extensions.
+    let displayName: string
+    if (extensionManifest && !isErrorLike(extensionManifest) && extensionManifest.title) {
+        displayName = `${JSON.stringify(extensionManifest.title)} (${extensionID})`
+    } else {
+        displayName = extensionID
+    }
+    return confirm(
+        `Add Sourcegraph extension ${displayName}?\n\nIt can:\n- Read repositories and files you view using Sourcegraph\n- Read and change your Sourcegraph settings`
+    )
+}
+
+/** Converts a ConfigurationCascadeOrError to a ConfigurationCascade, returning the first error it finds. */
+function extractErrors(
+    c: ConfigurationCascadeOrError<ConfigurationSubject, Settings>
+): ConfigurationCascade | ErrorLike {
+    if (c.subjects === null || isErrorLike(c.subjects)) {
+        return new Error('Subjects was ' + c.subjects)
+    } else if (c.merged === null || isErrorLike(c.merged)) {
+        return new Error('Merged was ' + c.merged)
+    } else if (c.subjects.find(isErrorLike)) {
+        return new Error('One of the subjects was ' + c.subjects.find(isErrorLike))
+    } else {
+        return c as ConfigurationCascade
+    }
+}

--- a/src/extensions/ExtensionsArea.scss
+++ b/src/extensions/ExtensionsArea.scss
@@ -1,4 +1,5 @@
 @import '../components/Area';
+@import './ExtensionCard';
 
 .extensions-area {
     width: 100%;

--- a/src/extensions/ExtensionsList.tsx
+++ b/src/extensions/ExtensionsList.tsx
@@ -1,0 +1,294 @@
+import { ConfiguredExtension } from '@sourcegraph/extensions-client-common/lib/extensions/extension'
+import * as ECCGQL from '@sourcegraph/extensions-client-common/lib/schema/graphqlschema'
+import { ConfigurationSubject } from '@sourcegraph/extensions-client-common/lib/settings'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import * as React from 'react'
+import { RouteComponentProps } from 'react-router'
+import { combineLatest, concat, from, Observable, of, Subject, Subscription } from 'rxjs'
+import {
+    catchError,
+    debounceTime,
+    delay,
+    filter,
+    map,
+    switchMap,
+    take,
+    takeUntil,
+    withLatestFrom,
+} from 'rxjs/operators'
+import { gql, queryGraphQL } from '../backend/graphql'
+import * as GQL from '../backend/graphqlschema'
+import { Form } from '../components/Form'
+import { asError, createAggregateError, ErrorLike, isErrorLike } from '../util/errors'
+import { ExtensionCard } from './ExtensionCard'
+import { ConfigurationCascadeProps, ExtensionsProps } from './ExtensionsClientCommonContext'
+
+export const registryExtensionFragment = gql`
+    fragment RegistryExtensionFields on RegistryExtension {
+        id
+        publisher {
+            __typename
+            ... on User {
+                id
+                username
+                displayName
+                url
+            }
+            ... on Org {
+                id
+                name
+                displayName
+                url
+            }
+        }
+        extensionID
+        extensionIDWithoutRegistry
+        name
+        manifest {
+            raw
+            title
+            description
+        }
+        createdAt
+        updatedAt
+        url
+        remoteURL
+        registryName
+        isLocal
+    }
+`
+
+interface Props extends ConfigurationCascadeProps, ExtensionsProps, RouteComponentProps<{}> {
+    subject: Pick<ConfigurationSubject, 'id' | 'viewerCanAdminister'>
+    emptyElement?: React.ReactFragment
+}
+
+const LOADING: 'loading' = 'loading'
+
+interface ExtensionsResult {
+    /** The configured extensions. */
+    extensions: ConfiguredExtension[]
+
+    /** An error message that should be displayed to the user (in addition to the configured extensions). */
+    error: string | null
+}
+
+interface State {
+    /** The current value of the query field. */
+    query: string
+
+    /** The data to display. */
+    data: {
+        /** The query that was used to retrieve the results. */
+        query: string
+
+        /** The results, loading, or an error. */
+        resultOrError: typeof LOADING | ExtensionsResult | ErrorLike
+    }
+}
+
+/**
+ * Displays a list of all extensions used by a configuration subject.
+ */
+export class ExtensionsList extends React.PureComponent<Props, State> {
+    private static URL_QUERY_PARAM = 'query'
+
+    private updates = new Subject<void>()
+
+    private componentUpdates = new Subject<Props>()
+    private queryChanges = new Subject<string>()
+    private subscriptions = new Subscription()
+
+    constructor(props: Props) {
+        super(props)
+        this.state = {
+            query: this.getQueryFromProps(props),
+            data: { query: '', resultOrError: LOADING },
+        }
+    }
+
+    private getQueryFromProps(props: Pick<Props, 'location'>): string {
+        const params = new URLSearchParams(location.search)
+        return params.get(ExtensionsList.URL_QUERY_PARAM) || ''
+    }
+
+    public componentDidMount(): void {
+        this.subscriptions.add(
+            this.queryChanges.subscribe(query => {
+                this.setState({ query })
+            })
+        )
+
+        const debouncedQueryChanges = this.queryChanges.pipe(debounceTime(50))
+
+        // Update URL when query field changes.
+        this.subscriptions.add(
+            debouncedQueryChanges.subscribe(query => {
+                let search: string
+                if (query) {
+                    const searchParams = new URLSearchParams()
+                    searchParams.set(ExtensionsList.URL_QUERY_PARAM, query)
+                    search = searchParams.toString()
+                } else {
+                    search = ''
+                }
+                this.props.history.replace({
+                    search,
+                    hash: this.props.location.hash,
+                })
+            })
+        )
+
+        // Update query field when URL is changed manually.
+        this.subscriptions.add(
+            this.componentUpdates
+                .pipe(
+                    filter(({ history }) => history.action !== 'REPLACE'),
+                    map(({ location }) => this.getQueryFromProps({ location })),
+                    withLatestFrom(debouncedQueryChanges),
+                    filter(([urlQuery, debouncedStateQuery]) => urlQuery !== debouncedStateQuery)
+                )
+                .subscribe(([urlQuery]) => this.setState({ query: urlQuery }))
+        )
+
+        this.subscriptions.add(
+            combineLatest(debouncedQueryChanges)
+                .pipe(
+                    switchMap(([query]) => {
+                        const resultOrError = this.queryRegistryExtensions({ query }).pipe(
+                            catchError(err => [asError(err)])
+                        )
+                        return concat(
+                            of(LOADING).pipe(
+                                delay(250),
+                                takeUntil(resultOrError)
+                            ),
+                            resultOrError
+                        ).pipe(map(resultOrError => ({ data: { query, resultOrError } })))
+                    })
+                )
+                .subscribe(stateUpdate => this.setState(stateUpdate))
+        )
+
+        this.componentUpdates.next(this.props)
+        this.queryChanges.next(this.state.query)
+    }
+
+    public componentWillReceiveProps(nextProps: Props): void {
+        this.componentUpdates.next(nextProps)
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    public render(): JSX.Element | null {
+        return (
+            <div className="configured-extensions-list">
+                <Form onSubmit={this.onSubmit}>
+                    <div className="form-group">
+                        <input
+                            className="form-control"
+                            type="search"
+                            placeholder="Search extensions..."
+                            name="query"
+                            value={this.state.query}
+                            onChange={this.onQueryChange}
+                            autoFocus={true}
+                            autoComplete="off"
+                            autoCorrect="off"
+                            autoCapitalize="off"
+                            spellCheck={false}
+                        />
+                    </div>
+                </Form>
+                {this.state.data.resultOrError === LOADING ? (
+                    <LoadingSpinner className="icon-inline" />
+                ) : isErrorLike(this.state.data.resultOrError) ? (
+                    <div className="alert alert-danger">{this.state.data.resultOrError.message}</div>
+                ) : (
+                    <>
+                        {this.state.data.resultOrError.error && (
+                            <div className="alert alert-danger my-2">{this.state.data.resultOrError.error}</div>
+                        )}
+                        {this.state.data.resultOrError.extensions.length === 0 ? (
+                            this.state.data.query ? (
+                                <span className="text-muted">
+                                    No extensions matching <strong>{this.state.data.query}</strong>
+                                </span>
+                            ) : (
+                                this.props.emptyElement || <span className="text-muted">No extensions found</span>
+                            )
+                        ) : (
+                            <div className="row mt-3">
+                                {this.state.data.resultOrError.extensions.map((e, i) => (
+                                    <ExtensionCard
+                                        key={i}
+                                        subject={this.props.subject}
+                                        node={e}
+                                        onDidUpdate={this.onDidUpdateExtension}
+                                        configurationCascade={this.props.configurationCascade}
+                                        extensions={this.props.extensions}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        )
+    }
+
+    private onSubmit: React.FormEventHandler = e => e.preventDefault()
+
+    private onQueryChange: React.FormEventHandler<HTMLInputElement> = e => this.queryChanges.next(e.currentTarget.value)
+
+    private queryRegistryExtensions = (args: { query?: string }): Observable<ExtensionsResult> =>
+        this.props.extensions.viewerConfiguredExtensions.pipe(
+            // Avoid refreshing (and changing order) when the user merely interacts with an extension (e.g.,
+            // toggling its enablement), to reduce UI jitter.
+            take(1),
+
+            switchMap(viewerExtensions =>
+                from(
+                    queryGraphQL(
+                        gql`
+                            query RegistryExtensions($query: String, $prioritizeExtensionIDs: [String!]!) {
+                                extensionRegistry {
+                                    extensions(query: $query, prioritizeExtensionIDs: $prioritizeExtensionIDs) {
+                                        nodes {
+                                            ...RegistryExtensionFields
+                                        }
+                                        error
+                                    }
+                                }
+                            }
+                            ${registryExtensionFragment}
+                        `,
+                        {
+                            ...args,
+                            prioritizeExtensionIDs: viewerExtensions.map(({ id }) => id),
+                        } as GQL.IExtensionsOnExtensionRegistryArguments
+                    )
+                ).pipe(
+                    map(({ data, errors }) => {
+                        if (!data || !data.extensionRegistry || !data.extensionRegistry.extensions || errors) {
+                            throw createAggregateError(errors)
+                        }
+                        return {
+                            registryExtensions: data.extensionRegistry.extensions.nodes,
+                            error: data.extensionRegistry.extensions.error,
+                        }
+                    })
+                )
+            ),
+            map(({ registryExtensions, error }) => ({
+                // TODO(sqs): The cast to extensions-client-common's GQL (called "ECCGQL") is needed, despite that
+                // module being copied from this repository. I don't know why.
+                extensions: this.props.extensions.withConfiguration(registryExtensions as ECCGQL.IRegistryExtension[]),
+                error,
+            }))
+        )
+
+    private onDidUpdateExtension = () => this.updates.next()
+}

--- a/src/extensions/ExtensionsOverviewPage.tsx
+++ b/src/extensions/ExtensionsOverviewPage.tsx
@@ -1,4 +1,3 @@
-import { ExtensionsList } from '@sourcegraph/extensions-client-common/lib/extensions/manager/ExtensionsList'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
@@ -6,6 +5,7 @@ import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { ExtensionsAreaRouteContext } from './ExtensionsArea'
 import { ExtensionsEmptyState } from './ExtensionsEmptyState'
+import { ExtensionsList } from './ExtensionsList'
 
 interface Props extends ExtensionsAreaRouteContext, RouteComponentProps<{}> {}
 

--- a/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -1,10 +1,11 @@
-import { isExtensionAdded, isExtensionEnabled } from '@sourcegraph/extensions-client-common/lib/extensions/extension'
-import { ExtensionToggle } from '@sourcegraph/extensions-client-common/lib/extensions/ExtensionToggle'
+import { isExtensionEnabled } from '@sourcegraph/extensions-client-common/lib/extensions/extension'
 import { ExtensionManifest } from '@sourcegraph/extensions-client-common/lib/schema/extension.schema'
 import * as React from 'react'
 import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
 import { NavItemWithIconDescriptor } from '../../util/contributions'
 import { isErrorLike } from '../../util/errors'
+import { isExtensionAdded } from '../ExtensionsClientCommonContext'
+import { ExtensionToggle } from '../ExtensionToggle'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionConfigurationState } from './ExtensionConfigurationState'
 

--- a/src/extensions/extensions-client-common.scss
+++ b/src/extensions/extensions-client-common.scss
@@ -1,6 +1,5 @@
 // Imports, styles, and CSS variables for @sourcegraph/extensions-client-common.
 @import '~@sourcegraph/extensions-client-common/lib/app/app.css';
-@import '~@sourcegraph/extensions-client-common/lib/extensions/extensions.css';
 
 :root {
     --primary-opacity-2: #{transparentize($primary, 0.8)};

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,10 +971,10 @@
     rxjs "^6.3.2"
     vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/extensions-client-common@^10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.5.0.tgz#c78c57ab005622b53fe7678afe2d11fc05c1d541"
-  integrity sha512-1ZWWLGjGKovV3N78AUvyaPiG+eCG8awiXNcKaDxPAgizM7iCjZrQUjdfhCCMR8nvTDY/d5EI76LlAU1hbuBVJw==
+"@sourcegraph/extensions-client-common@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-12.0.0.tgz#7c48b9725b15b8638dd7eccada9e3680840ef6d8"
+  integrity sha512-RIm3y6uHzFagOlia4UGocZw5AHRTl10xMQ7/p64rLJDOdd8Qx3m7IIJlNKnPnzYHObEretSuQs78dU/1gK9F7w==
   dependencies:
     "@slimsag/react-shortcuts" "^1.2.0"
     bootstrap "^4.1.3"


### PR DESCRIPTION
> This PR does not need to update the CHANGELOG because it is not user facing