### PR TITLE
pkg/highlight: move binary file detection to here

### DIFF
--- a/cmd/frontend/graphqlbackend/git_blob_test.go
+++ b/cmd/frontend/graphqlbackend/git_blob_test.go
@@ -1,6 +1,10 @@
 package graphqlbackend
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/pkg/highlight"
+)
 
 func TestIsBinary(t *testing.T) {
 	tests := []struct {
@@ -62,7 +66,7 @@ func TestIsBinary(t *testing.T) {
 	}
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
-			got := isBinary(tst.input)
+			got := highlight.IsBinary(tst.input)
 			if got != tst.want {
 				t.Fatalf("got %v want %v", got, tst.want)
 			}

--- a/cmd/frontend/internal/pkg/discussions/format.go
+++ b/cmd/frontend/internal/pkg/discussions/format.go
@@ -78,7 +78,7 @@ func formatTargetRepoLinesHTML(ctx context.Context, tr *types.DiscussionThreadTa
 		// contents along here.
 		isLightTheme := false
 		disableTimeout := false
-		html, _, err := highlight.Code(ctx, code, *tr.Path, disableTimeout, isLightTheme)
+		html, _, err := highlight.Code(ctx, []byte(code), *tr.Path, disableTimeout, isLightTheme)
 		if err != nil {
 			return err
 		}

--- a/pkg/highlight/highlight.go
+++ b/pkg/highlight/highlight.go
@@ -3,10 +3,13 @@ package highlight
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
+	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/sourcegraph/gosyntect"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
@@ -23,18 +26,36 @@ func init() {
 	client = gosyntect.New(syntectServer)
 }
 
-// Code highlights the given code with the given filepath (must contain at
-// least the file name + extension) and returns the properly escaped HTML table
-// representing the highlighted code.
+// IsBinary is a helper to tell if the content of a file is binary or not.
+func IsBinary(content []byte) bool {
+	// We first check if the file is valid UTF8, since we always consider that
+	// to be non-binary.
+	//
+	// Secondly, if the file is not valid UTF8, we check if the detected HTTP
+	// content type is text, which covers a whole slew of other non-UTF8 text
+	// encodings for us.
+	return !utf8.Valid(content) && !strings.HasPrefix(http.DetectContentType(content), "text/")
+}
+
+// Code highlights the given file content with the given filepath (must contain
+// at least the file name + extension) and returns the properly escaped HTML
+// table representing the highlighted code.
 //
 // The returned boolean represents whether or not highlighting was aborted due
 // to timeout. In this scenario, a plain text table is returned.
-func Code(ctx context.Context, code, filepath string, disableTimeout bool, isLightTheme bool) (template.HTML, bool, error) {
+func Code(ctx context.Context, content []byte, filepath string, disableTimeout bool, isLightTheme bool) (template.HTML, bool, error) {
 	if !disableTimeout {
 		var cancel func()
 		ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
 	}
+
+	// Never pass binary files to the syntax highlighter.
+	if IsBinary(content) {
+		return "", false, errors.New("cannot render binary file")
+	}
+	code := string(content)
+
 	themechoice := "Sourcegraph"
 	if isLightTheme {
 		themechoice = "Solarized (light)"


### PR DESCRIPTION
This is so that `pkg/highlight.Code` is the sole source for doing highlighting, which makes it usable from e.g. other GraphQL handlers easily.

> This PR does not need to update the CHANGELOG because no user-facing changes.
