### PR TITLE
Deprecate URI

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -17,8 +17,18 @@ declare module 'sourcegraph' {
         unsubscribe(): void
     }
 
+    /**
+     * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL)
+     */
     export class URI {
+        /**
+         * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL), which does not contain this method.
+         */
         static parse(value: string): URI
+
+        /**
+         * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL), which does not contain this method.
+         */
         static file(path: string): URI
 
         constructor(value: string)
@@ -28,7 +38,7 @@ declare module 'sourcegraph' {
         /**
          * Returns a JSON representation of this Uri.
          *
-         * @return An object.
+         * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL), which returns a string instead of an object.
          */
         toJSON(): any
     }


### PR DESCRIPTION
Let people know that they shouldn't rely on methods that are not present on [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) so we can replace it soon. The conversion back in forth is an annoyance atm.