### PR TITLE
make more conf.Watch usages async

### DIFF
--- a/cmd/frontend/auth/providers.go
+++ b/cmd/frontend/auth/providers.go
@@ -2,35 +2,54 @@ package auth
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
+
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
 
 var (
-	allProvidersMu sync.Mutex
+	// allProvidersRegistered once all providers are initially registered. Any
+	// user of the allProviders value should wait on this before using it
+	// (otherwise there would be a time period where some providers are not yet
+	// registered and requests could accidently go by unauthenticated).
+	allProvidersRegisteredOnce sync.Once
+	allProvidersRegistered     = make(chan struct{})
+
+	allProvidersMu sync.RWMutex
 	allProviders   []Provider // all configured authentication provider instances (modified by UpdateProviders)
 )
 
 // Providers returns a list of all authentication provider instances that are active in the site
 // config. The return value is immutable.
+//
+// It blocks until UpdateProviders has been called at least once.
 func Providers() []Provider {
 	if MockProviders != nil {
 		return MockProviders
 	}
-	allProvidersMu.Lock()
-	defer allProvidersMu.Unlock()
+
+	<-allProvidersRegistered
+	allProvidersMu.RLock()
+	defer allProvidersMu.RUnlock()
 	return allProviders
 }
 
 // GetProviderByConfigID returns the provider with the given config ID (if it is currently
 // registered via UpdateProviders).
+//
+// It blocks until UpdateProviders has been called at least once.
 func GetProviderByConfigID(id ProviderConfigID) Provider {
 	var ps []Provider
 	if MockProviders != nil {
 		ps = MockProviders
 	} else {
-		allProvidersMu.Lock()
-		defer allProvidersMu.Unlock()
+		<-allProvidersRegistered
+		allProvidersMu.RLock()
+		defer allProvidersMu.RUnlock()
 		ps = allProviders
 	}
 
@@ -80,3 +99,42 @@ func UpdateProviders(updates map[Provider]bool) {
 
 // MockProviders mocks the auth provider registry for tests.
 var MockProviders []Provider
+
+var isTest = (func() bool {
+	path, _ := os.Executable()
+	return filepath.Ext(path) == ".test"
+})()
+
+func init() {
+	if isTest {
+		// Tests do not call ConfWatch, so we close the channel now.
+		close(allProvidersRegistered)
+	}
+}
+
+var needRegisteredProviders int32
+
+// ConfWatch should be called strictly from init functions directly, not
+// asynchronously.
+//
+// It is guaranteed that any watcher added via this method during init will run
+// at least once before Providers or GetProviderByConfigID can return. This
+// inherently guarantees that any auth providers registered via this function
+// will be used and there is no time period between registration and the time
+// when conf.Watch fires where requests could go by without authentication.
+func ConfWatch(f func()) {
+	atomic.AddInt32(&needRegisteredProviders, 1)
+
+	go func() {
+		conf.Watch(func() {
+			f()
+
+			if atomic.AddInt32(&needRegisteredProviders, -1) <= 0 {
+				// Done registering providers.
+				allProvidersRegisteredOnce.Do(func() {
+					close(allProvidersRegistered)
+				})
+			}
+		})
+	}()
+}

--- a/cmd/frontend/auth/providers.go
+++ b/cmd/frontend/auth/providers.go
@@ -107,8 +107,12 @@ var isTest = (func() bool {
 
 func init() {
 	if isTest {
-		// Tests do not call ConfWatch, so we close the channel now.
-		close(allProvidersRegistered)
+		// Tests do not usually call ConfWatch or if they do, conf.Watch is not
+		// fired due to no config mocking in the tests, so we close the channel
+		// now.
+		allProvidersRegisteredOnce.Do(func() {
+			close(allProvidersRegistered)
+		})
 	}
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/config_watch.go
+++ b/cmd/frontend/internal/auth/userpasswd/config_watch.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
-	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -19,7 +18,7 @@ func init() {
 		pc *schema.BuiltinAuthProvider
 		pi auth.Provider
 	)
-	conf.Watch(func() {
+	auth.ConfWatch(func() {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -44,6 +43,6 @@ func init() {
 		auth.UpdateProviders(updates)
 		pc = newPC
 		pi = newPI
+		init = false
 	})
-	init = false
 }

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -141,7 +141,7 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 		// If the headerOrigin is the development or production Chrome Extension explicitly set the Allow-Control-Allow-Origin
 		// to the incoming header URL. Otherwise use the configured CORS origin.
 		headerOrigin := r.Header.Get("Origin")
-		isExtensionRequest := (headerOrigin == devExtension || headerOrigin == prodExtension) && !disableBrowserExtension
+		isExtensionRequest := (headerOrigin == devExtension || headerOrigin == prodExtension) && !conf.Get().DisableBrowserExtension
 		if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" || isExtensionRequest {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 
@@ -169,7 +169,7 @@ func isTrustedOrigin(r *http.Request) bool {
 	requestOrigin := r.Header.Get("Origin")
 
 	var isExtensionRequest bool
-	if !disableBrowserExtension {
+	if !conf.Get().DisableBrowserExtension {
 		isExtensionRequest = requestOrigin == devExtension || requestOrigin == prodExtension
 	}
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -44,12 +44,6 @@ var (
 	httpsAddr        = env.Get("SRC_HTTPS_ADDR", ":3443", "HTTPS (TLS) listen address for app and HTTP API. Only used if manual tls cert and key are specified.")
 	httpAddrInternal = env.Get("SRC_HTTP_ADDR_INTERNAL", ":3090", "HTTP listen address for internal HTTP API. This should never be exposed externally, as it lacks certain authz checks.")
 
-	externalURL             = conf.GetTODO().ExternalURL
-	disableBrowserExtension = conf.GetTODO().DisableBrowserExtension
-
-	tlsCert = conf.GetTODO().TlsCert
-	tlsKey  = conf.GetTODO().TlsKey
-
 	// dev browser browser extension ID. You can find this by going to chrome://extensions
 	devExtension = "chrome-extension://bmfbcejdknlknpncfpeloejonjoledha"
 	// production browser extension ID. This is found by viewing our extension in the chrome store.
@@ -64,6 +58,7 @@ func configureExternalURL() (*url.URL, error) {
 	} else {
 		hostPort = httpAddr
 	}
+	externalURL := conf.Get().ExternalURL
 	if externalURL == "" {
 		externalURL = "http://<http-addr>"
 	}
@@ -153,6 +148,8 @@ func Main() error {
 		hooks.AfterDBInit()
 	}
 
+	tlsCert := conf.Get().TlsCert
+	tlsKey := conf.Get().TlsKey
 	tlsCertAndKey := tlsCert != "" && tlsKey != ""
 	useTLS := httpsAddr != "" && (tlsCertAndKey || (globals.ExternalURL.Scheme == "https" && conf.GetTODO().TlsLetsencrypt != "off"))
 	if useTLS && globals.ExternalURL.Scheme == "http" {
@@ -269,7 +266,7 @@ func Main() error {
 		fmt.Println(logoColor)
 		fmt.Println(" ")
 	}
-	fmt.Printf("✱ Sourcegraph is ready at: %s\n", externalURL)
+	fmt.Printf("✱ Sourcegraph is ready at: %s\n", globals.ExternalURL)
 
 	srv.Wait()
 	return nil

--- a/cmd/frontend/shared/authz.go
+++ b/cmd/frontend/shared/authz.go
@@ -12,7 +12,7 @@ func init() {
 		_, _, seriousProblems, warnings := providersFromConfig(&cfg)
 		return append(seriousProblems, warnings...)
 	})
-	conf.Watch(func() {
+	go conf.Watch(func() {
 		allowAccessByDefault, authzProviders, _, _ := providersFromConfig(conf.Get())
 		authz.SetProviders(allowAccessByDefault, authzProviders)
 	})

--- a/enterprise/cmd/frontend/auth/gitlaboauth/config.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/config.go
@@ -29,45 +29,42 @@ func init() {
 		mu  sync.Mutex
 		cur = map[schema.GitLabAuthProvider]auth.Provider{} // tracks current mapping of valid config to auth.Provider
 	)
+	auth.ConfWatch(func() {
+		mu.Lock()
+		defer mu.Unlock()
 
-	go func() {
-		conf.Watch(func() {
-			mu.Lock()
-			defer mu.Unlock()
-
-			if !conf.Get().ExperimentalFeatures.GitlabAuth {
-				new := map[schema.GitLabAuthProvider]auth.Provider{}
-				updates := make(map[auth.Provider]bool)
-				for c, p := range cur {
-					if _, ok := new[c]; !ok {
-						updates[p] = false
-					}
-				}
-				auth.UpdateProviders(updates)
-				cur = new
-				ffIsEnabled = false
-				return
-			}
-
-			log15.Info("Reloading changed GitLab OAuth authentication provider configuration.")
-
-			new, _ := parseConfig(conf.Get())
+		if !conf.Get().ExperimentalFeatures.GitlabAuth {
+			new := map[schema.GitLabAuthProvider]auth.Provider{}
 			updates := make(map[auth.Provider]bool)
 			for c, p := range cur {
 				if _, ok := new[c]; !ok {
 					updates[p] = false
 				}
 			}
-			for c, p := range new {
-				if _, ok := cur[c]; !ok {
-					updates[p] = true
-				}
-			}
 			auth.UpdateProviders(updates)
 			cur = new
-			ffIsEnabled = true
-		})
-	}()
+			ffIsEnabled = false
+			return
+		}
+
+		log15.Info("Reloading changed GitLab OAuth authentication provider configuration.")
+
+		new, _ := parseConfig(conf.Get())
+		updates := make(map[auth.Provider]bool)
+		for c, p := range cur {
+			if _, ok := new[c]; !ok {
+				updates[p] = false
+			}
+		}
+		for c, p := range new {
+			if _, ok := cur[c]; !ok {
+				updates[p] = true
+			}
+		}
+		auth.UpdateProviders(updates)
+		cur = new
+		ffIsEnabled = true
+	})
 	conf.ContributeValidator(func(cfg schema.SiteConfiguration) (problems []string) {
 		_, problems = parseConfig(&cfg)
 		return problems

--- a/enterprise/cmd/frontend/auth/httpheader/config_watch.go
+++ b/enterprise/cmd/frontend/auth/httpheader/config_watch.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
-	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -19,7 +18,7 @@ func init() {
 		pc *schema.HTTPHeaderAuthProvider
 		pi auth.Provider
 	)
-	conf.Watch(func() {
+	auth.ConfWatch(func() {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -44,6 +43,6 @@ func init() {
 		auth.UpdateProviders(updates)
 		pc = newPC
 		pi = newPI
+		init = false
 	})
-	init = false
 }

--- a/enterprise/cmd/frontend/auth/openidconnect/config_watch.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/config_watch.go
@@ -31,7 +31,7 @@ func init() {
 		cur []*schema.OpenIDConnectAuthProvider
 		reg = map[schema.OpenIDConnectAuthProvider]auth.Provider{}
 	)
-	conf.Watch(func() {
+	auth.ConfWatch(func() {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -64,8 +64,8 @@ func init() {
 		}
 		auth.UpdateProviders(updates)
 		cur = new
+		init = false
 	})
-	init = false
 }
 
 func diffProviderConfig(old, new []*schema.OpenIDConnectAuthProvider) map[schema.OpenIDConnectAuthProvider]bool {

--- a/enterprise/cmd/frontend/auth/saml/config_watch.go
+++ b/enterprise/cmd/frontend/auth/saml/config_watch.go
@@ -30,7 +30,7 @@ func init() {
 		cur []*schema.SAMLAuthProvider
 		reg = map[schema.SAMLAuthProvider]auth.Provider{}
 	)
-	conf.Watch(func() {
+	auth.ConfWatch(func() {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -64,8 +64,8 @@ func init() {
 		}
 		auth.UpdateProviders(updates)
 		cur = new
+		init = false
 	})
-	init = false
 }
 
 func diffProviderConfig(old, new []*schema.SAMLAuthProvider) map[schema.SAMLAuthProvider]bool {

--- a/pkg/gosrc/import_path_test.go
+++ b/pkg/gosrc/import_path_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type testTransport map[string]string
@@ -34,12 +35,11 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestResolveImportPath(t *testing.T) {
-	defer func(orig []string) { noGoGetDomains.domains = orig }(noGoGetDomains.domains)
-	noGoGetDomains.domains = []string{"mygitolite.aws.me.org"}
-
-	conf := conf.Get()
-	defer func(orig []string) { conf.BlacklistGoGet = orig }(conf.BlacklistGoGet)
-	conf.BlacklistGoGet = []string{"nohttp.google.com"}
+	conf.Mock(&schema.SiteConfiguration{
+		NoGoGetDomains: "mygitolite.aws.me.org",
+		BlacklistGoGet: []string{"nohttp.google.com"},
+	})
+	defer conf.Mock(nil)
 
 	tests := []struct {
 		importPath string

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -22,13 +22,8 @@ import (
 	jaegermetrics "github.com/uber/jaeger-lib/metrics"
 )
 
-// Note: these configuration options require service restarts to take effect.
-// Keep in sync with the pkg/conf.requireRestart list.
 var (
-	lightstepAccessToken         = conf.Get().LightstepAccessToken
-	lightstepProject             = conf.Get().LightstepProject
 	lightstepIncludeSensitive, _ = strconv.ParseBool(env.Get("LIGHTSTEP_INCLUDE_SENSITIVE", "", "send span logs to LightStep"))
-	useJaeger                    = conf.Get().UseJaeger
 	logColors                    = map[log15.Lvl]color.Attribute{
 		log15.LvlCrit:  color.FgRed,
 		log15.LvlError: color.FgRed,
@@ -117,7 +112,7 @@ func Init(options ...Option) {
 		handler = log15.LvlFilterHandler(lvl, handler)
 	}
 	log15.Root().SetHandler(log15.LvlFilterHandler(lvl, handler))
-	if useJaeger {
+	if conf.Get().UseJaeger {
 		log15.Info("Distributed tracing enabled", "tracer", "jaeger")
 		cfg := jaegercfg.Configuration{
 			Sampler: &jaegercfg.SamplerConfig{
@@ -138,6 +133,7 @@ func Init(options ...Option) {
 		return
 	}
 
+	lightstepAccessToken := conf.Get().LightstepAccessToken
 	if lightstepAccessToken != "" {
 		log15.Info("Distributed tracing enabled", "tracer", "Lightstep")
 		opentracing.InitGlobalTracer(lightstep.NewTracer(lightstep.Options{
@@ -168,7 +164,7 @@ func lightStepSpanURL(span opentracing.Span) string {
 	t := span.(interface {
 		Start() time.Time
 	}).Start().UnixNano() / 1000
-	return fmt.Sprintf("https://app.lightstep.com/%s/trace?span_guid=%x&at_micros=%d#span-%x", lightstepProject, spanCtx.SpanID, t, spanCtx.SpanID)
+	return fmt.Sprintf("https://app.lightstep.com/%s/trace?span_guid=%x&at_micros=%d#span-%x", conf.Get().LightstepProject, spanCtx.SpanID, t, spanCtx.SpanID)
 }
 
 func jaegerSpanURL(span opentracing.Span) string {


### PR DESCRIPTION
`conf.Watch` should not be invoked in a blocker manner inside of `init` (per its docs), this change fixes that.

Prior to this change, these instances were _bad code_ (both for violating the `conf.Watch` docs *and* because doing heavy work inside of `init` is not good), but these instances were not causing any user facing issues. However, after an upcoming change these instances would result in a deadlock (which was automatically detected by `pkg/conf`'s deadlock detector).

My goal is to make these changes such that:

1. It is easily verifiable there are zero regressions in both behavior and security guarantees.
2. The changes are merged quickly, because this is blocking my management-console work.

### A note about imperfection

The changes here are not perfect. I have no doubt in my mind that some of these `conf.Watch` instances can be written more clearly. In specific:

- The auth `config_watch.go` files feel very duplicative and can probably be unified somehow (not a problem introduced by this PR, but a more general problem with the existing code).
- New constraints are introduced on `auth.UpdateProviders`, `authz.GetProviders` which long term are likely not the correct solutions. I would like someone more familiar with this code to address this because:
    1. It is hard for me to verify when auth/authz provider getter methods are invoked relative to other service operations. I could do it, but it would take me a while to do it and feel confident about it.
    2. There are higher level simplifications that I think could be made, but it is hard to say for certain without a good global overview of the code setup.

### Reviewing

If this change did not touch auth code, I would merge it now (I am very confident about it, and this is a big blocker for the management-console to land). Since this does, I will instead block on review by @beyang, @sqs, or @nicksnyder for authority sake.

Hopefully review comments fall into one of two categories:

1. Whether or not this change causes any regressions in functionality or security (merge blockers).
2. Whether or not we can improve the code here in various ways: I would prefer these be filed as separate issues if possible (issues me or someone else can follow up on in the future).
