### PR TITLE
Check for changelog entry in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,0 @@
-<!-- delete the irrelevant line below -->
-
-> This PR updates the CHANGELOG.md file to describe any user-facing changes.
-> This PR does not need to update the CHANGELOG because ...

--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -13,6 +13,7 @@ go env
 ./todo-security.sh
 ./no-localhost-guard.sh
 ./bash-syntax.sh
+./require-changelog.sh
 
 # TODO(sqs): Reenable this check when about.sourcegraph.com is reliable. Most failures come from its
 # downtime, not from broken URLs.

--- a/dev/check/require-changelog.sh
+++ b/dev/check/require-changelog.sh
@@ -8,7 +8,7 @@ if [ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]; then
     exit 0
 fi
 
-changed_files=$(git diff --name-only $BUILDKITE_PULL_REQUEST_BASE_BRANCH..)
+changed_files=$(git diff --name-only $BUILDKITE_PULL_REQUEST_BASE_BRANCH...)
 
 # If the changed files don't match any of these regular expressions
 # then no changelog entry is required.

--- a/dev/check/require-changelog.sh
+++ b/dev/check/require-changelog.sh
@@ -24,7 +24,7 @@ if echo "${changed_files}" | grep -q '^CHANGELOG\.md$'; then
     exit 0
 fi
 
-if git log $BUILDKITE_PULL_REQUEST_BASE_BRANCH.. --pretty=format:%B | grep NOCHANGELOG; then
+if git log $BUILDKITE_PULL_REQUEST_BASE_BRANCH.. --pretty=format:%B | grep -q NOCHANGELOG; then
     set +x
     echo "Found NOCHANGELOG in commit message so no CHANGELOG.md entry is required"
     exit 0

--- a/dev/check/require-changelog.sh
+++ b/dev/check/require-changelog.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -x
+
+if [ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]; then
+    set +x
+    echo "CHANGELOG.md entry not required since this isn't a pull request"
+    exit 0
+fi
+
+changed_files=$(git diff --name-only $BUILDKITE_PULL_REQUEST_BASE_BRANCH)
+
+# If the changed files don't match any of these regular expressions
+# then no changelog entry is required.
+if ! echo "${changed_files}" | grep -qE -e '(cmd|pkg|schema|xlang)/.*\.go$' -e '(shared|web)/.*\.(tsx?|json)$'; then
+    set +x
+    echo "CHANGELOG.md entry not required for these file changes"
+    exit 0
+fi
+
+if echo "${changed_files}" | grep -q '^CHANGELOG\.md$'; then
+    set +x
+    echo "CHANGELOG.md entry found"
+    exit 0
+fi
+
+if git log $BUILDKITE_PULL_REQUEST_BASE_BRANCH.. --pretty=format:%B | grep NOCHANGELOG; then
+    set +x
+    echo "Found NOCHANGELOG in commit message so no CHANGELOG.md entry is required"
+    exit 0
+fi
+
+set +x
+echo "Changes that impact customers require an entry in CHANGELOG.md."
+echo "If a changelog entry is not appropriate for this change then include NOCHANGELOG in any commit message on your branch."
+echo "git commit --allow-empty -m NOCHANGELOG"
+exit 1

--- a/dev/check/require-changelog.sh
+++ b/dev/check/require-changelog.sh
@@ -2,13 +2,13 @@
 
 set -x
 
-if [ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]; then
+if [ "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" != "master" ]; then
     set +x
-    echo "CHANGELOG.md entry not required since this isn't a pull request"
+    echo "CHANGELOG.md entry not required since this isn't a pull request into master"
     exit 0
 fi
 
-changed_files=$(git diff --name-only $BUILDKITE_PULL_REQUEST_BASE_BRANCH...)
+changed_files=$(git diff --name-only origin/master...)
 
 # If the changed files don't match any of these regular expressions
 # then no changelog entry is required.

--- a/dev/check/require-changelog.sh
+++ b/dev/check/require-changelog.sh
@@ -8,7 +8,7 @@ if [ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]; then
     exit 0
 fi
 
-changed_files=$(git diff --name-only $BUILDKITE_PULL_REQUEST_BASE_BRANCH)
+changed_files=$(git diff --name-only $BUILDKITE_PULL_REQUEST_BASE_BRANCH..)
 
 # If the changed files don't match any of these regular expressions
 # then no changelog entry is required.

--- a/dev/check/require-changelog.sh
+++ b/dev/check/require-changelog.sh
@@ -8,6 +8,8 @@ if [ "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" != "master" ]; then
     exit 0
 fi
 
+git fetch origin master
+
 changed_files=$(git diff --name-only origin/master...)
 
 # If the changed files don't match any of these regular expressions
@@ -24,7 +26,7 @@ if echo "${changed_files}" | grep -q '^CHANGELOG\.md$'; then
     exit 0
 fi
 
-if git log $BUILDKITE_PULL_REQUEST_BASE_BRANCH.. --pretty=format:%B | grep -q NOCHANGELOG; then
+if git log origin/master... --pretty=format:%B | grep -q NOCHANGELOG; then
     set +x
     echo "Found NOCHANGELOG in commit message so no CHANGELOG.md entry is required"
     exit 0


### PR DESCRIPTION
The PR issue template isn't foolproof enough since changes that need a changelog entry get merged without them (I am guilty of this as are others). Having a failing CI check will make this more obvious and harder to forget.

Only certain files trigger the changelog check (i.e. most Go files and ts/tsx files in web and shared).

If you are changing one of the above files and a changelog entry is not appropriate, then all you need to do is include `NOCHANGELOG` in any commit message on your branch (e.g. `git commit --allow-empty -m NOCHANGELOG`).