### PR TITLE
pkg/db/globalstatedb: add management console password state / generation

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -183,10 +183,12 @@ Foreign-key constraints:
 
 # Table "public.global_state"
 ```
-   Column    |  Type   |       Modifiers        
--------------+---------+------------------------
- site_id     | uuid    | not null
- initialized | boolean | not null default false
+         Column          |  Type   |         Modifiers         
+-------------------------+---------+---------------------------
+ site_id                 | uuid    | not null
+ initialized             | boolean | not null default false
+ mgmt_password_plaintext | text    | not null default ''::text
+ mgmt_password_bcrypt    | text    | not null default ''::text
 Indexes:
     "global_state_pkey" PRIMARY KEY, btree (site_id)
 

--- a/migrations/1528395563_.down.sql
+++ b/migrations/1528395563_.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE global_state DROP COLUMN mgmt_password_plaintext;
+ALTER TABLE global_state DROP COLUMN mgmt_password_bcrypt;
+END;

--- a/migrations/1528395563_.up.sql
+++ b/migrations/1528395563_.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE global_state ADD COLUMN mgmt_password_plaintext TEXT NOT NULL DEFAULT '';
+ALTER TABLE global_state ADD COLUMN mgmt_password_bcrypt TEXT NOT NULL DEFAULT '';
+END;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -188,6 +188,8 @@
 // 1528395561_.up.sql (311B)
 // 1528395562_.down.sql (65B)
 // 1528395562_.up.sql (420B)
+// 1528395563_.down.sql (133B)
+// 1528395563_.up.sql (181B)
 
 package migrations
 
@@ -4016,6 +4018,46 @@ func _1528395562_UpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395563_DownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xcf\xc9\x4f\x4a\xcc\x89\x2f\x2e\x49\x2c\x49\x55\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xc8\x4d\xcf\x2d\x89\x2f\x48\x2c\x2e\x2e\xcf\x2f\x4a\x89\x2f\xc8\x49\xcc\xcc\x2b\x49\xad\x28\x21\x4b\x77\x52\x72\x51\x65\x41\x89\x35\x97\xab\x9f\x8b\x35\x17\x20\x00\x00\xff\xff\x1a\x4d\x1c\xf4\x85\x00\x00\x00")
+
+func _1528395563_DownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395563_DownSql,
+		"1528395563_.down.sql",
+	)
+}
+
+func _1528395563_DownSql() (*asset, error) {
+	bytes, err := _1528395563_DownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395563_.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1d, 0x9a, 0xf8, 0x82, 0x97, 0xb1, 0x3a, 0x19, 0x21, 0x43, 0x55, 0x7d, 0xc4, 0x1b, 0x69, 0x92, 0xfc, 0xb3, 0x95, 0x35, 0x64, 0x2e, 0xdb, 0xc9, 0x23, 0xdf, 0x31, 0xbe, 0xa6, 0x7a, 0xef, 0x41}}
+	return a, nil
+}
+
+var __1528395563_UpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xcf\xc9\x4f\x4a\xcc\x89\x2f\x2e\x49\x2c\x49\x55\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\xc8\x4d\xcf\x2d\x89\x2f\x48\x2c\x2e\x2e\xcf\x2f\x4a\x89\x2f\xc8\x49\xcc\xcc\x2b\x49\xad\x28\x51\x08\x71\x8d\x08\x51\xf0\xf3\x0f\x51\xf0\x0b\xf5\xf1\x51\x70\x71\x75\x73\x0c\xf5\x09\x51\x50\x57\x27\xc7\xd4\xa4\xe4\xa2\xca\x02\x7c\x46\xba\xfa\xb9\x58\x73\x01\x02\x00\x00\xff\xff\x3d\x99\x20\xff\xb5\x00\x00\x00")
+
+func _1528395563_UpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395563_UpSql,
+		"1528395563_.up.sql",
+	)
+}
+
+func _1528395563_UpSql() (*asset, error) {
+	bytes, err := _1528395563_UpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395563_.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc8, 0x7, 0xaf, 0x1e, 0xeb, 0x6c, 0xdf, 0x93, 0xd8, 0xc2, 0xbd, 0x1, 0x30, 0x9f, 0x3c, 0x67, 0x56, 0x32, 0xdc, 0xfb, 0x1a, 0x33, 0x8b, 0x69, 0x2b, 0x1d, 0x5b, 0x7c, 0x97, 0xc5, 0x1d, 0x48}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -4482,6 +4524,10 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395562_.down.sql": _1528395562_DownSql,
 
 	"1528395562_.up.sql": _1528395562_UpSql,
+
+	"1528395563_.down.sql": _1528395563_DownSql,
+
+	"1528395563_.up.sql": _1528395563_UpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -4713,6 +4759,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395561_.up.sql":                                          &bintree{_1528395561_UpSql, map[string]*bintree{}},
 	"1528395562_.down.sql":                                        &bintree{_1528395562_DownSql, map[string]*bintree{}},
 	"1528395562_.up.sql":                                          &bintree{_1528395562_UpSql, map[string]*bintree{}},
+	"1528395563_.down.sql":                                        &bintree{_1528395563_DownSql, map[string]*bintree{}},
+	"1528395563_.up.sql":                                          &bintree{_1528395563_UpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/pkg/db/globalstatedb/globalstatedb.go
+++ b/pkg/db/globalstatedb/globalstatedb.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"database/sql"
 
+	cryptorand "crypto/rand"
+
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type State struct {
@@ -109,4 +114,163 @@ func tryInsertNew(ctx context.Context, dbh interface {
 		}
 	}
 	return err
+}
+
+// ManagementConsoleState describes state regarding the management console.
+type ManagementConsoleState struct {
+	// PasswordPlaintext is the plaintext version of the management console
+	// password. It is automatically generated if there is not an existing
+	// management console password. However, the plaintext version here only
+	// remains until the admin dismisses it. After that, only the bcrypt form
+	// remains (see DismissManagementConsolePassword).
+	PasswordPlaintext string
+
+	// PasswordBcrypt is the bcrypt form of the management console password.
+	PasswordBcrypt string
+}
+
+// ErrCannotUseManagementConsole is returned by AuthenticateManagementConsole
+// and GetManagementConsolePlaintextPassword if the site is not yet
+// initialized.
+var ErrCannotUseManagementConsole = errors.New("cannot use management console until site is initialized")
+
+// AuthenticateManagementConsole handles authentication for the management
+// console. It returns nil on success and an error otherwise.
+//
+// Because the management console is considered both public on the internet AND
+// without an authentication rate limit (this could lock out the real site
+// admin), authentication uses a prohibitively costly bcrypt hash which takes
+// 2.2s on e.g. a modern laptop. It is therefor also important for the password
+// to be very long and random.
+//
+// 🚨 SECURITY: This method MUST be called before granting anyone access to the
+// management console (it is the only form of authentication).
+func AuthenticateManagementConsole(ctx context.Context, password string) error {
+	mgmt, err := getManagementConsoleState(ctx)
+	if err != nil {
+		return err
+	}
+	return bcrypt.CompareHashAndPassword([]byte(mgmt.PasswordBcrypt), []byte(password))
+}
+
+// ClearManagementConsolePlaintextPassword clears the plaintext form of the
+// management console password so that it is no longer stored insecurely in the
+// DB. It is stored initially so the admin can retrieve it, and once the admin
+// does it is cleared.
+//
+// 🚨 SECURITY: Only site admins or someone authenticated via AuthenticateManagementConsole
+// should be allowed to invoke this method. Any other user could be a malicious
+// actor attempting to lock the admin out.
+func ClearManagementConsolePlaintextPassword(ctx context.Context) error {
+	_, err := dbconn.Global.ExecContext(ctx, "UPDATE global_state SET mgmt_password_plaintext=''")
+	if err != nil {
+		return errors.Wrap(err, "UPDATE")
+	}
+	return nil
+}
+
+// GetManagementConsolePlaintextPassword fetches and returns the management console
+// plaintext password form. After the admin is aware of this, ClearManagementConsolePlaintextPassword
+// should be called to clear it.
+//
+// 🚨 SECURITY: The result of this function should ONLY ever be shown to site
+// admins. Any other user could be a malicious actor.
+func GetManagementConsolePlaintextPassword(ctx context.Context) (string, error) {
+	mgmt, err := getManagementConsoleState(ctx)
+	if err != nil {
+		return "", err
+	}
+	return mgmt.PasswordPlaintext, nil
+}
+
+// getManagementConsoleState fetches and returns the global management console
+// state containing the password of the management console.
+func getManagementConsoleState(ctx context.Context) (*ManagementConsoleState, error) {
+	// We first enforce that the site is initialized. This is purely to ensure
+	// the table row is created for us already.
+	initialized, err := SiteInitialized(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !initialized {
+		return nil, ErrCannotUseManagementConsole
+	}
+
+	var finalState *ManagementConsoleState
+	err = dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
+		// Get the current management console state.
+		mgmt, err := doGetManagementConsoleState(ctx, tx)
+		if err != nil {
+			return errors.Wrap(err, "doGetManagementConsoleState")
+		}
+
+		// If there is no password (e.g. new instance, old instances migrated
+		// to new Sourcegraph version with management console, etc), then we
+		// generate and store one.
+		if mgmt.PasswordBcrypt != "" {
+			// We have a password already.
+			finalState = mgmt
+			return nil
+		}
+
+		// Generate a new password and store both plaintext and bcrypt forms.
+		passwordPlaintext, err := generateRandomPassword()
+		if err != nil {
+			return errors.Wrap(err, "generateRandomPassword")
+		}
+		passwordBcrypt, err := bcrypt.GenerateFromPassword([]byte(passwordPlaintext), 15)
+		if err != nil {
+			return errors.Wrap(err, "bcrypt")
+		}
+		_, err = tx.ExecContext(ctx,
+			"UPDATE global_state SET mgmt_password_plaintext=$1, mgmt_password_bcrypt=$2",
+			passwordPlaintext, passwordBcrypt,
+		)
+		if err != nil {
+			return errors.Wrap(err, "UPDATE")
+		}
+
+		finalState = &ManagementConsoleState{
+			PasswordPlaintext: passwordPlaintext,
+			PasswordBcrypt:    string(passwordBcrypt),
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "transaction")
+	}
+	return finalState, nil
+}
+
+func doGetManagementConsoleState(ctx context.Context, tx *sql.Tx) (*ManagementConsoleState, error) {
+	mgmt := &ManagementConsoleState{}
+	err := dbconn.Global.QueryRowContext(ctx, "SELECT mgmt_password_plaintext, mgmt_password_bcrypt FROM global_state LIMIT 1").Scan(
+		&mgmt.PasswordPlaintext,
+		&mgmt.PasswordBcrypt,
+	)
+	return mgmt, err
+}
+
+var allowedPasswordCharacters []rune
+
+func init() {
+	allowedPasswordCharacters = append(allowedPasswordCharacters, []rune("abcdefghijklmnopqrstuvwxyz")...)
+	allowedPasswordCharacters = append(allowedPasswordCharacters, []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")...)
+	allowedPasswordCharacters = append(allowedPasswordCharacters, []rune("0123456789")...)
+	allowedPasswordCharacters = append(allowedPasswordCharacters, []rune(`~!@#$%^&*_-+=<,>.?`)...)
+}
+
+// generateRandomPassword generates a random ASCII password of length 128 using
+// crypto/rand as the source.
+func generateRandomPassword() (string, error) {
+	data := make([]byte, 128)
+	_, err := cryptorand.Read(data)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate crypto/rand data")
+	}
+	var generated []rune
+	for _, n := range data {
+		generated = append(generated, allowedPasswordCharacters[int(n)%len(allowedPasswordCharacters)])
+	}
+	return string(generated), nil
 }

--- a/pkg/db/globalstatedb/globalstatedb_test.go
+++ b/pkg/db/globalstatedb/globalstatedb_test.go
@@ -3,6 +3,7 @@ package globalstatedb
 import (
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
 )
 
@@ -17,5 +18,80 @@ func TestGet(t *testing.T) {
 	}
 	if config.SiteID == "" {
 		t.Fatal("expected site_id to be set")
+	}
+}
+
+func TestGenerateRandomPassword(t *testing.T) {
+	pw, err := generateRandomPassword()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pw) != 128 {
+		t.Fatal("expected len == 128")
+	}
+
+	pw2, err := generateRandomPassword()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pw == pw2 {
+		t.Fatal("generated passwords must be random")
+	}
+}
+
+func TestManagementConsoleState(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := dbtesting.TestContext(t)
+
+	// Site must be initialized to get mgmt console state.
+	mgmt, err := getManagementConsoleState(ctx)
+	if err != ErrCannotUseManagementConsole {
+		t.Fatal("expected error")
+	}
+	if mgmt != nil {
+		t.Fatal("expected nil")
+	}
+
+	// Initialize the site.
+	_, err = EnsureInitialized(ctx, dbconn.Global)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now we can get mgmt console state.
+	mgmt, err = getManagementConsoleState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We expect auto generated plaintext + bcrypt passwords.
+	if len(mgmt.PasswordPlaintext) != 128 {
+		t.Fatal("expected 128 character password")
+	}
+	if mgmt.PasswordBcrypt == "" {
+		t.Fatal("expected bcrypt password hash")
+	}
+	passwordPlaintext := mgmt.PasswordPlaintext
+
+	// Clear the plaintext password so it is no longer stored insecurely in the DB.
+	if err := ClearManagementConsolePlaintextPassword(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should now be impossible to fetch plaintext password.
+	plaintext, err := GetManagementConsolePlaintextPassword(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plaintext != "" {
+		t.Fatal("expected plaintext password to be cleared")
+	}
+
+	// Now we should be able to authenticate.
+	err = AuthenticateManagementConsole(ctx, passwordPlaintext)
+	if err != nil {
+		t.Fatal("failed to authenticate", err)
 	}
 }


### PR DESCRIPTION
Depends on #1287

This PR adds to our global DB state the management console password. How this password will be used is outlined in https://github.com/sourcegraph/sourcegraph/issues/965#issuecomment-441552016

Actual usage of this password for authentication of the management console will come in a later PR. In the mean time, this poses zero security risk and as such I will merge quickly. @beyang @nicksnyder please review post-merge.