### PR TITLE
web: components: make CopyableText also support passwords

### DIFF
--- a/web/src/components/CopyableText.tsx
+++ b/web/src/components/CopyableText.tsx
@@ -11,6 +11,9 @@ interface Props {
 
     /** The size of the input element. */
     size?: number
+
+    /** Whether or not the text to be copied is a password. */
+    password?: boolean
 }
 
 interface State {
@@ -31,7 +34,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
             <div className={`copyable-text form-inline ${this.props.className || ''}`}>
                 <div className="input-group">
                     <input
-                        type="text"
+                        type={this.props.password ? 'password' : 'text'}
                         className="copyable-text__input form-control"
                         value={this.props.text}
                         size={this.props.size}


### PR DESCRIPTION
I am using this component to allow users to copy the management console
password via a UX that looks like this:

![image](https://user-images.githubusercontent.com/3173176/49711146-8d88a480-fbf2-11e8-99c0-7345ea81a4e2.png)

Helps #965