### PR TITLE
add RegistryExtension.publishedAt date, bump updated date after publishing release

### DIFF
--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -98,6 +98,7 @@ type RegistryExtension interface {
 	Manifest(ctx context.Context) (ExtensionManifest, error)
 	CreatedAt() *string
 	UpdatedAt() *string
+	PublishedAt(context.Context) (*string, error)
 	URL() string
 	RemoteURL() *string
 	RegistryName() (string, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3050,8 +3050,11 @@ type RegistryExtension implements Node {
     manifest: ExtensionManifest
     # The date when this extension was created on the registry.
     createdAt: String
-    # The date when this extension was last updated on the registry.
+    # The date when this extension was last updated on the registry (including updates to its metadata only, not
+    # publishing new releases).
     updatedAt: String
+    # The date when a release of this extension was most recently published, or null if there are no releases.
+    publishedAt: String
     # The URL to the extension on this Sourcegraph site.
     url: String!
     # The URL to the extension on the extension registry where it lives (if this is a remote

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3057,8 +3057,11 @@ type RegistryExtension implements Node {
     manifest: ExtensionManifest
     # The date when this extension was created on the registry.
     createdAt: String
-    # The date when this extension was last updated on the registry.
+    # The date when this extension was last updated on the registry (including updates to its metadata only, not
+    # publishing new releases).
     updatedAt: String
+    # The date when a release of this extension was most recently published, or null if there are no releases.
+    publishedAt: String
     # The URL to the extension on this Sourcegraph site.
     url: String!
     # The URL to the extension on the extension registry where it lives (if this is a remote

--- a/cmd/frontend/registry/extension_remote_graphql.go
+++ b/cmd/frontend/registry/extension_remote_graphql.go
@@ -67,6 +67,13 @@ func (r *registryExtensionRemoteResolver) UpdatedAt() *string {
 	return strptr(r.v.UpdatedAt.Format(time.RFC3339))
 }
 
+func (r *registryExtensionRemoteResolver) PublishedAt(context.Context) (*string, error) {
+	if r.v.IsSynthesizedLocalExtension {
+		return nil, nil
+	}
+	return strptr(r.v.PublishedAt.Format(time.RFC3339)), nil
+}
+
 func (r *registryExtensionRemoteResolver) URL() string {
 	return router.Extension(r.v.ExtensionID)
 }

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -35,7 +35,7 @@ func (r *extensionDBResolver) Publisher(ctx context.Context) (graphqlbackend.Reg
 
 func (r *extensionDBResolver) Name() string { return r.v.Name }
 func (r *extensionDBResolver) Manifest(ctx context.Context) (graphqlbackend.ExtensionManifest, error) {
-	manifest, err := getExtensionManifestWithBundleURL(ctx, r.v.NonCanonicalExtensionID, r.v.ID, "release")
+	manifest, _, err := getExtensionManifestWithBundleURL(ctx, r.v.NonCanonicalExtensionID, r.v.ID, "release")
 	if err != nil {
 		return nil, err
 	}
@@ -48,6 +48,14 @@ func (r *extensionDBResolver) CreatedAt() *string {
 
 func (r *extensionDBResolver) UpdatedAt() *string {
 	return strptr(r.v.UpdatedAt.Format(time.RFC3339))
+}
+
+func (r *extensionDBResolver) PublishedAt(ctx context.Context) (*string, error) {
+	_, publishedAt, err := getExtensionManifestWithBundleURL(ctx, r.v.NonCanonicalExtensionID, r.v.ID, "release")
+	if err != nil {
+		return nil, err
+	}
+	return strptr(publishedAt.Format(time.RFC3339)), nil
 }
 
 func (r *extensionDBResolver) URL() string {

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestGetExtensionManifestWithBundleURL(t *testing.T) {
@@ -17,36 +18,45 @@ func TestGetExtensionManifestWithBundleURL(t *testing.T) {
 		}
 		return *s
 	}
+	t0 := time.Unix(1234, 0)
 
 	t.Run(`manifest with "url"`, func(t *testing.T) {
 		mocks.releases.GetLatest = func(registryExtensionID int32, releaseTag string, includeArtifacts bool) (*dbRelease, error) {
 			return &dbRelease{
-				Manifest: `{"name":"x","url":"u"}`,
+				Manifest:  `{"name":"x","url":"u"}`,
+				CreatedAt: t0,
 			}, nil
 		}
 		defer func() { mocks.releases.GetLatest = nil }()
-		manifest, err := getExtensionManifestWithBundleURL(ctx, "x", 1, "t")
+		manifest, publishedAt, err := getExtensionManifestWithBundleURL(ctx, "x", 1, "t")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if want := `{"name":"x","url":"u"}`; manifest == nil || !jsonDeepEqual(*manifest, want) {
 			t.Errorf("got %q, want %q", nilOrEmpty(manifest), want)
 		}
+		if publishedAt != t0 {
+			t.Errorf("got %v, want %v", publishedAt, t0)
+		}
 	})
 
 	t.Run(`manifest without "url"`, func(t *testing.T) {
 		mocks.releases.GetLatest = func(registryExtensionID int32, releaseTag string, includeArtifacts bool) (*dbRelease, error) {
 			return &dbRelease{
-				Manifest: `{"name":"x"}`,
+				Manifest:  `{"name":"x"}`,
+				CreatedAt: t0,
 			}, nil
 		}
 		defer func() { mocks.releases.GetLatest = nil }()
-		manifest, err := getExtensionManifestWithBundleURL(ctx, "x", 1, "t")
+		manifest, publishedAt, err := getExtensionManifestWithBundleURL(ctx, "x", 1, "t")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want := `{"name":"x","url":"/-/static/extension/0-x.js?-1fmlvpbbdw2yo--x"}`; manifest == nil || !jsonDeepEqual(*manifest, want) {
+		if want := `{"name":"x","url":"/-/static/extension/0-x.js?fqw3qlts--x"}`; manifest == nil || !jsonDeepEqual(*manifest, want) {
 			t.Errorf("got %q, want %q", nilOrEmpty(manifest), want)
+		}
+		if publishedAt != t0 {
+			t.Errorf("got %v, want %v", publishedAt, t0)
 		}
 	})
 }

--- a/enterprise/cmd/frontend/internal/registry/http_api.go
+++ b/enterprise/cmd/frontend/internal/registry/http_api.go
@@ -58,7 +58,7 @@ var (
 )
 
 func toRegistryAPIExtension(ctx context.Context, v *dbExtension) (*registry.Extension, error) {
-	manifest, err := getExtensionManifestWithBundleURL(ctx, v.NonCanonicalExtensionID, v.ID, "release")
+	manifest, publishedAt, err := getExtensionManifestWithBundleURL(ctx, v.NonCanonicalExtensionID, v.ID, "release")
 	if err != nil {
 		return nil, err
 	}
@@ -71,11 +71,12 @@ func toRegistryAPIExtension(ctx context.Context, v *dbExtension) (*registry.Exte
 			Name: v.Publisher.NonCanonicalName,
 			URL:  baseURL + frontendregistry.PublisherExtensionsURL(v.Publisher.UserID != 0, v.Publisher.OrgID != 0, v.Publisher.NonCanonicalName),
 		},
-		Name:      v.Name,
-		Manifest:  manifest,
-		CreatedAt: v.CreatedAt,
-		UpdatedAt: v.UpdatedAt,
-		URL:       baseURL + frontendregistry.ExtensionURL(v.NonCanonicalExtensionID),
+		Name:        v.Name,
+		Manifest:    manifest,
+		CreatedAt:   v.CreatedAt,
+		UpdatedAt:   v.UpdatedAt,
+		PublishedAt: publishedAt,
+		URL:         baseURL + frontendregistry.ExtensionURL(v.NonCanonicalExtensionID),
 	}, nil
 }
 

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -16,6 +16,7 @@ type Extension struct {
 	Manifest    *string   `json:"manifest"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
+	PublishedAt time.Time `json:"publishedAt"`
 	URL         string    `json:"url"`
 
 	// RegistryURL is the URL of the remote registry that this extension was retrieved from. It is

--- a/web/src/components/time/Timestamp.tsx
+++ b/web/src/components/time/Timestamp.tsx
@@ -2,8 +2,8 @@ import formatDistance from 'date-fns/formatDistance'
 import * as React from 'react'
 
 interface Props {
-    /** The date string (RFC 3339). */
-    date: string
+    /** The date (if string, in RFC 3339 format). */
+    date: string | Date | number
 
     /** Omit the "about". */
     noAbout?: boolean

--- a/web/src/enterprise/extensions/registry/RegistryExtensionOverviewPage.tsx
+++ b/web/src/enterprise/extensions/registry/RegistryExtensionOverviewPage.tsx
@@ -1,3 +1,4 @@
+import maxDate from 'date-fns/max'
 import { isObject } from 'lodash'
 import GithubCircleIcon from 'mdi-react/GithubCircleIcon'
 import * as React from 'react'
@@ -89,11 +90,19 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                             <dt className="border-top pt-2">Extension ID</dt>
                             <dd>{this.props.extension.id}</dd>
                             {this.props.extension.registryExtension &&
-                                this.props.extension.registryExtension.updatedAt && (
+                                (this.props.extension.registryExtension.updatedAt ||
+                                    this.props.extension.registryExtension.publishedAt) && (
                                     <>
                                         <dt className="border-top pt-2">Last updated</dt>
                                         <dd>
-                                            <Timestamp date={this.props.extension.registryExtension.updatedAt} />
+                                            <Timestamp
+                                                date={maxDate(
+                                                    [
+                                                        this.props.extension.registryExtension.updatedAt,
+                                                        this.props.extension.registryExtension.publishedAt,
+                                                    ].filter((v): v is string => !!v)
+                                                )}
+                                            />
                                         </dd>
                                     </>
                                 )}

--- a/web/src/extensions/extension/ExtensionArea.tsx
+++ b/web/src/extensions/extension/ExtensionArea.tsx
@@ -43,6 +43,7 @@ export const registryExtensionFragment = gql`
         }
         createdAt
         updatedAt
+        publishedAt
         url
         remoteURL
         registryName


### PR DESCRIPTION
Previously, an extension's "last updated" date on its registry extension page showed the last time its metadata was updated. The only thing that would bump this date up is creating or renaming the extension. This date was misleading because people understandably expected the "last updated" date to be bumped up when a new release of the extension was published. This commit implements that behavior.

fixes #623

> This PR does not need to update the CHANGELOG because it is minor