### PR TITLE
Fix padding on extensions page and correct top margin #1008

### DIFF
--- a/web/src/enterprise/productSubscription/ProductCertificate.scss
+++ b/web/src/enterprise/productSubscription/ProductCertificate.scss
@@ -16,6 +16,15 @@
     &__logo {
         height: 5rem;
     }
+
+    .card-footer {
+        padding-left: 1rem;
+    }
+}
+
+.alert-subscription {
+    margin-top: 0.5rem;
+    padding-left: 1rem;
 }
 
 .theme-light {

--- a/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -139,7 +139,7 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
                         />
                     ) : (
                         license.userCount - actualUserCount < 0 && (
-                            <div className="alert alert-warning">
+                            <div className="alert alert-subscription alert-warning">
                                 You have exceeded your licensed users.{' '}
                                 <Link to="/site-admin/license">View your license details</Link> or{' '}
                                 <a href="https://about.sourcegraph.com/pricing" target="_blank">

--- a/web/src/extensions/extension/ExtensionAreaHeader.scss
+++ b/web/src/extensions/extension/ExtensionAreaHeader.scss
@@ -1,15 +1,15 @@
 .extension-area-header {
     padding-top: 0.5rem;
-	padding-left: .5rem;
-	padding-right: .5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 
     .container {
-		padding-left: 0;
-		padding-right: 0;
+        padding-left: 0;
+        padding-right: 0;
 
-		// Compensate for 1px border
-		// stylelint-disable-next-line declaration-property-unit-whitelist
-		margin-top: -1px;
+        // Compensate for 1px border
+        // stylelint-disable-next-line declaration-property-unit-whitelist
+        margin-top: -1px;
     }
 
     &__icon {

--- a/web/src/extensions/extension/ExtensionAreaHeader.scss
+++ b/web/src/extensions/extension/ExtensionAreaHeader.scss
@@ -1,9 +1,15 @@
 .extension-area-header {
     padding-top: 0.5rem;
+	padding-left: .5rem;
+	padding-right: .5rem;
 
     .container {
-        padding-left: 0;
-        padding-right: 0;
+		padding-left: 0;
+		padding-right: 0;
+
+		// Compensate for 1px border
+		// stylelint-disable-next-line declaration-property-unit-whitelist
+		margin-top: -1px;
     }
 
     &__icon {


### PR DESCRIPTION
Corrects issues in #1008 and aligns the top of the section on both the explore page and main page.
![screen shot 2018-11-26 at 1 15 49 pm](https://user-images.githubusercontent.com/11583013/49042579-660af400-f17d-11e8-9664-b6e024b4adba.png)
