### PR TITLE
xlang-go: fetch from `zipURL` when present in `initializationOptions`

### DIFF
--- a/enterprise/cmd/xlang-go/internal/server/build_server.go
+++ b/enterprise/cmd/xlang-go/internal/server/build_server.go
@@ -177,7 +177,7 @@ func (h *BuildHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jso
 
 		// Determine the root import path of this workspace (e.g., "github.com/user/repo").
 		span.SetTag("originalRootPath", params.OriginalRootURI)
-		fs, err := RemoteFS(ctx, conn, params.OriginalRootURI)
+		fs, err := RemoteFS(ctx, conn, params)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/xlang-go/internal/server/deps.go
+++ b/enterprise/cmd/xlang-go/internal/server/deps.go
@@ -478,7 +478,15 @@ func FetchCommonDeps() {
 }
 
 // NewDepRepoVFS returns a virtual file system interface for accessing
-// the files in the specified (public) repo at the given commit.
+// the files in the specified repo at the given commit. The returned VFS
+// is always backed by a zip archive in memory. The following sources are
+// tried in sequence, and the first one that has the repo is used:
+//
+// 1. Directly from gitserver (will be removed in favor of the raw API soon)
+// 2. GitHub's codeload endpoint
+// 3. A full `git clone` followed by `git archive --format=zip <rev>`
+//
+// Sources 1 and 2 are performance optimizations over cloning the whole repo.
 var NewDepRepoVFS = func(ctx context.Context, cloneURL *url.URL, rev string) (ctxvfs.FileSystem, error) {
 	// First check if we can clone from gitserver. gitserver automatically
 	// clones missing repositories, so to prevent cloning unmanaged

--- a/enterprise/cmd/xlang-go/internal/server/integration_test.go
+++ b/enterprise/cmd/xlang-go/internal/server/integration_test.go
@@ -275,13 +275,13 @@ func useGithubForVFS() func() {
 	}
 
 	origRemoteFS := gobuildserver.RemoteFS
-	gobuildserver.RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, workspaceURI lsp.DocumentURI) (ctxvfs.FileSystem, error) {
-		u, err := gituri.Parse(string(workspaceURI))
+	gobuildserver.RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, initializeParams lspext.InitializeParams) (ctxvfs.FileSystem, error) {
+		u, err := gituri.Parse(string(initializeParams.OriginalRootURI))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse workspace URI for remotefs")
 		}
 		if u.Rev() == "" {
-			return nil, errors.Errorf("rev is required in uri: %s", workspaceURI)
+			return nil, errors.Errorf("rev is required in uri: %s", initializeParams.OriginalRootURI)
 		}
 		return vfsutil.NewGitHubRepoVFS(string(u.Repo()), u.Rev())
 	}

--- a/enterprise/cmd/xlang-go/internal/server/proxy_test.go
+++ b/enterprise/cmd/xlang-go/internal/server/proxy_test.go
@@ -607,7 +607,7 @@ func yza() {}
 				}()
 
 				origRemoteFS := gobuildserver.RemoteFS
-				gobuildserver.RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, workspaceURI lsp.DocumentURI) (ctxvfs.FileSystem, error) {
+				gobuildserver.RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, initializeParams lspext.InitializeParams) (ctxvfs.FileSystem, error) {
 					return mapFS(test.fs), nil
 				}
 

--- a/enterprise/cmd/xlang-go/internal/server/vfs.go
+++ b/enterprise/cmd/xlang-go/internal/server/vfs.go
@@ -25,19 +25,19 @@ import (
 // to read the repo. We assume permission checks happen before a request reaches
 // a build server.
 var RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, initializeParams lspext.InitializeParams) (ctxvfs.FileSystem, error) {
-	zipURL := func() *string {
+	zipURL := func() string {
 		initializationOptions, ok := initializeParams.InitializationOptions.(map[string]interface{})
 		if !ok {
-			return nil
+			return ""
 		}
 		url, ok := initializationOptions["zipURL"].(string)
 		if ok {
-			return &url
+			return url
 		}
-		return nil
+		return ""
 	}()
-	if zipURL != nil {
-		return vfsutil.NewZipVFS(*zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)
+	if zipURL != "" {
+		return vfsutil.NewZipVFS(zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)
 	}
 
 	gitURL, err := gituri.Parse(string(initializeParams.OriginalRootURI))

--- a/enterprise/cmd/xlang-go/internal/server/vfs.go
+++ b/enterprise/cmd/xlang-go/internal/server/vfs.go
@@ -4,30 +4,68 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/ctxvfs"
-	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/gituri"
 	"github.com/sourcegraph/sourcegraph/pkg/vfsutil"
+	"github.com/sourcegraph/sourcegraph/xlang/lspext"
 )
 
 // RemoteFS fetches a zip archive from gitserver and returns a virtual file
 // system interface for accessing the files in the specified repo at the given
 // commit.
 //
+// - If the originalRootUri is not git://, it is assumed to be a zip URL, so the zip archive is fetched from there.
+// - If zipURL is specified in the initializationOptions, the zip archive will be fetched from there.
+// - Otherwise, the zip is fetched from gitserver.
+//
 // SECURITY NOTE: This DOES NOT check that the user or context has permissions
 // to read the repo. We assume permission checks happen before a request reaches
 // a build server.
-var RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, workspaceURI lsp.DocumentURI) (ctxvfs.FileSystem, error) {
-	u, err := gituri.Parse(string(workspaceURI))
+var RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, initializeParams lspext.InitializeParams) (ctxvfs.FileSystem, error) {
+	zipURL := func() *string {
+		initializationOptions, ok := initializeParams.InitializationOptions.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		url, ok := initializationOptions["zipURL"].(string)
+		if ok {
+			return &url
+		}
+		return nil
+	}()
+	if zipURL != nil {
+		return vfsutil.NewZipVFS(*zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)
+	}
+
+	gitURL, err := gituri.Parse(string(initializeParams.OriginalRootURI))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse workspace URI for remotefs")
 	}
-	if u.Rev() == "" {
-		return nil, errors.Errorf("rev is required in uri: %s", workspaceURI)
+	if gitURL.Rev() == "" {
+		return nil, errors.Errorf("rev is required in uri: %s", initializeParams.OriginalRootURI)
 	}
-	archiveFS := vfsutil.NewGitServer(u.Repo(), api.CommitID(u.Rev()))
+	archiveFS := vfsutil.NewGitServer(gitURL.Repo(), api.CommitID(gitURL.Rev()))
 	archiveFS.EvictOnClose = true
 	return archiveFS, nil
+}
+
+var zipFetch = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: "xlang",
+	Subsystem: "vfs",
+	Name:      "zip_fetch_total",
+	Help:      "Total number of times a zip archive was fetched for the currently-viewed repo.",
+})
+var zipFetchFailed = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: "xlang",
+	Subsystem: "vfs",
+	Name:      "zip_fetch_failed_total",
+	Help:      "Total number of times fetching a zip archive for the currently-viewed repo failed.",
+})
+
+func init() {
+	prometheus.MustRegister(zipFetch)
+	prometheus.MustRegister(zipFetchFailed)
 }

--- a/enterprise/cmd/xlang-go/internal/server/vfs.go
+++ b/enterprise/cmd/xlang-go/internal/server/vfs.go
@@ -30,11 +30,8 @@ var RemoteFS = func(ctx context.Context, conn *jsonrpc2.Conn, initializeParams l
 		if !ok {
 			return ""
 		}
-		url, ok := initializationOptions["zipURL"].(string)
-		if ok {
-			return url
-		}
-		return ""
+		url, _ := initializationOptions["zipURL"].(string)
+		return url
 	}()
 	if zipURL != "" {
 		return vfsutil.NewZipVFS(zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)

--- a/pkg/vfsutil/archive.go
+++ b/pkg/vfsutil/archive.go
@@ -21,9 +21,14 @@ type archiveReader struct {
 	io.Closer
 	Evicter
 
-	// Prefix is the path prefix to strip. For example a GitHub archive
-	// has a top-level dir "{repobasename}-{sha}/".
-	Prefix string
+	// StripTopLevelDir specifies whether or not to strip the top level
+	// directory in the zip archive (e.g. GitHub archives always have 1 top
+	// level directory "{repobasename}-{sha}/").
+	StripTopLevelDir bool
+
+	// prefix is the name of the directory that was stripped from the archive
+	// (or "" if nothing was stripped).
+	prefix string
 }
 
 // ArchiveFS is a ctxvfs.FileSystem backed by an Archiver.
@@ -61,9 +66,16 @@ func (fs *ArchiveFS) fetchOrWait(ctx context.Context) error {
 		fs.ar, fs.err = fs.fetch(ctx)
 		if fs.err == nil {
 			fs.fs = zipfs.New(&zip.ReadCloser{Reader: *fs.ar.Reader}, "")
-			if fs.ar.Prefix != "" {
+			if fs.ar.StripTopLevelDir {
+				entries, err := fs.fs.ReadDir("/")
+				if err == nil && len(entries) == 1 && entries[0].IsDir() {
+					fs.ar.prefix = entries[0].Name()
+				}
+			}
+
+			if fs.ar.prefix != "" {
 				ns := vfs.NameSpace{}
-				ns.Bind("/", fs.fs, "/"+fs.ar.Prefix, vfs.BindReplace)
+				ns.Bind("/", fs.fs, "/"+fs.ar.prefix, vfs.BindReplace)
 				fs.fs = ns
 			}
 		}
@@ -107,7 +119,7 @@ func (fs *ArchiveFS) ListAllFiles(ctx context.Context) ([]string, error) {
 	filenames := make([]string, 0, len(fs.ar.File))
 	for _, f := range fs.ar.File {
 		if f.Mode().IsRegular() {
-			filenames = append(filenames, strings.TrimPrefix(f.Name, fs.ar.Prefix))
+			filenames = append(filenames, strings.TrimPrefix(f.Name, fs.ar.prefix))
 		}
 	}
 	return filenames, nil

--- a/pkg/vfsutil/archive.go
+++ b/pkg/vfsutil/archive.go
@@ -119,7 +119,7 @@ func (fs *ArchiveFS) ListAllFiles(ctx context.Context) ([]string, error) {
 	filenames := make([]string, 0, len(fs.ar.File))
 	for _, f := range fs.ar.File {
 		if f.Mode().IsRegular() {
-			filenames = append(filenames, strings.TrimPrefix(f.Name, fs.ar.prefix))
+			filenames = append(filenames, strings.TrimPrefix(f.Name, fs.ar.prefix+"/"))
 		}
 	}
 	return filenames, nil

--- a/pkg/vfsutil/github_archive.go
+++ b/pkg/vfsutil/github_archive.go
@@ -1,21 +1,10 @@
 package vfsutil
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"path"
 	"regexp"
-	"strings"
 
-	"golang.org/x/net/context/ctxhttp"
-
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 )
 
 // NewGitHubRepoVFS creates a new VFS backed by a GitHub downloadable
@@ -25,63 +14,8 @@ func NewGitHubRepoVFS(repo, rev string) (*ArchiveFS, error) {
 		return nil, fmt.Errorf(`invalid GitHub repo %q: must be "github.com/user/repo"`, repo)
 	}
 
-	fetch := func(ctx context.Context) (ar *archiveReader, err error) {
-		span, ctx := opentracing.StartSpanFromContext(ctx, "Archive Fetch")
-		ext.Component.Set(span, "githubvfs")
-		span.SetTag("repo", repo)
-		span.SetTag("commit", rev)
-		defer func() {
-			if err != nil {
-				ext.Error.Set(span, true)
-				span.SetTag("err", err)
-			}
-			span.Finish()
-		}()
-
-		ff, err := cachedFetch(ctx, "githubvfs", repo+"@"+rev, func(ctx context.Context) (io.ReadCloser, error) {
-			ghFetch.Inc()
-			url := fmt.Sprintf("https://codeload.%s/zip/%s", repo, rev)
-			resp, err := ctxhttp.Get(ctx, nil, url)
-			if err != nil {
-				return nil, err
-			}
-			if resp.StatusCode != http.StatusOK {
-				resp.Body.Close()
-				return nil, errors.Errorf("github repo archive: URL %s returned HTTP %d", url, resp.StatusCode)
-			}
-			return resp.Body, nil
-		})
-		if err != nil {
-			ghFetchFailed.Inc()
-			return nil, err
-		}
-		f := ff.File
-
-		zr, err := zipNewFileReader(f)
-		if err != nil {
-			f.Close()
-			return nil, err
-		}
-
-		// GitHub zip files have a top-level dir "{repobasename}-{sha}/",
-		// so we need to remove that. The repobasename is in the canonical
-		// casing, which may be different from fs.repo.
-		if len(zr.File) == 0 {
-			f.Close()
-			return nil, errors.New("zip archive has no files")
-		}
-		prefix := zr.File[0].Name
-		if strings.Contains(prefix, "/") {
-			prefix = path.Dir(prefix)
-		}
-
-		return &archiveReader{
-			Reader: zr,
-			Closer: f,
-			Prefix: prefix + "/",
-		}, nil
-	}
-	return &ArchiveFS{fetch: fetch}, nil
+	url := fmt.Sprintf("https://codeload.%s/zip/%s", repo, rev)
+	return NewZipVFS(url, ghFetch.Inc, ghFetchFailed.Inc, false)
 }
 
 var githubRepoRx = regexp.MustCompile(`^github\.com/[\w.-]{1,100}/[\w.-]{1,100}$`)

--- a/pkg/vfsutil/zip.go
+++ b/pkg/vfsutil/zip.go
@@ -1,0 +1,70 @@
+package vfsutil
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/pkg/errors"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+// NewZipVFS downloads a zip archive from a URL (or fetches from the local cache
+// on disk) and returns a new VFS backed by that zip archive.
+func NewZipVFS(url string, onFetchStart, onFetchFailed func(), evictOnClose bool) (*ArchiveFS, error) {
+	fetch := func(ctx context.Context) (ar *archiveReader, err error) {
+		span, ctx := opentracing.StartSpanFromContext(ctx, "zip Fetch")
+		ext.Component.Set(span, "zipvfs")
+		span.SetTag("url", url)
+		defer func() {
+			if err != nil {
+				ext.Error.Set(span, true)
+				span.SetTag("err", err)
+			}
+			span.Finish()
+		}()
+
+		ff, err := cachedFetch(ctx, "zipvfs", url, func(ctx context.Context) (io.ReadCloser, error) {
+			onFetchStart()
+			request, err := http.NewRequest("GET", url, nil)
+			request.Header.Add("Accept", "application/zip")
+			resp, err := ctxhttp.Do(ctx, nil, request)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to fetch zip archive from %s", url)
+			}
+			if resp.StatusCode != http.StatusOK {
+				resp.Body.Close()
+				return nil, errors.Errorf("zip URL %s returned HTTP %d", url, resp.StatusCode)
+			}
+			return resp.Body, nil
+		})
+		if err != nil {
+			onFetchFailed()
+			return nil, errors.Wrapf(err, "failed to fetch/write/open zip archive from %s", url)
+		}
+		f := ff.File
+
+		zr, err := zipNewFileReader(f)
+		if err != nil {
+			f.Close()
+			return nil, errors.Wrapf(err, "failed to read zip archive from %s", url)
+		}
+
+		if len(zr.File) == 0 {
+			f.Close()
+			return nil, errors.Errorf("zip archive from %s is empty", url)
+		}
+
+		return &archiveReader{
+			Reader:           zr,
+			Closer:           f,
+			StripTopLevelDir: true,
+		}, nil
+	}
+
+	return &ArchiveFS{fetch: fetch, EvictOnClose: evictOnClose}, nil
+}

--- a/pkg/vfsutil/zip.go
+++ b/pkg/vfsutil/zip.go
@@ -31,6 +31,9 @@ func NewZipVFS(url string, onFetchStart, onFetchFailed func(), evictOnClose bool
 		ff, err := cachedFetch(ctx, "zipvfs", url, func(ctx context.Context) (io.ReadCloser, error) {
 			onFetchStart()
 			request, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to construct a new request with URL %s", url)
+			}
 			request.Header.Add("Accept", "application/zip")
 			resp, err := ctxhttp.Do(ctx, nil, request)
 			if err != nil {

--- a/xlang/lspext/lspext.go
+++ b/xlang/lspext/lspext.go
@@ -169,4 +169,7 @@ type ClientProxyInitializationOptions struct {
 	// LSP sessions using the same workspace and mode. See
 	// (contextID).session for more information.
 	Session string `json:"session,omitempty"`
+
+	// ZipURL is the zip URL to forward to the language server.
+	ZipURL string `json:"zipURL,omitempty"`
 }

--- a/xlang/proxy/client_proxy.go
+++ b/xlang/proxy/client_proxy.go
@@ -226,10 +226,13 @@ type contextID struct {
 	session string
 
 	share bool // if true, allow sharing server connections among multiple clients (with equal contextID values)
+
+	// zipURL is the URL where a language server can fetch a zip archive of the code files.
+	zipURL string `json:"zipURL,omitempty"`
 }
 
 func (id contextID) String() string {
-	return fmt.Sprintf("context(%s mode=%s session=%q)", id.rootURI.String(), id.mode, id.session)
+	return fmt.Sprintf("context(%s mode=%s session=%q zipURL=%q)", id.rootURI.String(), id.mode, id.session, id.zipURL)
 }
 
 // clientID is used to uniquely identify a client connection in this
@@ -427,6 +430,7 @@ func (c *clientProxyConn) handle(ctx context.Context, conn *jsonrpc2.Conn, req *
 		c.context.rootURI = *rootURI
 		c.context.mode = c.init.InitializationOptions.Mode
 		c.context.session = c.init.InitializationOptions.Session
+		c.context.zipURL = c.init.InitializationOptions.ZipURL
 		isolated := c.context.session == "isolated" // special value "isolated" yields a server-side generated unique session value
 		c.context.share = !isolated
 		if isolated {

--- a/xlang/proxy/client_proxy.go
+++ b/xlang/proxy/client_proxy.go
@@ -228,7 +228,7 @@ type contextID struct {
 	share bool // if true, allow sharing server connections among multiple clients (with equal contextID values)
 
 	// zipURL is the URL where a language server can fetch a zip archive of the code files.
-	zipURL string `json:"zipURL,omitempty"`
+	zipURL string
 }
 
 func (id contextID) String() string {

--- a/xlang/proxy/server_proxy.go
+++ b/xlang/proxy/server_proxy.go
@@ -499,7 +499,7 @@ func (c *serverProxyConn) lspInitialize(ctx context.Context) (*lsp.InitializeRes
 		Mode:            c.id.mode,
 	}
 
-	initParams.InitializationOptions = getInitializationOptions(ctx, c.id.mode)
+	initParams.InitializationOptions = getInitializationOptions(ctx, c.id)
 
 	var res lsp.InitializeResult
 	err := c.conn.Call(ctx, "initialize", initParams, &res, addTraceMeta(ctx))

--- a/xlang/proxy/util.go
+++ b/xlang/proxy/util.go
@@ -37,7 +37,8 @@ func (e *errorList) error() error {
 
 // getInitializationOptions returns the initializationOptions value to use in an LSP
 // initialize request.
-func getInitializationOptions(ctx context.Context, lang string) map[string]interface{} {
+func getInitializationOptions(ctx context.Context, id serverID) map[string]interface{} {
+	lang := id.mode
 	// HACK: if a ${lang}_bg request, strip the trailing suffix. We should really clean up the logic
 	// that handles background language servers to deal with them in a more principled fashion. In
 	// the meantime, this unbreaks background language server requests.
@@ -46,7 +47,12 @@ func getInitializationOptions(ctx context.Context, lang string) map[string]inter
 	}
 	for _, ls := range conf.EnabledLangservers() {
 		if ls.Language == lang {
-			return ls.InitializationOptions
+			initializationOptions := make(map[string]interface{})
+			for k, v := range ls.InitializationOptions {
+				initializationOptions[k] = v
+			}
+			initializationOptions["zipURL"] = id.zipURL
+			return initializationOptions
 		}
 	}
 	return nil


### PR DESCRIPTION
This adds support to xlang-go for checking for a new `zipURL` field in the `initializationOptions` in the `initialize` LSP request, and fetching the current repo's files from there if it's present. xlang-go will fall back to the old behavior of fetching from gitserver when that field is absent.

`zipURL` will be constructed by lang-go and passed to Go buildserver through LSP Proxy (see the [commit where I added it to lang-go](https://github.com/sourcegraph/lang-go/commit/280de6bce76b62f52d92821cdad44f6e75122933)).

> This PR does not need to update the CHANGELOG because 
