### PR TITLE
xlang-go: add the internal raw API as the highest priority source of zip archives

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -111,6 +111,7 @@ func NewInternalHandler(m *mux.Router) http.Handler {
 	m.Get(apirouter.Telemetry).Handler(trace.TraceRoute(telemetryHandler))
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL)))
 	m.Get(apirouter.ConfigurationRawJSON).Handler(trace.TraceRoute(handler(serveConfigurationRawJSON)))
+	m.Get(apirouter.Raw).Handler(trace.TraceRoute(handler(raw.NewHandler(raw.RepoProviderFunc(repoProvider)))))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/cmd/xlang-go/internal/server/vfs.go
+++ b/enterprise/cmd/xlang-go/internal/server/vfs.go
@@ -35,7 +35,14 @@ func remoteFS(ctx context.Context, conn *jsonrpc2.Conn, workspaceURI lsp.Documen
 	if u.Rev() == "" {
 		return nil, errors.Errorf("rev is required in uri: %s", workspaceURI)
 	}
-	archiveFS := vfsutil.NewGitServer(u.Repo(), api.CommitID(u.Rev()))
+
+	archiveFS, err := vfsutil.NewSourcegraphRepoVFS(string(u.Repo()), u.Rev())
+	if err == nil {
+		archiveFS.EvictOnClose = true
+		return archiveFS, nil
+	}
+
+	archiveFS = vfsutil.NewGitServer(u.Repo(), api.CommitID(u.Rev()))
 	archiveFS.EvictOnClose = true
 	return archiveFS, nil
 }

--- a/xlang/vfsutil/github_archive.go
+++ b/xlang/vfsutil/github_archive.go
@@ -1,21 +1,11 @@
 package vfsutil
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net/http"
 	"path"
 	"regexp"
-	"strings"
 
-	"golang.org/x/net/context/ctxhttp"
-
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 )
 
 // NewGitHubRepoVFS creates a new VFS backed by a GitHub downloadable
@@ -25,63 +15,13 @@ func NewGitHubRepoVFS(repo, rev string) (*ArchiveFS, error) {
 		return nil, fmt.Errorf(`invalid GitHub repo %q: must be "github.com/user/repo"`, repo)
 	}
 
-	fetch := func(ctx context.Context) (ar *archiveReader, err error) {
-		span, ctx := opentracing.StartSpanFromContext(ctx, "Archive Fetch")
-		ext.Component.Set(span, "githubvfs")
-		span.SetTag("repo", repo)
-		span.SetTag("commit", rev)
-		defer func() {
-			if err != nil {
-				ext.Error.Set(span, true)
-				span.SetTag("err", err)
-			}
-			span.Finish()
-		}()
-
-		ff, err := cachedFetch(ctx, "githubvfs", repo+"@"+rev, func(ctx context.Context) (io.ReadCloser, error) {
-			ghFetch.Inc()
-			url := fmt.Sprintf("https://codeload.%s/zip/%s", repo, rev)
-			resp, err := ctxhttp.Get(ctx, nil, url)
-			if err != nil {
-				return nil, err
-			}
-			if resp.StatusCode != http.StatusOK {
-				resp.Body.Close()
-				return nil, errors.Errorf("github repo archive: URL %s returned HTTP %d", url, resp.StatusCode)
-			}
-			return resp.Body, nil
-		})
-		if err != nil {
-			ghFetchFailed.Inc()
-			return nil, err
-		}
-		f := ff.File
-
-		zr, err := zipNewFileReader(f)
-		if err != nil {
-			f.Close()
-			return nil, err
-		}
-
-		// GitHub zip files have a top-level dir "{repobasename}-{sha}/",
-		// so we need to remove that. The repobasename is in the canonical
-		// casing, which may be different from fs.repo.
-		if len(zr.File) == 0 {
-			f.Close()
-			return nil, errors.New("zip archive has no files")
-		}
-		prefix := zr.File[0].Name
-		if strings.Contains(prefix, "/") {
-			prefix = path.Dir(prefix)
-		}
-
-		return &archiveReader{
-			Reader: zr,
-			Closer: f,
-			Prefix: prefix + "/",
-		}, nil
-	}
-	return &ArchiveFS{fetch: fetch}, nil
+	url := fmt.Sprintf("https://codeload.%s/zip/%s", repo, rev)
+	cacheKey := repo + "@" + rev
+	// GitHub zip files have a top-level dir "{repobasename}-{sha}/", so we need
+	// to remove that. The repobasename is in the canonical casing, which may be
+	// different from fs.repo.
+	rootDirInZip := path.Base(repo) + "-" + rev + "/"
+	return NewZipVFS(url, cacheKey, rootDirInZip, ghFetch.Inc, ghFetchFailed.Inc)
 }
 
 var githubRepoRx = regexp.MustCompile(`^github\.com/[\w.-]{1,100}/[\w.-]{1,100}$`)

--- a/xlang/vfsutil/sourcegraph_archive.go
+++ b/xlang/vfsutil/sourcegraph_archive.go
@@ -9,7 +9,7 @@ import (
 // returns a new VFS backed by that zip archive.
 func NewSourcegraphRepoVFS(repo, rev string) (*ArchiveFS, error) {
 	// TODO(chris) switch to the non-internal raw API once authorization is implemented.
-	url := api.InternalClient.URL + "/.internal/" + repo + "@" + rev + "/-/raw"
+	url := api.InternalClient.URL + "/.internal/" + repo + "@" + rev + "/-/raw/"
 	cacheKey := repo + "@" + rev
 	rootDirInZip := "/"
 	return NewZipVFS(url, cacheKey, rootDirInZip, sgFetch.Inc, sgFetchFailed.Inc)

--- a/xlang/vfsutil/sourcegraph_archive.go
+++ b/xlang/vfsutil/sourcegraph_archive.go
@@ -1,0 +1,34 @@
+package vfsutil
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+)
+
+// NewSourcegraphRepoVFS downloads a zip archive from Sourcegraph's raw API and
+// returns a new VFS backed by that zip archive.
+func NewSourcegraphRepoVFS(repo, rev string) (*ArchiveFS, error) {
+	// TODO(chris) switch to the non-internal raw API once authorization is implemented.
+	url := api.InternalClient.URL + "/.internal/" + repo + "@" + rev + "/-/raw"
+	cacheKey := repo + "@" + rev
+	rootDirInZip := "/"
+	return NewZipVFS(url, cacheKey, rootDirInZip, sgFetch.Inc, sgFetchFailed.Inc)
+}
+
+var sgFetch = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: "xlang",
+	Subsystem: "vfs",
+	Name:      "sourcegraph_fetch_total",
+	Help:      "Total number of fetches by SourcegraphRepoVFS of zip archives from the Sourcegraph raw API.",
+})
+var sgFetchFailed = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: "xlang",
+	Subsystem: "vfs",
+	Name:      "sourcegraph_fetch_failed_total",
+	Help:      "Total number of fetches by SourcegraphRepoVFS of zip archives from the Sourcegraph raw API that failed.",
+})
+
+func init() {
+	prometheus.MustRegister(sgFetch)
+	prometheus.MustRegister(sgFetchFailed)
+}

--- a/xlang/vfsutil/zip.go
+++ b/xlang/vfsutil/zip.go
@@ -34,7 +34,7 @@ func NewZipVFS(url, cacheKey, rootDirInZip string, onFetchStart, onFetchFailed f
 			request.Header.Add("Accept", "application/zip")
 			resp, err := ctxhttp.Do(ctx, nil, request)
 			if err != nil {
-				return nil, errors.Errorf("failed to fetch zip archive from %s: %s", url, err)
+				return nil, errors.Wrapf(err, "failed to fetch zip archive from %s", url)
 			}
 			if resp.StatusCode != http.StatusOK {
 				resp.Body.Close()
@@ -44,14 +44,14 @@ func NewZipVFS(url, cacheKey, rootDirInZip string, onFetchStart, onFetchFailed f
 		})
 		if err != nil {
 			onFetchFailed()
-			return nil, errors.Errorf("failed to fetch/write/open zip archive from %s: %s", url, err)
+			return nil, errors.Wrapf(err, "failed to fetch/write/open zip archive from %s", url)
 		}
 		f := ff.File
 
 		zr, err := zipNewFileReader(f)
 		if err != nil {
 			f.Close()
-			return nil, errors.Errorf("failed to read zip archive associated with local disk cache key %s: %s", cacheKey, err)
+			return nil, errors.Wrapf(err, "failed to read zip archive associated with local disk cache key %s", cacheKey)
 		}
 
 		if len(zr.File) == 0 {

--- a/xlang/vfsutil/zip.go
+++ b/xlang/vfsutil/zip.go
@@ -1,0 +1,73 @@
+package vfsutil
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/pkg/errors"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+// NewZipVFS downloads a zip archive from a URL (or fetches from the local cache
+// on disk) and returns a new VFS backed by that zip archive.
+func NewZipVFS(url, cacheKey, rootDirInZip string, onFetchStart, onFetchFailed func()) (*ArchiveFS, error) {
+	fetch := func(ctx context.Context) (ar *archiveReader, err error) {
+		span, ctx := opentracing.StartSpanFromContext(ctx, "zip Fetch")
+		ext.Component.Set(span, "zipvfs")
+		span.SetTag("url", url)
+		defer func() {
+			if err != nil {
+				ext.Error.Set(span, true)
+				span.SetTag("err", err)
+			}
+			span.Finish()
+		}()
+
+		ff, err := cachedFetch(ctx, "zipvfs", cacheKey, func(ctx context.Context) (io.ReadCloser, error) {
+			onFetchStart()
+			request, err := http.NewRequest("GET", url, nil)
+			request.Header.Add("Accept", "application/zip")
+			resp, err := ctxhttp.Do(ctx, nil, request)
+			if err != nil {
+				return nil, errors.Errorf("failed to fetch zip archive from %s: %s", url, err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				resp.Body.Close()
+				return nil, errors.Errorf("zip URL %s returned HTTP %d", url, resp.StatusCode)
+			}
+			return resp.Body, nil
+		})
+		if err != nil {
+			onFetchFailed()
+			return nil, errors.Errorf("failed to fetch/write/open zip archive from %s: %s", url, err)
+		}
+		f := ff.File
+
+		zr, err := zipNewFileReader(f)
+		if err != nil {
+			f.Close()
+			return nil, errors.Errorf("failed to read zip archive associated with local disk cache key %s: %s", cacheKey, err)
+		}
+
+		if len(zr.File) == 0 {
+			f.Close()
+			return nil, errors.Errorf("zip archive %s is empty", cacheKey)
+		}
+
+		return &archiveReader{
+			Reader: zr,
+			Closer: f,
+			Prefix: rootDirInZip,
+		}, nil
+	}
+
+	// TODO(chris) don't eagerly fetch here. Instead, make a composite ArchiveFS
+	fs := &ArchiveFS{fetch: fetch}
+	err := fs.fetchOrWait(context.Background())
+	return fs, err
+}


### PR DESCRIPTION
⚠️ This PR targets `sg/raw` so that the diff only shows my changes, but I do not intend to merge it into `sg/raw`. I will retarget `master` once `sg/raw` is merged into `master`. ⚠️ 

**Note to reviewers** This PR is based on the new raw API https://github.com/sourcegraph/sourcegraph/pull/800, so jump to the end of the list of commits to find my changes.

Previously there were 3 sources from which xlang-go could get a zip archive (tried in this order):

- From gitserver over HTTP (can serve private repos, whatever exists on the Sourcegraph instance)
- From codeload.github.com over HTTP
- Full git clone, followed by `git archive --format=zip`

This PR adds the internal raw API `.internal/<repo>@<rev>/-/raw` to the top of that list of sources where xlang-go could get a zip archive for a particular repo@rev.

I have left gitserver in the list because I suspect that the xlang-go could be deployed and run against older Sourcegraph instances that do not support the raw API, which would result in no code intelligence on private repos (codeload.github.com and the full git clone are both unauthenticated). @keegancsmith Does this sound correct?

Conveniently, this change doesn't actually depend on the raw API, since the absence of the raw API will simply cause a 404 and xlang-go will happily try the next source in the list.

Looking ahead to when code gets moved to go-langserver and gitserver is omitted, I anticipate we'd like to add some command line flag to supply a comma-separated list of format specifiers for arbitrary zip archive URLS, for example:

```
$ xlang-go -ziptemplates=https://codeload.%s/zip/%s
$ xlang-go -ziptemplates=https://codeload.%s/zip/%s,http://frontend/.api/%s@%s/-/raw
```

This could easily provide support for Athens https://docs.gomods.io/intro/protocol/

> This PR does not need to update the CHANGELOG because this doesn't make any user-visible changes.
