### PR TITLE
refactor: use non-deprecated GraphQL Repository.name (not uri)

### DIFF
--- a/packages/browser-extensions/src/shared/backend/search.tsx
+++ b/packages/browser-extensions/src/shared/backend/search.tsx
@@ -136,7 +136,7 @@ const symbolsFragment = `
             resource {
                 path
                 repository {
-                    uri
+                    name
                 }
             }
             url
@@ -168,7 +168,7 @@ export const fetchSuggestions = (options: SearchOptions, first: number) =>
                             isDirectory
                             url
                             repository {
-                                uri
+                                name
                             }
                         }
                         ... on Symbol {

--- a/packages/browser-extensions/src/shared/repo/backend.tsx
+++ b/packages/browser-extensions/src/shared/repo/backend.tsx
@@ -15,7 +15,7 @@ export const resolveParentRev = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query ResolveParentRev($repoPath: String!, $rev: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     mirrorInfo {
                         cloneInProgress
                     }
@@ -59,7 +59,7 @@ export const resolveRepo = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query ResolveRepo($repoPath: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     url
                 }
             }`,
@@ -85,7 +85,7 @@ export const resolveRev = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query ResolveRev($repoPath: String!, $rev: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     mirrorInfo {
                         cloneInProgress
                     }
@@ -180,7 +180,7 @@ export const fetchBlobContentLines = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query BlobContent($repoPath: String!, $commitID: String!, $filePath: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     commit(rev: $commitID) {
                         file(path: $filePath) {
                             content


### PR DESCRIPTION
The Repository.uri field in GraphQL (and in general) is deprecated in favor of Repository.name. This is just a different name for the same value (name is a better name than uri because the value is not actually a URI, so uri is a misnomer). The value that both fields contain is the string of the form github.com/foo/bar for a repository.

The GraphQL Query.repository resolver also has 2 equivalent args, name and uri, and this also changes calls to use the former (for the same reason).

There is no change in behavior.

Testing plan:

- Load a GitHub page and ensure the GraphQL queries calling Query.repository use the name arg name and succeed.