### PR TITLE
update stripe-go to support flat fee plan tier

### DIFF
--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -220,4 +220,5 @@ type ProductSubscriptionEvent interface {
 type PlanTier interface {
 	UnitAmount() int32
 	UpTo() int32
+	FlatAmount() int32
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3485,6 +3485,8 @@ type PlanTier {
     unitAmount: Int!
     # The maximum number of users that this tier applies to.
     upTo: Int!
+    # The base fee that this tier applies to.
+    flatAmount: Int!
 }
 
 # The information about a product subscription that determines its price.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3492,6 +3492,8 @@ type PlanTier {
     unitAmount: Int!
     # The maximum number of users that this tier applies to.
     upTo: Int!
+    # The base fee that this tier applies to.
+    flatAmount: Int!
 }
 
 # The information about a product subscription that determines its price.

--- a/enterprise/cmd/frontend/internal/dotcom/billing/plans_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/plans_graphql.go
@@ -26,6 +26,7 @@ type productPlan struct {
 type planTier struct {
 	unitAmount int64
 	upTo       int64
+	flatAmount int64
 }
 
 func (r *productPlan) ProductPlanID() string      { return r.productPlanID }
@@ -44,6 +45,7 @@ func (r *productPlan) PlanTiers() []graphqlbackend.PlanTier {
 
 func (r *planTier) UnitAmount() int32 { return int32(r.unitAmount) }
 func (r *planTier) UpTo() int32       { return int32(r.upTo) }
+func (r *planTier) FlatAmount() int32 { return int32(r.flatAmount) }
 
 // ToProductPlan returns a resolver for the GraphQL type ProductPlan from the given billing plan.
 func ToProductPlan(plan *stripe.Plan) (graphqlbackend.ProductPlan, error) {
@@ -64,6 +66,7 @@ func ToProductPlan(plan *stripe.Plan) (graphqlbackend.ProductPlan, error) {
 	var tiers []graphqlbackend.PlanTier
 	for _, tier := range plan.Tiers {
 		tiers = append(tiers, &planTier{
+			flatAmount: tier.FlatAmount,
 			unitAmount: tier.UnitAmount,
 			upTo:       tier.UpTo,
 		})

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20180831160525-549eb959f029
 	github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd
 	github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff
-	github.com/stripe/stripe-go v0.0.0-20181003141555-9e2a36d584c4
+	github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e
 	github.com/stvp/tempredis v0.0.0-20160122230306-83f7aae7ea49 // indirect
 	github.com/temoto/robotstxt-go v0.0.0-20180810133444-97ee4a9ee6ea
 	github.com/uber-go/atomic v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stripe/stripe-go v0.0.0-20181003141555-9e2a36d584c4 h1:J4BmydJMFWdlbtB3jqPTyAbq0LGBTqpofb+xJ9iH4gs=
 github.com/stripe/stripe-go v0.0.0-20181003141555-9e2a36d584c4/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
+github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e h1:Td8imVpXVet0O6vMMhqYx20aezAw5jcO9ia1c3Mvee4=
+github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20160122230306-83f7aae7ea49 h1:aBiMfOQ47GCfoTbNcnVyph/dnUuTWN0rSqEKFq3T58Y=
 github.com/stvp/tempredis v0.0.0-20160122230306-83f7aae7ea49/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/temoto/robotstxt-go v0.0.0-20180810133444-97ee4a9ee6ea h1:uTsERZ8h4VnqCoMip8dLd+uvk1R1xR2AviWn+pfoUa0=

--- a/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
+++ b/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
@@ -136,6 +136,7 @@ function queryProductPlans(): Observable<GQL.IProductPlan[]> {
                         planTiers {
                             unitAmount
                             upTo
+                            flatAmount
                         }
                     }
                 }

--- a/web/src/enterprise/dotcom/productPlans/ProductPlanTiered.tsx
+++ b/web/src/enterprise/dotcom/productPlans/ProductPlanTiered.tsx
@@ -18,13 +18,16 @@ export const ProductPlanTiered: React.FunctionComponent<{
 
 function formatAmountForTier(tier: GQL.IPlanTier, minQuantity: number | null): string {
     if (minQuantity !== null && tier.upTo !== 0 && tier.upTo <= minQuantity) {
+        const amount = tier.flatAmount
+            ? tier.flatAmount / 100
+            : (tier.unitAmount / 100) /* cents in a USD */ * minQuantity
         // Quote the total annual amount for users up to the minQuantity.
-        const amount = ((tier.unitAmount / 100) /* cents in a USD */ * minQuantity).toLocaleString('en-US', {
+        const localizedAmount = amount.toLocaleString('en-US', {
             style: 'currency',
             currency: 'USD',
             minimumFractionDigits: 0,
         })
-        return `${amount}/year total`
+        return `${localizedAmount}/year total`
     }
 
     // Quote the $/user/month amount.


### PR DESCRIPTION
Updates `stripe-go` to support using a flat fee for graduated tiers. This allows us to specify a total cost of $10 for the first $10 instead of a $1/user for the first 10 users.