### PR TITLE
pkg/db/dbutil: move cmd/frontend/db.Transaction helper to here

### DIFF
--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 )
 
 type externalServices struct{}
@@ -65,7 +66,7 @@ func (c *externalServices) Update(ctx context.Context, id int64, update *Externa
 		}
 		return nil
 	}
-	return Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
+	return dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
 		if update.DisplayName != nil {
 			if err := execUpdate(ctx, tx, sqlf.Sprintf("display_name=%s", update.DisplayName)); err != nil {
 				return err

--- a/cmd/frontend/db/helpers.go
+++ b/cmd/frontend/db/helpers.go
@@ -1,13 +1,7 @@
 package db
 
 import (
-	"context"
-	"database/sql"
-
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 )
 
 // LimitOffset specifies SQL LIMIT and OFFSET counts. A pointer to it is typically embedded in other options
@@ -23,34 +17,4 @@ func (o *LimitOffset) SQL() *sqlf.Query {
 		return &sqlf.Query{}
 	}
 	return sqlf.Sprintf("LIMIT %d OFFSET %d", o.Limit, o.Offset)
-}
-
-// Transaction calls f within a transaction, rolling back if any error is
-// returned by the function.
-func Transaction(ctx context.Context, db *sql.DB, f func(tx *sql.Tx) error) (err error) {
-	finish := func(tx *sql.Tx) {
-		if err != nil {
-			if err2 := tx.Rollback(); err2 != nil {
-				err = multierror.Append(err, err2)
-			}
-			return
-		}
-		err = tx.Commit()
-	}
-
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Transaction")
-	defer func() {
-		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", err.Error())
-		}
-		span.Finish()
-	}()
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer finish(tx)
-	return f(tx)
 }

--- a/enterprise/cmd/frontend/db/global_deps.go
+++ b/enterprise/cmd/frontend/db/global_deps.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/pkg/inventory"
 	"github.com/sourcegraph/sourcegraph/xlang"
 )
@@ -339,7 +340,7 @@ func (g *globalDeps) doListTotalRefsGo(ctx context.Context, source string) ([]ap
 }
 
 func (g *globalDeps) UpdateIndexForLanguage(ctx context.Context, language string, repo api.RepoID, deps []lspext.DependencyReference) (err error) {
-	err = db.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
+	err = dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
 		// Update the table.
 		err = g.update(ctx, tx, language, deps, repo)
 		if err != nil {

--- a/enterprise/cmd/frontend/db/pkgs.go
+++ b/enterprise/cmd/frontend/db/pkgs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 )
 
 // pkgs provides access to the `pkgs` table.
@@ -25,7 +26,7 @@ import (
 type pkgs struct{}
 
 func (p *pkgs) UpdateIndexForLanguage(ctx context.Context, language string, repo api.RepoID, pks []lspext.PackageInformation) (err error) {
-	err = db.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
+	err = dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
 		// Update the pkgs table.
 		err = p.update(ctx, tx, repo, language, pks)
 		if err != nil {

--- a/enterprise/cmd/frontend/db/pkgs_test.go
+++ b/enterprise/cmd/frontend/db/pkgs_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 )
 
 func TestPkgs_update_delete(t *testing.T) {
@@ -40,7 +41,7 @@ func TestPkgs_update_delete(t *testing.T) {
 	}}
 
 	t.Log("update")
-	if err := db.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
+	if err := dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
 		if err := Pkgs.update(ctx, tx, rp.ID, "go", pks); err != nil {
 			return err
 		}
@@ -155,7 +156,7 @@ func TestPkgs_ListPackages(t *testing.T) {
 
 	createdAt := time.Now()
 	for repo, pks := range repoToPkgs {
-		if err := db.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
+		if err := dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, `INSERT INTO repo(id, uri, created_at) VALUES ($1, $2, $3)`, repo, strconv.Itoa(int(repo)), createdAt); err != nil {
 				return err
 			}

--- a/pkg/db/dbutil/dbutil.go
+++ b/pkg/db/dbutil/dbutil.go
@@ -1,0 +1,40 @@
+package dbutil
+
+import (
+	"context"
+	"database/sql"
+
+	multierror "github.com/hashicorp/go-multierror"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+// Transaction calls f within a transaction, rolling back if any error is
+// returned by the function.
+func Transaction(ctx context.Context, db *sql.DB, f func(tx *sql.Tx) error) (err error) {
+	finish := func(tx *sql.Tx) {
+		if err != nil {
+			if err2 := tx.Rollback(); err2 != nil {
+				err = multierror.Append(err, err2)
+			}
+			return
+		}
+		err = tx.Commit()
+	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Transaction")
+	defer func() {
+		if err != nil {
+			ext.Error.Set(span, true)
+			span.SetTag("err", err.Error())
+		}
+		span.Finish()
+	}()
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer finish(tx)
+	return f(tx)
+}


### PR DESCRIPTION
I need to use this from `pkg/db/globalstatedb` in an upcoming PR, so this makes sense to move to a non-frontend package.