### PR TITLE
feat: call migration and wait till its done before calling browser storage

### DIFF
--- a/packages/browser-extensions/src/browser/storage.ts
+++ b/packages/browser-extensions/src/browser/storage.ts
@@ -1,21 +1,10 @@
 import { EMPTY, Observable } from 'rxjs'
 import { shareReplay } from 'rxjs/operators'
 import SafariStorageArea, { SafariSettingsChangeMessage, stringifyStorageArea } from './safari/StorageArea'
+import { MigratableStorageArea, noopMigration, provideMigrations } from './storage_migrations'
 import { StorageChange, StorageItems } from './types'
 
 export { StorageItems, defaultStorageItems } from './types'
-
-type MigrateFunc = (
-    items: StorageItems,
-    set: (items: Partial<StorageItems>) => void,
-    /**
-     * Remove an item from storage.
-     *
-     * @param key the key of the item you'd like to remove. We accept arbitary
-     * strings so we can remove items that are no longer in our types.
-     */
-    remove: (key: string) => void
-) => void
 
 export interface Storage {
     getManaged: (callback: (items: StorageItems) => void) => void
@@ -28,8 +17,8 @@ export interface Storage {
     getLocalItem: (key: keyof StorageItems, callback: (items: StorageItems) => void) => void
     setLocal: (items: Partial<StorageItems>, callback?: (() => void) | undefined) => void
     observeLocal: <T extends keyof StorageItems>(key: T) => Observable<StorageItems[T]>
-    addSyncMigration: (migrate: MigrateFunc) => void
-    addLocalMigration: (migrate: MigrateFunc) => void
+    setSyncMigration: MigratableStorageArea['setMigration']
+    setLocalMigration: MigratableStorageArea['setMigration']
     onChanged: (listener: (changes: Partial<StorageChange>, areaName: string) => void) => void
 }
 
@@ -94,37 +83,29 @@ const throwNoopErr = () => {
     throw new Error('do not call browser extension apis from an in page script')
 }
 
-const addMigration = (
-    get: Storage['getSync'],
-    set: Storage['setSync'],
-    remove: (keys: string | string[], callback?: (() => void) | undefined) => void
-) => (migrate: MigrateFunc) => {
-    get(items => {
-        migrate(items as StorageItems, set, remove)
-    })
-}
-
 export default ((): Storage => {
     if (window.SG_ENV === 'EXTENSION') {
         const chrome = global.chrome
         const safari = window.safari
 
-        const syncStorageArea: chrome.storage.StorageArea =
+        const syncStorageArea = provideMigrations(
             typeof chrome !== 'undefined'
                 ? chrome.storage.sync
                 : new SafariStorageArea((safari.extension as SafariExtension).settings, 'sync')
+        )
+
+        const localStorageArea = provideMigrations(
+            typeof chrome !== 'undefined'
+                ? chrome.storage.local
+                : new SafariStorageArea(stringifyStorageArea(window.localStorage), 'local')
+        )
 
         const managedStorageArea: chrome.storage.StorageArea =
             typeof chrome !== 'undefined'
                 ? chrome.storage.managed
                 : new SafariStorageArea((safari.extension as SafariExtension).settings, 'managed')
 
-        const localStorageArea: chrome.storage.StorageArea =
-            typeof chrome !== 'undefined'
-                ? chrome.storage.local
-                : new SafariStorageArea(stringifyStorageArea(window.localStorage), 'local')
-
-        return {
+        const storage: Storage = {
             getManaged: get(managedStorageArea),
             getManagedItem: getItem(managedStorageArea),
 
@@ -138,15 +119,19 @@ export default ((): Storage => {
             setLocal: set(localStorageArea),
             observeLocal: observe(localStorageArea),
 
-            addSyncMigration: addMigration(get(syncStorageArea), set(syncStorageArea), (keys, callback) =>
-                syncStorageArea.remove(keys, callback)
-            ),
-            addLocalMigration: addMigration(get(localStorageArea), set(localStorageArea), (keys, callback) =>
-                localStorageArea.remove(keys, callback)
-            ),
+            setSyncMigration: syncStorageArea.setMigration,
+            setLocalMigration: localStorageArea.setMigration,
 
             onChanged,
         }
+
+        // Only background script should set migrations.
+        if (window.EXTENSION_ENV !== 'BACKGROUND') {
+            storage.setSyncMigration(noopMigration)
+            storage.setLocalMigration(noopMigration)
+        }
+
+        return storage
     }
 
     // Running natively in the webpage(in Phabricator patch) so we don't need any storage.
@@ -162,7 +147,7 @@ export default ((): Storage => {
         getLocalItem: throwNoopErr,
         setLocal: throwNoopErr,
         observeLocal: noopObserve,
-        addSyncMigration: throwNoopErr,
-        addLocalMigration: throwNoopErr,
+        setSyncMigration: throwNoopErr,
+        setLocalMigration: throwNoopErr,
     }
 })()

--- a/packages/browser-extensions/src/browser/storage_migrations.ts
+++ b/packages/browser-extensions/src/browser/storage_migrations.ts
@@ -12,8 +12,8 @@ export const noopMigration: MigrateFunc = () => ({})
 
 export function provideMigrations(area: chrome.storage.StorageArea): MigratableStorageArea {
     const migrations = new Subject<MigrateFunc>()
-    const getCalls = new ReplaySubject()
-    const setCalls = new ReplaySubject()
+    const getCalls = new ReplaySubject<any[]>()
+    const setCalls = new ReplaySubject<any[]>()
 
     const migrated = migrations.pipe(
         switchMap(

--- a/packages/browser-extensions/src/browser/storage_migrations.ts
+++ b/packages/browser-extensions/src/browser/storage_migrations.ts
@@ -1,0 +1,65 @@
+import { Observable, ReplaySubject, Subject } from 'rxjs'
+import { share, switchMap, take } from 'rxjs/operators'
+import { StorageItems } from './types'
+
+type MigrateFunc = (items: StorageItems) => { newItems?: StorageItems; keysToRemove?: string[] }
+
+export interface MigratableStorageArea extends chrome.storage.StorageArea {
+    setMigration: (migrate: MigrateFunc) => void
+}
+
+export const noopMigration: MigrateFunc = () => ({})
+
+export function provideMigrations(area: chrome.storage.StorageArea): MigratableStorageArea {
+    const migrations = new Subject<MigrateFunc>()
+    const getCalls = new ReplaySubject()
+    const setCalls = new ReplaySubject()
+
+    const migrated = migrations.pipe(
+        switchMap(
+            migrate =>
+                new Observable(observer => {
+                    area.get(items => {
+                        const { newItems, keysToRemove } = migrate(items as StorageItems)
+                        area.remove(keysToRemove || [], () => {
+                            area.set(newItems || {}, () => {
+                                observer.next()
+                                observer.complete()
+                            })
+                        })
+                    })
+                })
+        ),
+        take(1),
+        share()
+    )
+
+    const initializedGets = migrated.pipe(switchMap(() => getCalls))
+    const initializedSets = migrated.pipe(switchMap(() => setCalls))
+
+    initializedSets.subscribe(args => {
+        area.set.apply(area, args)
+    })
+
+    initializedGets.subscribe(args => {
+        area.get.apply(area, args)
+    })
+
+    const get: chrome.storage.StorageArea['get'] = (...args) => {
+        getCalls.next(args)
+    }
+
+    const set: chrome.storage.StorageArea['set'] = (...args) => {
+        setCalls.next(args)
+    }
+
+    return {
+        ...area,
+        get,
+        set,
+
+        setMigration: migrate => {
+            migrations.next(migrate)
+        },
+    }
+}

--- a/packages/browser-extensions/src/extension/scripts/background.tsx
+++ b/packages/browser-extensions/src/extension/scripts/background.tsx
@@ -359,19 +359,21 @@ function handleManagedPermissionRequest(managedUrls: string[]): void {
 function setDefaultBrowserAction(): void {
     browserAction.setBadgeText({ text: '' })
 
-    featureFlags.isEnabled('simpleOptionsMenu').then(async enabled => {
-        if (enabled) {
-            await browserAction.setPopup({ popup: 'options.html?popup=true' })
-        }
-    })
+    featureFlags
+        .isEnabled('simpleOptionsMenu')
+        .then(async enabled => {
+            if (enabled) {
+                await browserAction.setPopup({ popup: 'options.html?popup=true' })
+            }
+        })
+        .catch(err => {
+            console.log('unable to get feature flag')
+        })
 }
 
 storage
     .observeSync('featureFlags')
-    .pipe(
-        map(({ simpleOptionsMenu }) => simpleOptionsMenu),
-        distinctUntilChanged()
-    )
+    .pipe(map(({ simpleOptionsMenu }) => simpleOptionsMenu), distinctUntilChanged())
     .subscribe(async useSimpleOptionsMenu => {
         if (useSimpleOptionsMenu) {
             browserAction.onClicked(noop)

--- a/packages/browser-extensions/src/extension/scripts/background.tsx
+++ b/packages/browser-extensions/src/extension/scripts/background.tsx
@@ -15,7 +15,7 @@ import * as permissions from '../../browser/permissions'
 import * as runtime from '../../browser/runtime'
 import storage, { defaultStorageItems } from '../../browser/storage'
 import * as tabs from '../../browser/tabs'
-import { featureFlagDefaults } from '../../browser/types'
+import { featureFlagDefaults, FeatureFlags } from '../../browser/types'
 import initializeCli from '../../libs/cli'
 import { ExtensionConnectionInfo, onFirstMessage } from '../../messaging'
 import { resolveClientConfiguration } from '../../shared/backend/server'
@@ -165,41 +165,51 @@ permissions.onRemoved(permissions => {
     })
 })
 
-// Ensure access tokens are in storage and they are in the correct shape.
-storage.addSyncMigration((items, set, remove) => {
-    if (!items.accessTokens) {
-        set({ accessTokens: {} })
+storage.setSyncMigration(items => {
+    const newItems = { ...defaultStorageItems, ...items }
+
+    // Ensure access tokens are in storage and they are in the correct shape.
+    if (!newItems.accessTokens) {
+        newItems.accessTokens = {}
     }
 
-    if (items.accessTokens) {
+    if (newItems.accessTokens) {
         const accessTokens = {}
 
-        for (const url of Object.keys(items.accessTokens)) {
-            const token = items.accessTokens[url]
+        for (const url of Object.keys(newItems.accessTokens)) {
+            const token = newItems.accessTokens[url]
             if (typeof token !== 'string' && token.id && token.token) {
                 accessTokens[url] = token
             }
         }
 
-        set({ accessTokens })
+        newItems.accessTokens = accessTokens
     }
-})
 
-// Ensure all feature flags are in storage.
-storage.addSyncMigration((items, set, remove) => {
+    let featureFlags: FeatureFlags = newItems.featureFlags
+
+    // Ensure featureFlags is in storage.
+    if (!newItems.featureFlags) {
+        featureFlags = featureFlagDefaults
+    } else {
+        featureFlags = { ...featureFlagDefaults, ...newItems.featureFlags }
+    }
+
+    const keysToRemove: string[] = []
+
+    // Ensure all feature flags are in storage.
     for (const key of Object.keys(featureFlagDefaults)) {
-        if (typeof items.featureFlags[key] === 'undefined') {
-            remove(key)
-            set({ featureFlags: { ...featureFlagDefaults, ...items.featureFlags, [key]: featureFlagDefaults[key] } })
+        if (typeof featureFlags[key] === 'undefined') {
+            keysToRemove.push(key)
+            featureFlags = {
+                ...featureFlagDefaults,
+                ...items.featureFlags,
+                [key]: featureFlagDefaults[key],
+            }
         }
     }
-})
 
-// Add access tokens to storage.
-storage.addSyncMigration((items, set) => {
-    if (!items.accessTokens) {
-        set({ accessTokens: {} })
-    }
+    return { newItems, keysToRemove }
 })
 
 tabs.onUpdated((tabId, changeInfo, tab) => {

--- a/packages/browser-extensions/src/shared/components/options/FeatureFlagCard.tsx
+++ b/packages/browser-extensions/src/shared/components/options/FeatureFlagCard.tsx
@@ -9,20 +9,20 @@ interface Props {
 }
 
 export class FeatureFlagCard extends React.Component<Props, {}> {
-    private onMermaidToggled = () => {
-        featureFlags.toggle('renderMermaidGraphsEnabled')
+    private onMermaidToggled = async () => {
+        await featureFlags.toggle('renderMermaidGraphsEnabled')
     }
 
-    private onInlineSymbolSearchToggled = () => {
-        featureFlags.toggle('inlineSymbolSearchEnabled')
+    private onInlineSymbolSearchToggled = async () => {
+        await featureFlags.toggle('inlineSymbolSearchEnabled')
     }
 
-    private onUseExtensionsToggled = () => {
-        featureFlags.toggle('useExtensions')
+    private onUseExtensionsToggled = async () => {
+        await featureFlags.toggle('useExtensions')
     }
 
-    private onSimpleOptionsMenu = () => {
-        featureFlags.toggle('simpleOptionsMenu')
+    private onSimpleOptionsMenu = async () => {
+        await featureFlags.toggle('simpleOptionsMenu')
     }
 
     public render(): JSX.Element | null {

--- a/packages/browser-extensions/src/shared/util/featureFlags.ts
+++ b/packages/browser-extensions/src/shared/util/featureFlags.ts
@@ -41,7 +41,11 @@ const createFeatureFlagStorage = ({ get, set }: FeatureFlagUtilities): FeatureFl
 })
 
 function bextGet<K extends keyof FeatureFlags>(key: K): Promise<FeatureFlags[K]> {
-    return new Promise(resolve => storage.getSync(({ featureFlags }) => resolve(featureFlags[key])))
+    return new Promise(resolve =>
+        storage.getSync(({ featureFlags }) => {
+            resolve(featureFlags[key])
+        })
+    )
 }
 
 function bextSet<K extends keyof FeatureFlags>(key: K, val: FeatureFlags[K]): Promise<FeatureFlags[K]> {


### PR DESCRIPTION
Migrations in the browser extension weren't completing before other calls to browser storage. This means that things can fail when the browser extension storage gets in a weird state ([example](https://github.com/sourcegraph/sourcegraph/pull/841#issuecomment-436431950)). This PR makes sure migrations are called before any other calls to the API are.

This PR is based on bext/options-menu to make it easier to merge that PR since it should be merged soon after this.