### PR TITLE
Use git wire protocol v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - The Git blame information shown at the end of a line is now provided by the [Git extras extension](https://sourcegraph.com/extensions/sourcegraph/git-extras). You must add that extension to continue using this feature.
+- The timeout when running `git ls-remote` to determine if a remote url is cloneable has been increased from 5s to 30s.
+- Git commands now use [version 2 of the Git wire protocol](https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html), which should speed up certain operations (e.g. `git ls-remote`, `git fetch`) when communicating with a v2 enabled server.
 
 ### Removed
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -979,6 +979,9 @@ func (s *Server) isCloneable(ctx context.Context, url string) error {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	out, err := s.runWithRemoteOpts(ctx, cmd, nil)
 	if err != nil {
+		if ctxerr := ctx.Err(); ctxerr != nil {
+			err = ctxerr
+		}
 		if len(out) > 0 {
 			err = fmt.Errorf("%s (output follows)\n\n%s", err, out)
 		}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -164,7 +164,7 @@ func shortGitCommandTimeout(args []string) time.Duration {
 		return longGitCommandTimeout
 
 	case "ls-remote":
-		return 5 * time.Second
+		return 30 * time.Second
 
 	default:
 		return time.Minute

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -965,7 +965,8 @@ var testRepoExists func(ctx context.Context, url string) error
 
 // isCloneable checks to see if the Git remote URL is cloneable.
 func (s *Server) isCloneable(ctx context.Context, url string) error {
-	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout([]string{"ls-remote"}))
+	args := []string{"ls-remote", url, "HEAD"}
+	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(args))
 	defer cancel()
 
 	if strings.ToLower(string(protocol.NormalizeRepo(api.RepoName(url)))) == "github.com/sourcegraphtest/alwayscloningtest" {
@@ -975,7 +976,7 @@ func (s *Server) isCloneable(ctx context.Context, url string) error {
 		return testRepoExists(ctx, url)
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", url, "HEAD")
+	cmd := exec.CommandContext(ctx, "git", args...)
 	out, err := s.runWithRemoteOpts(ctx, cmd, nil)
 	if err != nil {
 		if len(out) > 0 {

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -30,8 +30,15 @@ func (s *Server) runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress 
 	// And set a timeout to avoid indefinite hangs if the server is unreachable.
 	cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30")
 
-	// Unset credential helper because the command is non-interactive.
-	cmd.Args = append(cmd.Args[:1], append([]string{"-c", "credential.helper="}, cmd.Args[1:]...)...)
+	extraArgs := []string{
+		// Unset credential helper because the command is non-interactive.
+		"-c", "credential.helper=",
+
+		// Use Git wire protocol version 2.
+		// https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html
+		"-c", "protocol.version=2",
+	}
+	cmd.Args = append(cmd.Args[:1], append(extraArgs, cmd.Args[1:]...)...)
 
 	var b interface {
 		Bytes() []byte


### PR DESCRIPTION
fixes https://github.com/sourcegraph/sourcegraph/issues/699 

Also increases the timeout for ls-remote in case there are customers who don't have a v2 git server yet.