### PR TITLE
add a json(expr) function to the context expression language

### DIFF
--- a/shared/src/api/client/context/expr/evaluator.test.ts
+++ b/shared/src/api/client/context/expr/evaluator.test.ts
@@ -7,6 +7,7 @@ const FIXTURE_CONTEXT = new Map<string, any>(
         b: 1,
         c: 2,
         x: 'y',
+        o: { k: 'v' },
     })
 )
 
@@ -25,6 +26,7 @@ describe('evaluate', () => {
         'a || b': 1,
         '(a + b) * 2': 4,
         'x == "y"': true,
+        'json(o)': '{"k":"v"}',
         // TODO: Support operator precedence. See ./parser.test.ts for a commented-out precedence test case.
         //
         // 'x == "y" || x == "z"': true,
@@ -41,7 +43,7 @@ describe('evaluate', () => {
     for (const [expr, want] of Object.entries(TESTS)) {
         it(expr, () => {
             const value = evaluate(expr, FIXTURE_CONTEXT)
-            assert.strictEqual(value, want)
+            assert.deepStrictEqual(value, want)
         })
     }
 })

--- a/shared/src/api/client/context/expr/evaluator.ts
+++ b/shared/src/api/client/context/expr/evaluator.ts
@@ -30,6 +30,7 @@ export function evaluateTemplate(template: string, context: ComputedContext): an
 
 const FUNCS: { [name: string]: (...args: any[]) => any } = {
     get: (obj: any, key: string): any => obj[key],
+    json: (obj: any): string => JSON.stringify(obj),
 }
 
 function exec(node: Expression, context: ComputedContext): any {


### PR DESCRIPTION
This is useful when an action's commandArguments wants to pass an object, not just a scalar value, to a command as an argument.

Used in #1313 but is useful by itself.