### PR TITLE
graphqlbackend: add management console password fetch/clear functionality

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -310,6 +310,9 @@ type Mutation {
     requestTrial(email: String!): EmptyResponse
     # Manages the extension registry.
     extensionRegistry: ExtensionRegistryMutation!
+    # Clears the management console plaintext password forever. Only site
+    # admins can perform this action.
+    clearManagementConsolePlaintextPassword: EmptyResponse
     # Mutations that are only used on Sourcegraph.com.
     #
     # FOR INTERNAL USE ONLY.
@@ -2696,6 +2699,20 @@ type Site implements SettingsSubject {
         # Months of history.
         months: Int
     ): SiteUsageStatistics!
+    # Information about this site's management console.
+    #
+    # Only site admins may retrieve this information.
+    managementConsoleState: ManagementConsoleState!
+}
+
+# Information about this site's management console.
+#
+# Only site admins may retrieve this information.
+type ManagementConsoleState {
+    # The plaintext password of the management console, which is automatically
+    # generated. This can only be retrieved until the admin clears it, after
+    # which it is impossible to retrieve.
+    plaintextPassword: String
 }
 
 # The configuration for a site.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -317,6 +317,9 @@ type Mutation {
     requestTrial(email: String!): EmptyResponse
     # Manages the extension registry.
     extensionRegistry: ExtensionRegistryMutation!
+    # Clears the management console plaintext password forever. Only site
+    # admins can perform this action.
+    clearManagementConsolePlaintextPassword: EmptyResponse
     # Mutations that are only used on Sourcegraph.com.
     #
     # FOR INTERNAL USE ONLY.
@@ -2703,6 +2706,20 @@ type Site implements SettingsSubject {
         # Months of history.
         months: Int
     ): SiteUsageStatistics!
+    # Information about this site's management console.
+    #
+    # Only site admins may retrieve this information.
+    managementConsoleState: ManagementConsoleState!
+}
+
+# Information about this site's management console.
+#
+# Only site admins may retrieve this information.
+type ManagementConsoleState {
+    # The plaintext password of the management console, which is automatically
+    # generated. This can only be retrieved until the admin clears it, after
+    # which it is impossible to retrieve.
+    plaintextPassword: String
 }
 
 # The configuration for a site.


### PR DESCRIPTION
This will support informing site admins of the management console password and
giving them the ability to copy it. For a logical outline of how this will work
see https://github.com/sourcegraph/sourcegraph/issues/965#issuecomment-441552016

The actual UX which uses these GraphQL queries and mutations will be sent as
part of https://github.com/sourcegraph/sourcegraph/pull/966 since it cannot be
merged independently.

Helps #965