### PR TITLE
build: restore Cypress e2e tests

### DIFF
--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -126,7 +126,9 @@ func main() {
 		bk.Cmd("yarn workspace browser-extensions run tslint"),
 		bk.Cmd("yarn workspace browser-extensions run browserslist"),
 		bk.Cmd("yarn workspace browser-extensions run build"),
-		bk.Cmd("yarn workspace browser-extensions run test:ci"))
+		bk.Cmd("yarn workspace browser-extensions run test:ci"),
+		// Kill and retry the e2e tests after 3 minutes, and run at most 2 times.
+		bk.Cmd("sh -c \"for i in 1 2; do timeout 180 yarn workspace browser-extensions run test:e2e && break; done\""))
 
 	pipeline.AddWait()
 


### PR DESCRIPTION
I had originally removed them because they were flaky/hanging. See https://github.com/sourcegraph/sourcegraph/issues/697

This is a PR to experiment with way to make the e2e command more reliable.

> This PR does not need to update the CHANGELOG because it's test-related
