### PR TITLE
Reimplement /go/ links without the Go langserver

### DIFF
--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -100,7 +100,7 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	location, err := symbolLocation(r.Context(), vfs, importPath, receiver, symbolName)
+	location, err := symbolLocation(r.Context(), vfs, commitID, importPath, receiver, symbolName)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func symbolLocation(ctx context.Context, vfs ctxvfs.FileSystem, importPath string, receiver *string, symbol string) (*lsp.Location, error) {
+func symbolLocation(ctx context.Context, vfs ctxvfs.FileSystem, commitID api.CommitID, importPath string, receiver *string, symbol string) (*lsp.Location, error) {
 	bctx := buildContextFromVFS(ctx, vfs)
 
 	fileSet := token.NewFileSet()
@@ -188,7 +188,7 @@ func symbolLocation(ctx context.Context, vfs ctxvfs.FileSystem, importPath strin
 
 	position := fileSet.Position(*pos)
 	location := lsp.Location{
-		URI: lsp.DocumentURI("https://" + string(importPath) + "?master" + "#" + position.Filename),
+		URI: lsp.DocumentURI("https://" + string(importPath) + "?" + string(commitID) + "#" + position.Filename),
 		Range: lsp.Range{
 			Start: lsp.Position{
 				Line:      position.Line - 1,

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -153,6 +153,11 @@ func symbolLocation(ctx context.Context, vfs ctxvfs.FileSystem, commitID api.Com
 					}
 				}
 			}
+			for _, fun := range docType.Funcs {
+				if fun.Name == symbol {
+					return &fun.Decl.Name.NamePos
+				}
+			}
 			for _, spec := range docType.Decl.Specs {
 				if typeSpec, ok := spec.(*ast.TypeSpec); ok && typeSpec.Name.Name == symbol {
 					return &typeSpec.Name.NamePos

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -220,7 +220,7 @@ func buildContextFromVFS(ctx context.Context, vfs ctxvfs.FileSystem) build.Conte
 }
 
 func repoVFS(ctx context.Context, name api.RepoName, rev api.CommitID) (ctxvfs.FileSystem, error) {
-	if strings.HasPrefix(string(name), "github.com") {
+	if strings.HasPrefix(string(name), "github.com/") {
 		return vfsutil.NewGitHubRepoVFS(string(name), string(rev))
 	}
 

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -68,7 +68,7 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 		receiver = &symbolComponents[0]
 		symbolName = symbolComponents[1]
 	default:
-		return fmt.Errorf("Invalid def %s (must have 1 or 2 path components)", def)
+		return fmt.Errorf("invalid def %s (must have 1 or 2 path components)", def)
 	}
 
 	dir, err := gosrc.ResolveImportPath(httputil.CachingClient, importPath)

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -1,14 +1,27 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/build"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
-	"github.com/sourcegraph/go-lsp/lspext"
+	"github.com/sourcegraph/ctxvfs"
+	"github.com/sourcegraph/sourcegraph/pkg/vfsutil"
+	"golang.org/x/tools/go/buildutil"
+
+	"github.com/sourcegraph/go-lsp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
@@ -37,7 +50,27 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	//                                                        def
+	//                                                    vvvvvvvvvvvv
+	// http://sourcegraph.com/go/github.com/gorilla/mux/-/Router/Match
+	//                           ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^ ^^^^^
+	//                                 importPath      receiver? symbolname
 	importPath := strings.Split(symbolID, "/-/")[0]
+	def := strings.Split(symbolID, "/-/")[1]
+	var symbolName string
+	var receiver *string
+	symbolComponents := strings.Split(def, "/")
+	switch len(symbolComponents) {
+	case 1:
+		symbolName = symbolComponents[0]
+	case 2:
+		// This is a method call.
+		receiver = &symbolComponents[0]
+		symbolName = symbolComponents[1]
+	default:
+		return fmt.Errorf("Invalid def %s (must have 1 or 2 path components)", def)
+	}
+
 	dir, err := gosrc.ResolveImportPath(httputil.CachingClient, importPath)
 	if err != nil {
 		return err
@@ -62,30 +95,167 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	symbols, err := backend.Symbols.List(r.Context(), repo.Name, commitID, mode, lspext.WorkspaceSymbolParams{
-		Symbol: lspext.SymbolDescriptor{"id": symbolID},
-	})
+	vfs, err := repoVFS(r.Context(), repoName, commitID)
 	if err != nil {
 		return err
 	}
 
-	if len(symbols) > 0 {
-		symbol := symbols[0]
-		uri, err := gituri.Parse(string(symbol.Location.URI))
-		if err != nil {
-			return err
+	location, err := symbolLocation(r.Context(), vfs, importPath, receiver, symbolName)
+	if err != nil {
+		return err
+	}
+	if location == nil {
+		return &errcode.HTTPErr{
+			Status: http.StatusNotFound,
+			Err:    errors.New("symbol not found"),
 		}
-		filePath := uri.Fragment
-		dest := &url.URL{
-			Path:     "/" + path.Join(string(repo.Name), "-/blob", filePath),
-			Fragment: fmt.Sprintf("L%d:%d$references", symbol.Location.Range.Start.Line+1, symbol.Location.Range.Start.Character+1),
-		}
-		http.Redirect(w, r, dest.String(), http.StatusFound)
-		return nil
 	}
 
-	return &errcode.HTTPErr{
-		Status: http.StatusNotFound,
-		Err:    errors.New("symbol not found"),
+	uri, err := gituri.Parse(string(location.URI))
+	if err != nil {
+		return err
 	}
+	filePath := uri.Fragment
+	dest := &url.URL{
+		Path:     "/" + path.Join(string(repo.Name), "-/blob", filePath),
+		Fragment: fmt.Sprintf("L%d:%d$references", location.Range.Start.Line+1, location.Range.Start.Character+1),
+	}
+	http.Redirect(w, r, dest.String(), http.StatusFound)
+	return nil
+}
+
+func symbolLocation(ctx context.Context, vfs ctxvfs.FileSystem, importPath string, receiver *string, symbol string) (*lsp.Location, error) {
+	bctx := buildContextFromVFS(ctx, vfs)
+
+	fileSet := token.NewFileSet()
+	packages, err := parseDir(fileSet, &bctx, "/", nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	pos := (func() *token.Pos {
+		for _, pkg := range packages {
+			docPackage := doc.New(pkg, importPath, 0)
+			for _, docConst := range docPackage.Consts {
+				fmt.Printf("%#v", docConst.Decl.Specs)
+				for _, spec := range docConst.Decl.Specs {
+					if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+						for _, ident := range valueSpec.Names {
+							if ident.Name == symbol {
+								return &ident.NamePos
+							}
+						}
+					}
+				}
+			}
+			for _, docType := range docPackage.Types {
+				if receiver != nil && docType.Name == *receiver {
+					for _, method := range docType.Methods {
+						if method.Name == symbol {
+							return &method.Decl.Name.NamePos
+						}
+					}
+				}
+				for _, spec := range docType.Decl.Specs {
+					if typeSpec, ok := spec.(*ast.TypeSpec); ok && typeSpec.Name.Name == symbol {
+						return &typeSpec.Name.NamePos
+					}
+				}
+			}
+			for _, docVar := range docPackage.Vars {
+				for _, spec := range docVar.Decl.Specs {
+					if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+						for _, ident := range valueSpec.Names {
+							if ident.Name == symbol {
+								return &ident.NamePos
+							}
+						}
+					}
+				}
+			}
+			for _, docFunc := range docPackage.Funcs {
+				if docFunc.Name == symbol {
+					return &docFunc.Decl.Name.NamePos
+				}
+			}
+		}
+		return nil
+	})()
+
+	if pos == nil {
+		return nil, nil
+	}
+
+	position := fileSet.Position(*pos)
+	location := lsp.Location{
+		URI: lsp.DocumentURI("https://" + string(importPath) + "?master" + "#" + position.Filename),
+		Range: lsp.Range{
+			Start: lsp.Position{
+				Line:      position.Line - 1,
+				Character: position.Column - 1,
+			},
+			End: lsp.Position{
+				Line:      position.Line - 1,
+				Character: position.Column - 1,
+			},
+		},
+	}
+
+	return &location, nil
+}
+
+func buildContextFromVFS(ctx context.Context, vfs ctxvfs.FileSystem) build.Context {
+	bctx := build.Default
+	bctx.OpenFile = func(path string) (io.ReadCloser, error) {
+		return vfs.Open(ctx, path)
+	}
+	bctx.IsDir = func(path string) bool {
+		fi, err := vfs.Stat(ctx, path)
+		return err == nil && fi.Mode().IsDir()
+	}
+	bctx.ReadDir = func(path string) ([]os.FileInfo, error) {
+		return vfs.ReadDir(ctx, path)
+	}
+	return bctx
+}
+
+func repoVFS(ctx context.Context, name api.RepoName, rev api.CommitID) (ctxvfs.FileSystem, error) {
+	if strings.HasPrefix(string(name), "github.com") {
+		return vfsutil.NewGitHubRepoVFS(string(name), string(rev))
+	}
+
+	// Fall back to a full git clone for non-github.com repos.
+	return nil, fmt.Errorf("unable to fetch repo %s (only github.com repos are supported)", name)
+}
+
+// parseDir mirrors parser.ParseDir, but uses the passed in build context's VFS. In other words,
+// buildutil.parseFile : parser.ParseFile :: parseDir : parser.ParseDir
+func parseDir(fset *token.FileSet, bctx *build.Context, path string, filter func(os.FileInfo) bool, mode parser.Mode) (pkgs map[string]*ast.Package, first error) {
+	list, err := buildutil.ReadDir(bctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs = map[string]*ast.Package{}
+	for _, d := range list {
+		if strings.HasSuffix(d.Name(), ".go") && (filter == nil || filter(d)) {
+			filename := buildutil.JoinPath(bctx, path, d.Name())
+			if src, err := buildutil.ParseFile(fset, bctx, nil, buildutil.JoinPath(bctx, path, d.Name()), filename, mode); err == nil {
+				name := src.Name.Name
+				pkg, found := pkgs[name]
+				if !found {
+					pkg = &ast.Package{
+						Name:  name,
+						Files: map[string]*ast.File{},
+					}
+					pkgs[name] = pkg
+				}
+				pkg.Files[filename] = src
+			} else if first == nil {
+				first = err
+			}
+		}
+	}
+
+	return
 }

--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/ctxvfs"
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+)
+
+type symbolLocationArgs struct {
+	vfs        map[string]string
+	importPath string
+	receiver   *string
+	symbol     string
+}
+
+type test struct {
+	args symbolLocationArgs
+	want *lsp.Location
+}
+
+func mkLocation(uri string, line int, character int) *lsp.Location {
+	return &lsp.Location{
+		URI: "https://github.com/gorilla/mux?master#/mux.go",
+		Range: lsp.Range{
+			Start: lsp.Position{
+				Line:      line,
+				Character: character,
+			},
+			End: lsp.Position{
+				Line:      line,
+				Character: character,
+			},
+		},
+	}
+}
+
+func strptr(s string) *string {
+	return &s
+}
+
+func TestSymbolLocation(t *testing.T) {
+	vfs := map[string]string{
+		"mux.go": "package mux\nconst Foo = 5\ntype Bar int\nfunc (b Bar) Quux() {}\nvar Floop = 6",
+	}
+
+	tests := []test{
+		test{
+			args: symbolLocationArgs{
+				vfs:        vfs,
+				importPath: "github.com/gorilla/mux",
+				receiver:   nil,
+				symbol:     "NonexistentSymbol",
+			},
+			want: nil,
+		},
+		test{
+			args: symbolLocationArgs{
+				vfs:        vfs,
+				importPath: "github.com/gorilla/mux",
+				receiver:   nil,
+				symbol:     "Foo",
+			},
+			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 1, 6),
+		},
+		test{
+			args: symbolLocationArgs{
+				vfs:        vfs,
+				importPath: "github.com/gorilla/mux",
+				receiver:   nil,
+				symbol:     "Bar",
+			},
+			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 2, 5),
+		},
+		test{
+			args: symbolLocationArgs{
+				vfs:        vfs,
+				importPath: "github.com/gorilla/mux",
+				receiver:   strptr("Bar"),
+				symbol:     "Quux",
+			},
+			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 3, 13),
+		},
+		test{
+			args: symbolLocationArgs{
+				vfs:        vfs,
+				importPath: "github.com/gorilla/mux",
+				receiver:   nil,
+				symbol:     "Floop",
+			},
+			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 4, 4),
+		},
+	}
+	for i, test := range tests {
+		got, _ := symbolLocation(context.Background(), mapFS(test.args.vfs), test.args.importPath, test.args.receiver, test.args.symbol)
+		if got != test.want && (got == nil || test.want == nil || *got != *test.want) {
+			t.Errorf("Test #%d:\ngot  %#v\nwant %#v", i, got, test.want)
+		}
+	}
+}
+
+// mapFS lets us easily instantiate a VFS with a map[string]string
+// (which is less noisy than map[string][]byte in test fixtures).
+func mapFS(m map[string]string) *stringMapFS {
+	m2 := make(map[string][]byte, len(m))
+	filenames := make([]string, 0, len(m))
+	for k, v := range m {
+		m2[k] = []byte(v)
+		filenames = append(filenames, k)
+	}
+	return &stringMapFS{
+		FileSystem: ctxvfs.Map(m2),
+		filenames:  filenames,
+	}
+}
+
+type stringMapFS struct {
+	ctxvfs.FileSystem
+	filenames []string
+}
+
+func (fs *stringMapFS) ListAllFiles(ctx context.Context) ([]string, error) {
+	return fs.filenames, nil
+}

--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/sourcegraph/ctxvfs"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
 type symbolLocationArgs struct {
 	vfs        map[string]string
+	commitID   api.CommitID
 	importPath string
 	receiver   *string
 	symbol     string
@@ -22,7 +24,7 @@ type test struct {
 
 func mkLocation(uri string, line int, character int) *lsp.Location {
 	return &lsp.Location{
-		URI: "https://github.com/gorilla/mux?master#/mux.go",
+		URI: "https://github.com/gorilla/mux?deadbeefdeadbeefdeadbeefdeadbeefdeadbeef#/mux.go",
 		Range: lsp.Range{
 			Start: lsp.Position{
 				Line:      line,
@@ -49,6 +51,7 @@ func TestSymbolLocation(t *testing.T) {
 		test{
 			args: symbolLocationArgs{
 				vfs:        vfs,
+				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
 				receiver:   nil,
 				symbol:     "NonexistentSymbol",
@@ -58,42 +61,46 @@ func TestSymbolLocation(t *testing.T) {
 		test{
 			args: symbolLocationArgs{
 				vfs:        vfs,
+				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
 				receiver:   nil,
 				symbol:     "Foo",
 			},
-			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 1, 6),
+			want: mkLocation("https://github.com/gorilla/mux?deadbeefdeadbeefdeadbeefdeadbeefdeadbeef#mux.go", 1, 6),
 		},
 		test{
 			args: symbolLocationArgs{
 				vfs:        vfs,
+				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
 				receiver:   nil,
 				symbol:     "Bar",
 			},
-			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 2, 5),
+			want: mkLocation("https://github.com/gorilla/mux?deadbeefdeadbeefdeadbeefdeadbeefdeadbeef#mux.go", 2, 5),
 		},
 		test{
 			args: symbolLocationArgs{
 				vfs:        vfs,
+				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
 				receiver:   strptr("Bar"),
 				symbol:     "Quux",
 			},
-			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 3, 13),
+			want: mkLocation("https://github.com/gorilla/mux?deadbeefdeadbeefdeadbeefdeadbeefdeadbeef#mux.go", 3, 13),
 		},
 		test{
 			args: symbolLocationArgs{
 				vfs:        vfs,
+				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
 				receiver:   nil,
 				symbol:     "Floop",
 			},
-			want: mkLocation("https://github.com/gorilla/mux?master#mux.go", 4, 4),
+			want: mkLocation("https://github.com/gorilla/mux?deadbeefdeadbeefdeadbeefdeadbeefdeadbeef#mux.go", 4, 4),
 		},
 	}
 	for i, test := range tests {
-		got, _ := symbolLocation(context.Background(), mapFS(test.args.vfs), test.args.importPath, test.args.receiver, test.args.symbol)
+		got, _ := symbolLocation(context.Background(), mapFS(test.args.vfs), test.args.commitID, test.args.importPath, test.args.receiver, test.args.symbol)
 		if got != test.want && (got == nil || test.want == nil || *got != *test.want) {
 			t.Errorf("Test #%d:\ngot  %#v\nwant %#v", i, got, test.want)
 		}

--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -13,6 +13,7 @@ type symbolLocationArgs struct {
 	vfs        map[string]string
 	commitID   api.CommitID
 	importPath string
+	path       string
 	receiver   *string
 	symbol     string
 }
@@ -53,6 +54,7 @@ func TestSymbolLocation(t *testing.T) {
 				vfs:        vfs,
 				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
+				path:       "/",
 				receiver:   nil,
 				symbol:     "NonexistentSymbol",
 			},
@@ -63,6 +65,7 @@ func TestSymbolLocation(t *testing.T) {
 				vfs:        vfs,
 				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
+				path:       "/",
 				receiver:   nil,
 				symbol:     "Foo",
 			},
@@ -73,6 +76,7 @@ func TestSymbolLocation(t *testing.T) {
 				vfs:        vfs,
 				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
+				path:       "/",
 				receiver:   nil,
 				symbol:     "Bar",
 			},
@@ -83,6 +87,7 @@ func TestSymbolLocation(t *testing.T) {
 				vfs:        vfs,
 				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
+				path:       "/",
 				receiver:   strptr("Bar"),
 				symbol:     "Quux",
 			},
@@ -93,6 +98,7 @@ func TestSymbolLocation(t *testing.T) {
 				vfs:        vfs,
 				commitID:   "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				importPath: "github.com/gorilla/mux",
+				path:       "/",
 				receiver:   nil,
 				symbol:     "Floop",
 			},
@@ -100,7 +106,7 @@ func TestSymbolLocation(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		got, _ := symbolLocation(context.Background(), mapFS(test.args.vfs), test.args.commitID, test.args.importPath, test.args.receiver, test.args.symbol)
+		got, _ := symbolLocation(context.Background(), mapFS(test.args.vfs), test.args.commitID, test.args.importPath, test.args.path, test.args.receiver, test.args.symbol)
 		if got != test.want && (got == nil || test.want == nil || *got != *test.want) {
 			t.Errorf("Test #%d:\ngot  %#v\nwant %#v", i, got, test.want)
 		}

--- a/cmd/frontend/internal/app/pkg/golangserverutil/context.go
+++ b/cmd/frontend/internal/app/pkg/golangserverutil/context.go
@@ -1,0 +1,54 @@
+package golangserverutil
+
+import (
+	"go/build"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/sourcegraph/ctxvfs"
+
+	"golang.org/x/net/context"
+)
+
+func PrepareContext(bctx *build.Context, ctx context.Context, fs ctxvfs.FileSystem) {
+	// HACK: in the all Context's methods below we are trying to convert path to virtual one (/foo/bar/..)
+	// because some code may pass OS-specific arguments.
+	// See golang.org/x/tools/go/buildutil/allpackages.go which uses `filepath` for example
+
+	bctx.OpenFile = func(path string) (io.ReadCloser, error) {
+		path = filepath.ToSlash(path)
+		return fs.Open(ctx, path)
+	}
+	bctx.IsDir = func(path string) bool {
+		path = filepath.ToSlash(path)
+		fi, err := fs.Stat(ctx, path)
+		return err == nil && fi.Mode().IsDir()
+	}
+	bctx.HasSubdir = func(root, dir string) (rel string, ok bool) {
+		if !bctx.IsDir(dir) {
+			return "", false
+		}
+		if !PathHasPrefix(dir, root) {
+			return "", false
+		}
+		return PathTrimPrefix(dir, root), true
+	}
+	bctx.ReadDir = func(path string) ([]os.FileInfo, error) {
+		path = filepath.ToSlash(path)
+		return fs.ReadDir(ctx, path)
+	}
+	bctx.IsAbsPath = func(path string) bool {
+		path = filepath.ToSlash(path)
+		return IsAbs(path)
+	}
+	bctx.JoinPath = func(elem ...string) string {
+		// convert all backslashes to slashes to avoid
+		// weird paths like C:\mygopath\/src/github.com/...
+		for i, el := range elem {
+			elem[i] = filepath.ToSlash(el)
+		}
+		return path.Join(elem...)
+	}
+}

--- a/cmd/frontend/internal/app/pkg/golangserverutil/util.go
+++ b/cmd/frontend/internal/app/pkg/golangserverutil/util.go
@@ -1,0 +1,139 @@
+package golangserverutil
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/sourcegraph/go-lsp"
+)
+
+func trimFilePrefix(s string) string {
+	return strings.TrimPrefix(s, "file://")
+}
+
+func normalizePath(s string) string {
+	if isURI(s) {
+		return UriToPath(lsp.DocumentURI(s))
+	}
+	s = filepath.ToSlash(s)
+	if !strings.HasPrefix(s, "/") {
+		s = "/" + s
+	}
+	return s
+}
+
+// PathHasPrefix returns true if s is starts with the given prefix
+func PathHasPrefix(s, prefix string) bool {
+	s = normalizePath(s)
+	prefix = normalizePath(prefix)
+	if s == prefix {
+		return true
+	}
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return s == prefix || strings.HasPrefix(s, prefix)
+}
+
+// PathTrimPrefix removes the prefix from s
+func PathTrimPrefix(s, prefix string) string {
+	s = normalizePath(s)
+	prefix = normalizePath(prefix)
+	if s == prefix {
+		return ""
+	}
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return strings.TrimPrefix(s, prefix)
+}
+
+// PathEqual returns true if both a and b are equal
+func PathEqual(a, b string) bool {
+	return PathTrimPrefix(a, b) == ""
+}
+
+// IsVendorDir tells if the specified directory is a vendor directory.
+func IsVendorDir(dir string) bool {
+	return strings.HasPrefix(dir, "vendor/") || strings.Contains(dir, "/vendor/")
+}
+
+// IsURI tells if s denotes an URI
+func IsURI(s lsp.DocumentURI) bool {
+	return isURI(string(s))
+}
+
+func isURI(s string) bool {
+	return strings.HasPrefix(s, "file://")
+}
+
+// PathToURI converts given absolute path to file URI
+func PathToURI(path string) lsp.DocumentURI {
+	path = filepath.ToSlash(path)
+	parts := strings.SplitN(path, "/", 2)
+
+	// If the first segment is a Windows drive letter, prefix with a slash and skip encoding
+	head := parts[0]
+	if head != "" {
+		head = "/" + head
+	}
+
+	rest := ""
+	if len(parts) > 1 {
+		rest = "/" + parts[1]
+	}
+
+	return lsp.DocumentURI("file://" + head + rest)
+}
+
+// UriToPath converts given file URI to path
+func UriToPath(uri lsp.DocumentURI) string {
+	u, err := url.Parse(string(uri))
+	if err != nil {
+		return trimFilePrefix(string(uri))
+	}
+	return u.Path
+}
+
+var regDriveLetter = regexp.MustCompile("^/[a-zA-Z]:")
+
+// UriToRealPath converts the given file URI to the platform specific path
+func UriToRealPath(uri lsp.DocumentURI) string {
+	path := UriToPath(uri)
+
+	if regDriveLetter.MatchString(path) {
+		// remove the leading slash if it starts with a drive letter
+		// and convert to back slashes
+		path = filepath.FromSlash(path[1:])
+	}
+
+	return path
+}
+
+// IsAbs returns true if the given path is absolute
+func IsAbs(path string) bool {
+	// Windows implementation accepts path-like and filepath-like arguments
+	return strings.HasPrefix(path, "/") || filepath.IsAbs(path)
+}
+
+// Panicf takes the return value of recover() and outputs data to the log with
+// the stack trace appended. Arguments are handled in the manner of
+// fmt.Printf. Arguments should format to a string which identifies what the
+// panic code was doing. Returns a non-nil error if it recovered from a panic.
+func Panicf(r interface{}, format string, v ...interface{}) error {
+	if r != nil {
+		// Same as net/http
+		const size = 64 << 10
+		buf := make([]byte, size)
+		buf = buf[:runtime.Stack(buf, false)]
+		id := fmt.Sprintf(format, v...)
+		log.Printf("panic serving %s: %v\n%s", id, r, string(buf))
+		return fmt.Errorf("unexpected panic: %v", r)
+	}
+	return nil
+}

--- a/pkg/gosrc/import_path.go
+++ b/pkg/gosrc/import_path.go
@@ -138,6 +138,7 @@ func resolveStaticImportPath(importPath string) (*Directory, error) {
 		if err != nil {
 			return nil, err
 		}
+		d.ImportPath = strings.Replace(d.ImportPath, "github.com/golang/", "golang.org/x/", 1)
 		d.ProjectRoot = strings.Replace(d.ProjectRoot, "github.com/golang/", "golang.org/x/", 1)
 		return d, nil
 	}

--- a/pkg/gosrc/import_path_test.go
+++ b/pkg/gosrc/import_path_test.go
@@ -73,13 +73,13 @@ func TestResolveImportPath(t *testing.T) {
 			VCS:         "git",
 		}},
 		{"golang.org/x/foo", &Directory{
-			ImportPath:  "github.com/golang/foo",
+			ImportPath:  "golang.org/x/foo",
 			ProjectRoot: "golang.org/x/foo",
 			CloneURL:    "https://github.com/golang/foo",
 			VCS:         "git",
 		}},
 		{"golang.org/x/foo/bar", &Directory{
-			ImportPath:  "github.com/golang/foo/bar",
+			ImportPath:  "golang.org/x/foo/bar",
 			ProjectRoot: "golang.org/x/foo",
 			CloneURL:    "https://github.com/golang/foo",
 			VCS:         "git",


### PR DESCRIPTION
This is needed for 3.0 preview on Sourcegraph.com https://github.com/sourcegraph/sourcegraph/issues/1187