### PR TITLE
remove canonicalURLRedirect feature flag (always enable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - The `siteID` site configuration option was removed because it is no longer needed. If you previously specified this in site configuration, a new, random site ID will be generated upon server startup. You can safely remove the existing `siteID` value from your site configuration after upgrading.
+- The `experimentalFeatures.canonicalURLRedirect` site config property is always enabled, and the feature flag to disable it was removed. It was initially enabled by default in 2.13.
 
 ### Removed
 

--- a/cmd/frontend/internal/cli/middleware/redirect.go
+++ b/cmd/frontend/internal/cli/middleware/redirect.go
@@ -58,24 +58,8 @@ func CanonicalURL(next http.Handler) http.Handler {
 			return
 		}
 
-		var canonicalURLRedirect bool
-		if conf.ExperimentalFeatures != nil {
-			switch conf.ExperimentalFeatures.CanonicalURLRedirect {
-			case "enabled", "": // default enabled
-				canonicalURLRedirect = true
-			case "disabled":
-				// noop
-			default:
-				text := "Misconfigured experimentalFeatures.canonicalURLRedirect values in site configuration."
-				log15.Error(text, "invalidValue", conf.ExperimentalFeatures.CanonicalURLRedirect)
-				http.Error(w, text, http.StatusInternalServerError)
-				return
-			}
-		}
-
-		requireHostMatch := conf.ExperimentalFeatures != nil && canonicalURLRedirect
 		useXForwardedProto := httpToHTTPSRedirect == "load-balanced"
-		if reqURL := getRequestURL(r, useXForwardedProto); (requireHostMatch && reqURL.Host != externalURL.Host) || (requireSchemeMatch && !doesSchemeMatch(r, externalURL, useXForwardedProto)) {
+		if reqURL := getRequestURL(r, useXForwardedProto); reqURL.Host != externalURL.Host || (requireSchemeMatch && !doesSchemeMatch(r, externalURL, useXForwardedProto)) {
 			// Redirect.
 			dest := externalURL.ResolveReference(&url.URL{Path: reqURL.Path, RawQuery: reqURL.RawQuery, Fragment: reqURL.Fragment})
 			http.Redirect(w, r, dest.String(), http.StatusMovedPermanently)

--- a/doc/admin/site_config/all.md
+++ b/doc/admin/site_config/all.md
@@ -229,17 +229,6 @@ This property must be one of the following enum values:
 
 Default: `"disabled"`
 
-### canonicalURLRedirect (string, enum)
-
-Enables or disables redirecting to the canonical URL (underneath the `externalURL`) for incoming HTTP requests. Enabled by default.
-
-This property must be one of the following enum values:
-
-- `enabled`
-- `disabled`
-
-Default: `"enabled"`
-
 ### discussions (string, enum)
 
 Enables the code discussions experiment.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -141,11 +141,10 @@ type Discussions struct {
 
 // ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 type ExperimentalFeatures struct {
-	CanonicalURLRedirect string `json:"canonicalURLRedirect,omitempty"`
-	Discussions          string `json:"discussions,omitempty"`
-	GithubAuth           bool   `json:"githubAuth,omitempty"`
-	JumpToDefOSSIndex    string `json:"jumpToDefOSSIndex,omitempty"`
-	UpdateScheduler2     string `json:"updateScheduler2,omitempty"`
+	Discussions       string `json:"discussions,omitempty"`
+	GithubAuth        bool   `json:"githubAuth,omitempty"`
+	JumpToDefOSSIndex string `json:"jumpToDefOSSIndex,omitempty"`
+	UpdateScheduler2  string `json:"updateScheduler2,omitempty"`
 }
 
 // ExtensionRepository description: The location of the version control repository for this extension.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -69,13 +69,6 @@
           "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
-        "canonicalURLRedirect": {
-          "description":
-            "Enables or disables enforcing that HTTP requests use the externalURL as a prefix, by redirecting other requests to the same request URI on the externalURL. For example, if the externalURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Enabled by default.",
-          "type": "string",
-          "enum": ["enabled", "disabled"],
-          "default": "enabled"
-        },
         "discussions": {
           "description": "Enables the code discussions experiment.",
           "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -74,13 +74,6 @@ const SiteSchemaJSON = `{
           "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
-        "canonicalURLRedirect": {
-          "description":
-            "Enables or disables enforcing that HTTP requests use the externalURL as a prefix, by redirecting other requests to the same request URI on the externalURL. For example, if the externalURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Enabled by default.",
-          "type": "string",
-          "enum": ["enabled", "disabled"],
-          "default": "enabled"
-        },
         "discussions": {
           "description": "Enables the code discussions experiment.",
           "type": "string",


### PR DESCRIPTION
Close #466 (see that issue for context).

Note that #929 might remove this altogether, but it's still good to clean up old feature flags incrementally.

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
> This PR does not need to update the CHANGELOG because ...