### PR TITLE
run go generate before yarn

### DIFF
--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -3,9 +3,9 @@
 set -ex
 cd $(dirname "${BASH_SOURCE[0]}")/../..
 
+dev/generate.sh
+
 pushd ..
 yarn --frozen-lockfile --network-timeout 60000
 (cd web && yarn -s run build --color)
 popd
-
-dev/generate.sh


### PR DESCRIPTION
This fixes CI failures by running go generate before yarn so that the transient dependency causing the problems is not installed yet.

I've tested locally by going through the commands ran in CI and running `enterprise/dev/start.sh` as well as `enterprise/dev/dev-sourcegraph-server.sh`.