### PR TITLE
Remove incorrect config validation and fix external services migration

### DIFF
--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -13,10 +13,10 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
-	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
+	"github.com/sourcegraph/sourcegraph/pkg/legacyconf"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -381,7 +381,7 @@ func (c *externalServices) migrateJsonConfigToExternalServices(ctx context.Conte
 				Gitolite        []*schema.GitoliteConnection        `json:"gitolite"`
 				Phabricator     []*schema.PhabricatorConnection     `json:"phabricator"`
 			}
-			if err := jsonc.Unmarshal(conf.Raw().Site, &legacyConfig); err != nil {
+			if err := jsonc.Unmarshal(legacyconf.Raw(), &legacyConfig); err != nil {
 				return err
 			}
 			if err := migrate(legacyConfig.AwsCodeCommit, "AWSCodeCommit"); err != nil {

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -77,18 +77,6 @@ func init() {
 	}
 
 	ctx := context.Background()
-	// Authz providers depends on both site config state (i.e. auth.providers)
-	// and database state (i.e. external services). This is less than ideal:
-	// https://github.com/sourcegraph/sourcegraph/issues/1392.
-	// In the meantime, we need to watch for config changes and poll the database.
-	conf.ContributeValidator(func(cfg conf.Unified) []string {
-		_, _, seriousProblems, warnings := providersFromConfig(ctx, &cfg)
-		return append(seriousProblems, warnings...)
-	})
-	go conf.Watch(func() {
-		allowAccessByDefault, authzProviders, _, _ := providersFromConfig(ctx, conf.Get())
-		authz.SetProviders(allowAccessByDefault, authzProviders)
-	})
 	go func() {
 		t := time.NewTicker(5 * time.Second)
 		for range t.C {


### PR DESCRIPTION
Two commits:
1. Fixes external services migration, which I tested before integrating Stephen's config changes and didn't work after those changes.
2. Fixes https://github.com/sourcegraph/sourcegraph/issues/1408 by removing validation that was incorrect. The logic in ContributeValidator should only validate the cfg itself, not state in the DB (what it was doing before). The external service state in the DB is validated when the external service is created or edited.

