### PR TITLE
use correct source ID when Bitbucket token is used

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -234,7 +234,11 @@ func RunBitbucketServerRepositorySyncWorker(ctx context.Context) {
 func updateBitbucketServerRepos(ctx context.Context, conn *bitbucketServerConnection) {
 	repoChan := make(chan repoCreateOrUpdateRequest)
 	defer close(repoChan)
-	go createEnableUpdateRepos(ctx, fmt.Sprintf("bitbucket:%s", conn.config.Username), repoChan)
+	sourceID := conn.config.Token
+	if sourceID == "" {
+		sourceID = conn.config.Username
+	}
+	go createEnableUpdateRepos(ctx, fmt.Sprintf("bitbucket:%s", sourceID), repoChan)
 	for r := range conn.listAllRepos(ctx) {
 		if r.State != "AVAILABLE" {
 			continue


### PR DESCRIPTION
Previously we would not correctly differentiate between multiple token sources for bitbucket.