### PR TITLE
Allowing clients to pass a remote host mapping to the editor cmd

### DIFF
--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -12,7 +12,7 @@ func TestGuessRepoNameFromRemoteURL(t *testing.T) {
 		mapping string
 	}
 	tests := map[URLAndMapping]api.RepoName{
-		URLAndMapping{"github.com:a/b", "{}"}:                                 "github.com/a/b",
+		URLAndMapping{"github.com:a/b", "broken_json}"}:                       "github.com/a/b",
 		URLAndMapping{"github.com:a/b.git", "{}"}:                             "github.com/a/b",
 		URLAndMapping{"git@github.com:a/b", "{}"}:                             "github.com/a/b",
 		URLAndMapping{"git@github.com:a/b.git", "{}"}:                         "github.com/a/b",

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -7,19 +7,25 @@ import (
 )
 
 func TestGuessRepoNameFromRemoteURL(t *testing.T) {
-	tests := map[string]api.RepoName{
-		"github.com:a/b":                  "github.com/a/b",
-		"github.com:a/b.git":              "github.com/a/b",
-		"git@github.com:a/b":              "github.com/a/b",
-		"git@github.com:a/b.git":          "github.com/a/b",
-		"ssh://git@github.com/a/b.git":    "github.com/a/b",
-		"ssh://github.com/a/b.git":        "github.com/a/b",
-		"ssh://github.com:1234/a/b.git":   "github.com/a/b",
-		"https://github.com:1234/a/b.git": "github.com/a/b",
-		"http://alice@foo.com:1234/a/b":   "foo.com/a/b",
+	type URLAndMapping struct {
+		url     string
+		mapping string
+	}
+	tests := map[URLAndMapping]api.RepoName{
+		URLAndMapping{"github.com:a/b", "{}"}:                                 "github.com/a/b",
+		URLAndMapping{"github.com:a/b.git", "{}"}:                             "github.com/a/b",
+		URLAndMapping{"git@github.com:a/b", "{}"}:                             "github.com/a/b",
+		URLAndMapping{"git@github.com:a/b.git", "{}"}:                         "github.com/a/b",
+		URLAndMapping{"ssh://git@github.com/a/b.git", "{}"}:                   "github.com/a/b",
+		URLAndMapping{"ssh://github.com/a/b.git", "{}"}:                       "github.com/a/b",
+		URLAndMapping{"ssh://github.com:1234/a/b.git", "{}"}:                  "github.com/a/b",
+		URLAndMapping{"https://github.com:1234/a/b.git", "{}"}:                "github.com/a/b",
+		URLAndMapping{"https://github.com:1234/a/b.git", "{\"x\": \"y\"}"}:    "github.com/a/b",
+		URLAndMapping{"http://alice@foo.com:1234/a/b", "{}"}:                  "foo.com/a/b",
+		URLAndMapping{"http://alice@foo.com:1234/a/b", "{\"foo.com\": \"\"}"}: "/a/b",
 	}
 	for input, want := range tests {
-		got := guessRepoNameFromRemoteURL(input)
+		got := guessRepoNameFromRemoteURL(input.url, input.mapping)
 		if got != want {
 			t.Errorf("%s: got %q, want %q", input, got, want)
 		}

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -14,14 +14,14 @@ func TestGuessRepoNameFromRemoteURL(t *testing.T) {
 	tests := map[URLAndMapping]api.RepoName{
 		URLAndMapping{"github.com:a/b", "broken_json}"}:                       "github.com/a/b",
 		URLAndMapping{"github.com:a/b.git", "{}"}:                             "github.com/a/b",
-		URLAndMapping{"git@github.com:a/b", "{}"}:                             "github.com/a/b",
-		URLAndMapping{"git@github.com:a/b.git", "{}"}:                         "github.com/a/b",
-		URLAndMapping{"ssh://git@github.com/a/b.git", "{}"}:                   "github.com/a/b",
-		URLAndMapping{"ssh://github.com/a/b.git", "{}"}:                       "github.com/a/b",
-		URLAndMapping{"ssh://github.com:1234/a/b.git", "{}"}:                  "github.com/a/b",
-		URLAndMapping{"https://github.com:1234/a/b.git", "{}"}:                "github.com/a/b",
+		URLAndMapping{"git@github.com:a/b", ""}:                               "github.com/a/b",
+		URLAndMapping{"git@github.com:a/b.git", ""}:                           "github.com/a/b",
+		URLAndMapping{"ssh://git@github.com/a/b.git", ""}:                     "github.com/a/b",
+		URLAndMapping{"ssh://github.com/a/b.git", ""}:                         "github.com/a/b",
+		URLAndMapping{"ssh://github.com:1234/a/b.git", ""}:                    "github.com/a/b",
+		URLAndMapping{"https://github.com:1234/a/b.git", ""}:                  "github.com/a/b",
 		URLAndMapping{"https://github.com:1234/a/b.git", "{\"x\": \"y\"}"}:    "github.com/a/b",
-		URLAndMapping{"http://alice@foo.com:1234/a/b", "{}"}:                  "foo.com/a/b",
+		URLAndMapping{"http://alice@foo.com:1234/a/b", ""}:                    "foo.com/a/b",
 		URLAndMapping{"http://alice@foo.com:1234/a/b", "{\"foo.com\": \"\"}"}: "/a/b",
 	}
 	for input, want := range tests {


### PR DESCRIPTION
**What this does**
This is a workaround for https://github.com/sourcegraph/sourcegraph/issues/462, which allows clients to map repository hostnames to any path they want.
It doesn't actually solve the issue - I think a better solution would be to configure this in the Sourcegraph configuration itself (like the ticket suggests). That's far more complicated to do and would require actual Sourcegraph users to change their configurations, so that's probably something the Sourcegraph team should change.

**Why is this necessary?**
With this workaround, users will need to configure their own mapping in their IDE plugin configuration. That will allow people to use the extension even if their git repositories don't use the one valid path mapping or are github.
After this is pushed and I follow this up with a fix to the sourcegraph-jetbrains plugin, I'll be able to deprecate the [CopySourcegraphLink](https://github.com/erezeshkol/CopySourcegraphLink) plugin in favour of the official Sourcegraph plugin.

**Example**
At Yelp, we configured our Sourcegraph server to show the git repo git.internal.com/services/my_service at sourcegraph.yelpserver.com/services/my_service.
Currently, the editor endpoint will create links that point to sourcegraph.yelpserver.com/git.internal.com/services/my_service.
Using the new parameter, I'll be able to pass {"git.internal.com": ""} and get the correct path.

@KattMingMing, @nicksnyder we exchanged a few emails about this - here's a workaround that can be removed once there's a proper fix to the issue, but will at least unblock merging the plugins until then. Let me know what you think :)