### PR TITLE
Support HEAD requests to the raw API

### DIFF
--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -92,7 +92,7 @@ func newRouter() *mux.Router {
 	repo.Path("/badge.svg").Methods("GET").Name(RepoBadge)
 
 	// Must come last
-	base.PathPrefix("/").Methods("GET").Name(UI)
+	base.PathPrefix("/").Name(UI)
 
 	return base
 }

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -86,6 +86,16 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 		requestedPath = "/" + requestedPath
 	}
 
+	if requestedPath == "/" && r.Method == "HEAD" {
+		_, err = gitserver.DefaultClient.RepoInfo(r.Context(), common.Repo.Name)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return err
+		}
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+
 	const (
 		textPlain       = "text/plain"
 		applicationZip  = "application/zip"
@@ -125,16 +135,6 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 		relativePath := strings.TrimPrefix(requestedPath, "/")
 		if relativePath == "" {
 			relativePath = "."
-		}
-
-		if r.Method == "HEAD" {
-			_, err = gitserver.DefaultClient.RepoInfo(r.Context(), common.Repo.Name)
-			if err != nil {
-				w.WriteHeader(http.StatusNotFound)
-				return err
-			}
-			w.WriteHeader(http.StatusOK)
-			return nil
 		}
 
 		f, _, err := vfsutil.GitServerFetchArchive(r.Context(), vfsutil.ArchiveOpts{

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -12,6 +12,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
+
 	"github.com/golang/gddo/httputil"
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/sourcegraph/pkg/vfsutil"
@@ -124,6 +126,17 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 		if relativePath == "" {
 			relativePath = "."
 		}
+
+		if r.Method == "HEAD" {
+			_, err = gitserver.DefaultClient.RepoInfo(r.Context(), common.Repo.Name)
+			if err != nil {
+				w.WriteHeader(http.StatusNotFound)
+				return err
+			}
+			w.WriteHeader(http.StatusOK)
+			return nil
+		}
+
 		f, _, err := vfsutil.GitServerFetchArchive(r.Context(), vfsutil.ArchiveOpts{
 			Repo:         common.Repo.Name,
 			Commit:       common.CommitID,

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -158,7 +158,7 @@ func newRouter() *mux.Router {
 	repoRev.Path("/blob{Path:.*}").Methods("GET").Name(routeBlob)
 
 	// raw
-	repoRev.Path("/raw{Path:.*}").Methods("GET").Name(routeRaw)
+	repoRev.Path("/raw{Path:.*}").Methods("GET", "HEAD").Name(routeRaw)
 
 	repo := r.PathPrefix(repoRevPath + "/" + routevar.RepoPathDelim).Subrouter()
 	repo.PathPrefix("/settings").Methods("GET").Name(routeRepoSettings)


### PR DESCRIPTION
This allows language servers to quickly determine whether or not the given repository exists on the Sourcegraph instance without needing to construct a Sourcegraph-specific GraphQL query. cc @felixfbecker this might be useful for TypeScript too.

See https://github.com/sourcegraph/go-langserver/pull/345#discussion_r240768252