### PR TITLE
create the blob url in the same context its being used

### DIFF
--- a/client/browser/src/browser/runtime.ts
+++ b/client/browser/src/browser/runtime.ts
@@ -17,6 +17,7 @@ export interface Message {
         | 'openOptionsPage'
         | 'fetched-files'
         | 'repo-closed'
+        | 'createBlobURL'
     payload?: any
 }
 


### PR DESCRIPTION
The content script was creating a blob url for extensions and then giving it to the background script to run in the web worker. This caused a security error to be thrown since the content script doesn't have permission to the script. Not sure how or why this is allowed in Chrome.

Closes https://github.com/sourcegraph/sourcegraph/issues/1285.