### PR TITLE
allow all viewers to view usage statistics data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Site and user usage statistics are now visible to all users. Previously only site admins (and users, for their own usage statistics) could view this information. The information consists of aggregate counts of actions such as searches, page views, etc.
 - The Git blame information shown at the end of a line is now provided by the [Git extras extension](https://sourcegraph.com/extensions/sourcegraph/git-extras). You must add that extension to continue using this feature.
 
 ### Removed

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1981,8 +1981,6 @@ type User implements Node & ConfigurationSubject {
     # Only the user and site admins can access this field.
     tags: [String!]!
     # The user's usage statistics on Sourcegraph.
-    #
-    # Only the user and site admins can access this field.
     usageStatistics: UserUsageStatistics!
     # The user's email addresses.
     #
@@ -2653,6 +2651,8 @@ type Configuration {
 }
 
 # UserUsageStatistics describes a user's usage statistics.
+#
+# This information is visible to all viewers.
 type UserUsageStatistics {
     # The number of search queries that the user has performed.
     searchQueries: Int!
@@ -2687,6 +2687,8 @@ enum UserActivePeriod {
 }
 
 # SiteUsageStatistics describes a site's aggregate usage statistics.
+#
+# This information is visible to all viewers.
 type SiteUsageStatistics {
     # Recent daily active users.
     daus: [SiteUsagePeriod!]!
@@ -2697,6 +2699,8 @@ type SiteUsageStatistics {
 }
 
 # SiteUsagePeriod describes a site's usage statistics for a given timespan.
+#
+# This information is visible to all viewers.
 type SiteUsagePeriod {
     # The time when this started.
     startTime: String!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1988,8 +1988,6 @@ type User implements Node & ConfigurationSubject {
     # Only the user and site admins can access this field.
     tags: [String!]!
     # The user's usage statistics on Sourcegraph.
-    #
-    # Only the user and site admins can access this field.
     usageStatistics: UserUsageStatistics!
     # The user's email addresses.
     #
@@ -2660,6 +2658,8 @@ type Configuration {
 }
 
 # UserUsageStatistics describes a user's usage statistics.
+#
+# This information is visible to all viewers.
 type UserUsageStatistics {
     # The number of search queries that the user has performed.
     searchQueries: Int!
@@ -2694,6 +2694,8 @@ enum UserActivePeriod {
 }
 
 # SiteUsageStatistics describes a site's aggregate usage statistics.
+#
+# This information is visible to all viewers.
 type SiteUsageStatistics {
     # Recent daily active users.
     daus: [SiteUsagePeriod!]!
@@ -2704,6 +2706,8 @@ type SiteUsageStatistics {
 }
 
 # SiteUsagePeriod describes a site's usage statistics for a given timespan.
+#
+# This information is visible to all viewers.
 type SiteUsagePeriod {
     # The time when this started.
     startTime: String!

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -2,16 +2,13 @@ package graphqlbackend
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/siteid"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/usagestats"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
@@ -114,34 +111,6 @@ func (r *siteResolver) HasCodeIntelligence() bool {
 
 func (r *siteResolver) ProductSubscription() *productSubscriptionStatus {
 	return &productSubscriptionStatus{}
-}
-
-func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
-	Days   *int32
-	Weeks  *int32
-	Months *int32
-}) (*siteUsageStatisticsResolver, error) {
-	if envvar.SourcegraphDotComMode() {
-		return nil, errors.New("site usage statistics are not available on sourcegraph.com")
-	}
-	opt := &usagestats.SiteUsageStatisticsOptions{}
-	if args.Days != nil {
-		d := int(*args.Days)
-		opt.DayPeriods = &d
-	}
-	if args.Weeks != nil {
-		w := int(*args.Weeks)
-		opt.WeekPeriods = &w
-	}
-	if args.Months != nil {
-		m := int(*args.Months)
-		opt.MonthPeriods = &m
-	}
-	activity, err := usagestats.GetSiteUsageStatistics(opt)
-	if err != nil {
-		return nil, err
-	}
-	return &siteUsageStatisticsResolver{activity}, nil
 }
 
 type siteConfigurationResolver struct{}

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/usagestats"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -13,10 +12,6 @@ import (
 )
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
-	// 🚨 SECURITY: Only the user and site admins are allowed to access user usage statistics.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
-		return nil, err
-	}
 	if envvar.SourcegraphDotComMode() {
 		return nil, errors.New("usage statistics are not available on sourcegraph.com")
 	}

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -1,17 +1,48 @@
 package graphqlbackend
 
 import (
-	"context"
 	"testing"
 
+	"github.com/graph-gophers/graphql-go/gqltesting"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/usagestats"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
-func TestUsers_UsageStatistics(t *testing.T) {
-	ctx := context.Background()
-	u := &UserResolver{user: &types.User{}}
-	_, err := u.UsageStatistics(ctx)
-	if err == nil {
-		t.Errorf("Non-admin, non-user can access endpoint")
+func TestUser_UsageStatistics(t *testing.T) {
+	resetMocks()
+	db.Mocks.Users.MockGetByID_Return(t, &types.User{ID: 1, Username: "alice"}, nil)
+	usagestats.MockGetByUserID = func(userID int32) (*types.UserUsageStatistics, error) {
+		return &types.UserUsageStatistics{
+			SearchQueries: 2,
+		}, nil
 	}
+	defer func() { usagestats.MockGetByUserID = nil }()
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: GraphQLSchema,
+			Query: `
+				{
+					node(id: "VXNlcjox") {
+						id
+						... on User {
+							usageStatistics {
+								searchQueries
+							}
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"node": {
+						"id": "VXNlcjox",
+						"usageStatistics": {
+							"searchQueries": 2
+						}
+					}
+				}
+			`,
+		},
+	})
 }

--- a/cmd/frontend/internal/pkg/usagestats/usage_stats.go
+++ b/cmd/frontend/internal/pkg/usagestats/usage_stats.go
@@ -41,8 +41,14 @@ const (
 	maxStorageDays = 93
 )
 
+var MockGetByUserID func(userID int32) (*types.UserUsageStatistics, error)
+
 // GetByUserID returns a single user's UserUsageStatistics.
 func GetByUserID(userID int32) (*types.UserUsageStatistics, error) {
+	if MockGetByUserID != nil {
+		return MockGetByUserID(userID)
+	}
+
 	userIDStr := strconv.Itoa(int(userID))
 	key := keyPrefix + userIDStr
 

--- a/doc/user/index.md
+++ b/doc/user/index.md
@@ -22,6 +22,7 @@ Welcome to Sourcegraph! As a developer, you can use Sourcegraph to get help whil
 All features:
 
 - [Usage statistics](usage_statistics.md)
+- [User surveys](user_surveys.md)
 
 ## What is Sourcegraph?
 

--- a/doc/user/usage_statistics.md
+++ b/doc/user/usage_statistics.md
@@ -1,7 +1,11 @@
-# Usage analytics
+# Usage statistics
 
-Sourcegraph records basic usage statistics for site admins. To view analytics, visit the **Site admin > Analytics** page. (The URL is `https://sourcegraph.example.com/site-admin/analytics`.)
+Sourcegraph records basic per-user usage statistics. To view analytics, visit the **Site admin > Usage stats** page. (The URL is `https://sourcegraph.example.com/site-admin/usage-statistics`.) This information is available via the GraphQL API to all viewers (not just site admins).
 
 Here you can see charts with counts of unique users by day, week, or month, split into authenticated and anonymous users.
 
 From this page, you can also see user-level activity, including counts of pageviews, searches, and code intelligence actions, and last active times. This user-level data is all stored locally on your Sourcegraph instance, and is never sent to Sourcegraph.com.
+
+## See also 
+
+- [User satisfaction surveys](user_surveys.md)

--- a/doc/user/usage_statistics/index.md
+++ b/doc/user/usage_statistics/index.md
@@ -1,8 +1,0 @@
-# Usage statistics
-
-Sourcegraph collects 2 kinds of usage statistics to track engagement and satisfaction:
-
-- [Usage analytics](analytics.md) (daily/weekly/monthly active users)
-- [User satisfaction surveys](user_surveys.md)
-
-The results are shown only to site admins.

--- a/doc/user/user_surveys.md
+++ b/doc/user/user_surveys.md
@@ -1,4 +1,4 @@
-## User surveys
+# User surveys
 
 After using Sourcegraph for a few days, users are presented with a request to answer "How likely is it that you would recommend Sourcegraph to a friend?", and to provide some qualitative product feedback.
 
@@ -7,3 +7,7 @@ Responses to this survey are visible to all site admins on the Sourcegraph insta
 On this page, admins can view individual satisfaction scores (from 0–10) and individual qualitative feedback, along with aggregate historical scores.
 
 Survey responses are also always sent to Sourcegraph.com.
+
+## See also 
+
+- [Usage statistics](usage_statistics.md)

--- a/packages/webapp/src/explore/exploreSections.tsx
+++ b/packages/webapp/src/explore/exploreSections.tsx
@@ -26,8 +26,6 @@ export const exploreSections: ReadonlyArray<ExploreSectionDescriptor> = [
     {
         render: props => <SiteUsageExploreSection {...props} />,
         condition: ({ authenticatedUser }) =>
-            (!window.context.sourcegraphDotComMode || window.context.debug) &&
-            !!authenticatedUser &&
-            authenticatedUser.siteAdmin,
+            (!window.context.sourcegraphDotComMode || window.context.debug) && !!authenticatedUser,
     },
 ]


### PR DESCRIPTION
Site and user usage statistics are now visible to all users. Previously only site admins (and users, for their own usage statistics) could view this information. The information consists of aggregate counts of actions such as searches, page views, etc.


> This PR updates the CHANGELOG.md file to describe any user-facing changes.
