### PR TITLE
fix: allow authorization header from browser extension

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -152,7 +152,7 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 			if r.Method == "OPTIONS" {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type")
+				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization")
 				w.WriteHeader(http.StatusOK)
 				return // do not invoke next handler
 			}


### PR DESCRIPTION
Allow `Authorization` to be sent as an http header from allowed origins.

The browser extension code switched to using access tokens because we thought Chrome stopped sending the bundle ID as the request origin which broke some things. It turns out that Chrome seemingly randomly decides to send the bundle ID as the request origin instead of the page's origin. When the origin is the browser extension's bundle ID, we would get rejected by preflight header checks.

Closes https://github.com/sourcegraph/sourcegraph/issues/969.
