### PR TITLE
prevent command palette from scrolling page down on GitHub

### DIFF
--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -39,6 +39,7 @@ export function initializeExtensions(
                 extensionsController={extensionsController}
                 menu={ContributableMenu.CommandPalette}
                 platformContext={platformContext}
+                autoFocus={false}
                 location={history.location}
             />
             <Notifications extensionsController={extensionsController} />

--- a/client/browser/src/libs/github/extensions.tsx
+++ b/client/browser/src/libs/github/extensions.tsx
@@ -53,6 +53,7 @@ export function injectExtensionsGlobalComponents(
                 extensionsController={extensionsController}
                 menu={ContributableMenu.CommandPalette}
                 platformContext={platformContext}
+                autoFocus={false}
                 location={location}
             />
         </ShortcutProvider>,

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -21,6 +21,16 @@ interface Props extends ExtensionsControllerProps, PlatformContextProps {
     /** Called when the user has selected an item in the list. */
     onSelect?: () => void
 
+    /**
+     * Whether the text input should have autofocus.
+     *
+     * When used in the browser extension, this sometimes results in the page being scrolled to the bottom in the
+     * web browser because it attempts to autofocus (and scroll to reveal) before the element is attached to the
+     * correct position. Therefore this should be set to true only in the Sourcegraph web app (or unless you're
+     * confident that it works otherwise and have tested it, in which case you should update this comment).
+     */
+    autoFocus: boolean
+
     location: H.Location
 }
 
@@ -33,6 +43,8 @@ interface State {
 
     /** Recently invoked actions, which should be sorted first in the list. */
     recentActions: string[] | null
+
+    autoFocus?: boolean
 }
 
 /** Displays a list of commands contributed by extensions for a specific menu. */
@@ -82,6 +94,10 @@ export class CommandList extends React.PureComponent<Props, State> {
                 .getContributions()
                 .subscribe(contributions => this.setState({ contributions }))
         )
+
+        setTimeout(() => {
+            this.setState({ autoFocus: true })
+        })
     }
 
     public componentDidUpdate(_prevProps: Props, prevState: State): void {
@@ -125,7 +141,7 @@ export class CommandList extends React.PureComponent<Props, State> {
                             spellCheck={false}
                             autoCorrect="off"
                             autoComplete="off"
-                            autoFocus={true}
+                            autoFocus={this.props.autoFocus || this.state.autoFocus}
                             onChange={this.onInputChange}
                             onKeyDown={this.onInputKeyDown}
                         />

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -96,6 +96,7 @@ export class NavLinks extends React.PureComponent<Props> {
                     extensionsController={this.props.extensionsController}
                     platformContext={this.props.platformContext}
                     toggleVisibilityKeybinding={this.props.keybindings.commandPalette}
+                    autoFocus={true}
                     location={this.props.location}
                 />
                 {this.props.authenticatedUser && (


### PR DESCRIPTION
The command palette input field is now autofocused only on Sourcegraph. It was causing the whole page to scroll down sometimes on GitHub. To be safe until this is fixed, this commit disables autofocus on sites other than Sourcegraph.