### PR TITLE
Fix URL (double "authoring")

### DIFF
--- a/doc/extensions/authoring/tutorials/hello-world.md
+++ b/doc/extensions/authoring/tutorials/hello-world.md
@@ -11,7 +11,7 @@ This guide shows you how to create a simple Sourcegraph extension that:
 
 ## Prerequisites
 
-Follow the instructions for [setting up your development environment](../authoring/development_environment.md) so you can build and publish the extension.
+Follow the instructions for [setting up your development environment](../development_environment.md) so you can build and publish the extension.
 
 ## Create the extension
 


### PR DESCRIPTION
This before had the URL `https://docs.sourcegraph.com/extensions/authoring/authoring/development_environment` and should now only have one "authoring"