### PR TITLE
DONOTMERGE: Unused MinimalRepoSet implementation

### DIFF
--- a/pkg/search/query/query.go
+++ b/pkg/search/query/query.go
@@ -494,6 +494,85 @@ func ExpandFileContent(q Q) Q {
 	return q
 }
 
+// ExpandRepo expands all Repo Q in q with listFn. An error is returned if
+// listFn returns an error.
+//
+// listFn is a function which takes a list of repo patterns and returns all
+// repository names that satisfies the patterns. A name satisfies the pattern
+// if all include match, and no exclude match.
+func ExpandRepo(q Q, listFn func(include, exclude []string) (map[string]bool, error)) (Q, error) {
+	// TODO(keegancsmith) listFn in Sourcegraph will talk to a DB. So it would
+	// be better to adjust this function to create arbitrary expressions
+	// containing only AND, OR, NOT, and REPO. Those expressions can then be
+	// translated into a SQL WHERE query. This can then reduce the amount of
+	// queries we run against the DB.
+
+	// We want nested ors/ands to be flattened
+	q = Simplify(q)
+
+	var retErr error
+	list := func(inc, exc []string) Q {
+		if retErr != nil {
+			return &Const{Value: false}
+		}
+		q, err := listFn(inc, exc)
+		if err != nil {
+			retErr = err
+			return &Const{Value: false}
+		}
+		if len(q) == 0 {
+			return &Const{Value: false}
+		}
+		return &RepoSet{Set: q}
+	}
+	q = Map(q, func(q Q) Q {
+		and, ok := q.(*And)
+		if !ok {
+			return q
+		}
+		// Children have already been mapped, so safe to modify slice (it
+		// should be a copy)
+		var inc, exc []string
+		children := and.Children[:0]
+		for _, cs := range and.Children {
+			switch c := cs.(type) {
+			case *Repo:
+				inc = append(inc, c.Pattern)
+			case *Not:
+				if r, ok := c.Child.(*Repo); ok {
+					exc = append(exc, r.Pattern)
+				} else {
+					children = append(children, c)
+				}
+			default:
+				children = append(children, c)
+			}
+		}
+		if len(inc) > 0 || len(exc) > 0 {
+			children = append(children, list(inc, exc))
+		}
+		return NewAnd(children...)
+	})
+	// We may still have Repo queries which are not a child of an And. So we
+	// need to naively translate those. First Not then Repo (since Repo can be
+	// a child of Not).
+	q = Map(q, func(q Q) Q {
+		if not, ok := q.(*Not); ok {
+			if r, ok := not.Child.(*Repo); ok {
+				return list(nil, []string{r.Pattern})
+			}
+		}
+		return q
+	})
+	q = Map(q, func(q Q) Q {
+		if r, ok := q.(*Repo); ok {
+			return list([]string{r.Pattern}, nil)
+		}
+		return q
+	})
+	return Simplify(q), retErr
+}
+
 // VisitAtoms runs `v` on all atom queries within `q`.
 func VisitAtoms(q Q, v func(q Q)) {
 	Map(q, func(iQ Q) Q {

--- a/pkg/search/query/query_test.go
+++ b/pkg/search/query/query_test.go
@@ -15,8 +15,10 @@
 package query
 
 import (
+	"errors"
 	"log"
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -95,6 +97,76 @@ func TestMap(t *testing.T) {
 	got := Map(in, f)
 	if !reflect.DeepEqual(got, out) {
 		t.Errorf("got %v, want %v", got, out)
+	}
+}
+
+func createListFunc(repos []string) func([]string, []string) (map[string]bool, error) {
+	return func(inc, exc []string) (map[string]bool, error) {
+		set := map[string]bool{}
+		for _, r := range repos {
+			set[r] = true
+		}
+		for r := range set {
+			for _, re := range inc {
+				if matched, err := regexp.MatchString(re, r); err != nil {
+					return nil, err
+				} else if !matched {
+					delete(set, r)
+				}
+			}
+			for _, re := range exc {
+				if matched, err := regexp.MatchString(re, r); err != nil {
+					return nil, err
+				} else if matched {
+					delete(set, r)
+				}
+			}
+		}
+		return set, nil
+	}
+}
+
+func TestExpandRepo(t *testing.T) {
+	list := createListFunc([]string{"foo", "bar", "baz"})
+
+	cases := map[string]string{
+		"r:":                         "(reposet bar baz foo)",
+		"r:b":                        "(reposet bar baz)",
+		"r:b r:a":                    "(reposet bar baz)",
+		"r:b -r:baz":                 "(reposet bar)",
+		"-r:f":                       "(reposet bar baz)",
+		"r:foo":                      "(reposet foo)",
+		"r:foo r:baz":                "FALSE",
+		"r:foo test":                 "(and substr:\"test\" (reposet foo))",
+		"r:foo test -hello":          "(and substr:\"test\" (not substr:\"hello\") (reposet foo))",
+		"(r:ba test (r:b r:a -r:z))": "(and substr:\"test\" (reposet bar))",
+	}
+	for qStr, want := range cases {
+		q, err := Parse(qStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := ExpandRepo(q, list)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.String() != want {
+			t.Errorf("expandRepo(%q) got %s want %s", qStr, got.String(), want)
+		}
+	}
+}
+
+func TestExpandRepo_error(t *testing.T) {
+	list := func(inc, exc []string) (map[string]bool, error) {
+		return nil, errors.New("fail")
+	}
+	q, err := Parse("(foo repo:bar) or (baz repo:bam)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = ExpandRepo(q, list)
+	if err == nil {
+		t.Fatalf("expected error, got %s", q.String())
 	}
 }
 


### PR DESCRIPTION
This was my original implementation for working out which repos to run against. It implemented set some basic set logic to evaluate the expressions. We now just convert expressions into DB queries. Creating PR for recording this in case we want to use this code in the future.