### PR TITLE
chore: reorganize WithResolvedRev render

### DIFF
--- a/client/browser/src/shared/components/WithResolvedRev.tsx
+++ b/client/browser/src/shared/components/WithResolvedRev.tsx
@@ -112,12 +112,15 @@ export class WithResolvedRev extends React.Component<WithResolvedRevProps, WithR
             return <this.props.requireAuthComponent {...this.props} error={this.state.requireAuthError} />
         }
 
+        if (this.props.cloningComponent && this.state.cloneInProgress) {
+            return <this.props.cloningComponent {...this.props} />
+        } else if (this.state.cloneInProgress) {
+            return null
+        }
         if (this.props.notFoundComponent && this.state.notFound) {
             return <this.props.notFoundComponent {...this.props} />
         }
-        if (this.props.cloningComponent && this.state.cloneInProgress) {
-            return <this.props.cloningComponent {...this.props} />
-        }
+
         if (this.props.repoPath && !this.state.commitID) {
             // commit not yet resolved but required if repoPath prop is provided;
             // render empty until commit resolved


### PR DESCRIPTION
Reorganize WithResolvedRev render function to check for cloning first. When a repo is cloning, the server responds with 404 so this may be the cause of https://github.com/sourcegraph/sourcegraph/issues/656 but I haven't come up with a repro that actually causes the bug even though I've seen it in the wild.