### PR TITLE
Hover actions from extensions, better handling of multiple def providers

### DIFF
--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -83,7 +83,6 @@ $theme-colors-light: (
 @import './shared/components/symbols';
 @import './shared/components/CodeViewToolbar.scss';
 @import './libs/options/styles.scss';
-@import '@sourcegraph/codeintellify/lib/HoverOverlay.scss';
 @import './libs/code_intelligence/HoverOverlay.scss';
 @import './shared';
 

--- a/client/browser/src/libs/code_intelligence/HoverOverlay.scss
+++ b/client/browser/src/libs/code_intelligence/HoverOverlay.scss
@@ -1,6 +1,7 @@
 @import '../bitbucket/style.scss';
 @import '../gitlab/style.scss';
 @import '../../shared/global-styles/variables.scss';
+@import '../../../../../shared/src/hover/HoverOverlay.scss';
 
 .hover-overlay-mount__phabricator {
     .hover-overlay {

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -5,9 +5,7 @@ import {
     DOMFunctions,
     findPositionsFromEvents,
     Hoverifier,
-    HoverOverlay,
     HoverState,
-    LinkComponent,
     PositionAdjuster,
 } from '@sourcegraph/codeintellify'
 import { propertyIsDefined } from '@sourcegraph/codeintellify/lib/helpers'
@@ -18,9 +16,12 @@ import { animationFrameScheduler, Observable, of, Subject, Subscription } from '
 import { filter, map, mergeMap, observeOn, withLatestFrom } from 'rxjs/operators'
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 
-import { HoverMerged } from '@sourcegraph/codeintellify/lib/types'
+import { ActionItemProps } from '../../../../../shared/src/actions/ActionItem'
 import { Model, ViewComponentData } from '../../../../../shared/src/api/client/model'
+import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
+import { getHoverActions, registerHoverContributions } from '../../../../../shared/src/hover/actions'
+import { HoverContext, HoverOverlay } from '../../../../../shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryContext } from '../../../../../shared/src/telemetry/telemetryContext'
@@ -30,17 +31,11 @@ import {
     RepoSpec,
     ResolvedRevSpec,
     RevSpec,
-    toPrettyBlobURL,
     toRootURI,
     toURIWithPath,
     ViewStateSpec,
 } from '../../../../../shared/src/util/url'
-import {
-    createJumpURLFetcher,
-    createLSPFromExtensions,
-    lspViaAPIXlang,
-    toTextDocumentIdentifier,
-} from '../../shared/backend/lsp'
+import { createLSPFromExtensions, lspViaAPIXlang, toTextDocumentIdentifier } from '../../shared/backend/lsp'
 import { ButtonProps, CodeViewToolbar } from '../../shared/components/CodeViewToolbar'
 import { eventLogger, sourcegraphUrl, useExtensions } from '../../shared/util/context'
 import { bitbucketServerCodeHost } from '../bitbucket/code_intelligence'
@@ -224,7 +219,7 @@ export interface FileInfo {
 function initCodeIntelligence(
     codeHost: CodeHost
 ): {
-    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
     controllers: ExtensionsControllerProps & PlatformContextProps
 } {
     const {
@@ -233,13 +228,7 @@ function initCodeIntelligence(
     }: PlatformContextProps & ExtensionsControllerProps = initializeExtensions(codeHost)
 
     const shouldUseExtensions = useExtensions || sourcegraphUrl === 'https://sourcegraph.com'
-    const { fetchHover, fetchDefinition } = shouldUseExtensions
-        ? createLSPFromExtensions(extensionsController)
-        : lspViaAPIXlang
-
-    /** Emits when the go to definition button was clicked */
-    const goToDefinitionClicks = new Subject<MouseEvent>()
-    const nextGoToDefinitionClick = (event: MouseEvent) => goToDefinitionClicks.next(event)
+    const { getHover } = shouldUseExtensions ? createLSPFromExtensions(extensionsController) : lspViaAPIXlang
 
     /** Emits when the close button was clicked */
     const closeButtonClicks = new Subject<MouseEvent>()
@@ -251,35 +240,24 @@ function initCodeIntelligence(
 
     const relativeElement = document.body
 
-    const fetchJumpURL = createJumpURLFetcher(fetchDefinition, location => platformContext.urlToFile(location))
-
     const containerComponentUpdates = new Subject<void>()
 
-    const hoverifier = createHoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>({
+    registerHoverContributions({ extensionsController, platformContext, history: H.createBrowserHistory() })
+
+    const hoverifier = createHoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>({
         closeButtonClicks,
-        goToDefinitionClicks,
         hoverOverlayElements,
         hoverOverlayRerenders: containerComponentUpdates.pipe(
             withLatestFrom(hoverOverlayElements),
             map(([, hoverOverlayElement]) => ({ hoverOverlayElement, relativeElement })),
             filter(propertyIsDefined('hoverOverlayElement'))
         ),
-        pushHistory: path => {
-            location.href = path
-        },
-        fetchHover: ({ line, character, part, ...rest }) =>
-            fetchHover({ ...rest, position: { line, character } }).pipe(
+        getHover: ({ line, character, part, ...rest }) =>
+            getHover({ ...rest, position: { line, character } }).pipe(
                 map(hover => (hover ? (hover as HoverMerged) : hover))
             ),
-        fetchJumpURL,
-        getReferencesURL: position => toPrettyBlobURL({ ...position, position, viewState: 'references' }),
+        getActions: context => getHoverActions({ extensionsController, platformContext }, context),
     })
-
-    const Link: LinkComponent = ({ to, children, ...rest }) => (
-        <a href={new URL(to, sourcegraphUrl).href} {...rest}>
-            {children}
-        </a>
-    )
 
     const classNames = ['hover-overlay-mount', `hover-overlay-mount__${codeHost.name}`]
 
@@ -316,7 +294,7 @@ function initCodeIntelligence(
         return mount
     }
 
-    class HoverOverlayContainer extends React.Component<{}, HoverState> {
+    class HoverOverlayContainer extends React.Component<{}, HoverState<HoverContext, HoverMerged, ActionItemProps>> {
         private portal: HTMLElement | null = null
 
         private observer: MutationObserver
@@ -358,16 +336,17 @@ function initCodeIntelligence(
                 ? createPortal(
                       <HoverOverlay
                           {...hoverOverlayProps}
-                          linkComponent={Link}
                           hoverRef={nextOverlayElement}
-                          onGoToDefinitionClick={nextGoToDefinitionClick}
+                          extensionsController={extensionsController!} // TODO!(sqs): fix
+                          platformContext={platformContext!} // TODO!(sqs): fix
+                          location={H.createLocation(window.location)}
                           onCloseButtonClick={nextCloseButtonClick}
                       />,
                       this.portal
                   )
                 : null
         }
-        private getHoverOverlayProps(): HoverState['hoverOverlayProps'] {
+        private getHoverOverlayProps(): HoverState<HoverContext, HoverMerged, ActionItemProps>['hoverOverlayProps'] {
             if (!this.state.hoverOverlayProps) {
                 return undefined
             }

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -14,7 +14,9 @@ const config = {
   // unexpected token import/export", then add it here. See
   // https://github.com/facebook/create-react-app/issues/5241#issuecomment-426269242 for more information on why
   // this is necessary.
-  transformIgnorePatterns: ['/node_modules/(?!abortable-rx|@sourcegraph/react-loading-spinner)'],
+  transformIgnorePatterns: [
+    '/node_modules/(?!abortable-rx|@sourcegraph/react-loading-spinner|@sourcegraph/codeintellify)',
+  ],
 
   // By default, don't clutter `yarn test --watch` output with the full coverage table. To see it, use the
   // `--coverageReporters text` jest option.

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
   "dependencies": {
     "@sentry/browser": "^4.4.2",
     "@slimsag/react-shortcuts": "^1.2.1",
-    "@sourcegraph/codeintellify": "^5.1.0",
+    "@sourcegraph/codeintellify": "^6.0.2",
     "@sourcegraph/extension-api-types": "link:packages/@sourcegraph/extension-api-types",
     "@sourcegraph/react-loading-spinner": "0.0.7",
     "@sqs/jsonc-parser": "^1.0.3",
@@ -200,6 +200,7 @@
     "react-visibility-sensor": "^5.0.2",
     "reactstrap": "https://registry.npmjs.org/@sqs/reactstrap/-/reactstrap-6.5.0-tmp1.tgz",
     "rxjs": "^6.3.3",
+    "sanitize-html": "^1.20.0",
     "sourcegraph": "link:packages/sourcegraph-extension-api",
     "string-score": "^1.0.1",
     "textarea-caret": "3.1.0",

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -59,13 +59,15 @@ export interface ActionItemProps {
     title?: React.ReactElement<any>
 }
 
-interface Props extends ActionItemProps {
+export interface ActionItemComponentProps {
     extensionsController:
         | ExtensionsControllerProps['extensionsController']
         | { executeCommand: (params: ExecuteCommandParams) => Promise<any> }
     platformContext: PlatformContextProps['platformContext'] | { forceUpdateTooltip: () => void }
     location: H.Location
 }
+
+interface Props extends ActionItemProps, ActionItemComponentProps {}
 
 const LOADING: 'loading' = 'loading'
 

--- a/shared/src/api/client/services/registry.ts
+++ b/shared/src/api/client/services/registry.ts
@@ -55,7 +55,7 @@ export abstract class DocumentFeatureProviderRegistry<
      * @returns an observable of the set of registered providers that apply to the document. The observable emits
      * initially and whenever the set changes (due to a provider being registered or unregistered).
      */
-    protected providersForDocument(
+    public providersForDocument(
         document: TextDocumentIdentifier,
         filter?: (registrationOptions: O) => boolean
     ): Observable<P[]> {

--- a/shared/src/api/protocol/contribution.ts
+++ b/shared/src/api/protocol/contribution.ts
@@ -197,6 +197,9 @@ export enum ContributableMenu {
     /** A directory page (including for the root directory of a repository). */
     DirectoryPage = 'directory/page',
 
+    /** The hover tooltip. */
+    Hover = 'hover',
+
     /** The panel toolbar. */
     PanelToolbar = 'panel/toolbar',
 

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -1,0 +1,113 @@
+@import '../node_modules/@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
+
+.hover-overlay {
+    position: absolute;
+    min-width: 6rem;
+    max-width: 32rem;
+    max-height: 15rem;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    z-index: 100;
+
+    $animation-duration: 100ms;
+    transition: opacity $animation-duration ease-in-out;
+
+    &__close-button {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: 0.25rem;
+        border-radius: 0;
+        background: transparent;
+        z-index: 1;
+        border: none;
+        opacity: 0;
+        transition: opacity $animation-duration ease-in-out;
+        &:focus {
+            outline: none; // override GitHub style
+        }
+        &:active {
+            box-shadow: none; // override GitHub style
+        }
+    }
+    &:hover &__close-button {
+        opacity: 1;
+    }
+
+    &__row {
+        display: block;
+        width: 100%;
+        margin: 0;
+        &:not(:first-child) {
+            border-top: 1px solid var(--border-color);
+        }
+        hr {
+            margin: 0.5rem -0.5rem;
+            background: var(--border-color);
+        }
+        p,
+        pre {
+            &:not(:last-child) {
+                margin-bottom: 0.5rem;
+            }
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+
+    &__contents {
+        flex: 1 1 auto;
+        overflow-y: auto;
+    }
+
+    &__content {
+        padding: 0.5rem;
+        overflow-x: auto;
+        word-wrap: normal;
+        p:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    &__actions {
+        flex: 0 0 auto;
+        display: flex;
+    }
+
+    &__action:not(:first-child) {
+        border-left: 1px solid var(--border-color);
+    }
+
+    &__action {
+        text-align: center;
+        border: none;
+    }
+
+    &__action,
+    &__actions-placeholder {
+        flex: 1 1 auto;
+        border-radius: 0;
+    }
+
+    &__loader-row {
+        text-align: center;
+    }
+
+    &__loader-row,
+    &__hover-error,
+    &__content-error,
+    &__alert-below {
+        padding: 0.5rem;
+    }
+
+    &__alert-below {
+        margin: 0;
+        overflow-y: auto;
+    }
+
+    code {
+        white-space: pre;
+    }
+}

--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -1,0 +1,233 @@
+import { HoverAttachment } from '@sourcegraph/codeintellify/lib/types'
+import { registerLanguage } from 'highlight.js/lib/highlight'
+import * as H from 'history'
+import { castArray } from 'lodash'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { createRenderer } from 'react-test-renderer/shallow'
+import { MarkupKind } from 'sourcegraph'
+import { HoverMerged } from '../api/client/types/hover'
+import { HoverOverlay, HoverOverlayProps } from './HoverOverlay'
+
+const renderShallow = (element: React.ReactElement<HoverOverlayProps>): React.ReactElement<any> => {
+    const renderer = createRenderer()
+    renderer.render(element)
+    // Render again because the first render call only renders the <TelemetryContext.Consumer> element, whose child
+    // is a render prop that returns what we actually want.
+    renderer.render(renderer.getRenderOutput().props.children())
+    return renderer.getRenderOutput()
+}
+
+describe('HoverOverlay', () => {
+    const NOOP_EXTENSIONS_CONTROLLER = { executeCommand: async () => void 0 }
+    const NOOP_PLATFORM_CONTEXT = { forceUpdateTooltip: () => void 0 }
+    const history = H.createMemoryHistory({ keyLength: 0 })
+    const commonProps: HoverOverlayProps = {
+        location: history.location,
+        extensionsController: NOOP_EXTENSIONS_CONTROLLER,
+        platformContext: NOOP_PLATFORM_CONTEXT,
+        showCloseButton: false,
+        hoveredToken: { repoName: 'r', commitID: 'c', rev: 'v', filePath: 'f', line: 1, character: 2 },
+        overlayPosition: { left: 0, top: 0 },
+    }
+
+    test('actions and hover undefined', () => {
+        expect(renderer.create(<HoverOverlay {...commonProps} />).toJSON()).toMatchSnapshot()
+    })
+
+    test('actions loading', () => {
+        expect(renderer.create(<HoverOverlay {...commonProps} actionsOrError="loading" />).toJSON()).toMatchSnapshot()
+    })
+
+    test('hover loading', () => {
+        expect(renderer.create(<HoverOverlay {...commonProps} hoverOrError="loading" />).toJSON()).toMatchSnapshot()
+    })
+
+    test('actions and hover loading', () => {
+        expect(
+            renderer.create(<HoverOverlay {...commonProps} actionsOrError="loading" hoverOrError="loading" />).toJSON()
+        ).toMatchSnapshot()
+    })
+
+    test('actions empty', () => {
+        const component = renderer.create(<HoverOverlay {...commonProps} actionsOrError={[]} />)
+        expect(component.toJSON()).toMatchSnapshot()
+    })
+
+    test('hover empty', () => {
+        expect(renderer.create(<HoverOverlay {...commonProps} hoverOrError={null} />).toJSON()).toMatchSnapshot()
+    })
+
+    test('actions and hover empty', () => {
+        expect(
+            renderer.create(<HoverOverlay {...commonProps} actionsOrError={[]} hoverOrError={null} />).toJSON()
+        ).toMatchSnapshot()
+    })
+
+    test('actions present', () => {
+        expect(
+            renderShallow(<HoverOverlay {...commonProps} actionsOrError={[{ action: { id: 'a', command: 'c' } }]} />)
+        ).toMatchSnapshot()
+    })
+
+    test('hover present', () => {
+        expect(
+            renderer
+                .create(
+                    <HoverOverlay
+                        {...commonProps}
+                        hoverOrError={{ contents: [{ kind: MarkupKind.Markdown, value: 'v' }] }}
+                    />
+                )
+                .toJSON()
+        ).toMatchSnapshot()
+    })
+
+    test('multiple hovers present', () => {
+        expect(
+            renderer
+                .create(
+                    <HoverOverlay
+                        {...commonProps}
+                        hoverOrError={{
+                            contents: [
+                                { kind: MarkupKind.Markdown, value: 'v' },
+                                { kind: MarkupKind.Markdown, value: 'v2' },
+                            ],
+                        }}
+                    />
+                )
+                .toJSON()
+        ).toMatchSnapshot()
+    })
+
+    test('actions and hover present', () => {
+        expect(
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError={[{ action: { id: 'a', command: 'c' } }]}
+                    hoverOrError={{ contents: [{ kind: MarkupKind.Markdown, value: 'v' }] }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    test('actions present, hover loading', () => {
+        expect(
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError={[{ action: { id: 'a', command: 'c' } }]}
+                    hoverOrError="loading"
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    test('hover present, actions loading', () => {
+        expect(
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError="loading"
+                    hoverOrError={{ contents: [{ kind: MarkupKind.Markdown, value: 'v' }] }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    test('actions error', () => {
+        expect(
+            renderShallow(<HoverOverlay {...commonProps} actionsOrError={{ message: 'm', code: 'c' }} />)
+        ).toMatchSnapshot()
+    })
+
+    test('hover error', () => {
+        expect(
+            renderShallow(<HoverOverlay {...commonProps} hoverOrError={{ message: 'm', code: 'c' }} />)
+        ).toMatchSnapshot()
+    })
+
+    test('actions and hover error', () => {
+        expect(
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError={{ message: 'm1', code: 'c1' }}
+                    hoverOrError={{ message: 'm2', code: 'c2' }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    test('actions error, hover present', () => {
+        expect(
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError={{ message: 'm', code: 'c' }}
+                    hoverOrError={{ contents: [{ kind: MarkupKind.Markdown, value: 'v' }] }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    test('hover error, actions present', () => {
+        expect(
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError={[{ action: { id: 'a', command: 'c' } }]}
+                    hoverOrError={{ message: 'm', code: 'c' }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    describe('hover content rendering', () => {
+        const renderMarkdownHover = (hover: HoverAttachment & HoverMerged) => {
+            const contents = castArray(
+                renderShallow(<HoverOverlay {...commonProps} hoverOrError={hover} />).props.children
+            ).find(e => e.props && e.props.className && e.props.className.includes('hover-overlay__contents'))
+            if (!contents) {
+                return null
+            }
+            return castArray(contents.props.children)
+                .map(c => {
+                    if (c.props && c.props.className && c.props.className.includes('hover-overlay__content')) {
+                        if (typeof c.props.children === 'string') {
+                            return c.props.children
+                        }
+                        return c.props.dangerouslySetInnerHTML.__html
+                    }
+                    return ''
+                })
+                .join('')
+                .trim()
+        }
+
+        const renderPlainTextHover = (hover: HoverAttachment & HoverMerged) =>
+            renderer
+                .create(<HoverOverlay {...commonProps} hoverOrError={hover} />)
+                .root.find(c => c.props && c.props.className && c.props.className.includes('hover-overlay__content'))
+                .props.children.map((c: renderer.ReactTestInstance) => c.props.children)
+
+        test('MarkupKind.Markdown', () => {
+            expect(renderMarkdownHover({ contents: [{ kind: MarkupKind.Markdown, value: '*v*' }] })).toEqual(
+                '<p><em>v</em></p>'
+            )
+        })
+
+        test('MarkupKind.PlainText', () => {
+            expect(renderPlainTextHover({ contents: [{ kind: MarkupKind.PlainText, value: 'v<' }] })).toEqual(['v<'])
+        })
+
+        test('code', () => {
+            registerLanguage('testlang', x => ({}))
+            expect(
+                renderMarkdownHover({ contents: [{ kind: MarkupKind.Markdown, value: '```testlang\n<>\n```' }] })
+            ).toEqual('<pre><code class="language-testlang">&lt;&gt;</code></pre>')
+        })
+    })
+})

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -1,0 +1,196 @@
+import { HoverOverlayProps as GenericHoverOverlayProps } from '@sourcegraph/codeintellify'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { castArray, isEqual } from 'lodash'
+import AlertCircleOutlineIcon from 'mdi-react/AlertCircleOutlineIcon'
+import CloseIcon from 'mdi-react/CloseIcon'
+import * as React from 'react'
+import { MarkupContent } from 'sourcegraph'
+import { ActionItem, ActionItemComponentProps, ActionItemProps } from '../actions/ActionItem'
+import { HoverMerged } from '../api/client/types/hover'
+import { TelemetryContext } from '../telemetry/telemetryContext'
+import { TelemetryService } from '../telemetry/telemetryService'
+import { isErrorLike } from '../util/errors'
+import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../util/url'
+import { highlightCodeSafe, renderMarkdown, toNativeEvent } from './helpers'
+
+const LOADING: 'loading' = 'loading'
+
+const transformMouseEvent = (handler: (event: MouseEvent) => void) => (event: React.MouseEvent<HTMLElement>) =>
+    handler(toNativeEvent(event))
+
+export type HoverContext = RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
+
+export type HoverData = HoverMerged
+
+export interface HoverOverlayProps
+    extends GenericHoverOverlayProps<HoverContext, HoverData, ActionItemProps>,
+        ActionItemComponentProps {
+    /** A ref callback to get the root overlay element. Use this to calculate the position. */
+    hoverRef?: React.Ref<HTMLDivElement>
+
+    /** An optional class name to apply to the outermost element of the HoverOverlay */
+    className?: string
+
+    /** Called when the close button is clicked */
+    onCloseButtonClick?: (event: MouseEvent) => void
+}
+
+const isEmptyHover = ({
+    hoveredToken,
+    hoverOrError,
+    actionsOrError,
+}: Pick<HoverOverlayProps, 'hoveredToken' | 'hoverOrError' | 'actionsOrError'>): boolean =>
+    !hoveredToken ||
+    ((!hoverOrError || hoverOrError === LOADING || isErrorLike(hoverOrError)) &&
+        (!actionsOrError || actionsOrError === LOADING || isErrorLike(actionsOrError)))
+
+class BaseHoverOverlay extends React.PureComponent<HoverOverlayProps & { telemetryService: TelemetryService }> {
+    public componentDidMount(): void {
+        this.logTelemetryEvent()
+    }
+
+    public componentDidUpdate(prevProps: HoverOverlayProps): void {
+        // Log a telemetry event for this hover being displayed, but only do it once per position and when it is
+        // non-empty.
+        if (
+            !isEmptyHover(this.props) &&
+            (!isEqual(this.props.hoveredToken, prevProps.hoveredToken) || isEmptyHover(prevProps))
+        ) {
+            this.logTelemetryEvent()
+        }
+    }
+
+    public render(): JSX.Element | null {
+        const {
+            hoverOrError,
+            hoverRef,
+            onCloseButtonClick,
+            overlayPosition,
+            showCloseButton,
+            actionsOrError,
+            className = '',
+            extensionsController,
+            platformContext,
+            location,
+        } = this.props
+
+        return (
+            <div
+                className={`hover-overlay card ${className}`}
+                ref={hoverRef}
+                // tslint:disable-next-line:jsx-ban-props needed for dynamic styling
+                style={
+                    overlayPosition
+                        ? {
+                              opacity: 1,
+                              visibility: 'visible',
+                              left: overlayPosition.left + 'px',
+                              top: overlayPosition.top + 'px',
+                          }
+                        : {
+                              opacity: 0,
+                              visibility: 'hidden',
+                          }
+                }
+            >
+                {showCloseButton && (
+                    <button
+                        className="hover-overlay__close-button btn btn-icon"
+                        onClick={onCloseButtonClick ? transformMouseEvent(onCloseButtonClick) : undefined}
+                    >
+                        <CloseIcon className="icon-inline" />
+                    </button>
+                )}
+                <div className="hover-overlay__contents">
+                    {hoverOrError === LOADING ? (
+                        <div className="hover-overlay__row hover-overlay__loader-row">
+                            <LoadingSpinner className="icon-inline" />
+                        </div>
+                    ) : isErrorLike(hoverOrError) ? (
+                        <div className="hover-overlay__row hover-overlay__hover-error alert alert-danger">
+                            <h4>
+                                <AlertCircleOutlineIcon className="icon-inline" /> Error:
+                            </h4>{' '}
+                            {hoverOrError.message}
+                        </div>
+                    ) : (
+                        // tslint:disable-next-line deprecation We want to handle the deprecated MarkedString
+                        hoverOrError &&
+                        castArray<string | MarkupContent | { language: string; value: string }>(hoverOrError.contents)
+                            .map(value => (typeof value === 'string' ? { kind: 'markdown', value } : value))
+                            .map((content, i) => {
+                                if ('kind' in content || !('language' in content)) {
+                                    if (content.kind === 'markdown') {
+                                        try {
+                                            return (
+                                                <div
+                                                    className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+                                                    key={i}
+                                                    dangerouslySetInnerHTML={{ __html: renderMarkdown(content.value) }}
+                                                />
+                                            )
+                                        } catch (err) {
+                                            return (
+                                                <div className="hover-overlay__row alert alert-danger" key={i}>
+                                                    <strong>
+                                                        <AlertCircleOutlineIcon className="icon-inline" /> Error:
+                                                    </strong>{' '}
+                                                    {err.message}
+                                                </div>
+                                            )
+                                        }
+                                    }
+                                    return (
+                                        <div className="hover-overlay__content hover-overlay__row" key={i}>
+                                            {String(content.value)}
+                                        </div>
+                                    )
+                                }
+                                return (
+                                    <code
+                                        className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+                                        key={i}
+                                        dangerouslySetInnerHTML={{
+                                            __html: highlightCodeSafe(content.value, content.language),
+                                        }}
+                                    />
+                                )
+                            })
+                    )}
+                </div>
+                {actionsOrError !== undefined &&
+                    actionsOrError !== null &&
+                    actionsOrError !== LOADING &&
+                    !isErrorLike(actionsOrError) &&
+                    actionsOrError.length > 0 && (
+                        <div className="hover-overlay__actions hover-overlay__row">
+                            {actionsOrError.map((action, i) => (
+                                <ActionItem
+                                    key={i}
+                                    className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+                                    {...action}
+                                    variant="actionItem"
+                                    disabledDuringExecution={true}
+                                    showLoadingSpinnerDuringExecution={true}
+                                    showInlineError={true}
+                                    extensionsController={extensionsController}
+                                    platformContext={platformContext}
+                                    location={location}
+                                />
+                            ))}
+                        </div>
+                    )}
+            </div>
+        )
+    }
+
+    private logTelemetryEvent(): void {
+        this.props.telemetryService.log('hover')
+    }
+}
+
+export const HoverOverlay = React.forwardRef<BaseHoverOverlay, HoverOverlayProps>((props, ref) => (
+    <TelemetryContext.Consumer>
+        {telemetryService => <BaseHoverOverlay {...props} telemetryService={telemetryService} ref={ref} />}
+    </TelemetryContext.Consumer>
+))

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -1,0 +1,587 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HoverOverlay actions and hover empty 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  />
+</div>
+`;
+
+exports[`HoverOverlay actions and hover error 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__row hover-overlay__hover-error alert alert-danger"
+    >
+      <h4>
+        <AlertCircleOutlineIcon
+          className="icon-inline"
+        />
+         Error:
+      </h4>
+       
+      m2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay actions and hover loading 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__row hover-overlay__loader-row"
+    >
+      <div
+        className="loading-spinner icon-inline"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay actions and hover present 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>v</p>
+",
+        }
+      }
+    />
+  </div>
+  <div
+    className="hover-overlay__actions hover-overlay__row"
+  >
+    <ActionItem
+      action={
+        Object {
+          "command": "c",
+          "id": "a",
+        }
+      }
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      disabledDuringExecution={true}
+      extensionsController={
+        Object {
+          "executeCommand": [Function],
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      platformContext={
+        Object {
+          "forceUpdateTooltip": [Function],
+        }
+      }
+      showInlineError={true}
+      showLoadingSpinnerDuringExecution={true}
+      variant="actionItem"
+    />
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay actions and hover undefined 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  />
+</div>
+`;
+
+exports[`HoverOverlay actions empty 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  />
+</div>
+`;
+
+exports[`HoverOverlay actions error 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  />
+</div>
+`;
+
+exports[`HoverOverlay actions error, hover present 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>v</p>
+",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay actions loading 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  />
+</div>
+`;
+
+exports[`HoverOverlay actions present 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  />
+  <div
+    className="hover-overlay__actions hover-overlay__row"
+  >
+    <ActionItem
+      action={
+        Object {
+          "command": "c",
+          "id": "a",
+        }
+      }
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      disabledDuringExecution={true}
+      extensionsController={
+        Object {
+          "executeCommand": [Function],
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      platformContext={
+        Object {
+          "forceUpdateTooltip": [Function],
+        }
+      }
+      showInlineError={true}
+      showLoadingSpinnerDuringExecution={true}
+      variant="actionItem"
+    />
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay actions present, hover loading 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__row hover-overlay__loader-row"
+    >
+      <Unknown
+        className="icon-inline"
+      />
+    </div>
+  </div>
+  <div
+    className="hover-overlay__actions hover-overlay__row"
+  >
+    <ActionItem
+      action={
+        Object {
+          "command": "c",
+          "id": "a",
+        }
+      }
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      disabledDuringExecution={true}
+      extensionsController={
+        Object {
+          "executeCommand": [Function],
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      platformContext={
+        Object {
+          "forceUpdateTooltip": [Function],
+        }
+      }
+      showInlineError={true}
+      showLoadingSpinnerDuringExecution={true}
+      variant="actionItem"
+    />
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay hover empty 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  />
+</div>
+`;
+
+exports[`HoverOverlay hover error 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__row hover-overlay__hover-error alert alert-danger"
+    >
+      <h4>
+        <AlertCircleOutlineIcon
+          className="icon-inline"
+        />
+         Error:
+      </h4>
+       
+      m
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay hover error, actions present 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__row hover-overlay__hover-error alert alert-danger"
+    >
+      <h4>
+        <AlertCircleOutlineIcon
+          className="icon-inline"
+        />
+         Error:
+      </h4>
+       
+      m
+    </div>
+  </div>
+  <div
+    className="hover-overlay__actions hover-overlay__row"
+  >
+    <ActionItem
+      action={
+        Object {
+          "command": "c",
+          "id": "a",
+        }
+      }
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      disabledDuringExecution={true}
+      extensionsController={
+        Object {
+          "executeCommand": [Function],
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      platformContext={
+        Object {
+          "forceUpdateTooltip": [Function],
+        }
+      }
+      showInlineError={true}
+      showLoadingSpinnerDuringExecution={true}
+      variant="actionItem"
+    />
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay hover loading 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__row hover-overlay__loader-row"
+    >
+      <div
+        className="loading-spinner icon-inline"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay hover present 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>v</p>
+",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay hover present, actions loading 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>v</p>
+",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`HoverOverlay multiple hovers present 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>v</p>
+",
+        }
+      }
+    />
+    <div
+      className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>v2</p>
+",
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/shared/src/hover/actions.test.ts
+++ b/shared/src/hover/actions.test.ts
@@ -1,0 +1,453 @@
+import { HoveredToken, LOADER_DELAY } from '@sourcegraph/codeintellify'
+import { Location } from '@sourcegraph/extension-api-types'
+import { createMemoryHistory } from 'history'
+import { from, of } from 'rxjs'
+import { first, map } from 'rxjs/operators'
+// tslint:disable-next-line:no-submodule-imports
+import { TestScheduler } from 'rxjs/testing'
+import { ActionItemProps } from '../actions/ActionItem'
+import { EMPTY_MODEL, Model } from '../api/client/model'
+import { Services } from '../api/client/services'
+import { CommandRegistry } from '../api/client/services/command'
+import { ContributionRegistry } from '../api/client/services/contribution'
+import { ProvideTextDocumentLocationSignature } from '../api/client/services/location'
+import { ContributableMenu, ReferenceParams, TextDocumentPositionParams } from '../api/protocol'
+import { getContributedActionItems } from '../contributions/contributions'
+import { EMPTY_SETTINGS_CASCADE } from '../settings/settings'
+import { toPrettyBlobURL } from '../util/url'
+import { getDefinitionURL, getHoverActionsContext, HoverActionsContext, registerHoverContributions } from './actions'
+import { HoverContext } from './HoverOverlay'
+
+const FIXTURE_PARAMS: TextDocumentPositionParams = {
+    textDocument: { uri: 'git://r?c#f' },
+    position: { line: 1, character: 1 },
+}
+
+const FIXTURE_LOCATION: Location = {
+    uri: 'git://r2?c2#f2',
+    range: {
+        start: { line: 2, character: 2 },
+        end: { line: 3, character: 3 },
+    },
+}
+
+const FIXTURE_HOVER_CONTEXT: HoveredToken & HoverContext = {
+    repoName: 'r',
+    commitID: 'c',
+    rev: 'v',
+    filePath: 'f',
+    line: 2,
+    character: 2,
+}
+
+function testModelService(
+    roots: Model['roots'] = [{ uri: 'git://r3?c3', inputRevision: 'v3' }]
+): { model: { value: Pick<Model, 'roots'> } } {
+    return { model: { value: { roots } } }
+}
+
+// Use toPrettyBlobURL as the urlToFile passed to these functions because it results in the most readable/familiar
+// expected test output.
+const urlToFile = toPrettyBlobURL
+
+const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
+
+describe('getHoverActionsContext', () => {
+    test('shows a loader for the definition if slow', () =>
+        scheduler().run(({ cold, expectObservable }) =>
+            expectObservable(
+                from(
+                    getHoverActionsContext(
+                        {
+                            extensionsController: {
+                                services: {
+                                    model: testModelService(),
+                                    textDocumentDefinition: {
+                                        getLocations: () =>
+                                            cold<Location[]>(`- ${LOADER_DELAY}ms --- d`, { d: [FIXTURE_LOCATION] }),
+                                    },
+                                    textDocumentReferences: {
+                                        providersForDocument: () =>
+                                            cold<ProvideTextDocumentLocationSignature<ReferenceParams, Location>[]>(
+                                                'a',
+                                                { a: [() => of(null)] }
+                                            ),
+                                    },
+                                },
+                            },
+                            platformContext: { urlToFile },
+                        },
+                        FIXTURE_HOVER_CONTEXT
+                    )
+                )
+                // tslint:disable-next-line:no-object-literal-type-assertion
+            ).toBe(`a ${LOADER_DELAY - 1}ms (bc)d`, {
+                a: {
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                },
+                b: {
+                    'goToDefinition.showLoading': true,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                },
+                c: {
+                    'goToDefinition.showLoading': true,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
+                    hoverPosition: FIXTURE_PARAMS,
+                },
+                d: {
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': '/r2@c2/-/blob/f2#L3:3',
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
+                    hoverPosition: FIXTURE_PARAMS,
+                },
+            } as { [key: string]: HoverActionsContext })
+        ))
+
+    test('shows no loader for the definition if fast', () =>
+        scheduler().run(({ cold, expectObservable }) =>
+            expectObservable(
+                from(
+                    getHoverActionsContext(
+                        {
+                            extensionsController: {
+                                services: {
+                                    model: testModelService(),
+                                    textDocumentDefinition: {
+                                        getLocations: () => cold<Location[]>(`-b`, { b: [FIXTURE_LOCATION] }),
+                                    },
+                                    textDocumentReferences: {
+                                        providersForDocument: () =>
+                                            cold<ProvideTextDocumentLocationSignature<ReferenceParams, Location>[]>(
+                                                'a',
+                                                { a: [() => of(null)] }
+                                            ),
+                                    },
+                                },
+                            },
+                            platformContext: { urlToFile },
+                        },
+                        FIXTURE_HOVER_CONTEXT
+                    )
+                )
+                // tslint:disable-next-line:no-object-literal-type-assertion
+            ).toBe(`a(bc)`, {
+                a: {
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                },
+                b: {
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': '/r2@c2/-/blob/f2#L3:3',
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                },
+                c: {
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': '/r2@c2/-/blob/f2#L3:3',
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
+                    hoverPosition: FIXTURE_PARAMS,
+                },
+            } as { [key: string]: HoverActionsContext })
+        ))
+})
+
+describe('getDefinitionURL', () => {
+    test('emits null if the locations result is null', async () =>
+        expect(
+            getDefinitionURL(
+                { urlToFile },
+                {
+                    model: testModelService(),
+                    textDocumentDefinition: { getLocations: () => of(null) },
+                },
+                FIXTURE_PARAMS
+            )
+                .pipe(first())
+                .toPromise()
+        ).resolves.toBe(null))
+
+    test('emits null if the locations result is empty', async () =>
+        expect(
+            getDefinitionURL(
+                { urlToFile },
+                {
+                    model: testModelService(),
+                    textDocumentDefinition: { getLocations: () => of([]) },
+                },
+                FIXTURE_PARAMS
+            )
+                .pipe(first())
+                .toPromise()
+        ).resolves.toBe(null))
+
+    describe('if there is exactly 1 location result', () => {
+        describe('when the result is inside the current root', () => {
+            test('emits the definition URL the user input revision (not commit SHA) of the root', async () =>
+                expect(
+                    getDefinitionURL(
+                        { urlToFile },
+                        {
+                            model: testModelService(),
+                            textDocumentDefinition: { getLocations: () => of<Location[]>([{ uri: 'git://r3?c3#f' }]) },
+                        },
+                        FIXTURE_PARAMS
+                    )
+                        .pipe(first())
+                        .toPromise()
+                ).resolves.toEqual({ url: '/r3@v3/-/blob/f', multiple: false }))
+        })
+
+        describe('when the result is not inside the current root (different repo and/or commit)', () => {
+            test('emits the definition URL with range', async () =>
+                expect(
+                    getDefinitionURL(
+                        { urlToFile },
+                        {
+                            model: testModelService(),
+                            textDocumentDefinition: { getLocations: () => of<Location[]>([FIXTURE_LOCATION]) },
+                        },
+                        FIXTURE_PARAMS
+                    )
+                        .pipe(first())
+                        .toPromise()
+                ).resolves.toEqual({ url: '/r2@c2/-/blob/f2#L3:3', multiple: false }))
+
+            test('emits the definition URL without range', async () =>
+                expect(
+                    getDefinitionURL(
+                        { urlToFile },
+                        {
+                            model: testModelService(),
+                            textDocumentDefinition: {
+                                getLocations: () => of<Location[]>([{ ...FIXTURE_LOCATION, range: undefined }]),
+                            },
+                        },
+                        FIXTURE_PARAMS
+                    )
+                        .pipe(first())
+                        .toPromise()
+                ).resolves.toEqual({ url: '/r2@c2/-/blob/f2', multiple: false }))
+        })
+    })
+
+    test('emits the definition panel URL if there is more than 1 location result', async () =>
+        expect(
+            getDefinitionURL(
+                { urlToFile },
+                {
+                    model: testModelService([{ uri: 'git://r?c', inputRevision: 'v' }]),
+                    textDocumentDefinition: {
+                        getLocations: () => of<Location[]>([FIXTURE_LOCATION, { ...FIXTURE_LOCATION, uri: 'other' }]),
+                    },
+                },
+                FIXTURE_PARAMS
+            )
+                .pipe(first())
+                .toPromise()
+        ).resolves.toEqual({ url: '/r@v/-/blob/f#L2:2&tab=def', multiple: true }))
+})
+
+describe('registerHoverContributions', () => {
+    const contribution = new ContributionRegistry(of(EMPTY_MODEL), { data: of(EMPTY_SETTINGS_CASCADE) }, of({}))
+    const commands = new CommandRegistry()
+    const textDocumentDefinition: Pick<Services['textDocumentDefinition'], 'getLocations'> = {
+        getLocations: () => of(null),
+    }
+    const history = createMemoryHistory()
+    const subscription = registerHoverContributions({
+        extensionsController: {
+            services: {
+                contribution,
+                commands,
+                model: testModelService(),
+                textDocumentDefinition,
+            },
+        },
+        platformContext: { urlToFile },
+        history,
+    })
+    afterAll(() => subscription.unsubscribe())
+
+    const getHoverActions = (context: HoverActionsContext) =>
+        contribution
+            .getContributions(undefined, context)
+            .pipe(
+                first(),
+                map(contributions => getContributedActionItems(contributions, ContributableMenu.Hover))
+            )
+            .toPromise()
+
+    describe('getHoverActions', () => {
+        const GO_TO_DEFINITION_ACTION: ActionItemProps = {
+            action: {
+                command: 'goToDefinition',
+                commandArguments: ['{"textDocument":{"uri":"git://r?c#f"},"position":{"line":1,"character":1}}'],
+                id: 'goToDefinition',
+                title: 'Go to definition',
+            },
+            altAction: undefined,
+        }
+        const GO_TO_DEFINITION_PRELOADED_ACTION: ActionItemProps = {
+            action: {
+                command: 'open',
+                commandArguments: ['/r2@c2/-/blob/f2#L3:3'],
+                id: 'goToDefinition.preloaded',
+                title: 'Go to definition',
+            },
+            altAction: undefined,
+        }
+        const FIND_REFERENCES_ACTION: ActionItemProps = {
+            action: {
+                command: 'open',
+                commandArguments: ['/r@v/-/blob/f#L2:2&tab=references'],
+                id: 'findReferences',
+                title: 'Find references',
+            },
+            altAction: undefined,
+        }
+
+        test('shows goToDefinition (non-preloaded) when the definition is loading', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': true,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([GO_TO_DEFINITION_ACTION]))
+
+        test('shows goToDefinition (non-preloaded) when the definition had an error', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': true,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([GO_TO_DEFINITION_ACTION]))
+
+        test('hides goToDefinition when the definition was not found', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': true,
+                    'goToDefinition.error': false,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([]))
+
+        test('shows goToDefinition.preloaded when goToDefinition.url is available', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': '/r2@c2/-/blob/f2#L3:3',
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': null,
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([GO_TO_DEFINITION_PRELOADED_ACTION]))
+
+        test('shows findReferences when the definition exists', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': '/r2@c2/-/blob/f2#L3:3',
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([GO_TO_DEFINITION_PRELOADED_ACTION, FIND_REFERENCES_ACTION]))
+
+        test('hides findReferences when the definition might exist (and is still loading)', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': true,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': false,
+                    'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([GO_TO_DEFINITION_ACTION, FIND_REFERENCES_ACTION]))
+
+        test('shows findReferences when the definition had an error', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': false,
+                    'goToDefinition.error': true,
+                    'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([GO_TO_DEFINITION_ACTION, FIND_REFERENCES_ACTION]))
+
+        test('shows findReferences when the definition was not found', async () =>
+            expect(
+                getHoverActions({
+                    'goToDefinition.showLoading': false,
+                    'goToDefinition.url': null,
+                    'goToDefinition.notFound': true,
+                    'goToDefinition.error': false,
+                    'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
+                    hoverPosition: FIXTURE_PARAMS,
+                })
+            ).resolves.toEqual([FIND_REFERENCES_ACTION]))
+    })
+
+    describe('goToDefinition command', () => {
+        test('reports no definition found', async () => {
+            textDocumentDefinition.getLocations = () => of(null) // mock
+            return expect(
+                commands.executeCommand({ command: 'goToDefinition', arguments: [JSON.stringify(FIXTURE_PARAMS)] })
+            ).rejects.toMatchObject({ message: 'No definition found.' })
+        })
+
+        test('reports panel already visible', async () => {
+            textDocumentDefinition.getLocations = () =>
+                of([FIXTURE_LOCATION, { ...FIXTURE_LOCATION, uri: 'git://r3?v3#f3' }]) // mock
+            history.push('/r@c/-/blob/f#L2:2&tab=def')
+            return expect(
+                commands.executeCommand({ command: 'goToDefinition', arguments: [JSON.stringify(FIXTURE_PARAMS)] })
+            ).rejects.toMatchObject({ message: 'Multiple definitions shown in panel below.' })
+        })
+
+        test('reports already at the definition', async () => {
+            textDocumentDefinition.getLocations = () => of([FIXTURE_LOCATION]) // mock
+            history.push('/r2@c2/-/blob/f2#L3:3')
+            return expect(
+                commands.executeCommand({ command: 'goToDefinition', arguments: [JSON.stringify(FIXTURE_PARAMS)] })
+            ).rejects.toMatchObject({ message: 'Already at the definition.' })
+        })
+    })
+})

--- a/shared/src/hover/actions.ts
+++ b/shared/src/hover/actions.ts
@@ -1,0 +1,376 @@
+import { HoveredToken, LOADER_DELAY } from '@sourcegraph/codeintellify'
+import * as H from 'history'
+import { isEqual, uniqWith } from 'lodash'
+import { combineLatest, merge, Observable, of, Subscription, Unsubscribable } from 'rxjs'
+import {
+    catchError,
+    delay,
+    distinctUntilChanged,
+    filter,
+    first,
+    map,
+    share,
+    startWith,
+    switchMap,
+    takeUntil,
+} from 'rxjs/operators'
+import { ActionItemProps } from '../actions/ActionItem'
+import { Context } from '../api/client/context/context'
+import { Model } from '../api/client/model'
+import { Services } from '../api/client/services'
+import { ContributableMenu, TextDocumentPositionParams } from '../api/protocol'
+import { getContributedActionItems } from '../contributions/contributions'
+import { ExtensionsControllerProps } from '../extensions/controller'
+import { PlatformContext, PlatformContextProps } from '../platform/context'
+import { asError, ErrorLike, isErrorLike } from '../util/errors'
+import { makeRepoURI, parseRepoURI, withWorkspaceRootInputRevision } from '../util/url'
+import { HoverContext } from './HoverOverlay'
+
+const LOADING: 'loading' = 'loading'
+
+/**
+ * This function is passed to {@link module:@sourcegraph/codeintellify.createHoverifier}, which uses it to fetch
+ * the list of buttons to display on the hover tooltip. This function in turn determines that by looking at all
+ * action contributions for the "hover" menu. It also defines two builtin hover actions: "Go to definition" and
+ * "Find references".
+ */
+export function getHoverActions(
+    { extensionsController, platformContext }: ExtensionsControllerProps & PlatformContextProps,
+    hoverContext: HoveredToken & HoverContext
+): Observable<ActionItemProps[]> {
+    return getHoverActionsContext({ extensionsController, platformContext }, hoverContext).pipe(
+        switchMap(context =>
+            extensionsController.services.contribution
+                .getContributions(undefined, context)
+                .pipe(map(contributions => getContributedActionItems(contributions, ContributableMenu.Hover)))
+        )
+    )
+}
+
+/**
+ * The scoped context properties for the hover.
+ *
+ * @internal Exported for testing only.
+ */
+export interface HoverActionsContext extends Context<TextDocumentPositionParams> {
+    ['goToDefinition.showLoading']: boolean
+    ['goToDefinition.url']: string | null
+    ['goToDefinition.notFound']: boolean
+    ['goToDefinition.error']: boolean
+    ['findReferences.url']: string | null
+    hoverPosition: TextDocumentPositionParams
+}
+
+/**
+ * Returns an observable that emits the scoped context for the hover upon subscription and whenever it changes.
+ *
+ * @internal Exported for testing only.
+ */
+export function getHoverActionsContext(
+    {
+        extensionsController,
+        platformContext: { urlToFile },
+    }:
+        | (ExtensionsControllerProps & PlatformContextProps)
+        | {
+              extensionsController: {
+                  services: {
+                      model: {
+                          model: { value: Pick<Model, 'roots'> }
+                      }
+                      textDocumentDefinition: Pick<Services['textDocumentDefinition'], 'getLocations'>
+                      textDocumentReferences: Pick<Services['textDocumentReferences'], 'providersForDocument'>
+                  }
+              }
+              platformContext: Pick<PlatformContext, 'urlToFile'>
+          },
+    hoverContext: HoveredToken & HoverContext
+): Observable<Context<TextDocumentPositionParams>> {
+    const params: TextDocumentPositionParams = {
+        textDocument: { uri: makeRepoURI(hoverContext) },
+        position: { line: hoverContext.line - 1, character: hoverContext.character - 1 },
+    }
+    const definitionURLOrError = getDefinitionURL({ urlToFile }, extensionsController.services, params).pipe(
+        map(result => (result ? result.url : result)), // we only care about the URL or null, not whether there are multiple
+        catchError(err => [asError(err) as ErrorLike]),
+        share()
+    )
+
+    return combineLatest(
+        // To reduce UI jitter, don't show "Go to definition" until (1) the result or an error was received or (2)
+        // the fairly long LOADER_DELAY has elapsed.
+        merge(
+            [undefined], // don't block on the first emission
+            of(LOADING).pipe(
+                delay(LOADER_DELAY),
+                takeUntil(definitionURLOrError)
+            ),
+            definitionURLOrError
+        ),
+
+        // Only show "Find references" if a reference provider is registered. Unlike definitions, references are
+        // not preloaded and here just involve statically constructing a URL, so no need to indicate loading.
+        extensionsController.services.textDocumentReferences
+            .providersForDocument(params.textDocument)
+            .pipe(map(providers => providers.length !== 0)),
+
+        // If there is no definition, delay showing "Find references" because it is likely that the token is
+        // punctuation or something else that has no meaningful references. This reduces UI jitter when it can be
+        // quickly determined that there is no definition. TODO(sqs): Allow reference providers to register
+        // "trigger characters" or have a "hasReferences" method to opt-out of being called for certain tokens.
+        merge(
+            of(true).pipe(
+                delay(LOADER_DELAY),
+                takeUntil(definitionURLOrError.pipe(filter(v => !!v)))
+            ),
+            definitionURLOrError.pipe(
+                filter(v => !!v),
+                map(v => !!v)
+            )
+        ).pipe(startWith(false))
+    ).pipe(
+        map(
+            ([definitionURLOrError, hasReferenceProvider, showFindReferences]): HoverActionsContext => ({
+                'goToDefinition.showLoading': definitionURLOrError === LOADING,
+                'goToDefinition.url':
+                    (definitionURLOrError !== LOADING && !isErrorLike(definitionURLOrError) && definitionURLOrError) ||
+                    null,
+                'goToDefinition.notFound':
+                    definitionURLOrError !== LOADING &&
+                    !isErrorLike(definitionURLOrError) &&
+                    definitionURLOrError === null,
+                'goToDefinition.error':
+                    isErrorLike(definitionURLOrError) && ((definitionURLOrError as any).stack as any),
+
+                'findReferences.url':
+                    hasReferenceProvider && showFindReferences
+                        ? urlToFile({ ...hoverContext, position: hoverContext, viewState: 'references' })
+                        : null,
+
+                // Store hoverPosition for the goToDefinition action's commandArguments to refer to.
+                hoverPosition: params,
+            })
+        ),
+        distinctUntilChanged((a, b) => isEqual(a, b))
+    )
+}
+
+/**
+ * Returns an observable that emits null if no definitions are found, {url, multiple: false} if exactly 1
+ * definition is found, {url: defPanelURL, multiple: true} if multiple definitions are found, or an error.
+ *
+ * @internal Exported for testing only.
+ */
+export function getDefinitionURL(
+    { urlToFile }: Pick<PlatformContext, 'urlToFile'>,
+    {
+        model,
+        textDocumentDefinition,
+    }: {
+        model: {
+            model: { value: Pick<Model, 'roots'> }
+        }
+        textDocumentDefinition: Pick<Services['textDocumentDefinition'], 'getLocations'>
+    },
+    params: TextDocumentPositionParams
+): Observable<{ url: string; multiple: boolean } | null> {
+    return textDocumentDefinition.getLocations(params).pipe(
+        map(definitions => {
+            if (definitions === null || definitions.length === 0) {
+                return null
+            }
+
+            // Get unique definitions.
+            definitions = uniqWith(definitions, isEqual)
+
+            if (definitions.length > 1) {
+                // Open the panel to show all definitions.
+                const uri = withWorkspaceRootInputRevision(
+                    model.model.value.roots || [],
+                    parseRepoURI(params.textDocument.uri)
+                )
+                return {
+                    url: urlToFile({
+                        ...uri,
+                        rev: uri.rev || '',
+                        filePath: uri.filePath || '',
+                        position: { line: params.position.line + 1, character: params.position.character + 1 },
+                        viewState: 'def',
+                    }),
+                    multiple: true,
+                }
+            }
+            const def = definitions[0]
+
+            // Preserve the input revision (e.g., a Git branch name instead of a Git commit SHA) if the result is
+            // inside one of the current roots. This avoids navigating the user from (e.g.) a URL with a nice Git
+            // branch name to a URL with a full Git commit SHA.
+            const uri = withWorkspaceRootInputRevision(model.model.value.roots || [], parseRepoURI(def.uri))
+
+            if (def.range) {
+                uri.position = {
+                    line: def.range.start.line + 1,
+                    character: def.range.start.character + 1,
+                }
+            }
+
+            return {
+                url: urlToFile({
+                    ...uri,
+                    rev: uri.rev || '',
+                    filePath: uri.filePath || '',
+                }),
+                multiple: false,
+            }
+        })
+    )
+}
+
+/**
+ * Registers contributions for hover-related functionality.
+ */
+export function registerHoverContributions({
+    extensionsController,
+    platformContext: { urlToFile },
+    history,
+}: (
+    | (ExtensionsControllerProps & PlatformContextProps)
+    | {
+          extensionsController: {
+              services: Pick<Services, 'commands' | 'contribution'> & {
+                  model: {
+                      model: { value: Pick<Model, 'roots'> }
+                  }
+                  textDocumentDefinition: Pick<Services['textDocumentDefinition'], 'getLocations'>
+              }
+          }
+          platformContext: Pick<PlatformContext, 'urlToFile'>
+      }) & {
+    history: H.History
+}): Unsubscribable {
+    const subscriptions = new Subscription()
+
+    // Registers the "Go to definition" action shown in the hover tooltip. When clicked, the action finds the
+    // definition of the token using the registered definition providers and navigates the user there.
+    //
+    // When the user hovers over a token (even before they click "Go to definition"), it attempts to preload the
+    // definition. If preloading succeeds and at least 1 definition is found, the "Go to definition" action becomes
+    // a normal link (<a href>) pointing to the definition's URL. Using a normal link here is good for a11y and UX
+    // (e.g., open-in-new-tab works and the browser status bar shows the URL).
+    //
+    // Otherwise (if preloading fails, or if preloading has not yet finished), clicking "Go to definition" executes
+    // the goToDefinition command. A loading indicator is displayed, and any errors that occur during execution are
+    // shown to the user.
+    //
+    // Future improvements:
+    //
+    // TODO(sqs): If the user middle-clicked or Cmd/Ctrl-clicked the button, it would be nice if when the
+    // definition was found, a new browser tab was opened to the destination. This is not easy because browsers
+    // usually block new tabs opened by JavaScript not directly triggered by a user mouse/keyboard interaction.
+    //
+    // TODO(sqs): Pin hover after an action has been clicked and before it has completed.
+    subscriptions.add(
+        extensionsController.services.contribution.registerContributions({
+            contributions: {
+                actions: [
+                    {
+                        id: 'goToDefinition',
+                        title: 'Go to definition',
+                        command: 'goToDefinition',
+                        commandArguments: [
+                            // tslint:disable:no-invalid-template-strings
+                            '${json(hoverPosition)}',
+                            // tslint:enable:no-invalid-template-strings
+                        ],
+                    },
+                    {
+                        // This action is used when preloading the definition succeeded and at least 1
+                        // definition was found.
+                        id: 'goToDefinition.preloaded',
+                        title: 'Go to definition',
+                        command: 'open',
+                        // tslint:disable-next-line:no-invalid-template-strings
+                        commandArguments: ['${goToDefinition.url}'],
+                    },
+                ],
+                menus: {
+                    hover: [
+                        // Do not show any actions if no definition provider is registered. (In that case,
+                        // goToDefinition.{error, loading, url} will all be falsey.)
+                        {
+                            action: 'goToDefinition',
+                            when: 'goToDefinition.error || goToDefinition.showLoading',
+                        },
+                        {
+                            action: 'goToDefinition.preloaded',
+                            when: 'goToDefinition.url',
+                        },
+                    ],
+                },
+            },
+        })
+    )
+    subscriptions.add(
+        extensionsController.services.commands.registerCommand({
+            command: 'goToDefinition',
+            run: async (paramsStr: string) => {
+                const params: TextDocumentPositionParams = JSON.parse(paramsStr)
+                const result = await getDefinitionURL({ urlToFile }, extensionsController.services, params)
+                    .pipe(first())
+                    .toPromise()
+                if (!result) {
+                    throw new Error('No definition found.')
+                }
+                if (result.url === H.createPath(history.location)) {
+                    // The user might be confused if they click "Go to definition" and don't go anywhere, which
+                    // occurs if they are *already* on the definition. Give a helpful tip if they do this.
+                    //
+                    // Note that these tips won't show up if the definition URL is already known by the time they
+                    // click "Go to definition", because then it's a normal link and not a button that executes
+                    // this command. TODO: It would be nice if they also showed up in that case.
+                    if (result.multiple) {
+                        // The user may not have noticed the panel at the bottom of the screen, so tell them
+                        // explicitly.
+                        throw new Error('Multiple definitions shown in panel below.')
+                    }
+                    throw new Error('Already at the definition.')
+                }
+                history.push(result.url)
+            },
+        })
+    )
+
+    // Register the "Find references" action shown in the hover tooltip. This is simpler than "Go to definition"
+    // because it just needs a URL that can be statically constructed from the current URL (it does not need to
+    // query any providers).
+    subscriptions.add(
+        extensionsController.services.contribution.registerContributions({
+            contributions: {
+                actions: [
+                    {
+                        id: 'findReferences',
+                        title: 'Find references',
+                        command: 'open',
+                        // tslint:disable-next-line:no-invalid-template-strings
+                        commandArguments: ['${findReferences.url}'],
+                    },
+                ],
+                menus: {
+                    hover: [
+                        // To reduce UI jitter, even though "Find references" can be shown immediately (because
+                        // the URL can be statically constructed), don't show it until either (1) "Go to
+                        // definition" is showing or (2) the LOADER_DELAY has elapsed. The part (2) of this
+                        // logic is implemented in the observable pipe that sets findReferences.url above.
+                        {
+                            action: 'findReferences',
+                            when:
+                                'findReferences.url && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error || goToDefinition.notFound)',
+                        },
+                    ],
+                },
+            },
+        })
+    )
+
+    return subscriptions
+}

--- a/shared/src/hover/helpers.ts
+++ b/shared/src/hover/helpers.ts
@@ -1,0 +1,70 @@
+import { highlight, highlightAuto } from 'highlight.js/lib/highlight'
+import marked from 'marked'
+import * as React from 'react'
+import sanitize from 'sanitize-html'
+
+/**
+ * Escapes HTML by replacing characters like `<` with their HTML escape sequences like `&lt;`
+ */
+const escapeHTML = (html: string): string => {
+    const span = document.createElement('span')
+    span.textContent = html
+    return span.innerHTML
+}
+
+/**
+ * Attempts to syntax-highlight the given code.
+ * If the language is not given, it is auto-detected.
+ * If an error occurs, the code is returned as plain text with escaped HTML entities
+ *
+ * @param code The code to highlight
+ * @param language The language of the code, if known
+ * @return Safe HTML
+ */
+export const highlightCodeSafe = (code: string, language?: string): string => {
+    try {
+        if (language === 'plaintext' || language === 'text') {
+            return escapeHTML(code)
+        }
+        if (language) {
+            return highlight(language, code, true).value
+        }
+        return highlightAuto(code).value
+    } catch (err) {
+        console.warn('Error syntax-highlighting hover markdown code block', err)
+        return escapeHTML(code)
+    }
+}
+
+/**
+ * Renders the given markdown to HTML, highlighting code and sanitizing dangerous HTML.
+ * Can throw an exception on parse errors.
+ */
+export const renderMarkdown = (markdown: string): string => {
+    const rendered = marked(markdown, {
+        gfm: true,
+        breaks: true,
+        sanitize: false,
+        highlight: (code, language) => highlightCodeSafe(code, language),
+    })
+    return sanitize(rendered, {
+        // Allow highligh.js styles, e.g.
+        // <span class="hljs-keyword">
+        // <code class="language-javascript">
+        allowedTags: [...sanitize.defaults.allowedTags, 'span'],
+        allowedAttributes: {
+            span: ['class'],
+            code: ['class'],
+        },
+    })
+}
+
+/**
+ * Converts a synthetic React event to a persisted, native Event object.
+ *
+ * @param event The synthetic React event object
+ */
+export const toNativeEvent = <E extends React.SyntheticEvent<T>, T>(event: E): E['nativeEvent'] => {
+    event.persist()
+    return event.nativeEvent
+}

--- a/shared/src/index.scss
+++ b/shared/src/index.scss
@@ -9,6 +9,7 @@
 @import './components/Toggle';
 @import './components/Tabs';
 @import './extensions/ExtensionStatus';
+@import './hover/HoverOverlay';
 @import './notifications/NotificationItem';
 @import './notifications/Notifications';
 @import './panel/Panel';

--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -165,6 +165,12 @@
               },
               "type": "array"
             },
+            "hover": {
+              "items": {
+                "$ref": "#/properties/contributes/definitions/MenuItemContribution"
+              },
+              "type": "array"
+            },
             "panel/toolbar": {
               "items": {
                 "$ref": "#/properties/contributes/definitions/MenuItemContribution"

--- a/web/src/contributions.ts
+++ b/web/src/contributions.ts
@@ -3,6 +3,7 @@ import React from 'react'
 import { Subscription } from 'rxjs'
 import { ExtensionsControllerProps } from '../../shared/src/extensions/controller'
 import { registerHighlightContributions } from '../../shared/src/highlight/contributions'
+import { registerHoverContributions } from '../../shared/src/hover/actions'
 import { PlatformContextProps } from '../../shared/src/platform/context'
 
 interface Props extends ExtensionsControllerProps, PlatformContextProps {
@@ -18,6 +19,7 @@ export class GlobalContributions extends React.Component<Props> {
 
     public componentDidMount(): void {
         registerHighlightContributions() // no way to unregister these
+        this.subscriptions.add(registerHoverContributions(this.props))
     }
 
     public componentWillUnmount(): void {

--- a/web/src/repo/blob/Blob.scss
+++ b/web/src/repo/blob/Blob.scss
@@ -1,4 +1,3 @@
-@import '@sourcegraph/codeintellify/lib/HoverOverlay.scss';
 @import './LineDecorationAttachment';
 @import './discussions/DiscussionsGutterOverlay.scss';
 

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -1,30 +1,24 @@
-import { createHoverifier, HoveredToken, Hoverifier, HoverOverlay, HoverState } from '@sourcegraph/codeintellify'
-import { HoverMerged } from '@sourcegraph/codeintellify/lib/types'
+import { createHoverifier, HoveredToken, Hoverifier, HoverState } from '@sourcegraph/codeintellify'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { isEqual, upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
-import { Link, LinkProps } from 'react-router-dom'
-import { merge, Observable, of, Subject, Subscribable, Subscription } from 'rxjs'
+import { merge, Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, switchMap, tap, withLatestFrom } from 'rxjs/operators'
+import { ActionItemProps } from '../../../../shared/src/actions/ActionItem'
+import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { getHoverActions } from '../../../../shared/src/hover/actions'
+import { HoverContext, HoverOverlay } from '../../../../shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { memoizeObservable } from '../../../../shared/src/util/memoizeObservable'
 import { propertyIsDefined } from '../../../../shared/src/util/types'
-import {
-    FileSpec,
-    ModeSpec,
-    PositionSpec,
-    RepoSpec,
-    ResolvedRevSpec,
-    RevSpec,
-    toPrettyBlobURL,
-} from '../../../../shared/src/util/url'
-import { getHover, getJumpURL } from '../../backend/features'
+import { FileSpec, ModeSpec, PositionSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
+import { getHover } from '../../backend/features'
 import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -72,12 +66,10 @@ interface Props extends RouteComponentProps<{ revspec: string }>, PlatformContex
     onDidUpdateExternalLinks: (externalLinks: GQL.IExternalLink[] | undefined) => void
 }
 
-interface State extends HoverState {
+interface State extends HoverState<HoverContext, HoverMerged, ActionItemProps> {
     /** The commit, undefined while loading, or an error. */
     commitOrError?: GQL.IGitCommit | ErrorLike
 }
-
-const LinkComponent = (props: LinkProps) => <Link {...props} />
 
 /** Displays a commit. */
 export class RepositoryCommitPage extends React.Component<Props, State> {
@@ -92,22 +84,21 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
     private nextRepositoryCommitPageElement = (element: HTMLElement | null) =>
         this.repositoryCommitPageElements.next(element)
 
-    /** Emits when the go to definition button was clicked */
-    private goToDefinitionClicks = new Subject<MouseEvent>()
-    private nextGoToDefinitionClick = (event: MouseEvent) => this.goToDefinitionClicks.next(event)
-
     /** Emits when the close button was clicked */
     private closeButtonClicks = new Subject<MouseEvent>()
     private nextCloseButtonClick = (event: MouseEvent) => this.closeButtonClicks.next(event)
 
     private subscriptions = new Subscription()
-    private hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
+    private hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
 
     constructor(props: Props) {
         super(props)
-        this.hoverifier = createHoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>({
+        this.hoverifier = createHoverifier<
+            RepoSpec & RevSpec & FileSpec & ResolvedRevSpec,
+            HoverMerged,
+            ActionItemProps
+        >({
             closeButtonClicks: this.closeButtonClicks,
-            goToDefinitionClicks: this.goToDefinitionClicks,
             hoverOverlayElements: this.hoverOverlayElements,
             hoverOverlayRerenders: this.componentUpdates.pipe(
                 withLatestFrom(this.hoverOverlayElements, this.repositoryCommitPageElements),
@@ -119,11 +110,8 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                 // Can't reposition HoverOverlay if it wasn't rendered
                 filter(propertyIsDefined('hoverOverlayElement'))
             ),
-            pushHistory: path => this.props.history.push(path),
-            fetchHover: hoveredToken =>
-                getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props) as Subscribable<HoverMerged>,
-            fetchJumpURL: hoveredToken => getJumpURL(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
-            getReferencesURL: position => toPrettyBlobURL({ ...position, position, viewState: 'references' }),
+            getHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
+            getActions: context => getHoverActions(this.props, context),
         })
         this.subscriptions.add(this.hoverifier)
         this.state = this.hoverifier.hoverState
@@ -261,9 +249,10 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                 {this.state.hoverOverlayProps && (
                     <HoverOverlay
                         {...this.state.hoverOverlayProps}
-                        linkComponent={LinkComponent}
                         hoverRef={this.nextOverlayElement}
-                        onGoToDefinitionClick={this.nextGoToDefinitionClick}
+                        extensionsController={this.props.extensionsController}
+                        platformContext={this.props.platformContext}
+                        location={this.props.location}
                         onCloseButtonClick={this.nextCloseButtonClick}
                     />
                 )}

--- a/web/src/repo/compare/FileDiffHunks.tsx
+++ b/web/src/repo/compare/FileDiffHunks.tsx
@@ -4,6 +4,8 @@ import { isEqual } from 'lodash'
 import * as React from 'react'
 import { NEVER, Subject, Subscription } from 'rxjs'
 import { filter } from 'rxjs/operators'
+import { ActionItemProps } from '../../../../shared/src/actions/ActionItem'
+import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { isDefined } from '../../../../shared/src/util/types'
@@ -202,7 +204,7 @@ interface Props extends PlatformContextProps {
     className: string
     location: H.Location
     history: H.History
-    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
 }
 
 interface State {}

--- a/web/src/repo/compare/FileDiffNode.tsx
+++ b/web/src/repo/compare/FileDiffNode.tsx
@@ -4,6 +4,8 @@ import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
+import { ActionItemProps } from '../../../../shared/src/actions/ActionItem'
+import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
@@ -24,7 +26,7 @@ export interface FileDiffNodeProps extends PlatformContextProps, ExtensionsContr
     className?: string
     location: H.Location
     history: H.History
-    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
 }
 
 interface State {

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -1,15 +1,17 @@
-import { createHoverifier, HoveredToken, Hoverifier, HoverOverlay, HoverState } from '@sourcegraph/codeintellify'
-import { HoverMerged } from '@sourcegraph/codeintellify/lib/types'
+import { createHoverifier, HoveredToken, Hoverifier, HoverState } from '@sourcegraph/codeintellify'
 import { isEqual, upperFirst } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import * as React from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
-import { Link, LinkProps } from 'react-router-dom'
-import { Subject, Subscribable, Subscription } from 'rxjs'
+import { Subject, Subscription } from 'rxjs'
 import { filter, map, withLatestFrom } from 'rxjs/operators'
+import { ActionItemProps } from '../../../../shared/src/actions/ActionItem'
+import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { getHoverActions } from '../../../../shared/src/hover/actions'
+import { HoverContext, HoverOverlay } from '../../../../shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { propertyIsDefined } from '../../../../shared/src/util/types'
@@ -21,9 +23,8 @@ import {
     RepoSpec,
     ResolvedRevSpec,
     RevSpec,
-    toPrettyBlobURL,
 } from '../../../../shared/src/util/url'
-import { getHover, getJumpURL } from '../../backend/features'
+import { getHover } from '../../backend/features'
 import { HeroPage } from '../../components/HeroPage'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
 import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
@@ -47,7 +48,7 @@ interface Props
     repo: GQL.IRepository
 }
 
-interface State extends HoverState {
+interface State extends HoverState<HoverContext, HoverMerged, ActionItemProps> {
     error?: string
 }
 
@@ -68,8 +69,6 @@ export interface RepositoryCompareAreaPageProps extends PlatformContextProps {
     routePrefix: string
 }
 
-const LinkComponent = (props: LinkProps) => <Link {...props} />
-
 /**
  * Renders pages related to a repository comparison.
  */
@@ -85,22 +84,21 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
     private nextRepositoryCompareAreaElement = (element: HTMLElement | null) =>
         this.repositoryCompareAreaElements.next(element)
 
-    /** Emits when the go to definition button was clicked */
-    private goToDefinitionClicks = new Subject<MouseEvent>()
-    private nextGoToDefinitionClick = (event: MouseEvent) => this.goToDefinitionClicks.next(event)
-
     /** Emits when the close button was clicked */
     private closeButtonClicks = new Subject<MouseEvent>()
     private nextCloseButtonClick = (event: MouseEvent) => this.closeButtonClicks.next(event)
 
     private subscriptions = new Subscription()
-    private hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
+    private hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
 
     constructor(props: Props) {
         super(props)
-        this.hoverifier = createHoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>({
+        this.hoverifier = createHoverifier<
+            RepoSpec & RevSpec & FileSpec & ResolvedRevSpec,
+            HoverMerged,
+            ActionItemProps
+        >({
             closeButtonClicks: this.closeButtonClicks,
-            goToDefinitionClicks: this.goToDefinitionClicks,
             hoverOverlayElements: this.hoverOverlayElements,
             hoverOverlayRerenders: this.componentUpdates.pipe(
                 withLatestFrom(this.hoverOverlayElements, this.repositoryCompareAreaElements),
@@ -112,11 +110,8 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
                 // Can't reposition HoverOverlay if it wasn't rendered
                 filter(propertyIsDefined('hoverOverlayElement'))
             ),
-            pushHistory: path => this.props.history.push(path),
-            fetchHover: hoveredToken =>
-                getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props) as Subscribable<HoverMerged>,
-            fetchJumpURL: hoveredToken => getJumpURL(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
-            getReferencesURL: position => toPrettyBlobURL({ ...position, position, viewState: 'references' }),
+            getHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
+            getActions: context => getHoverActions(this.props, context),
         })
         this.subscriptions.add(this.hoverifier)
         this.state = this.hoverifier.hoverState
@@ -210,9 +205,10 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
                 {this.state.hoverOverlayProps && (
                     <HoverOverlay
                         {...this.state.hoverOverlayProps}
-                        linkComponent={LinkComponent}
                         hoverRef={this.nextOverlayElement}
-                        onGoToDefinitionClick={this.nextGoToDefinitionClick}
+                        extensionsController={this.props.extensionsController}
+                        platformContext={this.props.platformContext}
+                        location={this.props.location}
                         onCloseButtonClick={this.nextCloseButtonClick}
                     />
                 )}

--- a/web/src/repo/compare/RepositoryCompareDiffPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareDiffPage.tsx
@@ -3,6 +3,8 @@ import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
+import { ActionItemProps } from '../../../../shared/src/actions/ActionItem'
+import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
@@ -102,7 +104,7 @@ interface RepositoryCompareDiffPageProps
 
     /** The head of the comparison. */
     head: { repoName: string; repoID: GQL.ID; rev: string | null; commitID: string }
-    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
 }
 
 /** A page with the file diffs in the comparison. */

--- a/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -5,6 +5,8 @@ import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { merge, Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, switchMap } from 'rxjs/operators'
+import { ActionItemProps } from '../../../../shared/src/actions/ActionItem'
+import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
@@ -81,7 +83,7 @@ interface Props
 
     /** The head of the comparison. */
     head: { repoName: string; repoID: GQL.ID; rev?: string | null }
-    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
+    hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
 }
 
 interface State {

--- a/web/src/search/input/CodeIntellifyBlob.tsx
+++ b/web/src/search/input/CodeIntellifyBlob.tsx
@@ -1,37 +1,27 @@
-import {
-    createHoverifier,
-    findPositionsFromEvents,
-    HoveredToken,
-    HoverOverlay,
-    HoverState,
-} from '@sourcegraph/codeintellify'
+import { createHoverifier, findPositionsFromEvents, HoveredToken, HoverState } from '@sourcegraph/codeintellify'
 import { getTokenAtPosition } from '@sourcegraph/codeintellify/lib/token_position'
-import { HoverMerged } from '@sourcegraph/codeintellify/lib/types'
 import { Position } from '@sourcegraph/extension-api-types'
 import * as H from 'history'
 import * as React from 'react'
-import { Link, LinkProps } from 'react-router-dom'
-import { Subject, Subscribable, Subscription } from 'rxjs'
+import { Subject, Subscription } from 'rxjs'
 import { catchError, filter, map, withLatestFrom } from 'rxjs/operators'
+import { ActionItemProps } from '../../../../shared/src/actions/ActionItem'
+import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { getHoverActions } from '../../../../shared/src/hover/actions'
+import { HoverContext, HoverOverlay } from '../../../../shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '../../../../shared/src/languages'
+import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { isDefined, propertyIsDefined } from '../../../../shared/src/util/types'
-import {
-    FileSpec,
-    ModeSpec,
-    PositionSpec,
-    RepoSpec,
-    ResolvedRevSpec,
-    RevSpec,
-    toPrettyBlobURL,
-} from '../../../../shared/src/util/url'
-import { getHover, getJumpURL } from '../../backend/features'
+import { FileSpec, ModeSpec, PositionSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
+import { getHover } from '../../backend/features'
 import { fetchBlob } from '../../repo/blob/BlobPage'
 
-interface Props extends ExtensionsControllerProps {
+interface Props extends ExtensionsControllerProps, PlatformContextProps {
     history: H.History
+    location: H.Location
     className: string
     startLine: number
     endLine: number
@@ -42,7 +32,7 @@ interface Props extends ExtensionsControllerProps {
     defaultHoverPosition: Position
 }
 
-interface State extends HoverState {
+interface State extends HoverState<HoverContext, HoverMerged, ActionItemProps> {
     /**
      * The blob data or error that happened.
      * undefined while loading.
@@ -50,8 +40,6 @@ interface State extends HoverState {
     blobOrError?: GQL.IGitBlob | ErrorLike
     target?: EventTarget
 }
-
-const LinkComponent = (props: LinkProps) => <Link {...props} />
 
 const domFunctions = {
     getCodeElementFromTarget: (target: HTMLElement): HTMLTableCellElement | null => {
@@ -110,10 +98,6 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
     private nextCodeIntellifyBlobElements = (element: HTMLElement | null) =>
         this.codeIntellifyBlobElements.next(element)
 
-    /** Emits when the go to definition button was clicked */
-    private goToDefinitionClicks = new Subject<MouseEvent>()
-    private nextGoToDefinitionClick = (event: MouseEvent) => this.goToDefinitionClicks.next(event)
-
     /** Emits when the close button was clicked */
     private closeButtonClicks = new Subject<MouseEvent>()
     private nextCloseButtonClick = (event: MouseEvent) => this.closeButtonClicks.next(event)
@@ -128,11 +112,13 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
         super(props)
         this.state = {}
 
-        const hoverifier = createHoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>({
+        const hoverifier = createHoverifier<
+            RepoSpec & RevSpec & FileSpec & ResolvedRevSpec,
+            HoverMerged,
+            ActionItemProps
+        >({
             closeButtonClicks: this.closeButtonClicks,
-            goToDefinitionClicks: this.goToDefinitionClicks,
             hoverOverlayElements: this.hoverOverlayElements,
-            pushHistory: path => this.props.history.push(path),
             hoverOverlayRerenders: this.componentUpdates.pipe(
                 withLatestFrom(this.hoverOverlayElements, this.codeIntellifyBlobElements),
                 map(([, hoverOverlayElement, codeIntellifyBlobElement]) => ({
@@ -148,10 +134,8 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
                 filter(propertyIsDefined('relativeElement')),
                 filter(propertyIsDefined('hoverOverlayElement'))
             ),
-            fetchHover: hoveredToken =>
-                getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props) as Subscribable<HoverMerged>,
-            fetchJumpURL: hoveredToken => getJumpURL(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
-            getReferencesURL: position => toPrettyBlobURL({ ...position, position, viewState: 'references' }),
+            getHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
+            getActions: context => getHoverActions(this.props, context),
         })
 
         this.subscriptions.add(hoverifier)
@@ -284,9 +268,10 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
                 {this.state.hoverOverlayProps && (
                     <HoverOverlay
                         {...hoverOverlayProps}
-                        linkComponent={LinkComponent}
                         hoverRef={this.nextOverlayElement}
-                        onGoToDefinitionClick={this.nextGoToDefinitionClick}
+                        extensionsController={this.props.extensionsController}
+                        platformContext={this.props.platformContext}
+                        location={this.props.location}
                         onCloseButtonClick={this.nextCloseButtonClick}
                         showCloseButton={false}
                         className={this.props.tooltipClass}
@@ -301,7 +286,9 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
      * so that it aligns the right side of the hover overlay with the right side of the target element.
      *
      */
-    private adjustHoverOverlayPosition(target: EventTarget | null): HoverState['hoverOverlayProps'] {
+    private adjustHoverOverlayPosition(
+        target: EventTarget | null
+    ): HoverState<HoverContext, HoverMerged, ActionItemProps>['hoverOverlayProps'] {
         const viewPortEdge = window.innerWidth
         if (!this.state.hoverOverlayProps) {
             return undefined

--- a/web/src/search/input/MainPage.tsx
+++ b/web/src/search/input/MainPage.tsx
@@ -6,6 +6,7 @@ import * as React from 'react'
 import { parseSearchURLQuery } from '..'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { Form } from '../../components/Form'
 import { HeroPage } from '../../components/HeroPage'
 import { PageTitle } from '../../components/PageTitle'
@@ -16,7 +17,7 @@ import { CodeIntellifyBlob } from './CodeIntellifyBlob'
 import { QueryInputForModal } from './QueryInputForModal'
 import { SearchButton } from './SearchButton'
 
-interface Props extends ExtensionsControllerProps {
+interface Props extends ExtensionsControllerProps, PlatformContextProps {
     authenticatedUser: GQL.IUser | null
     location: H.Location
     history: H.History

--- a/web/src/tracking/services/serverAdminWrapper.tsx
+++ b/web/src/tracking/services/serverAdminWrapper.tsx
@@ -28,10 +28,9 @@ class ServerAdminWrapper {
             if (eventAction === 'SearchSubmitted') {
                 logUserEvent(GQL.UserEvent.SEARCHQUERY)
             } else if (
-                eventAction === 'SymbolHovered' ||
-                eventAction === 'FindRefsClicked' ||
-                eventAction === 'FindImplementationsClicked' ||
-                eventAction === 'GoToDefClicked'
+                eventAction === 'goToDefinition' ||
+                eventAction === 'goToDefinition.preloaded' ||
+                eventAction === 'findReferences'
             ) {
                 logUserEvent(GQL.UserEvent.CODEINTEL)
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,35 +1482,36 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@sourcegraph/codeintellify@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-5.1.0.tgz#1f3801f9f92713b6b18eb88a0cd0e0c329448423"
-  integrity sha512-Qxvw5QwuMxGJK33kvDAryeSKGU05WtNmaKXayly8v4UjORKXzJ7uowTExWXiNrU3BWWvo+L2fetZJmbs/+yhfA==
+"@sourcegraph/codeintellify@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.0.2.tgz#22751c6fe68f241e63bda5193582b1ff53e20bf1"
+  integrity sha512-WquHQ8tGFPTEObV0+shpDL+jF8LbWMI7hJ5LcGb4XbOLCgFfw5e4ETWE5lRrRSUf86FGpjDPIUMju8pTZdvUeQ==
   dependencies:
-    "@sourcegraph/event-positions" "^1.0.0"
-    "@sourcegraph/react-loading-spinner" "0.0.7"
-    highlight.js "^9.12.0"
+    "@sourcegraph/event-positions" "^1.0.1"
+    "@sourcegraph/extension-api-types" "^1.0.1"
     lodash "^4.17.10"
-    marked "^0.4.0 || ^0.5.0"
-    mdi-react "^5.1.0"
     rxjs "^6.3.3"
-    sanitize-html "^1.18.2"
     ts-key-enum "^2.0.0"
-    vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/event-positions@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/event-positions/-/event-positions-1.0.0.tgz#0ed852ccb6d4b4074007b8bc18185ffb6ae7b775"
-  integrity sha512-MUTu6kkOcRINJTLNmYfdFAjkzhogU2tyJR5beFBj1nOe9AP+RKRekhO2xc0LS5YnsB4ZxgUthey+clSiMF+jlg==
+"@sourcegraph/event-positions@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@sourcegraph/event-positions/-/event-positions-1.0.1.tgz#aa83c38170275db4e696a6d5fc0f4d1e733713be"
+  integrity sha512-CTmFVVcw0C+z6DWpW2EiyeAqhC1mrcAndyKh+ZSriRu3r4ZL1/6JG6JQFSqydLp4PelXOh/p8GqtdDdQae83Vw==
   dependencies:
+    "@sourcegraph/extension-api-types" "^1.1.0"
     lodash "^4.17.10"
     rxjs "^6.3.2"
-    vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "1.0.2"
+"@sourcegraph/extension-api-types@^1.0.1", "@sourcegraph/extension-api-types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/extension-api-types/-/extension-api-types-1.1.0.tgz#a947b1784c721e6e81988785e0a6fe6b9ebec7a3"
+  integrity sha512-XSImr1Xcjvtq0OrKTUhQLd8RhFMAvsIzCEqYLZ99fI/+252SJowuOGMGe7vMp0XLZ5cZxswJcdYdTiM6XOOsZA==
   dependencies:
     sourcegraph "*"
+
+"@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -8221,7 +8222,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^9.0.0, highlight.js@^9.12.0, highlight.js@^9.13.1:
+highlight.js@^9.0.0, highlight.js@^9.13.1:
   version "9.13.1"
   resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
   integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
@@ -8344,7 +8345,7 @@ html-webpack-plugin@^4.0.0-beta.2:
     tapable "^1.1.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.9.0, htmlparser2@^3.9.2:
+htmlparser2@^3.10.0, htmlparser2@^3.9.2:
   version "3.10.0"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
   integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
@@ -10065,7 +10066,7 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.mergewith@^4.6.0:
+lodash.mergewith@^4.6.0, lodash.mergewith@^4.6.1:
   version "4.6.1"
   resolved "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
   integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
@@ -10257,11 +10258,6 @@ marked@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
   integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
-
-"marked@^0.4.0 || ^0.5.0":
-  version "0.5.1"
-  resolved "https://registry.npmjs.org/marked/-/marked-0.5.1.tgz#062f43b88b02ee80901e8e8d8e6a620ddb3aa752"
-  integrity sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw==
 
 marked@^0.5.2:
   version "0.5.2"
@@ -12253,7 +12249,7 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.23:
+postcss@^6.0.1, postcss@^6.0.23:
   version "6.0.23"
   resolved "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
@@ -13554,21 +13550,21 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
-sanitize-html@^1.18.2:
-  version "1.19.1"
-  resolved "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.19.1.tgz#e8b33c69578054d6ee4f57ea152d6497f3f6fb7d"
-  integrity sha512-zNYr6FvBn4bZukr9x2uny6od/9YdjCLwF+FqxivqI0YOt/m9GIxfX+tWhm52tBAPUXiTTb4bJTGVagRz5b06bw==
+sanitize-html@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.0.tgz#9a602beb1c9faf960fb31f9890f61911cc4d9156"
+  integrity sha512-BpxXkBoAG+uKCHjoXFmox6kCSYpnulABoGcZ/R3QyY9ndXbIM5S94eOr1IqnzTG8TnbmXaxWoDDzKC5eJv7fEQ==
   dependencies:
-    chalk "^2.3.0"
-    htmlparser2 "^3.9.0"
+    chalk "^2.4.1"
+    htmlparser2 "^3.10.0"
     lodash.clonedeep "^4.5.0"
     lodash.escaperegexp "^4.1.2"
     lodash.isplainobject "^4.0.6"
     lodash.isstring "^4.0.1"
-    lodash.mergewith "^4.6.0"
-    postcss "^6.0.14"
+    lodash.mergewith "^4.6.1"
+    postcss "^7.0.5"
     srcset "^1.0.0"
-    xtend "^4.0.0"
+    xtend "^4.0.1"
 
 sass-graph@^2.2.4:
   version "2.2.4"
@@ -14087,7 +14083,8 @@ sourcegraph@*:
   integrity sha512-fyx0nFtySTdn+Y1JR7LPdl2lj9vHCbSgoLjzMEW5iuBjVuVHXdVldq3kjBYoI98MI6L53qATT993sDVrq4Jqwg==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "20.1.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -15679,11 +15676,6 @@ vm-browserify@0.0.4:
   integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
   dependencies:
     indexof "0.0.1"
-
-vscode-languageserver-types@^3.8.2:
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz#b704b024cef059f7b326611c99b9c8753c0a18b4"
-  integrity sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The goal of this PR is to make [basic-code-intel](sourcegraph/sourcegraph-basic-code-intel#9) an awesome experience when you need go-to-definition, hovers, and find-references when browsing code in any language with no configuration. That means that the initial experience of site admins and users will be much better, because they get to see code intelligence with *much* less setup required.

This incorporates the codeintellify PR sourcegraph/codeintellify#70. That PR makes it so that codeintellify (which implements our hover tooltip) supports custom actions, instead of hardcoding "Go to definition" and "Find references".

This commit makes the web app (and TODO soon the browser extension) make use of that, so that:

1. The "Go to definition" and "Find references" actions work in the same way in the web app and browser extension as all other action buttons. This means those actions are no longer hard-coded in a separate library.
2. These buttons are selectively displayed in a smarter way based on (e.g.) whether there are any registered definition or reference providers for the current document. This fixes the issue where both buttons were always shown if there was a hover, even if the client app knew they would not return anything.
3. The buttons can do smarter things, like opening up the definition panel if there are multiple definitions (instead of just jumping to the 1st definition).
4. Extensions can add their own actions to the hover, such as "Find implementations", "Show history" (eg when a func, or calls to a func, were added/removed in Git history), "Show authors", "Show users", "Show stack traces", etc.

(I initially began implementing this so that basic-code-intel could add "Go to definition (fuzzy)" to the hover using (4), but I think that the improvements in (2) and (3) actually make that unnecessary for basic-code-intel. (It's still important to prioritize precise definitions in the panel; that will come soon.) See sourcegraph/sourcegraph-basic-code-intel#9 for the basic-code-intel changes that make use of this new behavior. (Note that there are *no* new extension APIs added in this PR, just improved handling of what already exists.))

TODOs before merging:

- [x] Update the browser extension impl code to use this
- [x] Add more tests to actions.test.ts
- [x] Fix issue where the input rev is discarded and the absolute commit ID SHA is used
- [x] Add back logTelemetryEvent for code intel action logging - make HoverOverlay record it