### PR TITLE
fix: request field that code now uses

### DIFF
--- a/client/browser/src/shared/backend/extensions.ts
+++ b/client/browser/src/shared/backend/extensions.ts
@@ -193,9 +193,7 @@ const configurationCascadeFragment = gql`
             }
             latestSettings {
                 id
-                configuration {
-                    contents
-                }
+                contents
             }
             settingsURL
             viewerCanAdminister


### PR DESCRIPTION
Updates a gql request to use the field that [this PR](https://github.com/sourcegraph/sourcegraph/pull/872) changed all the code to use.