### PR TITLE
Create a service that hosts ephemeral git repositories

### DIFF
--- a/cmd/web-repo-proxy/README.md
+++ b/cmd/web-repo-proxy/README.md
@@ -1,0 +1,1 @@
+web-repo-proxy is a utility to serve Git repositories based on data from the web. The initial application is to serve the code from Stackoverflow posts as Git repositories so that we can show code intelligence for them. See [the original feature request](https://github.com/sourcegraph/sourcegraph/issues/423).

--- a/cmd/web-repo-proxy/README.md
+++ b/cmd/web-repo-proxy/README.md
@@ -31,29 +31,29 @@ curl -i http://localhost:4014/create-repository \
   -d @create-repository.json
 
     HTTP/1.1 200 OK
-    Date: Mon, 12 Nov 2018 20:01:38 GMT
+    Date: Wed, 14 Nov 2018 16:01:20 GMT
     Content-Length: 66
     Content-Type: text/plain; charset=utf-8
 
-    {"urlPath":"/repository/5b25c3bb/testRepo","goodUntil":1542054698}
+    {"urlPath":"/repository/testRepo-60d25052","goodUntil":1542213080}
 
 # List all repositories (when run with INSECURE_DEV="true")
 curl -i http://localhost:4014/list-repositories
 
-HTTP/1.1 200 OK
-Date: Mon, 12 Nov 2018 20:02:02 GMT
-Content-Length: 54
-Content-Type: text/plain; charset=utf-8
+    HTTP/1.1 200 OK
+    Date: Wed, 14 Nov 2018 16:02:15 GMT
+    Content-Length: 54
+    Content-Type: text/plain; charset=utf-8
 
-{"repository_paths":["/repository/5b25c3bb/testRepo"]}
+    {"repository_paths":["/repository/testRepo-60d25052"]}
 
 # Clone the repository
-git clone http://localhost:4014/repository/5b25c3bb/testRepo
+git clone http://localhost:4014/repository/testRepo-60d25052
 
-    Cloning into 'testRepo'...
+    Cloning into 'testRepo-60d25052'...
 
-ls -l testRepo
+ls -l testRepo-60d25052
 
-    -rw-r--r--  1 fae  staff  16 Nov 12 15:02 another_file
-    -rw-r--r--  1 fae  staff  14 Nov 12 15:02 asdf
+    -rw-r--r--  1 fae  staff  16 Nov 14 11:02 another_file
+    -rw-r--r--  1 fae  staff  14 Nov 14 11:02 asdf
 ```

--- a/cmd/web-repo-proxy/README.md
+++ b/cmd/web-repo-proxy/README.md
@@ -1,1 +1,59 @@
-web-repo-proxy is a utility to serve Git repositories based on data from the web. The initial application is to serve the code from Stackoverflow posts as Git repositories so that we can show code intelligence for them. See [the original feature request](https://github.com/sourcegraph/sourcegraph/issues/423).
+`web-repo-proxy` is a utility to serve short-lived Git repositories based on arbitrary code from a client. The initial application is to proxy the code from Stackoverflow posts through Git repositories so that browser extensions can show code intelligence for them. See [the original feature request](https://github.com/sourcegraph/sourcegraph/issues/423).
+
+# Usage
+
+`web-repo-proxy` accepts the following environment variables:
+
+- `REPOSITORIES_ROOT`: the path on disk to store the repositories (Default: `"./repositories"`).
+- `REPOSITORY_TTL`: the duration to save repositories before deleting them (Default: `"30m"`).
+- `LISTENER_PORT`: the network port to listen on (Default: `4014`).
+- `INSECURE_DEV`: for testing, runs the process as a local listener only, and enables the `/list-repositories` request (Default: `false`).
+
+# Testing
+
+To try it out locally:
+
+```
+cat >create-repository.json
+{
+  "repositoryName": "testRepo",
+  "fileContents": {
+    "asdf": "this is a file",
+    "another_file": "files everywhere"
+  }
+}
+^D
+
+# Create a repository
+curl -i http://localhost:4014/create-repository \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d @create-repository.json
+
+    HTTP/1.1 200 OK
+    Date: Mon, 12 Nov 2018 20:01:38 GMT
+    Content-Length: 66
+    Content-Type: text/plain; charset=utf-8
+
+    {"urlPath":"/repository/5b25c3bb/testRepo","goodUntil":1542054698}
+
+# List all repositories (when run with INSECURE_DEV="true")
+curl -i http://localhost:4014/list-repositories
+
+HTTP/1.1 200 OK
+Date: Mon, 12 Nov 2018 20:02:02 GMT
+Content-Length: 54
+Content-Type: text/plain; charset=utf-8
+
+{"repository_paths":["/repository/5b25c3bb/testRepo"]}
+
+# Clone the repository
+git clone http://localhost:4014/repository/5b25c3bb/testRepo
+
+    Cloning into 'testRepo'...
+
+ls -l testRepo
+
+    -rw-r--r--  1 fae  staff  16 Nov 12 15:02 another_file
+    -rw-r--r--  1 fae  staff  14 Nov 12 15:02 asdf
+```

--- a/cmd/web-repo-proxy/main.go
+++ b/cmd/web-repo-proxy/main.go
@@ -108,6 +108,8 @@ var (
 	repositoriesMutex       = &sync.Mutex{}
 )
 
+// Delete a repository on disk and remove it from the global lookup.
+// Doesn't affect repositoryDeletionuQueue.
 func deleteRepository(r *repository) {
 	repositoriesMutex.Lock()
 	delete(repositories, r.key)
@@ -115,6 +117,8 @@ func deleteRepository(r *repository) {
 	os.RemoveAll(r.filePathRoot())
 }
 
+// Check whether any repositories at the start of repositoryDeletionQueue
+// have expired, and delete them if so.
 func deleteExpiredRepositories() {
 	curTime := time.Now().Unix()
 	for r := repositoryDeletionQueue.Front(); r != nil; r = repositoryDeletionQueue.Front() {
@@ -133,9 +137,9 @@ func deleteExpiredRepositories() {
 	}
 }
 
+// Watches the repository deletion queue and removes repositories once
+// their goodUntil field is past.
 func repositoryDeleter() {
-	// Watches the repository deletion queue and removes repositories once
-	// their goodUntil field is past.
 	for {
 		deleteExpiredRepositories()
 		time.Sleep(time.Second)

--- a/cmd/web-repo-proxy/main.go
+++ b/cmd/web-repo-proxy/main.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -25,81 +24,44 @@ import (
 )
 
 var (
-	repositoriesRoot    = env.Get("REPOSITORIES_ROOT", "./repositories", "Root path to store repository data")
-	repositoryTTLString = env.Get("REPOSITORY_TTL", "30m", "How long to keep repositories, as a duration string")
-	repositoryTTL       = time.Duration(0)
+	repositoriesRoot = env.Get("REPOSITORIES_ROOT", "./repositories", "Root path to store repository data")
+	repositoryTTL    = mustParseDuration(env.Get("REPOSITORY_TTL", "30m", "How long to keep repositories, as a duration string"))
 
 	listenerPort = env.Get("LISTENER_PORT", "4014", "The network port to listen on")
 
 	maxRequestSize = 0x10000 // Repo creation requests must be at most 64KB.
 )
 
-type repository struct {
-	key  string
-	name string
-}
-
-// filePathRoot returns the location of this repository on disk.
-func (r *repository) filePathRoot() string {
-	return filepath.Join(repositoriesRoot, fmt.Sprintf("%s-%s", r.key, r.name))
-}
-
-// urlRoot returns the URL path to use when cloning this repository over http.
-func (r *repository) urlRoot() string {
-	root := "/repository/" + r.key
-	if r.name != "" {
-		return root + "/" + r.name
+func mustParseDuration(durationString string) time.Duration {
+	duration, err := time.ParseDuration(durationString)
+	if err != nil {
+		panic(fmt.Sprintf("Unrecognized duration string '%v'", durationString))
 	}
-	return root
+	return duration
+}
+
+// A repository is represented by its directory name under repositoriesRoot.
+type repository string
+
+// filePathForReponsitory returns the location of this repository on disk.
+func (r *repository) filePath() string {
+	return filepath.Join(repositoriesRoot, string(*r))
+}
+
+// urlPath returns the URL path to use when cloning this repository over http.
+func (r *repository) urlPath() string {
+	return "/repository/" + string(*r)
 }
 
 // goodUntil checks the repository's directory on disk and returns the time
 // it will expire, or an error if the repository couldn't be read.
 func (r *repository) goodUntil() (time.Time, error) {
-	info, err := os.Lstat(r.filePathRoot())
+	path := r.filePath()
+	info, err := os.Lstat(path)
 	if err != nil {
 		return time.Time{}, err
 	}
 	return info.ModTime().Add(repositoryTTL), nil
-}
-
-// serveFile handles an http file request within the given repository.
-func (r *repository) serveFile(responseWriter http.ResponseWriter, request *http.Request, path string) {
-	if r.name != "" {
-		if !strings.HasPrefix(path, r.name+"/") {
-			// All repository file requests must include the repository name
-			// if it has one.
-			responseWriter.WriteHeader(http.StatusNotFound)
-			log15.Warn("Repository request doesn't include repository name", "path", request.URL.Path, "repository key", r.key, "repository name", r.name)
-			return
-		}
-		// Trim the name off the path.
-		truncatedPath := path[len(r.name):]
-		// To serve a repository over static http we need to serve files from its
-		// .git subdirectory.
-		filePath := filepath.Join(r.filePathRoot(), ".git", filepath.Clean(truncatedPath))
-		http.ServeFile(responseWriter, request, filePath)
-	}
-}
-
-// Returns repository objects for every directory matching the given key.
-// Typically this should return 0 or 1 result.
-func repositoriesForKey(key string) []*repository {
-	files, err := ioutil.ReadDir(repositoriesRoot)
-	if err != nil {
-		return nil
-	}
-	matches := []*repository{}
-	for _, file := range files {
-		fileName := file.Name()
-		if strings.HasPrefix(fileName, key+"-") {
-			matches = append(matches, &repository{
-				key:  key,
-				name: fileName[len(key)+1:],
-			})
-		}
-	}
-	return matches
 }
 
 func createRandomKey() string {
@@ -108,17 +70,23 @@ func createRandomKey() string {
 }
 
 // createNewRepository creates a new repository with the given name and data.
-// Returns a repository object if successful, otherwise returns error.
+// Returns a repository string if successful, otherwise returns error.
 func createNewRepository(name string, data map[string]string) (*repository, error) {
 	// Create a temporary directory to initialize with the repository data.
-	repositoryRoot, err := ioutil.TempDir("", "web-repo-proxy")
+	tempRoot, err := ioutil.TempDir("", "web-repo-proxy")
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		// If there was an error, clean up what's left on disk.
+		if err != nil {
+			os.RemoveAll(tempRoot)
+		}
+	}()
 
 	// Write out the given data to the file system.
 	for filename, content := range data {
-		filePath := filepath.Join(repositoryRoot, filename)
+		filePath := filepath.Join(tempRoot, filename)
 		err = ioutil.WriteFile(filePath, []byte(content), 0644)
 		if err != nil {
 			return nil, err
@@ -135,7 +103,7 @@ func createNewRepository(name string, data map[string]string) (*repository, erro
 	}
 	for _, command := range gitCommands {
 		cmd := exec.Command("git", command...)
-		cmd.Dir = repositoryRoot
+		cmd.Dir = tempRoot
 		err = cmd.Run()
 		if err != nil {
 			return nil, err
@@ -143,23 +111,17 @@ func createNewRepository(name string, data map[string]string) (*repository, erro
 	}
 
 	// Choose the real repository path and move it there.
-	for {
-		repository := repository{
-			key:  createRandomKey(),
-			name: name,
-		}
-		newRoot := repository.filePathRoot()
-		err = os.Rename(repositoryRoot, newRoot)
-		if err != nil {
-			return nil, err
-		}
-		repositoryRoot = newRoot
-		// Corner case: only finish if we picked a unique key.
-		repos := repositoriesForKey(repository.key)
-		if len(repos) <= 1 {
+	for i := 0; i < 3; i++ {
+		// Retry up to 3 times to avoid ephemeral errors and name collisions.
+		var repository = repository(name + "-" + createRandomKey())
+		repositoryRoot := repository.filePath()
+		err = os.Rename(tempRoot, repositoryRoot)
+		if err == nil {
 			return &repository, nil
 		}
 	}
+	// If we still failed after 3 tries, return the most recent error.
+	return nil, err
 }
 
 // Check whether any repositories have expired, and delete them if so.
@@ -215,9 +177,8 @@ type CreateRepositoryResponse struct {
 // Given a Reader with a create-repository request, return the corresponding
 // CreateRepositoryRequest with guaranteed-safe values, or an error.
 func sanitizedCreateRequest(requestBody io.Reader) (*CreateRepositoryRequest, error) {
-	decoder := json.NewDecoder(requestBody)
 	var request CreateRepositoryRequest
-	err := decoder.Decode(&request)
+	err := json.NewDecoder(requestBody).Decode(&request)
 	if err != nil {
 		return nil, errors.Wrap(err, "Couldn't decode create-repository request")
 	}
@@ -256,8 +217,9 @@ func handleCreateRepository() http.HandlerFunc {
 		goodUntil, _ := repo.goodUntil()
 		// Send successful response to client.
 		response := CreateRepositoryResponse{
-			UrlPath:   repo.urlRoot(),
-			GoodUntil: goodUntil.Unix()}
+			UrlPath:   repo.urlPath(),
+			GoodUntil: goodUntil.Unix(),
+		}
 		responseJSON, err := json.Marshal(response)
 		if err != nil {
 			log15.Error("/create-repository couldn't marshal response for client", "error", err)
@@ -269,27 +231,30 @@ func handleCreateRepository() http.HandlerFunc {
 }
 
 func handleRepository() http.HandlerFunc {
-	// Right now repo keys must be hexadecimal strings.
-	repoKeyRegexp := regexp.MustCompile(`^/repository/([0-9a-f]+)/(.*)$`)
-
 	return func(responseWriter http.ResponseWriter, request *http.Request) {
-		pathComponents := repoKeyRegexp.FindStringSubmatch(request.URL.Path)
-		if len(pathComponents) < 3 {
-			// A malformed URL: we need at least a repository key and file subpath.
+		if !strings.HasPrefix(request.URL.Path, "/repository/") {
+			// This should never happen, but let's make sure.
 			responseWriter.WriteHeader(http.StatusNotFound)
 			log15.Warn("Malformed repository request", "path", request.URL.Path)
 			return
 		}
-		repoKey := pathComponents[1]
-		repositories := repositoriesForKey(repoKey)
-		if len(repositories) == 0 {
-			// No matching repository was found.
+		trailingPath := request.URL.Path[12:]
+
+		// Trim the repository string off the start of the path.
+		pathComponents := strings.SplitN(trailingPath, "/", 2)
+		if len(pathComponents) < 2 {
+			// A malformed URL: we need at least a repository name and file subpath.
 			responseWriter.WriteHeader(http.StatusNotFound)
-			log15.Warn("Request for unknown repository", "path", request.URL.Path, "repoKey", repoKey)
+			log15.Warn("Malformed repository request", "path", request.URL.Path)
 			return
 		}
-		repo := repositories[0]
-		repo.serveFile(responseWriter, request, pathComponents[2])
+
+		// Serve the requested file.
+		repo := repository(pathComponents[0])
+		repositoryRoot := repo.filePath()
+		// ".git" because we serve as a bare repository.
+		filePath := filepath.Join(repositoryRoot, ".git", filepath.Clean(pathComponents[1]))
+		http.ServeFile(responseWriter, request, filePath)
 	}
 }
 
@@ -306,13 +271,8 @@ func handleListRepositories() http.HandlerFunc {
 		}
 		repositoryPaths := []string{}
 		for _, file := range files {
-			components := strings.SplitN(file.Name(), "-", 2)
-			if len(components) != 2 {
-				log15.Warn("Unrecognized file in repositories root", "fileName", file.Name())
-				continue
-			}
-			repo := repository{key: components[0], name: components[1]}
-			repositoryPaths = append(repositoryPaths, repo.urlRoot())
+			repo := repository(file.Name())
+			repositoryPaths = append(repositoryPaths, repo.urlPath())
 		}
 		response := ListRepositoriesResponse{repositoryPaths}
 		responseJSON, err := json.Marshal(response)
@@ -329,13 +289,7 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 
-	// Make sure the TTL and repository root are valid.
-	ttl, err := time.ParseDuration(repositoryTTLString)
-	if err != nil {
-		panic(fmt.Sprintf("Unrecognized repository TTL '%v'", repositoryTTLString))
-	}
-	repositoryTTL = ttl
-	err = os.MkdirAll(repositoriesRoot, 0755)
+	err := os.MkdirAll(repositoriesRoot, 0755)
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't access repositories root path", "repositoriesRoot", repositoriesRoot))
 	}

--- a/cmd/web-repo-proxy/main.go
+++ b/cmd/web-repo-proxy/main.go
@@ -113,7 +113,7 @@ func createNewRepository(name string, data map[string]string) (*repository, erro
 	// Choose the real repository path and move it there.
 	for i := 0; i < 3; i++ {
 		// Retry up to 3 times to avoid ephemeral errors and name collisions.
-		var repository = repository(name + "-" + createRandomKey())
+		repository := repository(name + "-" + createRandomKey())
 		repositoryRoot := repository.filePath()
 		err = os.Rename(tempRoot, repositoryRoot)
 		if err == nil {

--- a/cmd/web-repo-proxy/main.go
+++ b/cmd/web-repo-proxy/main.go
@@ -347,7 +347,6 @@ func main() {
 	http.HandleFunc("/repository/", handleRepository())
 	if env.InsecureDev {
 		// list-repositories is for testing, not production.
-		fmt.Printf("enabling list-repositories")
 		http.HandleFunc("/list-repositories", handleListRepositories())
 	}
 

--- a/cmd/web-repo-proxy/main.go
+++ b/cmd/web-repo-proxy/main.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/pkg/env"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+/*var (
+	addr = flag.String
+)*/
+
+var (
+	repositoriesRoot = "/Users/fae/gitproxy"
+	repositoryTTL    = 30 * 60 // 30 minutes
+)
+
+type CreateRepositoryRequest struct {
+	PathPrefix   string            `json:"path_prefix"`
+	FileContents map[string]string `json:"file_contents"`
+}
+
+type CreateRepositoryResponse struct {
+	Path      string `json:"path"`
+	Error     string `json:"error"`
+	GoodUntil int64  `json:"good_until"`
+}
+
+type repository struct {
+	key        string
+	pathPrefix string
+	goodUntil  int64
+}
+
+func (r *repository) filePathRoot() string {
+	return filepath.Join(repositoriesRoot, r.key)
+}
+
+func (r *repository) urlRoot() string {
+	root := "/repository/" + r.key
+	if r.pathPrefix != "" {
+		return root + "/" + r.pathPrefix
+	}
+	return root
+}
+
+func (r *repository) filePathForURLSubpath(subpath string) string {
+	root := r.filePathRoot()
+	// To serve a repository over static http we need to serve files from its
+	// .git subdirectory.
+	return filepath.Join(root, ".git", filepath.Clean(subpath))
+}
+
+func (r *repository) writeToDisk(data map[string]string) error {
+	path := r.filePathRoot()
+	// Create path if it doesn't exist
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	for filename, content := range data {
+		filePath := filepath.Join(path, filename)
+		err = ioutil.WriteFile(filePath, []byte(content), 0644)
+		if err != nil {
+			return err
+		}
+	}
+	repo, err := git.PlainInit(path, false)
+	if err != nil {
+		fmt.Printf("PlainInit failed\n")
+		return err
+	}
+	worktree, err := repo.Worktree()
+	if err != nil {
+		fmt.Printf("Worktree failed\n")
+		return err
+	}
+	for filename := range data {
+		_, err = worktree.Add(filename)
+		if err != nil {
+			fmt.Printf("Add [%s] failed\n", filename)
+			return err
+		}
+	}
+	_, err = worktree.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Sourcegraph git proxy",
+			Email: "sourcegraph@sourcegraph.com",
+			When:  time.Now(),
+		},
+	})
+	if err != nil {
+		fmt.Printf("Commit failed\n")
+		return err
+	}
+
+	// This command builds info/refs in
+	// the repository, which we need to serve repos as static files.
+	// go-git doesn't support update-server-info (see
+	// https://github.com/src-d/go-git/blob/master/COMPATIBILITY.md) so we
+	// need to do it the old-fashioned way.
+	cmd := exec.Command("git", "update-server-info")
+	cmd.Dir = path
+	return cmd.Run()
+}
+
+var (
+	repositories      = map[string]*repository{}
+	repositoriesMutex = &sync.Mutex{}
+)
+
+func createRandomKey() string {
+	keyIndex := rand.Int31()
+	return strconv.FormatInt(int64(keyIndex), 16)
+}
+
+// Generates a unique key, adds a repository with that key to the global
+// list, and returns the new repository.
+func createEmptyRepository() *repository {
+	key := createRandomKey()
+
+	repositoriesMutex.Lock()
+	for repositories[key] != nil {
+		repositoriesMutex.Unlock()
+		key = createRandomKey()
+		repositoriesMutex.Lock()
+	}
+	repository := &repository{key: key}
+	repositories[key] = repository
+	repositoriesMutex.Unlock()
+	return repository
+}
+
+func handleCreateRepository() http.HandlerFunc {
+	return func(responseWriter http.ResponseWriter, request *http.Request) {
+		decoder := json.NewDecoder(request.Body)
+		var createRepositoryRequest CreateRepositoryRequest
+		err := decoder.Decode(&createRepositoryRequest)
+		if err != nil {
+			fmt.Printf("Couldn't decode request: %s\n", request.Body)
+		} else {
+			fmt.Printf("Decoded request: %#v\n", createRepositoryRequest)
+			// TODO: sanitize / bounds-check all inputs.
+			repo := createEmptyRepository()
+			repo.pathPrefix = createRepositoryRequest.PathPrefix
+			repo.goodUntil = time.Now().Unix() + int64(repositoryTTL)
+			err = repo.writeToDisk(createRepositoryRequest.FileContents)
+			if err != nil {
+				fmt.Printf("Couldn't write the repository to disk: %v\n", err)
+			} else {
+				response := CreateRepositoryResponse{
+					Path:      repo.urlRoot(),
+					GoodUntil: repo.goodUntil}
+				responseJSON, err := json.Marshal(response)
+				if err != nil {
+					responseWriter.WriteHeader(http.StatusInternalServerError)
+				} else {
+					responseWriter.Write(responseJSON)
+				}
+			}
+		}
+	}
+}
+
+func handleRepository() http.HandlerFunc {
+	repoKeyRegexp := regexp.MustCompile(`^/repository/([0-9a-f]+)/(.*)$`)
+
+	return func(responseWriter http.ResponseWriter, request *http.Request) {
+		pathComponents := repoKeyRegexp.FindStringSubmatch(request.URL.Path)
+		if len(pathComponents) >= 3 {
+			repoKey := pathComponents[1]
+			repo := repositories[repoKey]
+			if repo != nil {
+				fmt.Printf("I have repository [%s]\n", repoKey)
+				if strings.HasPrefix(pathComponents[2], repo.pathPrefix) {
+					truncatedPath := pathComponents[2][len(repo.pathPrefix):]
+					filePath := repo.filePathForURLSubpath(truncatedPath)
+					http.ServeFile(responseWriter, request, filePath)
+				} else {
+					fmt.Printf("Expected prefix [%s] for repo [%s]\n", repo.pathPrefix, repoKey)
+				}
+			} else {
+				fmt.Printf("I don't recognize repository [%s]\n", repoKey)
+			}
+		} else {
+			fmt.Printf("I don't recognize that as a repository command (%s)\n", request.URL.Path)
+		}
+		// Trim "/repository" off the path.
+		/*path := request.URL.Path[11:]
+		path := path.Clean(request.URL.Path)
+		pathComponents := strings.Split(path, "/")*/
+	}
+}
+
+func handleListRepositories() http.HandlerFunc {
+	type ListRepositoriesResponse struct {
+		RepositoryPaths []string `json:"repository_paths"`
+	}
+	return func(responseWriter http.ResponseWriter, request *http.Request) {
+		repositoryPaths := []string{}
+		for key, repo := range repositories {
+			path := key
+			if repo.pathPrefix != "" {
+				path += "/" + repo.pathPrefix
+			}
+			repositoryPaths = append(repositoryPaths, path)
+		}
+		response := ListRepositoriesResponse{repositoryPaths}
+		responseJSON, err := json.Marshal(response)
+		if err != nil {
+			responseWriter.WriteHeader(http.StatusInternalServerError)
+		} else {
+			responseWriter.Write(responseJSON)
+		}
+	}
+}
+
+func main() {
+	env.Lock()
+	env.HandleHelpFlag()
+
+	http.HandleFunc("/create-repository", handleCreateRepository())
+	http.HandleFunc("/repository/", handleRepository())
+	http.HandleFunc("/list-repositories", handleListRepositories())
+	log.Fatal(http.ListenAndServe(":4014", nil))
+}

--- a/cmd/web-repo-proxy/main.go
+++ b/cmd/web-repo-proxy/main.go
@@ -171,7 +171,7 @@ type CreateRepositoryRequest struct {
 
 type CreateRepositoryResponse struct {
 	URLPath   string `json:"urlPath"`
-	GoodUntil int64  `json:"goodUntil"`
+	GoodUntil string `json:"goodUntil"`
 }
 
 // Given a Reader with a create-repository request, return the corresponding
@@ -227,7 +227,7 @@ func handleCreateRepository() http.HandlerFunc {
 		// Send successful response to client.
 		response := CreateRepositoryResponse{
 			URLPath:   repo.urlPath(),
-			GoodUntil: goodUntil.Unix(),
+			GoodUntil: goodUntil.Format(time.RFC3339),
 		}
 		responseJSON, err := json.Marshal(response)
 		if err != nil {

--- a/cmd/web-repo-proxy/main_test.go
+++ b/cmd/web-repo-proxy/main_test.go
@@ -1,34 +1,38 @@
+// Unit tests for web-repo-proxy.
+//
+// To run with end-to-end tests (starting a server and cloning repositories
+// from it) use the endToEnd flag, e.g. "go test -endToEnd".
+
 package main
 
 import (
-	"container/list"
+	"context"
 	"encoding/json"
+	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
-// Extract the http handler functions from their generators.
 var (
+	// Extract the http handler functions from their generators.
 	createRepositoryHandler = handleCreateRepository()
 	repositoryHandler       = handleRepository()
 	listRepositoriesHandler = handleListRepositories()
-)
 
-// This clears out all cached repository data. It does not delete the on-disk
-// repositories (that is done at the end of the full test).
-func resetRepositoriesForTest() {
-	repositoriesMutex.Lock()
-	repositories = map[string]*repository{}
-	repositoryDeletionQueue = list.New()
-	repositoriesMutex.Unlock()
-}
+	// Whether to run an end-to-end test (starting the server and cloning a
+	// repository).
+	endToEnd = flag.Bool("endToEnd", false, "run database integration tests")
+)
 
 func TestMain(m *testing.M) {
 	// Create a temporary directory to store our repositories.
@@ -49,8 +53,8 @@ var sanitizedCreateRequestTests = []sanitizedCreateRequestTest{
 	sanitizedCreateRequestTest{
 		description: "Decoding a simple request",
 		requestString: `{
-      "repository_name": "simple_name",
-      "file_contents": {
+      "repositoryName": "simple_name",
+      "fileContents": {
         "a_file": "file contents\n"
       }
     }`,
@@ -62,8 +66,8 @@ var sanitizedCreateRequestTests = []sanitizedCreateRequestTest{
 	sanitizedCreateRequestTest{
 		description: "Repository name is encoded as a safe url string",
 		requestString: `{
-      "repository_name": "stackoverflow.com/questions/1760757",
-      "file_contents": {
+      "repositoryName": "stackoverflow.com/questions/1760757",
+      "fileContents": {
         "a_file": "file contents\n"
       }
     }`,
@@ -75,8 +79,8 @@ var sanitizedCreateRequestTests = []sanitizedCreateRequestTest{
 	sanitizedCreateRequestTest{
 		description: "Reject filenames that use subpaths",
 		requestString: `{
-      "repository_name": "simple_name",
-      "file_contents": {
+      "repositoryName": "simple_name",
+      "fileContents": {
         "dir/file": "file contents\n"
       }
     }`,
@@ -104,8 +108,8 @@ func TestSanitizedCreateRequest(t *testing.T) {
 
 func TestCreateRepository(t *testing.T) {
 	request := httptest.NewRequest("POST", "/create-repository", strings.NewReader(`{
-    "repository_name": "testRepo",
-    "file_contents": {
+    "repositoryName": "testRepo",
+    "fileContents": {
       "a_file": "file contents\n"
     }
   }`))
@@ -118,29 +122,17 @@ func TestCreateRepository(t *testing.T) {
 		return
 	}
 	response := CreateRepositoryResponse{}
-	responseDecoder := json.NewDecoder(result.Body)
-	err := responseDecoder.Decode(&response)
+	err := json.NewDecoder(result.Body).Decode(&response)
 	if err != nil {
 		t.Errorf("Couldn't decode create-repository response: %v", err)
 		return
 	}
 
-	// Get the repository key from the returned path.
-	repoKeyRegexp := regexp.MustCompile(`^/repository/([0-9a-f]+)`)
-	pathComponents := repoKeyRegexp.FindStringSubmatch(response.Path)
-	if len(pathComponents) < 2 {
-		t.Errorf("Didn't recognize repository key in create-repository response")
-		return
-	}
-	repoKey := pathComponents[1]
-	repo := repositories[repoKey]
-	if repo == nil {
-		t.Errorf("Returned repository [%s] doesn't exist", repoKey)
-		return
-	}
+	// Get the repository name from the returned path.
+	repo := repository(strings.TrimPrefix(response.URLPath, "/repository/"))
 
 	// Make sure the repo exists on disk with the given data.
-	filePath := filepath.Join(repositoriesRoot, repoKey, "a_file")
+	filePath := filepath.Join(repositoriesRoot, string(repo), "a_file")
 	fileContents, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		t.Errorf("Couldn't read repository file at path %v", filePath)
@@ -154,8 +146,8 @@ func TestCreateRepository(t *testing.T) {
 // Verify that requests over 64KB produce an error.
 func TestCreateRepositoryLargeRequest(t *testing.T) {
 	request := httptest.NewRequest("POST", "/create-repository", strings.NewReader(`{
-    "repository_name": "testRepo",
-    "file_contents": {
+    "repositoryName": "testRepo",
+    "fileContents": {
       "a_file": "`+strings.Repeat(" ", 66000)+`"
     }
   }`))
@@ -168,16 +160,27 @@ func TestCreateRepositoryLargeRequest(t *testing.T) {
 	}
 }
 
+// Verify that repositories with empty file contents produce an error.
+func TestCreateEmptyRepository(t *testing.T) {
+	request := httptest.NewRequest("POST", "/create-repository", strings.NewReader(`{
+    "repositoryName": "emptyRepo"
+  }`))
+	responseWriter := httptest.NewRecorder()
+	createRepositoryHandler(responseWriter, request)
+
+	result := responseWriter.Result()
+	if result.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected error code 400 for repository with empty file contents, got %v", result.StatusCode)
+	}
+}
+
 func TestRepositoryRequest(t *testing.T) {
 	// Real repositories are hard to unit test because our server gives access
 	// to the bare repositories, so realistically we'd need to clone from them.
 	// Instead, create a fake repository entry where we know the contents.
-	resetRepositoriesForTest()
-	repository := &repository{
-		key:            "abcdef",
-		repositoryName: "testName",
-		savedToDisk:    true}
-	dirPath := filepath.Join(repository.filePathRoot(), ".git", "testdir")
+	// For an end-to-end test that uses cloning, see e2e_test.go.
+	repository := repository("testRepo-abcdef")
+	dirPath := filepath.Join(repository.filePath(), ".git", "testdir")
 	err := os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
 		t.Errorf("Couldn't create test repository directory '%s'", dirPath)
@@ -189,10 +192,9 @@ func TestRepositoryRequest(t *testing.T) {
 		t.Errorf("Couldn't create test repository file '%s'", filePath)
 		return
 	}
-	repositories[repository.key] = repository
 
 	// Now we can try fetching "testfile" through the repository handler.
-	request := httptest.NewRequest("GET", "/repository/abcdef/testName/testdir/testfile", nil)
+	request := httptest.NewRequest("GET", repository.urlPath()+"/testdir/testfile", nil)
 	responseWriter := httptest.NewRecorder()
 	repositoryHandler(responseWriter, request)
 
@@ -204,5 +206,85 @@ func TestRepositoryRequest(t *testing.T) {
 	body, _ := ioutil.ReadAll(result.Body)
 	if string(body) != "test\ncontents\n" {
 		t.Errorf("Wrong file contents: want:\n{test\ncontents\n}\ngot:\n{%s}", string(body))
+	}
+}
+
+func TestEndToEnd(t *testing.T) {
+	// This test starts the server and clones a git repository over the network,
+	// so only run it if the -endToEnd flag was specified.
+	if !*endToEnd {
+		return
+	}
+
+	// Build the server. We can't start it directly with "go run" because
+	// that runs the server as a forked child and we can't stop the process
+	// directly.
+	err := exec.Command("go", "build").Run()
+	if err != nil {
+		t.Errorf("Couldn't build server: %v", err)
+		return
+	}
+
+	// Start up a full server.
+	context, cancel := context.WithCancel(context.Background())
+	server := exec.CommandContext(context, "./web-repo-proxy")
+	server.Env = append(os.Environ(),
+		"REPOSITORIES_ROOT="+repositoriesRoot)
+	err = server.Start()
+	if err != nil {
+		t.Errorf("Couldn't start repository server: %v", err)
+		return
+	}
+	// Shutdown the server when finished
+	defer server.Wait()
+	defer cancel()
+
+	// Delay to let the server start listening.
+	time.Sleep(time.Second / 10)
+
+	// The server is running, send it a repository creation request.
+	request := strings.NewReader(`{
+    "repositoryName": "endToEnd",
+    "fileContents": {
+      "a_file": "file contents\n"
+    }
+  }`)
+	response, err := http.Post("http://localhost:4014/create-repository", "application/json", request)
+	if err != nil {
+		t.Errorf("create-repository request failed: %v", err)
+		return
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("create-repository returned error code %v", response.StatusCode)
+		return
+	}
+
+	// We got a successful response, extract the new repository path.
+	parsedResponse := CreateRepositoryResponse{}
+	err = json.NewDecoder(response.Body).Decode(&parsedResponse)
+	if err != nil {
+		t.Errorf("Couldn't parse create-repository response: %v", err)
+		return
+	}
+	url, _ := url.Parse("http://localhost:4014" + parsedResponse.URLPath)
+
+	// Try cloning from the server into a new temporary directory.
+	tempDir, _ := ioutil.TempDir("", "web-repo-proxy-endtoend")
+	defer os.RemoveAll(tempDir)
+	gitCmd := exec.Command("git", "clone", url.String())
+	gitCmd.Dir = tempDir
+	err = gitCmd.Run()
+	if err != nil {
+		t.Errorf("Couldn't run git-clone: %v", err)
+		return
+	}
+
+	// Check that the repository has the right contents.
+	repoName := path.Base(url.Path)
+	filePath := filepath.Join(tempDir, repoName, "a_file")
+	fileContents, _ := ioutil.ReadFile(filePath)
+	if string(fileContents) != "file contents\n" {
+		t.Errorf("Wrong file contents, expected:\n{\nfile contents\n}, got:\n{\n%v}", string(fileContents))
 	}
 }

--- a/cmd/web-repo-proxy/main_test.go
+++ b/cmd/web-repo-proxy/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestStuff(t *testing.T) {
+
+}

--- a/cmd/web-repo-proxy/main_test.go
+++ b/cmd/web-repo-proxy/main_test.go
@@ -1,14 +1,13 @@
 // Unit tests for web-repo-proxy.
 //
-// To run with end-to-end tests (starting a server and cloning repositories
-// from it) use the endToEnd flag, e.g. "go test -endToEnd".
+// To run without end-to-end tests (starting a server and cloning repositories
+// from it) run go test with the -short option.
 
 package main
 
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -28,10 +27,6 @@ var (
 	createRepositoryHandler = handleCreateRepository()
 	repositoryHandler       = handleRepository()
 	listRepositoriesHandler = handleListRepositories()
-
-	// Whether to run an end-to-end test (starting the server and cloning a
-	// repository).
-	endToEnd = flag.Bool("endToEnd", false, "run database integration tests")
 )
 
 func TestMain(m *testing.M) {
@@ -211,9 +206,9 @@ func TestRepositoryRequest(t *testing.T) {
 
 func TestEndToEnd(t *testing.T) {
 	// This test starts the server and clones a git repository over the network,
-	// so only run it if the -endToEnd flag was specified.
-	if !*endToEnd {
-		return
+	// so don't run in short mode.
+	if testing.Short() {
+		t.Skip()
 	}
 
 	// Build the server. We can't start it directly with "go run" because

--- a/cmd/web-repo-proxy/main_test.go
+++ b/cmd/web-repo-proxy/main_test.go
@@ -1,9 +1,169 @@
 package main
 
 import (
+	"container/list"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 )
 
-func TestStuff(t *testing.T) {
+// Extract the http handler functions from their generators.
+var (
+	createRepositoryHandler = handleCreateRepository()
+	repositoryHandler       = handleRepository()
+	listRepositoriesHandler = handleListRepositories()
+)
 
+// This clears out all cached repository data. It does not delete the on-disk
+// repositories (that is done at the end of the full test).
+func resetRepositoriesForTest() {
+	repositoriesMutex.Lock()
+	repositories = map[string]*repository{}
+	repositoryDeletionQueue = list.New()
+	repositoriesMutex.Unlock()
+}
+
+func TestMain(m *testing.M) {
+	// Create a temporary directory to store our repositories.
+	repositoriesRoot, _ = ioutil.TempDir("", "web-repo-proxy-test")
+	result := m.Run()
+	os.RemoveAll(repositoriesRoot)
+	os.Exit(result)
+}
+
+type sanitizedCreateRequestTest struct {
+	description         string
+	requestString       string
+	expected            *CreateRepositoryRequest
+	expectedErrorString string
+}
+
+var sanitizedCreateRequestTests = []sanitizedCreateRequestTest{
+	sanitizedCreateRequestTest{
+		description: "Decoding a simple request",
+		requestString: `{
+      "repository_name": "simple_name",
+      "file_contents": {
+        "a_file": "file contents\n"
+      }
+    }`,
+		expected: &CreateRepositoryRequest{
+			RepositoryName: "simple_name",
+			FileContents:   map[string]string{"a_file": "file contents\n"},
+		},
+	},
+	sanitizedCreateRequestTest{
+		description: "Repository name is encoded as a safe url string",
+		requestString: `{
+      "repository_name": "stackoverflow.com/questions/1760757",
+      "file_contents": {
+        "a_file": "file contents\n"
+      }
+    }`,
+		expected: &CreateRepositoryRequest{
+			RepositoryName: "stackoverflow.com%2Fquestions%2F1760757",
+			FileContents:   map[string]string{"a_file": "file contents\n"},
+		},
+	},
+	sanitizedCreateRequestTest{
+		description: "Reject filenames that use subpaths",
+		requestString: `{
+      "repository_name": "simple_name",
+      "file_contents": {
+        "dir/file": "file contents\n"
+      }
+    }`,
+		expectedErrorString: "Repository filenames can't contain '/'",
+	},
+}
+
+func TestSanitizedCreateRequest(t *testing.T) {
+	for _, test := range sanitizedCreateRequestTests {
+		stringReader := strings.NewReader(test.requestString)
+		result, err := sanitizedCreateRequest(stringReader)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("[%s] Got %+v, want %+v", test.description, result, test.expected)
+			continue
+		}
+		errorString := ""
+		if err != nil {
+			errorString = err.Error()
+		}
+		if errorString != test.expectedErrorString {
+			t.Errorf("[%s] Expected error [%s], got [%s]", test.description, test.expectedErrorString, errorString)
+		}
+	}
+}
+
+func TestCreateRepository(t *testing.T) {
+	request := httptest.NewRequest("POST", "/create-repository", strings.NewReader(`{
+    "repository_name": "testRepo",
+    "file_contents": {
+      "a_file": "file contents\n"
+    }
+  }`))
+	responseWriter := httptest.NewRecorder()
+	createRepositoryHandler(responseWriter, request)
+
+	result := responseWriter.Result()
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("Create repository returned error code %v", result.StatusCode)
+		return
+	}
+	response := CreateRepositoryResponse{}
+	responseDecoder := json.NewDecoder(result.Body)
+	err := responseDecoder.Decode(&response)
+	if err != nil {
+		t.Errorf("Couldn't decode create-repository response: %v", err)
+		return
+	}
+
+	// Get the repository key from the returned path.
+	repoKeyRegexp := regexp.MustCompile(`^/repository/([0-9a-f]+)`)
+	pathComponents := repoKeyRegexp.FindStringSubmatch(response.Path)
+	if len(pathComponents) < 2 {
+		t.Errorf("Didn't recognize repository key in create-repository response")
+		return
+	}
+	repoKey := pathComponents[1]
+	repo := repositories[repoKey]
+	if repo == nil {
+		t.Errorf("Returned repository [%s] doesn't exist", repoKey)
+		return
+	}
+
+	// Make sure the repo exists on disk with the given data.
+	filePath := filepath.Join(repositoriesRoot, repoKey, "a_file")
+	fileContents, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Errorf("Couldn't read repository file at path %v", filePath)
+		return
+	}
+	if string(fileContents) != "file contents\n" {
+		t.Errorf("Wrong file contents: {\n%v}", string(fileContents))
+	}
+}
+
+// Verify that requests over 64KB produce an error.
+func TestCreateRepositoryLargeRequest(t *testing.T) {
+	request := httptest.NewRequest("POST", "/create-repository", strings.NewReader(`{
+    "repository_name": "testRepo",
+    "file_contents": {
+      "a_file": "`+strings.Repeat(" ", 66000)+`"
+    }
+  }`))
+	responseWriter := httptest.NewRecorder()
+	createRepositoryHandler(responseWriter, request)
+
+	result := responseWriter.Result()
+	if result.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected error code 400 for overlong request, got %v", result.StatusCode)
+	}
 }


### PR DESCRIPTION
This is a server that hosts ephemeral git repositories, intended for applying code intelligence to web pages and similar short-term sources.

Helps https://github.com/sourcegraph/sourcegraph/issues/423

Server parameters and testing procedure are documented in `README.md`.