### PR TITLE
Reduce the number of aws code commit repos fetched per api call from 50 to 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+## 2.13.2 (unreleased)
+
+- Fixed an issue where Sourcegraph would try to fetch more than the allowed number of repositories from AWS CodeCommit.
+
 ## 2.13.1
 
 ### Changed

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -308,7 +308,9 @@ func makeSHA256(data []byte) []byte {
 }
 
 func (c *awsCodeCommitConnection) listAllRepositories(ctx context.Context) <-chan *awscodecommit.Repository {
-	const maxItems = 50
+	// The document limit per page is here:
+	// https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/codecommit/model/MaximumRepositoryNamesExceededException.html
+	const maxItems = 25
 	ch := make(chan *awscodecommit.Repository, maxItems)
 	go func() {
 		defer close(ch)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/835