### PR TITLE
Made the editor cmd support a revision argument

### DIFF
--- a/cmd/frontend/internal/app/mocks.go
+++ b/cmd/frontend/internal/app/mocks.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"context"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/pkg/actor"
+)
+
+// testContext creates a new context.Context for use by tests
+func testContext() context.Context {
+	db.Mocks = db.MockStores{}
+
+	ctx := context.Background()
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
+	_, ctx = opentracing.StartSpanFromContext(ctx, "dummy")
+
+	return ctx
+}


### PR DESCRIPTION
This resolves [https://github.com/sourcegraph/sourcegraph/issues/952](https://github.com/sourcegraph/sourcegraph/issues/952).
The tests show the desired behaviour. Basically, if a revision is passed, it will be used, otherwise, the branch name will be used (if both are passed, revision takes priority).

I've never seen or written Go code before so writing the tests was a bit of trial-and-error. cmd/frontend/internal/app/mocks.go is a duplicate of cmd/frontend/backend/mocks.go, with some things I didn't need removed. 
Duplication is bad, but I wasn't sure how to get rid of it, since it seems like I can't use the testContext from the backend package in the app package. If there's a solution to this, please let me know :)

@KattMingMing after this is shipped, it unblocks https://github.com/sourcegraph/sourcegraph-jetbrains/issues/5. Afterwards, we just need to figure out the repo url mapping, and my plugin can be assimilated into yours.

