### PR TITLE
search: Convert a search query into a repo dbquery

### DIFF
--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -180,7 +180,7 @@ func RepoQuery(q query.Q) (dbquery.Q, error) {
 	// Replace all atoms (except constants and repo) with nothing. We use
 	// nothing to count the number of ancestor not nodes.
 	var err error
-	q = query.Map(q, func(q query.Q) query.Q {
+	q = query.Map(q, nil, func(q query.Q) query.Q {
 		switch c := q.(type) {
 		case *query.Repo:
 		case *query.Const:
@@ -194,7 +194,7 @@ func RepoQuery(q query.Q) (dbquery.Q, error) {
 			return c.Child
 
 		case *query.Not:
-			return query.Map(q, func(q query.Q) query.Q {
+			return query.Map(q, nil, func(q query.Q) query.Q {
 				if c, ok := q.(*nothing); ok {
 					c.NotCount++
 				}
@@ -212,7 +212,7 @@ func RepoQuery(q query.Q) (dbquery.Q, error) {
 
 	// Convert the nothing atoms into constants (since they have the correct
 	// NotCount now).
-	q = query.Map(q, func(q query.Q) query.Q {
+	q = query.Map(q, nil, func(q query.Q) query.Q {
 		if c, ok := q.(*nothing); ok {
 			return &query.Const{Value: c.NotCount%2 == 0}
 		}

--- a/pkg/search/query/parse.go
+++ b/pkg/search/query/parse.go
@@ -308,14 +308,14 @@ func parseExprList(in []byte) ([]Q, int, error) {
 			newQS = append(newQS, q)
 		}
 	}
-	qs = mapQueryList(newQS, func(q Q) Q {
-		return Map(q, func(q Q) Q {
+	for _, q := range newQS {
+		VisitAtoms(q, func(q Q) {
 			if sc, ok := q.(setCaser); ok {
 				sc.setCase(setCase)
 			}
-			return q
 		})
-	})
+	}
+	qs = newQS
 	if typeT != 100 {
 		qs = []Q{&Type{Type: typeT, Child: NewAnd(qs...)}}
 	}

--- a/pkg/search/query/query.go
+++ b/pkg/search/query/query.go
@@ -501,15 +501,24 @@ func ExpandFileContent(q Q) Q {
 	return q
 }
 
+// IsAtom returns true if q is an atom. An atom is a Q without children Q. For
+// example And is not an atom, but Repo is.
+func IsAtom(q Q) bool {
+	switch q.(type) {
+	case *And:
+	case *Or:
+	case *Not:
+	case *Type:
+	default:
+		return true
+	}
+	return false
+}
+
 // VisitAtoms runs `v` on all atom queries within `q`.
 func VisitAtoms(q Q, v func(q Q)) {
 	Map(q, nil, func(iQ Q) Q {
-		switch iQ.(type) {
-		case *And:
-		case *Or:
-		case *Not:
-		case *Type:
-		default:
+		if IsAtom(iQ) {
 			v(iQ)
 		}
 		return iQ

--- a/pkg/search/query/query.go
+++ b/pkg/search/query/query.go
@@ -352,10 +352,10 @@ func flatten(q Q) (Q, bool) {
 	}
 }
 
-func mapQueryList(qs []Q, f func(Q) Q) []Q {
+func mapQueryList(qs []Q, pre, post func(Q) Q) []Q {
 	var neg []Q
 	for _, sub := range qs {
-		neg = append(neg, Map(sub, f))
+		neg = append(neg, Map(sub, pre, post))
 	}
 	return neg
 }
@@ -371,7 +371,7 @@ func invertConst(q Q) Q {
 func evalAndOrConstants(q Q, children []Q) Q {
 	_, isAnd := q.(*And)
 
-	children = mapQueryList(children, evalConstants)
+	children = mapQueryList(children, nil, evalConstants)
 
 	newCH := children[:0]
 	for _, ch := range children {
@@ -455,19 +455,26 @@ func Simplify(q Q) Q {
 	return q
 }
 
-// Map runs f over the q.
-func Map(q Q, f func(q Q) Q) Q {
+// Map runs pre and post over the q. pre if non-nil is called in prefix
+// order. post if non-nil is called in postfix order.
+func Map(q Q, pre, post func(q Q) Q) Q {
+	if pre != nil {
+		q = pre(q)
+	}
 	switch s := q.(type) {
 	case *And:
-		q = &And{Children: mapQueryList(s.Children, f)}
+		q = &And{Children: mapQueryList(s.Children, pre, post)}
 	case *Or:
-		q = &Or{Children: mapQueryList(s.Children, f)}
+		q = &Or{Children: mapQueryList(s.Children, pre, post)}
 	case *Not:
-		q = &Not{Child: Map(s.Child, f)}
+		q = &Not{Child: Map(s.Child, pre, post)}
 	case *Type:
-		q = &Type{Type: s.Type, Child: Map(s.Child, f)}
+		q = &Type{Type: s.Type, Child: Map(s.Child, pre, post)}
 	}
-	return f(q)
+	if post != nil {
+		q = post(q)
+	}
+	return q
 }
 
 // Expand expands Substr queries into (OR file_substr content_substr)
@@ -496,7 +503,7 @@ func ExpandFileContent(q Q) Q {
 
 // VisitAtoms runs `v` on all atom queries within `q`.
 func VisitAtoms(q Q, v func(q Q)) {
-	Map(q, func(iQ Q) Q {
+	Map(q, nil, func(iQ Q) Q {
 		switch iQ.(type) {
 		case *And:
 		case *Or:


### PR DESCRIPTION
For searcher we need an exact list of repositories to search, since it isn't
efficient enough to just search all repositories. This function returns a repo
list query given a search query. The dbquery will return all repositories
which may contain a match according to the expression.