### PR TITLE
Implement the shield and badge endpoints using api.gddo.org/importers

### DIFF
--- a/cmd/frontend/backend/backcompat.go
+++ b/cmd/frontend/backend/backcompat.go
@@ -2,7 +2,12 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 
+	"github.com/die-net/lrucache"
+	"github.com/gregjones/httpcache"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
@@ -11,9 +16,34 @@ import (
 
 var MockBackcompatBackendDefsTotalRefs func(ctx context.Context, repo api.RepoName) (int, error)
 
+// 100 MiB cache, no age-based eviction
+var httpClient = &http.Client{Transport: httpcache.NewTransport(lrucache.New(100*1024*1024, 0))}
+
+type GDDOResponse struct {
+	Results []GDDOResult `json:"results"`
+}
+
+type GDDOResult struct {
+	Path string `json:"path"`
+}
+
 func BackcompatBackendDefsTotalRefs(ctx context.Context, repo api.RepoName) (int, error) {
 	if MockBackcompatBackendDefsTotalRefs != nil {
 		return MockBackcompatBackendDefsTotalRefs(ctx, repo)
 	}
-	panic("TODO!(sqs): removed")
+	// Assumes the import path is the same as the repo name - not always true!
+	response, err := httpClient.Get("https://api.godoc.org/importers/" + string(repo))
+	if err != nil {
+		return 0, err
+	}
+	var result *GDDOResponse
+	bytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return 0, err
+	}
+	err = json.Unmarshal(bytes, &result)
+	if err != nil {
+		return 0, err
+	}
+	return len(result.Results), nil
 }

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -34,7 +34,7 @@ func TestRepoShield(t *testing.T) {
 	c := newTest()
 
 	wantResp := map[string]interface{}{
-		"value": "?",
+		"value": " 200 projects",
 	}
 
 	backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/derekparker/delve v1.1.0 // indirect
 	github.com/dghubble/gologin v1.0.2-0.20181013174641-0e442dd5bb73
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/die-net/lrucache v0.0.0-20180825112409-f89ea99a4e43
 	github.com/emersion/go-imap v1.0.0-beta.1
 	github.com/emersion/go-sasl v0.0.0-20161116183048-7e096a0a6197 // indirect
 	github.com/ericchiang/k8s v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/dghubble/gologin v1.0.2-0.20181013174641-0e442dd5bb73 h1:6jaxc0Dji7N+
 github.com/dghubble/gologin v1.0.2-0.20181013174641-0e442dd5bb73/go.mod h1:+EjjX5AiOREcyqxhz0c6I8OsL+6F9/38WD1CDcClx+Y=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/die-net/lrucache v0.0.0-20180825112409-f89ea99a4e43 h1:vP/Cyr4SjftyA4DVbGAk8akxe1dnmrXmgvbl1nX2Ak8=
+github.com/die-net/lrucache v0.0.0-20180825112409-f89ea99a4e43/go.mod h1:ew0MSjCVDdtGMjF3kzLK9hwdgF5mOE8SbYVF3Rc7mkU=
 github.com/docker/distribution v0.0.0-20180720172123-0dae0957e5fe h1:ZRQNMB7Sw5jf9g/0imDbI+vTFNk4J7qBdtFI5/zf1kg=
 github.com/docker/distribution v0.0.0-20180720172123-0dae0957e5fe/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20180221142240-453f2b8b40b9 h1:j5P9Aya3JMe0sv7rAfRWIohQVP3YxHgui125drv1DAM=
@@ -413,9 +415,11 @@ github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1 h1:O1d7nVzpGmP5
 github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1/go.mod h1:tpps84QRlOVVLYk5QpKYX8Tr289D1v/UTWDLqeguiqM=
 github.com/sourcegraph/godockerize v0.0.0-20181126200657-4f825419611b h1:EuY/1gvLCQi/T/L9J5o6+yUe5NFRPMxzNXxc/hp7eNU=
 github.com/sourcegraph/godockerize v0.0.0-20181126200657-4f825419611b/go.mod h1:EnJwbnfidbH57UXewOZLIrwQVpu/spwbS/BMN0sPfCA=
+github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 h1:K7hzuWsJGoU8ILHJzrXxsuvXvLHpP/g4iUk7VFj2lY8=
 github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8/go.mod h1:0VfoEApmSPgPhnePllwhrB4vwCUkI0K0w8aueOgoJQI=
 github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d h1:FxF0pen6r1WOqbm4kVDR3JV078HfPz65inWcMh1aVQI=
 github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d/go.mod h1:8HCyYaC38XwX0AOu0+fuY02Y5Z7CkITW0oVJavbna4Q=
+github.com/sourcegraph/gosaml2 v0.0.0-20180820053343-1b78a6b41538 h1:K+cXn79iIvSN1c6Sq2hxk7n8T3ax0lII+FkvuOwgmPc=
 github.com/sourcegraph/gosaml2 v0.0.0-20180820053343-1b78a6b41538/go.mod h1:ZqB/uu1WtCDmlwK8c+TO8+QSfDkJsWx9LYjQBgGxxtk=
 github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10 h1:9XH6ZJgu6KrVimEwZVXfTOvkGU1CHAvdc7mbZrMwA/U=
 github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10/go.mod h1:G6fSBYyOm5huBpPQ4qhXejeVbKeehdP7WEmwb5Si7gM=


### PR DESCRIPTION
This reverts https://github.com/sourcegraph/sourcegraph/pull/1300 and reimplements the shield and badge endpoints using the api.gddo.org/importers API.

Resolves https://github.com/sourcegraph/sourcegraph/issues/1277