### PR TITLE
cmd/management-console: bind a different port

### DIFF
--- a/cmd/management-console/main.go
+++ b/cmd/management-console/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/tracer"
 )
 
-const port = "6075"
+const port = "2633"
 
 func main() {
 	env.Lock()


### PR DESCRIPTION
Prior to this change the management-console service tried to bind port 6075,
which is already bound by the same service for pprof/debugging. This meant it
failed to bind the port, and the sourcegraph/server Docker image would exit
fatally.

We now bind port 2633 instead.