### PR TITLE
Add user survey count and average, and a WAU chart to the site-admin …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Configured repositories are periodically scheduled for updates using a new algorithm. You can disable the new algorithm with the following site configuration: `"experimentalFeatures": { "updateScheduler2": "disabled" }`. If you do so, please file a public issue to describe why you needed to disable it.
 - When using HTTP header authentication, [`stripUsernameHeaderPrefix`](https://docs.sourcegraph.com/admin/auth/#username-header-prefixes) field lets an admin specify a prefix to strip from the HTTP auth header when converting the header value to a username.
 - Sourcegraph extensions whose title begins with `WIP:` or `[WIP]` are considered [work-in-progress extensions](https://docs.sourcegraph.com/extensions/authoring/creating_and_publishing#work-in-progress-wip-extensions) and are indicated as such to avoid users accidentally using them.
+- Information about user survey submissions and a chart showing weekly active users is now displayed on the site admin Overview page.
 
 ### Changed
 

--- a/web/src/components/Overview.scss
+++ b/web/src/components/Overview.scss
@@ -23,6 +23,10 @@
             color: $color-text;
             display: flex;
             align-items: center;
+            cursor: pointer;
+        }
+        &-link:hover {
+            text-decoration: underline;
         }
         &-icon {
             margin-right: 0.5rem;
@@ -40,6 +44,9 @@
             align-items: center;
             white-space: pre;
         }
+    }
+    &__children {
+        width: 100%;
     }
 }
 

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -8,33 +8,64 @@ export const OverviewList: React.FunctionComponent<{ children: React.ReactNode |
     children,
 }) => <ul className="overview-list">{children}</ul>
 
+export interface Props {
+    link?: string
+    title: string
+    children?: React.ReactNode | React.ReactNode[]
+    actions?: React.ReactFragment
+    icon?: React.ComponentType<{ className?: string }>
+    defaultExpanded?: boolean
+}
+
+export interface State {
+    expanded: boolean
+}
+
 /**
  * A row item used for an overview page, with an icon, linked elements, and right-hand actions.
  */
-export const OverviewItem: React.FunctionComponent<{
-    link?: string
-    children: React.ReactNode | React.ReactNode[]
-    actions?: React.ReactFragment
-    icon?: React.ComponentType<{ className?: string }>
-}> = ({ link, children, actions, icon: Icon }) => {
-    let e: React.ReactFragment = (
-        <>
-            {Icon && <Icon className="icon-inline overview-item__header-icon" />}
-            {children}
-        </>
-    )
-    if (link !== undefined) {
-        e = (
-            <Link to={link} className="overview-item__header-link">
-                {e}
-            </Link>
+export class OverviewItem extends React.Component<Props, State> {
+    public state: State = { expanded: this.props.defaultExpanded || false }
+
+    public render(): JSX.Element | null {
+        let e: React.ReactFragment = (
+            <>
+                {this.props.icon && <this.props.icon className="icon-inline overview-item__header-icon" />}
+                {this.props.title}
+            </>
+        )
+        let actions = this.props.actions
+        if (this.props.children !== undefined) {
+            e = (
+                <div className="overview-item__header-link" onClick={this.toggleExpand}>
+                    {e}
+                </div>
+            )
+            actions = (
+                <>
+                    <button className="btn btn-secondary btn-sm" onClick={this.toggleExpand}>
+                        View more
+                    </button>
+                    {actions && actions}
+                </>
+            )
+        } else if (this.props.link !== undefined) {
+            e = (
+                <Link to={this.props.link} className="overview-item__header-link">
+                    {e}
+                </Link>
+            )
+        }
+
+        return (
+            <div className="overview-item">
+                <div className="overview-item__header">{e}</div>
+                {actions && <div className="overview-item__actions">{actions}</div>}
+                {this.props.children &&
+                    this.state.expanded && <div className="overview-item__children">{this.props.children}</div>}
+            </div>
         )
     }
 
-    return (
-        <div className="overview-item">
-            <div className="overview-item__header">{e}</div>
-            {actions && <div className="overview-item__actions">{actions}</div>}
-        </div>
-    )
+    private toggleExpand = () => this.setState(prevState => ({ expanded: !prevState.expanded }))
 }

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -10,10 +10,24 @@ export const OverviewList: React.FunctionComponent<{ children: React.ReactNode |
 
 export interface Props {
     link?: string
+
+    /**
+     * Content in the overview item's always-visible, single-line title bar.
+     */
     title: string
+
+    /**
+     * Optional children that appear below the item's title bar that can be expanded/collapsed.
+     * If present, a "View more" button that expands or collapses the children will be added to the item's actions.
+     */
     children?: React.ReactNode | React.ReactNode[]
+
     actions?: React.ReactFragment
     icon?: React.ComponentType<{ className?: string }>
+
+    /**
+     * Whether the item's children are expanded and visible by default.
+     */
     defaultExpanded?: boolean
 }
 
@@ -44,7 +58,7 @@ export class OverviewItem extends React.Component<Props, State> {
             actions = (
                 <>
                     <button className="btn btn-secondary btn-sm" onClick={this.toggleExpand}>
-                        View more
+                        {this.state.expanded ? 'Hide' : 'View more'}
                     </button>
                     {actions && actions}
                 </>
@@ -62,7 +76,9 @@ export class OverviewItem extends React.Component<Props, State> {
                 <div className="overview-item__header">{e}</div>
                 {actions && <div className="overview-item__actions">{actions}</div>}
                 {this.props.children &&
-                    this.state.expanded && <div className="overview-item__children">{this.props.children}</div>}
+                    this.state.expanded && (
+                        <div className="overview-item__children mt-4 mb-2">{this.props.children}</div>
+                    )}
             </div>
         )
     }

--- a/web/src/site-admin/SiteAdminOverviewPage.scss
+++ b/web/src/site-admin/SiteAdminOverviewPage.scss
@@ -2,4 +2,10 @@
     &__active {
         color: green;
     }
+
+    &__detail-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
 }

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -1,6 +1,7 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { upperFirst } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
+import ChartLineIcon from 'mdi-react/ChartLineIcon'
 import CityIcon from 'mdi-react/CityIcon'
 import EmoticonIcon from 'mdi-react/EmoticonIcon'
 import EyeIcon from 'mdi-react/EyeIcon'
@@ -64,121 +65,130 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                 {!this.state.info && <LoadingSpinner className="icon-inline" />}
                 <OverviewList>
                     {this.state.info && (
-                        <OverviewItem
-                            link="/explore"
-                            icon={EyeIcon}
-                            actions={
-                                <Link to="/explore" className="btn btn-primary btn-sm">
-                                    Explore
-                                </Link>
-                            }
-                        >
-                            Explore
-                        </OverviewItem>
+                        <>
+                            <OverviewItem
+                                link="/explore"
+                                icon={EyeIcon}
+                                actions={
+                                    <Link to="/explore" className="btn btn-primary btn-sm">
+                                        Explore
+                                    </Link>
+                                }
+                                title="Explore"
+                            />
+                            <OverviewItem
+                                link="/site-admin/repositories"
+                                icon={RepositoryIcon}
+                                actions={
+                                    <>
+                                        <Link to="/site-admin/configuration" className="btn btn-primary btn-sm">
+                                            <SettingsIcon className="icon-inline" /> Configure repositories
+                                        </Link>
+                                        <Link to="/site-admin/repositories" className="btn btn-secondary btn-sm">
+                                            View all
+                                        </Link>
+                                    </>
+                                }
+                                title={`${numberWithCommas(this.state.info.repositories)} ${
+                                    this.state.info.repositories !== null
+                                        ? pluralize('repository', this.state.info.repositories, 'repositories')
+                                        : '?'
+                                }`}
+                            />
+                            <OverviewItem
+                                link="/site-admin/users"
+                                icon={UserIcon}
+                                actions={
+                                    <>
+                                        <Link to="/site-admin/users/new" className="btn btn-primary btn-sm">
+                                            <AddIcon className="icon-inline" /> Create user account
+                                        </Link>
+                                        <Link to="/site-admin/configuration" className="btn btn-secondary btn-sm">
+                                            <SettingsIcon className="icon-inline" /> Configure SSO
+                                        </Link>
+                                        <Link to="/site-admin/users" className="btn btn-secondary btn-sm">
+                                            View all
+                                        </Link>
+                                    </>
+                                }
+                                title={`${numberWithCommas(this.state.info.users)} ${pluralize(
+                                    'user',
+                                    this.state.info.users
+                                )}`}
+                            />
+                            <OverviewItem
+                                link="/site-admin/organizations"
+                                icon={CityIcon}
+                                actions={
+                                    <>
+                                        <Link to="/organizations/new" className="btn btn-primary btn-sm">
+                                            <AddIcon className="icon-inline" /> Create organization
+                                        </Link>
+                                        <Link to="/site-admin/organizations" className="btn btn-secondary btn-sm">
+                                            View all
+                                        </Link>
+                                    </>
+                                }
+                                title={`${numberWithCommas(this.state.info.orgs)} ${pluralize(
+                                    'organization',
+                                    this.state.info.orgs
+                                )}`}
+                            />
+                            <OverviewItem
+                                link="/site-admin/surveys"
+                                icon={EmoticonIcon}
+                                actions={
+                                    <>
+                                        <Link to="/site-admin/surveys" className="btn btn-secondary btn-sm">
+                                            View all
+                                        </Link>
+                                    </>
+                                }
+                                title={`${numberWithCommas(this.state.info.surveyResponses.totalCount)} ${pluralize(
+                                    'survey response',
+                                    this.state.info.surveyResponses.totalCount
+                                )} ${
+                                    this.state.info.surveyResponses.totalCount >= 5
+                                        ? `, ${numberWithCommas(
+                                              this.state.info.surveyResponses.averageScore
+                                          )} average in last 30 days (from 0–10)`
+                                        : ''
+                                }`}
+                            />
+                        </>
                     )}
-                    {this.state.info && (
+                    {this.state.stats && (
                         <OverviewItem
-                            link="/site-admin/repositories"
-                            icon={RepositoryIcon}
-                            actions={
-                                <>
-                                    <Link to="/site-admin/configuration" className="btn btn-primary btn-sm">
-                                        <SettingsIcon className="icon-inline" /> Configure repositories
-                                    </Link>
-                                    <Link to="/site-admin/repositories" className="btn btn-secondary btn-sm">
-                                        View all
-                                    </Link>
-                                </>
-                            }
+                            icon={ChartLineIcon}
+                            title={`${this.state.stats.waus[1].userCount} ${pluralize(
+                                'active user',
+                                this.state.stats.waus[1].userCount
+                            )} last week`}
+                            defaultExpanded={true}
                         >
-                            {numberWithCommas(this.state.info.repositories)}&nbsp;
-                            {this.state.info.repositories !== null
-                                ? pluralize('repository', this.state.info.repositories, 'repositories')
-                                : '?'}
-                        </OverviewItem>
-                    )}
-                    {this.state.info && (
-                        <OverviewItem
-                            link="/site-admin/users"
-                            icon={UserIcon}
-                            actions={
-                                <>
-                                    <Link to="/site-admin/users/new" className="btn btn-primary btn-sm">
-                                        <AddIcon className="icon-inline" /> Create user account
-                                    </Link>
-                                    <Link to="/site-admin/configuration" className="btn btn-secondary btn-sm">
-                                        <SettingsIcon className="icon-inline" /> Configure SSO
-                                    </Link>
-                                    <Link to="/site-admin/users" className="btn btn-secondary btn-sm">
-                                        View all
-                                    </Link>
-                                </>
-                            }
-                        >
-                            {numberWithCommas(this.state.info.users)}&nbsp;{pluralize('user', this.state.info.users)}
-                        </OverviewItem>
-                    )}
-                    {this.state.info && (
-                        <OverviewItem
-                            link="/site-admin/organizations"
-                            icon={CityIcon}
-                            actions={
-                                <>
-                                    <Link to="/organizations/new" className="btn btn-primary btn-sm">
-                                        <AddIcon className="icon-inline" /> Create organization
-                                    </Link>
-                                    <Link to="/site-admin/organizations" className="btn btn-secondary btn-sm">
-                                        View all
-                                    </Link>
-                                </>
-                            }
-                        >
-                            {numberWithCommas(this.state.info.orgs)}&nbsp;{pluralize(
-                                'organization',
-                                this.state.info.orgs
+                            {this.state.error && (
+                                <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>
                             )}
-                        </OverviewItem>
-                    )}
-                    {this.state.info && (
-                        <OverviewItem
-                            link="/site-admin/surveys"
-                            icon={EmoticonIcon}
-                            actions={
+                            {this.state.stats && (
                                 <>
-                                    <Link to="/site-admin/surveys" className="btn btn-secondary btn-sm">
-                                        View all
-                                    </Link>
+                                    <br />
+                                    <UsageChart
+                                        {...this.props}
+                                        stats={this.state.stats}
+                                        chartID="waus"
+                                        header={
+                                            <h3>
+                                                Weekly unique users (<Link to="/site-admin/usage-statistics">
+                                                    see more
+                                                </Link>)
+                                            </h3>
+                                        }
+                                    />
                                 </>
-                            }
-                        >
-                            {numberWithCommas(this.state.info.surveyResponses.totalCount)}&nbsp;{pluralize(
-                                'survey response',
-                                this.state.info.surveyResponses.totalCount
                             )}
-                            {this.state.info.surveyResponses.totalCount >= 5 &&
-                                `, ${numberWithCommas(
-                                    this.state.info.surveyResponses.averageScore
-                                )} average in last 30 days (from 0–10)`}
                         </OverviewItem>
                     )}
                 </OverviewList>
-                {this.state.error && <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>}
-                {this.state.stats && (
-                    <>
-                        <br />
-                        <UsageChart
-                            {...this.props}
-                            stats={this.state.stats}
-                            chartID="waus"
-                            className="mt-5 mb-5"
-                            header={
-                                <h2>
-                                    Weekly unique users (<Link to="/site-admin/usage-statistics">see more</Link>)
-                                </h2>
-                            }
-                        />
-                    </>
-                )}
             </div>
         )
     }

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -5,6 +5,7 @@ import ChartLineIcon from 'mdi-react/ChartLineIcon'
 import CityIcon from 'mdi-react/CityIcon'
 import EmoticonIcon from 'mdi-react/EmoticonIcon'
 import EyeIcon from 'mdi-react/EyeIcon'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
 import UserIcon from 'mdi-react/UserIcon'
 import * as React from 'react'
@@ -129,7 +130,7 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                             <SettingsIcon className="icon-inline" /> Configure repositories
                                         </Link>
                                         <Link to="/site-admin/repositories" className="btn btn-secondary btn-sm">
-                                            View all
+                                            <OpenInNewIcon className="icon-inline" /> View all
                                         </Link>
                                     </>
                                 }
@@ -151,7 +152,7 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                             <SettingsIcon className="icon-inline" /> Configure SSO
                                         </Link>
                                         <Link to="/site-admin/users" className="btn btn-secondary btn-sm">
-                                            View all
+                                            <OpenInNewIcon className="icon-inline" /> View all
                                         </Link>
                                     </>
                                 }
@@ -169,7 +170,7 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                             <AddIcon className="icon-inline" /> Create organization
                                         </Link>
                                         <Link to="/site-admin/organizations" className="btn btn-secondary btn-sm">
-                                            View all
+                                            <OpenInNewIcon className="icon-inline" /> View all
                                         </Link>
                                     </>
                                 }
@@ -182,11 +183,9 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                 link="/site-admin/surveys"
                                 icon={EmoticonIcon}
                                 actions={
-                                    <>
-                                        <Link to="/site-admin/surveys" className="btn btn-secondary btn-sm">
-                                            View all
-                                        </Link>
-                                    </>
+                                    <Link to="/site-admin/surveys" className="btn btn-secondary btn-sm">
+                                        <OpenInNewIcon className="icon-inline" /> View all
+                                    </Link>
                                 }
                                 title={`${numberWithCommas(this.state.info.surveyResponses.totalCount)} ${pluralize(
                                     'survey response',
@@ -214,21 +213,25 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                 <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>
                             )}
                             {this.state.stats && (
-                                <>
-                                    <br />
-                                    <UsageChart
-                                        {...this.props}
-                                        stats={this.state.stats}
-                                        chartID="waus"
-                                        header={
+                                <UsageChart
+                                    {...this.props}
+                                    stats={this.state.stats}
+                                    chartID="waus"
+                                    showLegend={false}
+                                    header={
+                                        <div className="site-admin-overview-page__detail-header">
+                                            <h2>Weekly unique users</h2>
                                             <h3>
-                                                Weekly unique users (<Link to="/site-admin/usage-statistics">
-                                                    see more
-                                                </Link>)
+                                                <Link
+                                                    to="/site-admin/usage-statistics"
+                                                    className="btn btn-secondary btn-sm"
+                                                >
+                                                    <OpenInNewIcon className="icon-inline" /> View all usage statistics
+                                                </Link>
                                             </h3>
-                                        }
-                                    />
-                                </>
+                                        </div>
+                                    }
+                                />
                             )}
                         </OverviewItem>
                     )}

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -156,9 +156,9 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                 this.state.info.surveyResponses.totalCount
                             )}
                             {this.state.info.surveyResponses.totalCount >= 5 &&
-                                `${numberWithCommas(
+                                `, ${numberWithCommas(
                                     this.state.info.surveyResponses.averageScore
-                                )} average score (0–10)`}
+                                )} average in last 30 days (from 0–10)`}
                         </OverviewItem>
                     )}
                 </OverviewList>

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -32,6 +32,52 @@ interface State {
     error?: Error
 }
 
+const fetchOverview: () => Observable<OverviewInfo> = () =>
+    queryGraphQL(gql`
+        query Overview {
+            repositories {
+                totalCount(precise: true)
+            }
+            users {
+                totalCount
+            }
+            organizations {
+                totalCount
+            }
+            surveyResponses {
+                totalCount
+                averageScore
+            }
+        }
+    `).pipe(
+        map(dataOrThrowErrors),
+        map(data => ({
+            repositories: data.repositories.totalCount,
+            users: data.users.totalCount,
+            orgs: data.organizations.totalCount,
+            surveyResponses: data.surveyResponses,
+        }))
+    )
+
+const fetchWeeklyActiveUsers: () => Observable<GQL.ISiteUsageStatistics> = () =>
+    queryGraphQL(gql`
+        query WAUs {
+            site {
+                usageStatistics {
+                    waus {
+                        userCount
+                        registeredUserCount
+                        anonymousUserCount
+                        startTime
+                    }
+                }
+            }
+        }
+    `).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.site.usageStatistics)
+    )
+
 /**
  * A page displaying an overview of site admin information.
  */
@@ -201,49 +247,3 @@ interface OverviewInfo {
         averageScore: number
     }
 }
-
-const fetchOverview: () => Observable<OverviewInfo> = () =>
-    queryGraphQL(gql`
-        query Overview {
-            repositories {
-                totalCount(precise: true)
-            }
-            users {
-                totalCount
-            }
-            organizations {
-                totalCount
-            }
-            surveyResponses {
-                totalCount
-                averageScore
-            }
-        }
-    `).pipe(
-        map(dataOrThrowErrors),
-        map(data => ({
-            repositories: data.repositories.totalCount,
-            users: data.users.totalCount,
-            orgs: data.organizations.totalCount,
-            surveyResponses: data.surveyResponses,
-        }))
-    )
-
-const fetchWeeklyActiveUsers: () => Observable<GQL.ISiteUsageStatistics> = () =>
-    queryGraphQL(gql`
-        query WAUs {
-            site {
-                usageStatistics {
-                    waus {
-                        userCount
-                        registeredUserCount
-                        anonymousUserCount
-                        startTime
-                    }
-                }
-            }
-        }
-    `).pipe(
-        map(dataOrThrowErrors),
-        map(data => data.site.usageStatistics)
-    )

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -1,28 +1,36 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { upperFirst } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import CityIcon from 'mdi-react/CityIcon'
+import EmoticonIcon from 'mdi-react/EmoticonIcon'
 import EyeIcon from 'mdi-react/EyeIcon'
+import HistoryIcon from 'mdi-react/HistoryIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
 import UserIcon from 'mdi-react/UserIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable, Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { createAggregateError } from '../../../shared/src/errors'
-import { gql } from '../../../shared/src/graphql'
+import { dataOrThrowErrors, gql } from '../../../shared/src/graphql'
+import * as GQL from '../../../shared/src/graphqlschema'
 import { queryGraphQL } from '../backend/graphql'
 import { OverviewItem, OverviewList } from '../components/Overview'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { RepositoryIcon } from '../util/icons' // TODO: Switch to mdi icon
 import { numberWithCommas, pluralize } from '../util/strings'
+import { fetchSiteUsageStatistics } from './backend'
+import { UsageChart } from './SiteAdminUsageStatisticsPage'
 
 interface Props {
     overviewComponents: ReadonlyArray<React.ComponentType>
+    isLightTheme: boolean
 }
 
 interface State {
     info?: OverviewInfo
+    stats?: GQL.ISiteUsageStatistics
+    error?: Error
 }
 
 /**
@@ -37,6 +45,9 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
         eventLogger.logViewEvent('SiteAdminOverview')
 
         this.subscriptions.add(fetchOverview().subscribe(info => this.setState({ info })))
+        this.subscriptions.add(
+            fetchSiteUsageStatistics().subscribe(stats => this.setState({ stats }), error => this.setState({ error }))
+        )
     }
 
     public componentWillUnmount(): void {
@@ -128,7 +139,46 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                             )}
                         </OverviewItem>
                     )}
+                    {this.state.info && (
+                        <OverviewItem
+                            link="/site-admin/surveys"
+                            icon={EmoticonIcon}
+                            actions={
+                                <>
+                                    <Link to="/site-admin/surveys" className="btn btn-secondary btn-sm">
+                                        View all
+                                    </Link>
+                                </>
+                            }
+                        >
+                            {numberWithCommas(this.state.info.surveyResponses.totalCount)}&nbsp;{pluralize(
+                                'survey response',
+                                this.state.info.surveyResponses.totalCount
+                            )}
+                            {this.state.info.surveyResponses.totalCount >= 5 &&
+                                `${numberWithCommas(
+                                    this.state.info.surveyResponses.averageScore
+                                )} average score (0–10)`}
+                        </OverviewItem>
+                    )}
                 </OverviewList>
+                {this.state.error && <p className="alert alert-danger">{upperFirst(this.state.error.message)}</p>}
+                {this.state.stats && (
+                    <>
+                        <br />
+                        <UsageChart
+                            {...this.props}
+                            stats={this.state.stats}
+                            chartID="waus"
+                            className="mt-5 mb-5"
+                            header={
+                                <h2>
+                                    Weekly unique users (<Link to="/site-admin/usage-statistics">see more</Link>)
+                                </h2>
+                            }
+                        />
+                    </>
+                )}
             </div>
         )
     }
@@ -138,6 +188,10 @@ interface OverviewInfo {
     repositories: number | null
     users: number
     orgs: number
+    surveyResponses: {
+        totalCount: number
+        averageScore: number
+    }
 }
 
 function fetchOverview(): Observable<OverviewInfo> {
@@ -152,17 +206,18 @@ function fetchOverview(): Observable<OverviewInfo> {
             organizations {
                 totalCount
             }
+            surveyResponses {
+                totalCount
+                averageScore
+            }
         }
     `).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.repositories || !data.users || !data.organizations) {
-                throw createAggregateError(errors)
-            }
-            return {
-                repositories: data.repositories.totalCount,
-                users: data.users.totalCount,
-                orgs: data.organizations.totalCount,
-            }
-        })
+        map(dataOrThrowErrors),
+        map(data => ({
+            repositories: data.repositories.totalCount,
+            users: data.users.totalCount,
+            orgs: data.organizations.totalCount,
+            surveyResponses: data.surveyResponses,
+        }))
     )
 }

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -26,7 +26,7 @@ interface ChartOptions {
 const chartGeneratorOptions: ChartOptions = {
     daus: { label: 'Daily unique users', dateFormat: 'E, MMM d' },
     waus: { label: 'Weekly unique users', dateFormat: 'E, MMM d' },
-    maus: { label: 'Monthly unique users', dateFormat: 'MMMM YYYY' },
+    maus: { label: 'Monthly unique users', dateFormat: 'MMMM yyyy' },
 }
 
 const CHART_ID_KEY = 'latest-usage-statistics-chart-id'
@@ -197,7 +197,6 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
     }
 
     public render(): JSX.Element | null {
-        const chart = chartGeneratorOptions[this.state.chartID]
         return (
             <div className="site-admin-usage-statistics-page">
                 <PageTitle title="Usage statistics - Admin" />
@@ -213,28 +212,7 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
                             onChange={this.onChartIndexChange}
                             selected={this.state.chartID}
                         />
-                        {
-                            <>
-                                <h3>{chart.label}</h3>
-                                <BarChart
-                                    showLabels={true}
-                                    showLegend={true}
-                                    width={500}
-                                    height={200}
-                                    isLightTheme={this.props.isLightTheme}
-                                    data={this.state.stats[this.state.chartID].map(p => ({
-                                        xLabel: format(Date.parse(p.startTime) + 1000 * 60 * 60 * 24, chart.dateFormat),
-                                        yValues: {
-                                            Registered: p.registeredUserCount,
-                                            Anonymous: p.anonymousUserCount,
-                                        },
-                                    }))}
-                                />
-                                <small className="site-admin-usage-statistics-page__tz-note">
-                                    <i>GMT/UTC time</i>
-                                </small>
-                            </>
-                        }
+                        <UsageChart {...this.props} chartID={this.state.chartID} stats={this.state.stats} />
                     </>
                 )}
                 <h3 className="mt-4">All registered users</h3>
@@ -274,3 +252,37 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
         this.setState({ chartID: e.target.value as keyof ChartOptions })
     }
 }
+
+interface UsageChartPageProps {
+    isLightTheme: boolean
+    stats: GQL.ISiteUsageStatistics
+    chartID: keyof ChartOptions
+    className?: string
+    header?: JSX.Element
+}
+
+export const UsageChart: React.FunctionComponent<UsageChartPageProps> = (props: UsageChartPageProps) => (
+    <div className={props.className}>
+        {props.header ? props.header : <h3>{chartGeneratorOptions[props.chartID].label}</h3>}
+        <BarChart
+            showLabels={true}
+            showLegend={true}
+            width={500}
+            height={200}
+            isLightTheme={props.isLightTheme}
+            data={props.stats[props.chartID].map(p => ({
+                xLabel: format(
+                    Date.parse(p.startTime) + 1000 * 60 * 60 * 24,
+                    chartGeneratorOptions[props.chartID].dateFormat
+                ),
+                yValues: {
+                    Registered: p.registeredUserCount,
+                    Anonymous: p.anonymousUserCount,
+                },
+            }))}
+        />
+        <small className="site-admin-usage-statistics-page__tz-note">
+            <i>GMT/UTC time</i>
+        </small>
+    </div>
+)

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -31,6 +31,40 @@ const chartGeneratorOptions: ChartOptions = {
 
 const CHART_ID_KEY = 'latest-usage-statistics-chart-id'
 
+interface UsageChartPageProps {
+    isLightTheme: boolean
+    stats: GQL.ISiteUsageStatistics
+    chartID: keyof ChartOptions
+    className?: string
+    header?: JSX.Element
+}
+
+export const UsageChart: React.FunctionComponent<UsageChartPageProps> = (props: UsageChartPageProps) => (
+    <div className={props.className}>
+        {props.header ? props.header : <h3>{chartGeneratorOptions[props.chartID].label}</h3>}
+        <BarChart
+            showLabels={true}
+            showLegend={true}
+            width={500}
+            height={200}
+            isLightTheme={props.isLightTheme}
+            data={props.stats[props.chartID].map(p => ({
+                xLabel: format(
+                    Date.parse(p.startTime) + 1000 * 60 * 60 * 24,
+                    chartGeneratorOptions[props.chartID].dateFormat
+                ),
+                yValues: {
+                    Registered: p.registeredUserCount,
+                    Anonymous: p.anonymousUserCount,
+                },
+            }))}
+        />
+        <small className="site-admin-usage-statistics-page__tz-note">
+            <i>GMT/UTC time</i>
+        </small>
+    </div>
+)
+
 interface UserUsageStatisticsHeaderFooterProps {
     nodes: GQL.IUser[]
 }
@@ -252,37 +286,3 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
         this.setState({ chartID: e.target.value as keyof ChartOptions })
     }
 }
-
-interface UsageChartPageProps {
-    isLightTheme: boolean
-    stats: GQL.ISiteUsageStatistics
-    chartID: keyof ChartOptions
-    className?: string
-    header?: JSX.Element
-}
-
-export const UsageChart: React.FunctionComponent<UsageChartPageProps> = (props: UsageChartPageProps) => (
-    <div className={props.className}>
-        {props.header ? props.header : <h3>{chartGeneratorOptions[props.chartID].label}</h3>}
-        <BarChart
-            showLabels={true}
-            showLegend={true}
-            width={500}
-            height={200}
-            isLightTheme={props.isLightTheme}
-            data={props.stats[props.chartID].map(p => ({
-                xLabel: format(
-                    Date.parse(p.startTime) + 1000 * 60 * 60 * 24,
-                    chartGeneratorOptions[props.chartID].dateFormat
-                ),
-                yValues: {
-                    Registered: p.registeredUserCount,
-                    Anonymous: p.anonymousUserCount,
-                },
-            }))}
-        />
-        <small className="site-admin-usage-statistics-page__tz-note">
-            <i>GMT/UTC time</i>
-        </small>
-    </div>
-)

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -37,6 +37,7 @@ interface UsageChartPageProps {
     chartID: keyof ChartOptions
     className?: string
     header?: JSX.Element
+    showLegend?: boolean
 }
 
 export const UsageChart: React.FunctionComponent<UsageChartPageProps> = (props: UsageChartPageProps) => (
@@ -44,7 +45,7 @@ export const UsageChart: React.FunctionComponent<UsageChartPageProps> = (props: 
         {props.header ? props.header : <h3>{chartGeneratorOptions[props.chartID].label}</h3>}
         <BarChart
             showLabels={true}
-            showLegend={true}
+            showLegend={props.showLegend === undefined ? true : props.showLegend}
             width={500}
             height={200}
             isLightTheme={props.isLightTheme}


### PR DESCRIPTION
…Overview page

Fixes https://github.com/sourcegraph/sourcegraph/issues/1014

Adds survey results and usage stats to the site-admin overview page. @sqs I know eventually we'll be contributing this usage chart via extension, but this is a quick and easy addition using the existing chart logic. Okay to add this now?

How it looks (with 5+ surveys submitted recently): 
![image](https://user-images.githubusercontent.com/5589410/48583111-2ae60680-e8db-11e8-80fd-219b925c90b0.png)


If <5 have been submitted recently:
![image](https://user-images.githubusercontent.com/5589410/48583199-59fc7800-e8db-11e8-8ab8-d9d5e3f2ed61.png)


> This PR updates the CHANGELOG.md file to describe any user-facing changes.
