### PR TITLE
refactor: DRY references to Web Worker global scope

### DIFF
--- a/shared/src/api/extension/api/extensions.ts
+++ b/shared/src/api/extension/api/extensions.ts
@@ -7,6 +7,9 @@ export interface ExtExtensionsAPI {
     $deactivateExtension(extensionID: string): Promise<void>
 }
 
+/** The WebWorker's global scope */
+declare const self: any
+
 /** @internal */
 export class ExtExtensions implements ExtExtensionsAPI, Unsubscribable {
     /** Extensions' deactivate functions. */
@@ -28,9 +31,9 @@ export class ExtExtensions implements ExtExtensionsAPI, Unsubscribable {
         // Load the extension bundle and retrieve the extension entrypoint module's exports on
         // the global `module` property.
         try {
-            ;(self as any).exports = {}
-            ;(self as any).module = {}
-            ;(self as any).importScripts(bundleURL)
+            self.exports = {}
+            self.module = {}
+            self.importScripts(bundleURL)
         } catch (err) {
             throw new Error(
                 `error thrown while executing extension ${JSON.stringify(
@@ -38,9 +41,9 @@ export class ExtExtensions implements ExtExtensionsAPI, Unsubscribable {
                 )} bundle (in importScripts of ${bundleURL}): ${err}`
             )
         }
-        const extensionExports = (self as any).module.exports
-        delete (self as any).exports
-        delete (self as any).module
+        const extensionExports = self.module.exports
+        delete self.exports
+        delete self.module
 
         if (!('activate' in extensionExports)) {
             throw new Error(


### PR DESCRIPTION
Avoids repetition of `(self as any)`, and also possibly makes this code clearer for future onlookers who may not be familiar with web workers.