### PR TITLE
Remove @sourcegraph/phabricator-extension

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -235,7 +235,7 @@ export function watchExtensionsClientCommon(): ChildProcess {
 const PHABRICATOR_EXTENSION_FILES = './packages/browser-extensions/build/phabricator/**'
 
 /**
- * Copies the bundles from the `@sourcegraph/phabricator-extension` package over to the ui/assets
+ * Copies the phabricator extension over to the ui/assets
  * folder so they can be served by the webapp.
  * The package is published from https://github.com/sourcegraph/browser-extensions
  */

--- a/packages/browser-extensions/build/phabricator/package-lock.json
+++ b/packages/browser-extensions/build/phabricator/package-lock.json
@@ -1,4 +1,0 @@
-{
-  "name": "@sourcegraph/phabricator-extension",
-  "lockfileVersion": 1
-}

--- a/packages/browser-extensions/build/phabricator/package.json
+++ b/packages/browser-extensions/build/phabricator/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "@sourcegraph/phabricator-extension",
-  "description": "The Sourcegraph Phabricator extension bundle",
-  "license": "MIT"
-}

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -59,7 +59,6 @@
     "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^3.9.1",
     "@sourcegraph/extensions-client-common": "^12.0.0",
-    "@sourcegraph/phabricator-extension": "^1.18.0",
     "@sqs/jsonc-parser": "^1.0.3",
     "@types/react": "16.4.14",
     "@types/react-dom": "16.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1418,11 +1418,6 @@
     rxjs "^6.3.2"
     vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/phabricator-extension@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/phabricator-extension/-/phabricator-extension-1.18.0.tgz#238be49e449fe7f773e6ff6881e3c480a5e6aaed"
-  integrity sha512-V6VvLyzPo9fqGY1il0krQ5Xs2c60dnL7CEvtQMuvP8RglYu4wiEbxXkC8r+qKrF0cS8caFpQK8Tg88ZANQkUYQ==
-
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@sourcegraph/prettierrc/-/prettierrc-2.2.0.tgz#af4a6fcd465b0a39a07ffbd8f2d3414d01e603e8"


### PR DESCRIPTION
This package is no longer necessary now that the browser extension lives in this repo too.

> This PR does not need to update the CHANGELOG because it's build related.
