### PR TITLE
Generate random ids for anonymous users for usage analytics

### DIFF
--- a/web/src/tracking/eventLogger.tsx
+++ b/web/src/tracking/eventLogger.tsx
@@ -151,8 +151,8 @@ class EventLogger {
      *
      * Only used on Sourcegraph.com, not on self-hosted Sourcegraph instances.
      */
-    private getTelligentDuid(): string {
-        return telligent.getTelligentDuid() || ''
+    private getTelligentDuid(): string | null {
+        return telligent.getTelligentDuid()
     }
 
     /**
@@ -177,7 +177,7 @@ class EventLogger {
         }
 
         let id = localStorage.getItem(uidKey)
-        if (id === null) {
+        if (id === null || id === '') {
             id = this.generateAnonUserID()
             localStorage.setItem(uidKey, id)
         }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1257

Unfortunately it looks like this has been a bug for a while. This fix will ensure anonymous users receive random uuids for usage statistic tracking. Browser ext didn't have the same issue, which may have masked this one.