### PR TITLE
pkg/conf/confdb: new package for storing critical + site configuration in DB

### DIFF
--- a/cmd/frontend/db/migrations/bindata.go
+++ b/cmd/frontend/db/migrations/bindata.go
@@ -186,6 +186,8 @@
 // ../../../../migrations/1528395560_.up.sql (173B)
 // ../../../../migrations/1528395561_.down.sql (29B)
 // ../../../../migrations/1528395561_.up.sql (311B)
+// ../../../../migrations/1528395562_.down.sql (65B)
+// ../../../../migrations/1528395562_.up.sql (420B)
 
 package migrations
 
@@ -3974,6 +3976,46 @@ func _1528395561_UpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395562_DownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\x48\x2e\xca\x2c\xc9\x4c\x4e\xcc\x89\x4f\xcc\x4b\x89\x2f\xce\x2c\x49\x8d\x4f\xce\xcf\x4b\xcb\x4c\xb7\xe6\x82\x28\x8a\x0c\x40\x52\x93\x5f\x04\x56\x62\xcd\x05\x08\x00\x00\xff\xff\x16\xe6\xc4\xed\x41\x00\x00\x00")
+
+func _1528395562_DownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395562_DownSql,
+		"1528395562_.down.sql",
+	)
+}
+
+func _1528395562_DownSql() (*asset, error) {
+	bytes, err := _1528395562_DownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395562_.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2, 0x6, 0x11, 0xa0, 0x44, 0x5d, 0x39, 0x49, 0x6, 0x38, 0x64, 0x42, 0x37, 0x39, 0x85, 0xb, 0x10, 0xb3, 0xa9, 0xb3, 0xcd, 0xdc, 0x6, 0xf0, 0x81, 0x9e, 0xb7, 0xfe, 0x44, 0x42, 0x3f, 0x81}}
+	return a, nil
+}
+
+var __1528395562_UpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\xd0\xc1\x4a\xec\x30\x14\xc6\xf1\xf5\xe4\x29\x3e\xb2\x69\x0b\x7d\x83\x59\xe5\xde\x39\x62\xb0\x4d\x6b\x9b\xa2\x75\x13\x4a\x13\x25\x20\xe9\xd8\x49\x51\xdf\x5e\x3a\x50\x46\x91\xd9\xb8\x0c\x1f\x3f\x72\xf8\xff\x6f\x48\x68\x82\xee\x6b\xc2\x38\xfb\xe8\xc7\xe1\xd5\x4c\xb3\x39\xf9\xe8\x20\x5a\x90\xea\x4a\xa4\xc9\x36\x25\x39\x92\x75\x4a\xb2\x3d\xdb\xa8\xf8\x57\x7c\xb3\x43\xb0\x67\x6c\xc6\x29\x3c\xfb\x17\xa4\x6c\xc7\xbd\xe5\x68\xa9\x91\xa2\x80\xaa\x34\x54\x57\x14\xa8\x1b\x59\x8a\xa6\xc7\x1d\xf5\x39\x03\x00\x1e\x3f\x8f\x8e\xff\x3e\x62\x13\x39\xdb\xf1\x71\x0a\xd1\x85\x78\xe2\x88\xee\x23\xfe\x9c\x66\x37\x44\x67\xcd\x10\x39\xb4\x2c\xa9\xd5\xa2\xac\xf1\x20\xf5\xed\xf9\x89\xa7\x4a\xd1\xe5\xf7\x03\xdd\x88\xae\xd0\x08\xd3\x7b\x9a\xad\x7c\x39\xda\xbf\x72\x76\x69\xd1\x29\x79\xdf\x11\xa4\x3a\xd0\x23\xf8\xb5\x26\x66\x09\xfe\x6d\x71\x1c\x95\xba\xda\x2d\xf5\x36\xc7\x5a\x24\xdb\xb3\xaf\x00\x00\x00\xff\xff\x50\x39\xf0\x7b\xa4\x01\x00\x00")
+
+func _1528395562_UpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395562_UpSql,
+		"1528395562_.up.sql",
+	)
+}
+
+func _1528395562_UpSql() (*asset, error) {
+	bytes, err := _1528395562_UpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395562_.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8, 0xec, 0x70, 0xe7, 0xc6, 0x41, 0x72, 0xc, 0x70, 0xfb, 0xab, 0x51, 0x1, 0x16, 0x31, 0x89, 0x2c, 0xb8, 0x4c, 0x66, 0x7e, 0xde, 0xe5, 0x4c, 0xa2, 0x41, 0xc6, 0x75, 0x78, 0xbd, 0x9f, 0xcc}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -4436,6 +4478,10 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395561_.down.sql": _1528395561_DownSql,
 
 	"1528395561_.up.sql": _1528395561_UpSql,
+
+	"1528395562_.down.sql": _1528395562_DownSql,
+
+	"1528395562_.up.sql": _1528395562_UpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -4665,6 +4711,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395560_.up.sql":                                          &bintree{_1528395560_UpSql, map[string]*bintree{}},
 	"1528395561_.down.sql":                                        &bintree{_1528395561_DownSql, map[string]*bintree{}},
 	"1528395561_.up.sql":                                          &bintree{_1528395561_UpSql, map[string]*bintree{}},
+	"1528395562_.down.sql":                                        &bintree{_1528395562_DownSql, map[string]*bintree{}},
+	"1528395562_.up.sql":                                          &bintree{_1528395562_UpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -37,6 +37,21 @@ Indexes:
 
 ```
 
+# Table "public.critical_and_site_config"
+```
+   Column   |           Type           |                               Modifiers                               
+------------+--------------------------+-----------------------------------------------------------------------
+ id         | integer                  | not null default nextval('critical_and_site_config_id_seq'::regclass)
+ type       | critical_or_site         | not null
+ contents   | text                     | not null
+ created_at | timestamp with time zone | not null default now()
+ updated_at | timestamp with time zone | not null default now()
+Indexes:
+    "critical_and_site_config_pkey" PRIMARY KEY, btree (id)
+    "critical_and_site_config_unique" UNIQUE, btree (id, type)
+
+```
+
 # Table "public.discussion_comments"
 ```
      Column     |           Type           |                            Modifiers                             

--- a/migrations/1528395562_.down.sql
+++ b/migrations/1528395562_.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE critical_and_site_config;
+DROP TYPE critical_or_site;

--- a/migrations/1528395562_.up.sql
+++ b/migrations/1528395562_.up.sql
@@ -1,0 +1,9 @@
+CREATE TYPE critical_or_site AS ENUM ('critical', 'site');
+CREATE TABLE critical_and_site_config (
+	"id" SERIAL NOT NULL PRIMARY KEY,
+    "type" critical_or_site NOT NULL,
+	"contents" text NOT NULL,
+	"created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+	"updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX "critical_and_site_config_unique" ON critical_and_site_config(id, type);

--- a/pkg/conf/confdb/confdb.go
+++ b/pkg/conf/confdb/confdb.go
@@ -1,0 +1,255 @@
+package confdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/jsonx"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/dbconn"
+)
+
+// Config contains the contents of a critical/site config along with associated metadata.
+type Config struct {
+	ID        int32     // the unique ID of this config
+	Type      string    // either "critical" or "site"
+	Contents  string    // the raw JSON content (with comments and trailing commas allowed)
+	CreatedAt time.Time // the date when this config was created
+	UpdatedAt time.Time // the date when this config was updated
+}
+
+// SiteConfig contains the contents of a site config along with associated metadata.
+type SiteConfig Config
+
+// CriticalConfig contains the contents of a critical config along with associated metadata.
+type CriticalConfig Config
+
+// SiteCreateIfUpToDate saves the given site config "contents" to the database iff the
+// supplied "lastID" is equal to the one that was most recently saved to the database.
+//
+// The site config that was most recently saved to the database is returned.
+// An error is returned if "contents" is invalid JSON.
+//
+// 🚨 SECURITY: This method does NOT verify the user is an admin. The caller is
+// responsible for ensuring this or that the response never makes it to a user.
+func SiteCreateIfUpToDate(ctx context.Context, lastID *int32, contents string) (latest *SiteConfig, err error) {
+	tx, done, err := newTransaction(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	newLastID, err := addDefault(ctx, tx, typeSite, defaultSiteConfig)
+	if err != nil {
+		return nil, err
+	}
+	if newLastID != nil {
+		lastID = newLastID
+	}
+
+	criticalSite, err := createIfUpToDate(ctx, tx, typeSite, lastID, contents)
+	return (*SiteConfig)(criticalSite), err
+}
+
+// CriticalCreateIfUpToDate saves the given critical config "contents" to the database iff the
+// supplied "lastID" is equal to the one that was most recently saved to the database.
+//
+// The critical config that was most recently saved to the database is returned.
+// An error is returned if "contents" is invalid JSON.
+//
+// 🚨 SECURITY: This method does NOT verify the user is an admin. The caller is
+// responsible for ensuring this or that the response never makes it to a user.
+func CriticalCreateIfUpToDate(ctx context.Context, lastID *int32, contents string) (latest *CriticalConfig, err error) {
+	tx, done, err := newTransaction(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	newLastID, err := addDefault(ctx, tx, typeCritical, defaultCriticalConfig)
+	if err != nil {
+		return nil, err
+	}
+	if newLastID != nil {
+		lastID = newLastID
+	}
+
+	criticalSite, err := createIfUpToDate(ctx, tx, typeCritical, lastID, contents)
+	return (*CriticalConfig)(criticalSite), err
+}
+
+// SiteGetLatest returns the site config that was most recently saved to the database.
+// This returns nil, nil if there is not yet a site config in the database.
+//
+// 🚨 SECURITY: This method does NOT verify the user is an admin. The caller is
+// responsible for ensuring this or that the response never makes it to a user.
+func SiteGetLatest(ctx context.Context) (latest *SiteConfig, err error) {
+	tx, done, err := newTransaction(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	_, err = addDefault(ctx, tx, typeSite, defaultSiteConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	site, err := getLatest(ctx, tx, typeSite)
+	return (*SiteConfig)(site), err
+}
+
+// CriticalGetLatest returns critical site config that was most recently saved to the database.
+// This returns nil, nil if there is not yet a critical config in the database.
+//
+// 🚨 SECURITY: This method does NOT verify the user is an admin. The caller is
+// responsible for ensuring this or that the response never makes it to a user.
+func CriticalGetLatest(ctx context.Context) (latest *CriticalConfig, err error) {
+	tx, done, err := newTransaction(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	_, err = addDefault(ctx, tx, typeCritical, defaultCriticalConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	critical, err := getLatest(ctx, tx, typeCritical)
+	return (*CriticalConfig)(critical), err
+}
+
+func newTransaction(ctx context.Context) (tx queryable, done func(), err error) {
+	rtx, err := dbconn.Global.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rtx, func() {
+		if err != nil {
+			rollErr := rtx.Rollback()
+			if rollErr != nil {
+				err = multierror.Append(err, rollErr)
+			}
+			return
+		}
+		err = rtx.Commit()
+	}, nil
+}
+
+func addDefault(ctx context.Context, tx queryable, configType string, contents string) (newLastID *int32, err error) {
+	latest, err := getLatest(ctx, tx, configType)
+	if err != nil {
+		return nil, err
+	}
+	if latest != nil {
+		// We have an existing config!
+		return nil, nil
+	}
+
+	// Create the default.
+	latest, err = createIfUpToDate(ctx, tx, configType, nil, contents)
+	if err != nil {
+		return nil, err
+	}
+	return &latest.ID, nil
+}
+
+func createIfUpToDate(ctx context.Context, tx queryable, configType string, lastID *int32, contents string) (latest *Config, err error) {
+	// Validate JSON syntax before saving.
+	if _, errs := jsonx.Parse(contents, jsonx.ParseOptions{Comments: true, TrailingCommas: true}); len(errs) > 0 {
+		return nil, fmt.Errorf("invalid settings JSON: %v", errs)
+	}
+
+	new := Config{
+		Contents: contents,
+	}
+
+	latest, err = getLatest(ctx, tx, configType)
+	if err != nil {
+		return nil, err
+	}
+
+	creatorIsUpToDate := latest != nil && lastID != nil && latest.ID == *lastID
+	if latest == nil || creatorIsUpToDate {
+		err := tx.QueryRowContext(
+			ctx,
+			"INSERT INTO critical_and_site_config(type, contents) VALUES($1, $2) RETURNING id, created_at, updated_at",
+			configType, new.Contents,
+		).Scan(&new.ID, &new.CreatedAt, &new.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		latest = &new
+	}
+	return latest, nil
+}
+
+func getLatest(ctx context.Context, tx queryable, configType string) (*Config, error) {
+	q := sqlf.Sprintf("SELECT s.id, s.type, s.contents, s.created_at, s.updated_at FROM critical_and_site_config s WHERE type=%s ORDER BY id DESC LIMIT 1", configType)
+	rows, err := tx.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return nil, err
+	}
+	versions, err := parseQueryRows(ctx, rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(versions) != 1 {
+		// No config has been written yet.
+		return nil, nil
+	}
+	return versions[0], nil
+}
+
+func parseQueryRows(ctx context.Context, rows *sql.Rows) ([]*Config, error) {
+	versions := []*Config{}
+	defer rows.Close()
+	for rows.Next() {
+		f := Config{}
+		err := rows.Scan(&f.ID, &f.Type, &f.Contents, &f.CreatedAt, &f.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, &f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return versions, nil
+}
+
+// queryable allows us to reuse the same logic for certain operations both
+// inside and outside an explicit transaction.
+type queryable interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}
+
+const (
+	typeCritical = "critical"
+	typeSite     = "site"
+)
+
+// SetDefaultConfigs should be invoked once early on in the program
+// startup, before calls to e.g. conf.Get are made. It will panic if called
+// more than once.
+func SetDefaultConfigs(critical, site string) {
+	if setDefaultConfigsCalled {
+		panic("confdb.SetDefaultConfigs may not be called twice")
+	}
+	setDefaultConfigsCalled = true
+	defaultCriticalConfig = critical
+	defaultSiteConfig = site
+}
+
+var (
+	setDefaultConfigsCalled bool
+	defaultCriticalConfig   string
+	defaultSiteConfig       string
+)

--- a/pkg/conf/confdb/confdb_test.go
+++ b/pkg/conf/confdb/confdb_test.go
@@ -1,0 +1,191 @@
+package confdb
+
+import (
+	"strings"
+	"testing"
+
+	dbtesting "github.com/sourcegraph/sourcegraph/cmd/frontend/db/testing"
+)
+
+func TestCriticalGetLatestDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := dbtesting.TestContext(t)
+
+	latest, err := CriticalGetLatest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if latest == nil {
+		t.Errorf("expected non-nil latest config since default config should be created, got: %+v", latest)
+	}
+}
+
+func TestCriticalCreate_RejectInvalidJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := dbtesting.TestContext(t)
+
+	malformedJSON := "[This is malformed.}"
+
+	_, err := CriticalCreateIfUpToDate(ctx, nil, malformedJSON)
+
+	if err == nil || !strings.Contains(err.Error(), "invalid settings JSON") {
+		t.Fatalf("expected parse error after creating configuration with malformed JSON, got: %+v", err)
+	}
+}
+
+func TestCriticalCreateIfUpToDate(t *testing.T) {
+	type input struct {
+		lastID   int32
+		contents string
+	}
+
+	type output struct {
+		ID       int32
+		contents string
+	}
+
+	type pair struct {
+		input    input
+		expected output
+	}
+
+	type test struct {
+		name     string
+		sequence []pair
+	}
+
+	for _, test := range []test{
+		test{
+			name: "create_one",
+			sequence: []pair{
+				pair{
+					input{
+						lastID:   0,
+						contents: `"This is a test."`,
+					},
+					output{
+						ID:       2,
+						contents: `"This is a test."`,
+					},
+				},
+			},
+		},
+		test{
+			name: "create_two",
+			sequence: []pair{
+				pair{
+					input{
+						lastID:   0,
+						contents: `"This is the first one."`,
+					},
+					output{
+						ID:       2,
+						contents: `"This is the first one."`,
+					},
+				},
+				pair{
+					input{
+						lastID:   2,
+						contents: `"This is the second one."`,
+					},
+					output{
+						ID:       3,
+						contents: `"This is the second one."`,
+					},
+				},
+			},
+		},
+		test{
+			name: "do_not_update_if_outdated",
+			sequence: []pair{
+				pair{
+					input{
+						lastID:   0,
+						contents: `"This is the first one."`,
+					},
+					output{
+						ID:       2,
+						contents: `"This is the first one."`,
+					},
+				},
+				pair{
+					input{
+						lastID:   0,
+						contents: `"This configuration is now behind the first one, so it shouldn't be saved."`,
+					},
+					output{
+						ID:       2,
+						contents: `"This is the first one."`,
+					},
+				},
+			},
+		},
+		test{
+			name: "maintain_commments_and_whitespace",
+			sequence: []pair{
+				pair{
+					input{
+						lastID: 0,
+						contents: `{"fieldA": "valueA",
+
+// This is a comment.
+             "fieldB": "valueB",
+						}`,
+					},
+					output{
+						ID: 2,
+						contents: `{"fieldA": "valueA",
+
+// This is a comment.
+             "fieldB": "valueB",
+						}`,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := dbtesting.TestContext(t)
+			for _, p := range test.sequence {
+				output, err := CriticalCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if output == nil {
+					t.Fatal("got unexpected nil configuration after creation")
+				}
+
+				if output.Contents != p.expected.contents {
+					t.Fatalf("returned configuration contents after creation - expected: %q, got:%q", p.expected.contents, output.Contents)
+				}
+				if output.ID != p.expected.ID {
+					t.Fatalf("returned configuration ID after creation - expected: %v, got:%v", p.expected.ID, output.ID)
+				}
+
+				latest, err := CriticalGetLatest(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if latest == nil {
+					t.Errorf("got unexpected nil configuration after GetLatest")
+				}
+
+				if latest.Contents != p.expected.contents {
+					t.Fatalf("returned configuration contents after GetLatest - expected: %q, got:%q", p.expected.contents, latest.Contents)
+				}
+				if latest.ID != p.expected.ID {
+					t.Fatalf("returned configuration ID after GetLatest - expected: %v, got:%v", p.expected.ID, latest.ID)
+				}
+			}
+		})
+	}
+}

--- a/pkg/conf/confdb/db_test.go
+++ b/pkg/conf/confdb/db_test.go
@@ -1,0 +1,9 @@
+package confdb
+
+import (
+	dbtesting "github.com/sourcegraph/sourcegraph/cmd/frontend/db/testing"
+)
+
+func init() {
+	dbtesting.DBNameSuffix = "confdb"
+}

--- a/pkg/conf/confdb/doc.go
+++ b/pkg/conf/confdb/doc.go
@@ -1,0 +1,7 @@
+// Package confdb contains the DB logic for configuration storage / manipulation.
+//
+// Only the frontend and management console will directly import this package.
+//
+// All other users should go through the conf package and NOT interact with the
+// database on their own.
+package confdb


### PR DESCRIPTION
This introduces a new package `pkg/conf/confdb` which is for storing critical + site configuration in the DB. This package lives under `pkg/conf` because it will be used by both the frontend and management console services.