### PR TITLE
Revert "enable experimentalFeatures.canonicalURLRedirect by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Site and user usage statistics are now visible to all users. Previously only site admins (and users, for their own usage statistics) could view this information. The information consists of aggregate counts of actions such as searches, page views, etc.
 - The Git blame information shown at the end of a line is now provided by the [Git extras extension](https://sourcegraph.com/extensions/sourcegraph/git-extras). You must add that extension to continue using this feature.
 - The `appURL` site configuration option was renamed to `externalURL`.
+- The default for `experimentalFeatures.canonicalURLRedirect` in site config was changed back to `disabled`.
 
 ### Fixed
 

--- a/cmd/frontend/internal/cli/middleware/redirect.go
+++ b/cmd/frontend/internal/cli/middleware/redirect.go
@@ -61,9 +61,9 @@ func CanonicalURL(next http.Handler) http.Handler {
 		var canonicalURLRedirect bool
 		if conf.ExperimentalFeatures != nil {
 			switch conf.ExperimentalFeatures.CanonicalURLRedirect {
-			case "enabled", "": // default enabled
+			case "enabled":
 				canonicalURLRedirect = true
-			case "disabled":
+			case "disabled", "":
 				// noop
 			default:
 				text := "Misconfigured experimentalFeatures.canonicalURLRedirect values in site configuration."

--- a/doc/admin/site_config/all.md
+++ b/doc/admin/site_config/all.md
@@ -231,14 +231,14 @@ Default: `"disabled"`
 
 ### canonicalURLRedirect (string, enum)
 
-Enables or disables redirecting to the canonical URL (underneath the `externalURL`) for incoming HTTP requests. Enabled by default.
+Enables or disables redirecting to the canonical URL for incoming HTTP requests. Enabled by default.
 
 This property must be one of the following enum values:
 
 - `enabled`
 - `disabled`
 
-Default: `"enabled"`
+Default: `"disabled"`
 
 ### discussions (string, enum)
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -71,10 +71,10 @@
         },
         "canonicalURLRedirect": {
           "description":
-            "Enables or disables enforcing that HTTP requests use the externalURL as a prefix, by redirecting other requests to the same request URI on the externalURL. For example, if the externalURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Enabled by default.",
+            "Enables or disables enforcing that HTTP requests use the externalURL as a prefix, by redirecting other requests to the same request URI on the externalURL. For example, if the externalURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Disabled by default.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "enabled"
+          "default": "disabled"
         },
         "discussions": {
           "description": "Enables the code discussions experiment.",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -76,10 +76,10 @@ const SiteSchemaJSON = `{
         },
         "canonicalURLRedirect": {
           "description":
-            "Enables or disables enforcing that HTTP requests use the externalURL as a prefix, by redirecting other requests to the same request URI on the externalURL. For example, if the externalURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Enabled by default.",
+            "Enables or disables enforcing that HTTP requests use the externalURL as a prefix, by redirecting other requests to the same request URI on the externalURL. For example, if the externalURL is https://sourcegraph.example.com and the site is also available under the DNS name http://foo, then a request to http://foo/bar would be redirected to https://sourcegraph.example.com/bar. Disabled by default.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "enabled"
+          "default": "disabled"
         },
         "discussions": {
           "description": "Enables the code discussions experiment.",


### PR DESCRIPTION
This reverts commit 4ffb62cc0b95168b4aa8a0009e70181127925dd9 because it was causing the issue at https://github.com/sourcegraph/sourcegraph/issues/807.

> This PR updates the CHANGELOG.md file to describe any user-facing changes.