### PR TITLE
fix: don't process test files with webpack

### DIFF
--- a/packages/browser-extensions/config/shared/webpack.ts
+++ b/packages/browser-extensions/config/shared/webpack.ts
@@ -41,6 +41,7 @@ export const tsRule: webpack.RuleSetRule = {
         {
             loader: 'ts-loader',
             options: {
+                configFile: path.resolve(__dirname, '../tsconfig.webpack.json'),
                 compilerOptions: {
                     target: 'es6',
                     module: 'esnext',

--- a/packages/browser-extensions/config/tsconfig.webpack.json
+++ b/packages/browser-extensions/config/tsconfig.webpack.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "exclude": ["**/*.test.ts", "./node_modules", "./build", "./*.safariextension"]
+}


### PR DESCRIPTION
This PR stops webpack and ts-loader from processing test files. They weren't getting bundled but don't ever need to be processed by webpack at all.