### PR TITLE
add license check for github/gitlab oauth

### DIFF
--- a/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/enterprise/pkg/license"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -24,6 +26,11 @@ import (
 func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
+
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
+	}
+	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 
 	const mockUserID = 123
 

--- a/enterprise/cmd/frontend/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/middleware_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/enterprise/pkg/license"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -24,6 +26,11 @@ import (
 func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
+
+	licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+		return &license.Info{Tags: licensing.EnterpriseTags}, "test-signature", nil
+	}
+	defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 
 	const mockUserID = 123
 

--- a/enterprise/cmd/frontend/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/auth/oauth/middleware.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
@@ -24,6 +25,12 @@ func NewHandler(serviceType, authPrefix string, isAPIHandler bool, next http.Han
 		// next.
 		if actor.FromContext(r.Context()).IsAuthenticated() {
 			next.ServeHTTP(w, r)
+			return
+		}
+
+		// License check.
+		if !licensing.IsFeatureEnabledLenient(licensing.FeatureACLs) {
+			licensing.WriteSubscriptionErrorResponseForFeature(w, "integration with external service ACLs")
 			return
 		}
 

--- a/enterprise/cmd/frontend/internal/licensing/features.go
+++ b/enterprise/cmd/frontend/internal/licensing/features.go
@@ -18,6 +18,10 @@ const (
 	// be used.
 	FeatureExternalAuthProvider Feature = "sso-external-user-auth-provider"
 
+	// FeatureACLs is whether ACLs may be used, such as GitHub or GitLab repository permissions and
+	// integration with GitHub/GitLab for user authentication.
+	FeatureACLs Feature = "acls"
+
 	// FeatureExtensionRegistry is whether publishing extensions to this Sourcegraph instance is
 	// allowed. If not, then extensions must be published to Sourcegraph.com. All instances may use
 	// extensions published to Sourcegraph.com.
@@ -36,6 +40,9 @@ func isFeatureEnabled(info license.Info, feature Feature) bool {
 		// Enterprise Starter and Enterprise both allow SSO. Core doesn't, but this func is only
 		// called when there is a valid license.
 		return true
+	case FeatureACLs:
+		// Enterprise Starter does not support ACLs.
+		return !info.HasTag(EnterpriseStarterTag)
 	case FeatureExtensionRegistry:
 		// Enterprise Starter does not support a local extension registry.
 		return !info.HasTag(EnterpriseStarterTag)

--- a/enterprise/cmd/frontend/internal/licensing/features_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/features_test.go
@@ -20,6 +20,11 @@ func TestIsFeatureEnabled(t *testing.T) {
 		check(t, FeatureExternalAuthProvider, EnterpriseTags, true)
 	})
 
+	t.Run(string(FeatureACLs), func(t *testing.T) {
+		check(t, FeatureACLs, EnterpriseStarterTags, false)
+		check(t, FeatureACLs, EnterpriseTags, true)
+	})
+
 	t.Run(string(FeatureExtensionRegistry), func(t *testing.T) {
 		check(t, FeatureExtensionRegistry, EnterpriseStarterTags, false)
 		check(t, FeatureExtensionRegistry, EnterpriseTags, true)


### PR DESCRIPTION
ACLs are a Sourcegraph Enterprise feature. This check enforces that there is a valid Sourcegraph Enterprise license when this feature is used to authenticate a user.