### PR TITLE
frontend: Add support for nested patterns when listing repos

### DIFF
--- a/cmd/frontend/db/query/query.go
+++ b/cmd/frontend/db/query/query.go
@@ -123,5 +123,5 @@ func Print(q Q) string {
 type printfBindVar struct{}
 
 func (printfBindVar) BindVar(i int) string {
-	return "%q"
+	return "%#v"
 }

--- a/cmd/frontend/db/query/query.go
+++ b/cmd/frontend/db/query/query.go
@@ -45,6 +45,21 @@ type not struct {
 //
 // Eval handles And, Or, Not and booleans. Otherwise every other Q will be
 // passed to atomToQueryFn.
+//
+// For example in the expression
+//
+//   And("atom1", Or(true, "atom2", &atom3{})
+//
+// atomToQueryFn is responsible for converting "atom1", "atom2" and &atom3{}
+// into sqlf.Query patterns. Eval will return the expression:
+//
+//   (query1 AND (query2 OR query3))
+//
+// Where queryN is the respective output of atomToQueryFn.
+//
+// Typically we expect atomToQueryFn to return a SQL condition like "name LIKE
+// $q". It should also handle unexpected values/types being passed in via
+// returning an error. See ExampleEval for a real example of a atomToQueryFn.
 func Eval(q Q, atomToQueryFn func(q Q) (*sqlf.Query, error)) (*sqlf.Query, error) {
 	childQueries := func(qs []Q) ([]*sqlf.Query, error) {
 		x := make([]*sqlf.Query, 0, len(qs))

--- a/cmd/frontend/db/query/query.go
+++ b/cmd/frontend/db/query/query.go
@@ -1,0 +1,112 @@
+// Package query provides an expression tree structure which can be converted
+// into WHERE queries. It is used by DB APIs to expose a more powerful query
+// interface.
+package query
+
+import (
+	"fmt"
+
+	"github.com/keegancsmith/sqlf"
+)
+
+// Q is a query item. It is converted into a *sqlf.Query by Eval.
+type Q interface{}
+
+// And returns a Q which when evaluated will join the children by "AND".
+func And(children ...Q) Q {
+	return &and{Children: children}
+}
+
+// Or returns a Q which when evaluated will join the children by "OR".
+func Or(children ...Q) Q {
+	return &or{Children: children}
+}
+
+// Not returns a Q which when evaluated will wrap child with "NOT".
+func Not(child Q) Q {
+	return &not{Child: child}
+}
+
+type and struct {
+	Children []Q
+}
+
+type or struct {
+	Children []Q
+}
+
+type not struct {
+	Child Q
+}
+
+// Eval runs all atoms of q through queryFn, returning the final query to
+// run. If any call of queryFn returns an error, that error is returned by
+// Eval.
+//
+// Eval handles And, Or, Not and booleans. Otherwise every other Q will be
+// passed to queryFn.
+func Eval(q Q, queryFn func(q Q) (*sqlf.Query, error)) (*sqlf.Query, error) {
+	childQueries := func(qs []Q) ([]*sqlf.Query, error) {
+		x := make([]*sqlf.Query, 0, len(qs))
+		for _, q := range qs {
+			c, err := Eval(q, queryFn)
+			if err != nil {
+				return nil, err
+			}
+			x = append(x, c)
+		}
+		return x, nil
+	}
+
+	switch c := q.(type) {
+	case *and:
+		children, err := childQueries(c.Children)
+		if err != nil {
+			return nil, err
+		}
+		if len(children) == 0 {
+			return sqlf.Sprintf("TRUE"), nil
+		}
+		return sqlf.Sprintf("(%s)", sqlf.Join(children, "AND")), nil
+
+	case *or:
+		children, err := childQueries(c.Children)
+		if err != nil {
+			return nil, err
+		}
+		if len(children) == 0 {
+			return sqlf.Sprintf("FALSE"), nil
+		}
+		return sqlf.Sprintf("(%s)", sqlf.Join(children, "OR")), nil
+
+	case *not:
+		child, err := Eval(c.Child, queryFn)
+		if err != nil {
+			return nil, err
+		}
+		return sqlf.Sprintf("NOT(%s)", child), nil
+
+	case bool:
+		if c {
+			return sqlf.Sprintf("TRUE"), nil
+		}
+		return sqlf.Sprintf("FALSE"), nil
+
+	default:
+		return queryFn(q)
+	}
+}
+
+// Print returns a string representing Q.
+func Print(q Q) string {
+	rq, _ := Eval(q, func(q Q) (*sqlf.Query, error) {
+		return sqlf.Sprintf("%s", q), nil
+	})
+	return fmt.Sprintf(rq.Query(printfBindVar{}), rq.Args()...)
+}
+
+type printfBindVar struct{}
+
+func (printfBindVar) BindVar(i int) string {
+	return "%q"
+}

--- a/cmd/frontend/db/query/query_test.go
+++ b/cmd/frontend/db/query/query_test.go
@@ -11,28 +11,59 @@ import (
 )
 
 func ExampleEval() {
-	rq, err := query.Eval(
-		query.And(
-			query.Or("foo", false),
-			query.Not("bar"),
-			true),
-		func(q query.Q) (*sqlf.Query, error) {
-			p, ok := q.(string)
-			if !ok {
-				return nil, errors.Errorf("unexpected token in query: %q", q)
-			}
-			return sqlf.Sprintf("name LIKE %s", "%"+p+"%"), nil
-		})
+	q := query.And(
+		query.Or("foo", false),
+		query.Not("bar"),
+		true)
+
+	rq, err := query.Eval(q, func(q query.Q) (*sqlf.Query, error) {
+		p, ok := q.(string)
+		if !ok {
+			return nil, errors.Errorf("unexpected token in query: %q", q)
+		}
+		return sqlf.Sprintf("name LIKE %s", "%"+p+"%"), nil
+	})
 	if err != nil {
 		log.Fatal("unexpected error", err)
 	}
 
-	fmt.Println(rq.Query(sqlf.PostgresBindVar))
-	fmt.Println(rq.Args())
-	fmt.Println(query.Print(rq))
-	// Output: ((name LIKE $1 OR FALSE) AND NOT(name LIKE $2) AND TRUE)
-	// [%foo% %bar%]
-	// ((name LIKE "%foo%" OR FALSE) AND NOT(name LIKE "%bar%") AND TRUE)
+	fmt.Println("Expression:", query.Print(q))
+	fmt.Println("SQL Query: ", rq.Query(sqlf.PostgresBindVar))
+	fmt.Println("SQL Args:  ", rq.Args())
+	// Output:
+	// Expression: (("foo" OR FALSE) AND NOT("bar") AND TRUE)
+	// SQL Query:  ((name LIKE $1 OR FALSE) AND NOT(name LIKE $2) AND TRUE)
+	// SQL Args:   [%foo% %bar%]
+}
+
+func ExampleEval_types() {
+	type equal struct{ Value string }
+	type prefix struct{ Value string }
+	q := query.And(
+		&prefix{"github.com/gorilla/"},
+		query.Not(&equal{"github.com/gorilla/mux"}))
+
+	rq, err := query.Eval(q, func(q query.Q) (*sqlf.Query, error) {
+		switch c := q.(type) {
+		case *prefix:
+			return sqlf.Sprintf("name LIKE %s", c.Value+"%"), nil
+		case *equal:
+			return sqlf.Sprintf("name = %s", c.Value), nil
+		default:
+			return nil, errors.Errorf("unexpected token in query: %q", q)
+		}
+	})
+	if err != nil {
+		log.Fatal("unexpected error", err)
+	}
+
+	fmt.Println("Expression:", query.Print(q))
+	fmt.Println("SQL Query: ", rq.Query(sqlf.PostgresBindVar))
+	fmt.Println("SQL Args:  ", rq.Args())
+	// Output:
+	// Expression: (&query_test.prefix{Value:"github.com/gorilla/"} AND NOT(&query_test.equal{Value:"github.com/gorilla/mux"}))
+	// SQL Query:  (name LIKE $1 AND NOT(name = $2))
+	// SQL Args:   [github.com/gorilla/% github.com/gorilla/mux]
 }
 
 func TestEval_cornercase(t *testing.T) {

--- a/cmd/frontend/db/query/query_test.go
+++ b/cmd/frontend/db/query/query_test.go
@@ -1,0 +1,72 @@
+package query_test
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
+)
+
+func ExampleEval() {
+	rq, err := query.Eval(
+		query.And(
+			query.Or("foo", false),
+			query.Not("bar"),
+			true),
+		func(q query.Q) (*sqlf.Query, error) {
+			return sqlf.Sprintf("name LIKE %s", "%"+q.(string)+"%"), nil
+		})
+	if err != nil {
+		log.Fatal("unexpected error", err)
+	}
+
+	fmt.Println(rq.Query(sqlf.PostgresBindVar))
+	fmt.Println(rq.Args())
+	fmt.Println(query.Print(rq))
+	// Output: ((name LIKE $1 OR FALSE) AND NOT(name LIKE $2) AND TRUE)
+	// [%foo% %bar%]
+	// ((name LIKE "%foo%" OR FALSE) AND NOT(name LIKE "%bar%") AND TRUE)
+}
+
+func TestEval_cornercase(t *testing.T) {
+	cases := []struct {
+		q    query.Q
+		want string
+	}{{
+		q:    query.And(),
+		want: "TRUE",
+	}, {
+		q:    query.And("test"),
+		want: `("test")`,
+	}, {
+		q:    query.Or(),
+		want: "FALSE",
+	}, {
+		q:    query.Or("test"),
+		want: `("test")`,
+	}}
+	for _, c := range cases {
+		got := query.Print(c.q)
+		if got != c.want {
+			t.Errorf("got %s, want %s", got, c.want)
+		}
+	}
+}
+
+func TestEval_error(t *testing.T) {
+	_, err := query.Eval(
+		query.And(
+			query.Or(
+				query.Not("bar"),
+				false),
+			query.Not(true)),
+		func(q query.Q) (*sqlf.Query, error) {
+			return nil, errors.New("42")
+		})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/frontend/db/query/query_test.go
+++ b/cmd/frontend/db/query/query_test.go
@@ -1,12 +1,12 @@
 package query_test
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"testing"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
 )
 
@@ -17,7 +17,11 @@ func ExampleEval() {
 			query.Not("bar"),
 			true),
 		func(q query.Q) (*sqlf.Query, error) {
-			return sqlf.Sprintf("name LIKE %s", "%"+q.(string)+"%"), nil
+			p, ok := q.(string)
+			if !ok {
+				return nil, errors.Errorf("unexpected token in query: %q", q)
+			}
+			return sqlf.Sprintf("name LIKE %s", "%"+p+"%"), nil
 		})
 	if err != nil {
 		log.Fatal("unexpected error", err)

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
 	dbtesting "github.com/sourcegraph/sourcegraph/cmd/frontend/db/testing"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
@@ -440,6 +441,130 @@ func TestRepos_List_patterns(t *testing.T) {
 		}
 		if got := repoNames(repos); !reflect.DeepEqual(got, test.want) {
 			t.Errorf("include %q exclude %q: got repos %q, want %q", test.includePatterns, test.excludePattern, got, test.want)
+		}
+	}
+}
+
+// TestRepos_List_patterns tests the behavior of Repos.List when called with
+// a QueryPattern.
+func TestRepos_List_queryPattern(t *testing.T) {
+	ctx := dbtesting.TestContext(t)
+
+	ctx = actor.WithActor(ctx, &actor.Actor{})
+
+	createdRepos := []*types.Repo{
+		{Name: "a/b"},
+		{Name: "c/d"},
+		{Name: "e/f"},
+		{Name: "g/h"},
+	}
+	for _, repo := range createdRepos {
+		createRepo(ctx, t, repo)
+	}
+	tests := []struct {
+		q    query.Q
+		want []api.RepoName
+		err  bool
+	}{
+		// These are the same tests as TestRepos_List_patterns, but in an
+		// expression form.
+		{
+			q:    "(a|c)",
+			want: []api.RepoName{"a/b", "c/d"},
+		},
+		{
+			q:    query.And("(a|c)", "b"),
+			want: []api.RepoName{"a/b"},
+		},
+		{
+			q:    query.And("(a|c)", query.Not("d")),
+			want: []api.RepoName{"a/b"},
+		},
+		{
+			q:    query.Not("(d|e)"),
+			want: []api.RepoName{"a/b", "g/h"},
+		},
+
+		// Some extra tests which test the pattern compiler
+		{
+			q:    "^a/b$",
+			want: []api.RepoName{"a/b"},
+		},
+		{
+			// Should match only e/f, but pattern compiler doesn't handle this
+			// so matches nothing.
+			q:    "[a-zA-Z]/e",
+			want: nil,
+		},
+
+		// Test OR support
+		{
+			q:    query.Or(query.Not("(d|e)"), "d"),
+			want: []api.RepoName{"a/b", "c/d", "g/h"},
+		},
+
+		// Test deeply nested
+		{
+			q: query.Or(
+				query.And(
+					true,
+					query.Not(query.Or("a", "c"))),
+				query.And(query.Not("e"), query.Not("a"))),
+			want: []api.RepoName{"c/d", "e/f", "g/h"},
+		},
+
+		// Corner cases for Or
+		{
+			q:    query.Or(), // empty Or is false
+			want: nil,
+		},
+		{
+			q:    query.Or("a"),
+			want: []api.RepoName{"a/b"},
+		},
+
+		// Corner cases for And
+		{
+			q:    query.And(), // empty And is true
+			want: []api.RepoName{"a/b", "c/d", "e/f", "g/h"},
+		},
+		{
+			q:    query.And("a"),
+			want: []api.RepoName{"a/b"},
+		},
+		{
+			q:    query.And("a", "d"),
+			want: nil,
+		},
+
+		// Bad pattern
+		{
+			q:   query.And("a/b", ")*"),
+			err: true,
+		},
+		// Only want strings
+		{
+			q:   query.And("a/b", 1),
+			err: true,
+		},
+	}
+	for _, test := range tests {
+		repos, err := Repos.List(ctx, ReposListOptions{
+			PatternQuery: test.q,
+			Enabled:      true,
+		})
+		if err != nil {
+			if test.err {
+				continue
+			}
+			t.Fatal(err)
+		}
+		if test.err {
+			t.Errorf("%s: expected error", query.Print(test.q))
+			continue
+		}
+		if got := repoNames(repos); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("%s: got repos %q, want %q", query.Print(test.q), got, test.want)
 		}
 	}
 }

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -464,7 +464,7 @@ func TestRepos_List_queryPattern(t *testing.T) {
 	tests := []struct {
 		q    query.Q
 		want []api.RepoName
-		err  bool
+		err  string
 	}{
 		// These are the same tests as TestRepos_List_patterns, but in an
 		// expression form.
@@ -540,12 +540,12 @@ func TestRepos_List_queryPattern(t *testing.T) {
 		// Bad pattern
 		{
 			q:   query.And("a/b", ")*"),
-			err: true,
+			err: "error parsing regexp",
 		},
 		// Only want strings
 		{
 			q:   query.And("a/b", 1),
-			err: true,
+			err: "unexpected token",
 		},
 	}
 	for _, test := range tests {
@@ -554,12 +554,15 @@ func TestRepos_List_queryPattern(t *testing.T) {
 			Enabled:      true,
 		})
 		if err != nil {
-			if test.err {
-				continue
+			if test.err == "" {
+				t.Fatal(err)
 			}
-			t.Fatal(err)
+			if !strings.Contains(err.Error(), test.err) {
+				t.Errorf("expected error to contain %q, got: %v", test.err, err)
+			}
+			continue
 		}
-		if test.err {
+		if test.err != "" {
 			t.Errorf("%s: expected error", query.Print(test.q))
 			continue
 		}


### PR DESCRIPTION
For hierarchical search we can no longer rely on just a list of include and
exclude patterns, but instead have logical operators between the repo
expressions. This commit introduces a basic query expression which is And, Or,
Not and atoms (interface{}). It is up to the query logic itself to interpret
what to do with the atoms. In the case of repo listing, we expect strings and
use the same pattern logic for names as IncludePatterns supports.