### PR TITLE
chore: ready for publishing sourcegraph module to npm locally

### DIFF
--- a/packages/sourcegraph-extension-api/node_modules/.bin
+++ b/packages/sourcegraph-extension-api/node_modules/.bin
@@ -1,0 +1,1 @@
+../../../node_modules/.bin/

--- a/packages/sourcegraph-extension-api/package.json
+++ b/packages/sourcegraph-extension-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcegraph",
-  "version": "20.0.0",
+  "version": "19.0.1",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",
   "bugs": {

--- a/packages/sourcegraph-extension-api/package.json
+++ b/packages/sourcegraph-extension-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcegraph",
-  "version": "19.0.0",
+  "version": "20.0.0",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",
   "bugs": {
@@ -15,11 +15,13 @@
   "module": "src/index.js",
   "types": "src/sourcegraph.d.ts",
   "files": [
-    "src"
+    "src",
+    "dist/docs"
   ],
   "sideEffects": false,
   "scripts": {
     "tslint": "tslint -c tslint.json -p tsconfig.json './src/**/*.{ts,js}'",
-    "docs": "typedoc"
+    "docs": "typedoc",
+    "prepublishOnly": "yarn run tslint && yarn run docs"
   }
 }


### PR DESCRIPTION
This PR does not need to update the CHANGELOG because it does not add, change or remove functionality.

This commit ensures that running `npm publish` from the `packages/sourcegraph-extension-api` directory locally will render the API docs for the sourcegraph.d.ts file and include that in the published package.
