### PR TITLE
rename repoPath -> repoName in frontend code

### DIFF
--- a/client/browser/src/libs/bitbucket/api.ts
+++ b/client/browser/src/libs/bitbucket/api.ts
@@ -10,8 +10,8 @@ import { PRPageInfo } from './scrape'
 //
 // PR API /rest/api/1.0/projects/SG/repos/go-langserver/pull-requests/1
 
-const buildURL = (project: string, repoName: string, path: string) =>
-    `${window.location.origin}/rest/api/1.0/projects/${encodeURIComponent(project)}/repos/${repoName}${path}`
+const buildURL = (project: string, repoSlug: string, path: string) =>
+    `${window.location.origin}/rest/api/1.0/projects/${encodeURIComponent(project)}/repos/${repoSlug}${path}`
 
 const get = <T>(url: string): Observable<T> => ajax.get(url).pipe(map(({ response }) => response as T))
 
@@ -39,7 +39,7 @@ interface PRResponse {
     toRef: Ref
 }
 
-interface GetCommitsForPRInput extends Pick<PRPageInfo, 'project' | 'repoName'> {
+interface GetCommitsForPRInput extends Pick<PRPageInfo, 'project' | 'repoSlug'> {
     /** Required here. */
     prID: number
 }
@@ -50,14 +50,14 @@ interface GetCommitsForPRInput extends Pick<PRPageInfo, 'project' | 'repoName'> 
 export const getCommitsForPR: (
     info: GetCommitsForPRInput
 ) => Observable<{ baseCommitID: string; headCommitID: string }> = memoizeObservable(
-    ({ project, repoName, prID }) =>
-        get<PRResponse>(buildURL(project, repoName, `/pull-requests/${prID}`)).pipe(
+    ({ project, repoSlug, prID }) =>
+        get<PRResponse>(buildURL(project, repoSlug, `/pull-requests/${prID}`)).pipe(
             map(({ fromRef, toRef }) => ({ baseCommitID: toRef.latestCommit, headCommitID: fromRef.latestCommit }))
         ),
     ({ prID }) => prID.toString()
 )
 
-interface GetBaseCommitInput extends Pick<PRPageInfo, 'project' | 'repoName'> {
+interface GetBaseCommitInput extends Pick<PRPageInfo, 'project' | 'repoSlug'> {
     commitID: string
 }
 
@@ -71,8 +71,8 @@ interface CommitResponse {
 
 // Commit API /rest/api/1.0/projects/SG/repos/go-langserver/commits/b8a948dc75cc9d0c01ece01d0ba9d1eeace573aa
 export const getBaseCommit: (info: GetBaseCommitInput) => Observable<string> = memoizeObservable(
-    ({ project, repoName, commitID }) =>
-        get<CommitResponse>(buildURL(project, repoName, `/commits/${commitID}`)).pipe(
+    ({ project, repoSlug, commitID }) =>
+        get<CommitResponse>(buildURL(project, repoSlug, `/commits/${commitID}`)).pipe(
             map(({ parents }) => first(parents)),
             filter(isDefined),
             map(({ id }) => id)

--- a/client/browser/src/libs/bitbucket/file_info.ts
+++ b/client/browser/src/libs/bitbucket/file_info.ts
@@ -21,14 +21,14 @@ export const resolveFileInfo = (codeView: HTMLElement): Observable<FileInfo> =>
 export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo> =>
     of(codeView).pipe(
         map(getPRInfoFromCodeView),
-        switchMap(({ commitID, project, repoName, prID, ...rest }) => {
+        switchMap(({ commitID, project, repoSlug, prID, ...rest }) => {
             if (commitID) {
-                return getBaseCommit({ commitID, project, repoName }).pipe(
+                return getBaseCommit({ commitID, project, repoSlug }).pipe(
                     map(baseCommitID => ({ baseCommitID, headCommitID: commitID, ...rest }))
                 )
             }
 
-            return getCommitsForPR({ project, repoName, prID: prID! }).pipe(map(commits => ({ ...rest, ...commits })))
+            return getCommitsForPR({ project, repoSlug, prID: prID! }).pipe(map(commits => ({ ...rest, ...commits })))
         }),
         map(({ headCommitID, ...rest }) => ({ ...rest, commitID: headCommitID })),
         switchMap(info =>
@@ -40,14 +40,14 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                 }))
             )
         ),
-        switchMap(({ repoPath, filePath, baseCommitID, ...rest }) =>
+        switchMap(({ repoName, filePath, baseCommitID, ...rest }) =>
             fetchBlobContentLines({
-                repoPath,
+                repoName,
                 filePath,
                 commitID: baseCommitID,
             }).pipe(
                 map(lines => ({
-                    repoPath,
+                    repoName,
                     filePath,
                     baseCommitID,
                     baseContent: lines.join('\n'),

--- a/client/browser/src/libs/bitbucket/scrape.ts
+++ b/client/browser/src/libs/bitbucket/scrape.ts
@@ -1,8 +1,8 @@
 import { FileInfo } from '../code_intelligence'
 
-export interface PageInfo extends Pick<FileInfo, 'repoPath' | 'filePath' | 'rev'> {
+export interface PageInfo extends Pick<FileInfo, 'repoName' | 'filePath' | 'rev'> {
     project: string
-    repoName: string
+    repoSlug: string
 }
 
 const getFileInfoFromLink = (codeView: HTMLElement, linkSelector: string, fileInfoRegexp: RegExp) => {
@@ -23,7 +23,7 @@ const getFileInfoFromLink = (codeView: HTMLElement, linkSelector: string, fileIn
     }
 
     const project = pathMatch[1]
-    const repoName = pathMatch[2]
+    const repoSlug = pathMatch[2]
     const filePath = pathMatch[3]
 
     // Looks like 'refs/heads/<rev>'
@@ -37,16 +37,16 @@ const getFileInfoFromLink = (codeView: HTMLElement, linkSelector: string, fileIn
     const rev = atMatch ? atMatch[1] : at
 
     return {
-        repoPath: [host, project, repoName].join('/'),
+        repoName: [host, project, repoSlug].join('/'),
         filePath,
         rev,
         project,
-        repoName,
+        repoSlug,
     }
 }
 
 export const getFileInfoFromCodeView = (codeView: HTMLElement): PageInfo & Pick<FileInfo, 'commitID'> => {
-    const { repoPath, filePath, rev, project, repoName } = getFileInfoFromLink(
+    const { repoName, filePath, rev, project, repoSlug } = getFileInfoFromLink(
         codeView,
         'a.raw-view-link',
         // Looks like '/projects/<project>/repos/<repo name>/raw/<file path>'
@@ -61,12 +61,12 @@ export const getFileInfoFromCodeView = (codeView: HTMLElement): PageInfo & Pick<
     const commitID = commitLink.dataset.commitid!
 
     return {
-        repoPath,
+        repoName,
         filePath,
         rev,
         commitID,
         project,
-        repoName,
+        repoSlug,
     }
 }
 
@@ -88,7 +88,7 @@ const getFileInfoFromFilePathLink = (codeView: HTMLElement) => {
     }
 
     const project = pathMatch[1]
-    const repoName = pathMatch[2]
+    const repoSlug = pathMatch[2]
 
     const commitMatch = path.match(/\/commits\/(.*?)$/)
 
@@ -98,11 +98,11 @@ const getFileInfoFromFilePathLink = (codeView: HTMLElement) => {
     filePath = filePath.replace(/\?.*$/, '')
 
     return {
-        repoPath: [host, project, repoName].join('/'),
+        repoName: [host, project, repoSlug].join('/'),
         filePath,
         commitID,
         project,
-        repoName,
+        repoSlug,
     }
 }
 
@@ -112,10 +112,10 @@ export interface PRPageInfo extends PageInfo {
 }
 
 export const getPRInfoFromCodeView = (codeView: HTMLElement): PRPageInfo => {
-    let repoPath: string
+    let repoName: string
     let filePath: string
     let project: string
-    let repoName: string
+    let repoSlug: string
     let commitID: string | undefined
 
     try {
@@ -126,17 +126,17 @@ export const getPRInfoFromCodeView = (codeView: HTMLElement): PRPageInfo => {
             /\/projects\/(.*?)\/repos\/(.*?)\/browse\/(.*)$/
         )
 
-        repoPath = info.repoPath
+        repoName = info.repoName
         filePath = info.filePath
         project = info.project
-        repoName = info.repoName
+        repoSlug = info.repoSlug
     } catch (e) {
         const info = getFileInfoFromFilePathLink(codeView)
 
-        repoPath = info.repoPath
+        repoName = info.repoName
         filePath = info.filePath
         project = info.project
-        repoName = info.repoName
+        repoSlug = info.repoSlug
         commitID = info.commitID
     }
 
@@ -157,11 +157,11 @@ export const getPRInfoFromCodeView = (codeView: HTMLElement): PRPageInfo => {
     }
 
     return {
-        repoPath: repoPath!,
+        repoName: repoName!,
         filePath: filePath!,
         commitID: commitID!,
         prID: prIDMatch ? parseInt(prIDMatch[1], 10) : undefined,
         project: project!,
-        repoName: repoName!,
+        repoSlug: repoSlug!,
     }
 }

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -158,10 +158,10 @@ export interface CodeHost {
 
 export interface FileInfo {
     /**
-     * The path for the repo the file belongs to. If a `baseRepoPath` is provided, this value
-     * is treated as the head repo path.
+     * The path for the repo the file belongs to. If a `baseRepoName` is provided, this value
+     * is treated as the head repo name.
      */
-    repoPath: string
+    repoName: string
     /**
      * The path for the file path for a given `codeView`. If a `baseFilePath` is provided, this value
      * is treated as the head file path.
@@ -177,10 +177,10 @@ export interface FileInfo {
      */
     rev?: string
     /**
-     * The repo bath for the BASE side of a diff. This is useful for Phabricator
+     * The repo name for the BASE side of a diff. This is useful for Phabricator
      * staging areas since they are separate repos.
      */
-    baseRepoPath?: string
+    baseRepoName?: string
     /**
      * The base file path.
      */
@@ -466,12 +466,12 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                         const roots: Model['roots'] = [{ uri: toRootURI(info) }]
 
                         // When codeView is a diff, add BASE too.
-                        if (baseContent! && info.baseRepoPath && info.baseCommitID && info.baseFilePath) {
+                        if (baseContent! && info.baseRepoName && info.baseCommitID && info.baseFilePath) {
                             visibleViewComponents.push({
                                 type: 'textEditor',
                                 item: {
                                     uri: toURIWithPath({
-                                        repoPath: info.baseRepoPath,
+                                        repoName: info.baseRepoName,
                                         commitID: info.baseCommitID,
                                         filePath: info.baseFilePath,
                                     }),
@@ -487,7 +487,7 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                             })
                             roots.push({
                                 uri: toRootURI({
-                                    repoPath: info.baseRepoPath,
+                                    repoName: info.baseRepoName,
                                     commitID: info.baseCommitID,
                                 }),
                             })
@@ -507,7 +507,7 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                     const resolveContext: ContextResolver<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec> = ({
                         part,
                     }) => ({
-                        repoPath: part === 'base' ? info.baseRepoPath || info.repoPath : info.repoPath,
+                        repoName: part === 'base' ? info.baseRepoName || info.repoName : info.repoName,
                         commitID: part === 'base' ? info.baseCommitID! : info.commitID,
                         filePath: part === 'base' ? info.baseFilePath || info.filePath : info.filePath,
                         rev: part === 'base' ? info.baseRev || info.baseCommitID! : info.rev || info.commitID,

--- a/client/browser/src/libs/code_intelligence/util/file_info.ts
+++ b/client/browser/src/libs/code_intelligence/util/file_info.ts
@@ -7,19 +7,19 @@ import { FileInfo } from '../code_intelligence'
 
 export const ensureRevisionsAreCloned = (files: Observable<FileInfo>): Observable<FileInfo> =>
     files.pipe(
-        switchMap(({ repoPath, commitID, baseCommitID, ...rest }) => {
+        switchMap(({ repoName, commitID, baseCommitID, ...rest }) => {
             // Although we get the commit SHA's from elesewhere, we still need to
             // use `resolveRev` otherwise we can't guarantee Sourcegraph has the
             // revision cloned.
 
             // Head
-            const resolvingHeadRev = resolveRev({ repoPath, rev: commitID }).pipe(retryWhenCloneInProgressError())
+            const resolvingHeadRev = resolveRev({ repoName, rev: commitID }).pipe(retryWhenCloneInProgressError())
 
             const requests = [resolvingHeadRev]
 
             // If theres a base, resolve it as well.
             if (baseCommitID) {
-                const resolvingBaseRev = resolveRev({ repoPath, rev: baseCommitID }).pipe(
+                const resolvingBaseRev = resolveRev({ repoName, rev: baseCommitID }).pipe(
                     retryWhenCloneInProgressError()
                 )
 
@@ -27,10 +27,10 @@ export const ensureRevisionsAreCloned = (files: Observable<FileInfo>): Observabl
             }
 
             return zip(...requests).pipe(
-                map(() => ({ repoPath, commitID, baseCommitID, ...rest })),
+                map(() => ({ repoName, commitID, baseCommitID, ...rest })),
                 catchError(err => {
                     if (err.code === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
-                        return [{ repoPath, commitID, baseCommitID, ...rest }]
+                        return [{ repoName, commitID, baseCommitID, ...rest }]
                     } else {
                         throw err
                     }

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -158,9 +158,9 @@ export const githubCodeHost: CodeHost = {
     buildJumpURLLocation: (def: JumpURLLocation) => {
         const rev = def.rev
         // If we're provided options, we can make the j2d URL more specific.
-        const { repoPath } = parseURL()
+        const { repoName } = parseURL()
 
-        const sameRepo = repoPath === def.repoPath
+        const sameRepo = repoName === def.repoName
         // Stay on same page in PR if possible.
         if (sameRepo && def.part) {
             const containers = getFileContainers()
@@ -178,7 +178,7 @@ export const githubCodeHost: CodeHost = {
             }
         }
 
-        return `https://${def.repoPath}/blob/${rev}/${def.filePath}#L${def.position.line}${
+        return `https://${def.repoName}/blob/${rev}/${def.filePath}#L${def.position.line}${
             def.position.character ? ':' + def.position.character : ''
         }`
     },

--- a/client/browser/src/libs/github/file_info.ts
+++ b/client/browser/src/libs/github/file_info.ts
@@ -11,9 +11,9 @@ import { getDeltaFileName, getDiffResolvedRev, getGitHubState, parseURL } from '
 export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo> =>
     of(codeView).pipe(
         map(codeView => {
-            const { repoPath } = parseURL()
+            const { repoName } = parseURL()
 
-            return { codeView, repoPath }
+            return { codeView, repoName }
         }),
         map(({ codeView, ...rest }) => {
             const { headFilePath, baseFilePath } = getDeltaFileName(codeView)
@@ -35,13 +35,13 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                 ...data,
             }
         }),
-        switchMap(({ repoPath, headRev, baseRev, ...rest }) => {
-            const resolvingHeadRev = resolveRev({ repoPath, rev: headRev }).pipe(retryWhenCloneInProgressError())
-            const resolvingBaseRev = resolveRev({ repoPath, rev: baseRev }).pipe(retryWhenCloneInProgressError())
+        switchMap(({ repoName, headRev, baseRev, ...rest }) => {
+            const resolvingHeadRev = resolveRev({ repoName, rev: headRev }).pipe(retryWhenCloneInProgressError())
+            const resolvingBaseRev = resolveRev({ repoName, rev: baseRev }).pipe(retryWhenCloneInProgressError())
 
             return zip(resolvingHeadRev, resolvingBaseRev).pipe(
                 map(([headCommitID, baseCommitID]) => ({
-                    repoPath,
+                    repoName,
                     headRev,
                     baseRev,
                     headCommitID,
@@ -51,12 +51,12 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
             )
         }),
         map(info => ({
-            repoPath: info.repoPath,
+            repoName: info.repoName,
             filePath: info.headFilePath,
             commitID: info.headCommitID,
             rev: info.headRev,
 
-            baseRepoPath: info.repoPath,
+            baseRepoName: info.repoName,
             baseFilePath: info.baseFilePath || info.headFilePath,
             baseCommitID: info.baseCommitID,
             baseRev: info.baseRev,
@@ -67,7 +67,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
     )
 
 export const resolveFileInfo = (): Observable<FileInfo> => {
-    const { repoPath, filePath, rev } = parseURL()
+    const { repoName, filePath, rev } = parseURL()
     if (!filePath) {
         return throwError(
             new Error(
@@ -82,7 +82,7 @@ export const resolveFileInfo = (): Observable<FileInfo> => {
         const commitID = getCommitIDFromPermalink()
 
         return of({
-            repoPath,
+            repoName,
             filePath,
             commitID,
             rev: rev || commitID,
@@ -109,14 +109,17 @@ export const resolveSnippetFileInfo = (codeView: HTMLElement): Observable<FileIn
         }),
         filter(isDefined),
         filter(propertyIsDefined('owner')),
-        filter(propertyIsDefined('repoName')),
+        filter(propertyIsDefined('ghRepoName')),
         filter(propertyIsDefined('rev')),
         filter(propertyIsDefined('filePath')),
-        map(({ owner, repoName, ...rest }) => ({ repoPath: `${window.location.host}/${owner}/${repoName}`, ...rest })),
-        switchMap(({ repoPath, rev, ...rest }) =>
-            resolveRev({ repoPath, rev }).pipe(
+        map(({ owner, ghRepoName, ...rest }) => ({
+            repoName: `${window.location.host}/${owner}/${ghRepoName}`,
+            ...rest,
+        })),
+        switchMap(({ repoName, rev, ...rest }) =>
+            resolveRev({ repoName, rev }).pipe(
                 retryWhenCloneInProgressError(),
-                map(commitID => ({ ...rest, repoPath, commitID, rev: rev || commitID }))
+                map(commitID => ({ ...rest, repoName, commitID, rev: rev || commitID }))
             )
         )
     )

--- a/client/browser/src/libs/github/index.tsx
+++ b/client/browser/src/libs/github/index.tsx
@@ -2,7 +2,7 @@ import { MaybeDiffSpec, ParsedRepoURI } from '../../shared/repo'
 
 export interface GitHubURL extends ParsedRepoURI {
     user?: string
-    repoName?: string
+    ghRepoName?: string
     isDelta?: boolean
     isPullRequest?: boolean
     isCommit?: boolean
@@ -13,7 +13,7 @@ export interface GitHubURL extends ParsedRepoURI {
 export interface GitHubBlobUrl {
     mode: GitHubMode
     owner: string
-    repoName: string
+    ghRepoName: string
     revAndPath: string
     lineNumber: string | undefined
     rev: string
@@ -23,7 +23,7 @@ export interface GitHubBlobUrl {
 export interface GitHubPullUrl {
     mode: GitHubMode
     owner: string
-    repoName: string
+    ghRepoName: string
     view: string
     rev: string
     id: number
@@ -33,7 +33,7 @@ export interface GitHubPullUrl {
 export interface GitHubRepositoryUrl {
     mode: GitHubMode
     owner: string
-    repoName: string
+    ghRepoName: string
     rev?: string
     filePath?: string
 }

--- a/client/browser/src/libs/github/inject.tsx
+++ b/client/browser/src/libs/github/inject.tsx
@@ -49,7 +49,7 @@ function injectServerBanner(): void {
         return
     }
 
-    const { isPullRequest, repoPath } = parseURL()
+    const { isPullRequest, repoName } = parseURL()
     if (!isPullRequest) {
         return
     }
@@ -69,7 +69,7 @@ function injectServerBanner(): void {
         }
         container.appendChild(mount)
     }
-    render(<Alerts repoPath={repoPath} />, mount)
+    render(<Alerts repoName={repoName} />, mount)
 }
 
 /**
@@ -90,12 +90,12 @@ function injectOpenOnSourcegraphButton(): void {
         }
         pageheadActions.insertBefore(container, pageheadActions.children[0])
         if (container) {
-            const { repoPath, rev } = parseURL()
-            if (repoPath) {
+            const { repoName, rev } = parseURL()
+            if (repoName) {
                 render(
                     <WithResolvedRev
                         component={ContextualSourcegraphButton}
-                        repoPath={repoPath}
+                        repoName={repoName}
                         rev={rev}
                         defaultBranch={'HEAD'}
                         notFoundComponent={ConfigureSourcegraphButton}

--- a/client/browser/src/libs/gitlab/api.ts
+++ b/client/browser/src/libs/gitlab/api.ts
@@ -31,10 +31,10 @@ interface DiffVersionsResponse {
     base_commit_sha: string
 }
 
-type GetBaseCommitIDInput = Pick<GitLabDiffInfo, 'owner' | 'repoName' | 'mergeRequestID' | 'diffID'>
+type GetBaseCommitIDInput = Pick<GitLabDiffInfo, 'owner' | 'projectName' | 'mergeRequestID' | 'diffID'>
 
-const buildURL = (owner: string, repoName: string, path: string) =>
-    `${window.location.origin}/api/v4/projects/${encodeURIComponent(owner)}%2f${repoName}${path}`
+const buildURL = (owner: string, projectName: string, path: string) =>
+    `${window.location.origin}/api/v4/projects/${encodeURIComponent(owner)}%2f${projectName}${path}`
 
 const get = <T>(url: string): Observable<T> => ajax.get(url).pipe(map(({ response }) => response as T))
 
@@ -42,8 +42,8 @@ const get = <T>(url: string): Observable<T> => ajax.get(url).pipe(map(({ respons
  * Get the base commit ID for a merge request.
  */
 export const getBaseCommitIDForMergeRequest: (info: GetBaseCommitIDInput) => Observable<string> = memoizeObservable(
-    ({ owner, repoName, mergeRequestID, diffID }: GetBaseCommitIDInput) => {
-        const mrURL = buildURL(owner, repoName, `/merge_requests/${mergeRequestID}`)
+    ({ owner, projectName, mergeRequestID, diffID }: GetBaseCommitIDInput) => {
+        const mrURL = buildURL(owner, projectName, `/merge_requests/${mergeRequestID}`)
 
         // If we have a `diffID`, retrieve the information for that individual diff.
         if (diffID) {
@@ -66,9 +66,9 @@ interface CommitResponse {
  * Get the base commit ID for a commit.
  */
 export const getBaseCommitIDForCommit: (
-    { owner, repoName, commitID }: Pick<GetBaseCommitIDInput, 'owner' | 'repoName'> & { commitID: string }
-) => Observable<string> = memoizeObservable(({ owner, repoName, commitID }) =>
-    get<CommitResponse>(buildURL(owner, repoName, `/repository/commits/${commitID}`)).pipe(
+    { owner, projectName, commitID }: Pick<GetBaseCommitIDInput, 'owner' | 'projectName'> & { commitID: string }
+) => Observable<string> = memoizeObservable(({ owner, projectName, commitID }) =>
+    get<CommitResponse>(buildURL(owner, projectName, `/repository/commits/${commitID}`)).pipe(
         map(({ parent_ids }) => first(parent_ids)!) // ! because it'll always have a parent if we are looking at the commit page.
     )
 )

--- a/client/browser/src/libs/gitlab/file_info.ts
+++ b/client/browser/src/libs/gitlab/file_info.ts
@@ -18,7 +18,7 @@ import {
  * Resolves file information for a page with a single file, not including diffs with only one file.
  */
 export const resolveFileInfo = (): Observable<FileInfo> => {
-    const { repoPath, filePath, rev } = getFilePageInfo()
+    const { repoName, filePath, rev } = getFilePageInfo()
     if (!filePath) {
         return throwError(
             new Error(
@@ -33,7 +33,7 @@ export const resolveFileInfo = (): Observable<FileInfo> => {
         const commitID = getCommitIDFromPermalink()
 
         return of({
-            repoPath,
+            repoName,
             filePath,
             commitID,
             rev,
@@ -50,12 +50,12 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
     of(undefined).pipe(
         map(getDiffPageInfo),
         // Resolve base commit ID.
-        switchMap(({ owner, repoName, mergeRequestID, diffID, baseCommitID, ...rest }) => {
+        switchMap(({ owner, projectName, mergeRequestID, diffID, baseCommitID, ...rest }) => {
             const gettingBaseCommitID = baseCommitID
                 ? // Commit was found in URL.
                   of(baseCommitID)
                 : // Commit needs to be fetched from the API.
-                  getBaseCommitIDForMergeRequest({ owner, repoName, mergeRequestID, diffID })
+                  getBaseCommitIDForMergeRequest({ owner, projectName, mergeRequestID, diffID })
 
             return gettingBaseCommitID.pipe(map(baseCommitID => ({ baseCommitID, baseRev: baseCommitID, ...rest })))
         }),
@@ -92,9 +92,9 @@ export const resolveCommitFileInfo = (codeView: HTMLElement): Observable<FileInf
     of(undefined).pipe(
         map(getCommitPageInfo),
         // Resolve base commit ID.
-        switchMap(({ owner, repoName, commitID, ...rest }) =>
-            getBaseCommitIDForCommit({ owner, repoName, commitID }).pipe(
-                map(baseCommitID => ({ owner, repoName, commitID, baseCommitID, ...rest }))
+        switchMap(({ owner, projectName, commitID, ...rest }) =>
+            getBaseCommitIDForCommit({ owner, projectName, commitID }).pipe(
+                map(baseCommitID => ({ owner, projectName, commitID, baseCommitID, ...rest }))
             )
         ),
         map(info => ({ ...info, rev: info.commitID, baseRev: info.baseCommitID })),

--- a/client/browser/src/libs/phabricator/file_info.ts
+++ b/client/browser/src/libs/phabricator/file_info.ts
@@ -22,7 +22,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
         }),
         switchMap(info => {
             const resolveBaseCommitID = resolveDiffRev({
-                repoPath: info.baseRepoPath,
+                repoName: info.baseRepoName,
                 differentialID: info.differentialID,
                 diffID: (info.leftDiffID || info.diffID)!,
                 leftDiffID: info.leftDiffID,
@@ -31,9 +31,9 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                 filePath: info.baseFilePath || info.filePath,
                 isBase: true,
             }).pipe(
-                map(({ commitID, stagingRepoPath }) => ({
+                map(({ commitID, stagingRepoName }) => ({
                     baseCommitID: commitID,
-                    baseRepoPath: stagingRepoPath || info.baseRepoPath,
+                    baseRepoName: stagingRepoName || info.baseRepoName,
                 })),
                 catchError(err => {
                     throw err
@@ -41,7 +41,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
             )
 
             const resolveHeadCommitID = resolveDiffRev({
-                repoPath: info.headRepoPath,
+                repoName: info.headRepoName,
                 differentialID: info.differentialID,
                 diffID: info.diffID!,
                 leftDiffID: info.leftDiffID,
@@ -50,9 +50,9 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                 filePath: info.filePath,
                 isBase: false,
             }).pipe(
-                map(({ commitID, stagingRepoPath }) => ({
+                map(({ commitID, stagingRepoName }) => ({
                     headCommitID: commitID,
-                    headRepoPath: stagingRepoPath || info.headRepoPath,
+                    headRepoName: stagingRepoName || info.headRepoName,
                 })),
                 catchError(err => {
                     throw err
@@ -60,25 +60,25 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
             )
 
             return zip(resolveBaseCommitID, resolveHeadCommitID).pipe(
-                map(([{ baseCommitID, baseRepoPath }, { headCommitID, headRepoPath }]) => ({
+                map(([{ baseCommitID, baseRepoName }, { headCommitID, headRepoName }]) => ({
                     baseCommitID,
                     headCommitID,
                     ...info,
-                    baseRepoPath,
-                    headRepoPath,
+                    baseRepoName,
+                    headRepoName,
                 }))
             )
         }),
         switchMap(info => {
             const fetchingBaseFile = fetchBlobContentLines({
-                repoPath: info.baseRepoPath,
+                repoName: info.baseRepoName,
                 filePath: info.baseFilePath || info.filePath,
                 commitID: info.baseCommitID,
                 rev: info.baseRev,
             })
 
             const fetchingHeadFile = fetchBlobContentLines({
-                repoPath: info.headRepoPath,
+                repoName: info.headRepoName,
                 filePath: info.filePath,
                 commitID: info.headCommitID,
                 rev: info.headRev,
@@ -89,12 +89,12 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
             )
         }),
         map(info => ({
-            repoPath: info.headRepoPath,
+            repoName: info.headRepoName,
             filePath: info.filePath,
             commitID: info.headCommitID,
             rev: info.headRev,
 
-            baseRepoPath: info.baseRepoPath,
+            baseRepoName: info.baseRepoName,
             baseFilePath: info.baseFileContent ? info.baseFilePath || info.filePath : undefined,
             baseCommitID: info.baseCommitID,
             baseRev: info.baseRev,

--- a/client/browser/src/libs/phabricator/index.tsx
+++ b/client/browser/src/libs/phabricator/index.tsx
@@ -19,9 +19,9 @@ export interface DifferentialState {
     leftDiffID?: number
     diffID?: number
     baseRev: string
-    baseRepoPath: string
+    baseRepoName: string
     headRev: string
-    headRepoPath: string
+    headRepoName: string
 }
 
 /**
@@ -35,13 +35,13 @@ export interface ChangesetState {
     differentialID: number
     leftDiffID?: number
     diffID: number
-    repoPath: number
+    repoName: number
     filePath: number
 }
 
 export interface RevisionState {
     mode: PhabricatorMode
-    repoPath: string
+    repoName: string
     baseCommitID: string
     headCommitID: string
 }
@@ -52,7 +52,7 @@ export interface RevisionState {
  */
 export interface ChangeState {
     mode: PhabricatorMode
-    repoPath: string
+    repoName: string
     filePath: string
     commitID: string
 }

--- a/client/browser/src/libs/phabricator/util.tsx
+++ b/client/browser/src/libs/phabricator/util.tsx
@@ -192,7 +192,7 @@ export function getPhabricatorState(
             }
             match.callsign = callsign
             getRepoDetailsFromCallsign(callsign)
-                .then(({ repoPath }) => {
+                .then(({ repoName }) => {
                     const commitID = getCommitIDFromPageTag()
                     if (!commitID) {
                         console.error('cannot determine commitIDision from page')
@@ -200,7 +200,7 @@ export function getPhabricatorState(
                         return
                     }
                     resolve({
-                        repoPath,
+                        repoName,
                         filePath: match.filePath,
                         mode: PhabricatorMode.Diffusion,
                         commitID,
@@ -242,7 +242,7 @@ export function getPhabricatorState(
                         return
                     }
                     getRepoDetailsFromCallsign(callsign)
-                        .then(({ repoPath }) => {
+                        .then(({ repoName }) => {
                             let baseRev = `phabricator/base/${diffID}`
                             let headRev = `phabricator/diff/${diffID}`
 
@@ -281,9 +281,9 @@ export function getPhabricatorState(
                                 }
                             }
                             resolve({
-                                baseRepoPath: repoPath,
+                                baseRepoName: repoName,
                                 baseRev,
-                                headRepoPath: repoPath,
+                                headRepoName: repoName,
                                 headRev, // This will be blank on GitHub, but on a manually staged instance should exist
                                 differentialID,
                                 diffID,
@@ -312,7 +312,7 @@ export function getPhabricatorState(
                 rev: revisionMatch[2],
             }
             getRepoDetailsFromCallsign(match.callsign)
-                .then(({ repoPath }) => {
+                .then(({ repoName }) => {
                     const headCommitID = match.rev
                     const baseCommitID = getBaseCommitIDFromRevisionPage()
                     if (!baseCommitID) {
@@ -320,7 +320,7 @@ export function getPhabricatorState(
                         return null
                     }
                     resolve({
-                        repoPath,
+                        repoName,
                         baseCommitID,
                         headCommitID,
                         mode: PhabricatorMode.Revision,
@@ -351,14 +351,14 @@ export function getPhabricatorState(
             }
             match.callsign = callsign
             getRepoDetailsFromCallsign(callsign)
-                .then(({ repoPath }) => {
+                .then(({ repoName }) => {
                     const commitID = getCommitIDFromPageTag()
                     if (!commitID) {
                         console.error('cannot determine revision from page.')
                         return null
                     }
                     resolve({
-                        repoPath,
+                        repoName,
                         filePath: match.filePath,
                         mode: PhabricatorMode.Change,
                         commitID,
@@ -400,7 +400,7 @@ export function getPhabricatorState(
                     }
 
                     getRepoDetailsFromCallsign(callsign)
-                        .then(({ repoPath }) => {
+                        .then(({ repoName }) => {
                             let baseRev = `phabricator/base/${diffID}`
                             let headRev = `phabricator/diff/${diffID}`
 
@@ -421,9 +421,9 @@ export function getPhabricatorState(
                             }
 
                             resolve({
-                                baseRepoPath: repoPath,
+                                baseRepoName: repoName,
                                 baseRev,
-                                headRepoPath: repoPath,
+                                headRepoName: repoName,
                                 headRev, // This will be blank on GitHub, but on a manually staged instance should exist
                                 differentialID,
                                 diffID,
@@ -623,23 +623,23 @@ export function metaClickOverride(): void {
     }
 }
 
-export function normalizeRepoPath(origin: string): string {
-    let repoPath = origin
-    repoPath = repoPath.replace('\\', '')
+export function normalizeRepoName(origin: string): string {
+    let repoName = origin
+    repoName = repoName.replace('\\', '')
     if (origin.startsWith('git@')) {
-        repoPath = origin.substr('git@'.length)
-        repoPath = repoPath.replace(':', '/')
+        repoName = origin.substr('git@'.length)
+        repoName = repoName.replace(':', '/')
     } else if (origin.startsWith('git://')) {
-        repoPath = origin.substr('git://'.length)
+        repoName = origin.substr('git://'.length)
     } else if (origin.startsWith('https://')) {
-        repoPath = origin.substr('https://'.length)
+        repoName = origin.substr('https://'.length)
     } else if (origin.includes('@')) {
         // Assume the origin looks like `username@host:repo/path`
         const split = origin.split('@')
-        repoPath = split[1]
-        repoPath = repoPath.replace(':', '/')
+        repoName = split[1]
+        repoName = repoName.replace(':', '/')
     }
-    return repoPath.replace(/.git$/, '')
+    return repoName.replace(/.git$/, '')
 }
 
 export function getContainerForBlobAnnotation(): {

--- a/client/browser/src/shared/backend/context.ts
+++ b/client/browser/src/shared/backend/context.ts
@@ -38,8 +38,8 @@ export function getContext(ctx: Partial<RequestContext> = {}): RequestContext {
     const out = { ...defaultContext, ...ctx }
 
     if (!repoKey && out.isRepoSpecific) {
-        const { repoPath } = parseURL()
-        out.repoKey = repoPath
+        const { repoName } = parseURL()
+        out.repoKey = repoName
     }
 
     return out

--- a/client/browser/src/shared/backend/errors.tsx
+++ b/client/browser/src/shared/backend/errors.tsx
@@ -54,16 +54,16 @@ export const normalizeAjaxError = (err: any): void => {
 export const ECLONEINPROGESS = 'ECLONEINPROGESS'
 export class CloneInProgressError extends Error {
     public readonly code = ECLONEINPROGESS
-    constructor(repoPath: string) {
-        super(`${repoPath} is clone in progress`)
+    constructor(repoName: string) {
+        super(`${repoName} is clone in progress`)
     }
 }
 
 export const EREPONOTFOUND = 'EREPONOTFOUND'
 export class RepoNotFoundError extends Error {
     public readonly code = EREPONOTFOUND
-    constructor(repoPath: string) {
-        super(`repo ${repoPath} not found`)
+    constructor(repoName: string) {
+        super(`repo ${repoName} not found`)
     }
 }
 

--- a/client/browser/src/shared/components/Alerts.tsx
+++ b/client/browser/src/shared/components/Alerts.tsx
@@ -11,7 +11,7 @@ interface State {
 }
 
 interface Props {
-    repoPath: string
+    repoName: string
 }
 
 const SERVER_CONFIGURATION_KEY = 'NeedsServerConfigurationAlertDismissed'
@@ -28,7 +28,7 @@ export class Alerts extends React.Component<Props, State> {
 
     public componentDidMount(): void {
         this.updateAlerts()
-        resolveRev({ repoPath: this.props.repoPath })
+        resolveRev({ repoName: this.props.repoName })
             .toPromise()
             .catch(e => {
                 this.setState(() => ({ ...this.state, needsConfig: true }))
@@ -41,7 +41,7 @@ export class Alerts extends React.Component<Props, State> {
             if (!items[SERVER_CONFIGURATION_KEY]) {
                 alerts.push(SERVER_CONFIGURATION_KEY)
             }
-            if (!items[REPO_CONFIGURATION_KEY] || !items[REPO_CONFIGURATION_KEY][this.props.repoPath]) {
+            if (!items[REPO_CONFIGURATION_KEY] || !items[REPO_CONFIGURATION_KEY][this.props.repoName]) {
                 alerts.push(REPO_CONFIGURATION_KEY)
             }
             this.setState(() => ({ ...this.state, alerts }))
@@ -56,7 +56,7 @@ export class Alerts extends React.Component<Props, State> {
         if (this.state.needsConfig && this.state.alerts.includes(REPO_CONFIGURATION_KEY) && !isSourcegraphDotCom()) {
             return (
                 <NeedsRepositoryConfigurationAlert
-                    repoPath={this.props.repoPath}
+                    repoName={this.props.repoName}
                     alertKey={REPO_CONFIGURATION_KEY}
                     onClose={this.updateAlerts}
                 />

--- a/client/browser/src/shared/components/BlobAnnotator.tsx
+++ b/client/browser/src/shared/components/BlobAnnotator.tsx
@@ -97,7 +97,7 @@ export class BlobAnnotator extends React.Component<Props, State> {
         createTooltips()
         this.addTooltipEventListeners(this.props.getTableElement())
         fetchBlobContentLines({
-            repoPath: this.props.repoPath,
+            repoName: this.props.repoName,
             commitID: this.props.commitID,
             filePath: this.props.filePath,
         }).subscribe(
@@ -142,7 +142,7 @@ export class BlobAnnotator extends React.Component<Props, State> {
         let props: OpenInSourcegraphProps
         if (this.isDelta) {
             props = {
-                repoPath: this.props.repoPath!,
+                repoName: this.props.repoName!,
                 filePath: this.props.filePath,
                 rev: this.props.commitID!,
                 query: {
@@ -153,7 +153,7 @@ export class BlobAnnotator extends React.Component<Props, State> {
             }
         } else {
             props = {
-                repoPath: this.props.repoPath,
+                repoName: this.props.repoName,
                 filePath: this.props.filePath,
                 rev: this.props.rev!,
             }
@@ -552,7 +552,7 @@ export class BlobAnnotator extends React.Component<Props, State> {
             // this.setFixedTooltip()
 
             // Jump to definition inside of a pull request if the file exists in the PR.
-            const sameRepo = this.props.repoPath === defCtx.repoPath
+            const sameRepo = this.props.repoName === defCtx.repoName
             if (sameRepo && this.props.isPullRequest) {
                 const containers = github.getFileContainers()
                 for (const container of Array.from(containers)) {
@@ -575,7 +575,7 @@ export class BlobAnnotator extends React.Component<Props, State> {
                     : defCtx.commitID || defCtx.rev
                 : defCtx.commitID || defCtx.rev
             // tslint:disable-next-line
-            const url = `https://${defCtx.repoPath}/blob/${rev || 'HEAD'}/${defCtx.filePath}#L${defCtx.position.line}${
+            const url = `https://${defCtx.repoName}/blob/${rev || 'HEAD'}/${defCtx.filePath}#L${defCtx.position.line}${
                 defCtx.position.character ? ':' + defCtx.position.character : ''
             }`
             window.location.href = url

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -83,7 +83,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                             label={'View File (base)'}
                             ariaLabel="View file on Sourcegraph"
                             openProps={{
-                                repoPath: this.props.baseRepoPath || this.props.repoPath,
+                                repoName: this.props.baseRepoName || this.props.repoName,
                                 filePath: this.props.baseFilePath || this.props.filePath,
                                 rev: this.props.baseRev || this.props.baseCommitID,
                                 query: {
@@ -107,7 +107,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                         label={`View File${this.props.baseCommitID ? ' (head)' : ''}`}
                         ariaLabel="View file on Sourcegraph"
                         openProps={{
-                            repoPath: this.props.repoPath,
+                            repoName: this.props.repoName,
                             filePath: this.props.filePath,
                             rev: this.props.rev || this.props.commitID,
                             query: this.props.commitID

--- a/client/browser/src/shared/components/ContextualSourcegraphButton.tsx
+++ b/client/browser/src/shared/components/ContextualSourcegraphButton.tsx
@@ -20,7 +20,7 @@ export class ContextualSourcegraphButton extends React.Component<{}, {}> {
         state: GitHubBlobUrl | GitHubPullUrl | GitHubRepositoryUrl
     ): { label: string; openProps: OpenInSourcegraphProps; ariaLabel?: string } {
         const props: OpenInSourcegraphProps = {
-            repoPath: `${window.location.host}/${state.owner}/${state.repoName}`,
+            repoName: `${window.location.host}/${state.owner}/${state.ghRepoName}`,
             rev: state.rev || '',
         }
         return {

--- a/client/browser/src/shared/components/LegacyCodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/LegacyCodeViewToolbar.tsx
@@ -26,7 +26,7 @@ export interface ButtonProps {
 }
 
 interface CodeViewToolbarProps extends Partial<PlatformContextProps>, Partial<ExtensionsControllerProps> {
-    repoPath: string
+    repoName: string
     filePath: string
 
     baseCommitID: string
@@ -86,7 +86,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                     label={`View File${this.props.headCommitID ? ' (base)' : ''}`}
                     ariaLabel="View file on Sourcegraph"
                     openProps={{
-                        repoPath: this.props.repoPath,
+                        repoName: this.props.repoName,
                         filePath: this.props.filePath,
                         rev: this.props.baseRev || this.props.baseCommitID,
                         query: this.props.headCommitID
@@ -106,7 +106,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                         label={'View File (head)'}
                         ariaLabel="View file on Sourcegraph"
                         openProps={{
-                            repoPath: this.props.repoPath,
+                            repoName: this.props.repoName,
                             filePath: this.props.filePath,
                             rev: this.props.headRev || this.props.headCommitID,
                             query: {

--- a/client/browser/src/shared/components/NeedsRepositoryConfigurationAlert.tsx
+++ b/client/browser/src/shared/components/NeedsRepositoryConfigurationAlert.tsx
@@ -7,7 +7,7 @@ import { sourcegraphUrl } from '../util/context'
 interface Props {
     onClose: () => void
     alertKey: string
-    repoPath: string
+    repoName: string
 }
 
 /**
@@ -16,7 +16,7 @@ interface Props {
  */
 export class NeedsRepositoryConfigurationAlert extends React.Component<Props, {}> {
     private sync = () => {
-        const obj = { [this.props.alertKey]: { [this.props.repoPath]: true } }
+        const obj = { [this.props.alertKey]: { [this.props.repoName]: true } }
         storage.setSync(obj, () => {
             this.props.onClose()
         })

--- a/client/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -20,9 +20,9 @@ export class OpenOnSourcegraph extends React.Component<Props, {}> {
     }
 
     private getOpenInSourcegraphUrl(props: OpenInSourcegraphProps): string {
-        const baseUrl = repoUrlCache[props.repoPath] || sourcegraphUrl
+        const baseUrl = repoUrlCache[props.repoName] || sourcegraphUrl
         // Build URL for Web
-        let url = `${baseUrl}/${props.repoPath}`
+        let url = `${baseUrl}/${props.repoName}`
         if (props.commit) {
             return `${url}/-/compare/${props.commit.baseRev}...${props.commit.headRev}?utm_source=${getPlatformName()}`
         }

--- a/client/browser/src/shared/components/ServerAuthButton.tsx
+++ b/client/browser/src/shared/components/ServerAuthButton.tsx
@@ -5,7 +5,7 @@ import { Button } from './Button'
 
 interface Props {
     error?: AuthRequiredError
-    repoPath: string
+    repoName: string
 }
 
 export class ServerAuthButton extends React.Component<Props, {}> {
@@ -25,7 +25,7 @@ export class ServerAuthButton extends React.Component<Props, {}> {
 
         return (
             <Button
-                url={`${url}/${this.props.repoPath}`}
+                url={`${url}/${this.props.repoName}`}
                 className={className}
                 ariaLabel={ariaLabel}
                 label={label}

--- a/client/browser/src/shared/components/WithResolvedRev.tsx
+++ b/client/browser/src/shared/components/WithResolvedRev.tsx
@@ -16,7 +16,7 @@ interface WithResolvedRevProps {
     cloningComponent?: any
     notFoundComponent?: any // for 404s
     requireAuthComponent?: any // for 401s
-    repoPath: string
+    repoName: string
     rev?: string
     [key: string]: any
 }
@@ -38,13 +38,13 @@ export class WithResolvedRev extends React.Component<WithResolvedRevProps, WithR
         this.subscriptions.add(
             this.componentUpdates
                 .pipe(
-                    switchMap(({ repoPath, rev }) => {
-                        if (!repoPath) {
+                    switchMap(({ repoName, rev }) => {
+                        if (!repoName) {
                             return [undefined]
                         }
                         // Defer Observable so it retries the request on resubscription
                         return (
-                            defer(() => resolveRev({ repoPath, rev }))
+                            defer(() => resolveRev({ repoName, rev }))
                                 // On a CloneInProgress error, retry after 5s
                                 .pipe(
                                     retryWhen(errors =>
@@ -96,7 +96,7 @@ export class WithResolvedRev extends React.Component<WithResolvedRevProps, WithR
     }
 
     public componentWillReceiveProps(nextProps: WithResolvedRevProps): void {
-        if (this.props.repoPath !== nextProps.repoPath || this.props.rev !== nextProps.rev) {
+        if (this.props.repoName !== nextProps.repoName || this.props.rev !== nextProps.rev) {
             // clear state so the child won't render until the revision is resolved for new props
             this.state = { cloneInProgress: false, notFound: false, requireAuthError: undefined }
             this.componentUpdates.next(nextProps)
@@ -121,8 +121,8 @@ export class WithResolvedRev extends React.Component<WithResolvedRevProps, WithR
             return <this.props.notFoundComponent {...this.props} />
         }
 
-        if (this.props.repoPath && !this.state.commitID) {
-            // commit not yet resolved but required if repoPath prop is provided;
+        if (this.props.repoName && !this.state.commitID) {
+            // commit not yet resolved but required if repoName prop is provided;
             // render empty until commit resolved
             return null
         }

--- a/client/browser/src/shared/repo/index.tsx
+++ b/client/browser/src/shared/repo/index.tsx
@@ -17,7 +17,7 @@ export interface RepoSpec {
     /**
      * Example: github.com/gorilla/mux
      */
-    repoPath: string
+    repoName: string
 }
 
 export interface RevSpec {
@@ -95,8 +95,8 @@ export interface AbsoluteRepoFilePosition
         Partial<ReferencesModeSpec> {}
 
 interface DiffRepoSpec {
-    baseRepoPath: string
-    headRepoPath: string
+    baseRepoName: string
+    headRepoName: string
 }
 
 interface DiffRevSpec {
@@ -112,7 +112,7 @@ export interface DiffResolvedRevSpec {
 export interface DiffRepoRev extends DiffRepoSpec, DiffRevSpec {}
 
 export interface OpenInSourcegraphProps {
-    repoPath: string
+    repoName: string
     rev: string
     filePath?: string
     commit?: {
@@ -163,7 +163,7 @@ const parsePosition = (str: string): Position => {
  */
 export function parseRepoURI(uri: RepoURI): ParsedRepoURI {
     const parsed = new URL(uri)
-    const repoPath = parsed.hostname + parsed.pathname
+    const repoName = parsed.hostname + parsed.pathname
     const rev = parsed.search.substr('?'.length) || undefined
     let commitID: string | undefined
     if (rev && rev.match(/[0-9a-fA-f]{40}/)) {
@@ -195,7 +195,7 @@ export function parseRepoURI(uri: RepoURI): ParsedRepoURI {
         throw new Error('unexpected fragment: ' + parsed.hash)
     }
 
-    return { repoPath, rev, commitID, filePath: filePath || undefined, position, range }
+    return { repoName, rev, commitID, filePath: filePath || undefined, position, range }
 }
 
 /**
@@ -216,8 +216,8 @@ export function parseBrowserRepoURL(href: string, w: Window = window): ParsedRep
         repoRev = pathname.substring(0, indexOfSep) // the whole string leading up to the separator (allows rev to be multiple path parts)
     }
     const repoRevSplit = repoRev.split('@')
-    const repoPath = repoRevSplit[0]
-    if (!repoPath) {
+    const repoName = repoRevSplit[0]
+    if (!repoName) {
         throw new Error('unexpected repo url: ' + href)
     }
     const rev: string | undefined = repoRevSplit[1]
@@ -244,7 +244,7 @@ export function parseBrowserRepoURL(href: string, w: Window = window): ParsedRep
         }
     }
 
-    return { repoPath, rev, commitID, filePath, position }
+    return { repoName, rev, commitID, filePath, position }
 }
 
 const positionStr = (pos: Position) => pos.line + '' + (pos.character ? ',' + pos.character : '')
@@ -254,7 +254,7 @@ const positionStr = (pos: Position) => pos.line + '' + (pos.character ? ',' + po
  */
 export function makeRepoURI(parsed: ParsedRepoURI): RepoURI {
     const rev = parsed.commitID || parsed.rev
-    let uri = `git://${parsed.repoPath}`
+    let uri = `git://${parsed.repoName}`
     uri += rev ? '?' + rev : ''
     uri += parsed.filePath ? '#' + parsed.filePath : ''
     uri += parsed.position || parsed.range ? ':' : ''
@@ -263,7 +263,7 @@ export function makeRepoURI(parsed: ParsedRepoURI): RepoURI {
     return uri
 }
 
-export const toRootURI = (ctx: AbsoluteRepo) => `git://${ctx.repoPath}?${ctx.commitID}`
+export const toRootURI = (ctx: AbsoluteRepo) => `git://${ctx.repoName}?${ctx.commitID}`
 export function toURIWithPath(ctx: AbsoluteRepoFile): string {
-    return `git://${ctx.repoPath}?${ctx.commitID}#${ctx.filePath}`
+    return `git://${ctx.repoName}?${ctx.commitID}#${ctx.filePath}`
 }

--- a/client/browser/src/shared/util/url.tsx
+++ b/client/browser/src/shared/util/url.tsx
@@ -46,9 +46,9 @@ function toReferencesHash(group: 'local' | 'external' | undefined): string {
 
 export function toAbsoluteBlobURL(ctx: AbsoluteRepoFile & Partial<PositionSpec> & Partial<ReferencesModeSpec>): string {
     const rev = ctx.commitID ? ctx.commitID : ctx.rev
-    const url = repoUrlCache[ctx.repoPath] || sourcegraphUrl
+    const url = repoUrlCache[ctx.repoName] || sourcegraphUrl
 
-    return `${url}/${ctx.repoPath}${rev ? '@' + rev : ''}/-/blob/${ctx.filePath}${toPositionHash(
+    return `${url}/${ctx.repoName}${rev ? '@' + rev : ''}/-/blob/${ctx.filePath}${toPositionHash(
         ctx.position
     )}${toReferencesHash(ctx.referencesMode)}`
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1651,7 +1651,7 @@ type GitRevisionRange {
 
 # A Phabricator repository.
 type PhabricatorRepo {
-    # The canonical repo path (e.g. "github.com/gorilla/mux").
+    # The canonical repo name (e.g. "github.com/gorilla/mux").
     name: String!
     # An alias for name.
     uri: String! @deprecated(reason: "use name instead")

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1658,7 +1658,7 @@ type GitRevisionRange {
 
 # A Phabricator repository.
 type PhabricatorRepo {
-    # The canonical repo path (e.g. "github.com/gorilla/mux").
+    # The canonical repo name (e.g. "github.com/gorilla/mux").
     name: String!
     # An alias for name.
     uri: String! @deprecated(reason: "use name instead")

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -7,7 +7,7 @@ import { highlightNode } from '../util/dom'
 import { Repo } from '../util/url'
 
 export interface FetchFileCtx {
-    repoPath: string
+    repoName: string
     commitID: string
     filePath: string
     disableTimeout?: boolean
@@ -58,9 +58,9 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
             combineLatest(this.propsChanges, this.visibilityChanges)
                 .pipe(
                     filter(([, isVisible]) => isVisible),
-                    switchMap(([{ repoPath, filePath, commitID, isLightTheme }]) =>
+                    switchMap(([{ repoName, filePath, commitID, isLightTheme }]) =>
                         props.fetchHighlightedFileLines({
-                            repoPath,
+                            repoName,
                             commitID,
                             filePath,
                             isLightTheme,

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -92,7 +92,7 @@ export class FileMatch extends React.PureComponent<Props> {
 
         const title = (
             <RepoFileLink
-                repoPath={result.repository.name}
+                repoName={result.repository.name}
                 repoURL={result.repository.url}
                 filePath={result.file.path}
                 fileURL={result.file.url}
@@ -196,7 +196,7 @@ export class FileMatch extends React.PureComponent<Props> {
                             onClick={this.props.onSelect}
                         >
                             <CodeExcerpt
-                                repoPath={result.repository.name}
+                                repoName={result.repository.name}
                                 commitID={result.file.commit.oid}
                                 filePath={result.file.path}
                                 context={context}

--- a/shared/src/components/RepoFileLink.tsx
+++ b/shared/src/components/RepoFileLink.tsx
@@ -2,18 +2,18 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 
 /**
- *  Returns the friendly display form of the repository path (e.g., removing "github.com/").
+ *  Returns the friendly display form of the repository name (e.g., removing "github.com/").
  */
-export function displayRepoPath(repoPath: string): string {
-    let parts = repoPath.split('/')
+export function displayRepoName(repoName: string): string {
+    let parts = repoName.split('/')
     if (parts.length >= 3 && parts[0].includes('.')) {
-        parts = parts.slice(1) // remove hostname from repo path (reduce visual noise)
+        parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
     }
     return parts.join('/')
 }
 
 /**
- * Splits the repository path into the dir and base components.
+ * Splits the repository name into the dir and base components.
  */
 export function splitPath(path: string): [string, string] {
     const components = path.split('/')
@@ -21,7 +21,7 @@ export function splitPath(path: string): [string, string] {
 }
 
 interface Props {
-    repoPath: string
+    repoName: string
     repoURL: string
     filePath: string
     fileURL: string
@@ -31,11 +31,11 @@ interface Props {
  * A link to a repository or a file within a repository, formatted as "repo" or "repo > file". Unless you
  * absolutely need breadcrumb-like behavior, use this instead of FilePathBreadcrumb.
  */
-export const RepoFileLink: React.FunctionComponent<Props> = ({ repoPath, repoURL, filePath, fileURL }) => {
+export const RepoFileLink: React.FunctionComponent<Props> = ({ repoName, repoURL, filePath, fileURL }) => {
     const [fileBase, fileName] = splitPath(filePath)
     return (
         <>
-            <Link to={repoURL}>{displayRepoPath(repoPath)}</Link> ›{' '}
+            <Link to={repoURL}>{displayRepoName(repoName)}</Link> ›{' '}
             <Link to={fileURL}>
                 {fileBase ? `${fileBase}/` : null}
                 <strong>{fileName}</strong>

--- a/shared/src/components/RepoLink.tsx
+++ b/shared/src/components/RepoLink.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { Link } from 'react-router-dom'
-import { displayRepoPath, splitPath } from '../components/RepoFileLink'
+import { displayRepoName, splitPath } from '../components/RepoFileLink'
 
 interface Props {
-    repoPath: string
+    repoName: string
 
     /**
      * The link's destination. If null, the element is text, not a link.
@@ -15,8 +15,8 @@ interface Props {
     onClick?: React.MouseEventHandler<HTMLElement>
 }
 
-export const RepoLink: React.FunctionComponent<Props> = ({ repoPath, to, className, onClick }) => {
-    const [repoBase, repoName] = splitPath(displayRepoPath(repoPath))
+export const RepoLink: React.FunctionComponent<Props> = ({ repoName: fullRepoName, to, className, onClick }) => {
+    const [repoBase, repoName] = splitPath(displayRepoName(fullRepoName))
     const children = (
         <>
             {' '}

--- a/shared/src/panel/views/FileLocations.tsx
+++ b/shared/src/panel/views/FileLocations.tsx
@@ -118,8 +118,8 @@ export class FileLocations extends React.PureComponent<Props, State> {
                 if (!locationsByURI.has(loc.uri)) {
                     locationsByURI.set(loc.uri, [])
 
-                    const { repoPath } = parseRepoURI(loc.uri)
-                    orderedURIs.push({ uri: loc.uri, repo: repoPath })
+                    const { repoName } = parseRepoURI(loc.uri)
+                    orderedURIs.push({ uri: loc.uri, repo: repoName })
                 }
                 locationsByURI.get(loc.uri)!.push(loc)
             }
@@ -163,19 +163,19 @@ function refsToFileMatch(uri: string, refs: Location[]): IFileMatch {
     return {
         file: {
             path: p.filePath || '',
-            url: toPrettyBlobURL({ repoPath: p.repoPath, filePath: p.filePath!, rev: p.commitID || '' }),
+            url: toPrettyBlobURL({ repoName: p.repoName, filePath: p.filePath!, rev: p.commitID || '' }),
             commit: {
                 oid: p.commitID || p.rev,
             },
         },
         repository: {
-            name: p.repoPath,
+            name: p.repoName,
             // This is the only usage of toRepoURL, and it is arguably simpler than getting the value from the
             // GraphQL API. We will be removing these old-style git: URIs eventually, so it's not worth fixing this
             // deprecated usage.
             //
             // tslint:disable-next-line deprecation
-            url: toRepoURL(p.repoPath),
+            url: toRepoURL(p.repoName),
         },
         limitHit: false,
         lineMatches: refs.filter(propertyIsDefined('range')).map(

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -134,7 +134,7 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
             {
                 name: 'repo',
                 defaultSize: 175,
-                key: loc => parseRepoURI(loc.uri).repoPath,
+                key: loc => parseRepoURI(loc.uri).repoName,
             },
         ]
         const groupByFile =
@@ -217,7 +217,7 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
                                                         title={group.key}
                                                     >
                                                         <span className="hierarchical-locations-view__item-name-text">
-                                                            <RepoLink to={null} repoPath={group.key} />
+                                                            <RepoLink to={null} repoName={group.key} />
                                                         </span>
                                                     </span>
                                                     <span className="badge badge-secondary badge-pill hierarchical-locations-view__item-badge">

--- a/shared/src/util/url.test.ts
+++ b/shared/src/util/url.test.ts
@@ -16,14 +16,14 @@ describe('parseRepoURI', () => {
     it('should parse repo', () => {
         const parsed = parseRepoURI('git://github.com/gorilla/mux')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
         })
     })
 
     it('should parse repo with rev', () => {
         const parsed = parseRepoURI('git://github.com/gorilla/mux?branch')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
         })
     })
@@ -31,7 +31,7 @@ describe('parseRepoURI', () => {
     it('should parse repo with commitID', () => {
         const parsed = parseRepoURI('git://github.com/gorilla/mux?24fca303ac6da784b9e8269f724ddeb0b2eea5e7')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
             commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
         })
@@ -40,7 +40,7 @@ describe('parseRepoURI', () => {
     it('should parse repo with rev and file', () => {
         const parsed = parseRepoURI('git://github.com/gorilla/mux?branch#mux.go')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
         })
@@ -49,7 +49,7 @@ describe('parseRepoURI', () => {
     it('should parse repo with rev and file and line', () => {
         const parsed = parseRepoURI('git://github.com/gorilla/mux?branch#mux.go:3')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {
@@ -62,7 +62,7 @@ describe('parseRepoURI', () => {
     it('should parse repo with rev and file and position', () => {
         const parsed = parseRepoURI('git://github.com/gorilla/mux?branch#mux.go:3,5')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {
@@ -75,7 +75,7 @@ describe('parseRepoURI', () => {
     it('should parse repo with rev and file and range', () => {
         const parsed = parseRepoURI('git://github.com/gorilla/mux?branch#mux.go:3,5-6,9')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             range: {
@@ -95,14 +95,14 @@ describe('parseRepoURI', () => {
 describe('makeRepoURI', () => {
     it('should make repo', () => {
         const uri = makeRepoURI({
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
         })
         assertDeepStrictEqual(uri, 'git://github.com/gorilla/mux')
     })
 
     it('should make repo with rev', () => {
         const uri = makeRepoURI({
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
         })
         assertDeepStrictEqual(uri, 'git://github.com/gorilla/mux?branch')
@@ -110,7 +110,7 @@ describe('makeRepoURI', () => {
 
     it('should make repo with commitID', () => {
         const uri = makeRepoURI({
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
         })
@@ -119,7 +119,7 @@ describe('makeRepoURI', () => {
 
     it('should make repo with rev and file', () => {
         const uri = makeRepoURI({
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
         })
@@ -128,7 +128,7 @@ describe('makeRepoURI', () => {
 
     it('should make repo with rev and file and line', () => {
         const uri = makeRepoURI({
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {
@@ -141,7 +141,7 @@ describe('makeRepoURI', () => {
 
     it('should make repo with rev and file and position', () => {
         const uri = makeRepoURI({
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {
@@ -159,7 +159,7 @@ describe('util/url', () => {
     const localRefMode = { ...lineCharPosition, viewState: 'references' }
     const externalRefMode = { ...lineCharPosition, viewState: 'references:external' }
     const ctx = {
-        repoPath: 'github.com/gorilla/mux',
+        repoName: 'github.com/gorilla/mux',
         rev: '',
         commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
         filePath: 'mux.go',

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -4,7 +4,7 @@ export interface RepoSpec {
     /**
      * Example: github.com/gorilla/mux
      */
-    repoPath: string
+    repoName: string
 }
 
 export interface RevSpec {
@@ -114,7 +114,7 @@ const parsePosition = (str: string): Position => {
  */
 export function parseRepoURI(uri: RepoURI): ParsedRepoURI {
     const parsed = new URL(uri)
-    const repoPath = parsed.hostname + parsed.pathname
+    const repoName = parsed.hostname + parsed.pathname
     const rev = parsed.search.substr('?'.length) || undefined
     let commitID: string | undefined
     if (rev && rev.match(/[0-9a-fA-f]{40}/)) {
@@ -146,7 +146,7 @@ export function parseRepoURI(uri: RepoURI): ParsedRepoURI {
         throw new Error('unexpected fragment: ' + parsed.hash)
     }
 
-    return { repoPath, rev, commitID, filePath: filePath || undefined, position, range }
+    return { repoName, rev, commitID, filePath: filePath || undefined, position, range }
 }
 
 /**
@@ -405,7 +405,7 @@ export function encodeRepoRev(repo: string, rev?: string): string {
 export function toPrettyBlobURL(
     ctx: RepoFile & Partial<PositionSpec> & Partial<ViewStateSpec> & Partial<RangeSpec> & Partial<RenderModeSpec>
 ): string {
-    return `/${encodeRepoRev(ctx.repoPath, ctx.rev)}/-/blob/${ctx.filePath}${toRenderModeQuery(
+    return `/${encodeRepoRev(ctx.repoName, ctx.rev)}/-/blob/${ctx.filePath}${toRenderModeQuery(
         ctx
     )}${toPositionOrRangeHash(ctx)}${toViewStateHashComponent(ctx.viewState)}`
 }
@@ -430,7 +430,7 @@ const positionStr = (pos: Position) => pos.line + '' + (pos.character ? ',' + po
  */
 export function makeRepoURI(parsed: ParsedRepoURI): RepoURI {
     const rev = parsed.commitID || parsed.rev
-    let uri = `git://${parsed.repoPath}`
+    let uri = `git://${parsed.repoName}`
     uri += rev ? '?' + rev : ''
     uri += parsed.filePath ? '#' + parsed.filePath : ''
     uri += parsed.position || parsed.range ? ':' : ''

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -121,7 +121,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
             </Switch>
             {parseHash(props.location.hash).viewState && (
                 <ResizablePanel
-                    repoName={`git://${parseBrowserRepoURL(props.location.pathname).repoPath}`}
+                    repoName={`git://${parseBrowserRepoURL(props.location.pathname).repoName}`}
                     history={props.history}
                     location={props.location}
                     extensionsController={props.extensionsController}

--- a/web/src/backend/features.ts
+++ b/web/src/backend/features.ts
@@ -29,7 +29,7 @@ export function getHover(
 ): Observable<HoverMerged | null> {
     return extensionsController.services.textDocumentHover
         .getHover({
-            textDocument: { uri: `git://${ctx.repoPath}?${ctx.commitID}#${ctx.filePath}` },
+            textDocument: { uri: `git://${ctx.repoName}?${ctx.commitID}#${ctx.filePath}` },
             position: {
                 character: ctx.position.character - 1,
                 line: ctx.position.line - 1,
@@ -49,7 +49,7 @@ export function getDefinition(
     { extensionsController }: ExtensionsControllerProps
 ): Observable<Location[] | null> {
     return extensionsController.services.textDocumentDefinition.getLocations({
-        textDocument: { uri: `git://${ctx.repoPath}?${ctx.commitID}#${ctx.filePath}` },
+        textDocument: { uri: `git://${ctx.repoName}?${ctx.commitID}#${ctx.filePath}` },
         position: {
             character: ctx.position.character - 1,
             line: ctx.position.line - 1,
@@ -81,7 +81,7 @@ export function getJumpURL(
             if (def.range) {
                 uri.position = { line: def.range.start.line + 1, character: def.range.start.character + 1 }
             }
-            if (uri.repoPath === ctx.repoPath && uri.commitID === ctx.commitID) {
+            if (uri.repoName === ctx.repoName && uri.commitID === ctx.commitID) {
                 // Use pretty rev from the current context for same-repo J2D.
                 uri.rev = ctx.rev
                 return toPrettyBlobURL(uri)
@@ -102,7 +102,7 @@ export function getReferences(
     { extensionsController }: ExtensionsControllerProps
 ): Observable<Location[] | null> {
     return extensionsController.services.textDocumentReferences.getLocations({
-        textDocument: { uri: `git://${ctx.repoPath}?${ctx.commitID}#${ctx.filePath}` },
+        textDocument: { uri: `git://${ctx.repoName}?${ctx.commitID}#${ctx.filePath}` },
         position: {
             character: ctx.position.character - 1,
             line: ctx.position.line - 1,
@@ -124,7 +124,7 @@ export function getImplementations(
     { extensionsController }: ExtensionsControllerProps
 ): Observable<Location[] | null> {
     return extensionsController.services.textDocumentImplementation.getLocations({
-        textDocument: { uri: `git://${ctx.repoPath}?${ctx.commitID}#${ctx.filePath}` },
+        textDocument: { uri: `git://${ctx.repoName}?${ctx.commitID}#${ctx.filePath}` },
         position: {
             character: ctx.position.character - 1,
             line: ctx.position.line - 1,
@@ -143,6 +143,6 @@ export function getDecorations(
     { extensionsController }: ExtensionsControllerProps
 ): Observable<TextDocumentDecoration[] | null> {
     return extensionsController.services.textDocumentDecoration.getDecorations({
-        uri: `git://${ctx.repoPath}?${ctx.commitID}#${ctx.filePath}`,
+        uri: `git://${ctx.repoName}?${ctx.commitID}#${ctx.filePath}`,
     })
 }

--- a/web/src/repo/FilePathBreadcrumb.tsx
+++ b/web/src/repo/FilePathBreadcrumb.tsx
@@ -52,7 +52,7 @@ export const FilePathBreadcrumb: React.FunctionComponent<
         filePath: string
         isDir: boolean
     }
-> = ({ repoPath, rev, filePath, isDir }) => {
+> = ({ repoName, rev, filePath, isDir }) => {
     const parts = filePath.split('/')
     // tslint:disable-next-line:jsx-no-lambda
     return (
@@ -62,9 +62,9 @@ export const FilePathBreadcrumb: React.FunctionComponent<
             partToUrl={i => {
                 const partPath = parts.slice(0, i + 1).join('/')
                 if (isDir || i < parts.length - 1) {
-                    return toTreeURL({ repoPath, rev, filePath: partPath })
+                    return toTreeURL({ repoName, rev, filePath: partPath })
                 }
-                return toPrettyBlobURL({ repoPath, rev, filePath: partPath })
+                return toPrettyBlobURL({ repoName, rev, filePath: partPath })
             }}
             // tslint:disable-next-line:jsx-no-lambda
             partToClassName={i => (i === parts.length - 1 ? 'part-last' : 'part-directory')}

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -93,7 +93,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
 
         // Fetch repository.
         const repositoryChanges = parsedRouteChanges.pipe(
-            map(({ repoPath }) => repoPath),
+            map(({ repoName }) => repoName),
             distinctUntilChanged()
         )
         this.subscriptions.add(
@@ -101,13 +101,13 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                 repositoryChanges,
                 this.repositoryAdds.pipe(
                     withLatestFrom(repositoryChanges),
-                    map(([, repoPath]) => repoPath)
+                    map(([, repoName]) => repoName)
                 )
             )
                 .pipe(
                     tap(() => this.setState({ repoOrError: undefined })),
-                    switchMap(repoPath =>
-                        fetchRepository({ repoPath }).pipe(
+                    switchMap(repoName =>
+                        fetchRepository({ repoName }).pipe(
                             catchError(error => {
                                 switch (error.code) {
                                     case EREPOSEEOTHER:
@@ -135,10 +135,10 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
 
         // Update header and other global state.
         this.subscriptions.add(
-            parsedRouteChanges.subscribe(({ repoPath, rev, rawRev, rest }) => {
-                this.setState({ repoPath, rev, rawRev, rest })
+            parsedRouteChanges.subscribe(({ repoName, rev, rawRev, rest }) => {
+                this.setState({ repoName, rev, rawRev, rest })
 
-                queryUpdates.next(searchQueryForRepoRev(repoPath, rev))
+                queryUpdates.next(searchQueryForRepoRev(repoName, rev))
             })
         )
 
@@ -161,7 +161,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             roots = [
                                 {
                                     uri: makeRepoURI({
-                                        repoPath: this.state.repoPath,
+                                        repoName: this.state.repoName,
                                         rev: resolvedRevOrError.commitID,
                                     }),
                                 },
@@ -200,7 +200,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
             return null
         }
 
-        const { repoPath, filePath, commitRange, position, range } = parseBrowserRepoURL(
+        const { repoName, filePath, commitRange, position, range } = parseBrowserRepoURL(
             location.pathname + location.search + location.hash
         )
         const viewerCanAdminister = !!this.props.authenticatedUser && this.props.authenticatedUser.siteAdmin
@@ -211,7 +211,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                 case EREPONOTFOUND:
                     return (
                         <RepositoryErrorPage
-                            repo={repoPath}
+                            repo={repoName}
                             repoID={null}
                             error={this.state.repoOrError}
                             viewerCanAdminister={viewerCanAdminister}
@@ -313,7 +313,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                             // tslint:disable-next-line:jsx-no-lambda
                             render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoPath={this.state.repoPath}>
+                                <RepositoryGitDataContainer repoName={this.state.repoName}>
                                     <RepositoryCommitPage
                                         {...routeComponentProps}
                                         {...transferProps}
@@ -327,7 +327,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                             // tslint:disable-next-line:jsx-no-lambda
                             render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoPath={this.state.repoPath}>
+                                <RepositoryGitDataContainer repoName={this.state.repoName}>
                                     <RepositoryBranchesArea {...routeComponentProps} {...transferProps} />
                                 </RepositoryGitDataContainer>
                             )}
@@ -337,7 +337,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                             // tslint:disable-next-line:jsx-no-lambda
                             render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoPath={this.state.repoPath}>
+                                <RepositoryGitDataContainer repoName={this.state.repoName}>
                                     <RepositoryReleasesArea {...routeComponentProps} {...transferProps} />
                                 </RepositoryGitDataContainer>
                             )}
@@ -347,7 +347,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                             // tslint:disable-next-line:jsx-no-lambda
                             render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoPath={this.state.repoPath}>
+                                <RepositoryGitDataContainer repoName={this.state.repoName}>
                                     <RepositoryCompareArea {...routeComponentProps} {...transferProps} />
                                 </RepositoryGitDataContainer>
                             )}
@@ -357,7 +357,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                             // tslint:disable-next-line:jsx-no-lambda
                             render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoPath={this.state.repoPath}>
+                                <RepositoryGitDataContainer repoName={this.state.repoName}>
                                     <RepositoryStatsArea {...routeComponentProps} {...transferProps} />
                                 </RepositoryGitDataContainer>
                             )}

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -4,7 +4,7 @@ import SettingsIcon from 'mdi-react/SettingsIcon'
 import * as React from 'react'
 import { ActionsNavItems } from '../../../shared/src/actions/ActionsNavItems'
 import { ContributableMenu } from '../../../shared/src/api/protocol'
-import { displayRepoPath, splitPath } from '../../../shared/src/components/RepoFileLink'
+import { displayRepoName, splitPath } from '../../../shared/src/components/RepoFileLink'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
@@ -181,7 +181,7 @@ export class RepoHeader extends React.PureComponent<Props, State> {
         const leftActions = this.state.repoHeaderContributions.filter(({ position }) => position === 'left')
         const rightActions = this.state.repoHeaderContributions.filter(({ position }) => position === 'right')
 
-        const [repoDir, repoBase] = splitPath(displayRepoPath(this.props.repo.name))
+        const [repoDir, repoBase] = splitPath(displayRepoName(this.props.repo.name))
         const context: RepoHeaderContext = {
             repoName: this.props.repo.name,
             encodedRev: this.props.rev,

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -80,8 +80,8 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
 
     public componentDidMount(): void {
         const repoRevChanges = this.propsUpdates.pipe(
-            // Pick repoPath and rev out of the props
-            map(props => ({ repoPath: props.repo.name, rev: props.rev })),
+            // Pick repoName and rev out of the props
+            map(props => ({ repoName: props.repo.name, rev: props.rev })),
             distinctUntilChanged((a, b) => isEqual(a, b))
         )
 
@@ -91,8 +91,8 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
                 .pipe(
                     // Reset resolved rev / error state
                     tap(() => this.props.onResolvedRevOrError(undefined)),
-                    switchMap(({ repoPath, rev }) =>
-                        defer(() => resolveRev({ repoPath, rev })).pipe(
+                    switchMap(({ repoName, rev }) =>
+                        defer(() => resolveRev({ repoName, rev })).pipe(
                             // On a CloneInProgress error, retry after 1s
                             retryWhen(errors =>
                                 errors.pipe(
@@ -215,7 +215,7 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
                             popoverElement={
                                 <RevisionsPopover
                                     repo={this.props.repo.id}
-                                    repoPath={this.props.repo.name}
+                                    repoName={this.props.repo.name}
                                     defaultBranch={this.props.resolvedRevOrError.defaultBranch}
                                     currentRev={this.props.rev}
                                     currentCommitID={this.props.resolvedRevOrError.commitID}

--- a/web/src/repo/RepoRevSidebar.tsx
+++ b/web/src/repo/RepoRevSidebar.tsx
@@ -109,7 +109,7 @@ export class RepoRevSidebar extends React.PureComponent<Props, State> {
                     >
                         <Tree
                             key="files"
-                            repoPath={this.props.repoPath}
+                            repoName={this.props.repoName}
                             rev={this.props.rev}
                             commitID={this.props.commitID}
                             history={this.props.history}

--- a/web/src/repo/RepositoriesPopover.tsx
+++ b/web/src/repo/RepositoriesPopover.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { CircleChevronLeftIcon } from '../../../shared/src/components/icons'
-import { displayRepoPath } from '../../../shared/src/components/RepoFileLink'
+import { displayRepoName } from '../../../shared/src/components/RepoFileLink'
 import { gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { createAggregateError } from '../../../shared/src/util/errors'
@@ -52,7 +52,7 @@ const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({ node, cu
                 node.id === currentRepo ? 'connection-popover__node-link--active' : ''
             }`}
         >
-            {displayRepoPath(node.name)}
+            {displayRepoName(node.name)}
             {node.id === currentRepo && (
                 <CircleChevronLeftIcon className="icon-inline connection-popover__node-link-icon" />
             )}

--- a/web/src/repo/RepositoryGitDataContainer.tsx
+++ b/web/src/repo/RepositoryGitDataContainer.tsx
@@ -5,7 +5,7 @@ import { defer, Subject, Subscription } from 'rxjs'
 import { catchError, delay, distinctUntilChanged, map, retryWhen, switchMap, tap } from 'rxjs/operators'
 import { RepoQuestionIcon } from '../../../shared/src/components/icons'
 import { RepositoryIcon } from '../../../shared/src/components/icons' // TODO: Switch to mdi icon
-import { displayRepoPath } from '../../../shared/src/components/RepoFileLink'
+import { displayRepoName } from '../../../shared/src/components/RepoFileLink'
 import { ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { HeroPage } from '../components/HeroPage'
 import { CloneInProgressError, ECLONEINPROGESS, EREVNOTFOUND, resolveRev } from './backend'
@@ -17,7 +17,7 @@ export const RepositoryCloningInProgressPage: React.FunctionComponent<{ repoName
 }) => (
     <HeroPage
         icon={RepositoryIcon}
-        title={displayRepoPath(repoName)}
+        title={displayRepoName(repoName)}
         className="repository-cloning-in-progress-page"
         subtitle="Cloning in progress"
         detail={<code>{progress}</code>}
@@ -31,7 +31,7 @@ export const EmptyRepositoryPage: React.FunctionComponent = () => (
 
 interface Props {
     /** The repository. */
-    repoPath: string
+    repoName: string
 
     /** The fragment to render if the repository's Git data is accessible. */
     children: React.ReactNode
@@ -61,11 +61,11 @@ export class RepositoryGitDataContainer extends React.PureComponent<Props, State
         this.subscriptions.add(
             this.propsUpdates
                 .pipe(
-                    map(({ repoPath }) => repoPath),
+                    map(({ repoName }) => repoName),
                     distinctUntilChanged(),
                     tap(() => this.setState({ gitDataPresentOrError: undefined })),
-                    switchMap(repoPath =>
-                        defer(() => resolveRev({ repoPath })).pipe(
+                    switchMap(repoName =>
+                        defer(() => resolveRev({ repoName })).pipe(
                             // On a CloneInProgress error, retry after 1s
                             retryWhen(errors =>
                                 errors.pipe(
@@ -116,7 +116,7 @@ export class RepositoryGitDataContainer extends React.PureComponent<Props, State
                 case ECLONEINPROGESS:
                     return (
                         <RepositoryCloningInProgressPage
-                            repoName={this.props.repoPath}
+                            repoName={this.props.repoName}
                             progress={(this.state.gitDataPresentOrError as CloneInProgressError).progress}
                         />
                     )

--- a/web/src/repo/RevisionsPopover.tsx
+++ b/web/src/repo/RevisionsPopover.tsx
@@ -135,7 +135,7 @@ const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({ node, curr
 
 interface Props {
     repo: GQL.ID
-    repoPath: string
+    repoName: string
     defaultBranch: string | undefined
 
     /** The current revision, or undefined for the default branch. */

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -15,7 +15,7 @@ import { ActionItem } from '../../../shared/src/actions/ActionItem'
 import { ActionsContainer } from '../../../shared/src/actions/ActionsContainer'
 import { ContributableMenu } from '../../../shared/src/api/protocol'
 import { RepositoryIcon } from '../../../shared/src/components/icons' // TODO: Switch to mdi icon
-import { displayRepoPath } from '../../../shared/src/components/RepoFileLink'
+import { displayRepoName } from '../../../shared/src/components/RepoFileLink'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
@@ -98,7 +98,7 @@ const fetchTreeCommits = memoizeObservable(
 )
 
 interface Props extends SettingsCascadeProps, ExtensionsControllerProps, PlatformContextProps {
-    repoPath: string
+    repoName: string
     repoID: GQL.ID
     repoDescription: string
     // filePath is the tree's path in TreePage. We call it filePath for consistency elsewhere.
@@ -141,7 +141,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                 .pipe(
                     distinctUntilChanged(
                         (x, y) =>
-                            x.repoPath === y.repoPath &&
+                            x.repoName === y.repoName &&
                             x.rev === y.rev &&
                             x.commitID === y.commitID &&
                             x.filePath === y.filePath
@@ -149,7 +149,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                     tap(props => this.logViewEvent(props)),
                     switchMap(props =>
                         fetchTree({
-                            repoPath: props.repoPath,
+                            repoName: props.repoName,
                             commitID: props.commitID,
                             rev: props.rev,
                             filePath: props.filePath,
@@ -176,7 +176,7 @@ export class TreePage extends React.PureComponent<Props, State> {
     }
 
     private getQueryPrefix(): string {
-        let queryPrefix = searchQueryForRepoRev(this.props.repoPath, this.props.rev)
+        let queryPrefix = searchQueryForRepoRev(this.props.repoName, this.props.rev)
         if (this.props.filePath) {
             queryPrefix += `file:^${escapeRegExp(this.props.filePath)}/ `
         }
@@ -202,7 +202,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 <header>
                                     <h2 className="tree-page__title">
                                         <RepositoryIcon className="icon-inline" />{' '}
-                                        {displayRepoPath(this.props.repoPath)}
+                                        {displayRepoName(this.props.repoName)}
                                     </h2>
                                     {this.props.repoDescription && <p>{this.props.repoDescription}</p>}
                                     <div className="btn-group mb-3">
@@ -212,27 +212,27 @@ export class TreePage extends React.PureComponent<Props, State> {
                                         >
                                             <SourceCommitIcon className="icon-inline" /> Commits
                                         </Link>
-                                        <Link className="btn btn-secondary" to={`/${this.props.repoPath}/-/branches`}>
+                                        <Link className="btn btn-secondary" to={`/${this.props.repoName}/-/branches`}>
                                             <SourceBranchIcon className="icon-inline" /> Branches
                                         </Link>
-                                        <Link className="btn btn-secondary" to={`/${this.props.repoPath}/-/tags`}>
+                                        <Link className="btn btn-secondary" to={`/${this.props.repoName}/-/tags`}>
                                             <TagIcon className="icon-inline" /> Tags
                                         </Link>
                                         <Link
                                             className="btn btn-secondary"
                                             to={
                                                 this.props.rev
-                                                    ? `/${this.props.repoPath}/-/compare/...${encodeURIComponent(
+                                                    ? `/${this.props.repoName}/-/compare/...${encodeURIComponent(
                                                           this.props.rev
                                                       )}`
-                                                    : `/${this.props.repoPath}/-/compare`
+                                                    : `/${this.props.repoName}/-/compare`
                                             }
                                         >
                                             <HistoryIcon className="icon-inline" /> Compare
                                         </Link>
                                         <Link
                                             className={`btn btn-secondary`}
-                                            to={`/${this.props.repoPath}/-/stats/contributors`}
+                                            to={`/${this.props.repoName}/-/stats/contributors`}
                                         >
                                             <UserIcon className="icon-inline" /> Contributors
                                         </Link>
@@ -346,11 +346,11 @@ export class TreePage extends React.PureComponent<Props, State> {
                                     queryConnection={this.queryCommits}
                                     nodeComponent={GitCommitNode}
                                     nodeComponentProps={{
-                                        repoName: this.props.repoPath,
+                                        repoName: this.props.repoName,
                                         className: 'list-group-item',
                                         compact: true,
                                     }}
-                                    updateOnChange={`${this.props.repoPath}:${this.props.rev}:${this.props.filePath}`}
+                                    updateOnChange={`${this.props.repoName}:${this.props.rev}:${this.props.filePath}`}
                                     defaultFirst={7}
                                     history={this.props.history}
                                     shouldUpdateURLQuery={false}
@@ -376,7 +376,7 @@ export class TreePage extends React.PureComponent<Props, State> {
     }
 
     private getPageTitle(): string {
-        const repoStr = displayRepoPath(this.props.repoPath)
+        const repoStr = displayRepoName(this.props.repoName)
         if (this.props.filePath) {
             return `${basename(this.props.filePath)} - ${repoStr}`
         }

--- a/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -51,7 +51,7 @@ export class GoToCodeHostAction extends React.PureComponent<Props, State> {
                         }
                         return merge(
                             of({ fileExternalLinksOrError: undefined }),
-                            fetchFileExternalLinks({ repoPath: repo.name, rev, filePath }).pipe(
+                            fetchFileExternalLinks({ repoName: repo.name, rev, filePath }).pipe(
                                 catchError(err => [asError(err)]),
                                 map(c => ({ fileExternalLinksOrError: c }))
                             )

--- a/web/src/repo/backend.tsx
+++ b/web/src/repo/backend.tsx
@@ -16,15 +16,15 @@ export interface CloneInProgressError extends Error {
     code: typeof ECLONEINPROGESS
     progress?: string
 }
-const createCloneInProgressError = (repoPath: string, progress: string | undefined): CloneInProgressError =>
-    Object.assign(new Error(`Repository ${repoPath} is clone in progress`), {
+const createCloneInProgressError = (repoName: string, progress: string | undefined): CloneInProgressError =>
+    Object.assign(new Error(`Repository ${repoName} is clone in progress`), {
         code: ECLONEINPROGESS as typeof ECLONEINPROGESS,
         progress,
     })
 
 export const EREPONOTFOUND = 'EREPONOTFOUND'
-const createRepoNotFoundError = (repoPath: string): Error =>
-    Object.assign(new Error(`Repository ${repoPath} not found`), { code: EREPONOTFOUND })
+const createRepoNotFoundError = (repoName: string): Error =>
+    Object.assign(new Error(`Repository ${repoName} not found`), { code: EREPONOTFOUND })
 
 export const EREVNOTFOUND = 'EREVNOTFOUND'
 const createRevNotFoundError = (rev?: string): Error =>
@@ -45,11 +45,11 @@ const createRepoSeeOtherError = (redirectURL: string): RepoSeeOtherError =>
  * Fetch the repository.
  */
 export const fetchRepository = memoizeObservable(
-    (args: { repoPath: string }): Observable<GQL.IRepository> =>
+    (args: { repoName: string }): Observable<GQL.IRepository> =>
         queryGraphQL(
             gql`
-                query Repository($repoPath: String!) {
-                    repository(name: $repoPath) {
+                query Repository($repoName: String!) {
+                    repository(name: $repoName) {
                         id
                         name
                         url
@@ -77,7 +77,7 @@ export const fetchRepository = memoizeObservable(
                     throw createRepoSeeOtherError(data.repository.redirectURL)
                 }
                 if (!data.repository) {
-                    throw createRepoNotFoundError(args.repoPath)
+                    throw createRepoNotFoundError(args.repoName)
                 }
                 return data.repository
             })
@@ -99,11 +99,11 @@ export interface ResolvedRev {
  *         Errors with a `CloneInProgressError` if the repo is still being cloned.
  */
 export const resolveRev = memoizeObservable(
-    (ctx: { repoPath: string; rev?: string }): Observable<ResolvedRev> =>
+    (ctx: { repoName: string; rev?: string }): Observable<ResolvedRev> =>
         queryGraphQL(
             gql`
-                query ResolveRev($repoPath: String!, $rev: String!) {
-                    repository(name: $repoPath) {
+                query ResolveRev($repoName: String!, $rev: String!) {
+                    repository(name: $repoName) {
                         mirrorInfo {
                             cloneInProgress
                             cloneProgress
@@ -131,11 +131,11 @@ export const resolveRev = memoizeObservable(
                     throw createRepoSeeOtherError(data.repository.redirectURL)
                 }
                 if (!data.repository) {
-                    throw createRepoNotFoundError(ctx.repoPath)
+                    throw createRepoNotFoundError(ctx.repoName)
                 }
                 if (data.repository.mirrorInfo.cloneInProgress) {
                     throw createCloneInProgressError(
-                        ctx.repoPath,
+                        ctx.repoName,
                         data.repository.mirrorInfo.cloneProgress || undefined
                     )
                 }
@@ -166,13 +166,13 @@ const fetchHighlightedFile = memoizeObservable(
         queryGraphQL(
             gql`
                 query HighlightedFile(
-                    $repoPath: String!
+                    $repoName: String!
                     $commitID: String!
                     $filePath: String!
                     $disableTimeout: Boolean!
                     $isLightTheme: Boolean!
                 ) {
-                    repository(name: $repoPath) {
+                    repository(name: $repoName) {
                         commit(rev: $commitID) {
                             file(path: $filePath) {
                                 isDirectory
@@ -234,8 +234,8 @@ export const fetchFileExternalLinks = memoizeObservable(
     (ctx: RepoRev & { filePath: string }): Observable<GQL.IExternalLink[]> =>
         queryGraphQL(
             gql`
-                query FileExternalLinks($repoPath: String!, $rev: String!, $filePath: String!) {
-                    repository(name: $repoPath) {
+                query FileExternalLinks($repoName: String!, $rev: String!, $filePath: String!) {
+                    repository(name: $repoName) {
                         commit(rev: $rev) {
                             file(path: $filePath) {
                                 externalURLs {
@@ -269,8 +269,8 @@ export const fetchTree = memoizeObservable(
     (args: AbsoluteRepoFile & { first?: number }): Observable<GQL.IGitTree> =>
         queryGraphQL(
             gql`
-                query Tree($repoPath: String!, $rev: String!, $commitID: String!, $filePath: String!, $first: Int) {
-                    repository(name: $repoPath) {
+                query Tree($repoName: String!, $rev: String!, $commitID: String!, $filePath: String!, $first: Int) {
+                    repository(name: $repoName) {
                         commit(rev: $commitID, inputRevspec: $rev) {
                             tree(path: $filePath) {
                                 isRoot
@@ -308,8 +308,8 @@ export const fetchTreeEntries = memoizeObservable(
     (args: AbsoluteRepoFile & { first?: number }): Observable<GQL.IGitTree> =>
         queryGraphQL(
             gql`
-                query Tree($repoPath: String!, $rev: String!, $commitID: String!, $filePath: String!, $first: Int) {
-                    repository(name: $repoPath) {
+                query Tree($repoName: String!, $rev: String!, $commitID: String!, $filePath: String!, $first: Int) {
+                    repository(name: $repoName) {
                         commit(rev: $commitID, inputRevspec: $rev) {
                             tree(path: $filePath) {
                                 entries(first: $first, recursiveSingleChild: true) {

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -179,7 +179,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         this.subscriptions.add(hoverifier)
 
         const resolveContext = () => ({
-            repoPath: this.props.repoPath,
+            repoName: this.props.repoName,
             rev: this.props.rev,
             commitID: this.props.commitID,
             filePath: this.props.filePath,
@@ -291,7 +291,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         const modelChanges: Observable<
             AbsoluteRepoFile & LSPSelector & Pick<BlobProps, 'content'>
         > = this.componentUpdates.pipe(
-            map(props => pick(props, 'repoPath', 'rev', 'commitID', 'filePath', 'mode', 'content')),
+            map(props => pick(props, 'repoName', 'rev', 'commitID', 'filePath', 'mode', 'content')),
             distinctUntilChanged((a, b) => isEqual(a, b)),
             share()
         )
@@ -305,7 +305,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                         {
                             type: 'textEditor' as 'textEditor',
                             item: {
-                                uri: `git://${model.repoPath}?${model.commitID}#${model.filePath}`,
+                                uri: `git://${model.repoName}?${model.commitID}#${model.filePath}`,
                                 languageId: model.mode,
                                 text: model.content,
                             },
@@ -404,7 +404,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         position: HoveredToken & RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
     ): LSPTextDocumentPositionParams {
         return {
-            repoPath: position.repoPath,
+            repoName: position.repoName,
             filePath: position.filePath,
             commitID: position.commitID,
             rev: position.rev,

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -35,7 +35,7 @@ export function fetchBlobCacheKey(parsed: ParsedRepoURI & { isLightTheme: boolea
 
 export const fetchBlob = memoizeObservable(
     (args: {
-        repoPath: string
+        repoName: string
         commitID: string
         filePath: string
         isLightTheme: boolean
@@ -44,13 +44,13 @@ export const fetchBlob = memoizeObservable(
         queryGraphQL(
             gql`
                 query Blob(
-                    $repoPath: String!
+                    $repoName: String!
                     $commitID: String!
                     $filePath: String!
                     $isLightTheme: Boolean!
                     $disableTimeout: Boolean!
                 ) {
-                    repository(name: $repoPath) {
+                    repository(name: $repoName) {
                         commit(rev: $commitID) {
                             file(path: $filePath) {
                                 content
@@ -130,7 +130,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
         this.subscriptions.add(
             combineLatest(
                 this.propsUpdates.pipe(
-                    map(props => pick(props, 'repoPath', 'commitID', 'filePath', 'isLightTheme')),
+                    map(props => pick(props, 'repoName', 'commitID', 'filePath', 'isLightTheme')),
                     distinctUntilChanged((a, b) => isEqual(a, b))
                 ),
                 this.extendHighlightingTimeoutClicks.pipe(
@@ -140,9 +140,9 @@ export class BlobPage extends React.PureComponent<Props, State> {
             )
                 .pipe(
                     tap(() => this.setState({ blobOrError: undefined })),
-                    switchMap(([{ repoPath, commitID, filePath, isLightTheme }, extendHighlightingTimeout]) =>
+                    switchMap(([{ repoName, commitID, filePath, isLightTheme }, extendHighlightingTimeout]) =>
                         fetchBlob({
-                            repoPath,
+                            repoName,
                             commitID,
                             filePath,
                             isLightTheme,
@@ -172,7 +172,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
     public componentWillReceiveProps(newProps: Props): void {
         this.propsUpdates.next(newProps)
         if (
-            newProps.repoPath !== this.props.repoPath ||
+            newProps.repoName !== this.props.repoName ||
             newProps.commitID !== this.props.commitID ||
             newProps.filePath !== this.props.filePath ||
             ToggleRenderedFileMode.getModeFromURL(newProps.location) !==
@@ -278,7 +278,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
                     !this.state.blobOrError.highlight.aborted && (
                         <Blob
                             className="blob-page__blob"
-                            repoPath={this.props.repoPath}
+                            repoName={this.props.repoName}
                             commitID={this.props.commitID}
                             filePath={this.props.filePath}
                             content={this.state.blobOrError.content}
@@ -312,7 +312,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
                 <BlobPanel
                     {...this.props}
                     repoID={this.props.repoID}
-                    repoPath={this.props.repoPath}
+                    repoName={this.props.repoName}
                     commitID={this.props.commitID}
                     platformContext={this.props.platformContext}
                     extensionsController={this.props.extensionsController}
@@ -332,8 +332,8 @@ export class BlobPage extends React.PureComponent<Props, State> {
     private onExtendHighlightingTimeoutClick = () => this.extendHighlightingTimeoutClicks.next()
 
     private getPageTitle(): string {
-        const repoPathSplit = this.props.repoPath.split('/')
-        const repoStr = repoPathSplit.length > 2 ? repoPathSplit.slice(1).join('/') : this.props.repoPath
+        const repoNameSplit = this.props.repoName.split('/')
+        const repoStr = repoNameSplit.length > 2 ? repoNameSplit.slice(1).join('/') : this.props.repoName
         if (this.props.filePath) {
             const fileOrDir = this.props.filePath.split('/').pop()
             return `${fileOrDir} - ${repoStr}`

--- a/web/src/repo/blob/LineDecorationAttachment.tsx
+++ b/web/src/repo/blob/LineDecorationAttachment.tsx
@@ -22,7 +22,7 @@ export class LineDecorationAttachment extends React.PureComponent<LineDecoration
 
     public componentWillReceiveProps(nextProps: Readonly<LineDecorationAttachmentProps>): void {
         if (
-            nextProps.repoPath !== this.props.repoPath ||
+            nextProps.repoName !== this.props.repoName ||
             nextProps.rev !== this.props.rev ||
             nextProps.filePath !== this.props.filePath ||
             nextProps.line !== this.props.line ||

--- a/web/src/repo/blob/discussions/DiscussionsCreate.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsCreate.tsx
@@ -13,7 +13,7 @@ import { DiscussionsNavbar } from './DiscussionsNavbar'
 
 interface Props {
     repoID: GQL.ID
-    repoPath: string
+    repoName: string
     commitID: string
     rev: string | undefined
     filePath: string

--- a/web/src/repo/blob/discussions/DiscussionsTree.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsTree.tsx
@@ -7,7 +7,7 @@ import { DiscussionsThread } from './DiscussionsThread'
 
 interface Props {
     repoID: GQL.ID
-    repoPath: string
+    repoName: string
     commitID: string
     rev: string | undefined
     filePath: string

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -33,7 +33,7 @@ interface Props
     location: H.Location
     history: H.History
     repoID: GQL.ID
-    repoPath: string
+    repoName: string
     commitID: string
     isLightTheme: boolean
     authenticatedUser: GQL.IUser | null
@@ -57,7 +57,7 @@ interface PanelSubject extends AbsoluteRepoFile, ModeSpec, Partial<PositionSpec>
 function toSubject(props: Props): PanelSubject {
     const parsedHash = parseHash(props.location.hash)
     return {
-        repoPath: props.repoPath,
+        repoName: props.repoName,
         repoID: props.repoID,
         commitID: props.commitID,
         rev: props.rev,
@@ -161,7 +161,7 @@ export class BlobPanel extends React.PureComponent<Props> {
                                 reactElement: (
                                     <RepoRevSidebarCommits
                                         key="commits"
-                                        repoName={subject.repoPath}
+                                        repoName={subject.repoName}
                                         repoID={this.props.repoID}
                                         rev={subject.rev}
                                         filePath={subject.filePath}
@@ -188,7 +188,7 @@ export class BlobPanel extends React.PureComponent<Props> {
                                               reactElement: (
                                                   <DiscussionsTree
                                                       repoID={this.props.repoID}
-                                                      repoPath={subject.repoPath}
+                                                      repoName={subject.repoName}
                                                       commitID={subject.commitID}
                                                       rev={subject.rev}
                                                       filePath={subject.filePath}

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -131,7 +131,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
         hoveredToken: HoveredToken & RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
     ): LSPTextDocumentPositionParams {
         return {
-            repoPath: hoveredToken.repoPath,
+            repoName: hoveredToken.repoName,
             rev: hoveredToken.rev,
             filePath: hoveredToken.filePath,
             commitID: hoveredToken.commitID,
@@ -222,13 +222,13 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                                 nodeComponent={FileDiffNode}
                                 nodeComponentProps={{
                                     base: {
-                                        repoPath: this.props.repo.name,
+                                        repoName: this.props.repo.name,
                                         repoID: this.props.repo.id,
                                         rev: commitParentOrEmpty(this.state.commitOrError),
                                         commitID: commitParentOrEmpty(this.state.commitOrError),
                                     },
                                     head: {
-                                        repoPath: this.props.repo.name,
+                                        repoName: this.props.repo.name,
                                         repoID: this.props.repo.id,
                                         rev: this.state.commitOrError.oid,
                                         commitID: this.state.commitOrError.oid,

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -48,7 +48,7 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                     visibleViewComponents.push({
                         type: 'textEditor',
                         item: {
-                            uri: `git://${nodeProps.base.repoPath}?${nodeProps.base.commitID}#${fileDiff.oldPath}`,
+                            uri: `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`,
                             languageId: getModeFromPath(fileDiff.oldPath),
                             text: dummyText,
                         },
@@ -60,7 +60,7 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                     visibleViewComponents.push({
                         type: 'textEditor',
                         item: {
-                            uri: `git://${nodeProps.head.repoPath}?${nodeProps.head.commitID}#${fileDiff.newPath}`,
+                            uri: `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`,
                             languageId: getModeFromPath(fileDiff.newPath),
                             text: dummyText,
                         },

--- a/web/src/repo/compare/FileDiffHunks.tsx
+++ b/web/src/repo/compare/FileDiffHunks.tsx
@@ -176,7 +176,7 @@ const diffDomFunctions: DOMFunctions = {
 }
 
 interface Part {
-    repoPath: string
+    repoName: string
     repoID: GQL.ID
     rev: string
     commitID: string
@@ -256,9 +256,9 @@ export class FileDiffHunks extends React.Component<Props, State> {
                 positionJumps: NEVER, // TODO support diff URLs
                 resolveContext: hoveredToken => {
                     // if part is undefined, it doesn't matter whether we chose head or base, the line stayed the same
-                    const { repoPath, rev, filePath, commitID } = this.props[hoveredToken.part || 'head']
+                    const { repoName, rev, filePath, commitID } = this.props[hoveredToken.part || 'head']
                     // If a hover or go-to-definition was invoked on this part, we know the file path must exist
-                    return { repoPath, filePath: filePath!, rev, commitID }
+                    return { repoName, filePath: filePath!, rev, commitID }
                 },
             })
         )

--- a/web/src/repo/compare/FileDiffNode.tsx
+++ b/web/src/repo/compare/FileDiffNode.tsx
@@ -15,10 +15,10 @@ export interface FileDiffNodeProps extends PlatformContextProps, ExtensionsContr
     node: GQL.IFileDiff
 
     /** The base repository and revision. */
-    base: { repoPath: string; repoID: GQL.ID; rev: string; commitID: string }
+    base: { repoName: string; repoID: GQL.ID; rev: string; commitID: string }
 
     /** The head repository and revision. */
-    head: { repoPath: string; repoID: GQL.ID; rev: string; commitID: string }
+    head: { repoName: string; repoID: GQL.ID; rev: string; commitID: string }
 
     lineNumbers: boolean
     className?: string

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -58,10 +58,10 @@ export interface RepositoryCompareAreaPageProps extends PlatformContextProps {
     repo: GQL.IRepository
 
     /** The base of the comparison. */
-    base: { repoPath: string; repoID: GQL.ID; rev?: string | null }
+    base: { repoName: string; repoID: GQL.ID; rev?: string | null }
 
     /** The head of the comparison. */
-    head: { repoPath: string; repoID: GQL.ID; rev?: string | null }
+    head: { repoName: string; repoID: GQL.ID; rev?: string | null }
 
     /** The URL route prefix for the comparison. */
     routePrefix: string
@@ -127,7 +127,7 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
         hoveredToken: HoveredToken & RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
     ): LSPTextDocumentPositionParams {
         return {
-            repoPath: hoveredToken.repoPath,
+            repoName: hoveredToken.repoName,
             rev: hoveredToken.rev,
             filePath: hoveredToken.filePath,
             commitID: hoveredToken.commitID,
@@ -164,8 +164,8 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
 
         const commonProps: RepositoryCompareAreaPageProps = {
             repo: this.props.repo,
-            base: { repoID: this.props.repo.id, repoPath: this.props.repo.name, rev: spec && spec.base },
-            head: { repoID: this.props.repo.id, repoPath: this.props.repo.name, rev: spec && spec.head },
+            base: { repoID: this.props.repo.id, repoName: this.props.repo.name, rev: spec && spec.base },
+            head: { repoID: this.props.repo.id, repoName: this.props.repo.name, rev: spec && spec.head },
             routePrefix: this.props.match.url,
             platformContext: this.props.platformContext,
         }

--- a/web/src/repo/compare/RepositoryCompareDiffPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareDiffPage.tsx
@@ -98,10 +98,10 @@ interface RepositoryCompareDiffPageProps
         PlatformContextProps,
         ExtensionsControllerProps {
     /** The base of the comparison. */
-    base: { repoPath: string; repoID: GQL.ID; rev: string | null; commitID: string }
+    base: { repoName: string; repoID: GQL.ID; rev: string | null; commitID: string }
 
     /** The head of the comparison. */
-    head: { repoPath: string; repoID: GQL.ID; rev: string | null; commitID: string }
+    head: { repoName: string; repoID: GQL.ID; rev: string | null; commitID: string }
     hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
 }
 

--- a/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -77,10 +77,10 @@ interface Props
         PlatformContextProps,
         ExtensionsControllerProps {
     /** The base of the comparison. */
-    base: { repoPath: string; repoID: GQL.ID; rev?: string | null }
+    base: { repoName: string; repoID: GQL.ID; rev?: string | null }
 
     /** The head of the comparison. */
-    head: { repoPath: string; repoID: GQL.ID; rev?: string | null }
+    head: { repoName: string; repoID: GQL.ID; rev?: string | null }
     hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
 }
 
@@ -153,13 +153,13 @@ export class RepositoryCompareOverviewPage extends React.PureComponent<Props, St
                         <RepositoryCompareDiffPage
                             {...this.props}
                             base={{
-                                repoPath: this.props.base.repoPath,
+                                repoName: this.props.base.repoName,
                                 repoID: this.props.base.repoID,
                                 rev: this.props.base.rev || null,
                                 commitID: this.state.rangeOrError.baseRevSpec.object!.oid,
                             }}
                             head={{
-                                repoPath: this.props.head.repoPath,
+                                repoName: this.props.head.repoName,
                                 repoID: this.props.head.repoID,
                                 rev: this.props.head.rev || null,
                                 commitID: this.state.rangeOrError.headRevSpec.object!.oid,

--- a/web/src/repo/explore/RepositoriesExploreSection.tsx
+++ b/web/src/repo/explore/RepositoriesExploreSection.tsx
@@ -94,7 +94,7 @@ export class RepositoriesExploreSection extends React.PureComponent<Props, State
                                             to={repo.url}
                                         >
                                             <h3 className="mb-0 text-truncate">
-                                                <RepoLink to={null} repoPath={repo.name} />
+                                                <RepoLink to={null} repoName={repo.name} />
                                             </h3>
                                             <span className="text-truncate">{repo.description || <>&nbsp;</>}</span>
                                         </Link>

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -50,7 +50,7 @@ export const repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute> = [
                                 element={
                                     <FilePathBreadcrumb
                                         key="path"
-                                        repoPath={context.repo.name}
+                                        repoName={context.repo.name}
                                         rev={context.rev}
                                         filePath={filePath}
                                         isDir={objectType === 'tree'}
@@ -63,7 +63,7 @@ export const repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute> = [
                     <RepoRevSidebar
                         className="repo-rev-container__sidebar"
                         repoID={context.repo.id}
-                        repoPath={context.repo.name}
+                        repoName={context.repo.name}
                         rev={context.rev}
                         commitID={context.resolvedRev.commitID}
                         filePath={context.match.params.filePath || '' || ''}
@@ -77,7 +77,7 @@ export const repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute> = [
                         <div className="repo-rev-container__content">
                             {objectType === 'blob' ? (
                                 <BlobPage
-                                    repoPath={context.repo.name}
+                                    repoName={context.repo.name}
                                     repoID={context.repo.id}
                                     commitID={context.resolvedRev.commitID}
                                     rev={context.rev}
@@ -96,7 +96,7 @@ export const repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute> = [
                                 />
                             ) : (
                                 <TreePage
-                                    repoPath={context.repo.name}
+                                    repoName={context.repo.name}
                                     repoID={context.repo.id}
                                     repoDescription={context.repo.description}
                                     commitID={context.resolvedRev.commitID}

--- a/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -27,12 +27,12 @@ interface QuerySpec {
 
 interface RepositoryContributorNodeProps extends QuerySpec {
     node: GQL.IRepositoryContributor
-    repoPath: string
+    repoName: string
 }
 
 const RepositoryContributorNode: React.FunctionComponent<RepositoryContributorNodeProps> = ({
     node,
-    repoPath,
+    repoName,
     revisionRange,
     after,
     path,
@@ -40,7 +40,7 @@ const RepositoryContributorNode: React.FunctionComponent<RepositoryContributorNo
     const commit = node.commits.nodes[0] as GQL.IGitCommit | undefined
 
     const query: string = [
-        searchQueryForRepoRev(repoPath),
+        searchQueryForRepoRev(repoName),
         'type:diff',
         `author:${quoteIfNeeded(node.person.email)}`,
         after ? `after:${quoteIfNeeded(after)}` : '',
@@ -159,7 +159,7 @@ interface Props extends RepositoryStatsAreaPageProps, RouteComponentProps<{}> {}
 
 class FilteredContributorsConnection extends FilteredConnection<
     GQL.IRepositoryContributor,
-    Pick<RepositoryContributorNodeProps, 'repoPath' | 'revisionRange' | 'after' | 'path'>
+    Pick<RepositoryContributorNodeProps, 'repoName' | 'revisionRange' | 'after' | 'path'>
 > {}
 
 interface State extends QuerySpec {}
@@ -348,7 +348,7 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                     queryConnection={this.queryRepositoryContributors}
                     nodeComponent={RepositoryContributorNode}
                     nodeComponentProps={{
-                        repoPath: this.props.repo.name,
+                        repoName: this.props.repo.name,
                         revisionRange,
                         after,
                         path,

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -35,8 +35,8 @@ export function parseSearchURLQuery(query: string): SearchOptions | undefined {
     }
 }
 
-export function searchQueryForRepoRev(repoPath: string, rev?: string): string {
-    return `repo:${quoteIfNeeded(`^${escapeRegExp(repoPath)}$${rev ? `@${abbreviateOID(rev)}` : ''}`)} `
+export function searchQueryForRepoRev(repoName: string, rev?: string): string {
+    return `repo:${quoteIfNeeded(`^${escapeRegExp(repoName)}$${rev ? `@${abbreviateOID(rev)}` : ''}`)} `
 }
 
 function abbreviateOID(oid: string): string {

--- a/web/src/search/input/CodeIntellifyBlob.tsx
+++ b/web/src/search/input/CodeIntellifyBlob.tsx
@@ -83,7 +83,7 @@ const domFunctions = {
     },
 }
 
-const REPO_PATH = 'github.com/gorilla/mux'
+const REPO_NAME = 'github.com/gorilla/mux'
 const COMMIT_ID = '9e1f5955c0d22b55d9e20d6faa28589f83b2faca'
 const REV = undefined
 const FILE_PATH = 'mux.go'
@@ -159,7 +159,7 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
             hoverifier.hoverify({
                 positionEvents,
                 resolveContext: () => ({
-                    repoPath: REPO_PATH,
+                    repoName: REPO_NAME,
                     commitID: COMMIT_ID,
                     rev: REV || '',
                     filePath: FILE_PATH,
@@ -191,7 +191,7 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
     public componentDidMount(): void {
         // Fetch repository revision.
         fetchBlob({
-            repoPath: REPO_PATH,
+            repoName: REPO_NAME,
             commitID: COMMIT_ID,
             filePath: FILE_PATH,
             isLightTheme: false,
@@ -234,7 +234,7 @@ export class CodeIntellifyBlob extends React.Component<Props, State> {
         position: HoveredToken & RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
     ): LSPTextDocumentPositionParams {
         return {
-            repoPath: position.repoPath,
+            repoName: position.repoName,
             filePath: position.filePath,
             commitID: position.commitID,
             rev: position.rev,

--- a/web/src/search/input/ScopePage.tsx
+++ b/web/src/search/input/ScopePage.tsx
@@ -192,7 +192,7 @@ export class ScopePage extends React.Component<ScopePageProps, State> {
                                                     <div key={i} className="scope-page__row">
                                                         <Link to={repo.url} className="scope-page__link">
                                                             <RepositoryIcon className="icon-inline scope-page__link-icon" />
-                                                            <RepoLink repoPath={repo.name} to={null} />
+                                                            <RepoLink repoName={repo.name} to={null} />
                                                         </Link>
                                                     </div>
                                                 ))}

--- a/web/src/search/input/SearchFilterChips.tsx
+++ b/web/src/search/input/SearchFilterChips.tsx
@@ -120,8 +120,8 @@ export class SearchFilterChips extends React.PureComponent<Props> {
                 switch (match.path) {
                     case '/:repoRev+': {
                         // Repo page
-                        const [repoPath] = match.params.repoRev!.split('@')
-                        scopes.push(scopeForRepo(repoPath))
+                        const [repoName] = match.params.repoRev!.split('@')
+                        scopes.push(scopeForRepo(repoName))
                         break
                     }
                     case '/:repoRev+/-/tree/:filePath+':
@@ -129,17 +129,17 @@ export class SearchFilterChips extends React.PureComponent<Props> {
                         // Blob/tree page
                         const isTree = match.path === '/:repoRev+/-/tree/:filePath+'
 
-                        const [repoPath] = match.params.repoRev!.split('@')
+                        const [repoName] = match.params.repoRev!.split('@')
 
                         scopes.push({
-                            value: `repo:^${escapeRegExp(repoPath)}$`,
+                            value: `repo:^${escapeRegExp(repoName)}$`,
                         })
 
                         if (match.params.filePath) {
                             const dirname = isTree ? match.params.filePath : path.dirname(match.params.filePath)
                             if (dirname !== '.') {
                                 scopes.push({
-                                    value: `repo:^${escapeRegExp(repoPath)}$ file:^${escapeRegExp(dirname)}/`,
+                                    value: `repo:^${escapeRegExp(repoName)}$ file:^${escapeRegExp(dirname)}/`,
                                 })
                             }
                         }
@@ -163,8 +163,8 @@ export class SearchFilterChips extends React.PureComponent<Props> {
     }
 }
 
-function scopeForRepo(repoPath: string): ISearchScope {
+function scopeForRepo(repoName: string): ISearchScope {
     return {
-        value: `repo:^${escapeRegExp(repoPath)}$`,
+        value: `repo:^${escapeRegExp(repoName)}$`,
     }
 }

--- a/web/src/search/results/CommitSearchResult.tsx
+++ b/web/src/search/results/CommitSearchResult.tsx
@@ -63,7 +63,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props)
     const title: React.ReactChild = (
         <div className="commit-search-result__title">
             <RepoLink
-                repoPath={props.result.commit.repository.name}
+                repoName={props.result.commit.repository.name}
                 to={
                     props.result.commit.tree
                         ? props.result.commit.tree.canonicalURL
@@ -130,7 +130,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = (props: Props)
 
     if (props.result.diffPreview) {
         const commonCtx: RepoSpec = {
-            repoPath: props.result.commit.repository.name,
+            repoName: props.result.commit.repository.name,
         }
 
         interface AbsoluteRepoFilePositionNonReadonly

--- a/web/src/search/results/RepositorySearchResult.tsx
+++ b/web/src/search/results/RepositorySearchResult.tsx
@@ -26,7 +26,7 @@ export const RepositorySearchResult: React.FunctionComponent<Props> = (props: Pr
         title={
             <>
                 <RepoLink
-                    repoPath={props.result.name}
+                    repoName={props.result.name}
                     to={props.result.url}
                     // tslint:disable-next-line:jsx-no-lambda
                     onClick={() => {

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -50,7 +50,7 @@ class RepositoryNode extends React.PureComponent<RepositoryNodeProps, Repository
             <li className="repository-node list-group-item py-2">
                 <div className="d-flex align-items-center justify-content-between">
                     <div>
-                        <RepoLink repoPath={this.props.node.name} to={this.props.node.url} />
+                        <RepoLink repoName={this.props.node.name} to={this.props.node.url} />
                         {this.props.node.enabled ? (
                             <small
                                 data-tooltip="Access to this repository is enabled. All users can view and search it."

--- a/web/src/tracking/eventLogger.tsx
+++ b/web/src/tracking/eventLogger.tsx
@@ -135,7 +135,7 @@ class EventLogger {
         })
         if (match) {
             const u = parseBrowserRepoURL(window.location.href)
-            props.repo = u.repoPath
+            props.repo = u.repoName
             props.rev = u.rev
             if (u.filePath) {
                 props.path = u.filePath

--- a/web/src/tree/ChildTreeLayer.tsx
+++ b/web/src/tree/ChildTreeLayer.tsx
@@ -25,7 +25,7 @@ export const ChildTreeLayer: React.FunctionComponent<ChildTreeLayerProps> = (pro
         depth: props.depth + 1,
         expandedTrees: props.expandedTrees,
         parent: props.parent,
-        repoPath: props.repoPath,
+        repoName: props.repoName,
         rev: props.rev,
         onToggleExpand: props.onToggleExpand,
         onHover: props.onHover,

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -231,7 +231,7 @@ export class Tree extends React.PureComponent<Props, State> {
                     depth={0}
                     history={this.props.history}
                     location={this.props.location}
-                    repoPath={this.props.repoPath}
+                    repoName={this.props.repoName}
                     rev={this.props.rev}
                     commitID={this.props.commitID}
                     index={0}

--- a/web/src/tree/TreeLayer.tsx
+++ b/web/src/tree/TreeLayer.tsx
@@ -83,7 +83,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                 .pipe(
                     distinctUntilChanged(
                         (x, y) =>
-                            x.repoPath === y.repoPath &&
+                            x.repoName === y.repoName &&
                             x.rev === y.rev &&
                             x.commitID === y.commitID &&
                             x.parentPath === y.parentPath &&
@@ -92,7 +92,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                     filter(props => props.isExpanded),
                     switchMap(props => {
                         const treeFetch = fetchTreeEntries({
-                            repoPath: props.repoPath,
+                            repoName: props.repoName,
                             rev: props.rev,
                             commitID: props.commitID,
                             filePath: props.parentPath || '',
@@ -132,7 +132,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                     debounceTime(100),
                     mergeMap(path =>
                         fetchTreeEntries({
-                            repoPath: this.props.repoPath,
+                            repoName: this.props.repoName,
                             rev: this.props.rev,
                             commitID: this.props.commitID,
                             filePath: path,

--- a/web/src/tree/TreeRoot.tsx
+++ b/web/src/tree/TreeRoot.tsx
@@ -75,7 +75,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                 .pipe(
                     distinctUntilChanged(
                         (x, y) =>
-                            x.repoPath === y.repoPath &&
+                            x.repoName === y.repoName &&
                             x.rev === y.rev &&
                             x.commitID === y.commitID &&
                             x.parentPath === y.parentPath &&
@@ -85,7 +85,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                     filter(props => props.isExpanded),
                     switchMap(props => {
                         const treeFetch = fetchTreeEntries({
-                            repoPath: props.repoPath,
+                            repoName: props.repoName,
                             rev: props.rev,
                             commitID: props.commitID,
                             filePath: props.parentPath || '',
@@ -115,7 +115,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                     debounceTime(100),
                     mergeMap(path =>
                         fetchTreeEntries({
-                            repoPath: this.props.repoPath,
+                            repoName: this.props.repoName,
                             rev: this.props.rev,
                             commitID: this.props.commitID,
                             filePath: path,

--- a/web/src/util/url.test.ts
+++ b/web/src/util/url.test.ts
@@ -13,7 +13,7 @@ function assertDeepStrictEqual(actual: any, expected: any, message?: string): vo
 }
 
 const ctx = {
-    repoPath: 'github.com/gorilla/mux',
+    repoName: 'github.com/gorilla/mux',
     rev: '',
     commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
     filePath: 'mux.go',
@@ -34,27 +34,27 @@ describe('parseBrowserRepoURL', () => {
     it('should parse github repo', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
         })
     })
     it('should parse repo', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
         })
     })
 
     it('should parse github repo with rev', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@branch')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
         })
     })
     it('should parse repo with rev', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@branch')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
             rev: 'branch',
         })
     })
@@ -62,12 +62,12 @@ describe('parseBrowserRepoURL', () => {
     it('should parse github repo with multi-path-part rev', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@foo/baz/bar')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'foo/baz/bar',
         })
         const parsed2 = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@foo/baz/bar/-/blob/mux.go')
         assertDeepStrictEqual(parsed2, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'foo/baz/bar',
             filePath: 'mux.go',
         })
@@ -75,12 +75,12 @@ describe('parseBrowserRepoURL', () => {
     it('should parse repo with multi-path-part rev', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@foo/baz/bar')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
             rev: 'foo/baz/bar',
         })
         const parsed2 = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@foo/baz/bar/-/blob/mux.go')
         assertDeepStrictEqual(parsed2, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
             rev: 'foo/baz/bar',
             filePath: 'mux.go',
         })
@@ -91,7 +91,7 @@ describe('parseBrowserRepoURL', () => {
             'https://sourcegraph.com/github.com/gorilla/mux@24fca303ac6da784b9e8269f724ddeb0b2eea5e7'
         )
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
             commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
         })
@@ -101,7 +101,7 @@ describe('parseBrowserRepoURL', () => {
             'https://sourcegraph.com/gorilla/mux@24fca303ac6da784b9e8269f724ddeb0b2eea5e7'
         )
         assertDeepStrictEqual(parsed, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
             rev: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
             commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
         })
@@ -110,7 +110,7 @@ describe('parseBrowserRepoURL', () => {
     it('should parse github repo with rev and file', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@branch/-/blob/mux.go')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
         })
@@ -118,7 +118,7 @@ describe('parseBrowserRepoURL', () => {
     it('should parse repo with rev and file', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@branch/-/blob/mux.go')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
         })
@@ -127,7 +127,7 @@ describe('parseBrowserRepoURL', () => {
     it('should parse github repo with rev and file and line', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@branch/-/blob/mux.go#L3')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {
@@ -139,7 +139,7 @@ describe('parseBrowserRepoURL', () => {
     it('should parse repo with rev and file and line', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@branch/-/blob/mux.go#L3')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {
@@ -152,7 +152,7 @@ describe('parseBrowserRepoURL', () => {
     it('should parse github repo with rev and file and position', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@branch/-/blob/mux.go#L3:5')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'github.com/gorilla/mux',
+            repoName: 'github.com/gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {
@@ -164,7 +164,7 @@ describe('parseBrowserRepoURL', () => {
     it('should parse repo with rev and file and position', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@branch/-/blob/mux.go#L3:5')
         assertDeepStrictEqual(parsed, {
-            repoPath: 'gorilla/mux',
+            repoName: 'gorilla/mux',
             rev: 'branch',
             filePath: 'mux.go',
             position: {

--- a/web/src/util/url.ts
+++ b/web/src/util/url.ts
@@ -16,14 +16,14 @@ import {
 
 export function toTreeURL(ctx: RepoFile): string {
     const rev = ctx.commitID || ctx.rev || ''
-    return `/${encodeRepoRev(ctx.repoPath, rev)}/-/tree/${ctx.filePath}`
+    return `/${encodeRepoRev(ctx.repoName, rev)}/-/tree/${ctx.filePath}`
 }
 
 export function toAbsoluteBlobURL(
     ctx: AbsoluteRepoFile & Partial<PositionSpec> & Partial<ViewStateSpec> & Partial<RenderModeSpec>
 ): string {
     const rev = ctx.commitID ? ctx.commitID : ctx.rev
-    return `/${encodeRepoRev(ctx.repoPath, rev)}/-/blob/${ctx.filePath}${toPositionOrRangeHash(
+    return `/${encodeRepoRev(ctx.repoName, rev)}/-/blob/${ctx.filePath}${toPositionOrRangeHash(
         ctx
     )}${toViewStateHashComponent(ctx.viewState)}`
 }
@@ -63,10 +63,10 @@ function formatLineOrPositionOrRange(lpr: LineOrPositionOrRange): string {
  */
 export function replaceRevisionInURL(href: string, newRev: string): string {
     const parsed = parseBrowserRepoURL(window.location.href)
-    const repoRev = `/${encodeRepoRev(parsed.repoPath, parsed.rev)}`
+    const repoRev = `/${encodeRepoRev(parsed.repoName, parsed.rev)}`
 
     const u = new URL(window.location.href)
-    u.pathname = `/${encodeRepoRev(parsed.repoPath, newRev)}${u.pathname.slice(repoRev.length)}`
+    u.pathname = `/${encodeRepoRev(parsed.repoName, newRev)}${u.pathname.slice(repoRev.length)}`
     return `${u.pathname}${u.search}${u.hash}`
 }
 
@@ -95,8 +95,8 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI {
     } else {
         repoRev = pathname.substring(0, indexOfSep) // the whole string leading up to the separator (allows rev to be multiple path parts)
     }
-    const { repoPath, rev } = parseRepoRev(repoRev)
-    if (!repoPath) {
+    const { repoName, rev } = parseRepoRev(repoRev)
+    if (!repoName) {
         throw new Error('unexpected repo url: ' + href)
     }
     const commitID = rev && /^[a-f0-9]{40}$/i.test(rev) ? rev : undefined
@@ -136,7 +136,7 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI {
         }
     }
 
-    return { repoPath, rev, commitID, filePath, commitRange, position, range }
+    return { repoName, rev, commitID, filePath, commitRange, position, range }
 }
 
 export function lprToRange(lpr: LineOrPositionOrRange): Range | undefined {
@@ -172,7 +172,7 @@ export function lprToSelectionsZeroIndexed(lpr: LineOrPositionOrRange): Selectio
 
 /** The results of parsing a repo-rev string like "my/repo@my/rev". */
 export interface ParsedRepoRev {
-    repoPath: string
+    repoName: string
 
     /** The URI-decoded revision (e.g., "my#branch" in "my/repo@my%23branch"). */
     rev?: string
@@ -187,7 +187,7 @@ export interface ParsedRepoRev {
 export function parseRepoRev(repoRev: string): ParsedRepoRev {
     const [repo, rev] = repoRev.split('@', 2)
     return {
-        repoPath: decodeURIComponent(repo),
+        repoName: decodeURIComponent(repo),
         rev: rev && decodeURIComponent(rev),
         rawRev: rev,
     }


### PR DESCRIPTION
The purpose is to use the term "repo name" instead of "repo path" consistently, similar to the backend code's consistent usage of "repo name" (was "repo URI") from https://github.com/sourcegraph/sourcegraph/pull/681.

Global find-replaces in ts,tsx,json,js,graphql:

- `repoPath` -> `repoName`
- `RepoPath` -> `RepoName`
- `repo path` -> `repo name`
- `REPO_PATH` -> `REPO_NAME`

And then a few manual fixups. Nothing in the GraphQL schema changed (except for 1 comment), so there is no worry about backcompat.

There is no user-facing impact.

NOCHANGELOG