### PR TITLE
Add GitHub authz provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 - A new Explore area is linked from the top navigation bar (when the `localStorage.explore=true;location.reload()` feature flag is enabled).
 - Authentication via GitHub is now supported. To enable, add an item to the `auth.providers` list with `type: "github"`.
+- GitHub repository permissions are supported if authentication via GitHub is enabled. See the
+  documentation for the `authorization` field of the `GitHubConnection` configuration.
 - The repository settings mirroring page now shows when a repo is next scheduled for an update (requires experiment `"updateScheduler2": "enabled"`).
 - Configured repositories are periodically scheduled for updates using a new algorithm. You can disable the new algorithm with the following site configuration: `"experimentalFeatures": { "updateScheduler2": "disabled" }`. If you do so, please file a public issue to describe why you needed to disable it.
 - When using HTTP header authentication, [`stripUsernameHeaderPrefix`](https://docs.sourcegraph.com/admin/auth/#username-header-prefixes) field lets an admin specify a prefix to strip from the HTTP auth header when converting the header value to a username.

--- a/cmd/frontend/internal/authz/github/cache.go
+++ b/cmd/frontend/internal/authz/github/cache.go
@@ -1,0 +1,34 @@
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// pcache describes the shape of the repo permissions cache that Provider uses internally.
+type pcache interface {
+	GetMulti(keys ...string) [][]byte
+	SetMulti(keyvals ...[2]string)
+	Get(key string) ([]byte, bool)
+	Set(key string, b []byte)
+	Delete(key string)
+}
+
+type userRepoCacheKey struct {
+	User string
+	Repo string
+}
+
+type userRepoCacheVal struct {
+	Read bool
+	TTL  time.Duration
+}
+
+func publicRepoCacheKey(ghrepoID string) string {
+	return fmt.Sprintf("r:%s", ghrepoID)
+}
+
+type publicRepoCacheVal struct {
+	Public bool
+	TTL    time.Duration
+}

--- a/cmd/frontend/internal/authz/github/github.go
+++ b/cmd/frontend/internal/authz/github/github.go
@@ -1,0 +1,334 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/pkg/rcache"
+)
+
+type Provider struct {
+	client   *github.Client
+	codeHost *github.CodeHost
+	cacheTTL time.Duration
+	cache    pcache
+}
+
+type pcache interface {
+	GetMulti(keys ...string) [][]byte
+	SetMulti(keyvals ...[2]string)
+	Get(key string) ([]byte, bool)
+	Set(key string, b []byte)
+	Delete(key string)
+}
+
+func NewProvider(githubURL *url.URL, baseToken string, cacheTTL time.Duration, mockCache pcache) *Provider {
+	apiURL, _ := github.APIRoot(githubURL)
+	client := github.NewClient(apiURL, baseToken, nil)
+
+	p := &Provider{
+		codeHost: github.NewCodeHost(githubURL),
+		client:   client,
+		cache:    mockCache,
+		cacheTTL: cacheTTL,
+	}
+	// Note: this will use the same underlying Redis instance and key namespace for every instance
+	// of Provider.  This is by design, so that different instances, even in different processes,
+	// will share cache entries.
+	if p.cache == nil {
+		p.cache = rcache.NewWithTTL(fmt.Sprintf("githubAuthz:%s", githubURL.String()), int(math.Ceil(cacheTTL.Seconds())))
+	}
+	return p
+}
+
+var _ authz.Provider = ((*Provider)(nil))
+
+func (p *Provider) Repos(ctx context.Context, repos map[authz.Repo]struct{}) (mine map[authz.Repo]struct{}, others map[authz.Repo]struct{}) {
+	return authz.GetCodeHostRepos(p.codeHost, repos)
+}
+
+type userRepoCacheVal struct {
+	Read bool
+	TTL  time.Duration
+}
+
+type publicRepoCacheVal struct {
+	Public bool
+	TTL    time.Duration
+}
+
+func (p *Provider) RepoPerms(ctx context.Context, userAccount *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (map[api.RepoName]map[authz.Perm]bool, error) {
+	repos, _ = p.Repos(ctx, repos)
+	if len(repos) == 0 {
+		return nil, nil
+	}
+
+	explicitRepos, err := p.userRepos(ctx, userAccount, repos)
+	if err != nil {
+		return nil, err
+	}
+
+	perms := make(map[api.RepoName]map[authz.Perm]bool) // permissions to return
+	var nonExplicitRepos map[authz.Repo]struct{}
+	if explicitRepos == nil {
+		nonExplicitRepos = repos
+	} else {
+		// repos to which user doesn't have explicit access
+		nonExplicitRepos = map[authz.Repo]struct{}{}
+		for repo := range repos {
+			if hasAccess, ok := explicitRepos[repo.ExternalRepoSpec.ID]; ok {
+				perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: hasAccess}
+			} else {
+				nonExplicitRepos[repo] = struct{}{}
+			}
+		}
+	}
+
+	if len(nonExplicitRepos) > 0 {
+		publicRepos, err := p.publicRepos(ctx, nonExplicitRepos)
+		if err != nil {
+			return nil, err
+		}
+		if publicRepos != nil {
+			for repo := range nonExplicitRepos {
+				if publicRepos[repo.ExternalRepoSpec.ID] {
+					perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: true}
+				}
+			}
+		}
+	}
+
+	return perms, nil
+}
+
+func (p *Provider) publicRepos(ctx context.Context, repos map[authz.Repo]struct{}) (map[string]bool, error) {
+	cachedIsPublic, err := p.getCachedPublicRepos(ctx, repos)
+	if err != nil {
+		return nil, err
+	}
+	if len(cachedIsPublic) >= len(repos) {
+		return cachedIsPublic, nil
+	}
+
+	missing := make(map[string]struct{})
+	for r := range repos {
+		if _, ok := cachedIsPublic[r.ExternalRepoSpec.ID]; !ok {
+			missing[r.ExternalRepoSpec.ID] = struct{}{}
+		}
+	}
+
+	missingIsPublic, err := p.fetchPublicRepos(ctx, missing)
+	if err != nil {
+		return nil, err
+	}
+	p.setCachedPublicRepos(ctx, missingIsPublic)
+
+	for k, v := range missingIsPublic {
+		cachedIsPublic[k] = v
+	}
+	return cachedIsPublic, nil
+}
+
+func (p *Provider) setCachedPublicRepos(ctx context.Context, isPublic map[string]bool) error {
+	setArgs := make([][2]string, 0, len(isPublic))
+	for k, v := range isPublic {
+		key := fmt.Sprintf("r:%s", k)
+		val, err := json.Marshal(publicRepoCacheVal{
+			Public: v,
+			TTL:    p.cacheTTL,
+		})
+		if err != nil {
+			return err
+		}
+		setArgs = append(setArgs, [2]string{key, string(val)})
+	}
+	p.cache.SetMulti(setArgs...)
+	return nil
+}
+
+func (p *Provider) getCachedPublicRepos(ctx context.Context, repos map[authz.Repo]struct{}) (isPublic map[string]bool, err error) {
+	if len(repos) == 0 {
+		return nil, nil
+	}
+	isPublic = make(map[string]bool)
+	repoList := make([]string, 0, len(repos))
+	getArgs := make([]string, 0, len(repos))
+	for r := range repos {
+		getArgs = append(getArgs, fmt.Sprintf("r:%s", r))
+		repoList = append(repoList, r.ExternalRepoSpec.ID)
+	}
+	vals := p.cache.GetMulti(getArgs...)
+	if len(vals) != len(repos) {
+		return nil, fmt.Errorf("number of cache items did not match number of keys")
+	}
+
+	for i, v := range vals {
+		if len(v) == 0 {
+			continue
+		}
+		var val publicRepoCacheVal
+		if err := json.Unmarshal(v, &val); err != nil {
+			return nil, err
+		}
+		isPublic[repoList[i]] = val.Public
+	}
+
+	return isPublic, nil
+}
+
+// fetchPublicRepos returns a map where the keys are GitHub repository node IDs and the values are booleans
+// indicating whether a repository is public (true) or private (false).
+func (p *Provider) fetchPublicRepos(ctx context.Context, repos map[string]struct{}) (map[string]bool, error) {
+	isPublic := make(map[string]bool)
+	for ghRepoID := range repos {
+		ghRepo, err := p.client.GetRepositoryByNodeID(ctx, "", ghRepoID)
+		if err == github.ErrNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		isPublic[ghRepoID] = !ghRepo.IsPrivate
+	}
+	return isPublic, nil
+}
+
+func (p *Provider) userRepos(ctx context.Context, userAccount *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (isAllowed map[string]bool, err error) {
+	if userAccount == nil {
+		return nil, nil
+	}
+	cachedUserRepos, err := p.getCachedUserRepos(ctx, userAccount, repos)
+	if err != nil {
+		return nil, err
+	}
+	if len(cachedUserRepos) >= len(repos) {
+		return cachedUserRepos, nil
+	}
+
+	missing := make(map[string]struct{})
+	for r := range repos {
+		if _, ok := cachedUserRepos[r.ExternalRepoSpec.ID]; !ok {
+			missing[r.ExternalRepoSpec.ID] = struct{}{}
+		}
+	}
+
+	uncachedUserRepos := make(map[string]bool)
+	publicRepos := make(map[string]bool)
+	for r := range missing {
+		canAccess, isPublic, err := p.fetchUserRepo(ctx, userAccount, r)
+		if err != nil {
+			return nil, err
+		}
+		uncachedUserRepos[r] = canAccess
+		publicRepos[r] = isPublic
+	}
+
+	if err := p.setCachedUserRepos(ctx, userAccount, uncachedUserRepos); err != nil {
+		return nil, err
+	}
+	if err := p.setCachedPublicRepos(ctx, publicRepos); err != nil { // also cache whether repos are public
+		return nil, err
+	}
+	for k, v := range uncachedUserRepos {
+		cachedUserRepos[k] = v
+	}
+	return cachedUserRepos, nil
+}
+
+func (p *Provider) fetchUserRepo(ctx context.Context, userAccount *extsvc.ExternalAccount, repoID string) (canAccess bool, isPublic bool, err error) {
+	_, tok, err := github.GetExternalAccountData(&userAccount.ExternalAccountData)
+	if err != nil {
+		return false, false, err
+	}
+	ghRepo, err := p.client.GetRepositoryByNodeID(ctx, tok.AccessToken, repoID)
+	if err != nil {
+		if err == github.ErrNotFound {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	return true, !ghRepo.IsPrivate, nil
+}
+
+func (p *Provider) setCachedUserRepos(ctx context.Context, userAccount *extsvc.ExternalAccount, isAllowed map[string]bool) error {
+	setArgs := make([][2]string, 0, len(isAllowed))
+	for k, v := range isAllowed {
+		rkey, err := json.Marshal(struct {
+			User string
+			Repo string
+		}{userAccount.AccountID, k})
+		if err != nil {
+			return err
+		}
+		rval, err := json.Marshal(userRepoCacheVal{
+			Read: v,
+			TTL:  p.cacheTTL,
+		})
+		if err != nil {
+			return err
+		}
+		setArgs = append(setArgs, [2]string{string(rkey), string(rval)})
+	}
+	p.cache.SetMulti(setArgs...)
+	return nil
+}
+
+func (p *Provider) getCachedUserRepos(ctx context.Context, userAccount *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (map[string]bool, error) {
+	getArgs := make([]string, 0, len(repos))
+	repoList := make([]string, 0, len(repos))
+	for repo := range repos {
+		rkey, err := json.Marshal(struct {
+			User string
+			Repo string
+		}{userAccount.AccountID, repo.ExternalRepoSpec.ID})
+		if err != nil {
+			return nil, err
+		}
+		getArgs = append(getArgs, string(rkey))
+		repoList = append(repoList, repo.ExternalRepoSpec.ID)
+	}
+
+	cacheVals := p.cache.GetMulti(getArgs...)
+	if len(cacheVals) == 0 {
+		return nil, nil
+	}
+	cachedIsAllowed := make(map[string]bool)
+	for i, v := range cacheVals {
+		if len(v) == 0 {
+			continue
+		}
+
+		var val userRepoCacheVal
+		if err := json.Unmarshal(v, &val); err != nil {
+			return nil, err
+		}
+		cachedIsAllowed[repoList[i]] = val.Read
+	}
+	return cachedIsAllowed, nil
+}
+
+// FetchAccount always returns nil, because the GitHub API doesn't currently provide a way to fetch user by external SSO account.
+func (p *Provider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+	return nil, nil
+}
+
+func (p *Provider) ServiceID() string {
+	return p.codeHost.ServiceID()
+}
+
+func (p *Provider) ServiceType() string {
+	return p.codeHost.ServiceType()
+}
+
+func (p *Provider) Validate() (problems []string) {
+	return nil
+}

--- a/cmd/frontend/internal/authz/github/github_test.go
+++ b/cmd/frontend/internal/authz/github/github_test.go
@@ -1,0 +1,273 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
+	"golang.org/x/oauth2"
+)
+
+type Provider_RepoPerms_Test struct {
+	description string
+	githubURL   *url.URL
+	cacheTTL    time.Duration
+	calls       []Provider_RepoPerms_call
+}
+
+type Provider_RepoPerms_call struct {
+	description string
+	userAccount *extsvc.ExternalAccount
+	repos       map[authz.Repo]struct{}
+	wantPerms   map[api.RepoName]map[authz.Perm]bool
+	wantErr     error
+}
+
+func (p *Provider_RepoPerms_Test) run(t *testing.T) {
+	githubMock := newMockGitHub([]*github.Repository{
+		{ID: "u0/private"},
+		{ID: "u0/public"},
+		{ID: "u1/private"},
+		{ID: "u1/public"},
+		{ID: "u99/private"},
+		{ID: "u99/public"},
+	}, map[string][]string{
+		"t0": []string{"u0/private", "u0/public"},
+		"t1": []string{"u1/private", "u1/public"},
+	}, []string{"u0/public", "u1/public", "u99/public"})
+	github.GetRepositoryByNodeIDMock = githubMock.GetRepositoryByNodeID
+
+	provider := NewProvider(p.githubURL, "base-token", p.cacheTTL, make(authz.MockCache))
+	for j := 0; j < 2; j++ { // run twice for cache coherency
+		for _, c := range p.calls {
+			t.Run(fmt.Sprintf("%s: run %d", c.description, j), func(t *testing.T) {
+				c := c
+				ctx := context.Background()
+
+				gotPerms, gotErr := provider.RepoPerms(ctx, c.userAccount, c.repos)
+				if gotErr != c.wantErr {
+					t.Errorf("expected err %v, got err %v", c.wantErr, gotErr)
+				} else if !reflect.DeepEqual(gotPerms, c.wantPerms) {
+					dmp := diffmatchpatch.New()
+					t.Errorf("expected perms did not equal actual, diff:\n%s",
+						dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(c.wantPerms), spew.Sdump(gotPerms), false)))
+				}
+			})
+		}
+	}
+}
+
+func TestProvider_RepoPerms(t *testing.T) {
+	tests := []Provider_RepoPerms_Test{
+		{
+			description: "common_case",
+			githubURL:   mustURL(t, "https://github.com"),
+			cacheTTL:    3 * time.Hour,
+			calls: []Provider_RepoPerms_call{
+				{
+					description: "t0_repos",
+					userAccount: ua("u0", "t0"),
+					repos: map[authz.Repo]struct{}{
+						rp("r0", "u0/private", "https://github.com/"):  struct{}{},
+						rp("r1", "u0/public", "https://github.com/"):   struct{}{},
+						rp("r2", "u1/private", "https://github.com/"):  struct{}{},
+						rp("r3", "u1/public", "https://github.com/"):   struct{}{},
+						rp("r4", "u99/private", "https://github.com/"): struct{}{},
+						rp("r5", "u99/public", "https://github.com/"):  struct{}{},
+					},
+					wantPerms: map[api.RepoName]map[authz.Perm]bool{
+						"r0": readPerms,
+						"r1": readPerms,
+						"r2": noPerms,
+						"r3": readPerms,
+						"r4": noPerms,
+						"r5": readPerms,
+					},
+				},
+				{
+					description: "t1_repos",
+					userAccount: ua("u1", "t1"),
+					repos: map[authz.Repo]struct{}{
+						rp("r0", "u0/private", "https://github.com/"):  struct{}{},
+						rp("r1", "u0/public", "https://github.com/"):   struct{}{},
+						rp("r2", "u1/private", "https://github.com/"):  struct{}{},
+						rp("r3", "u1/public", "https://github.com/"):   struct{}{},
+						rp("r4", "u99/private", "https://github.com/"): struct{}{},
+						rp("r5", "u99/public", "https://github.com/"):  struct{}{},
+					},
+					wantPerms: map[api.RepoName]map[authz.Perm]bool{
+						"r0": noPerms,
+						"r1": readPerms,
+						"r2": readPerms,
+						"r3": readPerms,
+						"r4": noPerms,
+						"r5": readPerms,
+					},
+				},
+				{
+					description: "repos_with_unknown_token_(only_public_repos)",
+					userAccount: ua("unknown-user", "unknown-token"),
+					repos: map[authz.Repo]struct{}{
+						rp("r0", "u0/private", "https://github.com/"):  struct{}{},
+						rp("r1", "u0/public", "https://github.com/"):   struct{}{},
+						rp("r2", "u1/private", "https://github.com/"):  struct{}{},
+						rp("r3", "u1/public", "https://github.com/"):   struct{}{},
+						rp("r4", "u99/private", "https://github.com/"): struct{}{},
+						rp("r5", "u99/public", "https://github.com/"):  struct{}{},
+					},
+					wantPerms: map[api.RepoName]map[authz.Perm]bool{
+						"r0": noPerms,
+						"r1": readPerms,
+						"r2": noPerms,
+						"r3": readPerms,
+						"r4": noPerms,
+						"r5": readPerms,
+					},
+				},
+				{
+					description: "public repos",
+					userAccount: nil,
+					repos: map[authz.Repo]struct{}{
+						rp("r0", "u0/private", "https://github.com/"):  struct{}{},
+						rp("r1", "u0/public", "https://github.com/"):   struct{}{},
+						rp("r2", "u1/private", "https://github.com/"):  struct{}{},
+						rp("r3", "u1/public", "https://github.com/"):   struct{}{},
+						rp("r4", "u99/private", "https://github.com/"): struct{}{},
+						rp("r5", "u99/public", "https://github.com/"):  struct{}{},
+					},
+					wantPerms: map[api.RepoName]map[authz.Perm]bool{
+						"r1": readPerms,
+						"r3": readPerms,
+						"r5": readPerms,
+					},
+				},
+				{
+					description: "t0 select",
+					userAccount: ua("u0", "t0"),
+					repos: map[authz.Repo]struct{}{
+						rp("r2", "u1/private", "https://github.com/"): struct{}{},
+					},
+					wantPerms: map[api.RepoName]map[authz.Perm]bool{
+						"r2": noPerms,
+					},
+				},
+				{
+					description: "t0 missing",
+					userAccount: ua("u0", "t0"),
+					repos: map[authz.Repo]struct{}{
+						rp("r00", "404", "https://github.com/"):             struct{}{},
+						rp("r11", "u0/public", "https://other.github.com/"): struct{}{},
+					},
+					wantPerms: map[api.RepoName]map[authz.Perm]bool{
+						"r00": noPerms,
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, test.run)
+	}
+}
+
+var (
+	readPerms = map[authz.Perm]bool{authz.Read: true}
+	noPerms   = map[authz.Perm]bool{authz.Read: false}
+)
+
+func mustURL(t *testing.T, u string) *url.URL {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}
+
+func ua(accountID, token string) *extsvc.ExternalAccount {
+	var a extsvc.ExternalAccount
+	a.AccountID = accountID
+	github.SetExternalAccountData(&a.ExternalAccountData, nil, &oauth2.Token{
+		AccessToken: token,
+	})
+	return &a
+}
+func rp(name, ghid, serviceID string) authz.Repo {
+	return authz.Repo{
+		RepoName: api.RepoName(name),
+		ExternalRepoSpec: api.ExternalRepoSpec{
+			ID:          ghid,
+			ServiceType: github.ServiceType,
+			ServiceID:   serviceID,
+		},
+	}
+}
+
+type mockGitHub struct {
+	// Repos is a map from repo ID to repository
+	Repos map[string]*github.Repository
+
+	// TokenRepos is a map from auth token to list of repo IDs that are explicitly readable with that token
+	TokenRepos map[string]map[string]struct{}
+
+	// PublicRepos is the set of repo IDs corresponding to public repos
+	PublicRepos map[string]struct{}
+}
+
+func newMockGitHub(repos []*github.Repository, tokenRepos map[string][]string, publicRepos []string) *mockGitHub {
+	rp := make(map[string]*github.Repository)
+	for _, r := range repos {
+		rp[r.ID] = r
+	}
+	tr := make(map[string]map[string]struct{})
+	for t, rps := range tokenRepos {
+		tr[t] = make(map[string]struct{})
+		for _, r := range rps {
+			tr[t][r] = struct{}{}
+		}
+	}
+	pr := make(map[string]struct{})
+	for _, r := range publicRepos {
+		pr[r] = struct{}{}
+	}
+	return &mockGitHub{
+		Repos:       rp,
+		TokenRepos:  tr,
+		PublicRepos: pr,
+	}
+}
+
+func (m *mockGitHub) GetRepositoryByNodeID(ctx context.Context, token, id string) (repo *github.Repository, err error) {
+	if _, isPublic := m.PublicRepos[id]; isPublic {
+		r, ok := m.Repos[id]
+		if !ok {
+			return nil, github.ErrNotFound
+		}
+		return r, nil
+	}
+
+	if token == "" {
+		return nil, github.ErrNotFound
+	}
+
+	tr := m.TokenRepos[token]
+	if tr == nil {
+		return nil, github.ErrNotFound
+	}
+	if _, explicit := tr[id]; !explicit {
+		return nil, github.ErrNotFound
+	}
+	r, ok := m.Repos[id]
+	if !ok {
+		return nil, github.ErrNotFound
+	}
+	return r, nil
+}

--- a/cmd/frontend/internal/authz/mock.go
+++ b/cmd/frontend/internal/authz/mock.go
@@ -1,0 +1,29 @@
+package authz
+
+type MockCache map[string]string
+
+func (m MockCache) Get(key string) ([]byte, bool) {
+	v, ok := m[key]
+	return []byte(v), ok
+}
+func (m MockCache) GetMulti(keys ...string) [][]byte {
+	if keys == nil {
+		return nil
+	}
+	vals := make([][]byte, len(keys))
+	for i, k := range keys {
+		vals[i] = []byte(m[k])
+	}
+	return vals
+}
+func (m MockCache) Set(key string, b []byte) {
+	m[key] = string(b)
+}
+func (m MockCache) SetMulti(keyvals ...[2]string) {
+	for _, kv := range keyvals {
+		m[kv[0]] = kv[1]
+	}
+}
+func (m MockCache) Delete(key string) {
+	delete(m, key)
+}

--- a/cmd/frontend/shared/authz.go
+++ b/cmd/frontend/shared/authz.go
@@ -41,5 +41,10 @@ func providersFromConfig(cfg *schema.SiteConfiguration) (
 	seriousProblems = append(seriousProblems, glproblems...)
 	warnings = append(warnings, glwarnings...)
 
+	ghp, ghproblems, ghwarnings := githubProvidersFromConfig(cfg)
+	authzProviders = append(authzProviders, ghp...)
+	seriousProblems = append(seriousProblems, ghproblems...)
+	warnings = append(warnings, ghwarnings...)
+
 	return allowAccessByDefault, authzProviders, seriousProblems, warnings
 }

--- a/cmd/frontend/shared/authz_github.go
+++ b/cmd/frontend/shared/authz_github.go
@@ -1,0 +1,35 @@
+package shared
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz"
+	permgh "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz/github"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func githubProvidersFromConfig(cfg *schema.SiteConfiguration) (
+	authzProviders []authz.Provider,
+	seriousProblems []string,
+	warnings []string,
+) {
+	for _, g := range cfg.Github {
+		if g.Authorization == nil {
+			continue
+		}
+
+		ghURL, err := url.Parse(g.Url)
+		if err != nil {
+			seriousProblems = append(seriousProblems, fmt.Sprintf("Could not parse URL for GitHub instance %q: %s", g.Url, err))
+			continue // omit authz provider if could not parse URL
+		}
+
+		var ttl time.Duration
+		ttl, warnings = parseTTLOrDefault(g.Authorization.Ttl, 3*time.Hour, warnings)
+
+		authzProviders = append(authzProviders, permgh.NewProvider(ghURL, g.Token, ttl, nil))
+	}
+	return authzProviders, seriousProblems, warnings
+}

--- a/cmd/frontend/shared/authz_gitlab.go
+++ b/cmd/frontend/shared/authz_gitlab.go
@@ -31,15 +31,7 @@ func gitlabProvidersFromConfig(cfg *schema.SiteConfiguration) (
 		}
 
 		var ttl time.Duration
-		if gl.Authorization.Ttl == "" {
-			ttl = time.Hour * 3
-		} else {
-			ttl, err = time.ParseDuration(gl.Authorization.Ttl)
-			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("Could not parse time duration %q, falling back to 3 hours.", gl.Authorization.Ttl))
-				ttl = time.Hour * 3
-			}
-		}
+		ttl, warnings = parseTTLOrDefault(gl.Authorization.Ttl, 3*time.Hour, warnings)
 
 		op := permgl.GitLabAuthzProviderOp{
 			BaseURL:   glURL,

--- a/cmd/frontend/shared/authz_test.go
+++ b/cmd/frontend/shared/authz_test.go
@@ -65,7 +65,7 @@ func Test_providersFromConfig(t *testing.T) {
 				},
 				Gitlab: []*schema.GitLabConnection{
 					{
-						Authorization: &schema.Authorization{
+						Authorization: &schema.GitLabAuthorization{
 							AuthnProvider: schema.AuthnProvider{
 								ConfigID:       "okta-config-id",
 								Type:           "saml",
@@ -110,7 +110,7 @@ func Test_providersFromConfig(t *testing.T) {
 				},
 				Gitlab: []*schema.GitLabConnection{
 					{
-						Authorization: &schema.Authorization{
+						Authorization: &schema.GitLabAuthorization{
 							AuthnProvider: schema.AuthnProvider{
 								ConfigID:       "onelogin-config-id",
 								GitlabProvider: "onelogin",
@@ -121,7 +121,7 @@ func Test_providersFromConfig(t *testing.T) {
 						Token: "asdf",
 					},
 					{
-						Authorization: &schema.Authorization{
+						Authorization: &schema.GitLabAuthorization{
 							AuthnProvider: schema.AuthnProvider{
 								ConfigID:       "okta-config-id",
 								GitlabProvider: "okta",
@@ -160,7 +160,7 @@ func Test_providersFromConfig(t *testing.T) {
 			cfg: schema.SiteConfiguration{
 				Gitlab: []*schema.GitLabConnection{
 					{
-						Authorization: &schema.Authorization{
+						Authorization: &schema.GitLabAuthorization{
 							AuthnProvider: schema.AuthnProvider{
 								ConfigID:       "onelogin-config-id",
 								GitlabProvider: "onelogin",
@@ -191,7 +191,7 @@ func Test_providersFromConfig(t *testing.T) {
 			cfg: schema.SiteConfiguration{
 				Gitlab: []*schema.GitLabConnection{
 					{
-						Authorization: &schema.Authorization{},
+						Authorization: &schema.GitLabAuthorization{},
 						Url:           "https://gitlab-0.mine",
 						Token:         "asdf",
 					},
@@ -238,7 +238,7 @@ func Test_providersFromConfig(t *testing.T) {
 				},
 				Gitlab: []*schema.GitLabConnection{
 					{
-						Authorization: &schema.Authorization{
+						Authorization: &schema.GitLabAuthorization{
 							AuthnProvider: schema.AuthnProvider{
 								ConfigID:       "okta-config-id",
 								GitlabProvider: "okta",
@@ -263,7 +263,7 @@ func Test_providersFromConfig(t *testing.T) {
 				},
 			},
 			expSeriousProblems: []string{"`authz.authnProvider.type` was not specified, which means GitLab users cannot be resolved."},
-			expWarnings:        []string{"Could not parse time duration \"invalid\", falling back to 3 hours."},
+			expWarnings:        []string{"Could not parse time duration \"invalid\", falling back to 3h0m0s."},
 		},
 	}
 

--- a/cmd/frontend/shared/common.go
+++ b/cmd/frontend/shared/common.go
@@ -1,0 +1,18 @@
+package shared
+
+import (
+	"fmt"
+	"time"
+)
+
+func parseTTLOrDefault(ttl string, defaultVal time.Duration, warnings []string) (_ time.Duration, updatedWarnings []string) {
+	if ttl == "" {
+		return defaultVal, warnings
+	}
+	parsed, err := time.ParseDuration(ttl)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("Could not parse time duration %q, falling back to %v.", ttl, defaultVal))
+		return defaultVal, warnings
+	}
+	return parsed, warnings
+}

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -209,7 +209,7 @@ func GetGitHubRepository(ctx context.Context, args protocol.RepoLookupArgs) (rep
 	canUseGraphQLAPI := conn.config.Token != "" // GraphQL API requires authentication
 	if canUseGraphQLAPI && args.ExternalRepo != nil && args.ExternalRepo.ServiceType == github.ServiceType {
 		// Look up by external repository spec.
-		ghrepo, err := conn.client.GetRepositoryByNodeID(ctx, args.ExternalRepo.ID)
+		ghrepo, err := conn.client.GetRepositoryByNodeID(ctx, "", args.ExternalRepo.ID)
 		if ghrepo != nil {
 			repo = ghrepoToRepoInfo(ghrepo, conn)
 		}

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -302,7 +302,6 @@ func newGitHubConnection(config *schema.GitHubConnection) (*githubConnection, er
 	baseURL = NormalizeBaseURL(baseURL)
 	originalHostname := baseURL.Hostname()
 
-	// GitHub.com's API is hosted on api.github.com.
 	apiURL, githubDotCom := github.APIRoot(baseURL)
 
 	transport, err := cachedTransportWithCertTrusted(config.Certificate)

--- a/enterprise/cmd/frontend/auth/githuboauth/user.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/user.go
@@ -21,6 +21,7 @@ func getOrCreateUser(ctx context.Context, p *provider, ghUser *github.User, toke
 
 	var data extsvc.ExternalAccountData
 	data.SetAccountData(ghUser)
+	data.SetAuthData(token)
 	userID, safeErrMsg, err := auth.CreateOrUpdateUser(ctx, db.NewUser{
 		Username:        login,
 		Email:           deref(ghUser.Email),

--- a/pkg/extsvc/github/client_test.go
+++ b/pkg/extsvc/github/client_test.go
@@ -68,7 +68,7 @@ func TestNewRepoCache_GitHubDotCom(t *testing.T) {
 	// (2) have a TTL of 10 minutes
 	key := sha256.Sum256([]byte(token + ":" + githubProxyURL.String()))
 	prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
-	got := NewRepoCache(url, token)
+	got := NewRepoCache(url, token, "", 0)
 	want := rcache.NewWithTTL(prefix, 600)
 	if *got != *want {
 		t.Errorf("TestNewRepoCache_GitHubDotCom: got %#v, want %#v", *got, *want)
@@ -84,7 +84,7 @@ func TestNewRepoCache_GitHubEnterprise(t *testing.T) {
 	// (2) have a TTL of 30 seconds
 	key := sha256.Sum256([]byte(token + ":" + url.String()))
 	prefix := "gh_repo:" + base64.URLEncoding.EncodeToString(key[:])
-	got := NewRepoCache(url, token)
+	got := NewRepoCache(url, token, "", 0)
 	want := rcache.NewWithTTL(prefix, 30)
 	if *got != *want {
 		t.Errorf("TestNewRepoCache_GitHubEnterprise: got %#v, want %#v", *got, *want)

--- a/pkg/extsvc/github/codehost.go
+++ b/pkg/extsvc/github/codehost.go
@@ -19,3 +19,21 @@ func ExternalRepoSpec(repo *Repository, baseURL url.URL) *api.ExternalRepoSpec {
 		ServiceID:   extsvc.NormalizeBaseURL(&baseURL).String(),
 	}
 }
+
+type CodeHost struct {
+	id string
+}
+
+var _ extsvc.CodeHost = ((*CodeHost)(nil))
+
+func NewCodeHost(baseURL *url.URL) *CodeHost {
+	return &CodeHost{id: extsvc.NormalizeBaseURL(baseURL).String()}
+}
+
+func (h *CodeHost) ServiceID() string {
+	return h.id
+}
+
+func (h *CodeHost) ServiceType() string {
+	return ServiceType
+}

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -100,12 +100,12 @@ func (c *Client) GetRepository(ctx context.Context, owner, name string) (*Reposi
 }
 
 // GetRepositoryByNodeIDMock is set by tests to mock (*Client).GetRepositoryByNodeID.
-var GetRepositoryByNodeIDMock func(ctx context.Context, id string) (*Repository, error)
+var GetRepositoryByNodeIDMock func(ctx context.Context, token, id string) (*Repository, error)
 
 // GetRepositoryByNodeID gets a repository from GitHub by its GraphQL node ID using the specified user token.
-func (c *Client) GetRepositoryByNodeIDWithToken(ctx context.Context, token, id string) (*Repository, error) {
+func (c *Client) GetRepositoryByNodeID(ctx context.Context, token, id string) (*Repository, error) {
 	if GetRepositoryByNodeIDMock != nil {
-		return GetRepositoryByNodeIDMock(ctx, id)
+		return GetRepositoryByNodeIDMock(ctx, token, id)
 	}
 
 	key := nodeIDCacheKey(id)
@@ -118,11 +118,6 @@ func (c *Client) GetRepositoryByNodeIDWithToken(ctx context.Context, token, id s
 		}
 		return repo, keys, err
 	})
-}
-
-// GetRepositoryByNodeID gets a repository from GitHub by its GraphQL node ID.
-func (c *Client) GetRepositoryByNodeID(ctx context.Context, id string) (*Repository, error) {
-	return c.GetRepositoryByNodeIDWithToken(ctx, "", id)
 }
 
 // cachedGetRepository caches the getRepositoryFromAPI call.

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -89,7 +89,7 @@ func (c *Client) GetRepository(ctx context.Context, owner, name string) (*Reposi
 	}
 
 	key := ownerNameCacheKey(owner, name)
-	return c.cachedGetRepository(ctx, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
+	return c.cachedGetRepository(ctx, "", key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
 		keys = append(keys, key)
 		repo, err = c.getRepositoryFromAPI(ctx, owner, name)
 		if repo != nil {
@@ -102,16 +102,17 @@ func (c *Client) GetRepository(ctx context.Context, owner, name string) (*Reposi
 // GetRepositoryByNodeIDMock is set by tests to mock (*Client).GetRepositoryByNodeID.
 var GetRepositoryByNodeIDMock func(ctx context.Context, id string) (*Repository, error)
 
-// GetRepositoryByNodeID gets a repository from GitHub by its GraphQL node ID.
-func (c *Client) GetRepositoryByNodeID(ctx context.Context, id string) (*Repository, error) {
+// GetRepositoryByNodeID gets a repository from GitHub by its GraphQL node ID using the specified user token.
+func (c *Client) GetRepositoryByNodeIDWithToken(ctx context.Context, token, id string) (*Repository, error) {
 	if GetRepositoryByNodeIDMock != nil {
 		return GetRepositoryByNodeIDMock(ctx, id)
 	}
 
 	key := nodeIDCacheKey(id)
-	return c.cachedGetRepository(ctx, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
+	// 🚨 SECURITY: must forward token here to ensure caching by token
+	return c.cachedGetRepository(ctx, token, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
 		keys = append(keys, key)
-		repo, err = c.getRepositoryByNodeIDFromAPI(ctx, id)
+		repo, err = c.getRepositoryByNodeIDFromAPI(ctx, token, id)
 		if repo != nil {
 			keys = append(keys, nameWithOwnerCacheKey(repo.NameWithOwner)) // also cache under "owner/name"
 		}
@@ -119,9 +120,15 @@ func (c *Client) GetRepositoryByNodeID(ctx context.Context, id string) (*Reposit
 	})
 }
 
+// GetRepositoryByNodeID gets a repository from GitHub by its GraphQL node ID.
+func (c *Client) GetRepositoryByNodeID(ctx context.Context, id string) (*Repository, error) {
+	return c.GetRepositoryByNodeIDWithToken(ctx, "", id)
+}
+
 // cachedGetRepository caches the getRepositoryFromAPI call.
-func (c *Client) cachedGetRepository(ctx context.Context, key string, getRepositoryFromAPI func(context.Context) (repo *Repository, keys []string, err error)) (*Repository, error) {
-	if cached := c.getRepositoryFromCache(ctx, key); cached != nil {
+func (c *Client) cachedGetRepository(ctx context.Context, token, key string, getRepositoryFromAPI func(ctx context.Context) (repo *Repository, keys []string, err error)) (*Repository, error) {
+	// 🚨 SECURITY: must forward token here to ensure caching by token
+	if cached := c.getRepositoryFromCache(ctx, token, key); cached != nil {
 		reposGitHubCacheCounter.WithLabelValues("hit").Inc()
 		if cached.NotFound {
 			return nil, ErrNotFound
@@ -133,7 +140,8 @@ func (c *Client) cachedGetRepository(ctx context.Context, key string, getReposit
 	if IsNotFound(err) {
 		// Before we do anything, ensure we cache NotFound responses.
 		// Do this if client is unauthed or authed, it's okay since we're only caching not found responses here.
-		c.addRepositoryToCache(keys, &cachedRepo{NotFound: true})
+		// 🚨 SECURITY: must forward token here to ensure caching by token
+		c.addRepositoryToCache(token, keys, &cachedRepo{NotFound: true})
 		reposGitHubCacheCounter.WithLabelValues("notfound").Inc()
 	}
 	if err != nil {
@@ -141,7 +149,8 @@ func (c *Client) cachedGetRepository(ctx context.Context, key string, getReposit
 		return nil, err
 	}
 
-	c.addRepositoryToCache(keys, &cachedRepo{Repository: *repo})
+	// 🚨 SECURITY: must forward token here to ensure caching by token
+	c.addRepositoryToCache(token, keys, &cachedRepo{Repository: *repo})
 	reposGitHubCacheCounter.WithLabelValues("miss").Inc()
 
 	return repo, nil
@@ -169,8 +178,9 @@ type cachedRepo struct {
 
 // getRepositoryFromCache attempts to get a response from the redis cache.
 // It returns nil error for cache-hit condition and non-nil error for cache-miss.
-func (c *Client) getRepositoryFromCache(ctx context.Context, key string) *cachedRepo {
-	b, ok := c.repoCache.Get(strings.ToLower(key))
+func (c *Client) getRepositoryFromCache(ctx context.Context, token, key string) *cachedRepo {
+	// 🚨 SECURITY: must forward token here to ensure caching by token
+	b, ok := c.cache(token).Get(strings.ToLower(key))
 	if !ok {
 		return nil
 	}
@@ -182,26 +192,35 @@ func (c *Client) getRepositoryFromCache(ctx context.Context, key string) *cached
 
 	return &cached
 }
+func firstNonEmpty(strs ...string) string {
+	for _, s := range strs {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
 
 // addRepositoryToCache will cache the value for repo. The caller can provide multiple cache keys
 // for the multiple ways that this repository can be retrieved (e.g., both "owner/name" and the
 // GraphQL node ID).
-func (c *Client) addRepositoryToCache(keys []string, repo *cachedRepo) {
+func (c *Client) addRepositoryToCache(token string, keys []string, repo *cachedRepo) {
 	b, err := json.Marshal(repo)
 	if err != nil {
 		return
 	}
 	for _, key := range keys {
-		c.repoCache.Set(strings.ToLower(key), b)
+		c.cache(token).Set(strings.ToLower(key), b)
 	}
 }
 
 // addRepositoriesToCache will cache repositories that exist
 // under relevant cache keys.
-func (c *Client) addRepositoriesToCache(repos []*Repository) {
+func (c *Client) addRepositoriesToCache(token string, repos []*Repository) {
 	for _, repo := range repos {
 		keys := []string{nameWithOwnerCacheKey(repo.NameWithOwner), nodeIDCacheKey(repo.ID)} // cache under multiple
-		c.addRepositoryToCache(keys, &cachedRepo{Repository: *repo})
+		// 🚨 SECURITY: must forward token here to ensure caching by token
+		c.addRepositoryToCache(token, keys, &cachedRepo{Repository: *repo})
 	}
 }
 
@@ -253,7 +272,7 @@ func (c *Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) (
 	var restRepos []restRepository
 	path := "v3/repositories"
 	if sinceRepoID > 0 {
-		path += "?since=" + strconv.FormatInt(sinceRepoID, 10)
+		path += "?per_page=100&since=" + strconv.FormatInt(sinceRepoID, 10)
 	}
 	if err := c.requestGet(ctx, path, &restRepos); err != nil {
 		return nil, err
@@ -267,11 +286,11 @@ func (c *Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) (
 
 // getRepositoryByNodeIDFromAPI attempts to fetch a repository by GraphQL node ID from the GitHub
 // API without use of the redis cache.
-func (c *Client) getRepositoryByNodeIDFromAPI(ctx context.Context, id string) (*Repository, error) {
+func (c *Client) getRepositoryByNodeIDFromAPI(ctx context.Context, token, id string) (*Repository, error) {
 	var result struct {
 		Node *Repository `json:"node"`
 	}
-	if err := c.requestGraphQL(ctx, `
+	if err := c.requestGraphQL(ctx, token, `
 query Repository($id: ID!) {
 	node(id: $id) {
 		... on Repository {
@@ -295,29 +314,30 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 	if err != nil {
 		return nil, err
 	}
-	c.addRepositoriesToCache(repos)
+	c.addRepositoriesToCache("", repos)
 	return repos, nil
 }
 
 // ListViewerRepositories lists GitHub repositories affiliated with the viewer
 // (the currently authenticated user). page is the page of results to
 // return. Pages are 1-indexed (so the first call should be for page 1).
-func (c *Client) ListViewerRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+func (c *Client) ListViewerRepositories(ctx context.Context, token string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	var restRepos []restRepository
 	var path string
 	if c.githubDotCom {
-		path = fmt.Sprintf("user/repos?sort=pushed&page=%d", page)
+		path = fmt.Sprintf("user/repos?sort=pushed&page=%d&per_page=100", page)
 	} else {
-		path = fmt.Sprintf("v3/user/repos?sort=pushed&page=%d", page)
+		path = fmt.Sprintf("v3/user/repos?sort=pushed&page=%d&per_page=100", page)
 	}
-	if err := c.requestGet(ctx, path, &restRepos); err != nil {
+	if err := c.requestGetWithToken(ctx, token, path, &restRepos); err != nil {
 		return nil, false, 1, err
 	}
 	repos = make([]*Repository, 0, len(restRepos))
 	for _, restRepo := range restRepos {
 		repos = append(repos, convertRestRepo(restRepo))
 	}
-	c.addRepositoriesToCache(repos)
+	// 🚨 SECURITY: must forward token here to ensure caching by token
+	c.addRepositoriesToCache(token, repos)
 	return repos, len(repos) > 0, 1, nil
 }
 
@@ -349,6 +369,6 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 	for _, restRepo := range response.Items {
 		repos = append(repos, convertRestRepo(restRepo))
 	}
-	c.addRepositoriesToCache(repos)
+	c.addRepositoriesToCache("", repos)
 	return repos, len(repos) > 0, 1, nil
 }

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -237,7 +237,7 @@ func (c *Client) getRepositoryFromAPI(ctx context.Context, owner, name string) (
 	// example) a server with autoAddRepos and no GitHub connection configured when someone visits
 	// http://[sourcegraph-hostname]/github.com/foo/bar.
 	var result restRepository
-	if err := c.requestGet(ctx, fmt.Sprintf("/repos/%s/%s", owner, name), &result); err != nil {
+	if err := c.requestGet(ctx, "", fmt.Sprintf("/repos/%s/%s", owner, name), &result); err != nil {
 		return nil, err
 	}
 	return convertRestRepo(result), nil
@@ -269,7 +269,7 @@ func (c *Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) (
 	if sinceRepoID > 0 {
 		path += "?per_page=100&since=" + strconv.FormatInt(sinceRepoID, 10)
 	}
-	if err := c.requestGet(ctx, path, &restRepos); err != nil {
+	if err := c.requestGet(ctx, "", path, &restRepos); err != nil {
 		return nil, err
 	}
 	var repos []*Repository
@@ -324,7 +324,7 @@ func (c *Client) ListViewerRepositories(ctx context.Context, token string, page 
 	} else {
 		path = fmt.Sprintf("v3/user/repos?sort=pushed&page=%d&per_page=100", page)
 	}
-	if err := c.requestGetWithToken(ctx, token, path, &restRepos); err != nil {
+	if err := c.requestGet(ctx, token, path, &restRepos); err != nil {
 		return nil, false, 1, err
 	}
 	repos = make([]*Repository, 0, len(restRepos))
@@ -354,7 +354,7 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 		path = "v3/search/repositories?" + urlValues.Encode()
 	}
 	var response restSearchResponse
-	if err := c.requestGet(ctx, path, &response); err != nil {
+	if err := c.requestGet(ctx, "", path, &response); err != nil {
 		return nil, false, 1, err
 	}
 	if response.IncompleteResults {

--- a/pkg/extsvc/github/repos_test.go
+++ b/pkg/extsvc/github/repos_test.go
@@ -31,13 +31,24 @@ func TestSplitRepositoryNameWithOwner(t *testing.T) {
 type mockHTTPResponseBody struct {
 	count        int
 	responseBody string
+	status       int
+}
+
+func newMockHTTPResponseBody(responseBody string, status int) *mockHTTPResponseBody {
+	return &mockHTTPResponseBody{
+		responseBody: responseBody,
+	}
 }
 
 func (s *mockHTTPResponseBody) RoundTrip(req *http.Request) (*http.Response, error) {
 	s.count++
+	status := s.status
+	if status == 0 {
+		status = http.StatusOK
+	}
 	return &http.Response{
 		Request:    req,
-		StatusCode: http.StatusOK,
+		StatusCode: status,
 		Body:       ioutil.NopCloser(strings.NewReader(s.responseBody)),
 	}, nil
 }
@@ -57,10 +68,12 @@ func (s mockHTTPEmptyResponse) RoundTrip(req *http.Request) (*http.Response, err
 func newTestClient(t *testing.T) *Client {
 	rcache.SetupForTest(t)
 	return &Client{
-		apiURL:     &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
-		httpClient: &http.Client{},
-		RateLimit:  &ratelimit.Monitor{},
-		repoCache:  rcache.NewWithTTL("__test__gh_repo", 1000),
+		apiURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+		httpClient:      &http.Client{},
+		RateLimit:       &ratelimit.Monitor{},
+		repoCache:       map[string]*rcache.Cache{},
+		repoCachePrefix: "__test__gh_repo",
+		repoCacheTTL:    1000,
 	}
 }
 
@@ -285,5 +298,66 @@ func TestClient_ListRepositoriesForSearch(t *testing.T) {
 	}
 	if !repoListsAreEqual(repos, wantRepos) {
 		t.Errorf("got repositories:\n%s\nwant:\n%s", stringForRepoList(repos), stringForRepoList(wantRepos))
+	}
+}
+
+// 🚨 SECURITY: test that cache entries are keyed by auth token
+func TestClient_GetRepositoryByNodeIDWithToken(t *testing.T) {
+	c := newTestClient(t)
+
+	c.httpClient.Transport = newMockHTTPResponseBody(`{ "data": { "node": { "id": "i0" } } }`, http.StatusOK)
+	got, err := c.GetRepositoryByNodeIDWithToken(context.Background(), "tok0", "id0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := (&Repository{ID: "i0"}); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	c.httpClient.Transport = newMockHTTPResponseBody(`{ "data": { "node": { "id": "SHOULD NOT BE SEEN" } } }`, http.StatusOK)
+	got, err = c.GetRepositoryByNodeIDWithToken(context.Background(), "tok0", "id0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := (&Repository{ID: "i0"}); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	c.httpClient.Transport = newMockHTTPResponseBody(`{ "data": { "node": { "id": "i0-tok1" } } }`, http.StatusOK)
+	got, err = c.GetRepositoryByNodeIDWithToken(context.Background(), "tok1", "id0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := (&Repository{ID: "i0-tok1"}); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	c.httpClient.Transport = newMockHTTPResponseBody(`{}`, http.StatusNotFound)
+	_, err = c.GetRepositoryByNodeIDWithToken(context.Background(), "tok0", "id1")
+	if err != ErrNotFound {
+		t.Errorf("expected err %v, but got %v", ErrNotFound, err)
+	}
+
+	// "not found" should be cached
+	c.httpClient.Transport = newMockHTTPResponseBody(`{ "data": { "node": { "id": "id1" } } }`, http.StatusOK)
+	_, err = c.GetRepositoryByNodeIDWithToken(context.Background(), "tok0", "id1")
+	if err != ErrNotFound {
+		t.Errorf("expected err %v, but got %v", ErrNotFound, err)
+	}
+	// "not found" not cached with different auth token
+	got, err = c.GetRepositoryByNodeIDWithToken(context.Background(), "tok1", "id1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := (&Repository{ID: "id1"}); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	// "not found" not cached with no auth token
+	got, err = c.GetRepositoryByNodeIDWithToken(context.Background(), "", "id1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := (&Repository{ID: "id1"}); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/pkg/rcache/rcache.go
+++ b/pkg/rcache/rcache.go
@@ -7,7 +7,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/garyburd/redigo/redis"
-
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/redispool"
 	"gopkg.in/inconshreveable/log15.v2"
@@ -41,6 +40,68 @@ func NewWithTTL(keyPrefix string, ttlSeconds int) *Cache {
 	return &Cache{
 		keyPrefix:  keyPrefix,
 		ttlSeconds: ttlSeconds,
+	}
+}
+
+func (r *Cache) GetMulti(keys ...string) [][]byte {
+	c := pool.Get()
+	defer c.Close()
+
+	if len(keys) == 0 {
+		return nil
+	}
+	rkeys := make([]interface{}, len(keys))
+	for i, key := range keys {
+		rkeys[i] = r.rkeyPrefix() + key
+	}
+
+	vals, err := redis.Values(c.Do("MGET", rkeys...))
+	if err != nil && err != redis.ErrNil {
+		log15.Warn("failed to execute redis command", "cmd", "MGET", "error", err)
+	}
+
+	strVals := make([][]byte, len(vals))
+	for i, val := range vals {
+		b, err := redis.Bytes(val, nil)
+		if err != nil {
+			log15.Warn("failed to parse bytes from Redis value", "value", val)
+			continue
+		}
+		strVals[i] = b
+	}
+	return strVals
+}
+
+func (r *Cache) SetMulti(keyvals ...[2]string) {
+	c := pool.Get()
+	defer c.Close()
+
+	if len(keyvals) == 0 {
+		return
+	}
+
+	for _, kv := range keyvals {
+		k, v := kv[0], kv[1]
+		if !utf8.Valid([]byte(k)) {
+			if conf.IsDev(conf.DeployType()) {
+				panic(fmt.Sprintf("rcache: keys must be valid utf8 %v", []byte(k)))
+			} else {
+				log15.Error("rcache: keys must be valid utf8", "key", []byte(k))
+			}
+			continue
+		}
+		if r.ttlSeconds == 0 {
+			if err := c.Send("SET", r.rkeyPrefix()+k, []byte(v)); err != nil {
+				log15.Warn("failed to write redis command to client output buffer", "cmd", "SET", "error", err)
+			}
+		} else {
+			if err := c.Send("SETEX", r.rkeyPrefix()+k, r.ttlSeconds, []byte(v)); err != nil {
+				log15.Warn("failed to write redis command to client output buffer", "cmd", "SETEX", "error", err)
+			}
+		}
+	}
+	if err := c.Flush(); err != nil {
+		log15.Warn("failed to flush Redis client", "error", err)
 	}
 }
 

--- a/pkg/rcache/rcache_test.go
+++ b/pkg/rcache/rcache_test.go
@@ -1,6 +1,9 @@
 package rcache
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestCache_namespace(t *testing.T) {
 	SetupForTest(t)
@@ -68,7 +71,7 @@ func TestCache_simple(t *testing.T) {
 	c := New("some_prefix")
 	_, ok := c.Get("a")
 	if ok {
-		t.Fatal("Initial Get should of found nothing")
+		t.Fatal("Initial Get should find nothing")
 	}
 
 	c.Set("a", []byte("b"))
@@ -85,4 +88,63 @@ func TestCache_simple(t *testing.T) {
 	if ok {
 		t.Fatal("Get after delete should of found nothing")
 	}
+}
+
+func TestCache_multi(t *testing.T) {
+	SetupForTest(t)
+
+	c := New("some_prefix")
+	vals := c.GetMulti("k0", "k1", "k2")
+	if got, exp := vals, [][]byte{nil, nil, nil}; !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v on initial fetch, got %v", exp, got)
+	}
+
+	c.Set("k0", []byte("b"))
+	if got, exp := c.GetMulti("k0"), bytes("b"); !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+
+	c.SetMulti([2]string{"k0", "a"})
+	if got, exp := c.GetMulti("k0"), bytes("a"); !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+
+	c.SetMulti([2]string{"k0", "a"}, [2]string{"k1", "b"})
+	if got, exp := c.GetMulti("k0"), bytes("a"); !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+	if got, exp := c.GetMulti("k1"), bytes("b"); !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+	if got, exp := c.GetMulti("k0", "k1"), bytes("a", "b"); !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+	if got, exp := c.GetMulti("k1", "k0"), bytes("b", "a"); !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+
+	c.SetMulti([2]string{"k0", "x"}, [2]string{"k1", "y"}, [2]string{"k2", "z"})
+	if got, exp := c.GetMulti("k0", "k1", "k2"), bytes("x", "y", "z"); !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+	got, exist := c.Get("k0")
+	if exp := "x"; !exist || string(got) != exp {
+		t.Errorf("Expected %v, but got %v", exp, string(got))
+	}
+
+	c.Delete("k0")
+	if got, exp := c.GetMulti("k0", "k1", "k2"), [][]byte{nil, []byte("y"), []byte("z")}; !reflect.DeepEqual(exp, got) {
+		t.Errorf("Expected %v, but got %v", exp, got)
+	}
+}
+
+func bytes(s ...string) [][]byte {
+	if s == nil {
+		return nil
+	}
+	t := make([][]byte, len(s))
+	for i, v := range s {
+		t[i] = []byte(v)
+	}
+	return t
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -96,12 +96,6 @@ type AuthnProvider struct {
 	GitlabProvider string `json:"gitlabProvider"`
 	Type           string `json:"type"`
 }
-
-// Authorization description: If non-null, enables GitLab permission checks. This requires that the value of `token` be an access token with "sudo" and "api" scopes.
-type Authorization struct {
-	AuthnProvider AuthnProvider `json:"authnProvider"`
-	Ttl           string        `json:"ttl,omitempty"`
-}
 type BitbucketServerConnection struct {
 	Certificate                 string `json:"certificate,omitempty"`
 	ExcludePersonalRepositories bool   `json:"excludePersonalRepositories,omitempty"`
@@ -169,25 +163,37 @@ type GitHubAuthProvider struct {
 	Type         string `json:"type"`
 	Url          string `json:"url,omitempty"`
 }
+
+// GitHubAuthorization description: If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type "github" with the same `url` field as specified in this `GitHubConnection`.
+type GitHubAuthorization struct {
+	Ttl string `json:"ttl,omitempty"`
+}
 type GitHubConnection struct {
-	Certificate                 string   `json:"certificate,omitempty"`
-	GitURLType                  string   `json:"gitURLType,omitempty"`
-	InitialRepositoryEnablement bool     `json:"initialRepositoryEnablement,omitempty"`
-	Repos                       []string `json:"repos,omitempty"`
-	RepositoryPathPattern       string   `json:"repositoryPathPattern,omitempty"`
-	RepositoryQuery             []string `json:"repositoryQuery,omitempty"`
-	Token                       string   `json:"token"`
-	Url                         string   `json:"url"`
+	Authorization               *GitHubAuthorization `json:"authorization,omitempty"`
+	Certificate                 string               `json:"certificate,omitempty"`
+	GitURLType                  string               `json:"gitURLType,omitempty"`
+	InitialRepositoryEnablement bool                 `json:"initialRepositoryEnablement,omitempty"`
+	Repos                       []string             `json:"repos,omitempty"`
+	RepositoryPathPattern       string               `json:"repositoryPathPattern,omitempty"`
+	RepositoryQuery             []string             `json:"repositoryQuery,omitempty"`
+	Token                       string               `json:"token"`
+	Url                         string               `json:"url"`
+}
+
+// GitLabAuthorization description: If non-null, enforces GitLab repository permissions. This requires that the value of `token` be an access token with "sudo" and "api" scopes.
+type GitLabAuthorization struct {
+	AuthnProvider AuthnProvider `json:"authnProvider"`
+	Ttl           string        `json:"ttl,omitempty"`
 }
 type GitLabConnection struct {
-	Authorization               *Authorization `json:"authorization,omitempty"`
-	Certificate                 string         `json:"certificate,omitempty"`
-	GitURLType                  string         `json:"gitURLType,omitempty"`
-	InitialRepositoryEnablement bool           `json:"initialRepositoryEnablement,omitempty"`
-	ProjectQuery                []string       `json:"projectQuery,omitempty"`
-	RepositoryPathPattern       string         `json:"repositoryPathPattern,omitempty"`
-	Token                       string         `json:"token"`
-	Url                         string         `json:"url"`
+	Authorization               *GitLabAuthorization `json:"authorization,omitempty"`
+	Certificate                 string               `json:"certificate,omitempty"`
+	GitURLType                  string               `json:"gitURLType,omitempty"`
+	InitialRepositoryEnablement bool                 `json:"initialRepositoryEnablement,omitempty"`
+	ProjectQuery                []string             `json:"projectQuery,omitempty"`
+	RepositoryPathPattern       string               `json:"repositoryPathPattern,omitempty"`
+	Token                       string               `json:"token"`
+	Url                         string               `json:"url"`
 }
 type GitoliteConnection struct {
 	Blacklist                  string `json:"blacklist,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -630,6 +630,19 @@
           "description":
             "Defines whether repositories from this GitHub instance should be enabled and cloned when they are first seen by Sourcegraph. If false, the site admin must explicitly enable GitHub repositories (in the site admin area) to clone them and make them searchable on Sourcegraph. If true, they will be enabled and cloned immediately (subject to rate limiting by GitHub); site admins can still disable them explicitly, and they'll remain disabled.",
           "type": "boolean"
+        },
+        "authorization": { "$ref": "#/definitions/GitHubAuthorization" }
+      }
+    },
+    "GitHubAuthorization": {
+      "description":
+        "If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type \"github\" with the same `url` field as specified in this `GitHubConnection`.",
+      "type": "object",
+      "properties": {
+        "ttl": {
+          "description": "The TTL of the repository permissions data cache.",
+          "type": "string",
+          "default": "3h"
         }
       }
     },
@@ -689,41 +702,42 @@
             "Defines whether repositories from this GitLab instance should be enabled and cloned when they are first seen by Sourcegraph. If false, the site admin must explicitly enable GitLab repositories (in the site admin area) to clone them and make them searchable on Sourcegraph. If true, they will be enabled and cloned immediately (subject to rate limiting by GitLab); site admins can still disable them explicitly, and they'll remain disabled.",
           "type": "boolean"
         },
-        "authorization": {
-          "description":
-            "If non-null, enables GitLab permission checks. This requires that the value of `token` be an access token with \"sudo\" and \"api\" scopes.",
+        "authorization": { "$ref": "#/definitions/GitLabAuthorization" }
+      }
+    },
+    "GitLabAuthorization": {
+      "description":
+        "If non-null, enforces GitLab repository permissions. This requires that the value of `token` be an access token with \"sudo\" and \"api\" scopes.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authnProvider"],
+      "properties": {
+        "authnProvider": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["authnProvider"],
+          "required": ["configID", "type", "gitlabProvider"],
+          "description": "Identifies the authentication provider to use to identify users to GitLab.",
           "properties": {
-            "authnProvider": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["configID", "type", "gitlabProvider"],
-              "description": "Identifies the authentication provider to use to identify users to GitLab.",
-              "properties": {
-                "configID": {
-                  "type": "string",
-                  "description": "The value of the `configID` field of the targeted authentication provider."
-                },
-                "type": {
-                  "type": "string",
-                  "description": "The `type` field of the targeted authentication provider."
-                },
-                "gitlabProvider": {
-                  "type": "string",
-                  "description":
-                    "The provider name that identifies the authentication provider to GitLab. This is the name passed to the `?provider=` query parameter in calls to the GitLab Users API."
-                }
-              }
-            },
-            "ttl": {
-              "description":
-                "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
+            "configID": {
               "type": "string",
-              "default": "3h"
+              "description": "The value of the `configID` field of the targeted authentication provider."
+            },
+            "type": {
+              "type": "string",
+              "description": "The `type` field of the targeted authentication provider."
+            },
+            "gitlabProvider": {
+              "type": "string",
+              "description":
+                "The provider name that identifies the authentication provider to GitLab. This is the name passed to the `?provider=` query parameter in calls to the GitLab Users API."
             }
           }
+        },
+        "ttl": {
+          "description":
+            "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
+          "type": "string",
+          "default": "3h"
         }
       }
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -635,6 +635,19 @@ const SiteSchemaJSON = `{
           "description":
             "Defines whether repositories from this GitHub instance should be enabled and cloned when they are first seen by Sourcegraph. If false, the site admin must explicitly enable GitHub repositories (in the site admin area) to clone them and make them searchable on Sourcegraph. If true, they will be enabled and cloned immediately (subject to rate limiting by GitHub); site admins can still disable them explicitly, and they'll remain disabled.",
           "type": "boolean"
+        },
+        "authorization": { "$ref": "#/definitions/GitHubAuthorization" }
+      }
+    },
+    "GitHubAuthorization": {
+      "description":
+        "If non-null, enforces GitHub repository permissions. This requires that there is an item in the ` + "`" + `auth.providers` + "`" + ` field of type \"github\" with the same ` + "`" + `url` + "`" + ` field as specified in this ` + "`" + `GitHubConnection` + "`" + `.",
+      "type": "object",
+      "properties": {
+        "ttl": {
+          "description": "The TTL of the repository permissions data cache.",
+          "type": "string",
+          "default": "3h"
         }
       }
     },
@@ -694,41 +707,42 @@ const SiteSchemaJSON = `{
             "Defines whether repositories from this GitLab instance should be enabled and cloned when they are first seen by Sourcegraph. If false, the site admin must explicitly enable GitLab repositories (in the site admin area) to clone them and make them searchable on Sourcegraph. If true, they will be enabled and cloned immediately (subject to rate limiting by GitLab); site admins can still disable them explicitly, and they'll remain disabled.",
           "type": "boolean"
         },
-        "authorization": {
-          "description":
-            "If non-null, enables GitLab permission checks. This requires that the value of ` + "`" + `token` + "`" + ` be an access token with \"sudo\" and \"api\" scopes.",
+        "authorization": { "$ref": "#/definitions/GitLabAuthorization" }
+      }
+    },
+    "GitLabAuthorization": {
+      "description":
+        "If non-null, enforces GitLab repository permissions. This requires that the value of ` + "`" + `token` + "`" + ` be an access token with \"sudo\" and \"api\" scopes.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authnProvider"],
+      "properties": {
+        "authnProvider": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["authnProvider"],
+          "required": ["configID", "type", "gitlabProvider"],
+          "description": "Identifies the authentication provider to use to identify users to GitLab.",
           "properties": {
-            "authnProvider": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["configID", "type", "gitlabProvider"],
-              "description": "Identifies the authentication provider to use to identify users to GitLab.",
-              "properties": {
-                "configID": {
-                  "type": "string",
-                  "description": "The value of the ` + "`" + `configID` + "`" + ` field of the targeted authentication provider."
-                },
-                "type": {
-                  "type": "string",
-                  "description": "The ` + "`" + `type` + "`" + ` field of the targeted authentication provider."
-                },
-                "gitlabProvider": {
-                  "type": "string",
-                  "description":
-                    "The provider name that identifies the authentication provider to GitLab. This is the name passed to the ` + "`" + `?provider=` + "`" + ` query parameter in calls to the GitLab Users API."
-                }
-              }
-            },
-            "ttl": {
-              "description":
-                "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
+            "configID": {
               "type": "string",
-              "default": "3h"
+              "description": "The value of the ` + "`" + `configID` + "`" + ` field of the targeted authentication provider."
+            },
+            "type": {
+              "type": "string",
+              "description": "The ` + "`" + `type` + "`" + ` field of the targeted authentication provider."
+            },
+            "gitlabProvider": {
+              "type": "string",
+              "description":
+                "The provider name that identifies the authentication provider to GitLab. This is the name passed to the ` + "`" + `?provider=` + "`" + ` query parameter in calls to the GitLab Users API."
             }
           }
+        },
+        "ttl": {
+          "description":
+            "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
+          "type": "string",
+          "default": "3h"
         }
       }
     },


### PR DESCRIPTION
> This PR updates the CHANGELOG.md file to describe any user-facing changes.

This adds support for GitHub repository permissions. You can enable this by setting the `authorization` field in the `GitHubConnection`.

A couple of changes in dependency packages were necessary; these are factored out as separate commits:
* `rcache`: add `GetMulti` and `SetMulti` to the `rcache.Cache` interface
* `githuboauth`: set the OAuth access token in the `AuthData` field
* `codehost/github`: ability to pass explicit tokens to some methods to override the default token used to authenticate to the GitHub API

The actual change is in the final commit. It adds the appropriate config fields and the `authz/github.Provider` type. Unlike the GitLab authz provider, the GitHub authz provider requires a user to authenticate via GitHub (i.e., we don't try to infer the correct GitHub account from other SSO providers, because limitations in the GitHub API prevent us from doing so). There is also a different caching strategy than in the GitLab support that has some nice properties (lower upper bound on latency for large repository sets) and it may make sense to migrate GitLab to this in a later PR.

One outstanding TODO is to invalidate cache items when the cache TTL changes. This seems unnecessary for v0, but I will implement it in an immediate follow-up PR.