### PR TITLE
fix 1360: when cross-repo definition has no associated rev, default to HEAD

### DIFF
--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -156,7 +156,7 @@ export const githubCodeHost: CodeHost = {
     getCommandPaletteMount,
     getGlobalDebugMount,
     buildJumpURLLocation: (def: JumpURLLocation) => {
-        const rev = def.rev
+        const rev = def.rev || 'HEAD'
         // If we're provided options, we can make the j2d URL more specific.
         const { repoName } = parseURL()
 


### PR DESCRIPTION
The issue was caused by cross-repo definitions without an associated revision:

![image](https://user-images.githubusercontent.com/1741180/49945151-7694cb80-feec-11e8-9dea-7080a43f4f71.png)

The website code handles this gracefully in [encodeRepoRev](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/shared/src/util/url.ts#L402)

This fix mimics the website's behaviour for the Github CodeHost by defaulting to HEAD in `buildJumpURLLocation` if the definition has no associated revision.