### PR TITLE
move gitlab authz config code to separate file

### DIFF
--- a/cmd/frontend/shared/authz.go
+++ b/cmd/frontend/shared/authz.go
@@ -1,15 +1,8 @@
 package shared
 
 import (
-	"fmt"
-	"net/url"
-	"time"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz"
-	permgl "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz/gitlab"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
-	"github.com/sourcegraph/sourcegraph/pkg/env"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -43,84 +36,10 @@ func providersFromConfig(cfg *schema.SiteConfiguration) (
 		}
 	}()
 
-	// Authorization (i.e., permissions) providers
-	for _, gl := range cfg.Gitlab {
-		if gl.Authorization == nil {
-			continue
-		}
-
-		glURL, err := url.Parse(gl.Url)
-		if err != nil {
-			seriousProblems = append(seriousProblems, fmt.Sprintf("Could not parse URL for GitLab instance %q: %s", gl.Url, err))
-			continue // omit authz provider if could not parse URL
-		}
-
-		var ttl time.Duration
-		if gl.Authorization.Ttl == "" {
-			ttl = time.Hour * 3
-		} else {
-			ttl, err = time.ParseDuration(gl.Authorization.Ttl)
-			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("Could not parse time duration %q, falling back to 3 hours.", gl.Authorization.Ttl))
-				ttl = time.Hour * 3
-			}
-		}
-
-		op := permgl.GitLabAuthzProviderOp{
-			BaseURL:   glURL,
-			SudoToken: gl.Token,
-			AuthnConfigID: auth.ProviderConfigID{
-				ID:   gl.Authorization.AuthnProvider.ConfigID,
-				Type: gl.Authorization.AuthnProvider.Type,
-			},
-			GitLabProvider: gl.Authorization.AuthnProvider.GitlabProvider,
-			CacheTTL:       ttl,
-			MockCache:      nil,
-		}
-		if gl.Authorization.AuthnProvider.ConfigID == "" {
-			// Note: In the future when we support sign-in via GitLab, we can check if that is
-			// enabled and instead fall back to that.
-			if env.InsecureDev {
-				log15.Warn("Using username matching for debugging purposes, because `authz.authnProvider.configID` in the config was empty. This should ONLY occur in a development build.")
-				op.UseNativeUsername = true
-			} else {
-				seriousProblems = append(seriousProblems, "`authz.authnProvider.configID` was empty. No users will be granted access to these repositories.")
-			}
-		} else if gl.Authorization.AuthnProvider.Type == "" {
-			seriousProblems = append(seriousProblems, "`authz.authnProvider.type` was not specified, which means GitLab users cannot be resolved.")
-		} else if gl.Authorization.AuthnProvider.GitlabProvider == "" {
-			seriousProblems = append(seriousProblems, "`authz.authnProvider.gitlabProvider` was not specified, which means GitLab users cannot be resolved.")
-		} else {
-			// Best-effort determine if the authz.authnConfigID field refers to an item in auth.provider
-			found := false
-			for _, p := range cfg.AuthProviders {
-				if p.Openidconnect != nil && p.Openidconnect.ConfigID == gl.Authorization.AuthnProvider.ConfigID && p.Openidconnect.Type == gl.Authorization.AuthnProvider.Type {
-					found = true
-					break
-				}
-				if p.Saml != nil && p.Saml.ConfigID == gl.Authorization.AuthnProvider.ConfigID && p.Saml.Type == gl.Authorization.AuthnProvider.Type {
-					found = true
-					break
-				}
-			}
-			if !found {
-				seriousProblems = append(seriousProblems, fmt.Sprintf("Could not find item in `auth.providers` with config ID %q and type %q", gl.Authorization.AuthnProvider.ConfigID, gl.Authorization.AuthnProvider.Type))
-			}
-		}
-
-		authzProviders = append(authzProviders, NewGitLabProvider(op))
-	}
-
-	for _, provider := range authzProviders {
-		for _, problem := range provider.Validate() {
-			warnings = append(warnings, fmt.Sprintf("GitLab config for %s was invalid: %s", provider.ServiceID(), problem))
-		}
-	}
+	glp, glproblems, glwarnings := gitlabProvidersFromConfig(cfg)
+	authzProviders = append(authzProviders, glp...)
+	seriousProblems = append(seriousProblems, glproblems...)
+	warnings = append(warnings, glwarnings...)
 
 	return allowAccessByDefault, authzProviders, seriousProblems, warnings
-}
-
-// NewGitLabProvider is a mockable constructor for new GitLabAuthzProvider instances.
-var NewGitLabProvider = func(op permgl.GitLabAuthzProviderOp) authz.Provider {
-	return permgl.NewProvider(op)
 }

--- a/cmd/frontend/shared/authz_gitlab.go
+++ b/cmd/frontend/shared/authz_gitlab.go
@@ -1,0 +1,99 @@
+package shared
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/auth"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz"
+	permgl "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz/gitlab"
+	"github.com/sourcegraph/sourcegraph/pkg/env"
+	"github.com/sourcegraph/sourcegraph/schema"
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+func gitlabProvidersFromConfig(cfg *schema.SiteConfiguration) (
+	authzProviders []authz.Provider,
+	seriousProblems []string,
+	warnings []string,
+) {
+	// Authorization (i.e., permissions) providers
+	for _, gl := range cfg.Gitlab {
+		if gl.Authorization == nil {
+			continue
+		}
+
+		glURL, err := url.Parse(gl.Url)
+		if err != nil {
+			seriousProblems = append(seriousProblems, fmt.Sprintf("Could not parse URL for GitLab instance %q: %s", gl.Url, err))
+			continue // omit authz provider if could not parse URL
+		}
+
+		var ttl time.Duration
+		if gl.Authorization.Ttl == "" {
+			ttl = time.Hour * 3
+		} else {
+			ttl, err = time.ParseDuration(gl.Authorization.Ttl)
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("Could not parse time duration %q, falling back to 3 hours.", gl.Authorization.Ttl))
+				ttl = time.Hour * 3
+			}
+		}
+
+		op := permgl.GitLabAuthzProviderOp{
+			BaseURL:   glURL,
+			SudoToken: gl.Token,
+			AuthnConfigID: auth.ProviderConfigID{
+				ID:   gl.Authorization.AuthnProvider.ConfigID,
+				Type: gl.Authorization.AuthnProvider.Type,
+			},
+			GitLabProvider: gl.Authorization.AuthnProvider.GitlabProvider,
+			CacheTTL:       ttl,
+			MockCache:      nil,
+		}
+		if gl.Authorization.AuthnProvider.ConfigID == "" {
+			// Note: In the future when we support sign-in via GitLab, we can check if that is
+			// enabled and instead fall back to that.
+			if env.InsecureDev {
+				log15.Warn("Using username matching for debugging purposes, because `authz.authnProvider.configID` in the config was empty. This should ONLY occur in a development build.")
+				op.UseNativeUsername = true
+			} else {
+				seriousProblems = append(seriousProblems, "`authz.authnProvider.configID` was empty. No users will be granted access to these repositories.")
+			}
+		} else if gl.Authorization.AuthnProvider.Type == "" {
+			seriousProblems = append(seriousProblems, "`authz.authnProvider.type` was not specified, which means GitLab users cannot be resolved.")
+		} else if gl.Authorization.AuthnProvider.GitlabProvider == "" {
+			seriousProblems = append(seriousProblems, "`authz.authnProvider.gitlabProvider` was not specified, which means GitLab users cannot be resolved.")
+		} else {
+			// Best-effort determine if the authz.authnConfigID field refers to an item in auth.provider
+			found := false
+			for _, p := range cfg.AuthProviders {
+				if p.Openidconnect != nil && p.Openidconnect.ConfigID == gl.Authorization.AuthnProvider.ConfigID && p.Openidconnect.Type == gl.Authorization.AuthnProvider.Type {
+					found = true
+					break
+				}
+				if p.Saml != nil && p.Saml.ConfigID == gl.Authorization.AuthnProvider.ConfigID && p.Saml.Type == gl.Authorization.AuthnProvider.Type {
+					found = true
+					break
+				}
+			}
+			if !found {
+				seriousProblems = append(seriousProblems, fmt.Sprintf("Could not find item in `auth.providers` with config ID %q and type %q", gl.Authorization.AuthnProvider.ConfigID, gl.Authorization.AuthnProvider.Type))
+			}
+		}
+
+		authzProviders = append(authzProviders, NewGitLabProvider(op))
+	}
+	for _, provider := range authzProviders {
+		for _, problem := range provider.Validate() {
+			warnings = append(warnings, fmt.Sprintf("GitLab config for %s was invalid: %s", provider.ServiceID(), problem))
+		}
+	}
+	return authzProviders, seriousProblems, warnings
+}
+
+// NewGitLabProvider is a mockable constructor for new GitLabAuthzProvider instances.
+var NewGitLabProvider = func(op permgl.GitLabAuthzProviderOp) authz.Provider {
+	return permgl.NewProvider(op)
+}


### PR DESCRIPTION
<!-- delete the irrelevant line below -->

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
> This PR does not need to update the CHANGELOG because ...

In anticipation of authz changes.