### PR TITLE
allow settings updates GraphQL requests even on private GitHub repositories

### DIFF
--- a/shared/src/settings/edit.ts
+++ b/shared/src/settings/edit.ts
@@ -105,7 +105,8 @@ function editSettings(
                     }
                 }
             `[graphQLContent],
-            { subject, lastID, edit }
+            { subject, lastID, edit },
+            false
         )
     )
         .pipe(
@@ -142,7 +143,8 @@ export function overwriteSettings(
                     }
                 }
             `[graphQLContent],
-            { subject, lastID, contents }
+            { subject, lastID, contents },
+            false
         )
     )
         .pipe(


### PR DESCRIPTION
Fixes an issue where users who perform an action that needs to update user settings will see an error:

> A EditSettings GraphQL request to the public Sourcegraph.com was blocked because the current repository is private.

These requests are safe to perform on private GitHub repo pages because the payload does not send any sensitive data.

cc @karkum