### PR TITLE
cmd/server: add CONFIGURAITON_MODE=server flag to frontend process

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -140,7 +140,7 @@ func Main() {
 		`lsp-proxy: lsp-proxy`,
 		`searcher: searcher`,
 		`github-proxy: github-proxy`,
-		`frontend: frontend`,
+		`frontend: env CONFIGURATION_MODE=server frontend`,
 		`repo-updater: repo-updater`,
 		`indexer: indexer`,
 		`syntect_server: sh -c 'env QUIET=true ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_PORT=9238 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' ROCKET_ENV=production syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"'`,


### PR DESCRIPTION
After https://github.com/sourcegraph/sourcegraph/pull/1131, `sourcegraph/server` fails to start with the following error:

```shell
22:17:12          frontend | panic: cannot call this function while in client mode
22:17:12          frontend | goroutine 1 [running]:
22:17:12          frontend | github.com/sourcegraph/sourcegraph/pkg/conf.InitConfigurationServerFrontendOnly(0x2b32560, 0xc000221af0, 0x2b32560)
22:17:12          frontend | 	/buildkite/builds/buildkite-agent-5f44c797d5-v2jv6-1/sourcegraph/.golang/sourcegraph/src/github.com/sourcegraph/sourcegraph/pkg/conf/conf.go:100 +0x221
frontend died. Shutting down...
```

I'm fairly certain is happening b/c the godockerize directives for the `frontend` process aren't being added to the `sourcegraph/server` dockerfile, so the `env CONFIGURATION_MODE=server` directive is being ignored. 

Adding the environment variable to the Procfile used in `sourcegraph/server` should supply the correct environment varible to the `frontend` binary when it's being run inside the monolith `sourcegraph/server` image. 