### PR TITLE
Allow jsonSchemaId to be passed separately

### DIFF
--- a/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
@@ -98,7 +98,8 @@ export class RegistryExtensionManifestPage extends React.PureComponent<Props, St
                             id="registry-extension-edit-page__data"
                             value={this.props.extension.rawManifest}
                             height={500}
-                            jsonSchema={extensionSchemaJSON}
+                            jsonSchemaId="extension.schema.json#"
+                            extraSchemas={[extensionSchemaJSON]}
                             readOnly={true}
                             isLightTheme={this.props.isLightTheme}
                             history={this.props.history}

--- a/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -16,7 +16,10 @@ import { EditorAction } from '../site-admin/configHelpers'
 const disposableToFn = (disposable: _monaco.IDisposable) => () => disposable.dispose()
 
 interface Props
-    extends Pick<_monacoSettingsEditorModule.Props, 'id' | 'readOnly' | 'height' | 'jsonSchema' | 'isLightTheme'> {
+    extends Pick<
+            _monacoSettingsEditorModule.Props,
+            'id' | 'readOnly' | 'height' | 'jsonSchemaId' | 'extraSchemas' | 'isLightTheme'
+        > {
     value: string
 
     actions?: EditorAction[]

--- a/web/src/settings/SettingsFile.tsx
+++ b/web/src/settings/SettingsFile.tsx
@@ -18,9 +18,14 @@ interface Props {
     settings: GQL.ISettings | null
 
     /**
-     * The JSON Schema that describes the document.
+     * The id of the JSON schema for the document.
      */
-    jsonSchema: { $id: string }
+    jsonSchemaId: string
+
+    /**
+     * Extra schemas that are transitively referenced by jsonSchemaId.
+     */
+    extraSchemas?: { $id: string }[]
 
     /**
      * Called when the user saves changes to the settings file's contents.
@@ -212,7 +217,8 @@ export class SettingsFile extends React.PureComponent<Props, State> {
                         />
                         <MonacoSettingsEditor
                             value={contents}
-                            jsonSchema={this.props.jsonSchema}
+                            jsonSchemaId={this.props.jsonSchemaId}
+                            extraSchemas={this.props.extraSchemas}
                             onChange={this.onEditorChange}
                             readOnly={this.state.saving}
                             monacoRef={this.monacoRef}

--- a/web/src/settings/SettingsPage.tsx
+++ b/web/src/settings/SettingsPage.tsx
@@ -27,7 +27,8 @@ export class SettingsPage extends React.PureComponent<Props, State> {
         return (
             <SettingsFile
                 settings={this.props.data.subjects[this.props.data.subjects.length - 1].latestSettings}
-                jsonSchema={this.props.data.settingsJSONSchema}
+                jsonSchemaId="settings.schema.json#"
+                extraSchemas={[this.props.data.settingsJSONSchema]}
                 commitError={this.state.commitError}
                 onDidCommit={this.onDidCommit}
                 onDidDiscard={this.onDidDiscard}

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -260,7 +260,8 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                             <DynamicallyImportedMonacoSettingsEditor
                                 value={contents || ''}
                                 actions={siteConfigActions}
-                                jsonSchema={siteSchemaJSON}
+                                jsonSchemaId="site.schema.json#"
+                                extraSchemas={[siteSchemaJSON]}
                                 onDirtyChange={this.onDirtyChange}
                                 canEdit={this.state.site.configuration.canUpdate}
                                 saving={this.state.saving}


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/914 and a pre-requisite for https://github.com/sourcegraph/sourcegraph/pull/1103

It will allow me to validate a config against a definition in site.schema.json like this:
```
jsonSchemaId="site.schema.json#/definitions/GitHubConnection"
extraSchemas={[siteSchemaJSON]}
```