### PR TITLE
initialize ext host client last to ensure initialization has finished

### DIFF
--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -65,7 +65,6 @@ export function createExtensionHostClientConnection(
             services.context.data.next(applyContextUpdate(services.context.data.value, updates))
         )
     )
-    subscription.add(new ClientExtensions(connection, services.extensions))
     subscription.add(
         new ClientWindows(
             connection,
@@ -120,6 +119,7 @@ export function createExtensionHostClientConnection(
             )
         )
     )
+    subscription.add(new ClientExtensions(connection, services.extensions))
 
     return {
         setTracer: tracer => {


### PR DESCRIPTION
On initial page load, when the extension host is set up for the first time:

1. The extension host is started
2. The extension host receives data such as the current settings, workspace roots, open documents, etc. 
3. The extension host is asked to activate the extensions that need to be activated

It is important that (2) occur before (3) because extensions often assume that that initial data is present synchronously. If an extension's activate function tries to access data like `sourcegraph.workspace.roots` before (2) is finished, it will be empty.

The fix is to put the ExtensionsClient instantiation last. This ensures that all other XyzClient classes have been constructed first.

This is a difficult thing to test in the current integration tests (`shared/src/api/integration-test/*.test.ts` files). It would be good to improve the testing infra so that this could be tested. Maybe we can do that together tomorrow @lguychard.