### PR TITLE
move command palette icon to left to reduce jitter on GitHub

### DIFF
--- a/client/browser/src/libs/github/extensions.tsx
+++ b/client/browser/src/libs/github/extensions.tsx
@@ -20,7 +20,7 @@ export function getCommandPaletteMount(): HTMLElement {
     const createCommandList = (): HTMLElement => {
         const commandListElem = document.createElement('div')
         commandListElem.className = commandListClass
-        headerElem!.appendChild(commandListElem)
+        headerElem!.insertAdjacentElement('afterbegin', commandListElem)
 
         return commandListElem
     }


### PR DESCRIPTION
On GitHub with the browser extension, the command palette button was previously on the right side. This meant that all the other icons (notifications, add repos, avatar) got moved over when the element was injected. Now it is on the left, so there is no jitter.

![screenshot from 2018-12-01 14-25-01](https://user-images.githubusercontent.com/1976/49333512-12314e00-f575-11e8-8b0c-a2d9c4b7cc4f.png)
