### PR TITLE
fix(browser-extensions): use correct URL for repo suggestions

### DIFF
--- a/packages/browser-extensions/src/shared/backend/search.tsx
+++ b/packages/browser-extensions/src/shared/backend/search.tsx
@@ -80,7 +80,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | null 
             return {
                 type: 'repo',
                 title: item.name,
-                url: `/${item.name}`,
+                url: item.url,
                 urlLabel: 'go to repository',
             }
         }
@@ -158,7 +158,8 @@ export const fetchSuggestions = (options: SearchOptions, first: number) =>
                     suggestions(first: $first) {
                         ... on Repository {
                             __typename
-                            uri
+                            name
+                            url
                         }
                         ... on File {
                             __typename


### PR DESCRIPTION
All repo suggestions in the browser extension location bar search were evaluating to `/undefined` (e.g., `https://sourcegraph.com/undefined`).

Previously, `/${item.name}` was evaluating to `/undefined` because `name` was not requested in the GraphQL query.