### PR TITLE
pkg/conf: fix ordering when installing frontend conf server

### DIFF
--- a/pkg/conf/client.go
+++ b/pkg/conf/client.go
@@ -201,5 +201,7 @@ func (h httpFetcher) FetchConfig() (string, error) {
 type passthroughFetcherFrontendOnly struct{}
 
 func (p passthroughFetcherFrontendOnly) FetchConfig() (string, error) {
+	<-configurationServerFrontendOnlyInitialized
+
 	return configurationServerFrontendOnly.Raw(), nil
 }

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -106,10 +106,11 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 	// Install the passthrough fetcher for defaultClient in order to avoid deadlock issues.
 	defaultClient.fetcher = passthroughFetcherFrontendOnly{}
 
+	configurationServerFrontendOnly = server
 	close(configurationServerFrontendOnlyInitialized)
 
 	go defaultClient.continuouslyUpdate()
-	configurationServerFrontendOnly = server
+
 	return server
 }
 


### PR DESCRIPTION
It was possible for the [continuouslyUpdate()](https://sourcegraph.sgdev.org/github.com/sourcegraph/sourcegraph/-/blob/pkg/conf/client.go?utm_source=inline-symbol#L152:18-152:36) logic to be scheduled to run before [configurationServerFrontendOnly](https://sourcegraph.sgdev.org/github.com/sourcegraph/sourcegraph/-/blob/pkg/conf/conf.go?utm_source=inline-symbol#L48:2-48:33) was installed (which would cause a NPE exception).

This PR fixes that. 