### PR TITLE
Blank out the value of the shield endpoint since it's unimplemented

### DIFF
--- a/cmd/frontend/internal/app/badge.go
+++ b/cmd/frontend/internal/app/badge.go
@@ -44,11 +44,6 @@ func badgeValueFmt(totalRefs int) string {
 }
 
 func serveRepoBadge(w http.ResponseWriter, r *http.Request) error {
-	value, err := badgeValue(r)
-	if err != nil {
-		return err
-	}
-
 	v := url.Values{}
 	v.Set("logo", "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3Ny4wNzUgNzcuNyI+PHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQ3LjMyMyA3Ny43Yy0zLjU5NCAwLTYuNzktMi4zOTYtNy43ODctNS45OWwtMTcuMTcyLTYxLjdjLS45OTgtNC4zOTMgMS41OTgtOC43ODYgNS45OS05Ljc4NCA0LjE5My0xIDguMzg3IDEuMzk3IDkuNTg0IDUuMzlsMTYuOTczIDYxLjdjMS4xOTggNC4zOTQtMS4zOTcgOC43ODYtNS41OSA5Ljk4NC0uNi4yLTEuMzk3LjQtMS45OTcuNHoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNMTcuMzcyIDcwLjcxYy00LjM5MyAwLTcuOTg3LTMuNTkzLTcuOTg3LTcuOTg1IDAtMS45OTcuOC0zLjk5NCAxLjk5Ny01LjM5Mkw1NC4xMTIgOS40MWMyLjk5NS0zLjM5MyA3Ljk4Ni0zLjU5MyAxMS4zOC0uNTk4czMuNTk1IDcuOTg3LjYgMTEuMzhsLTQyLjczIDQ3LjcyM2MtMS41OTcgMS43OTgtMy43OTQgMi43OTYtNS45OSAyLjc5NnoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNNjkuMDg3IDU2LjczNGMtLjc5OCAwLTEuNTk3LS4yLTIuNTk2LS40TDUuNTkgMzYuMzY4QzEuNCAzNC45Ny0uOTk3IDMwLjM3Ny40IDI2LjE4NGMxLjM5Ny00LjE5MyA1Ljk5LTYuNTkgMTAuMTgzLTUuMTlsNjAuOSAxOS45NjZjNC4xOTMgMS4zOTcgNi41OSA1Ljk5IDUuMTkgMTAuMTg0LS45OTYgMy4zOTQtMy45OSA1LjU5LTcuNTg2IDUuNTl6Ii8+PC9zdmc+")
 
@@ -58,9 +53,10 @@ func serveRepoBadge(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	u := &url.URL{
-		Scheme:   "https",
-		Host:     "img.shields.io",
-		Path:     "/badge/used by-" + badgeValueFmt(value) + "-brightgreen.svg",
+		Scheme: "https",
+		Host:   "img.shields.io",
+		// %3F is a question mark (?)
+		Path:     "/badge/used by-%3F-brightgreen.svg",
 		RawQuery: v.Encode(),
 	}
 	http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)

--- a/cmd/frontend/internal/httpapi/repo_shield.go
+++ b/cmd/frontend/internal/httpapi/repo_shield.go
@@ -38,15 +38,11 @@ func badgeValueFmt(totalRefs int) string {
 }
 
 func serveRepoShield(w http.ResponseWriter, r *http.Request) error {
-	value, err := badgeValue(r)
-	if err != nil {
-		return err
-	}
 	return writeJSON(w, &struct {
 		// Note: Named lowercase because the JSON is consumed by shields.io JS
 		// code.
 		Value string `json:"value"`
 	}{
-		Value: badgeValueFmt(value),
+		Value: "?",
 	})
 }

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -34,7 +34,7 @@ func TestRepoShield(t *testing.T) {
 	c := newTest()
 
 	wantResp := map[string]interface{}{
-		"value": " 200 projects",
+		"value": "?",
 	}
 
 	backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/584 removed the implementation of the shield endpoint and replaced it with a panic. This replaces it with a dummy question mark `?` until we get around to fixing it later.