### PR TITLE
pkg/conf: Add deadlock detector for frontend

### DIFF
--- a/cmd/frontend/db/phabricator.go
+++ b/cmd/frontend/db/phabricator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -18,24 +19,33 @@ type errPhabricatorRepoNotFound struct {
 	args []interface{}
 }
 
-var phabricatorRepos = atomicvalue.New()
+var (
+	phabricatorRepos          = atomicvalue.New()
+	phabricatorReposReadyOnce sync.Once
+	phabricatorReposReady     = make(chan struct{})
+)
 
 func init() {
-	conf.Watch(func() {
-		phabricatorRepos.Set(func() interface{} {
-			repos := map[api.RepoName]*types.PhabricatorRepo{}
-			for _, config := range conf.Get().Phabricator {
-				for _, repo := range config.Repos {
-					repos[api.RepoName(repo.Path)] = &types.PhabricatorRepo{
-						Name:     api.RepoName(repo.Path),
-						Callsign: repo.Callsign,
-						URL:      config.Url,
+	go func() {
+		conf.ConfigurationServerReady()
+
+		conf.Watch(func() {
+			phabricatorRepos.Set(func() interface{} {
+				repos := map[api.RepoName]*types.PhabricatorRepo{}
+				for _, config := range conf.Get().Phabricator {
+					for _, repo := range config.Repos {
+						repos[api.RepoName(repo.Path)] = &types.PhabricatorRepo{
+							Name:     api.RepoName(repo.Path),
+							Callsign: repo.Callsign,
+							URL:      config.Url,
+						}
 					}
 				}
-			}
-			return repos
+				return repos
+			})
 		})
-	})
+	}()
+
 }
 
 func (err errPhabricatorRepoNotFound) Error() string {

--- a/cmd/frontend/db/phabricator.go
+++ b/cmd/frontend/db/phabricator.go
@@ -27,8 +27,6 @@ var (
 
 func init() {
 	go func() {
-		conf.WaitUntilConfigurationServerInitialized()
-
 		conf.Watch(func() {
 			phabricatorRepos.Set(func() interface{} {
 				repos := map[api.RepoName]*types.PhabricatorRepo{}

--- a/cmd/frontend/db/phabricator.go
+++ b/cmd/frontend/db/phabricator.go
@@ -27,7 +27,7 @@ var (
 
 func init() {
 	go func() {
-		conf.ConfigurationServerReady()
+		conf.WaitUntilConfigurationServerInitialized()
 
 		conf.Watch(func() {
 			phabricatorRepos.Set(func() interface{} {

--- a/cmd/frontend/db/phabricator.go
+++ b/cmd/frontend/db/phabricator.go
@@ -44,6 +44,10 @@ func init() {
 				return repos
 			})
 		})
+
+		phabricatorReposReadyOnce.Do(func() {
+			close(phabricatorReposReady)
+		})
 	}()
 
 }
@@ -137,6 +141,7 @@ func (p *phabricator) GetByName(ctx context.Context, name api.RepoName) (*types.
 	if Mocks.Phabricator.GetByName != nil {
 		return Mocks.Phabricator.GetByName(name)
 	}
+	<-phabricatorReposReady
 	phabricatorRepos := phabricatorRepos.Get().(map[api.RepoName]*types.PhabricatorRepo)
 	if r := phabricatorRepos[name]; r != nil {
 		return r, nil

--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -2,8 +2,12 @@
 package globals
 
 import (
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals/confserver"
+	"io/ioutil"
 	"net/url"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
 
 // AppURL is the fully-resolved frontend app URL.
@@ -12,6 +16,33 @@ var AppURL = &url.URL{Scheme: "http", Host: "example.com"}
 // ConfigurationServerFrontendOnly provides the contents of the site configuration
 // to other services and manages modifications to it.
 //
-// 🚨 This is instantiated by pkg/conf's init method to avoid deadlock issues. Any another service
-// that attempts to use this variable will panic.
-var ConfigurationServerFrontendOnly *confserver.Server
+// Any another service that attempts to use this variable will panic.
+var ConfigurationServerFrontendOnly = conf.InitConfigurationServerFrontendOnly(configurationSource{
+	configFilePath: os.Getenv("SOURCEGRAPH_CONFIG_FILE"),
+})
+
+type configurationSource struct {
+	configFilePath string
+}
+
+func (c configurationSource) Read() (string, error) {
+	data, err := ioutil.ReadFile(c.FilePath())
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to read config file from %q", c.FilePath())
+	}
+
+	return string(data), err
+}
+
+func (c configurationSource) Write(input string) error {
+	return ioutil.WriteFile(c.FilePath(), []byte(input), 0600)
+}
+
+func (c configurationSource) FilePath() string {
+	filePath := c.configFilePath
+	if filePath == "" {
+		filePath = "/etc/sourcegraph/config.json"
+	}
+
+	return filePath
+}

--- a/pkg/conf/client.go
+++ b/pkg/conf/client.go
@@ -8,14 +8,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+
 	"github.com/sourcegraph/sourcegraph/pkg/api"
-	"github.com/sourcegraph/sourcegraph/pkg/conf/store"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type client struct {
-	store *store.Store
+	store *Store
 
 	fetcher fetcher
 
@@ -201,5 +200,5 @@ func (h httpFetcher) FetchConfig() (string, error) {
 type passthroughFetcherFrontendOnly struct{}
 
 func (p passthroughFetcherFrontendOnly) FetchConfig() (string, error) {
-	return globals.ConfigurationServerFrontendOnly.Raw(), nil
+	return configurationServerFrontendOnly.Raw(), nil
 }

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -89,7 +89,6 @@ func init() {
 		close(configurationServerFrontendOnlyInitialized)
 
 		go defaultClient.continuouslyUpdate()
-
 	}
 }
 

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -102,7 +102,7 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 		panic("cannot call this function except in server mode")
 	}
 
-	var server *Server
+	server := NewServer(source)
 	server.Start()
 
 	// Install the passthrough fetcher for defaultClient in order to avoid deadlock issues.

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -48,10 +48,10 @@ var (
 	configurationServerFrontendOnlyInitialized = make(chan struct{})
 )
 
-// ConfigurationServerReady blocks until frontend's configuration server has been initialized iff the
+// WaitUntilConfigurationServerInitialized blocks until frontend's configuration server has been initialized iff the
 // caller of pkg/conf is the frontend binary. This function is a no-op for every other caller
-//of pkg/conf.
-func ConfigurationServerReady() {
+// of pkg/conf.
+func WaitUntilConfigurationServerInitialized() {
 	<-configurationServerFrontendOnlyInitialized
 }
 

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -104,7 +104,7 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 	}
 
 	if mode == modeClient {
-		panic("cannot call this function except in client mode")
+		panic("cannot call this function while in client mode")
 	}
 
 	server := NewServer(source)

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -48,13 +48,6 @@ var (
 	configurationServerFrontendOnlyInitialized = make(chan struct{})
 )
 
-// WaitUntilConfigurationServerInitialized blocks until frontend's configuration server has been initialized iff the
-// caller of pkg/conf is the frontend binary. This function is a no-op for every other caller
-// of pkg/conf.
-func WaitUntilConfigurationServerInitialized() {
-	<-configurationServerFrontendOnlyInitialized
-}
-
 func init() {
 	clientStore := NewStore()
 	defaultClient = &client{

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -98,8 +98,13 @@ func init() {
 // occur. This function should only ever be called once.
 func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 	mode := getMode()
-	if mode != modeServer {
-		panic("cannot call this function except in server mode")
+
+	if mode == modeTest {
+		return nil
+	}
+
+	if mode == modeClient {
+		panic("cannot call this function except in client mode")
 	}
 
 	server := NewServer(source)

--- a/pkg/conf/reposource/custom.go
+++ b/pkg/conf/reposource/custom.go
@@ -32,8 +32,6 @@ func init() {
 	})
 
 	go func() {
-		conf.WaitUntilConfigurationServerInitialized()
-
 		conf.Watch(func() {
 			cloneURLConfig := conf.Get().GitCloneURLToRepositoryName
 			newCloneURLResolvers := make([]*cloneURLResolver, len(cloneURLConfig))

--- a/pkg/conf/reposource/custom.go
+++ b/pkg/conf/reposource/custom.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	log15 "gopkg.in/inconshreveable/log15.v2"
 
@@ -12,8 +14,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// cloneURLResolvers is the list of clone-URL-to-repo-name mappings, derived from the site config
-var cloneURLResolvers []*cloneURLResolver
+var (
+	// cloneURLResolvers is the list of clone-URL-to-repo-URI mappings, derived from the site config
+	cloneURLResolvers          atomic.Value
+	cloneURLResolversReadyOnce sync.Once
+	cloneURLResolversReady     = make(chan struct{})
+)
 
 func init() {
 	conf.ContributeValidator(func(c schema.SiteConfiguration) (problems []string) {
@@ -25,23 +31,30 @@ func init() {
 		return
 	})
 
-	conf.Watch(func() {
-		cloneURLConfig := conf.Get().GitCloneURLToRepositoryName
-		newCloneURLResolvers := make([]*cloneURLResolver, len(cloneURLConfig))
-		for i, c := range cloneURLConfig {
-			from, err := regexp.Compile(c.From)
-			if err != nil {
-				// Skip if there's an error. A user-visible validation error will appear due to the ContributeValidator call above.
-				log15.Error("Site config: unable to compile Git clone URL mapping regexp", "regexp", c.From)
-				continue
+	go func() {
+		conf.ConfigurationServerReady()
+
+		conf.Watch(func() {
+			cloneURLConfig := conf.Get().GitCloneURLToRepositoryName
+			newCloneURLResolvers := make([]*cloneURLResolver, len(cloneURLConfig))
+			for i, c := range cloneURLConfig {
+				from, err := regexp.Compile(c.From)
+				if err != nil {
+					// Skip if there's an error. A user-visible validation error will appear due to the ContributeValidator call above.
+					log15.Error("Site config: unable to compile Git clone URL mapping regexp", "regexp", c.From)
+					continue
+				}
+				newCloneURLResolvers[i] = &cloneURLResolver{
+					from: from,
+					to:   c.To,
+				}
 			}
-			newCloneURLResolvers[i] = &cloneURLResolver{
-				from: from,
-				to:   c.To,
-			}
-		}
-		cloneURLResolvers = newCloneURLResolvers
-	})
+			cloneURLResolvers.Store(newCloneURLResolvers)
+			cloneURLResolversReadyOnce.Do(func() {
+				close(cloneURLResolversReady)
+			})
+		})
+	}()
 }
 
 type cloneURLResolver struct {
@@ -52,7 +65,8 @@ type cloneURLResolver struct {
 // customCloneURLToRepoName maps from clone URL to repo name using custom mappings specified by the
 // user in site config. An empty string return value indicates no match.
 func customCloneURLToRepoName(cloneURL string) (repoName api.RepoName) {
-	for _, r := range cloneURLResolvers {
+	<-cloneURLResolversReady
+	for _, r := range cloneURLResolvers.Load().([]*cloneURLResolver) {
 		if name := mapString(r.from, cloneURL, r.to); name != "" {
 			return api.RepoName(name)
 		}

--- a/pkg/conf/reposource/custom.go
+++ b/pkg/conf/reposource/custom.go
@@ -32,7 +32,7 @@ func init() {
 	})
 
 	go func() {
-		conf.ConfigurationServerReady()
+		conf.WaitUntilConfigurationServerInitialized()
 
 		conf.Watch(func() {
 			cloneURLConfig := conf.Get().GitCloneURLToRepositoryName

--- a/pkg/conf/reposource/custom_test.go
+++ b/pkg/conf/reposource/custom_test.go
@@ -46,7 +46,7 @@ func Test_customCloneURLToRepoName(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		cloneURLResolvers = test.cloneURLResolvers
+		cloneURLResolvers.Store(test.cloneURLResolvers)
 		for cloneURL, expName := range test.cloneURLToRepoName {
 			if name := customCloneURLToRepoName(cloneURL); name != api.RepoName(expName) {
 				t.Errorf("In test case %d, expected %s -> %s, but got %s", i+1, cloneURL, expName, name)

--- a/pkg/conf/reposource/reposlist.go
+++ b/pkg/conf/reposource/reposlist.go
@@ -26,9 +26,10 @@ func init() {
 
 		conf.Watch(func() {
 			reposListInstance.Store(newReposList(conf.Get().ReposList))
-			reposListInstanceReadyOnce.Do(func() {
-				close(reposListInstanceReady)
-			})
+		})
+
+		reposListInstanceReadyOnce.Do(func() {
+			close(reposListInstanceReady)
 		})
 	}()
 }

--- a/pkg/conf/reposource/reposlist.go
+++ b/pkg/conf/reposource/reposlist.go
@@ -22,8 +22,6 @@ var (
 
 func init() {
 	go func() {
-		conf.WaitUntilConfigurationServerInitialized()
-
 		conf.Watch(func() {
 			reposListInstance.Store(newReposList(conf.Get().ReposList))
 		})

--- a/pkg/conf/reposource/reposlist.go
+++ b/pkg/conf/reposource/reposlist.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	go func() {
-		conf.ConfigurationServerReady()
+		conf.WaitUntilConfigurationServerInitialized()
 
 		conf.Watch(func() {
 			reposListInstance.Store(newReposList(conf.Get().ReposList))

--- a/pkg/conf/reposource/reposlist.go
+++ b/pkg/conf/reposource/reposlist.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
@@ -14,24 +15,27 @@ import (
 var (
 	// reposListInstance is the global instance of the repos.list repoSource. Do NOT reference this
 	// directly; use getReposListInstance() instead.
-	reposListInstance *reposList
-	reposListMu       sync.Mutex
+	reposListInstance          atomic.Value
+	reposListInstanceReadyOnce sync.Once
+	reposListInstanceReady     = make(chan struct{})
 )
 
 func init() {
-	conf.Watch(func() {
-		newReposListInstance := newReposList(conf.Get().ReposList)
+	go func() {
+		conf.ConfigurationServerReady()
 
-		reposListMu.Lock()
-		reposListInstance = newReposListInstance
-		reposListMu.Unlock()
-	})
+		conf.Watch(func() {
+			reposListInstance.Store(newReposList(conf.Get().ReposList))
+			reposListInstanceReadyOnce.Do(func() {
+				close(reposListInstanceReady)
+			})
+		})
+	}()
 }
 
 func getReposListInstance() *reposList {
-	reposListMu.Lock()
-	defer reposListMu.Unlock()
-	return reposListInstance
+	<-reposListInstanceReady
+	return reposListInstance.Load().(*reposList)
 }
 
 type reposList struct {

--- a/pkg/conf/store.go
+++ b/pkg/conf/store.go
@@ -117,7 +117,6 @@ func (s *Store) WaitUntilInitialized() {
 	if mode == modeServer {
 		select {
 		case <-configurationServerFrontendOnlyInitialized:
-			// Configuration server is initialized or this is not running in server mode.
 		default:
 			panic("deadlock detected: you have called conf.Get or conf.Watch before the frontend has been initialized (you may need to use goroutines and use conf.WaitUntilConfigurationServerInitialized to block until the frontend has been initialized)")
 		}

--- a/pkg/conf/store.go
+++ b/pkg/conf/store.go
@@ -119,7 +119,7 @@ func (s *Store) WaitUntilInitialized() {
 		case <-configurationServerFrontendOnlyInitialized:
 			// Configuration server is initialized or this is not running in server mode.
 		default:
-			panic("deadlock detected: you have called conf.Get or conf.Watch before the frontend has been initialized (you may need to use goroutines and use conf.ConfigurationServerReady to block until the frontend has been initialized)")
+			panic("deadlock detected: you have called conf.Get or conf.Watch before the frontend has been initialized (you may need to use goroutines and use conf.WaitUntilConfigurationServerInitialized to block until the frontend has been initialized)")
 		}
 	}
 

--- a/pkg/trace/httptrace.go
+++ b/pkg/trace/httptrace.go
@@ -72,6 +72,10 @@ func init() {
 			sentryDSN = conf.Get().Log.Sentry.Dsn
 			raven.SetDSN(sentryDSN)
 		})
+
+		ravenReadyOnce.Do(func() {
+			close(ravenReady)
+		})
 	}()
 
 }

--- a/pkg/trace/httptrace.go
+++ b/pkg/trace/httptrace.go
@@ -55,7 +55,7 @@ func init() {
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(requestHeartbeat)
 
-	go func() {		
+	go func() {
 		conf.Watch(func() {
 			if conf.Get().Log == nil {
 				return

--- a/pkg/trace/httptrace.go
+++ b/pkg/trace/httptrace.go
@@ -55,9 +55,7 @@ func init() {
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(requestHeartbeat)
 
-	go func() {
-		conf.WaitUntilConfigurationServerInitialized()
-
+	go func() {		
 		conf.Watch(func() {
 			if conf.Get().Log == nil {
 				return

--- a/pkg/trace/httptrace.go
+++ b/pkg/trace/httptrace.go
@@ -56,7 +56,7 @@ func init() {
 	prometheus.MustRegister(requestHeartbeat)
 
 	go func() {
-		conf.ConfigurationServerReady()
+		conf.WaitUntilConfigurationServerInitialized()
 
 		conf.Watch(func() {
 			if conf.Get().Log == nil {

--- a/pkg/trace/httptrace.go
+++ b/pkg/trace/httptrace.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	log15 "gopkg.in/inconshreveable/log15.v2"
@@ -43,26 +44,36 @@ var requestHeartbeat = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help:      "Last time a request finished for a http endpoint.",
 }, metricLabels)
 
-var sentryDSN string
+var (
+	sentryDSN string
+
+	ravenReadyOnce sync.Once
+	ravenReady     = make(chan struct{})
+)
 
 func init() {
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(requestHeartbeat)
 
-	conf.Watch(func() {
-		if conf.Get().Log == nil {
-			return
-		}
-		if conf.Get().Log.Sentry == nil {
-			return
-		}
-		if conf.Get().Log.Sentry.Dsn == "" {
-			return
-		}
+	go func() {
+		conf.ConfigurationServerReady()
 
-		sentryDSN = conf.Get().Log.Sentry.Dsn
-		raven.SetDSN(sentryDSN)
-	})
+		conf.Watch(func() {
+			if conf.Get().Log == nil {
+				return
+			}
+			if conf.Get().Log.Sentry == nil {
+				return
+			}
+			if conf.Get().Log.Sentry.Dsn == "" {
+				return
+			}
+
+			sentryDSN = conf.Get().Log.Sentry.Dsn
+			raven.SetDSN(sentryDSN)
+		})
+	}()
+
 }
 
 // Middleware captures and exports metrics to Prometheus, etc.
@@ -126,6 +137,7 @@ func Middleware(next http.Handler) http.Handler {
 
 		// If status code is not 2xx, notify Sentry
 		if m.Code/100 != 2 && m.Code/100 != 3 {
+			<-ravenReady
 			raven.CaptureError(&httpErr{status: m.Code, method: r.Method, path: r.URL.Path}, map[string]string{
 				"method":        r.Method,
 				"url":           r.URL.String(),


### PR DESCRIPTION
Many packages that we have use `conf.Watch` or `conf.Get` in their `init` functions. Such packages are included in `frontend`'s dependencies. Since `frontend` is responsible for serving the configuration to everyone else, it's possible to get into a situation where one of frontend's dependencies' `init` functions will block forever since `frontend` hasn't been initialized yet (and can't be until its dependencies have been initialized). 

The solution is to make sure that calls to `pkg/conf` never block the `init` function. 

This PR: 

1) Adds a detector that will `panic` if you're trying to call `conf.Get` or `conf.Watch` before `frontend` has been initialized 
2) Fixes a couple deadlocks due to these issues
