### PR TITLE
update conf.Watch doc to mention it should always be called in a goroutine

### DIFF
--- a/pkg/conf/client.go
+++ b/pkg/conf/client.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -92,13 +91,15 @@ func (c *client) Mock(mockery *schema.SiteConfiguration) {
 	c.store.Mock(mockery)
 }
 
-// Watch calls the given function in a separate goroutine whenever the
-// configuration has changed. The new configuration can be received by calling
-// conf.Get.
+// Watch calls the given function whenever the configuration has changed. The new configuration is
+// accessed by calling conf.Get.
 //
 // Before Watch returns, it will invoke f to use the current configuration.
 //
 // Watch is a wrapper around client.Watch.
+//
+// IMPORTANT: Watch will block on config initialization. It therefore should *never* be called
+// synchronously in `init` functions.
 func Watch(f func()) {
 	defaultClient.Watch(f)
 }


### PR DESCRIPTION
(This just bit someone else diagnosing a startup deadlock.)

<!-- delete the irrelevant line below -->

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
> This PR does not need to update the CHANGELOG because ...