### PR TITLE
prepare browser extension for 3.0 preview release

### DIFF
--- a/client/browser/src/extension/scripts/background.tsx
+++ b/client/browser/src/extension/scripts/background.tsx
@@ -211,6 +211,16 @@ storage.setSyncMigration(items => {
         newItems.featureFlags.useExtensions = process.env.USE_EXTENSIONS === 'true'
     }
 
+    // TODO: Remove this block after a few releases
+    const clientSettings = JSON.parse(items.clientSettings || '{}')
+    if (clientSettings['codecov.endpoints']) {
+        if (typeof clientSettings.extensions === 'undefined') {
+            clientSettings.extensions = clientSettings.extensions || {}
+        }
+        clientSettings.extensions['souercegraph/codecov'] = true
+        newItems.clientSettings = JSON.stringify(clientSettings, null, 4)
+    }
+
     return { newItems, keysToRemove }
 })
 

--- a/client/browser/src/extension/scripts/background.tsx
+++ b/client/browser/src/extension/scripts/background.tsx
@@ -213,7 +213,7 @@ storage.setSyncMigration(items => {
 
     // TODO: Remove this block after a few releases
     const clientSettings = JSON.parse(items.clientSettings || '{}')
-    if (clientSettings['codecov.endpoints']) {
+    if (clientSettings['codecov.endpoints'] || typeof clientSettings['codecov.showCoverage'] !== 'undefined') {
         if (typeof clientSettings.extensions === 'undefined') {
             clientSettings.extensions = clientSettings.extensions || {}
         }

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -213,8 +213,11 @@ function initCodeIntelligence(
     hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
     controllers: Partial<ExtensionsControllerProps & PlatformContextProps>
 } {
+    const shouldUseExtensions = useExtensions || sourcegraphUrl === 'https://sourcegraph.com'
     const { platformContext, extensionsController }: Partial<ExtensionsControllerProps & PlatformContextProps> =
-        useExtensions && codeHost.getCommandPaletteMount ? initializeExtensions(codeHost.getCommandPaletteMount) : {}
+        shouldUseExtensions && codeHost.getCommandPaletteMount
+            ? initializeExtensions(codeHost.getCommandPaletteMount)
+            : {}
     const simpleProviderFns = extensionsController ? createLSPFromExtensions(extensionsController) : lspViaAPIXlang
 
     /** Emits when the go to definition button was clicked */


### PR DESCRIPTION
This PR does a couple things to help prepare for the 3.0 preview release (https://github.com/sourcegraph/sourcegraph/issues/1187):

- Enables codecov for users with client settings that contain a codecov token
- When pointed at sourcegraph.com, extensions are used no matter the feature flag's value