### PR TITLE
Fix adding public repos when no code hosts are configured

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -35,9 +35,6 @@ func init() {
 		var lastGitHubConf []*schema.GitHubConnection
 		for range t.C {
 			githubConf := conf.Get().Github
-			if reflect.DeepEqual(githubConf, lastGitHubConf) {
-				continue
-			}
 
 			var hasGitHubDotComConnection bool
 			for _, c := range githubConf {
@@ -57,6 +54,9 @@ func init() {
 				})
 			}
 
+			if reflect.DeepEqual(githubConf, lastGitHubConf) {
+				continue
+			}
 			lastGitHubConf = githubConf
 
 			var conns []*githubConnection

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -32,9 +32,6 @@ func init() {
 		var lastConfig []*schema.GitLabConnection
 		for range t.C {
 			gitlabConf := conf.Get().Gitlab
-			if reflect.DeepEqual(gitlabConf, lastConfig) {
-				continue
-			}
 
 			var hasGitLabDotComConnection bool
 			for _, c := range gitlabConf {
@@ -54,6 +51,9 @@ func init() {
 				})
 			}
 
+			if reflect.DeepEqual(gitlabConf, lastConfig) {
+				continue
+			}
 			lastConfig = gitlabConf
 
 			var conns []*gitlabConnection


### PR DESCRIPTION
fixes https://github.com/sourcegraph/sourcegraph/issues/1288

https://github.com/sourcegraph/sourcegraph/pull/1267 introduced a regression where the default connection list would get initialized to empty and then the first run through the loop we would read an empty config and conclude that nothing had changed. This was wrong because we need to have a default entry.

The simple fix is to move the equality check AFTER we have run the logic that adds the default value.