### PR TITLE
don't hoverify rendered markdown code views

### DIFF
--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -100,7 +100,11 @@ const commentSnippetCodeView: CodeView = {
     isDiff: false,
 }
 
-const resolveCodeView = (elem: HTMLElement): CodeViewWithOutSelector => {
+const resolveCodeView = (elem: HTMLElement): CodeViewWithOutSelector | null => {
+    if (elem.querySelector('.markdown-body')) {
+        return null
+    }
+
     const files = document.getElementsByClassName('file')
     const { filePath } = parseURL()
     const isSingleCodeFile = files.length === 1 && filePath && document.getElementsByClassName('diff-view').length === 0


### PR DESCRIPTION
`Error: Unable to determine start line of code view` was being thrown on code views that were just rendered markdown content. This shouldn't be the case as rendered markdown is not code.