### PR TITLE
feat: expose workspace roots in extension API

### DIFF
--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -93,6 +93,7 @@ function createControllers(documents: Observable<TextDocumentItem[] | null>): Co
             .pipe(take(1))
             .subscribe(({ context }) => {
                 extensionsController.setEnvironment({
+                    roots: [], // TODO(sqs): set roots in browser extension
                     extensions,
                     configuration,
                     visibleTextDocuments,

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -3,7 +3,6 @@ import { render } from 'react-dom'
 import { combineLatest, from, Observable } from 'rxjs'
 import { map, take } from 'rxjs/operators'
 import { Disposable } from 'vscode-languageserver'
-import { TextDocumentItem } from '../../../../../shared/src/api/client/types/textDocument'
 import { ContributableMenu } from '../../../../../shared/src/api/protocol'
 import { TextDocumentDecoration } from '../../../../../shared/src/api/protocol/plainTypes'
 import { CommandListPopoverButton } from '../../../../../shared/src/app/CommandList'
@@ -20,6 +19,7 @@ import {
 
 import { DOMFunctions } from '@sourcegraph/codeintellify'
 import * as H from 'history'
+import { Environment } from '../../../../../shared/src/api/client/environment'
 import {
     decorationAttachmentStyleForTheme,
     decorationStyleForTheme,
@@ -80,20 +80,20 @@ export interface Controllers {
     extensionsController: ClientController<SettingsSubject, Settings>
 }
 
-function createControllers(documents: Observable<TextDocumentItem[] | null>): Controllers {
+function createControllers(environment: Observable<Pick<Environment, 'roots' | 'visibleTextDocuments'>>): Controllers {
     const extensionsContextController = createExtensionsContextController(sourcegraphUrl)
     const extensionsController = createController(extensionsContextController!.context, createMessageTransports)
 
     combineLatest(
         extensionsContextController.viewerConfiguredExtensions,
         from(extensionsContextController.context.settingsCascade).pipe(map(logThenDropConfigurationErrors)),
-        documents
-    ).subscribe(([extensions, configuration, visibleTextDocuments]) => {
+        environment
+    ).subscribe(([extensions, configuration, { roots, visibleTextDocuments }]) => {
         from(extensionsController.environment)
             .pipe(take(1))
             .subscribe(({ context }) => {
                 extensionsController.setEnvironment({
-                    roots: [], // TODO(sqs): set roots in browser extension
+                    roots,
                     extensions,
                     configuration,
                     visibleTextDocuments,
@@ -110,9 +110,9 @@ function createControllers(documents: Observable<TextDocumentItem[] | null>): Co
  */
 export function initializeExtensions(
     getCommandPaletteMount: MountGetter,
-    documents: Observable<TextDocumentItem[] | null>
+    environment: Observable<Pick<Environment, 'roots' | 'visibleTextDocuments'>>
 ): Controllers {
-    const { extensionsContextController, extensionsController } = createControllers(documents)
+    const { extensionsContextController, extensionsController } = createControllers(environment)
     const history = H.createBrowserHistory()
 
     render(

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -558,6 +558,20 @@ declare module 'sourcegraph' {
     }
 
     /**
+     * A root directory (of the {@link workspace}). This is typically the root directory of a repository.
+     */
+    export interface WorkspaceRoot {
+        /**
+         * The URI of the root.
+         *
+         * @todo The format of this URI will be changed in the future. It must not be relied on.
+         *
+         * @example git://github.com/sourcegraph/sourcegraph?sha#mydir/myfile.txt
+         */
+        readonly uri: URI
+    }
+
+    /**
      * The logical workspace that the extension is running in, which may consist of multiple folders, projects, and
      * repositories.
      */
@@ -573,6 +587,20 @@ declare module 'sourcegraph' {
          * An event that is fired when a new text document is opened.
          */
         export const onDidOpenTextDocument: Subscribable<TextDocument>
+
+        /**
+         * The root directories of the workspace, if any.
+         *
+         * @example The repository that is currently being viewed is a root.
+         * @todo Currently only a single root is supported.
+         * @readonly
+         */
+        export const roots: ReadonlyArray<WorkspaceRoot>
+
+        /**
+         * An event that is fired when a workspace root is added or removed from the workspace.
+         */
+        export const onDidChangeRoots: Subscribable<void>
     }
 
     /**

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -558,7 +558,8 @@ declare module 'sourcegraph' {
     }
 
     /**
-     * A root directory (of the {@link workspace}). This is typically the root directory of a repository.
+     * A workspace root is a directory that has been added to a workspace. A workspace can have zero or more roots.
+     * Often, each root is the root directory of a repository.
      */
     export interface WorkspaceRoot {
         /**
@@ -566,7 +567,7 @@ declare module 'sourcegraph' {
          *
          * @todo The format of this URI will be changed in the future. It must not be relied on.
          *
-         * @example git://github.com/sourcegraph/sourcegraph?sha#mydir/myfile.txt
+         * @example git://github.com/sourcegraph/sourcegraph?sha#mydir1/mydir2
          */
         readonly uri: URI
     }

--- a/shared/src/api/client/api/roots.ts
+++ b/shared/src/api/client/api/roots.ts
@@ -1,0 +1,25 @@
+import { Observable, Subscription } from 'rxjs'
+import { createProxyAndHandleRequests } from '../../common/proxy'
+import { ExtRootsAPI } from '../../extension/api/roots'
+import { Connection } from '../../protocol/jsonrpc2/connection'
+import { WorkspaceRoot } from '../../protocol/plainTypes'
+
+/** @internal */
+export class ClientRoots {
+    private subscriptions = new Subscription()
+    private proxy: ExtRootsAPI
+
+    constructor(connection: Connection, environmentRoots: Observable<WorkspaceRoot[] | null>) {
+        this.proxy = createProxyAndHandleRequests('roots', connection, this)
+
+        this.subscriptions.add(
+            environmentRoots.subscribe(roots => {
+                this.proxy.$acceptRoots(roots || [])
+            })
+        )
+    }
+
+    public unsubscribe(): void {
+        this.subscriptions.unsubscribe()
+    }
+}

--- a/shared/src/api/client/controller.test.ts
+++ b/shared/src/api/client/controller.test.ts
@@ -30,6 +30,7 @@ const create = (environment?: Environment): TestController => {
 }
 
 const FIXTURE_ENVIRONMENT: Environment<any, any> = {
+    roots: [],
     visibleTextDocuments: [{ uri: 'file:///f', languageId: 'l', text: '' }],
     extensions: [{ id: 'x' }],
     configuration: {},

--- a/shared/src/api/client/controller.ts
+++ b/shared/src/api/client/controller.ts
@@ -19,6 +19,7 @@ import { ClientConfiguration } from './api/configuration'
 import { ClientContext } from './api/context'
 import { ClientDocuments } from './api/documents'
 import { ClientLanguageFeatures } from './api/languageFeatures'
+import { ClientRoots } from './api/roots'
 import { Search } from './api/search'
 import { ClientViews } from './api/views'
 import { ClientWindows } from './api/windows'
@@ -273,6 +274,15 @@ export class Controller<X extends Extension, C extends SettingsCascade> implemen
         )
         subscription.add(new Search(client, this.registries.queryTransformer))
         subscription.add(new ClientCommands(client, this.registries.commands))
+        subscription.add(
+            new ClientRoots(
+                client,
+                this.environment.pipe(
+                    map(({ roots }) => roots),
+                    distinctUntilChanged()
+                )
+            )
+        )
     }
 
     public set trace(value: Trace) {

--- a/shared/src/api/client/environment.ts
+++ b/shared/src/api/client/environment.ts
@@ -1,4 +1,5 @@
 import { SettingsCascade } from '../protocol'
+import { WorkspaceRoot } from '../protocol/plainTypes'
 import { Context, EMPTY_CONTEXT } from './context/context'
 import { Extension } from './extension'
 import { TextDocumentItem } from './types/textDocument'
@@ -13,6 +14,11 @@ import { TextDocumentItem } from './types/textDocument'
  * @template C settings cascade type
  */
 export interface Environment<X extends Extension = Extension, C extends SettingsCascade = SettingsCascade> {
+    /**
+     * The currently open workspace roots (typically a single repository).
+     */
+    readonly roots: WorkspaceRoot[] | null
+
     /**
      * The text documents that are currently visible. Each text document is represented to extensions as being
      * in its own visible CodeEditor.
@@ -31,6 +37,7 @@ export interface Environment<X extends Extension = Extension, C extends Settings
 
 /** An empty Sourcegraph extension client environment. */
 export const EMPTY_ENVIRONMENT: Environment<any, any> = {
+    roots: null,
     visibleTextDocuments: null,
     extensions: null,
     configuration: { final: {} },

--- a/shared/src/api/extension/api/roots.ts
+++ b/shared/src/api/extension/api/roots.ts
@@ -1,0 +1,33 @@
+import { Observable, Subject } from 'rxjs'
+import * as sourcegraph from 'sourcegraph'
+import { WorkspaceRoot as PlainWorkspaceRoot } from '../../protocol/plainTypes'
+import { URI } from '../types/uri'
+
+/** @internal */
+export interface ExtRootsAPI {
+    $acceptRoots(roots: PlainWorkspaceRoot[]): void
+}
+
+/** @internal */
+export class ExtRoots implements ExtRootsAPI {
+    private roots: ReadonlyArray<sourcegraph.WorkspaceRoot> = []
+
+    /**
+     * Returns all workspace roots.
+     *
+     * @internal
+     */
+    public getAll(): ReadonlyArray<sourcegraph.WorkspaceRoot> {
+        return this.roots
+    }
+
+    private changes = new Subject<void>()
+    public readonly onDidChange: Observable<void> = this.changes
+
+    public $acceptRoots(roots: PlainWorkspaceRoot[]): void {
+        this.roots = Object.freeze(
+            roots.map(plain => ({ ...plain, uri: new URI(plain.uri) } as sourcegraph.WorkspaceRoot))
+        )
+        this.changes.next()
+    }
+}

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -8,6 +8,7 @@ import { ExtConfiguration } from './api/configuration'
 import { ExtContext } from './api/context'
 import { ExtDocuments } from './api/documents'
 import { ExtLanguageFeatures } from './api/languageFeatures'
+import { ExtRoots } from './api/roots'
 import { ExtSearch } from './api/search'
 import { ExtViews } from './api/views'
 import { ExtWindows } from './api/windows'
@@ -81,6 +82,9 @@ function createExtensionHandle(initData: InitData, connection: Connection): type
     const documents = new ExtDocuments(sync)
     handleRequests(connection, 'documents', documents)
 
+    const roots = new ExtRoots()
+    handleRequests(connection, 'roots', roots)
+
     const windows = new ExtWindows(proxy('windows'), proxy('codeEditor'), documents)
     handleRequests(connection, 'windows', windows)
 
@@ -130,6 +134,10 @@ function createExtensionHandle(initData: InitData, connection: Connection): type
                 return documents.getAll()
             },
             onDidOpenTextDocument: documents.onDidOpenTextDocument,
+            get roots(): ReadonlyArray<sourcegraph.WorkspaceRoot> {
+                return roots.getAll()
+            },
+            onDidChangeRoots: roots.onDidChange,
         },
 
         configuration: {

--- a/shared/src/api/integration-test/helpers.test.ts
+++ b/shared/src/api/integration-test/helpers.test.ts
@@ -6,6 +6,7 @@ import { createExtensionHost } from '../extension/extensionHost'
 import { createMessageTransports } from '../protocol/jsonrpc2/helpers.test'
 
 const FIXTURE_ENVIRONMENT: Environment = {
+    roots: [{ uri: 'file:///' }],
     visibleTextDocuments: [
         {
             uri: 'file:///f',

--- a/shared/src/api/integration-test/roots.test.ts
+++ b/shared/src/api/integration-test/roots.test.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert'
+import { WorkspaceRoot } from 'sourcegraph'
+import { URI } from '../extension/types/uri'
+import { collectSubscribableValues, integrationTestContext } from './helpers.test'
+
+describe('Workspace roots (integration)', () => {
+    describe('workspace.roots', () => {
+        it('lists roots', async () => {
+            const { extensionHost, ready } = await integrationTestContext()
+
+            await ready
+            assert.deepStrictEqual(extensionHost.workspace.roots, [{ uri: new URI('file:///') }] as WorkspaceRoot[])
+        })
+
+        it('adds new text documents', async () => {
+            const { clientController, extensionHost, getEnvironment, ready } = await integrationTestContext()
+
+            const prevEnvironment = getEnvironment()
+            clientController.setEnvironment({
+                ...prevEnvironment,
+                roots: [{ uri: 'file:///a' }, { uri: 'file:///b' }],
+            })
+
+            await ready
+            assert.deepStrictEqual(extensionHost.workspace.roots, [
+                { uri: new URI('file:///a') },
+                { uri: new URI('file:///b') },
+            ] as WorkspaceRoot[])
+        })
+    })
+
+    describe('workspace.onDidChangeRoots', () => {
+        it('fires when a root is added or removed', async () => {
+            const { clientController, extensionHost, getEnvironment, ready } = await integrationTestContext()
+
+            await ready
+            const values = collectSubscribableValues(extensionHost.workspace.onDidChangeRoots)
+            assert.deepStrictEqual(values, [] as void[])
+
+            const prevEnvironment = getEnvironment()
+            clientController.setEnvironment({
+                ...prevEnvironment,
+                roots: [{ uri: 'file:///a' }],
+            })
+            await extensionHost.internal.sync()
+
+            assert.deepStrictEqual(values, [void 0])
+        })
+    })
+})

--- a/shared/src/api/protocol/plainTypes.ts
+++ b/shared/src/api/protocol/plainTypes.ts
@@ -1,5 +1,10 @@
 import * as sourcegraph from 'sourcegraph'
 
+/** The plain properties of a {@link module:sourcegraph.WorkspaceRoot}, without methods and accessors. */
+export interface WorkspaceRoot {
+    uri: string
+}
+
 /** The plain properties of a {@link module:sourcegraph.Position}, without methods and accessors. */
 export interface Position extends Pick<sourcegraph.Position, 'line' | 'character'> {}
 

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -8,6 +8,7 @@ import { combineLatest, from, Subscription } from 'rxjs'
 import { startWith } from 'rxjs/operators'
 import { EMPTY_ENVIRONMENT as EXTENSIONS_EMPTY_ENVIRONMENT } from '../../shared/src/api/client/environment'
 import { TextDocumentItem } from '../../shared/src/api/client/types/textDocument'
+import { WorkspaceRoot } from '../../shared/src/api/protocol/plainTypes'
 import { Notifications } from '../../shared/src/app/notifications/Notifications'
 import { createController as createExtensionsController } from '../../shared/src/client/controller'
 import { ConfiguredExtension } from '../../shared/src/extensions/extension'
@@ -260,6 +261,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                 // Extensions
                                 extensions={this.state.extensions}
                                 extensionsEnvironment={this.state.extensionsEnvironment}
+                                extensionsOnRootsChange={this.extensionsOnRootsChange}
                                 extensionsOnVisibleTextDocumentsChange={this.extensionsOnVisibleTextDocumentsChange}
                                 extensionsController={this.state.extensionsController}
                             />
@@ -319,6 +321,13 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                 }
                 return update
             },
+            () => this.state.extensionsController.setEnvironment(this.state.extensionsEnvironment)
+        )
+    }
+
+    private extensionsOnRootsChange = (roots: WorkspaceRoot[] | null): void => {
+        this.setState(
+            prevState => ({ extensionsEnvironment: { ...prevState.extensionsEnvironment, roots } }),
             () => this.state.extensionsController.setEnvironment(this.state.extensionsEnvironment)
         )
     }

--- a/web/src/extensions/environment/ExtensionsEnvironment.tsx
+++ b/web/src/extensions/environment/ExtensionsEnvironment.tsx
@@ -1,5 +1,6 @@
 import { Environment } from '../../../../shared/src/api/client/environment'
 import { TextDocumentItem } from '../../../../shared/src/api/client/types/textDocument'
+import { WorkspaceRoot } from '../../../../shared/src/api/protocol/plainTypes'
 import { ConfiguredExtension } from '../../../../shared/src/extensions/extension'
 import { Settings, SettingsCascade, SettingsSubject } from '../../../../shared/src/settings'
 
@@ -11,6 +12,11 @@ export interface ExtensionsEnvironmentProps {
 
 /** React props for components that participate in the Sourcegraph extensions environment. */
 export interface ExtensionsDocumentsProps {
+    /**
+     * Called when the Sourcegraph extensions environment's workspace roots change.
+     */
+    extensionsOnRootsChange: (roots: WorkspaceRoot[] | null) => void
+
     /**
      * Called when the Sourcegraph extensions environment's set of visible text documents changes.
      */

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -84,13 +84,16 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
+        const repoRevChanges = this.propsUpdates.pipe(
+            // Pick repoPath and rev out of the props
+            map(props => ({ repoPath: props.repo.name, rev: props.rev })),
+            distinctUntilChanged((a, b) => isEqual(a, b))
+        )
+
         // Fetch repository revision.
         this.subscriptions.add(
-            this.propsUpdates
+            repoRevChanges
                 .pipe(
-                    // Pick repoPath and rev out of the props
-                    map(props => ({ repoPath: props.repo.name, rev: props.rev })),
-                    distinctUntilChanged((a, b) => isEqual(a, b)),
                     // Reset resolved rev / error state
                     tap(() => this.props.onResolvedRevOrError(undefined)),
                     switchMap(({ repoPath, rev }) =>
@@ -130,6 +133,7 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
                     }
                 )
         )
+
         this.propsUpdates.next(this.props)
     }
 
@@ -191,6 +195,7 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
         const context: RepoRevContainerContext = {
             extensions: this.props.extensions,
             extensionsController: this.props.extensionsController,
+            extensionsOnRootsChange: this.props.extensionsOnRootsChange,
             extensionsOnVisibleTextDocumentsChange: this.props.extensionsOnVisibleTextDocumentsChange,
             isLightTheme: this.props.isLightTheme,
             repo: this.props.repo,

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -283,6 +283,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
                             settingsCascade={this.props.settingsCascade}
                             extensions={this.props.extensions}
                             extensionsController={this.props.extensionsController}
+                            extensionsOnRootsChange={this.props.extensionsOnRootsChange}
                             extensionsOnVisibleTextDocumentsChange={this.props.extensionsOnVisibleTextDocumentsChange}
                             wrapCode={this.state.wrapCode}
                             renderMode={renderMode}

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -257,6 +257,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                                 extensionsOnVisibleTextDocumentsChange={
                                     this.props.extensionsOnVisibleTextDocumentsChange
                                 }
+                                extensionsOnRootsChange={this.props.extensionsOnRootsChange}
                             />
                         </>
                     )}

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -202,6 +202,7 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
                                             extensionsOnVisibleTextDocumentsChange={
                                                 this.props.extensionsOnVisibleTextDocumentsChange
                                             }
+                                            extensionsOnRootsChange={this.props.extensionsOnRootsChange}
                                         />
                                     )}
                                 />

--- a/web/src/repo/compare/RepositoryCompareDiffPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareDiffPage.tsx
@@ -131,6 +131,7 @@ export class RepositoryCompareDiffPage extends React.PureComponent<RepositoryCom
                     history={this.props.history}
                     location={this.props.location}
                     extensionsOnVisibleTextDocumentsChange={this.props.extensionsOnVisibleTextDocumentsChange}
+                    extensionsOnRootsChange={this.props.extensionsOnRootsChange}
                 />
             </div>
         )

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -88,6 +88,7 @@ export const repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute> = [
                                     }
                                     settingsCascade={context.settingsCascade}
                                     extensions={context.extensions}
+                                    extensionsOnRootsChange={context.extensionsOnRootsChange}
                                     extensionsOnVisibleTextDocumentsChange={
                                         context.extensionsOnVisibleTextDocumentsChange
                                     }


### PR DESCRIPTION
These new APIs make it easier for language extensions to communicate with language servers, which generally have a 1-to-1 correspondence with workspace roots. Previously extensions could only know the documents that were open; now they can know which repos are open. (They could've determined this by manually munging the URI, but it's much cleaner to have an API designed for this.)

> This PR does not need to update the CHANGELOG because it is not user facing

Example snippets:

```typescript
    /** Gets the workspace root that contains the given URI. */
    function getWorkspaceRoot(uri: string): string | undefined {
        const root = sourcegraph.workspace.roots.find(root =>
            uri.startsWith(root.uri.toString())
        )
        return root ? root.uri.toString() : undefined
    }
```

```typescript
        sourcegraph.workspace.onDidChangeRoots).pipe(
            // Only startWith a root if there are roots. Otherwise, there is no need to start, because when a root
            // is present, the observable will emit.
            sourcegraph.workspace.roots.length > 0 ? startWith(void 0) : tap(),
            map(() => sourcegraph.workspace.roots)
        )
```