### PR TITLE
make config synchronously available to extensions

### DIFF
--- a/client/browser/src/extension/scripts/background.tsx
+++ b/client/browser/src/extension/scripts/background.tsx
@@ -398,9 +398,12 @@ storage
 /**
  * Fetches JavaScript from a URL and runs it in a web worker.
  */
-function spawnWebWorkerFromURL(url: string): Promise<Worker> {
+function spawnWebWorkerFromURL({
+    jsBundleURL,
+    settingsCascade,
+}: Pick<ExtensionConnectionInfo, 'jsBundleURL' | 'settingsCascade'>): Promise<Worker> {
     return ajax({
-        url,
+        url: jsBundleURL,
         crossDomain: true,
         responseType: 'blob',
     })
@@ -418,6 +421,7 @@ function spawnWebWorkerFromURL(url: string): Promise<Worker> {
                     bundleURL: blobURL,
                     sourcegraphURL: sourcegraphUrl,
                     clientApplication: 'other',
+                    settingsCascade,
                 }
                 worker.postMessage(initData)
                 return worker
@@ -453,7 +457,7 @@ const spawnAndConnect = ({
     connectionInfo: ExtensionConnectionInfo
     port: chrome.runtime.Port
 }): Promise<void> =>
-    spawnWebWorkerFromURL(connectionInfo.jsBundleURL).then(worker => {
+    spawnWebWorkerFromURL(connectionInfo).then(worker => {
         connectPortAndWorker(port, worker)
     })
 

--- a/client/browser/src/messaging.ts
+++ b/client/browser/src/messaging.ts
@@ -1,7 +1,9 @@
+import { InitData } from '../../../shared/src/api/extension/extensionHost'
+
 /**
  * The information necessary to connect to a Sourcegraph extension.
  */
-export interface ExtensionConnectionInfo {
+export interface ExtensionConnectionInfo extends Pick<InitData, 'settingsCascade'> {
     extensionID: string
     jsBundleURL: string
 }

--- a/client/browser/src/shared/backend/extensions.ts
+++ b/client/browser/src/shared/backend/extensions.ts
@@ -47,7 +47,8 @@ const createPlatformMessageTransports = (connectionInfo: ExtensionConnectionInfo
     })
 
 export function createMessageTransports(
-    extension: Pick<ConfiguredExtension, 'id' | 'manifest'>
+    extension: Pick<ConfiguredExtension, 'id' | 'manifest'>,
+    settingsCascade: SettingsCascade<any>
 ): Promise<MessageTransports> {
     if (!extension.manifest) {
         throw new Error(`unable to connect to extension ${JSON.stringify(extension.id)}: no manifest found`)
@@ -62,6 +63,7 @@ export function createMessageTransports(
     return createPlatformMessageTransports({
         extensionID: extension.id,
         jsBundleURL: extension.manifest.url,
+        settingsCascade,
     }).catch(err => {
         console.error('Error connecting to', extension.id + ':', err)
         throw err

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -657,10 +657,6 @@ declare module 'sourcegraph' {
         /**
          * Returns the full configuration object.
          *
-         * @todo This function throws an error if it is called synchronously in the extension's `activate`
-         *       function. This will be fixed before beta. See the test "Configuration (integration) / is usable in
-         *       synchronous activation functions".
-         *
          * @template C The configuration schema.
          * @return The full configuration object.
          */

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -1,6 +1,7 @@
 import { Subscription } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { createProxy, handleRequests } from '../common/proxy'
+import { SettingsCascade } from '../protocol'
 import { Connection, createConnection, Logger, MessageTransports } from '../protocol/jsonrpc2/connection'
 import { createWebWorkerMessageTransports } from '../protocol/jsonrpc2/transports/webWorker'
 import { ExtCommands } from './api/commands'
@@ -45,6 +46,12 @@ export interface InitData {
 
     /** @see {@link module:sourcegraph.internal.clientApplication} */
     clientApplication: 'sourcegraph' | 'other'
+
+    /**
+     * The settings cascade at the time of extension host initialization. It must be provided because extensions
+     * expect that the settings are synchronously available when their `activate` method is called.
+     */
+    settingsCascade: SettingsCascade<any>
 }
 
 /**
@@ -91,7 +98,7 @@ function createExtensionHandle(initData: InitData, connection: Connection): type
     const views = new ExtViews(proxy('views'))
     handleRequests(connection, 'views', views)
 
-    const configuration = new ExtConfiguration<any>(proxy('configuration'))
+    const configuration = new ExtConfiguration<any>(proxy('configuration'), initData.settingsCascade)
     handleRequests(connection, 'configuration', configuration)
 
     const languageFeatures = new ExtLanguageFeatures(proxy('languageFeatures'), documents)

--- a/shared/src/api/integration-test/configuration.test.ts
+++ b/shared/src/api/integration-test/configuration.test.ts
@@ -6,12 +6,9 @@ import { collectSubscribableValues, integrationTestContext } from './helpers.tes
 
 describe('Configuration (integration)', () => {
     it('is usable in synchronous activation functions', async () => {
-        // Test that extensions can access configuration synchronously in their `activate` functions.
         const { extensionHost } = await integrationTestContext()
         assert.doesNotThrow(() => extensionHost.configuration.subscribe(() => void 0))
-        // TODO(sqs): Make the `get` function usable synchronously so this test passes.
-        //
-        // assert.doesNotThrow(() => extensionHost.configuration.get())
+        assert.doesNotThrow(() => extensionHost.configuration.get())
     })
 
     describe('Configuration#get', () => {

--- a/shared/src/api/integration-test/helpers.test.ts
+++ b/shared/src/api/integration-test/helpers.test.ts
@@ -46,7 +46,14 @@ export async function integrationTestContext(): Promise<
     clientController.configurationUpdates.subscribe(({ resolve }) => resolve(Promise.resolve()))
 
     const extensionHost = createExtensionHost(
-        { bundleURL: '', sourcegraphURL: 'https://example.com', clientApplication: 'sourcegraph' },
+        {
+            bundleURL: '',
+            sourcegraphURL: 'https://example.com',
+            clientApplication: 'sourcegraph',
+            settingsCascade: {
+                final: { a: 1 },
+            },
+        },
         serverTransports
     )
 

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -118,8 +118,8 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                     'clientApplication.isSourcegraph': true,
                 },
             },
-            extensionsController: createExtensionsController(extensions.context, extension =>
-                Promise.resolve(createMessageTransports(extension))
+            extensionsController: createExtensionsController(extensions.context, (extension, settingsCascade) =>
+                Promise.resolve(createMessageTransports(extension, settingsCascade))
             ),
             viewerSubject: SITE_SUBJECT_NO_ADMIN,
             isMainPage: false,

--- a/web/src/extensions/ExtensionsClientCommonContext.tsx
+++ b/web/src/extensions/ExtensionsClientCommonContext.tsx
@@ -5,6 +5,7 @@ import { concat, Observable } from 'rxjs'
 import { distinctUntilChanged, map, switchMap, take, withLatestFrom } from 'rxjs/operators'
 import ExtensionHostWorker from 'worker-loader!./extensionHost.worker'
 import { InitData } from '../../../shared/src/api/extension/extensionHost'
+import { SettingsCascade } from '../../../shared/src/api/protocol'
 import { MessageTransports } from '../../../shared/src/api/protocol/jsonrpc2/connection'
 import { createWebWorkerMessageTransports } from '../../../shared/src/api/protocol/jsonrpc2/transports/webWorker'
 import { ControllerProps as GenericExtensionsControllerProps } from '../../../shared/src/client/controller'
@@ -118,7 +119,10 @@ export function updateHighestPrecedenceExtensionSettings(args: {
     )
 }
 
-export function createMessageTransports(extension: Pick<ConfiguredExtension, 'id' | 'manifest'>): MessageTransports {
+export function createMessageTransports(
+    extension: Pick<ConfiguredExtension, 'id' | 'manifest'>,
+    settingsCascade: SettingsCascade<any>
+): MessageTransports {
     if (!extension.manifest) {
         throw new Error(`unable to run extension ${JSON.stringify(extension.id)}: no manifest found`)
     }
@@ -135,6 +139,7 @@ export function createMessageTransports(extension: Pick<ConfiguredExtension, 'id
                 bundleURL: extension.manifest.url,
                 sourcegraphURL: window.context.externalURL,
                 clientApplication: 'sourcegraph',
+                settingsCascade,
             }
             worker.postMessage(initData)
             return createWebWorkerMessageTransports(worker)


### PR DESCRIPTION
fix #1062

This change exposes the need to refactor and clean this code up. For example, there are multiple things called controller, context, etc. That will be done in a followup.