### PR TITLE
fix: always use newInject for GitHub

### DIFF
--- a/packages/browser-extensions/src/extension/scripts/inject.tsx
+++ b/packages/browser-extensions/src/extension/scripts/inject.tsx
@@ -98,7 +98,7 @@ function injectApplication(): void {
         }
 
         if (isGitHub || isPhabricator || isGitlab || isBitbucket) {
-            if (isGitlab || isBitbucket || (await featureFlags.isEnabled('newInject'))) {
+            if (isGitHub || isGitlab || isBitbucket || (await featureFlags.isEnabled('newInject'))) {
                 const subscriptions = await injectCodeIntelligence()
                 window.addEventListener('unload', () => subscriptions.unsubscribe())
             }

--- a/packages/browser-extensions/src/libs/github/inject.tsx
+++ b/packages/browser-extensions/src/libs/github/inject.tsx
@@ -272,15 +272,6 @@ function injectCodeIntelligence(): void {
 }
 
 async function inject(): Promise<void> {
-    featureFlags
-        .isEnabled('newInject')
-        .then(isEnabled => {
-            if (!isEnabled) {
-                injectCodeIntelligence()
-            }
-        })
-        .catch(err => console.error('could not get feature flag', err))
-
     injectServerBanner()
     injectOpenOnSourcegraphButton()
 


### PR DESCRIPTION
GitHub should be always using the new inject method. All code hosts will be using it soon and the feature flag, along with a lot of soon to be dead code, will be removed. Those changes will be in a future PR.

Fixes https://github.com/sourcegraph/sourcegraph/issues/852.