### PR TITLE
db: rename "site config" to "global state"

### DIFF
--- a/cmd/frontend/db/global_state_mock.go
+++ b/cmd/frontend/db/global_state_mock.go
@@ -6,6 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
-type MockSiteConfig struct {
-	Get func(ctx context.Context) (*types.SiteConfig, error)
+type MockGlobalState struct {
+	Get func(ctx context.Context) (*types.GlobalState, error)
 }

--- a/cmd/frontend/db/global_state_test.go
+++ b/cmd/frontend/db/global_state_test.go
@@ -6,12 +6,12 @@ import (
 	dbtesting "github.com/sourcegraph/sourcegraph/cmd/frontend/db/testing"
 )
 
-func TestSiteConfig_Get(t *testing.T) {
+func TestGlobalState_Get(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
 	ctx := dbtesting.TestContext(t)
-	config, err := SiteConfig.Get(ctx)
+	config, err := GlobalState.Get(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/db/migrations/bindata.go
+++ b/cmd/frontend/db/migrations/bindata.go
@@ -182,6 +182,8 @@
 // ../../../../migrations/1528395558_.up.sql (110B)
 // ../../../../migrations/1528395559_.down.sql (95B)
 // ../../../../migrations/1528395559_.up.sql (732B)
+// ../../../../migrations/1528395560_.down.sql (141B)
+// ../../../../migrations/1528395560_.up.sql (173B)
 
 package migrations
 
@@ -3890,6 +3892,46 @@ func _1528395559_UpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395560_DownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\x72\x09\xf2\x0f\x50\x08\xf3\x74\x0d\x57\x28\xce\x2c\x49\x8d\x4f\xce\xcf\x4b\xcb\x4c\xb7\xe6\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xcf\xc9\x4f\x4a\xcc\x89\x2f\x2e\x49\x2c\x49\x55\x08\x72\xf5\x73\xf4\x75\x55\x08\xf1\xc7\xa6\xde\xd3\xcf\xc5\x35\x02\x45\x7d\x7c\x41\x76\x6a\x25\x76\x4d\x60\x29\x6b\x2e\x57\x3f\x17\x6b\x2e\x40\x00\x00\x00\xff\xff\xe1\xaa\xea\x73\x8d\x00\x00\x00")
+
+func _1528395560_DownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395560_DownSql,
+		"1528395560_.down.sql",
+	)
+}
+
+func _1528395560_DownSql() (*asset, error) {
+	bytes, err := _1528395560_DownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395560_.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa3, 0xa5, 0xbb, 0xee, 0xa7, 0xf5, 0xfd, 0x8b, 0x20, 0xee, 0x77, 0xab, 0xd, 0x1c, 0xd6, 0x72, 0xb8, 0xae, 0x7e, 0x10, 0x72, 0x1e, 0xc3, 0x53, 0xc4, 0xac, 0x4, 0x9a, 0x38, 0x60, 0xea, 0x9}}
+	return a, nil
+}
+
+var __1528395560_UpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x28\xce\x2c\x49\x8d\x4f\xce\xcf\x4b\xcb\x4c\x57\x08\x72\xf5\x73\xf4\x75\x55\x08\xf1\x57\x48\xcf\xc9\x4f\x4a\xcc\x89\x2f\x2e\x49\x2c\x49\x85\xa9\xf7\xf4\x73\x71\x8d\x40\x56\x1f\x5f\x90\x9d\x5a\x89\x43\x13\x58\xce\x9a\xcb\x39\xc8\xd5\x31\xc4\x55\x21\xcc\xd3\x35\x1c\xc5\x26\xc7\x60\x85\x60\x57\x1f\x57\xe7\x10\x05\x2d\x05\xb7\x20\x7f\x5f\x34\x0b\x5d\xfd\x5c\xac\xb9\x00\x01\x00\x00\xff\xff\xc2\x97\x2a\xe9\xad\x00\x00\x00")
+
+func _1528395560_UpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395560_UpSql,
+		"1528395560_.up.sql",
+	)
+}
+
+func _1528395560_UpSql() (*asset, error) {
+	bytes, err := _1528395560_UpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395560_.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x38, 0xa5, 0x25, 0x4e, 0xce, 0x7d, 0x8e, 0x85, 0xc6, 0x71, 0x4a, 0x21, 0xf5, 0xe4, 0x40, 0xb6, 0xd, 0x40, 0x6c, 0x56, 0x1, 0x38, 0x5d, 0xf4, 0x92, 0xc8, 0xf1, 0x1e, 0x56, 0x62, 0x4d, 0x20}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -4344,6 +4386,10 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395559_.down.sql": _1528395559_DownSql,
 
 	"1528395559_.up.sql": _1528395559_UpSql,
+
+	"1528395560_.down.sql": _1528395560_DownSql,
+
+	"1528395560_.up.sql": _1528395560_UpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -4569,6 +4615,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395558_.up.sql":                                          &bintree{_1528395558_UpSql, map[string]*bintree{}},
 	"1528395559_.down.sql":                                        &bintree{_1528395559_DownSql, map[string]*bintree{}},
 	"1528395559_.up.sql":                                          &bintree{_1528395559_UpSql, map[string]*bintree{}},
+	"1528395560_.down.sql":                                        &bintree{_1528395560_DownSql, map[string]*bintree{}},
+	"1528395560_.up.sql":                                          &bintree{_1528395560_UpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/cmd/frontend/db/mockstores.go
+++ b/cmd/frontend/db/mockstores.go
@@ -10,15 +10,15 @@ type MockStores struct {
 	DiscussionComments        MockDiscussionComments
 	DiscussionMailReplyTokens MockDiscussionMailReplyTokens
 
-	GlobalDeps MockGlobalDeps
-	Pkgs       MockPkgs
-	Repos      MockRepos
-	Orgs       MockOrgs
-	OrgMembers MockOrgMembers
-	Settings   MockSettings
-	SiteConfig MockSiteConfig
-	Users      MockUsers
-	UserEmails MockUserEmails
+	GlobalDeps  MockGlobalDeps
+	Pkgs        MockPkgs
+	Repos       MockRepos
+	Orgs        MockOrgs
+	OrgMembers  MockOrgMembers
+	Settings    MockSettings
+	GlobalState MockGlobalState
+	Users       MockUsers
+	UserEmails  MockUserEmails
 
 	Phabricator MockPhabricator
 

--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -150,6 +150,17 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.global_state"
+```
+   Column    |  Type   |       Modifiers        
+-------------+---------+------------------------
+ site_id     | uuid    | not null
+ initialized | boolean | not null default false
+Indexes:
+    "global_state_pkey" PRIMARY KEY, btree (site_id)
+
+```
+
 # Table "public.names"
 ```
  Column  |  Type   | Modifiers 
@@ -464,17 +475,6 @@ Foreign-key constraints:
  created_at         | timestamp with time zone | 
  user_id            | integer                  | 
  author_user_id     | integer                  | 
-
-```
-
-# Table "public.site_config"
-```
-   Column    |  Type   |       Modifiers        
--------------+---------+------------------------
- site_id     | uuid    | not null
- initialized | boolean | not null default false
-Indexes:
-    "site_config_pkey" PRIMARY KEY, btree (site_id)
 
 ```
 

--- a/cmd/frontend/db/stores.go
+++ b/cmd/frontend/db/stores.go
@@ -13,7 +13,7 @@ var (
 	Settings                  = &settings{}
 	Users                     = &users{}
 	UserEmails                = &userEmails{}
-	SiteConfig                = &siteConfig{}
+	GlobalState               = &globalState{}
 	CertCache                 = &certCache{}
 
 	SurveyResponses = &surveyResponses{}

--- a/cmd/frontend/db/users.go
+++ b/cmd/frontend/db/users.go
@@ -178,7 +178,7 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 	// creation and site initialization operations occur atomically (to guarantee to the legitimate
 	// site admin that if they successfully initialize the server, then no attacker's account could
 	// have been created as a site admin).
-	alreadyInitialized, err := (&siteConfig{}).ensureInitialized(ctx, tx)
+	alreadyInitialized, err := (&globalState{}).ensureInitialized(ctx, tx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -83,7 +83,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 	}
 	ctx := dbtesting.TestContext(t)
 
-	if _, err := SiteConfig.Get(ctx); err != nil {
+	if _, err := GlobalState.Get(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -111,8 +111,8 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 	siteID := siteid.Get()
 
 	// Show the site init screen?
-	siteConfig, err := db.SiteConfig.Get(req.Context())
-	showOnboarding := err == nil && !siteConfig.Initialized
+	globalState, err := db.GlobalState.Get(req.Context())
+	showOnboarding := err == nil && !globalState.Initialized
 
 	// Auth providers
 	var authProviders []authProviderInfo

--- a/cmd/frontend/internal/pkg/siteid/siteid.go
+++ b/cmd/frontend/internal/pkg/siteid/siteid.go
@@ -41,11 +41,11 @@ func Init() {
 		// if it doesn't yet exist.)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		config, err := db.SiteConfig.Get(ctx)
+		globalState, err := db.GlobalState.Get(ctx)
 		if err != nil {
-			fatalln("Error initializing site configuration:", err)
+			fatalln("Error initializing global state:", err)
 		}
-		siteID = config.SiteID
+		siteID = globalState.SiteID
 	}
 
 	inited = true

--- a/cmd/frontend/internal/pkg/siteid/siteid_test.go
+++ b/cmd/frontend/internal/pkg/siteid/siteid_test.go
@@ -44,8 +44,8 @@ func TestGet(t *testing.T) {
 
 	t.Run("from DB", func(t *testing.T) {
 		defer reset()
-		db.Mocks.SiteConfig.Get = func(ctx context.Context) (*types.SiteConfig, error) {
-			return &types.SiteConfig{SiteID: "a"}, nil
+		db.Mocks.GlobalState.Get = func(ctx context.Context) (*types.GlobalState, error) {
+			return &types.GlobalState{SiteID: "a"}, nil
 		}
 
 		if err := tryInit(); err != nil {
@@ -61,11 +61,11 @@ func TestGet(t *testing.T) {
 
 	t.Run("panics if DB unavailable", func(t *testing.T) {
 		defer reset()
-		db.Mocks.SiteConfig.Get = func(ctx context.Context) (*types.SiteConfig, error) {
+		db.Mocks.GlobalState.Get = func(ctx context.Context) (*types.GlobalState, error) {
 			return nil, errors.New("x")
 		}
 
-		want := fmt.Errorf("panic: [Error initializing site configuration: x]")
+		want := fmt.Errorf("panic: [Error initializing global state: x]")
 		if err := tryInit(); fmt.Sprint(err) != fmt.Sprint(want) {
 			t.Errorf("got error %q, want %q", err, want)
 		}
@@ -97,8 +97,8 @@ func TestGet(t *testing.T) {
 		defer reset()
 		os.Setenv("TRACKING_APP_ID", "a")
 		defer os.Unsetenv("TRACKING_APP_ID")
-		db.Mocks.SiteConfig.Get = func(ctx context.Context) (*types.SiteConfig, error) {
-			return &types.SiteConfig{SiteID: "b"}, nil
+		db.Mocks.GlobalState.Get = func(ctx context.Context) (*types.GlobalState, error) {
+			return &types.GlobalState{SiteID: "b"}, nil
 		}
 
 		if err := tryInit(); err != nil {

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -54,7 +54,7 @@ type DependencyReferencesOptions struct {
 	Limit int // e.g. 20
 }
 
-type SiteConfig struct {
+type GlobalState struct {
 	SiteID      string
 	Initialized bool // whether the initial site admin account has been created
 }

--- a/migrations/1528395560_.down.sql
+++ b/migrations/1528395560_.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP VIEW site_config;
+ALTER TABLE global_state RENAME TO site_config;
+ALTER INDEX global_state_pkey RENAME TO site_config_pkey;
+END;

--- a/migrations/1528395560_.up.sql
+++ b/migrations/1528395560_.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE site_config RENAME TO global_state;
+ALTER INDEX site_config_pkey RENAME TO global_state_pkey;
+CREATE VIEW site_config AS SELECT * FROM global_state;
+END;


### PR DESCRIPTION
This database table is used for storing a single row with values indicating the
generated site ID and whether or not the site is initialized.

Both values in this table currently are what I would consider to be 'global
state pertaining to Sourcegraph', and as such I believe it should be named
'global state' instead. This also allows makes it more obvious that other
global Sourcegraph state could one day go into this table.

The primary motivation for making this change is because "site config" is a
name which is very easy to confuse with the "site config JSON" and there is
in fact zero relationship between the two (and there can't be even when we
move site config to the DB, because that requires multiple rows and this global
state does not).

Helps #965