### PR TITLE
upgrade codeintellify

### DIFF
--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -1,5 +1,6 @@
 import { AdjustmentDirection, DOMFunctions, PositionAdjuster } from '@sourcegraph/codeintellify'
 import { of } from 'rxjs'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
 import { CodeHost, CodeViewResolver, CodeViewWithOutSelector } from '../code_intelligence'
 import { diffDOMFunctions, getLineRanges, singleFileDOMFunctions } from './dom_functions'
 import { resolveDiffFileInfo, resolveFileInfo } from './file_info'
@@ -31,7 +32,9 @@ const createToolbarMount = (codeView: HTMLElement) => {
  * Sometimes tabs are converted to spaces so we need to adjust. Luckily, there
  * is an attribute `cm-text` that contains the real text.
  */
-const createPositionAdjuster = (dom: DOMFunctions): PositionAdjuster => ({ direction, codeView, position }) => {
+const createPositionAdjuster = (
+    dom: DOMFunctions
+): PositionAdjuster<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec> => ({ direction, codeView, position }) => {
     const codeElement = dom.getCodeElementFromLineNumber(codeView, position.line, position.part)
     if (!codeElement) {
         throw new Error('(adjustPosition) could not find code element for line provided')

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -1,6 +1,7 @@
 import { AdjustmentDirection, PositionAdjuster } from '@sourcegraph/codeintellify'
 import { trimStart } from 'lodash'
 import { map } from 'rxjs/operators'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
 import { JumpURLLocation } from '../../shared/backend/lsp'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { CodeHost, CodeView, CodeViewResolver, CodeViewWithOutSelector } from '../code_intelligence'
@@ -47,7 +48,11 @@ const singleFileCodeView: CodeViewWithOutSelector = {
  * Some code snippets get leading white space trimmed. This adjusts based on
  * this. See an example here https://github.com/sourcegraph/browser-extensions/issues/188.
  */
-const adjustPositionForSnippet: PositionAdjuster = ({ direction, codeView, position }) =>
+const adjustPositionForSnippet: PositionAdjuster<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec> = ({
+    direction,
+    codeView,
+    position,
+}) =>
     fetchBlobContentLines(position).pipe(
         map(lines => {
             const codeElement = singleFileDOMFunctions.getCodeElementFromLineNumber(

--- a/client/browser/src/libs/phabricator/code_intelligence.ts
+++ b/client/browser/src/libs/phabricator/code_intelligence.ts
@@ -2,6 +2,7 @@ import { AdjustmentDirection, DiffPart, PositionAdjuster } from '@sourcegraph/co
 import { map } from 'rxjs/operators'
 import { convertSpacesToTabs, spacesToTabsAdjustment } from '.'
 import { Position } from '../../../../../shared/src/api/protocol/plainTypes'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
 import storage from '../../browser/storage'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { CodeHost, CodeView } from '../code_intelligence'
@@ -64,7 +65,11 @@ const adjustCharacter = (position: Position, adjustment: number): Position => ({
     character: position.character + adjustment,
 })
 
-const adjustPosition: PositionAdjuster = ({ direction, codeView, position }) =>
+const adjustPosition: PositionAdjuster<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec> = ({
+    direction,
+    codeView,
+    position,
+}) =>
     fetchBlobContentLines(position).pipe(
         map(lines => {
             const codeElement = diffDomFunctions.getCodeElementFromLineNumber(codeView, position.line, position.part)

--- a/client/browser/src/shared/backend/lsp.tsx
+++ b/client/browser/src/shared/backend/lsp.tsx
@@ -240,7 +240,7 @@ export type JumpURLLocation = RepoSpec & RevSpec & ResolvedRevSpec & FileSpec & 
 export function createJumpURLFetcher(
     fetchDefinition: SimpleProviderFns['fetchDefinition'],
     buildURL: (pos: JumpURLLocation) => string
-): JumpURLFetcher {
+): JumpURLFetcher<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec> {
     return ({ line, character, part, commitID, repoPath, ...rest }) =>
         fetchDefinition({ ...rest, commitID, repoPath, position: { line, character } }).pipe(
             map(def => {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
   "dependencies": {
     "@sentry/browser": "^4.4.1",
     "@slimsag/react-shortcuts": "^1.2.1",
-    "@sourcegraph/codeintellify": "^3.10.0",
+    "@sourcegraph/codeintellify": "^4.0.0",
     "@sourcegraph/react-loading-spinner": "0.0.6",
     "@sqs/jsonc-parser": "^1.0.3",
     "abortable-rx": "^1.0.9",

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -2,7 +2,6 @@ import {
     createHoverifier,
     findPositionsFromEvents,
     HoveredToken,
-    HoveredTokenContext,
     HoverOverlay,
     HoverState,
 } from '@sourcegraph/codeintellify'
@@ -22,10 +21,15 @@ import { asError, ErrorLike, isErrorLike } from '../../../../shared/src/util/err
 import { isDefined, propertyIsDefined } from '../../../../shared/src/util/types'
 import {
     AbsoluteRepoFile,
+    FileSpec,
     LineOrPositionOrRange,
     parseHash,
     RenderMode,
+    RepoSpec,
+    ResolvedRevSpec,
+    RevSpec,
     toPositionOrRangeHash,
+    toPrettyBlobURL,
 } from '../../../../shared/src/util/url'
 import { getDecorations, getHover, getJumpURL, ModeSpec } from '../../backend/features'
 import { LSPSelector, LSPTextDocumentPositionParams } from '../../backend/lsp'
@@ -155,7 +159,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             share()
         )
 
-        const hoverifier = createHoverifier({
+        const hoverifier = createHoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>({
             closeButtonClicks: this.closeButtonClicks,
             goToDefinitionClicks: this.goToDefinitionClicks,
             hoverOverlayElements: this.hoverOverlayElements,
@@ -170,6 +174,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             logTelemetryEvent,
             fetchHover: position => getHover(this.getLSPTextDocumentPositionParams(position), this.props),
             fetchJumpURL: position => getJumpURL(this.getLSPTextDocumentPositionParams(position), this.props),
+            getReferencesURL: position => toPrettyBlobURL({ ...position, position, viewState: 'references' }),
         })
         this.subscriptions.add(hoverifier)
 
@@ -396,7 +401,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
     }
 
     private getLSPTextDocumentPositionParams(
-        position: HoveredToken & HoveredTokenContext
+        position: HoveredToken & RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
     ): LSPTextDocumentPositionParams {
         return {
             repoPath: position.repoPath,

--- a/web/src/repo/compare/FileDiffHunks.tsx
+++ b/web/src/repo/compare/FileDiffHunks.tsx
@@ -7,6 +7,7 @@ import { filter } from 'rxjs/operators'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { isDefined } from '../../../../shared/src/util/types'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
 
 const DiffBoundary: React.FunctionComponent<{
     /** The "lines" property is set for end boundaries (only for start boundaries and between hunks). */
@@ -201,7 +202,7 @@ interface Props extends PlatformContextProps {
     className: string
     location: H.Location
     history: H.History
-    hoverifier: Hoverifier
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
 }
 
 interface State {}

--- a/web/src/repo/compare/FileDiffNode.tsx
+++ b/web/src/repo/compare/FileDiffNode.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
 import { DiffStat } from './DiffStat'
 import { FileDiffHunks } from './FileDiffHunks'
 
@@ -23,7 +24,7 @@ export interface FileDiffNodeProps extends PlatformContextProps, ExtensionsContr
     className?: string
     location: H.Location
     history: H.History
-    hoverifier: Hoverifier
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
 }
 
 interface State {

--- a/web/src/repo/compare/RepositoryCompareDiffPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareDiffPage.tsx
@@ -8,6 +8,7 @@ import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { createAggregateError } from '../../../../shared/src/util/errors'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
 import { queryGraphQL } from '../../backend/graphql'
 import { FileDiffConnection } from './FileDiffConnection'
 import { FileDiffNode } from './FileDiffNode'
@@ -101,7 +102,7 @@ interface RepositoryCompareDiffPageProps
 
     /** The head of the comparison. */
     head: { repoPath: string; repoID: GQL.ID; rev: string | null; commitID: string }
-    hoverifier: Hoverifier
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
 }
 
 /** A page with the file diffs in the comparison. */

--- a/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -10,6 +10,7 @@ import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
 import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -80,7 +81,7 @@ interface Props
 
     /** The head of the comparison. */
     head: { repoPath: string; repoID: GQL.ID; rev?: string | null }
-    hoverifier: Hoverifier
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
 }
 
 interface State {

--- a/web/src/search/input/CodeIntellifyBlob.tsx
+++ b/web/src/search/input/CodeIntellifyBlob.tsx
@@ -2,7 +2,6 @@ import {
     createHoverifier,
     findPositionsFromEvents,
     HoveredToken,
-    HoveredTokenContext,
     HoverOverlay,
     HoverState,
 } from '@sourcegraph/codeintellify'
@@ -18,6 +17,7 @@ import * as GQL from '../../../../shared/src/graphql/schema'
 import { getModeFromPath } from '../../../../shared/src/languages'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { isDefined, propertyIsDefined } from '../../../../shared/src/util/types'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec, toPrettyBlobURL } from '../../../../shared/src/util/url'
 import { getHover, getJumpURL } from '../../backend/features'
 import { LSPTextDocumentPositionParams } from '../../backend/lsp'
 import { fetchBlob } from '../../repo/blob/BlobPage'
@@ -120,7 +120,7 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
         super(props)
         this.state = {}
 
-        const hoverifier = createHoverifier({
+        const hoverifier = createHoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>({
             closeButtonClicks: this.closeButtonClicks,
             goToDefinitionClicks: this.goToDefinitionClicks,
             hoverOverlayElements: this.hoverOverlayElements,
@@ -142,6 +142,7 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
             ),
             fetchHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
             fetchJumpURL: hoveredToken => getJumpURL(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
+            getReferencesURL: position => toPrettyBlobURL({ ...position, position, viewState: 'references' }),
         })
 
         this.subscriptions.add(hoverifier)
@@ -230,7 +231,7 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
     }
 
     private getLSPTextDocumentPositionParams(
-        position: HoveredToken & HoveredTokenContext
+        position: HoveredToken & RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
     ): LSPTextDocumentPositionParams {
         return {
             repoPath: position.repoPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,10 +1122,10 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@sourcegraph/codeintellify@^3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-3.10.0.tgz#4b25747bc545f2b02d4a44a5235bdb10da8c1347"
-  integrity sha512-Xg4YOXUEQ/+DjRpsoiA0w5av9+Xk5ki/fBVpxcUzEKsJQ+V4Fi55wn8iEg6sm8nwHWPB0CRlsftjRmuWtzIl6Q==
+"@sourcegraph/codeintellify@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-4.0.0.tgz#59001ee68949dbbac0de2164399f448f7e6f4ef3"
+  integrity sha512-+ctLPrXY3mkpLw/rwMryno/jn47FUddK7t7RAJB72imFi8Mz8MgYZxhJFhgUkLva3e48WgBqkYyWhCQhw4wK7g==
   dependencies:
     "@sourcegraph/event-positions" "^1.0.0"
     "@sourcegraph/react-loading-spinner" "0.0.6"


### PR DESCRIPTION
This upgrades `@sourcegraph/codeintellify` and provides the references URL from Sourcegraph so that codeintellify does not duplicate the Sourcegraph URL generation logic.

It is a precursor to supporting contributable hover actions.

NOCHANGELOG