### PR TITLE
support marking extensions as work-in-progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The repository settings mirroring page now shows when a repo is next scheduled for an update (requires experiment `"updateScheduler2": "enabled"`).
 - Configured repositories are periodically scheduled for updates using a new algorithm. You can disable the new algorithm with the following site configuration: `"experimentalFeatures": { "updateScheduler2": "disabled" }`. If you do so, please file a public issue to describe why you needed to disable it.
 - When using HTTP header authentication, [`stripUsernameHeaderPrefix`](https://docs.sourcegraph.com/admin/auth/#username-header-prefixes) field lets an admin specify a prefix to strip from the HTTP auth header when converting the header value to a username.
+- Sourcegraph extensions whose title begins with `WIP:` or `[WIP]` are considered [work-in-progress extensions](https://docs.sourcegraph.com/extensions/authoring/creating_and_publishing#work-in-progress-wip-extensions) and are indicated as such to avoid users accidentally using them.
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -45,6 +45,7 @@ type RegistryExtensionConnectionArgs struct {
 	Publisher              *graphql.ID
 	Local                  bool
 	Remote                 bool
+	IncludeWIP             bool
 	PrioritizeExtensionIDs *[]string
 }
 
@@ -102,6 +103,7 @@ type RegistryExtension interface {
 	RemoteURL() *string
 	RegistryName() (string, error)
 	IsLocal() bool
+	IsWorkInProgress() bool
 	ViewerCanAdminister(ctx context.Context) (bool, error)
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2930,6 +2930,8 @@ type ExtensionRegistry {
         # Typically, the client passes the list of added and enabled extension IDs in this parameter so that the
         # results include those extensions first (which is typically what the user prefers).
         prioritizeExtensionIDs: [String!]
+        # Include WIP (work-in-progress) extensions.
+        includeWIP: Boolean = true
     ): RegistryExtensionConnection!
     # A list of publishers with at least 1 extension in the registry.
     publishers(
@@ -3061,6 +3063,8 @@ type RegistryExtension implements Node {
     registryName: String!
     # Whether the registry extension is published on this Sourcegraph site.
     isLocal: Boolean!
+    # Whether the extension is marked as a work-in-progress extension by the extension author.
+    isWorkInProgress: Boolean!
     # Whether the viewer has admin privileges on this registry extension.
     viewerCanAdminister: Boolean!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2937,6 +2937,8 @@ type ExtensionRegistry {
         # Typically, the client passes the list of added and enabled extension IDs in this parameter so that the
         # results include those extensions first (which is typically what the user prefers).
         prioritizeExtensionIDs: [String!]
+        # Include WIP (work-in-progress) extensions.
+        includeWIP: Boolean = true
     ): RegistryExtensionConnection!
     # A list of publishers with at least 1 extension in the registry.
     publishers(
@@ -3068,6 +3070,8 @@ type RegistryExtension implements Node {
     registryName: String!
     # Whether the registry extension is published on this Sourcegraph site.
     isLocal: Boolean!
+    # Whether the extension is marked as a work-in-progress extension by the extension author.
+    isWorkInProgress: Boolean!
     # Whether the viewer has admin privileges on this registry extension.
     viewerCanAdminister: Boolean!
 }

--- a/cmd/frontend/registry/extension_connection_graphql.go
+++ b/cmd/frontend/registry/extension_connection_graphql.go
@@ -86,6 +86,16 @@ func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]gr
 			}
 			remote = append(remote, xs...)
 		}
+		// Filter out WIP extensions from the remote extensions list if WIP extensions are excluded.
+		if !r.args.IncludeWIP {
+			keep := remote[:0]
+			for _, x := range remote {
+				if !IsWorkInProgressExtension(x.Manifest) {
+					keep = append(keep, x)
+				}
+			}
+			remote = keep
+		}
 
 		r.registryExtensions = make([]graphqlbackend.RegistryExtension, len(local)+len(remote))
 		copy(r.registryExtensions, local)
@@ -102,6 +112,12 @@ func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]gr
 				return pi && !pj
 			})
 		}
+
+		// Sort WIP extensions last. (The local extensions list is already sorted in that way, but
+		// the remote extensions list isn't, so therefore the combined list isn't.)
+		sort.SliceStable(r.registryExtensions, func(i, j int) bool {
+			return !r.registryExtensions[i].IsWorkInProgress() && r.registryExtensions[j].IsWorkInProgress()
+		})
 	})
 	return r.registryExtensions, r.err
 }

--- a/cmd/frontend/registry/extension_remote_graphql.go
+++ b/cmd/frontend/registry/extension_remote_graphql.go
@@ -91,6 +91,10 @@ func (r *registryExtensionRemoteResolver) RegistryName() (string, error) {
 
 func (r *registryExtensionRemoteResolver) IsLocal() bool { return r.v.IsSynthesizedLocalExtension }
 
+func (r *registryExtensionRemoteResolver) IsWorkInProgress() bool {
+	return IsWorkInProgressExtension(r.v.Manifest)
+}
+
 func (r *registryExtensionRemoteResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	return false, nil // can't administer remote extensions
 }

--- a/cmd/frontend/registry/extensions_test.go
+++ b/cmd/frontend/registry/extensions_test.go
@@ -186,6 +186,31 @@ func TestGetExtensionByExtensionID(t *testing.T) {
 	})
 }
 
+func TestIsWorkInProgressExtension(t *testing.T) {
+	tests := map[*string]bool{
+		nil:                           true,
+		strptr(`{`):                   false,
+		strptr(`{}`):                  false,
+		strptr(`{"title":null}`):      false,
+		strptr(`{"title":""}`):        false,
+		strptr(`{"title":"a b"}`):     false,
+		strptr(`{"title":"WIP: a"}`):  true,
+		strptr(`{"title":"[WIP] a"}`): true,
+	}
+	for manifest, want := range tests {
+		got := IsWorkInProgressExtension(manifest)
+		if got != want {
+			var label string
+			if manifest == nil {
+				label = "nil"
+			} else {
+				label = *manifest
+			}
+			t.Errorf("got %v, want %v (manifest: %s)", got, want, label)
+		}
+	}
+}
+
 var strnilptr *string
 
 func strptrptr(s string) **string {

--- a/doc/extensions/authoring/creating_and_publishing.md
+++ b/doc/extensions/authoring/creating_and_publishing.md
@@ -42,7 +42,19 @@ The last command builds and publishes your extension to Sourcegraph. It prints t
 
 > NOTE: If your extension is under development, prefix its title with "WIP" or similar to indicate that it's not ready. In the future, we will improve this experience. See [issue #480](https://github.com/sourcegraph/sourcegraph/issues/480) and [issue #489](https://github.com/sourcegraph/sourcegraph/issues/489).
 
-### Development: seeing local changes without republishing
+## Development
+
+### Work-in-progress (WIP) extensions
+
+To prevent other users from accidentally using unfinished and experimental extensions, Sourcegraph allows extension authors to mark extensions as **work-in-progress**. To mark an extension as a work-in-progress, start its title with `WIP:` or `[WIP]` (in its `package.json` file's `title` field).
+
+For example, an extension whose title is `WIP: Python code examples` is considered to be a work-in-progress extension.
+
+On the extension registry, work-in-progress extensions are hidden from or demoted on the list of extensions, and they display a special WIP badge. To find a work-in-progress extension, a user can search for it by name or navigate to its URL directly.
+
+When your work-in-progress extension is ready for use, just remove `WIP:` or `[WIP]` from the title and publish a new release to remove the work-in-progress marker.
+
+### Seeing local changes without republishing
 
 Using the above steps, each time you change your extension's source code, you must republish it. During development, you can speed up this process by using the Parcel bundler's development server. This lets you see changes in your browser without needing to republish. (You still need to reload the page.)
 

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
@@ -61,6 +61,7 @@ func toDBExtensionsListOptions(args graphqlbackend.RegistryExtensionConnectionAr
 	if args.PrioritizeExtensionIDs != nil {
 		opt.PrioritizeExtensionIDs = *args.PrioritizeExtensionIDs
 	}
+	opt.ExcludeWIP = !args.IncludeWIP
 	return opt, nil
 }
 

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -61,6 +61,10 @@ func (r *extensionDBResolver) RegistryName() (string, error) {
 
 func (r *extensionDBResolver) IsLocal() bool { return true }
 
+func (r *extensionDBResolver) IsWorkInProgress() bool {
+	return r.v.NonCanonicalIsWorkInProgress
+}
+
 func (r *extensionDBResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	err := toRegistryPublisherID(r.v).viewerCanAdminister(ctx)
 	if err == backend.ErrMustBeSiteAdmin || err == backend.ErrNotAnOrgMember || err == backend.ErrNotAuthenticated {

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -262,6 +262,47 @@ func TestRegistryExtensions(t *testing.T) {
 			t.Fatal("err == nil")
 		}
 	})
+
+	t.Run("List ExcludeWIP and sort non-WIP first", func(t *testing.T) {
+		// xwip1 is a WIP extension because its title begins with "WIP:".
+		xwip1 := createAndGet(t, user.ID, 0, "wiptest1")
+		_, err := dbReleases{}.Create(ctx, &dbRelease{
+			RegistryExtensionID: xwip1.ID,
+			CreatorUserID:       user.ID,
+			ReleaseTag:          "release",
+			Manifest:            `{"title": "WIP: x"}`,
+			Bundle:              strptr(""),
+			SourceMap:           strptr(""),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// xwip2 is a WIP extension because it has no published releases.
+		xwip2 := createAndGet(t, user.ID, 0, "wiptest2")
+
+		// xnonwip is a non-WIP extension.
+		xnonwip := createAndGet(t, user.ID, 0, "wiptest3")
+		_, err = dbReleases{}.Create(ctx, &dbRelease{
+			RegistryExtensionID: xnonwip.ID,
+			CreatorUserID:       user.ID,
+			ReleaseTag:          "release",
+			Manifest:            `{"title": "x"}`,
+			Bundle:              strptr(""),
+			SourceMap:           strptr(""),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		xnonwip.NonCanonicalIsWorkInProgress = false
+
+		// The non-WIP extension should be sorted first.
+		testList(t, dbExtensionsListOptions{ExcludeWIP: false, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 3}}, []*dbExtension{xnonwip, xwip1, xwip2})
+
+		// The WIP extension should be excluded.
+		testList(t, dbExtensionsListOptions{ExcludeWIP: true, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 3}}, []*dbExtension{xnonwip})
+	})
+
 }
 
 func asJSON(t *testing.T, v interface{}) string {

--- a/shared/src/controller.ts
+++ b/shared/src/controller.ts
@@ -144,8 +144,10 @@ export class Controller<S extends SettingsSubject, C extends Settings> {
         )
     }
 
-    public withConfiguration(registryExtensions: GQL.IRegistryExtension[]): ConfiguredExtension[] {
-        const configuredExtensions: ConfiguredExtension[] = []
+    public withConfiguration(
+        registryExtensions: GQL.IRegistryExtension[]
+    ): ConfiguredExtension<GQL.IRegistryExtension>[] {
+        const configuredExtensions: ConfiguredExtension<GQL.IRegistryExtension>[] = []
         for (const registryExtension of registryExtensions) {
             configuredExtensions.push({
                 id: registryExtension.extensionID,

--- a/web/src/extensions/ExtensionCard.tsx
+++ b/web/src/extensions/ExtensionCard.tsx
@@ -3,16 +3,18 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { ConfiguredExtension, isExtensionEnabled } from '../../../shared/src/extensions/extension'
 import { SettingsSubject } from '../../../shared/src/graphqlschema'
+import * as GQL from '../../../shared/src/graphqlschema'
 import { ExtensionManifest } from '../../../shared/src/schema/extension.schema'
 import { LinkOrSpan } from '../../../shared/src/ui/generic/LinkOrSpan'
 import { Settings } from '../schema/settings.schema'
 import { isErrorLike } from '../util/errors'
 import { ExtensionConfigurationState } from './extension/ExtensionConfigurationState'
+import { WorkInProgressBadge } from './extension/WorkInProgressBadge'
 import { ExtensionsProps, isExtensionAdded, SettingsCascadeProps } from './ExtensionsClientCommonContext'
 import { ExtensionToggle } from './ExtensionToggle'
 
 interface Props<S extends SettingsSubject, C extends Settings> extends SettingsCascadeProps, ExtensionsProps {
-    node: ConfiguredExtension
+    node: ConfiguredExtension<GQL.IRegistryExtension>
     subject: Pick<SettingsSubject, 'id' | 'viewerCanAdminister'>
     onDidUpdate: () => void
 }
@@ -52,6 +54,12 @@ export class ExtensionCard<S extends SettingsSubject, C extends Settings> extend
                                     {manifest && manifest.title ? manifest.title : node.id}
                                 </h4>
                                 <div className="extension-card__body-text d-inline-block mt-1">
+                                    {node.registryExtension &&
+                                        node.registryExtension.isWorkInProgress && (
+                                            <WorkInProgressBadge
+                                                viewerCanAdminister={node.registryExtension.viewerCanAdminister}
+                                            />
+                                        )}
                                     {node.manifest ? (
                                         isErrorLike(node.manifest) ? (
                                             <span className="text-danger small" title={node.manifest.message}>

--- a/web/src/extensions/ExtensionsList.tsx
+++ b/web/src/extensions/ExtensionsList.tsx
@@ -54,6 +54,8 @@ export const registryExtensionFragment = gql`
         remoteURL
         registryName
         isLocal
+        isWorkInProgress
+        viewerCanAdminister
     }
 `
 
@@ -66,7 +68,7 @@ const LOADING: 'loading' = 'loading'
 
 interface ExtensionsResult {
     /** The configured extensions. */
-    extensions: ConfiguredExtension[]
+    extensions: ConfiguredExtension<GQL.IRegistryExtension>[]
 
     /** An error message that should be displayed to the user (in addition to the configured extensions). */
     error: string | null
@@ -252,9 +254,17 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                 from(
                     queryGraphQL(
                         gql`
-                            query RegistryExtensions($query: String, $prioritizeExtensionIDs: [String!]!) {
+                            query RegistryExtensions(
+                                $query: String
+                                $prioritizeExtensionIDs: [String!]!
+                                $includeWIP: Boolean!
+                            ) {
                                 extensionRegistry {
-                                    extensions(query: $query, prioritizeExtensionIDs: $prioritizeExtensionIDs) {
+                                    extensions(
+                                        query: $query
+                                        prioritizeExtensionIDs: $prioritizeExtensionIDs
+                                        includeWIP: $includeWIP
+                                    ) {
                                         nodes {
                                             ...RegistryExtensionFields
                                         }
@@ -267,6 +277,7 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                         {
                             ...args,
                             prioritizeExtensionIDs: viewerExtensions.map(({ id }) => id),
+                            includeWIP: !!args.query,
                         } as GQL.IExtensionsOnExtensionRegistryArguments
                     )
                 ).pipe(

--- a/web/src/extensions/extension/ExtensionArea.tsx
+++ b/web/src/extensions/extension/ExtensionArea.tsx
@@ -47,6 +47,7 @@ export const registryExtensionFragment = gql`
         remoteURL
         registryName
         isLocal
+        isWorkInProgress
         viewerCanAdminister
     }
 `

--- a/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -9,6 +9,7 @@ import { isExtensionAdded } from '../ExtensionsClientCommonContext'
 import { ExtensionToggle } from '../ExtensionToggle'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionConfigurationState } from './ExtensionConfigurationState'
+import { WorkInProgressBadge } from './WorkInProgressBadge'
 
 interface ExtensionAreaHeaderProps extends ExtensionAreaRouteContext, RouteComponentProps<{}> {
     navItems: ReadonlyArray<ExtensionAreaHeaderNavItem>
@@ -32,6 +33,8 @@ export const ExtensionAreaHeader: React.SFC<ExtensionAreaHeaderProps> = (props: 
     } catch (e) {
         // noop
     }
+
+    const isWorkInProgress = props.extension.registryExtension && props.extension.registryExtension.isWorkInProgress
 
     return (
         <div className="extension-area-header border-bottom simple-area-header">
@@ -60,7 +63,19 @@ export const ExtensionAreaHeader: React.SFC<ExtensionAreaHeaderProps> = (props: 
                                     {manifest &&
                                         manifest.title && <div className="text-muted">{props.extension.id}</div>}
                                     {manifest &&
-                                        manifest.description && <p className="mt-1 mb-0">{manifest.description}</p>}
+                                        (manifest.description || isWorkInProgress) && (
+                                            <p className="mt-1 mb-0">
+                                                {isWorkInProgress && (
+                                                    <WorkInProgressBadge
+                                                        viewerCanAdminister={
+                                                            !!props.extension.registryExtension &&
+                                                            props.extension.registryExtension.viewerCanAdminister
+                                                        }
+                                                    />
+                                                )}
+                                                {manifest.description}
+                                            </p>
+                                        )}
                                 </div>
                             </div>
                         </div>

--- a/web/src/extensions/extension/WorkInProgressBadge.tsx
+++ b/web/src/extensions/extension/WorkInProgressBadge.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+/**
+ * Shows a "Work in progress" badge for extensions.
+ */
+export const WorkInProgressBadge: React.FunctionComponent<{ viewerCanAdminister: boolean }> = ({
+    viewerCanAdminister,
+}) => (
+    <span
+        className="badge badge-danger mr-2"
+        data-tooltip={
+            viewerCanAdminister
+                ? 'Remove "WIP" from the title when this extension is ready for use.'
+                : 'This extension is still under development and is not ready for use.'
+        }
+    >
+        Work in progress
+    </span>
+)


### PR DESCRIPTION
Problem: it's not clear which extensions on Sourcegraph.com are ready to be used. There is a convention to add "WIP" to the title, but that is not clearly communicated and still results in the extension being shown to users prominently.

An extension with no published releases or whose title begins with `WIP:` or `[WIP]` is considered a work-in-progress extension. WIP extensions:

- are not shown in the initial list of extensions on the extension registry (they are only shown when the user has typed in a query)
- are sorted last on the extension registry list of extensions when there is a query (unless the user has already added the WIP extension)
- have a red "Work in progress" badge on the extension card in the list
- have a red "Work in progress" badge on the extension's page


> This PR updates the CHANGELOG.md file to describe any user-facing changes.

fix #480 

![screenshot from 2018-11-15 00-09-15](https://user-images.githubusercontent.com/1976/48539339-b0ca6900-e86b-11e8-80b8-c8823d74c5f0.png)
![screenshot from 2018-11-14 23-48-27](https://user-images.githubusercontent.com/1976/48539340-b0ca6900-e86b-11e8-893f-08c88054448e.png)
![screenshot from 2018-11-14 23-48-19](https://user-images.githubusercontent.com/1976/48539341-b0ca6900-e86b-11e8-879e-6f099a5fdd88.png)
