### PR TITLE
ci: disable automatic deploys to dogfood, running e2e tests against dogfood 

### DIFF
--- a/doc/dev/web_app.md
+++ b/doc/dev/web_app.md
@@ -60,15 +60,27 @@ We use [Prettier](https://github.com/prettier/prettier) so you never have to wor
 
 ## Tests
 
-- We write unit tests and e2e tests.
-- Unit tests are for things that can be tested in isolation; you provide inputs and make assertion on the outputs and/or side effects.
-- Run unit tests via `yarn run test`.
-- E2E tests are for the whole app: JS, CSS, and backend. These tests require hitting a backend like https://sourcegraph.com or https://sourcegraph.sgdev.org (default `SOURCEGRAPH_BASE_URL=http://localhost:3080`).
-- Run E2E tests via `yarn run test-e2e`.
-- E2E tests send messages to a chrome debugger port (9222), telling chrome to do things like "go to this URL" and "click on this selector" and "execute this JavaScript in the page".
-- `yarn run test-e2e` will automatically start a headless chrome process; to prevent that, set the environment variable `SKIP_LAUNCH_CHROME=t`
-- E2E caveats:
-  - don't overdo them; they are the tip of the testing pyramid and the mass of tests should be at lower layers
-  - avoid coupling your tests too tightly to the implementation (e.g. with strict selectors that are coupled to the DOM structure), or we will have many test failures
-    - for example, mark your E2E element targets with a class like `.e2e-j2d-button`
-  - if you change a lot about the UI you should run e2e tetss before committing b/c you will likely break something.
+We write unit tests and e2e tests.
+
+### Unit tests
+
+Unit tests are for things that can be tested in isolation; you provide inputs and make assertion on the outputs and/or side effects.
+
+You can run unit tests via `yarn run test`.
+
+### E2E tests
+
+_🚨  Until the follow up work in https://github.com/sourcegraph/sourcegraph/issues/976 is completed, our E2E tests will be disabled in CI. **Before merging your PR, you should manually run e2e tests against a local instancing by running `./dev/launch.sh` in one terminal tab and `yarn run test-e2e` in another one**. Additionally, some E2E tests depend on the Go language server. Currently, that language server is in a transition state and can't be run on its own. Until @chrismwendt finishes up his work on that project, all tests that rely on Go code intelligence are skipped.🚨_
+
+E2E tests are for the whole app: JS, CSS, and backend. 
+
+These tests require hitting a backend like https://sourcegraph.com or https://sourcegraph.sgdev.org (default `SOURCEGRAPH_BASE_URL=http://localhost:3080`). E2E tests send messages to a chrome debugger port (9222), telling chrome to do things like "go to this URL" and "click on this selector" and "execute this JavaScript in the page".
+
+You can run E2E tests via `yarn run test-e2e`. This command will automatically start a headless chrome process; to prevent that, set the environment variable `SKIP_LAUNCH_CHROME=t`.
+
+#### E2E caveats 
+
+- don't overdo them; they are the tip of the testing pyramid and the mass of tests should be at lower layers
+- avoid coupling your tests too tightly to the implementation (e.g. with strict selectors that are coupled to the DOM structure), or we will have many test failures
+  - for example, mark your E2E element targets with a class like `.e2e-j2d-button`
+- if you change a lot about the UI you should run e2e tetss before committing b/c you will likely break something.

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -292,18 +292,20 @@ func main() {
 		pipeline.AddWait()
 
 		// Run e2e tests against dogfood
-		pipeline.AddStep(":chromium:",
-			// Protect against deploys while tests are running
-			bk.ConcurrencyGroup("deploy"),
-			bk.Concurrency(1),
-			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
-			bk.Cmd("yarn cache clean puppeteer"), // ensure it's downloaded even if the package was cached w/o downloading
-			bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
-			bk.Cmd("pushd web"),
-			bk.Cmd("yarn -s run test-e2e-sgdev --retries 5"),
-			bk.Cmd("popd"),
-			bk.ArtifactPaths("./puppeteer/*.png"))
-		pipeline.AddWait()
+		// TODO@ggilmore: disabled until the follow up work in https://github.com/sourcegraph/sourcegraph/issues/976
+		// is completed.
+		// pipeline.AddStep(":chromium:",
+		// 	// Protect against deploys while tests are running
+		// 	bk.ConcurrencyGroup("deploy"),
+		// 	bk.Concurrency(1),
+		// 	bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
+		// 	bk.Cmd("yarn cache clean puppeteer"), // ensure it's downloaded even if the package was cached w/o downloading
+		// 	bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
+		// 	bk.Cmd("pushd web"),
+		// 	bk.Cmd("yarn -s run test-e2e-sgdev --retries 5"),
+		// 	bk.Cmd("popd"),
+		// 	bk.ArtifactPaths("./puppeteer/*.png"))
+		// pipeline.AddWait()
 
 		// Deploy to prod
 		pipeline.AddStep(":rocket:",

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -274,6 +274,8 @@ func main() {
 
 	pipeline.AddWait()
 
+	// TODO@ggilmore: disabled until the follow up work in https://github.com/sourcegraph/sourcegraph/issues/976
+	// is completed.
 	// fetchClusterCredentials := func(name, zone, project string) bk.StepOpt {
 	// 	return bk.Cmd(fmt.Sprintf("gcloud container clusters get-credentials %s --zone %s --project %s", name, zone, project))
 	// }

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -274,22 +274,24 @@ func main() {
 
 	pipeline.AddWait()
 
-	fetchClusterCredentials := func(name, zone, project string) bk.StepOpt {
-		return bk.Cmd(fmt.Sprintf("gcloud container clusters get-credentials %s --zone %s --project %s", name, zone, project))
-	}
+	// fetchClusterCredentials := func(name, zone, project string) bk.StepOpt {
+	// 	return bk.Cmd(fmt.Sprintf("gcloud container clusters get-credentials %s --zone %s --project %s", name, zone, project))
+	// }
 
 	addDeploySteps := func() {
 		// Deploy to dogfood
-		pipeline.AddStep(":dog:",
-			// Protect against concurrent/out-of-order deploys
-			bk.ConcurrencyGroup("deploy"),
-			bk.Concurrency(1),
-			bk.Env("VERSION", version),
-			bk.Env("CONTEXT", "gke_sourcegraph-dev_us-central1-a_dogfood-cluster-7"),
-			bk.Env("NAMESPACE", "default"),
-			fetchClusterCredentials("dogfood-cluster-7", "us-central1-a", "sourcegraph-dev"),
-			bk.Cmd("./dev/ci/deploy-dogfood.sh"))
-		pipeline.AddWait()
+		// TODO@ggilmore: disabled until the follow up work in https://github.com/sourcegraph/sourcegraph/issues/976
+		// is completed.
+		// pipeline.AddStep(":dog:",
+		// 	// Protect against concurrent/out-of-order deploys
+		// 	bk.ConcurrencyGroup("deploy"),
+		// 	bk.Concurrency(1),
+		// 	bk.Env("VERSION", version),
+		// 	bk.Env("CONTEXT", "gke_sourcegraph-dev_us-central1-a_dogfood-cluster-7"),
+		// 	bk.Env("NAMESPACE", "default"),
+		// 	fetchClusterCredentials("dogfood-cluster-7", "us-central1-a", "sourcegraph-dev"),
+		// 	bk.Cmd("./dev/ci/deploy-dogfood.sh"))
+		// pipeline.AddWait()
 
 		// Run e2e tests against dogfood
 		// TODO@ggilmore: disabled until the follow up work in https://github.com/sourcegraph/sourcegraph/issues/976

--- a/web/src/e2e/index.test.e2e.tsx
+++ b/web/src/e2e/index.test.e2e.tsx
@@ -481,7 +481,11 @@ describe('e2e test suite', () => {
                     await getHoverContents() // verify there is a hover
                 })
 
-                it('gets displayed when navigating to a URL with a token position', async () => {
+                // Skipped until the Go language server is capable of being run locally (without needing
+                // access to sourcegraph-frontend's internal API)
+                // TODO@ggilmore
+                // TODO@chrismwendt
+                it.skip('gets displayed when navigating to a URL with a token position', async () => {
                     await page.goto(
                         baseURL +
                             '/github.com/sourcegraph/godockerize@05bac79edd17c0f55127871fa9c6f4d91bebf07c/-/blob/godockerize.go#L23:3'
@@ -496,7 +500,11 @@ describe('e2e test suite', () => {
                     )
                 })
 
-                describe('jump to definition', () => {
+                // Skipped until the Go language server is capable of being run locally (without needing
+                // access to sourcegraph-frontend's internal API)
+                // TODO@ggilmore
+                // TODO@chrismwendt
+                describe.skip('jump to definition', () => {
                     it('noops when on the definition', async () => {
                         await page.goto(
                             baseURL +
@@ -549,7 +557,11 @@ describe('e2e test suite', () => {
                 })
 
                 describe('find references', () => {
-                    it('opens widget and fetches local references', async function(): Promise<void> {
+                    // Skipped until the Go language server is capable of being run locally (without needing
+                    // access to sourcegraph-frontend's internal API)
+                    // TODO@ggilmore
+                    // TODO@chrismwendt
+                    it.skip('opens widget and fetches local references', async function(): Promise<void> {
                         this.timeout(120000)
 
                         await page.goto(


### PR DESCRIPTION
**This PR should not be merged until https://github.com/sourcegraph/infrastructure/pull/699 gets the final approval.**

As part of the plan described in https://github.com/sourcegraph/sourcegraph/issues/976, we're disabling auto-deploys to dogfood and e2e testing against dogfood until the follow-up work has been completed. 

This PR:

- Disables automatic deployments to dogfood
- Disables e2e testing in CI against dogfood
- Documents how to run e2e tests locally
- Disables e2e tests that depend on the go language server (which currently can't be run locally until @chrismwendt 's work on that is completed)

