### PR TITLE
chore(deps): upgrade typescript to 3.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
       "url": "/schema/site.schema.json"
     }
   ],
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "tslint": "^5.11.0",
     "tslint-language-service": "^0.9.9",
     "typedoc": "^0.13.0",
-    "typescript": "^3.1.6",
+    "typescript": "^3.2.1",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "utc-version": "^1.1.0",
     "webpack": "^4.23.1",

--- a/web/src/auth/withAuthenticatedUser.tsx
+++ b/web/src/auth/withAuthenticatedUser.tsx
@@ -2,18 +2,16 @@ import React from 'react'
 import { Redirect } from 'react-router'
 import * as GQL from '../../../shared/src/graphql/schema'
 
-type WithOptionalAuthenticatedUser<P extends object> = Pick<P, Exclude<keyof P, 'authenticatedUser'>> & {
-    authenticatedUser: GQL.IUser | null
-}
-
 /**
  * Wraps a React component and requires an authenticated user. If the viewer is not authenticated, it redirects to
  * the sign-in flow.
  */
 export const withAuthenticatedUser = <P extends object & { authenticatedUser: GQL.IUser }>(
     Component: React.ComponentType<P>
-): React.ComponentType<WithOptionalAuthenticatedUser<P>> => props => {
-    const { authenticatedUser } = props
+): React.ComponentType<Pick<P, Exclude<keyof P, 'authenticatedUser'>> & { authenticatedUser: GQL.IUser | null }> => ({
+    authenticatedUser,
+    ...props
+}) => {
     // If not logged in, redirect to sign in.
     if (!authenticatedUser) {
         const newUrl = new URL(window.location.href)
@@ -22,5 +20,5 @@ export const withAuthenticatedUser = <P extends object & { authenticatedUser: GQ
         newUrl.searchParams.set('returnTo', window.location.href)
         return <Redirect to={newUrl.pathname + newUrl.search} />
     }
-    return <Component {...props} authenticatedUser={authenticatedUser} />
+    return <Component {...{ ...props, authenticatedUser } as P} />
 }

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -144,7 +144,7 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
 
     public render(): JSX.Element | null {
         const NodeComponent = this.props.nodeComponent
-        const ListComponent = this.props.listComponent || 'ul'
+        const ListComponent: any = this.props.listComponent || 'ul' // TODO: remove cast when https://github.com/Microsoft/TypeScript/issues/28768 is fixed
         const HeadComponent = this.props.headComponent
         const FootComponent = this.props.footComponent
 
@@ -218,7 +218,7 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
         }
 
         const nodes = this.props.connection.nodes.map((node, i) => (
-            <NodeComponent key={hasID(node) ? node.id : i} node={node} {...this.props.nodeComponentProps} />
+            <NodeComponent key={hasID(node) ? node.id : i} node={node} {...this.props.nodeComponentProps!} />
         ))
 
         return (

--- a/web/src/enterprise/dotcom/productSubscriptions/ProductSubscriptionLabel.tsx
+++ b/web/src/enterprise/dotcom/productSubscriptions/ProductSubscriptionLabel.tsx
@@ -18,11 +18,11 @@ export const ProductSubscriptionLabel: React.FunctionComponent<{
     planField?: 'name' | 'nameWithBrand'
 
     className?: string
-}> = ({ productSubscription, planField = 'nameWithBrand', className = '' }) => (
+}> = ({ productSubscription, planField, className = '' }) => (
     <span className={className}>
         {productSubscription.invoiceItem ? (
             <>
-                {productSubscription.invoiceItem.plan[planField]} (
+                {productSubscription.invoiceItem.plan[planField || 'nameWithBrand']} (
                 {formatUserCount(productSubscription.invoiceItem.userCount)})
             </>
         ) : productSubscription.activeLicense && productSubscription.activeLicense.info ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -14461,10 +14461,15 @@ typedoc@^0.13.0:
     typedoc-default-themes "^0.5.0"
     typescript "3.1.x"
 
-typescript@3.1.x, typescript@^3.1.6:
+typescript@3.1.x:
   version "3.1.6"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+
+typescript@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
TypeScript 3.2 has better support for generic-typed object spreads, which helped in another commit.

Compile errors are due to:

- https://github.com/Microsoft/TypeScript/issues/28768
- others (TBD)