### PR TITLE
lazily inject toolbar mount

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -301,7 +301,7 @@ function initCodeIntelligence(
     }
 
     class HoverOverlayContainer extends React.Component<{}, HoverState> {
-        private portal: HTMLElement | null = getOverlayMount()
+        private portal: HTMLElement | null = null
 
         private observer: MutationObserver
 
@@ -329,7 +329,7 @@ function initCodeIntelligence(
             }
         }
         public componentDidUpdate(): void {
-            if (!document.body.contains(this.portal)) {
+            if (!this.portal || !document.body.contains(this.portal)) {
                 this.portal = getOverlayMount()
                 this.observer.observe(this.portal.parentElement!, { childList: true })
             }


### PR DESCRIPTION
Lazily inject the toolbar mount to prevent code which is intended to be ran on
pages with code views to be ran on other pages.

Closes https://github.com/sourcegraph/sourcegraph/issues/1212 and will handle a lot of errors being reported to Sentry at the moment.