### PR TITLE
support showing a loading spinner and error tooltip on ActionItem during command execution

### DIFF
--- a/client/browser/src/shared.scss
+++ b/client/browser/src/shared.scss
@@ -1,3 +1,4 @@
+@import '../../../shared/src/actions/ActionItem';
 @import '../../../shared/src/commandPalette/CommandList';
 @import '../../../shared/src/components/PopoverButton';
 @import '../../../shared/src/components/Toggle';

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -14,7 +14,7 @@ const config = {
   // unexpected token import/export", then add it here. See
   // https://github.com/facebook/create-react-app/issues/5241#issuecomment-426269242 for more information on why
   // this is necessary.
-  transformIgnorePatterns: ['/node_modules/(?!abortable-rx)'],
+  transformIgnorePatterns: ['/node_modules/(?!abortable-rx|@sourcegraph/react-loading-spinner)'],
 
   // By default, don't clutter `yarn test --watch` output with the full coverage table. To see it, use the
   // `--coverageReporters text` jest option.

--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -1,0 +1,17 @@
+.action-item {
+    // Show loader on top of the action's content. This avoids changing the element's width when loading, which
+    // looks bad.
+    &--loading {
+        position: relative;
+    }
+    &--loading &__content {
+        opacity: 0.3;
+    }
+    &__loader {
+        // Center horizontally.
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translateX(-50%) translateY(-50%);
+    }
+}

--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -1,4 +1,12 @@
 .action-item {
+    &__content {
+        display: flex;
+        align-items: center;
+    }
+    &--variant-action-item &__content {
+        justify-content: center;
+    }
+
     // Show loader on top of the action's content. This avoids changing the element's width when loading, which
     // looks bad.
     &--loading {

--- a/shared/src/actions/ActionItem.test.tsx
+++ b/shared/src/actions/ActionItem.test.tsx
@@ -77,12 +77,64 @@ describe('ActionItem', () => {
         expect(tree).toMatchSnapshot()
     })
 
+    test('run command with showLoadingSpinnerDuringExecution', async () => {
+        const { wait, done } = createBarrier()
+
+        const component = renderer.create(
+            <ActionItem
+                action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                variant="actionItem"
+                showLoadingSpinnerDuringExecution={true}
+                location={history.location}
+                extensionsController={{ ...NOOP_EXTENSIONS_CONTROLLER, executeCommand: async () => wait }}
+                platformContext={NOOP_PLATFORM_CONTEXT}
+            />
+        )
+
+        // Run command and wait for execution to finish.
+        let tree = component.toJSON()
+        tree!.props.onClick({ preventDefault: () => void 0, currentTarget: { blur: () => void 0 } })
+        tree = component.toJSON()
+        expect(tree).toMatchSnapshot()
+
+        // Finish execution. (Use setTimeout to wait for the executeCommand resolution to result in the setState
+        // call.)
+        done()
+        await new Promise<void>(r => setTimeout(r))
+        tree = component.toJSON()
+        expect(tree).toMatchSnapshot()
+    })
+
     test('run command with error', async () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
                 variant="actionItem"
                 disabledDuringExecution={true}
+                location={history.location}
+                extensionsController={{
+                    ...NOOP_EXTENSIONS_CONTROLLER,
+                    executeCommand: async () => Promise.reject('x'),
+                }}
+                platformContext={NOOP_PLATFORM_CONTEXT}
+            />
+        )
+
+        // Run command (which will reject with an error). (Use setTimeout to wait for the executeCommand resolution
+        // to result in the setState call.)
+        let tree = component.toJSON()
+        tree!.props.onClick({ preventDefault: () => void 0, currentTarget: { blur: () => void 0 } })
+        await new Promise<void>(r => setTimeout(r))
+        tree = component.toJSON()
+        expect(tree).toMatchSnapshot()
+    })
+
+    test('run command with error with showInlineError', async () => {
+        const component = renderer.create(
+            <ActionItem
+                action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                variant="actionItem"
+                showInlineError={true}
                 location={history.location}
                 extensionsController={{
                     ...NOOP_EXTENSIONS_CONTROLLER,

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -163,7 +163,10 @@ export class ActionItem extends React.PureComponent<Props, State> {
                         ? `Error: ${this.state.actionOrError.message}`
                         : tooltip
                 }
-                disabled={this.props.disabledDuringExecution && this.state.actionOrError === LOADING}
+                disabled={
+                    (this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
+                    this.state.actionOrError === LOADING
+                }
                 className={`action-item ${this.props.className || ''} ${
                     showLoadingSpinner ? 'action-item--loading' : ''
                 } ${this.props.variant === 'actionItem' ? 'action-item--variant-action-item' : ''}`}

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import H from 'history'
 import * as React from 'react'
 import { from, Subject, Subscription } from 'rxjs'
@@ -33,6 +34,11 @@ export interface ActionItemProps {
      * Whether to set the disabled attribute on the element when execution is started and not yet finished.
      */
     disabledDuringExecution?: boolean
+
+    /**
+     * Whether to show an animated loading spinner when execution is started and not yet finished.
+     */
+    showLoadingSpinnerDuringExecution?: boolean
 
     /** Instead of showing the icon and/or title, show this element. */
     title?: React.ReactElement<any>
@@ -125,11 +131,15 @@ export class ActionItem extends React.PureComponent<Props, State> {
             tooltip = this.props.action.description
         }
 
+        const showLoadingSpinner = this.props.showLoadingSpinnerDuringExecution && this.state.actionOrError === LOADING
+
         return (
             <LinkOrButton
                 data-tooltip={tooltip}
                 disabled={this.props.disabledDuringExecution && this.state.actionOrError === LOADING}
-                className={this.props.className}
+                className={`action-item ${this.props.className || ''} ${
+                    showLoadingSpinner ? 'action-item--loading' : ''
+                }`}
                 // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
                 // it as a button that executes the command.
                 to={
@@ -138,7 +148,18 @@ export class ActionItem extends React.PureComponent<Props, State> {
                 }
                 onSelect={this.runAction}
             >
-                {content}
+                <div
+                    className={`action-item__content d-flex align-items-center ${
+                        this.props.variant === 'actionItem' ? 'justify-content-center' : ''
+                    }`}
+                >
+                    {content}
+                </div>
+                {showLoadingSpinner && (
+                    <div className="action-item__loader">
+                        <LoadingSpinner className="icon-inline" />
+                    </div>
+                )}
             </LinkOrButton>
         )
     }

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -9,7 +9,7 @@ import { urlForOpenPanel } from '../commands/commands'
 import { LinkOrButton } from '../components/LinkOrButton'
 import { ExtensionsControllerProps } from '../extensions/controller'
 import { PlatformContextProps } from '../platform/context'
-import { asError, ErrorLike } from '../util/errors'
+import { asError, ErrorLike, isErrorLike } from '../util/errors'
 
 export interface ActionItemProps {
     /**
@@ -39,6 +39,20 @@ export interface ActionItemProps {
      * Whether to show an animated loading spinner when execution is started and not yet finished.
      */
     showLoadingSpinnerDuringExecution?: boolean
+
+    /**
+     * Whether to show the error (if any) from executing the command inline on this component and NOT in the global
+     * notifications UI component.
+     *
+     * This inline error display behavior is intended for actions that are scoped to a particular component. If the
+     * error were displayed in the global notifications UI component, it might not be clear which of the many
+     * possible scopes the error applies to.
+     *
+     * For example, the hover actions ("Go to definition", "Find references", etc.) use showInlineError == true
+     * because those actions are scoped to a specific token in a file. The command palette uses showInlineError ==
+     * false because it is a global UI component (and because showing tooltips on menu items would look strange).
+     */
+    showInlineError?: boolean
 
     /** Instead of showing the icon and/or title, show this element. */
     title?: React.ReactElement<any>
@@ -70,7 +84,7 @@ export class ActionItem extends React.PureComponent<Props, State> {
             this.commandExecutions
                 .pipe(
                     mergeMap(params =>
-                        from(this.props.extensionsController.executeCommand(params)).pipe(
+                        from(this.props.extensionsController.executeCommand(params, this.props.showInlineError)).pipe(
                             mapTo(null),
                             catchError(error => [asError(error)]),
                             map(c => ({ actionOrError: c })),
@@ -91,7 +105,16 @@ export class ActionItem extends React.PureComponent<Props, State> {
         // If the tooltip changes while it's visible, we need to force-update it to show the new value.
         const prevTooltip = prevProps.action.actionItem && prevProps.action.actionItem.description
         const tooltip = this.props.action.actionItem && this.props.action.actionItem.description
-        if (prevTooltip !== tooltip) {
+        const descriptionTooltipChanged = prevTooltip !== tooltip
+
+        const errorTooltipChanged =
+            this.props.showInlineError &&
+            (isErrorLike(prevState.actionOrError) !== isErrorLike(this.state.actionOrError) ||
+                (isErrorLike(prevState.actionOrError) &&
+                    isErrorLike(this.state.actionOrError) &&
+                    prevState.actionOrError.message !== this.state.actionOrError.message))
+
+        if (descriptionTooltipChanged || errorTooltipChanged) {
             this.props.platformContext.forceUpdateTooltip()
         }
     }
@@ -135,11 +158,15 @@ export class ActionItem extends React.PureComponent<Props, State> {
 
         return (
             <LinkOrButton
-                data-tooltip={tooltip}
+                data-tooltip={
+                    this.props.showInlineError && isErrorLike(this.state.actionOrError)
+                        ? `Error: ${this.state.actionOrError.message}`
+                        : tooltip
+                }
                 disabled={this.props.disabledDuringExecution && this.state.actionOrError === LOADING}
                 className={`action-item ${this.props.className || ''} ${
                     showLoadingSpinner ? 'action-item--loading' : ''
-                }`}
+                } ${this.props.variant === 'actionItem' ? 'action-item--variant-action-item' : ''}`}
                 // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
                 // it as a button that executes the command.
                 to={
@@ -148,13 +175,9 @@ export class ActionItem extends React.PureComponent<Props, State> {
                 }
                 onSelect={this.runAction}
             >
-                <div
-                    className={`action-item__content d-flex align-items-center ${
-                        this.props.variant === 'actionItem' ? 'justify-content-center' : ''
-                    }`}
-                >
-                    {content}
-                </div>
+                {/* Use custom CSS classes instead of Bootstrap CSS classes because this component is also
+                 used in the browser extension, which doesn't necessarily have Bootstrap CSS classes defined. */}
+                <div className="action-item__content">{content}</div>
                 {showLoadingSpinner && (
                     <div className="action-item__loader">
                         <LoadingSpinner className="icon-inline" />

--- a/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -3,129 +3,236 @@
 exports[`ActionItem actionItem variant 1`] = `
 <a
   aria-label="d"
-  className="nav-link "
+  className="action-item   action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
 >
-  <img
-    className="icon-inline"
-    src="u"
-  />
-   
-  g: 
-  t
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
 </a>
 `;
 
 exports[`ActionItem non-actionItem variant 1`] = `
 <a
   aria-label="d"
-  className="nav-link "
+  className="action-item    "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
 >
-  <img
-    className="icon-inline"
-    src="u"
-  />
-   
-  g: 
-  t
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
 </a>
 `;
 
 exports[`ActionItem render as link for "open" command 1`] = `
 <a
-  className="nav-link "
+  className="action-item    "
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
   to="https://example.com"
 >
-   
-  
-  t
+  <div
+    className="action-item__content"
+  >
+     
+    
+    t
+  </div>
 </a>
 `;
 
 exports[`ActionItem run command 1`] = `
 <a
   aria-label="d"
-  className="nav-link disabled"
+  className="action-item   action-item--variant-action-item disabled"
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
 >
-  <img
-    className="icon-inline"
-    src="u"
-  />
-   
-  g: 
-  t
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
 </a>
 `;
 
 exports[`ActionItem run command 2`] = `
 <a
   aria-label="d"
-  className="nav-link "
+  className="action-item   action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
 >
-  <img
-    className="icon-inline"
-    src="u"
-  />
-   
-  g: 
-  t
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
 </a>
 `;
 
 exports[`ActionItem run command with error 1`] = `
 <a
   aria-label="d"
-  className="nav-link "
+  className="action-item   action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
 >
-  <img
-    className="icon-inline"
-    src="u"
-  />
-   
-  g: 
-  t
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
+</a>
+`;
+
+exports[`ActionItem run command with error with showInlineError 1`] = `
+<a
+  aria-label="Error: x"
+  className="action-item   action-item--variant-action-item "
+  data-tooltip="Error: x"
+  onAuxClick={[Function]}
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+>
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
+</a>
+`;
+
+exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
+<a
+  aria-label="d"
+  className="action-item  action-item--loading action-item--variant-action-item disabled"
+  data-tooltip="d"
+  onAuxClick={[Function]}
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+>
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
+  <div
+    className="action-item__loader"
+  >
+    <div
+      className="loading-spinner icon-inline"
+    />
+  </div>
+</a>
+`;
+
+exports[`ActionItem run command with showLoadingSpinnerDuringExecution 2`] = `
+<a
+  aria-label="d"
+  className="action-item   action-item--variant-action-item "
+  data-tooltip="d"
+  onAuxClick={[Function]}
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+>
+  <div
+    className="action-item__content"
+  >
+    <img
+      className="icon-inline"
+      src="u"
+    />
+     
+    g: 
+    t
+  </div>
 </a>
 `;
 
 exports[`ActionItem title element 1`] = `
 <a
   aria-label="d"
-  className="nav-link "
+  className="action-item   action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
 >
-  <span>
-    t2
-  </span>
+  <div
+    className="action-item__content"
+  >
+    <span>
+      t2
+    </span>
+  </div>
 </a>
 `;

--- a/shared/src/index.scss
+++ b/shared/src/index.scss
@@ -1,3 +1,4 @@
+@import './actions/ActionItem';
 @import './commandPalette/CommandList';
 @import './components/CodeExcerpt';
 @import './components/FileMatch';

--- a/shared/src/panel/Panel.tsx
+++ b/shared/src/panel/Panel.tsx
@@ -115,6 +115,7 @@ export class Panel extends React.PureComponent<Props, State> {
                         toolbarFragment={
                             <ActionsNavItems
                                 listClass="w-100 justify-content-end"
+                                actionItemClass="nav-link"
                                 menu={ContributableMenu.PanelToolbar}
                                 extensionsController={this.props.extensionsController}
                                 platformContext={this.props.platformContext}

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -54,6 +54,7 @@ export class NavLinks extends React.PureComponent<Props> {
                 )}
                 <ActionsNavItems
                     menu={ContributableMenu.GlobalNav}
+                    actionItemClass="nav-link"
                     extensionsController={this.props.extensionsController}
                     platformContext={this.props.platformContext}
                     location={this.props.location}

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -239,6 +239,7 @@ export class RepoHeader extends React.PureComponent<Props, State> {
                 <ul className="navbar-nav">
                     <ActionsNavItems
                         menu={ContributableMenu.EditorTitle}
+                        actionItemClass="nav-link"
                         extensionsController={this.props.extensionsController}
                         platformContext={this.props.platformContext}
                         location={this.props.location}


### PR DESCRIPTION
If the new ActionItem prop showLoadingSpinnerDuringExecution is true, then a loading spinner is shown after the button is pressed if it executes a command. This will be used by hover buttons.

Also  adds support for showing the error inline on the button that executed the command. This is useful for errors that are scoped to a specific button instead of being global.

Used in #1313 but is useful by itself.

NOCHANGELOG