### PR TITLE
fix #1330: decorations are not cleaned when toggled

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -493,11 +493,12 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                             })
                         }
 
+                        let decoratedLines: number[] = []
                         if (extensionsController && !info.baseCommitID) {
                             extensionsController.services.textDocumentDecoration
                                 .getDecorations(toTextDocumentIdentifier(info))
                                 .subscribe(decorations => {
-                                    applyDecorations(dom, codeView, decorations || [])
+                                    decoratedLines = applyDecorations(dom, codeView, decorations || [], decoratedLines)
                                 })
                         }
 

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -74,27 +74,36 @@ const groupByLine = (decorations: TextDocumentDecoration[]) => {
     return grouped
 }
 
+export const cleanupDecorations = (dom: DOMFunctions, codeView: HTMLElement, lines: number[]): void => {
+    for (const lineNumber of lines) {
+        const codeElement = dom.getCodeElementFromLineNumber(codeView, lineNumber)
+        if (!codeElement) {
+            continue
+        }
+        codeElement.style.backgroundColor = null
+        const previousDecorations = codeElement.querySelectorAll('.line-decoration-attachment')
+        for (const d of previousDecorations) {
+            d.remove()
+        }
+    }
+}
+
 /**
  * Applies a decoration to a code view. This doesn't work with diff views yet.
  */
 export const applyDecorations = (
     dom: DOMFunctions,
     codeView: HTMLElement,
-    decorations: TextDocumentDecoration[]
-): void => {
-    for (const [lineNumber, decorationsForLine] of groupByLine(decorations)) {
+    decorations: TextDocumentDecoration[],
+    previousDecorations: number[]
+): number[] => {
+    cleanupDecorations(dom, codeView, previousDecorations)
+    const decorationsByLine = groupByLine(decorations)
+    for (const [lineNumber, decorationsForLine] of decorationsByLine) {
         const codeElement = dom.getCodeElementFromLineNumber(codeView, lineNumber)
         if (!codeElement) {
             throw new Error(`Unable to find code element for line ${lineNumber}`)
         }
-
-        // remove all previously existing declarations on this line
-        codeElement.style.backgroundColor = null
-        const previousDecorations = codeElement.querySelectorAll('.line-decoration-attachment')
-        for (const d of previousDecorations) {
-            d.remove()
-        }
-
         for (const decoration of decorationsForLine) {
             const style = decorationStyleForTheme(decoration, IS_LIGHT_THEME)
             if (style.backgroundColor) {
@@ -131,4 +140,5 @@ export const applyDecorations = (
             }
         }
     }
+    return [...decorationsByLine.keys()]
 }


### PR DESCRIPTION
Fix regression introduced by #1268 

Reintroduces the following limitation: it is effectively impossible to have decorations from several extensions displayed on a code view (#1339)