### PR TITLE
refactor: code host config watching

### DIFF
--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -29,10 +30,22 @@ import (
 var awsCodeCommitConnections = atomicvalue.New()
 
 func init() {
-	conf.Watch(func() {
-		awsCodeCommitConnections.Set(func() interface{} {
+	awsCodeCommitConnections.Set(func() interface{} {
+		return []*awsCodeCommitConnection{}
+	})
+
+	go func() {
+		t := time.NewTimer(10 * time.Second)
+		var lastConfig []*schema.AWSCodeCommitConnection
+		for range t.C {
+			config := conf.Get().AwsCodeCommit
+			if !reflect.DeepEqual(config, lastConfig) {
+				continue
+			}
+			lastConfig = config
+
 			var conns []*awsCodeCommitConnection
-			for _, c := range conf.Get().AwsCodeCommit {
+			for _, c := range config {
 				conn, err := newAWSCodeCommitConnection(c)
 				if err != nil {
 					log15.Error("Error processing configured AWS CodeCommit connection. Skipping it.", "region", c.Region, "error", err)
@@ -40,10 +53,15 @@ func init() {
 				}
 				conns = append(conns, conn)
 			}
-			return conns
-		})
-		awsCodeCommitRepositorySyncWorker.restart()
-	})
+
+			awsCodeCommitConnections.Set(func() interface{} {
+				return conns
+			})
+
+			awsCodeCommitRepositorySyncWorker.restart()
+		}
+
+	}()
 }
 
 // GetAWSCodeCommitRepositoryMock is set by tests that need to mock GetAWSCodeCommitRepository.

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -60,7 +60,6 @@ func init() {
 
 			awsCodeCommitRepositorySyncWorker.restart()
 		}
-
 	}()
 }
 

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -22,9 +23,19 @@ import (
 var gitlabConnections = atomicvalue.New()
 
 func init() {
-	conf.Watch(func() {
-		gitlabConnections.Set(func() interface{} {
+	gitlabConnections.Set(func() interface{} {
+		return []*gitlabConnection{}
+	})
+
+	go func() {
+		t := time.NewTicker(10 * time.Second)
+		var lastConfig []*schema.GitLabConnection
+		for range t.C {
 			gitlabConf := conf.Get().Gitlab
+			if !reflect.DeepEqual(gitlabConf, lastConfig) {
+				continue
+			}
+			lastConfig = gitlabConf
 
 			var hasGitLabDotComConnection bool
 			for _, c := range gitlabConf {
@@ -53,10 +64,14 @@ func init() {
 				}
 				conns = append(conns, conn)
 			}
-			return conns
-		})
-		gitLabRepositorySyncWorker.restart()
-	})
+
+			gitlabConnections.Set(func() interface{} {
+				return conns
+			})
+
+			gitLabRepositorySyncWorker.restart()
+		}
+	}()
 }
 
 // getGitLabConnection returns the GitLab connection (config + API client) that is responsible for


### PR DESCRIPTION
similar to https://github.com/sourcegraph/sourcegraph/pull/1267/files except for all other code hosts

part of https://github.com/sourcegraph/sourcegraph/issues/914#issuecomment-440067022

Codehost configs will soon be fetched from the database. This means this code can no longer user conf.Watch.

This PR preemptively refactors the code to not depend on conf.Watch. It also includes a minor improvement to not restart workers unless the relevant config actually changes.