### PR TITLE
do not block on slowest location provider

### DIFF
--- a/shared/src/api/client/services/hover.test.ts
+++ b/shared/src/api/client/services/hover.test.ts
@@ -88,7 +88,7 @@ describe('getHover', () => {
                 expectObservable(
                     getHover(
                         cold<ProvideTextDocumentHoverSignature[]>('-a-|', {
-                            a: [() => throwError('err'), () => of(FIXTURE_RESULT)],
+                            a: [() => of(FIXTURE_RESULT), () => throwError('err')],
                         }),
                         FIXTURE.TextDocumentPositionParams
                     )
@@ -101,7 +101,7 @@ describe('getHover', () => {
             scheduler().run(({ cold, expectObservable }) =>
                 expectObservable(
                     getHover(
-                        cold<ProvideTextDocumentHoverSignature[]>('-a-|', {
+                        cold<ProvideTextDocumentHoverSignature[]>('-a----|', {
                             a: [
                                 () =>
                                     of({
@@ -117,7 +117,14 @@ describe('getHover', () => {
                         }),
                         FIXTURE.TextDocumentPositionParams
                     )
-                ).toBe('-a-|', {
+                ).toBe('-(ia)-|', {
+                    // TODO: We don't actually *want* this "i" emission, but it is tricky to skip it in getHover
+                    // (without regressing such that getHover's returned observable waits to emit for the slowest
+                    // hover provider to emit its first result).
+                    i: {
+                        contents: [{ value: 'c1', kind: MarkupKind.PlainText }],
+                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    },
                     a: {
                         contents: [
                             { value: 'c1', kind: MarkupKind.PlainText },

--- a/shared/src/api/client/services/hover.ts
+++ b/shared/src/api/client/services/hover.ts
@@ -1,8 +1,9 @@
 import { combineLatest, from, Observable } from 'rxjs'
-import { catchError, map, switchMap } from 'rxjs/operators'
+import { catchError, defaultIfEmpty, distinctUntilChanged, filter, map, startWith, switchMap } from 'rxjs/operators'
 import { HoverMerged } from '../../client/types/hover'
 import { TextDocumentPositionParams } from '../../protocol'
 import { Hover } from '../../protocol/plainTypes'
+import { isEqual } from '../../util'
 import { DocumentFeatureProviderRegistry } from './registry'
 
 export type ProvideTextDocumentHoverSignature = (
@@ -23,6 +24,8 @@ export class TextDocumentHoverProviderRegistry extends DocumentFeatureProviderRe
     }
 }
 
+const INITIAL = Symbol('INITIAL')
+
 /**
  * Returns an observable that emits all providers' hovers whenever any of the last-emitted set of providers emits
  * hovers. If any provider emits an error, the error is logged and the provider is omitted from the emission of
@@ -35,25 +38,36 @@ export function getHover(
     providers: Observable<ProvideTextDocumentHoverSignature[]>,
     params: TextDocumentPositionParams
 ): Observable<HoverMerged | null> {
-    return providers
-        .pipe(
-            switchMap(providers => {
-                if (providers.length === 0) {
-                    return [[null]]
-                }
-                return combineLatest(
-                    providers.map(provider =>
-                        from(
-                            provider(params).pipe(
-                                catchError(err => {
-                                    console.error(err)
-                                    return [null]
-                                })
-                            )
+    return providers.pipe(
+        switchMap(providers => {
+            if (providers.length === 0) {
+                return [null]
+            }
+            return combineLatest(
+                providers.map(provider =>
+                    from(
+                        provider(params).pipe(
+                            // combineLatest waits to emit until all observables have emitted. Make all
+                            // observables emit immediately to avoid waiting for the slowest observable.
+                            startWith(INITIAL),
+
+                            catchError(err => {
+                                console.error(err)
+                                return [null]
+                            })
                         )
                     )
                 )
-            })
-        )
-        .pipe(map(HoverMerged.from))
+            ).pipe(
+                filter(results => results === null || !results.every(result => result === INITIAL)),
+                map(
+                    results =>
+                        results && results.filter((result): result is Hover | null | undefined => result !== INITIAL)
+                ),
+                map(HoverMerged.from),
+                defaultIfEmpty(null as HoverMerged | null),
+                distinctUntilChanged((a, b) => isEqual(a, b))
+            )
+        })
+    )
 }

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -103,7 +103,7 @@ describe('getLocation', () => {
             scheduler().run(({ cold, expectObservable }) =>
                 expectObservable(
                     getLocation(
-                        cold<ProvideTextDocumentLocationSignature[]>('-a-|', {
+                        cold<ProvideTextDocumentLocationSignature[]>('-a----|', {
                             a: [
                                 () =>
                                     of({
@@ -119,7 +119,14 @@ describe('getLocation', () => {
                         }),
                         FIXTURE.TextDocumentPositionParams
                     )
-                ).toBe('-a-|', {
+                ).toBe('-(ia)-|', {
+                    // TODO: We don't actually *want* this "i" emission, but it is tricky to skip it because we
+                    // need to use the INITIAL emission from combineLatest to avoid blocking on the slowest
+                    // provider.
+                    i: {
+                        uri: 'file:///f1',
+                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    },
                     a: [
                         {
                             uri: 'file:///f1',


### PR DESCRIPTION
fix #1256

The issue is that [combineLatest](https://www.learnrxjs.io/operators/combination/combinelatest.html) will not emit an initial value until each observable emits at least one value. Therefore the `getLocations` and `getHover` observables blocked until the slowest provider returned. That is usually the cross-repo reference provider, which can be quite slow.