### PR TITLE
SECURITY: allow UI endpoints to use access token authentication (take 2)

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -46,6 +46,7 @@ func newExternalHTTPHandler(ctx context.Context) (http.Handler, error) {
 	appHandler = handlerutil.CSRFMiddleware(appHandler, globals.ExternalURL.Scheme == "https") // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
 	appHandler = authMiddlewares.App(appHandler)                                               // 🚨 SECURITY: auth middleware
 	appHandler = session.CookieMiddleware(appHandler)                                          // app accepts cookies
+	appHandler = httpapi.AccessTokenAuthMiddleware(appHandler)                                 // app accepts access tokens
 
 	// Mount handlers and assets.
 	sm := http.NewServeMux()

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -20,6 +20,7 @@ func AccessTokenAuthMiddleware(next http.Handler) http.Handler {
 
 		var sudoUser string
 		token := r.URL.Query().Get("token")
+
 		if token == "" {
 			// Handle Authorization header
 			headerValue := r.Header.Get("Authorization")
@@ -39,6 +40,14 @@ func AccessTokenAuthMiddleware(next http.Handler) http.Handler {
 				log15.Error("Invalid Authorization header.", "err", err)
 				http.Error(w, "Invalid Authorization header.", http.StatusUnauthorized)
 				return
+			}
+		}
+
+		if token == "" {
+			// Handle token passed via basic auth (https://<token>@sourcegraph.com/foobar).
+			basicAuthUsername, _, _ := r.BasicAuth()
+			if basicAuthUsername != "" {
+				token = basicAuthUsername
 			}
 		}
 

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -127,29 +127,39 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 	})
 
 	// Test that an access token overwrites the actor set by a prior auth middleware.
-	t.Run("actor present, valid non-sudo token in query params", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/", nil)
-		q := url.Values{}
-		q.Add("token", "abcdef")
-		req.URL.RawQuery = q.Encode()
-		req = req.WithContext(actor.WithActor(context.Background(), &actor.Actor{UID: 456}))
-		var calledAccessTokensLookup bool
-		db.Mocks.AccessTokens.Lookup = func(tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
-			calledAccessTokensLookup = true
-			if want := "abcdef"; tokenHexEncoded != want {
-				t.Errorf("got %q, want %q", tokenHexEncoded, want)
+	const (
+		sourceQueryParam = "query-param"
+		sourceBasicAuth  = "basic-auth"
+	)
+	for _, source := range []string{sourceQueryParam, sourceBasicAuth} {
+		t.Run("actor present, valid non-sudo token in "+source, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			if source == sourceQueryParam {
+				q := url.Values{}
+				q.Add("token", "abcdef")
+				req.URL.RawQuery = q.Encode()
+			} else {
+				req.SetBasicAuth("abcdef", "")
 			}
-			if want := authz.ScopeUserAll; requiredScope != want {
-				t.Errorf("got %q, want %q", requiredScope, want)
+			req = req.WithContext(actor.WithActor(context.Background(), &actor.Actor{UID: 456}))
+			var calledAccessTokensLookup bool
+			db.Mocks.AccessTokens.Lookup = func(tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+				calledAccessTokensLookup = true
+				if want := "abcdef"; tokenHexEncoded != want {
+					t.Errorf("got %q, want %q", tokenHexEncoded, want)
+				}
+				if want := authz.ScopeUserAll; requiredScope != want {
+					t.Errorf("got %q, want %q", requiredScope, want)
+				}
+				return 123, nil
 			}
-			return 123, nil
-		}
-		defer func() { db.Mocks = db.MockStores{} }()
-		checkHTTPResponse(t, req, http.StatusOK, "user 123")
-		if !calledAccessTokensLookup {
-			t.Error("!calledAccessTokensLookup")
-		}
-	})
+			defer func() { db.Mocks = db.MockStores{} }()
+			checkHTTPResponse(t, req, http.StatusOK, "user 123")
+			if !calledAccessTokensLookup {
+				t.Error("!calledAccessTokensLookup")
+			}
+		})
+	}
 
 	t.Run("valid sudo token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/", nil)


### PR DESCRIPTION
This is a rebased version of #874. Please see individual commits for details.

This change is for supporting #800

> This PR does not need to update the CHANGELOG because not really user-facing.
