### PR TITLE
update the extension API to merge search filter contributions

### DIFF
--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -136,6 +136,7 @@ export class ContributionRegistry {
             distinctUntilChanged((a, b) => isEqual(a, b))
         )
     }
+
     /**
      * All contribution entries, emitted whenever the set of registered contributions changes.
      *

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -136,7 +136,6 @@ export class ContributionRegistry {
             distinctUntilChanged((a, b) => isEqual(a, b))
         )
     }
-
     /**
      * All contribution entries, emitted whenever the set of registered contributions changes.
      *
@@ -180,6 +179,13 @@ export function mergeContributions(contributions: Contributions[]): Contribution
                         merged.menus[menu] = [...merged.menus[menu]!, ...items]
                     }
                 }
+            }
+        }
+        if (c.searchFilters) {
+            if (!merged.searchFilters) {
+                merged.searchFilters = [...c.searchFilters]
+            } else {
+                merged.searchFilters = [...merged.searchFilters, ...c.searchFilters]
             }
         }
     }


### PR DESCRIPTION
Adds search filter contributions to the `mergeContributions` method which runs when various extensions are contributing to the app.

Resolves: https://github.com/sourcegraph/sourcegraph/issues/1303

NOCHANGELOG needed as it fixes an issue in a feature that hasn't been officially released.