### PR TITLE
refactor github config watching

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -32,8 +32,6 @@ func init() {
 
 	go func() {
 		t := time.NewTicker(time.Second)
-		defer t.Stop()
-
 		var lastGitHubConf []*schema.GitHubConnection
 		for range t.C {
 			githubConf := conf.Get().Github
@@ -73,6 +71,7 @@ func init() {
 			githubConnections.Set(func() interface{} {
 				return conns
 			})
+
 			gitHubRepositorySyncWorker.restart()
 		}
 	}()

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -30,8 +30,7 @@ func init() {
 	defer t.Stop()
 
 	var lastGitHubConf []*schema.GitHubConnection
-	for {
-		<-t.C
+	for range t.C {
 		githubConf := conf.Get().Github
 		if reflect.DeepEqual(githubConf, lastGitHubConf) {
 			continue


### PR DESCRIPTION
part of https://github.com/sourcegraph/sourcegraph/issues/914#issuecomment-440067022

In a followup PR, `githubConf := conf.Get().Github` will turn into an internal API call to fetch the config from the external services table in the database. This means this code can no longer user conf.Watch (since the code host config will no longer live in the config).

This PR preemptively refactors the code to not depend on conf.Watch. It also includes a minor improvement to not restart gitHubRepositorySyncWorker unless the relevant config actually changes.