### PR TITLE
Fix some bugs in the references panel

### DIFF
--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -14,6 +14,7 @@ import { asError } from '../../util/errors'
 import { parseRepoURI } from '../../util/url'
 import { registerPanelToolbarContributions } from './contributions'
 import { FileLocations, FileLocationsError, FileLocationsNotFound } from './FileLocations'
+import { groupLocations } from './locations'
 
 interface Props extends ExtensionsControllerProps, SettingsCascadeProps {
     /**
@@ -26,7 +27,7 @@ interface Props extends ExtensionsControllerProps, SettingsCascadeProps {
      * Usually this is set to the URI to the root of the repository that is currently being viewed to ensure that
      * it is listed first.
      */
-    defaultGroup?: string
+    defaultGroup: string
 
     /** Called when an item in the tree is selected. */
     onSelectTree?: () => void
@@ -128,12 +129,12 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
         const GROUPS: {
             name: string
             defaultSize: number
-            key: (uri: string) => string
+            key: (loc: Location) => string | undefined
         }[] = [
             {
                 name: 'repo',
                 defaultSize: 100,
-                key: (uri: string): string => parseRepoURI(uri).repoPath,
+                key: loc => parseRepoURI(loc.uri).repoPath,
             },
         ]
         const groupByFile =
@@ -144,88 +145,50 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
             GROUPS.push({
                 name: 'file',
                 defaultSize: 200,
-                key: (uri: string): string => parseRepoURI(uri).filePath || '',
+                key: loc => parseRepoURI(loc.uri).filePath,
             })
         }
 
-        // Grouped locations.
-        const locationsByGroup: Map<string, Location[]>[] = []
-
-        // Groups with >0 locations, in order (preserving order reduces jitter as more results stream in).
-        const orderedGroups: string[][] = this.props.defaultGroup ? [[GROUPS[0].key(this.props.defaultGroup)]] : []
-
-        // The selected groups, or the first group if none is selected.
-        const { locationsOrError } = this.state
-        const selectedGroups: string[] | undefined = GROUPS.map(
-            ({ key }, i) =>
-                this.state.selectedGroups && this.state.selectedGroups[i]
-                    ? this.state.selectedGroups[i]
-                    : key(this.props.defaultGroup || locationsOrError[0].uri) || key(locationsOrError[0].uri)
+        const { groups, selectedGroups, visibleLocations } = groupLocations<Location, string>(
+            this.state.locationsOrError,
+            this.state.selectedGroups || null,
+            GROUPS.map(({ key }) => key),
+            { uri: this.props.defaultGroup }
         )
-
-        if (selectedGroups) {
-            for (const loc of locationsOrError) {
-                const groups = GROUPS.map(({ key }) => key(loc.uri))
-                for (const [i, group] of groups.entries()) {
-                    if (!locationsByGroup[i]) {
-                        locationsByGroup[i] = new Map<string, Location[]>()
-                    }
-                    let locs = locationsByGroup[i].get(group)
-                    if (!locs) {
-                        locs = []
-                        if (!orderedGroups[i]) {
-                            orderedGroups[i] = []
-                        }
-                        if (!orderedGroups[i].includes(group)) {
-                            orderedGroups[i].push(group)
-                        }
-                    }
-                    locs.push(loc)
-                    locationsByGroup[i].set(group, locs)
-                }
-            }
-        }
-
-        // Ensure selected groups are valid.
-        for (const [i, group] of selectedGroups.entries()) {
-            if (!orderedGroups[i].includes(group)) {
-                selectedGroups[i] = orderedGroups[i][0]
-            }
-        }
 
         return (
             <div className={`hierarchical-locations-view ${this.props.className || ''}`}>
                 {selectedGroups &&
                     GROUPS.map(
-                        (group, i) =>
-                            ((groupByFile && group.name === 'file') || orderedGroups[i].length > 1) && (
+                        ({ name, defaultSize }, i) =>
+                            ((groupByFile && name === 'file') || groups[i].length > 1) && (
                                 <Resizable
                                     key={i}
                                     className="hierarchical-locations-view__resizable"
                                     handlePosition="right"
-                                    storageKey={`hierarchical-locations-view-resizable:${group.name}`}
-                                    defaultSize={group.defaultSize}
+                                    storageKey={`hierarchical-locations-view-resizable:${name}`}
+                                    defaultSize={defaultSize}
                                     element={
                                         <div className="list-group list-group-flush hierarchical-locations-view__list">
-                                            {orderedGroups[i].map((groupName, j) => (
+                                            {groups[i].map((group, j) => (
                                                 <span
                                                     key={j}
                                                     className={`list-group-item hierarchical-locations-view__item ${
-                                                        selectedGroups[i] === groupName ? 'active' : ''
+                                                        selectedGroups[i] === group.key ? 'active' : ''
                                                     }`}
                                                     // tslint:disable-next-line:jsx-no-lambda
-                                                    onClick={e => this.onSelectTree(e, i, groupName)}
+                                                    onClick={e => this.onSelectTree(e, selectedGroups, i, group.key)}
                                                 >
                                                     <span
                                                         className="hierarchical-locations-view__item-name"
-                                                        title={groupName}
+                                                        title={group.key}
                                                     >
                                                         <span className="hierarchical-locations-view__item-name-text">
-                                                            <RepoLink to={null} repoPath={groupName} />
+                                                            <RepoLink to={null} repoPath={group.key} />
                                                         </span>
                                                     </span>
                                                     <span className="badge badge-secondary badge-pill hierarchical-locations-view__item-badge">
-                                                        {(locationsByGroup[i].get(groupName) || []).length}
+                                                        {group.count}
                                                     </span>
                                                 </span>
                                             ))}
@@ -239,10 +202,7 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
                     )}
                 <FileLocations
                     className="hierarchical-locations-view__content"
-                    locations={of(
-                        locationsByGroup[locationsByGroup.length - 1].get(selectedGroups[selectedGroups.length - 1]) ||
-                            null
-                    )}
+                    locations={of(visibleLocations)}
                     onSelect={this.props.onSelectLocation}
                     icon={RepositoryIcon}
                     isLightTheme={this.props.isLightTheme}
@@ -252,13 +212,14 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
         )
     }
 
-    private onSelectTree = (e: React.MouseEvent<HTMLElement>, i: number, group: string): void => {
+    private onSelectTree = (
+        e: React.MouseEvent<HTMLElement>,
+        selectedGroups: string[],
+        i: number,
+        group: string
+    ): void => {
         e.preventDefault()
-
-        const selectedGroups = [...(this.state.selectedGroups || [])]
-        selectedGroups[i] = group
-        this.setState({ selectedGroups })
-
+        this.setState({ selectedGroups: selectedGroups.slice(0, i).concat(group) })
         if (this.props.onSelectTree) {
             this.props.onSelectTree()
         }

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -182,10 +182,6 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
                     }
                     locs.push(loc)
                     locationsByGroup[i].set(group, locs)
-
-                    if (selectedGroups[i] !== group) {
-                        break
-                    }
                 }
             }
         }
@@ -229,7 +225,7 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
                                                         </span>
                                                     </span>
                                                     <span className="badge badge-secondary badge-pill hierarchical-locations-view__item-badge">
-                                                        {locationsByGroup[i].get(groupName)!.length}
+                                                        {(locationsByGroup[i].get(groupName) || []).length}
                                                     </span>
                                                 </span>
                                             ))}

--- a/shared/src/panel/views/PanelView.tsx
+++ b/shared/src/panel/views/PanelView.tsx
@@ -38,16 +38,17 @@ export class PanelView extends React.PureComponent<Props, State> {
                     </div>
                 )}
                 {this.props.panelView.reactElement}
-                {this.props.panelView.locationProvider && (
-                    <HierarchicalLocationsView
-                        locations={this.props.panelView.locationProvider}
-                        defaultGroup={this.props.repoName}
-                        isLightTheme={this.props.isLightTheme}
-                        fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
-                        extensionsController={this.props.extensionsController}
-                        settingsCascade={this.props.settingsCascade}
-                    />
-                )}
+                {this.props.panelView.locationProvider &&
+                    this.props.repoName && (
+                        <HierarchicalLocationsView
+                            locations={this.props.panelView.locationProvider}
+                            defaultGroup={this.props.repoName}
+                            isLightTheme={this.props.isLightTheme}
+                            fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
+                            extensionsController={this.props.extensionsController}
+                            settingsCascade={this.props.settingsCascade}
+                        />
+                    )}
                 {!this.props.panelView.content &&
                     !this.props.panelView.reactElement &&
                     !this.props.panelView.locationProvider && <EmptyPanelView className="mt-3" />}

--- a/shared/src/panel/views/locations.test.ts
+++ b/shared/src/panel/views/locations.test.ts
@@ -1,0 +1,65 @@
+import assert from 'assert'
+import { GroupedLocations, groupLocations } from './locations'
+
+type TestLocation = string
+
+type TestGroup = string
+
+const LOCATIONS: TestLocation[] = ['a/a/0', 'b/a/0', 'a/a/1', 'a/b/0']
+
+const GROUP_KEYS: ((location: TestLocation) => TestGroup | undefined)[] = [
+    loc => loc.split('/')[0],
+    loc => loc.split('/')[1],
+]
+
+describe('groupLocations', () => {
+    it('groups 1 levels', () =>
+        assert.deepStrictEqual(
+            groupLocations<TestLocation, TestGroup>(LOCATIONS, null, GROUP_KEYS.slice(0, 1), LOCATIONS[0]),
+            {
+                groups: [[{ key: 'a', count: 3 }, { key: 'b', count: 1 }]],
+                selectedGroups: ['a'],
+                visibleLocations: ['a/a/0', 'a/a/1', 'a/b/0'],
+            } as GroupedLocations<TestLocation, TestGroup>
+        ))
+
+    it('groups 2 levels', () =>
+        assert.deepStrictEqual(groupLocations<TestLocation, TestGroup>(LOCATIONS, null, GROUP_KEYS, LOCATIONS[0]), {
+            groups: [
+                [{ key: 'a', count: 3 }, { key: 'b', count: 1 }],
+                [{ key: 'a', count: 2 }, { key: 'b', count: 1 }],
+            ],
+            selectedGroups: ['a', 'a'],
+            visibleLocations: ['a/a/0', 'a/a/1'],
+        } as GroupedLocations<TestLocation, TestGroup>))
+
+    it('supports initial selectedGroups', () =>
+        assert.deepStrictEqual(
+            groupLocations<TestLocation, TestGroup>(LOCATIONS, ['b', 'a'], GROUP_KEYS, LOCATIONS[0]),
+            {
+                groups: [[{ key: 'a', count: 3 }, { key: 'b', count: 1 }], [{ key: 'a', count: 1 }]],
+                selectedGroups: ['b', 'a'],
+                visibleLocations: ['b/a/0'],
+            } as GroupedLocations<TestLocation, TestGroup>
+        ))
+
+    it('handles selectedGroups element that does not exist', () =>
+        assert.deepStrictEqual(
+            groupLocations<TestLocation, TestGroup>(LOCATIONS, ['b', 'x'], GROUP_KEYS, LOCATIONS[0]),
+            {
+                groups: [[{ key: 'a', count: 3 }, { key: 'b', count: 1 }], [{ key: 'a', count: 1 }]],
+                selectedGroups: ['b', 'x'],
+                visibleLocations: [],
+            } as GroupedLocations<TestLocation, TestGroup>
+        ))
+
+    it('resolves selectedGroups undefined element', () =>
+        assert.deepStrictEqual(groupLocations<TestLocation, TestGroup>(LOCATIONS, ['a'], GROUP_KEYS, LOCATIONS[0]), {
+            groups: [
+                [{ key: 'a', count: 3 }, { key: 'b', count: 1 }],
+                [{ key: 'a', count: 2 }, { key: 'b', count: 1 }],
+            ],
+            selectedGroups: ['a', 'a'],
+            visibleLocations: ['a/a/0', 'a/a/1'],
+        } as GroupedLocations<TestLocation, TestGroup>))
+})

--- a/shared/src/panel/views/locations.ts
+++ b/shared/src/panel/views/locations.ts
@@ -1,0 +1,89 @@
+import { Location } from '../../api/protocol/plainTypes'
+
+/**
+ * Grouped locations returned by {@link groupLocations}.
+ *
+ * There are multiple levels of grouping. For example, the first level might be the repository, and the second
+ * level might be the file. Typically the levels are displayed as columns, with
+ *
+ * @template L The location type.
+ * @template G The type that describes a grouping level.
+ */
+export interface GroupedLocations<L, G> {
+    /**
+     * The groups to show at each level.
+     */
+    groups: { key: G; count: number }[][]
+
+    /**
+     * The selected group at each level.
+     */
+    selectedGroups: G[]
+
+    /**
+     * The locations to display (based on the selected group at each level).
+     */
+    visibleLocations: L[]
+}
+
+/**
+ * @template L The location type.
+ * @template G The type that describes a grouping level.
+ */
+export function groupLocations<L = Location, G = string>(
+    locations: L[],
+    selectedGroups: G[] | null,
+    groupKeys: ((location: L) => G | undefined)[],
+    locationForDefaultSelection: L
+): GroupedLocations<L, G> {
+    const groups: GroupedLocations<L, G>['groups'] = []
+
+    if (!selectedGroups) {
+        // Set default selection.
+        selectedGroups = []
+        for (const groupKey of groupKeys) {
+            const group = groupKey(locationForDefaultSelection)
+            if (group === undefined) {
+                break
+            }
+            selectedGroups.push(group)
+        }
+    }
+
+    const visibleLocations: L[] = []
+    for (const loc of locations) {
+        for (const [i, groupKey] of groupKeys.entries()) {
+            const group = groupKey(loc)
+            if (group === undefined) {
+                break
+            }
+            if (!groups[i]) {
+                groups[i] = []
+            }
+            const groupEntry = groups[i].find(g => g.key === group)
+            if (groupEntry) {
+                groupEntry.count++
+            } else {
+                groups[i].push({ key: group, count: 1 })
+            }
+            if (selectedGroups[i] === undefined) {
+                selectedGroups[i] = group
+            }
+            if (selectedGroups[i] !== group) {
+                // This location won't be visible and won't contribute to any more groups, so stop processing it.
+                break
+            }
+
+            // If this location is the rightmost selected group, it is visible.
+            if (i === groupKeys.length - 1) {
+                visibleLocations.push(loc)
+            }
+        }
+    }
+
+    return {
+        groups,
+        selectedGroups,
+        visibleLocations,
+    }
+}

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -180,6 +180,7 @@ export class BlobPanel extends React.PureComponent<Props> {
                                                       []
                                                   )
                                               )}
+                                              defaultGroup={this.props.repoPath}
                                               isLightTheme={this.props.isLightTheme}
                                               fetchHighlightedFileLines={fetchHighlightedFileLines}
                                               settingsCascade={this.props.settingsCascade}


### PR DESCRIPTION
I ran into some JavaScript errors when returning external refs from the new Go extension and I managed to change the grouping code enough to avoid these errors, but I admit I do not understand it very well and I may have introduced other problems. @sqs Can you take a look? :eyes: