### PR TITLE
 rename ConfigurationRawJSON -> Configuration

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -99,7 +99,7 @@ func NewInternalHandler(m *mux.Router) http.Handler {
 	m.Get(apirouter.GitUploadPack).Handler(trace.TraceRoute(handler(serveGitUploadPack)))
 	m.Get(apirouter.Telemetry).Handler(trace.TraceRoute(telemetryHandler))
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL)))
-	m.Get(apirouter.ConfigurationRawJSON).Handler(trace.TraceRoute(handler(serveConfigurationRawJSON)))
+	m.Get(apirouter.Configuration).Handler(trace.TraceRoute(handler(serveConfiguration)))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -159,13 +159,12 @@ func serveReposInventory(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func serveConfigurationRawJSON(w http.ResponseWriter, r *http.Request) error {
-	rawJSON := globals.ConfigurationServerFrontendOnly.Raw()
-	err := json.NewEncoder(w).Encode(rawJSON)
+func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
+	raw := globals.ConfigurationServerFrontendOnly.Raw()
+	err := json.NewEncoder(w).Encode(raw)
 	if err != nil {
 		return errors.Wrap(err, "Encode")
 	}
-
 	return nil
 }
 

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -45,7 +45,7 @@ const (
 	ReposListEnabled       = "internal.repos.list-enabled"
 	ReposUpdateIndex       = "internal.repos.update-index"
 	ReposUpdateMetadata    = "internal.repos.update-metadata"
-	ConfigurationRawJSON   = "internal.configuration.raw-json"
+	Configuration          = "internal.configuration"
 )
 
 // New creates a new API router with route URL pattern definitions but
@@ -111,7 +111,7 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/repos/update-index").Methods("POST").Name(ReposUpdateIndex)
 	base.Path("/repos/update-metadata").Methods("POST").Name(ReposUpdateMetadata)
 	base.Path("/repos/{RepoName:.*}").Methods("POST").Name(ReposGetByName)
-	base.Path("/configuration/raw-json").Methods("POST").Name(ConfigurationRawJSON)
+	base.Path("/configuration").Methods("POST").Name(Configuration)
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
 	addTelemetryRoute(base)

--- a/pkg/api/internal_client.go
+++ b/pkg/api/internal_client.go
@@ -280,10 +280,10 @@ func (c *internalClient) ReposListEnabled(ctx context.Context) ([]RepoName, erro
 	return names, err
 }
 
-func (c *internalClient) ConfigurationRawJSON(ctx context.Context) (string, error) {
-	var rawJSON string
-	err := c.postInternal(ctx, "configuration/raw-json", nil, &rawJSON)
-	return rawJSON, err
+func (c *internalClient) Configuration(ctx context.Context) (string, error) {
+	var raw string
+	err := c.postInternal(ctx, "configuration", nil, &raw)
+	return raw, err
 }
 
 func (c *internalClient) ReposUpdateMetadata(ctx context.Context, repo RepoName, description string, fork bool, archived bool) error {

--- a/pkg/conf/client.go
+++ b/pkg/conf/client.go
@@ -187,7 +187,7 @@ type fetcher interface {
 type httpFetcher struct{}
 
 func (h httpFetcher) FetchConfig() (string, error) {
-	rawJSON, err := api.InternalClient.ConfigurationRawJSON(context.Background())
+	rawJSON, err := api.InternalClient.Configuration(context.Background())
 	return rawJSON, err
 }
 


### PR DESCRIPTION
In the near future this will return a data structure and the name suffix
`RawJSON` no longer makes sense in that context. I am reducing the size of my
other PR's diff, and as such merging this separately.