### PR TITLE
reposource: Prevent race on mocking cloneURLResolvers

### DIFF
--- a/pkg/conf/reposource/custom_test.go
+++ b/pkg/conf/reposource/custom_test.go
@@ -45,6 +45,7 @@ func Test_customCloneURLToRepoName(t *testing.T) {
 		},
 	}}
 
+	cloneURLResolversOnce.Do(func() {}) // Prevent conf watching
 	for i, test := range tests {
 		cloneURLResolvers.Store(test.cloneURLResolvers)
 		for cloneURL, expName := range test.cloneURLToRepoName {


### PR DESCRIPTION
Test_customCloneURLToRepoName would fail sometimes, since conf.Watch in init
would race with the test for setting cloneURLResolvers. Since
cloneURLResolvers is only ever read from one function, we move the conf.Watch
logic to that function, and protect it with a sync.Once.

This test may be better written to mock the config, or adjusting the logic to
not depend on global state. But that is a larger change to make.

An example build failure is https://buildkite.com/sourcegraph/sourcegraph/builds/25536#d5c1a3c1-1c28-42ca-9454-fa0acc9f9a34
