### PR TITLE
all: fix deprecated comment format

### DIFF
--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -24,7 +24,7 @@ func (o *settingsResolver) Subject() *settingsSubject {
 	return o.subject
 }
 
-// DEPRECATED: Use the Contents field instead.
+// Deprecated: Use the Contents field instead.
 func (o *settingsResolver) Configuration() *configurationResolver {
 	return &configurationResolver{contents: o.settings.Contents}
 }

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
 
-// Depreacted: The GraphQL type Configuration is deprecated.
+// Deprecated: The GraphQL type Configuration is deprecated.
 type configurationResolver struct {
 	contents string
 	messages []string // error and warning messages

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
 
-// DEPRECATED: The GraphQL type Configuration is deprecated.
+// Depreacted: The GraphQL type Configuration is deprecated.
 type configurationResolver struct {
 	contents string
 	messages []string // error and warning messages

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -61,7 +61,7 @@ func UnmarshalUserID(id graphql.ID) (userID int32, err error) {
 func (r *UserResolver) DatabaseID() int32 { return r.user.ID }
 
 // Email returns the user's oldest email, if one exists.
-// DEPRECATED: use Emails instead.
+// Deprecated: use Emails instead.
 func (r *UserResolver) Email(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to access the email address.
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -83,8 +83,8 @@ type PatternInfo struct {
 	// and IncludePatterns are case sensitive.
 	PathPatternsAreCaseSensitive bool
 
-	// IncludePattern is DEPRECATED. Use IncludePatterns instead. If specified,
-	// IncludePattern will be appended to IncludePatterns.
+	// IncludePattern, if specified, will be appended to IncludePatterns.
+	// Deprecated: Use IncludePatterns instead.
 	IncludePattern string
 
 	// FileMatchLimit limits the number of files with matches that are returned.


### PR DESCRIPTION
Proper format described in https://rakyll.org/deprecated/

Found using "deprecatedComment" diagnostic from gocritic.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>