### PR TITLE
db_testing: drop existing test databases 

### DIFF
--- a/dev/ci/ci-db-backcompat.sh
+++ b/dev/ci/ci-db-backcompat.sh
@@ -33,7 +33,6 @@ echo ""
 
 # Recreate the test DB and run TestMigrations once to ensure that the schema version is the latest.
 set -ex
-./dev/ci/reset-test-db.sh || true
 go test -count=1 -v ./cmd/frontend/db/  -run=TestMigrations
 HEAD="$HEAD" OLD="${COMMIT_BEFORE_LAST_MIGRATION}" ./dev/ci/db-backcompat.sh
 set +ex

--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -89,7 +89,6 @@ func main() {
 		bk.Cmd("./dev/ci/ci-db-backcompat.sh"))
 
 	pipeline.AddStep(":go:",
-		bk.Cmd("./dev/ci/reset-test-db.sh || true"),
 		bk.Cmd("go test -coverprofile=coverage.txt -covermode=atomic -race ./..."),
 		bk.ArtifactPaths("coverage.txt"))
 


### PR DESCRIPTION
Currently, [TestContext(t *testing.T)](https://sourcegraph.sgdev.org/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/db/testing/db_testing.go?utm_source=inline-symbol#L61:6-61:17) always rolls the database forward to the latest migration. However:
- these migrations are never undone during testing 
- the test databases are re-used for different CI builds 

So, it's possible for a build to be broken in CI because the Buildkite agent that it's running on previously ran a build that had a migration that hasn't landed in master yet. 

This PR solves this by ensuring that the test database is re-created from scratch every time that a build runs in CI. 