### PR TITLE
fix: code intel broken on diffs with newly added files

### DIFF
--- a/packages/browser-extensions/src/libs/github/dom_functions.ts
+++ b/packages/browser-extensions/src/libs/github/dom_functions.ts
@@ -202,8 +202,10 @@ export const getDiffLineRanges: CodeView['getLineRanges'] = (codeView, part) => 
         if (isCode) {
             const line = row.querySelector<HTMLElement>(
                 `td${isDomSplitDiff() ? `:nth-of-type(${part === 'base' ? 2 : 4})` : '.blob-code'}`
-            )!
+            )
+
             if (
+                !line ||
                 line.classList.contains('empty-cell') ||
                 line.classList.contains(part === 'base' ? 'blob-code-addition' : 'blob-code-deletion')
             ) {

--- a/packages/browser-extensions/src/libs/github/dom_functions.ts
+++ b/packages/browser-extensions/src/libs/github/dom_functions.ts
@@ -197,7 +197,7 @@ export const getDiffLineRanges: CodeView['getLineRanges'] = (codeView, part) => 
 
     for (const row of codeView.querySelectorAll<HTMLTableRowElement>('tr')) {
         const isCode =
-            !row.classList.contains('js-expandable-line') && !row.classList.contains('js-inline-comments-container')
+            !row.classList.contains('js-expandable-line') && !row.classList.contains('js-inline-comments-container') && !row.querySelector('[data-line-number="..."]')
 
         if (isCode) {
             const line = row.querySelector<HTMLElement>(

--- a/packages/browser-extensions/src/libs/github/dom_functions.ts
+++ b/packages/browser-extensions/src/libs/github/dom_functions.ts
@@ -197,7 +197,9 @@ export const getDiffLineRanges: CodeView['getLineRanges'] = (codeView, part) => 
 
     for (const row of codeView.querySelectorAll<HTMLTableRowElement>('tr')) {
         const isCode =
-            !row.classList.contains('js-expandable-line') && !row.classList.contains('js-inline-comments-container') && !row.querySelector('[data-line-number="..."]')
+            !row.classList.contains('js-expandable-line') &&
+            !row.classList.contains('js-inline-comments-container') &&
+            !row.querySelector('[data-line-number="..."]')
 
         if (isCode) {
             const line = row.querySelector<HTMLElement>(


### PR DESCRIPTION
PR from https://github.com/sourcegraph/browser-extensions/pull/294

This PR changes:

Fixes sourcegraph/sourcegraph#605

This blue border on newly added files in diffs counted as a row, and since it doesn't have any class names, it isn't filtered out in isCode. Hence, we can't assume that line is non-null.

image

Testing plan:

I've tested on this PR: https://github.com/sourcegraph/sourcegraph/pull/586/files. The browser extension would break once scrolling past licenseusercount.go. I confirmed this PR fixes the issue so code intel works.

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
> This PR does not need to update the CHANGELOG because ...