### PR TITLE
don't fail all results on 1 invalid manifest

### DIFF
--- a/web/src/extensions/ExtensionsList.tsx
+++ b/web/src/extensions/ExtensionsList.tsx
@@ -279,7 +279,7 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                     )
                 ).pipe(
                     map(({ data, errors }) => {
-                        if (!data || !data.extensionRegistry || !data.extensionRegistry.extensions || errors) {
+                        if (!data || !data.extensionRegistry || !data.extensionRegistry.extensions) {
                             throw createAggregateError(errors)
                         }
                         return {


### PR DESCRIPTION
fix #1445 

Fixes the case where an extension has invalid JSON that fails to unmarshal into the Go type. For example, the following JSON used to cause the entire extension list to fail, but now the error is shown only on the single bad extension:

```
  "activationEvents": [
    {"language": "foo"}
  ],
```

(Note that `{"language": "foo"}` is not a valid entry for that; it should be `"onLanguage:foo"`.)

![screenshot from 2018-12-14 16-29-10](https://user-images.githubusercontent.com/1976/50036411-9e079900-ffbd-11e8-9d1b-2c9b8e9f74f9.png)

Also only returns valid extension JSON from the API.