### PR TITLE
Add TextDocumentDecorationType, use it to merge decorations from several sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Users can now request an Enterprise trial license from the site init page.
 - When searching, a filter button `case:yes` will now appear when relevant. This helps discovery and makes it easier to use our case-sensitive search syntax.
 - Extensions can now report progress in the UI through the `withProgress()` extension API.
+- When calling `editor.setDecorations()`, extensions must now provide an instance of `TextDocumentDecorationType` as first argument. This helps gracefully displaying decorations from several extensions.
 
 ### Changed
 

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -574,6 +574,15 @@ declare module 'sourcegraph' {
     }
 
     /**
+     * Represents a handle to a set of decorations
+     *
+     * To get an instance of {@link TextDocumentDecorationType}, use {@link createDecorationType}
+     */
+    export interface TextDocumentDecorationType {
+        key: string
+    }
+
+    /**
      * A text editor for code files (as opposed to a rich text editor for documents or other kinds of file format
      * editors).
      */
@@ -603,12 +612,14 @@ declare module 'sourcegraph' {
         readonly selections: Selection[]
 
         /**
-         * Draw decorations on this editor.
+         * Add a set of decorations to this editor. If a set of decorations already exists with the given
+         * {@link DecorationType}, they will be replaced.
          *
-         * @todo Implement a "decoration type" as in VS Code to make deltas more efficient.
-         * @param decorationType Currently unused. Always pass `null`.
+         * @see {@link TextDocumentDecorationType}
+         *
+         * @param decorationType DecorationType
          */
-        setDecorations(decorationType: null, decorations: TextDocumentDecoration[]): void
+        setDecorations(decorationType: TextDocumentDecorationType, decorations: TextDocumentDecoration[]): void
     }
 
     /**
@@ -668,6 +679,12 @@ declare module 'sourcegraph' {
          * @returns The panel view.
          */
         export function createPanelView(id: string): PanelView
+
+        /**
+         * Creates a decorationType that can be used to add decorations to code views
+         *
+         */
+        export function createDecorationType(): TextDocumentDecorationType
     }
 
     /**

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -574,7 +574,7 @@ declare module 'sourcegraph' {
     }
 
     /**
-     * Represents a handle to a set of decorations
+     * Represents a handle to a set of decorations.
      *
      * To get an instance of {@link TextDocumentDecorationType}, use {@link createDecorationType}
      */
@@ -617,7 +617,6 @@ declare module 'sourcegraph' {
          *
          * @see {@link TextDocumentDecorationType}
          *
-         * @param decorationType DecorationType
          */
         setDecorations(decorationType: TextDocumentDecorationType, decorations: TextDocumentDecoration[]): void
     }
@@ -681,8 +680,10 @@ declare module 'sourcegraph' {
         export function createPanelView(id: string): PanelView
 
         /**
-         * Creates a decorationType that can be used to add decorations to code views
+         * Creates a decorationType that can be used to add decorations to code views.
          *
+         * Use this to create a unique handle to a set of decorations, that can be applied to
+         * text editors using {@link setDecorations}.
          */
         export function createDecorationType(): TextDocumentDecorationType
     }

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -3,7 +3,10 @@ import * as sourcegraph from 'sourcegraph'
 import { ClientCodeEditorAPI } from '../../client/api/codeEditor'
 import { Range } from '../types/range'
 import { Selection } from '../types/selection'
+import { createDecorationType } from './decorations'
 import { ExtDocuments } from './documents'
+
+const DEFAULT_DECORATION_TYPE = createDecorationType()
 
 /** @internal */
 export class ExtCodeEditor implements sourcegraph.CodeEditor {
@@ -33,6 +36,9 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
         decorationType: sourcegraph.TextDocumentDecorationType,
         decorations: sourcegraph.TextDocumentDecoration[]
     ): void {
+        // Backcompat: extensions developed against an older version of the API
+        // may not supply a decorationType
+        decorationType = decorationType || DEFAULT_DECORATION_TYPE
         this.proxy.$setDecorations(this.resource, decorationType.key, decorations.map(fromTextDocumentDecoration))
     }
 

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -29,8 +29,11 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
         return this._selections.map(data => Selection.fromPlain(data))
     }
 
-    public setDecorations(_decorationType: null, decorations: sourcegraph.TextDocumentDecoration[]): void {
-        this.proxy.$setDecorations(this.resource, decorations.map(fromTextDocumentDecoration))
+    public setDecorations(
+        decorationType: sourcegraph.TextDocumentDecorationType,
+        decorations: sourcegraph.TextDocumentDecoration[]
+    ): void {
+        this.proxy.$setDecorations(this.resource, decorationType.key, decorations.map(fromTextDocumentDecoration))
     }
 
     public toJSON(): any {

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -33,7 +33,7 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
     }
 
     public setDecorations(
-        decorationType: sourcegraph.TextDocumentDecorationType,
+        decorationType: sourcegraph.TextDocumentDecorationType | null,
         decorations: sourcegraph.TextDocumentDecoration[]
     ): void {
         // Backcompat: extensions developed against an older version of the API

--- a/shared/src/api/extension/api/decorations.ts
+++ b/shared/src/api/extension/api/decorations.ts
@@ -1,0 +1,4 @@
+import idCreator from '../../../util/idCreator'
+
+const nextDecorationType = idCreator('TextDocumentDecorationType')
+export const createDecorationType = () => ({ key: nextDecorationType() })

--- a/shared/src/api/extension/api/decorations.ts
+++ b/shared/src/api/extension/api/decorations.ts
@@ -1,4 +1,3 @@
-import idCreator from '../../../util/idCreator'
+import { uniqueId } from 'lodash'
 
-const nextDecorationType = idCreator('TextDocumentDecorationType')
-export const createDecorationType = () => ({ key: nextDecorationType() })
+export const createDecorationType = () => ({ key: uniqueId('TextDocumentDecorationType') })

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -1,11 +1,11 @@
 import { Subscription, Unsubscribable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
-import idCreator from '../../util/idCreator'
 import { createProxy, handleRequests } from '../common/proxy'
 import { Connection, createConnection, Logger, MessageTransports } from '../protocol/jsonrpc2/connection'
 import { ExtCommands } from './api/commands'
 import { ExtConfiguration } from './api/configuration'
 import { ExtContext } from './api/context'
+import { createDecorationType } from './api/decorations'
 import { ExtDocuments } from './api/documents'
 import { ExtExtensions } from './api/extensions'
 import { ExtLanguageFeatures } from './api/languageFeatures'
@@ -122,9 +122,6 @@ function initializeExtensionHost(
 
     return { unsubscribe: () => subscriptions.unsubscribe(), __testAPI: api }
 }
-
-const nextDecorationType = idCreator('TextDocumentDecorationType')
-export const createDecorationType = () => ({ key: nextDecorationType() })
 
 function createExtensionAPI(
     initData: InitData,

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -1,5 +1,6 @@
 import { Subscription, Unsubscribable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
+import idCreator from '../../util/idCreator'
 import { createProxy, handleRequests } from '../common/proxy'
 import { Connection, createConnection, Logger, MessageTransports } from '../protocol/jsonrpc2/connection'
 import { ExtCommands } from './api/commands'
@@ -122,6 +123,9 @@ function initializeExtensionHost(
     return { unsubscribe: () => subscriptions.unsubscribe(), __testAPI: api }
 }
 
+const nextDecorationType = idCreator('TextDocumentDecorationType')
+export const createDecorationType = () => ({ key: nextDecorationType() })
+
 function createExtensionAPI(
     initData: InitData,
     connection: Connection
@@ -191,6 +195,7 @@ function createExtensionAPI(
                 return windows.getAll()
             },
             createPanelView: (id: string) => views.createPanelView(id),
+            createDecorationType,
         },
 
         workspace: {

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -63,26 +63,25 @@ describe('CodeEditor (integration)', () => {
                 },
             ])
             await extensionHost.internal.sync()
-            assert.deepStrictEqual(
+            expect(
                 await services.textDocumentDecoration
                     .getDecorations({ uri: 'file:///f' })
                     .pipe(take(1))
-                    .toPromise(),
-                [
-                    {
-                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                        after: {
-                            hoverMessage: 'foo',
-                        },
+                    .toPromise()
+            ).toEqual([
+                {
+                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    after: {
+                        hoverMessage: 'foo',
                     },
-                    {
-                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                        after: {
-                            hoverMessage: 'bar',
-                        },
+                },
+                {
+                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    after: {
+                        hoverMessage: 'bar',
                     },
-                ] as clientType.TextDocumentDecoration[]
-            )
+                },
+            ] as clientType.TextDocumentDecoration[])
 
             // Change decorations only for dt1, and check that merged decorations are coherent
             codeEditor.setDecorations(dt1, [
@@ -94,44 +93,42 @@ describe('CodeEditor (integration)', () => {
                 },
             ])
             await extensionHost.internal.sync()
-            assert.deepStrictEqual(
+            expect(
                 await services.textDocumentDecoration
                     .getDecorations({ uri: 'file:///f' })
                     .pipe(take(1))
-                    .toPromise(),
-                [
-                    {
-                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                        after: {
-                            hoverMessage: 'baz',
-                        },
+                    .toPromise()
+            ).toEqual([
+                {
+                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    after: {
+                        hoverMessage: 'baz',
                     },
-                    {
-                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                        after: {
-                            hoverMessage: 'bar',
-                        },
+                },
+                {
+                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    after: {
+                        hoverMessage: 'bar',
                     },
-                ] as clientType.TextDocumentDecoration[]
-            )
+                },
+            ] as clientType.TextDocumentDecoration[])
 
             // remove decorations for dt2, and verify that decorations for dt1 are still present
             codeEditor.setDecorations(dt2, [])
             await extensionHost.internal.sync()
-            assert.deepStrictEqual(
+            expect(
                 await services.textDocumentDecoration
                     .getDecorations({ uri: 'file:///f' })
                     .pipe(take(1))
-                    .toPromise(),
-                [
-                    {
-                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                        after: {
-                            hoverMessage: 'baz',
-                        },
+                    .toPromise()
+            ).toEqual([
+                {
+                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    after: {
+                        hoverMessage: 'baz',
                     },
-                ] as clientType.TextDocumentDecoration[]
-            )
+                },
+            ] as clientType.TextDocumentDecoration[])
         })
 
         it('is backwards compatible with extensions that do not provide a decoration type', async () => {
@@ -160,24 +157,23 @@ describe('CodeEditor (integration)', () => {
 
             // Both sets of decorations should be displayed
             await extensionHost.internal.sync()
-            assert.deepStrictEqual(
+            expect(
                 await services.textDocumentDecoration
                     .getDecorations({ uri: 'file:///f' })
                     .pipe(take(1))
-                    .toPromise(),
-                [
-                    {
-                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                        backgroundColor: 'red',
+                    .toPromise()
+            ).toEqual([
+                {
+                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    backgroundColor: 'red',
+                },
+                {
+                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                    after: {
+                        hoverMessage: 'foo',
                     },
-                    {
-                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                        after: {
-                            hoverMessage: 'foo',
-                        },
-                    },
-                ] as clientType.TextDocumentDecoration[]
-            )
+                },
+            ] as clientType.TextDocumentDecoration[])
         })
     })
 })

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -7,10 +7,11 @@ describe('CodeEditor (integration)', () => {
     describe('setDecorations', () => {
         test('adds decorations', async () => {
             const { services, extensionHost } = await integrationTestContext()
+            const dt = extensionHost.app.createDecorationType()
 
             // Set some decorations and check they are present on the client.
             const codeEditor = extensionHost.app.windows[0].visibleViewComponents[0]
-            codeEditor.setDecorations(null, [
+            codeEditor.setDecorations(dt, [
                 {
                     range: new Range(1, 2, 3, 4),
                     backgroundColor: 'red',
@@ -30,7 +31,7 @@ describe('CodeEditor (integration)', () => {
             ] as clientType.TextDocumentDecoration[])
 
             // Clear the decorations and ensure they are removed.
-            codeEditor.setDecorations(null, [])
+            codeEditor.setDecorations(dt, [])
             await extensionHost.internal.sync()
             expect(
                 await services.textDocumentDecoration
@@ -38,6 +39,99 @@ describe('CodeEditor (integration)', () => {
                     .pipe(take(1))
                     .toPromise()
             ).toEqual(null)
+        })
+
+        it('merges decorations from several types', async () => {
+            const { services, extensionHost } = await integrationTestContext()
+            const [dt1, dt2] = [extensionHost.app.createDecorationType(), extensionHost.app.createDecorationType()]
+
+            const codeEditor = extensionHost.app.windows[0].visibleViewComponents[0]
+            codeEditor.setDecorations(dt1, [
+                {
+                    range: new Range(1, 2, 3, 4),
+                    after: {
+                        hoverMessage: 'foo',
+                    },
+                },
+            ])
+            codeEditor.setDecorations(dt2, [
+                {
+                    range: new Range(1, 2, 3, 4),
+                    after: {
+                        hoverMessage: 'bar',
+                    },
+                },
+            ])
+            await extensionHost.internal.sync()
+            assert.deepStrictEqual(
+                await services.textDocumentDecoration
+                    .getDecorations({ uri: 'file:///f' })
+                    .pipe(take(1))
+                    .toPromise(),
+                [
+                    {
+                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                        after: {
+                            hoverMessage: 'foo',
+                        },
+                    },
+                    {
+                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                        after: {
+                            hoverMessage: 'bar',
+                        },
+                    },
+                ] as clientType.TextDocumentDecoration[]
+            )
+
+            // Change decorations only for dt1, and check that merged decorations are coherent
+            codeEditor.setDecorations(dt1, [
+                {
+                    range: new Range(1, 2, 3, 4),
+                    after: {
+                        hoverMessage: 'baz',
+                    },
+                },
+            ])
+            await extensionHost.internal.sync()
+            assert.deepStrictEqual(
+                await services.textDocumentDecoration
+                    .getDecorations({ uri: 'file:///f' })
+                    .pipe(take(1))
+                    .toPromise(),
+                [
+                    {
+                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                        after: {
+                            hoverMessage: 'baz',
+                        },
+                    },
+                    {
+                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                        after: {
+                            hoverMessage: 'bar',
+                        },
+                    },
+                ] as clientType.TextDocumentDecoration[]
+            )
+
+            // remove decorations for dt2, and verify that decorations for dt1 are still present
+            codeEditor.setDecorations(dt2, [])
+            await extensionHost.internal.sync()
+            assert.deepStrictEqual(
+                await services.textDocumentDecoration
+                    .getDecorations({ uri: 'file:///f' })
+                    .pipe(take(1))
+                    .toPromise(),
+                [
+                    {
+                        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+                        after: {
+                            hoverMessage: 'baz',
+                        },
+                    },
+                ] as clientType.TextDocumentDecoration[]
+            )
         })
     })
 })

--- a/shared/src/util/idCreator.ts
+++ b/shared/src/util/idCreator.ts
@@ -1,0 +1,4 @@
+export default (prefix: string) => {
+    let nextId = 0
+    return () => `${prefix}-${nextId++}`
+}

--- a/shared/src/util/idCreator.ts
+++ b/shared/src/util/idCreator.ts
@@ -1,4 +1,0 @@
-export default (prefix: string) => {
-    let nextId = 0
-    return () => `${prefix}-${nextId++}`
-}


### PR DESCRIPTION
This introduces a breaking change to the extension api: the first argument to `setDecorations()` must now be of type `TextDocumentDeclarationType` instead of `null`

This allows us to merge declarations of several types, fixing #1339 

This is inspired by [vscode's API](https://sourcegraph.com/github.com/Microsoft/vscode/-/blob/src/vs/vscode.d.ts#L1144), with two notable differences:
- In vscode, the DecorationType stores the style information for a set of declarations, but this styling can still be overridden by the second argument to `setDecorations()`. I did not go down this route as it would have amounted to a much bigger change without immediate benefits for #1339 
- In vscode, the DecorationType has a [`dispose()` method](https://sourcegraph.com/github.com/Microsoft/vscode/-/blob/src/vs/vscode.d.ts#690), that can be used to remove all decorations for the given type on all text editors. This is actually something I plan on implementing in a subsequent PR, as it would be really helpful to cleanup decorations when an extension gets deactivated.

TODO:

- [x] Edit CHANGELOG