### PR TITLE
fix #1359: resolve a code view even if it contains rendered Markdown in its PR comments

### DIFF
--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -101,7 +101,7 @@ const commentSnippetCodeView: CodeView = {
 }
 
 const resolveCodeView = (elem: HTMLElement): CodeViewWithOutSelector | null => {
-    if (elem.querySelector('.markdown-body')) {
+    if (elem.querySelector('.markdown-body:not(.comment-body)')) {
         return null
     }
 


### PR DESCRIPTION
#1322, in trying to avoid hoverifying rendered markdown on Github, has introduced the following regression: if a PR comment contained rendered markdown, we would not resolve the code view. This commit fixes it by narrowing the selector used.