### PR TITLE
improve handling of empty/invalid Authorization header

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -29,15 +29,14 @@ func AccessTokenAuthMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
-		if token == "" {
+		if headerValue := r.Header.Get("Authorization"); headerValue != "" && token == "" {
 			// Handle Authorization header
-			headerValue := r.Header.Get("Authorization")
 			var err error
 			token, sudoUser, err = authz.ParseAuthorizationHeader(headerValue)
 			if err != nil {
 				if authz.IsUnrecognizedScheme(err) {
 					// Ignore Authorization headers that we don't handle.
-					log15.Debug("Ignoring unrecognized Authorization header.", "err", err)
+					log15.Warn("Ignoring unrecognized Authorization header.", "err", err, "value", headerValue)
 					next.ServeHTTP(w, r)
 					return
 				}


### PR DESCRIPTION
Previously, if the Authorization header was empty, it would follow the "Ignoring unrecognized Authorization header" code path. The log message would not be seen and it would proceed to the next handler. The behavior was correct but unintentionally so. That code path is meant for when the scheme is unrecognized, not when the entire header is empty.

Fixes the code to use the intended code path when the header is empty, and to log the "Ignoring unrecognized Authorization header" messages with severity warning (because it does indicate an issue that is noteworthy).


> This PR does not need to update the CHANGELOG because it is not user facing