### PR TITLE
remove deprecated User.sourcegraphID field, add User.databaseID

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -191,7 +191,7 @@ func (*schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	}
 
 	// Add the current user as the first member of the new org.
-	_, err = db.OrgMembers.Create(ctx, newOrg.ID, currentUser.SourcegraphID())
+	_, err = db.OrgMembers.Create(ctx, newOrg.ID, currentUser.user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2013,8 +2013,6 @@ type User implements Node & SettingsSubject {
     id: ID!
     # The user's username.
     username: String!
-    # The unique numeric ID for the user.
-    sourcegraphID: Int! @deprecated(reason: "use id instead")
     # The user's primary email address.
     #
     # Only the user and site admins can access this field.
@@ -2094,6 +2092,10 @@ type User implements Node & SettingsSubject {
     #
     # FOR INTERNAL USE ONLY.
     urlForSiteAdminBilling: String
+    # The unique numeric ID for the user.
+    #
+    # FOR INTERNAL USE ONLY.
+    databaseID: Int!
 }
 
 # An access token that grants to the holder the privileges of the user who created it.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2020,8 +2020,6 @@ type User implements Node & SettingsSubject {
     id: ID!
     # The user's username.
     username: String!
-    # The unique numeric ID for the user.
-    sourcegraphID: Int! @deprecated(reason: "use id instead")
     # The user's primary email address.
     #
     # Only the user and site admins can access this field.
@@ -2101,6 +2099,10 @@ type User implements Node & SettingsSubject {
     #
     # FOR INTERNAL USE ONLY.
     urlForSiteAdminBilling: String
+    # The unique numeric ID for the user.
+    #
+    # FOR INTERNAL USE ONLY.
+    databaseID: Int!
 }
 
 # An access token that grants to the holder the privileges of the user who created it.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -57,7 +57,8 @@ func UnmarshalUserID(id graphql.ID) (userID int32, err error) {
 	return
 }
 
-func (r *UserResolver) SourcegraphID() int32 { return r.user.ID }
+// DatabaseID returns the numeric ID for the user in the database.
+func (r *UserResolver) DatabaseID() int32 { return r.user.ID }
 
 // Email returns the user's oldest email, if one exists.
 // DEPRECATED: use Emails instead.

--- a/enterprise/cmd/frontend/internal/dotcom/billing/customers.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/customers.go
@@ -130,7 +130,7 @@ func createCustomerID(ctx context.Context, userID int32) (string, error) {
 	}
 	custParams := &stripe.CustomerParams{
 		Params:      stripe.Params{Context: ctx},
-		Description: stripe.String(fmt.Sprintf("%s (%d)", user.Username(), user.SourcegraphID())),
+		Description: stripe.String(fmt.Sprintf("%s (%d)", user.Username(), user.DatabaseID())),
 	}
 
 	// Use the user's first verified email (if any).

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/invoices_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/invoices_graphql.go
@@ -60,7 +60,7 @@ func (ProductSubscriptionLicensingResolver) PreviewProductSubscriptionInvoice(ct
 		if err != nil {
 			return nil, err
 		}
-		tmp := accountUser.SourcegraphID()
+		tmp := accountUser.DatabaseID()
 		accountUserID = &tmp
 		custID, err = billing.GetOrAssignUserCustomerID(ctx, *accountUserID)
 		if err != nil {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -182,7 +182,7 @@ func (ProductSubscriptionLicensingResolver) CreateProductSubscription(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	id, err := dbSubscriptions{}.Create(ctx, user.SourcegraphID())
+	id, err := dbSubscriptions{}.Create(ctx, user.DatabaseID())
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (ProductSubscriptionLicensingResolver) CreatePaidProductSubscription(ctx co
 
 	// 🚨 SECURITY: Users may only create paid product subscriptions for themselves. Site admins may
 	// create them for any user.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, user.SourcegraphID()); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, user.DatabaseID()); err != nil {
 		return nil, err
 	}
 
@@ -249,14 +249,14 @@ func (ProductSubscriptionLicensingResolver) CreatePaidProductSubscription(ctx co
 
 	// Create the subscription in our database first, before processing payment. If payment fails,
 	// users can retry payment on the already created subscription.
-	subID, err := dbSubscriptions{}.Create(ctx, user.SourcegraphID())
+	subID, err := dbSubscriptions{}.Create(ctx, user.DatabaseID())
 	if err != nil {
 		return nil, err
 	}
 
 	// Get the billing customer for the current user, and update it to use the payment source
 	// provided to us.
-	custID, err := billing.GetOrAssignUserCustomerID(ctx, user.SourcegraphID())
+	custID, err := billing.GetOrAssignUserCustomerID(ctx, user.DatabaseID())
 	if err != nil {
 		return nil, err
 	}
@@ -453,14 +453,14 @@ func (ProductSubscriptionLicensingResolver) ProductSubscriptions(ctx context.Con
 			return nil, err
 		}
 	} else {
-		if err := backend.CheckSiteAdminOrSameUser(ctx, accountUser.SourcegraphID()); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, accountUser.DatabaseID()); err != nil {
 			return nil, err
 		}
 	}
 
 	var opt dbSubscriptionsListOptions
 	if accountUser != nil {
-		opt.UserID = accountUser.SourcegraphID()
+		opt.UserID = accountUser.DatabaseID()
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &productSubscriptionConnection{opt: opt}, nil

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -32,7 +32,7 @@ func extensionRegistryViewerPublishers(ctx context.Context) ([]graphqlbackend.Re
 	}
 	publishers = append(publishers, &registryPublisher{user: user})
 
-	orgs, err := db.Orgs.GetByUserID(ctx, user.SourcegraphID())
+	orgs, err := db.Orgs.GetByUserID(ctx, user.DatabaseID())
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (r *registryPublisher) ToOrg() (*graphqlbackend.OrgResolver, bool) { return
 func (r *registryPublisher) toDBRegistryPublisher() dbPublisher {
 	switch {
 	case r.user != nil:
-		return dbPublisher{UserID: r.user.SourcegraphID(), NonCanonicalName: r.user.Username()}
+		return dbPublisher{UserID: r.user.DatabaseID(), NonCanonicalName: r.user.Username()}
 	case r.org != nil:
 		return dbPublisher{OrgID: r.org.OrgID(), NonCanonicalName: r.org.Name()}
 	default:

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -21,7 +21,7 @@ export function refreshAuthenticatedUser(): Observable<never> {
             currentUser {
                 __typename
                 id
-                sourcegraphID
+                databaseID
                 username
                 avatarURL
                 email

--- a/web/src/tracking/eventLogger.tsx
+++ b/web/src/tracking/eventLogger.tsx
@@ -45,7 +45,7 @@ class EventLogger {
      * Set user-level properties in all external tracking services
      */
     public updateUser(user: GQL.IUser): void {
-        this.setUserIds(user.sourcegraphID, user.username)
+        this.setUserIds(user.databaseID, user.username)
         if (user.email) {
             this.setUserEmail(user.email)
         }
@@ -53,15 +53,15 @@ class EventLogger {
 
     /**
      * Set user ID in Telligent tracker script.
-     * @param uniqueSourcegraphId Unique Sourcegraph user ID (corresponds to User.ID from backend)
+     * @param uniqueUserDatabaseId Unique Sourcegraph user database ID (corresponds to databaseID from GraphQL)
      * @param username Human-readable user identifier, not guaranteed to always stay the same
      */
-    public setUserIds(uniqueSourcegraphId: number | null, username: string | null): void {
+    public setUserIds(uniqueUserDatabaseId: number | null, username: string | null): void {
         if (username) {
             telligent.setUserProperty('username', username)
         }
-        if (uniqueSourcegraphId) {
-            telligent.setUserProperty('user_id', uniqueSourcegraphId)
+        if (uniqueUserDatabaseId) {
+            telligent.setUserProperty('user_id', uniqueUserDatabaseId)
         }
     }
 


### PR DESCRIPTION
This field still should only be used for internal purposes, but it's not necessary to deprecate it because the name is not misleading anymore.