### PR TITLE
Extensions debuggability improvements

### DIFF
--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -45,10 +45,15 @@ func handleRegistryExtensionBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 🚨 SECURITY: Prevent this URL from being used in a <script> tag from other sites, because
-	// hosting user-provided scripts on this domain would let attackers steal sensitive data from
-	// anyone they lure to the attacker's site.
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	// 🚨 SECURITY: Prevent this URL from being rendered as an HTML page by browsers (to prevent an
+	// XSS attack). That would let attackers upload an HTML file with inline JavaScript and then
+	// cause victims to visit it, thereby executing the attacker's JavaScript in the context of
+	// Sourcegraph's domain.
+	//
+	// Note that it IS safe for the file to be served as application/javascript. If an attacker
+	// references it in a <script> tag on the attacker's site, the JavaScript will execute in the
+	// context of the attacker's site, not Sourcegraph. The script file being hosted by Sourcegraph
+	// does not give it any privileges with respect to Sourcegraph's domain.
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
 	w.Header().Set("X-Frame-Options", "deny")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -71,8 +76,10 @@ func handleRegistryExtensionBundle(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "extension has no source map", http.StatusNotFound)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		data = sourceMap
 	} else {
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
 		data = bundle
 	}
 	w.Write(data)

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle_test.go
@@ -1,0 +1,20 @@
+package registry
+
+import "testing"
+
+func TestParseExtensionBundleFilename(t *testing.T) {
+	tests := map[string]int64{
+		"123.js":        123,
+		"123-a-b.js":    123,
+		"123-a-b-c.map": 123,
+	}
+	for input, want := range tests {
+		got, err := parseExtensionBundleFilename(input)
+		if err != nil {
+			t.Errorf("%q: %s", input, err)
+		}
+		if got != want {
+			t.Errorf("%q: got %d, want %d", input, got, want)
+		}
+	}
+}

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
@@ -45,7 +45,7 @@ func TestGetExtensionManifestWithBundleURL(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want := `{"name":"x","url":"/-/static/extension/0.js?x---1fmlvpbbdw2yo"}`; manifest == nil || !jsonDeepEqual(*manifest, want) {
+		if want := `{"name":"x","url":"/-/static/extension/0-x.js?-1fmlvpbbdw2yo--x"}`; manifest == nil || !jsonDeepEqual(*manifest, want) {
 			t.Errorf("got %q, want %q", nilOrEmpty(manifest), want)
 		}
 	})

--- a/packages/browser-extensions/src/extension/scripts/background.tsx
+++ b/packages/browser-extensions/src/extension/scripts/background.tsx
@@ -399,6 +399,11 @@ function spawnWebWorkerFromURL(url: string): Promise<Worker> {
     })
         .toPromise()
         .then(response => {
+            // We need to import the extension's JavaScript file (in importScripts in the Web Worker) from a blob:
+            // URI, not its original http:/https: URL, because Chrome extensions are not allowed to be published
+            // with a CSP that allowlists https://* in script-src (see
+            // https://developer.chrome.com/extensions/contentSecurityPolicy#relaxing-remote-script). (Firefox
+            // add-ons have an even stricter restriction.)
             const blobURL = window.URL.createObjectURL(response.response)
             try {
                 const worker = new ExtensionHostWorker()

--- a/packages/sourcegraph-extension-api/src/extension/workerMain.ts
+++ b/packages/sourcegraph-extension-api/src/extension/workerMain.ts
@@ -74,7 +74,12 @@ export function extensionHostWorkerMain(self: DedicatedWorkerGlobalScope): void 
                 `Extension host is terminating because the extension's activate function threw an error.`,
                 err
             )
-            self.close()
+            // Calling self.close() here would kill the Web Worker, which sounds like a good idea (because it won't be used for
+            // anything else given the error that occurred). However, this makes it harder to inspect log messages and
+            // exceptions from this Web Worker in the browser devtools console. In Chrome, the filenames and line numbers from
+            // track traces and log messages open a new window when clicked (instead of opening in the Sources tab). Keeping
+            // the Web Worker alive fixes this issue. The Web Worker will be killed by the client when this extension is no
+            // longer active, so the resource consumption of not killing unused Web Workers is bounded.
         }
     }
 }

--- a/packages/sourcegraph-extension-api/src/extension/workerMain.ts
+++ b/packages/sourcegraph-extension-api/src/extension/workerMain.ts
@@ -41,7 +41,7 @@ export function extensionHostWorkerMain(self: DedicatedWorkerGlobalScope): void 
             }
 
             const initData: InitData = ev.data
-            if (typeof initData.bundleURL !== 'string' || !initData.bundleURL.startsWith('blob:')) {
+            if (typeof initData.bundleURL !== 'string') {
                 console.error(`Invalid extension bundle URL: ${initData.bundleURL}`)
                 self.close()
             }

--- a/packages/webapp/src/SourcegraphWebApp.tsx
+++ b/packages/webapp/src/SourcegraphWebApp.tsx
@@ -122,7 +122,9 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                     'clientApplication.isSourcegraph': true,
                 },
             },
-            extensionsController: createExtensionsController(extensions.context, createMessageTransports),
+            extensionsController: createExtensionsController(extensions.context, extension =>
+                Promise.resolve(createMessageTransports(extension))
+            ),
             viewerSubject: SITE_SUBJECT_NO_ADMIN,
             isMainPage: false,
         }


### PR DESCRIPTION
See commits.

This makes it so that:

1. On the webapp, extensions' log messages and exceptions are attributed to the exact JS file (not just a `blob:` URI that sometimes opens in a weird new tab)
1. The JS bundle filename now contains the extension ID, not just `123.js`, so it's easier to know which extension produced a given log or exception.