### PR TITLE
in DB backcompat test, run all tests in packages that have DB tests

### DIFF
--- a/dev/ci/db-backcompat.sh
+++ b/dev/ci/db-backcompat.sh
@@ -60,10 +60,14 @@ function runTest() {
 	    DB schema version:				${CURRENT_DB_SCHEMA}
 	EOF
 
+        # All DB tests are assumed to import the ./cmd/frontend/db/testing package, so use that to
+        # find which packages' tests need to be run.
+        PACKAGES_WITH_DB_TEST=$(go list -f '{{$printed := false}}{{range .TestImports}}{{if and (not $printed) (eq . "github.com/sourcegraph/sourcegraph/cmd/frontend/db/testing")}}{{$.ImportPath}}{{$printed = true}}{{end}}{{end}}' ./...)
+
         set -ex
         # Test without cache, because schema change does not
         # necessarily mean Go source has changed.
-        SKIP_MIGRATION_TEST=true go test -count=1 -v ./cmd/frontend/db/
+        SKIP_MIGRATION_TEST=true go test -count=1 -v $PACKAGES_WITH_DB_TEST
         set +ex
 
         NOW_DB_SCHEMA=$(psql -t -d sourcegraph-test-db -c 'select version from schema_migrations' | xargs echo -n)


### PR DESCRIPTION
Now that more packages have DB tests (other than just `./cmd/frontend/db`), the DB backcompat test script needs to run tests from multiple packages.

> This PR does not need to update the CHANGELOG because it is not user facing