### PR TITLE
fix: do not swallow errors in importScripts when loading extensions

### DIFF
--- a/packages/sourcegraph-extension-api/src/extension/workerMain.ts
+++ b/packages/sourcegraph-extension-api/src/extension/workerMain.ts
@@ -32,49 +32,53 @@ export function extensionHostWorkerMain(self: DedicatedWorkerGlobalScope): void 
     self.addEventListener('message', receiveExtensionURL)
 
     function receiveExtensionURL(ev: MessageEvent): void {
-        // Only listen for the 1st URL.
-        self.removeEventListener('message', receiveExtensionURL)
+        try {
+            // Only listen for the 1st URL.
+            self.removeEventListener('message', receiveExtensionURL)
 
-        if (ev.origin && ev.origin !== self.location.origin) {
-            console.error(`Invalid extension host message origin: ${ev.origin} (expected ${self.location.origin})`)
-            self.close()
-        }
-
-        const initData: InitData = ev.data
-        if (typeof initData.bundleURL !== 'string' || !initData.bundleURL.startsWith('blob:')) {
-            console.error(`Invalid extension bundle URL: ${initData.bundleURL}`)
-            self.close()
-        }
-
-        const api = createExtensionHost(initData)
-        // Make `import 'sourcegraph'` or `require('sourcegraph')` return the extension host's
-        // implementation of the `sourcegraph` module.
-        ;(self as any).require = (modulePath: string): any => {
-            if (modulePath === 'sourcegraph') {
-                return api
+            if (ev.origin && ev.origin !== self.location.origin) {
+                console.error(`Invalid extension host message origin: ${ev.origin} (expected ${self.location.origin})`)
+                self.close()
             }
-            throw new Error(`require: module not found: ${modulePath}`)
-        }
 
-        // Load the extension bundle and retrieve the extension entrypoint module's exports on the global
-        // `module` property.
-        ;(self as any).exports = {}
-        ;(self as any).module = {}
-        self.importScripts(initData.bundleURL)
-        const extensionExports = (self as any).module.exports
-        delete (self as any).module
-
-        if ('activate' in extensionExports) {
-            try {
-                tryCatchPromise(() => extensionExports.activate()).catch((err: any) => {
-                    console.error(`Error creating extension host:`, err)
-                    self.close()
-                })
-            } catch (err) {
-                console.error(`Error activating extension.`, err)
+            const initData: InitData = ev.data
+            if (typeof initData.bundleURL !== 'string' || !initData.bundleURL.startsWith('blob:')) {
+                console.error(`Invalid extension bundle URL: ${initData.bundleURL}`)
+                self.close()
             }
-        } else {
-            console.error(`Extension did not export an 'activate' function.`)
+
+            const api = createExtensionHost(initData)
+            // Make `import 'sourcegraph'` or `require('sourcegraph')` return the extension host's
+            // implementation of the `sourcegraph` module.
+            ;(self as any).require = (modulePath: string): any => {
+                if (modulePath === 'sourcegraph') {
+                    return api
+                }
+                throw new Error(`require: module not found: ${modulePath}`)
+            }
+
+            // Load the extension bundle and retrieve the extension entrypoint module's exports on the global
+            // `module` property.
+            ;(self as any).exports = {}
+            ;(self as any).module = {}
+            self.importScripts(initData.bundleURL)
+            const extensionExports = (self as any).module.exports
+            delete (self as any).module
+
+            if ('activate' in extensionExports) {
+                try {
+                    tryCatchPromise(() => extensionExports.activate()).catch((err: any) => {
+                        console.error(`Error creating extension host:`, err)
+                        self.close()
+                    })
+                } catch (err) {
+                    console.error(`Error activating extension.`, err)
+                }
+            } else {
+                console.error(`Extension did not export an 'activate' function.`)
+            }
+        } catch (err) {
+            console.error(err)
         }
     }
 }


### PR DESCRIPTION
If an extension has side effects (e.g., it has a top-level `const x foo()`) that throw, or if other errors occur during importScripts, the error would have been swallowed. This makes it so that the error is printed.