### PR TITLE
support providing extra context when evaluating the current contributions

### DIFF
--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -202,7 +202,7 @@ describe('ContributionRegistry', () => {
                         entries: Observable<ContributionsEntry[]>,
                         scope?: ContributionScope
                     ): Observable<Contributions> {
-                        return super.getContributionsFromEntries(entries, scope, () => void 0 /* noop log */)
+                        return super.getContributionsFromEntries(entries, scope, undefined, () => void 0 /* noop log */)
                     }
                 }()
                 expectObservable(


### PR DESCRIPTION
This makes it possible to construct (e.g.) a list of actions for a specific part of the UI, such as the hover, and provide information to the hover actions via context, without setting that context globally. For example, this would help with something like `definitionURL` if that were stored in the hover and used to determine the target of the "Go to definition" button.

Also adds support for typed property values in Context. This allows the context (which is used for `when` expressions and other expressions in an extension manifest) to contain properties whose value is a TypeScript type other than the primitive types (or Context itself). This is useful when, for example, 
you have a `TextDocumentPositionParams` value that is the value of a context property; using `Context<TextDocumentPositionParams>` makes it typecheck.