### PR TITLE
remove SearchOptions, clean up search URL generation code, add tests

### DIFF
--- a/client/browser/src/libs/cli/search.ts
+++ b/client/browser/src/libs/cli/search.ts
@@ -1,9 +1,9 @@
 import storage from '../../browser/storage'
 import * as tabs from '../../browser/tabs'
 
+import { buildSearchURLQuery } from '../../../../../shared/src/util/url'
 import { createSuggestionFetcher } from '../../shared/backend/search'
 import { sourcegraphUrl } from '../../shared/util/context'
-import { buildSearchURLQuery } from '../../shared/util/url'
 
 const isURL = /^https?:\/\//
 

--- a/client/browser/src/shared/components/SymbolsDropdownContainer.tsx
+++ b/client/browser/src/shared/components/SymbolsDropdownContainer.tsx
@@ -236,9 +236,7 @@ export class SymbolsDropdownContainer extends React.Component<Props, State> {
 
         const { repoKey } = getContext()
 
-        const symbolResults = fetchSymbols({
-            query: `repo:^${repoKey}\$ type:symbol ${queryText}`,
-        }).pipe(
+        const symbolResults = fetchSymbols(`repo:^${repoKey}\$ type:symbol ${queryText}`).pipe(
             catchError(err => {
                 console.error(err)
                 return [asError(err)]

--- a/client/browser/src/shared/util/url.tsx
+++ b/client/browser/src/shared/util/url.tsx
@@ -52,15 +52,3 @@ export function toAbsoluteBlobURL(ctx: AbsoluteRepoFile & Partial<PositionSpec> 
         ctx.position
     )}${toReferencesHash(ctx.referencesMode)}`
 }
-
-/**
- * Builds a URL query for given SearchOptions (without leading `?`)
- */
-export function buildSearchURLQuery(query: string): string {
-    const searchParams = new URLSearchParams()
-    searchParams.set('q', query)
-    return searchParams
-        .toString()
-        .replace(/%2F/g, '/')
-        .replace(/%3A/g, ':')
-}

--- a/shared/src/util/url.test.ts
+++ b/shared/src/util/url.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { makeRepoURI, parseHash, parseRepoURI, toPrettyBlobURL } from './url'
+import { buildSearchURLQuery, makeRepoURI, parseHash, parseRepoURI, toPrettyBlobURL } from './url'
 
 /**
  * Asserts deep object equality using node's assert.deepStrictEqual, except it (1) ignores differences in the
@@ -247,4 +247,13 @@ describe('util/url', () => {
             )
         })
     })
+})
+
+describe('buildSearchURLQuery', () => {
+    it('builds the URL query for a search', () => assert.strictEqual(buildSearchURLQuery('foo'), 'q=foo'))
+    it('handles an empty query', () => assert.strictEqual(buildSearchURLQuery(''), 'q='))
+    it('handles characters that need encoding', () =>
+        assert.strictEqual(buildSearchURLQuery('foo bar%baz'), 'q=foo+bar%25baz'))
+    it('preserves / and : for readability', () =>
+        assert.strictEqual(buildSearchURLQuery('repo:foo/bar'), 'q=repo:foo/bar'))
 })

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -446,3 +446,15 @@ export function makeRepoURI(parsed: ParsedRepoURI): RepoURI {
     uri += parsed.range ? positionStr(parsed.range.start) + '-' + positionStr(parsed.range.end) : ''
     return uri
 }
+
+/**
+ * Builds a URL query for the given query (without leading `?`).
+ */
+export function buildSearchURLQuery(query: string): string {
+    const searchParams = new URLSearchParams()
+    searchParams.set('q', query)
+    return searchParams
+        .toString()
+        .replace(/%2F/g, '/')
+        .replace(/%3A/g, ':')
+}

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -8,7 +8,7 @@ import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { authRequired } from '../auth'
 import { KeybindingsProps } from '../keybindings'
-import { parseSearchURLQuery, SearchOptions } from '../search'
+import { parseSearchURLQuery } from '../search'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
 import { NavLinks } from './NavLinks'
 
@@ -43,13 +43,12 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
         /**
          * Reads initial state from the props (i.e. URL parameters).
          */
-        const options = parseSearchURLQuery(props.location.search || '')
-        if (options) {
-            props.onNavbarQueryChange(options.query)
+        const query = parseSearchURLQuery(props.location.search || '')
+        if (query) {
+            props.onNavbarQueryChange(query)
         } else {
             // If we have no component state, then we may have gotten unmounted during a route change.
-            const state: SearchOptions | undefined = props.location.state
-            props.onNavbarQueryChange(state ? state.query : '')
+            props.onNavbarQueryChange(props.location.state ? props.location.state.query : '')
         }
     }
 
@@ -59,9 +58,9 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
 
     public componentDidUpdate(prevProps: Props): void {
         if (prevProps.location.search !== this.props.location.search) {
-            const options = parseSearchURLQuery(this.props.location.search || '')
-            if (options) {
-                this.props.onNavbarQueryChange(options.query)
+            const query = parseSearchURLQuery(this.props.location.search || '')
+            if (query) {
+                this.props.onNavbarQueryChange(query)
             }
         }
     }

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -370,7 +370,7 @@ export class TreePage extends React.PureComponent<Props, State> {
         event.preventDefault()
         submitSearch(
             this.props.history,
-            { query: this.getQueryPrefix() + this.state.query },
+            this.getQueryPrefix() + this.state.query,
             this.props.filePath ? 'tree' : 'repo'
         )
     }

--- a/web/src/repo/explore/RepositoriesExploreSection.tsx
+++ b/web/src/repo/explore/RepositoriesExploreSection.tsx
@@ -7,8 +7,8 @@ import { RepoLink } from '../../../../shared/src/components/RepoLink'
 import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { queryGraphQL } from '../../backend/graphql'
-import { buildSearchURLQuery } from '../../search'
 
 interface Props {}
 
@@ -102,7 +102,7 @@ export class RepositoriesExploreSection extends React.PureComponent<Props, State
                             )}
                         </div>
                         <div className="text-right mt-3">
-                            <Link to={`/search?${buildSearchURLQuery({ query: 'repo:' })}`}>
+                            <Link to={`/search?${buildSearchURLQuery('repo:')}`}>
                                 View all repositories<ChevronRightIcon className="icon-inline" />
                             </Link>
                         </div>

--- a/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -8,12 +8,13 @@ import * as GQL from '../../../../shared/src/graphql/schema'
 import { createAggregateError } from '../../../../shared/src/util/errors'
 import { memoizeObservable } from '../../../../shared/src/util/memoizeObservable'
 import { numberWithCommas, pluralize } from '../../../../shared/src/util/strings'
+import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { queryGraphQL } from '../../backend/graphql'
 import { FilteredConnection } from '../../components/FilteredConnection'
 import { Form } from '../../components/Form'
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
-import { buildSearchURLQuery, quoteIfNeeded, searchQueryForRepoRev } from '../../search'
+import { quoteIfNeeded, searchQueryForRepoRev } from '../../search'
 import { eventLogger } from '../../tracking/eventLogger'
 import { PersonLink } from '../../user/PersonLink'
 import { UserAvatar } from '../../user/UserAvatar'
@@ -72,9 +73,7 @@ const RepositoryContributorNode: React.FunctionComponent<RepositoryContributorNo
                 </div>
                 <div className="repository-contributor-node__count">
                     <Link
-                        to={`/search?${buildSearchURLQuery({
-                            query,
-                        })}`}
+                        to={`/search?${buildSearchURLQuery(query)}`}
                         className="font-weight-bold"
                         data-tooltip={
                             revisionRange &&

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -1,6 +1,5 @@
 import { Observable } from 'rxjs'
 import { catchError, map, mergeMap, switchMap } from 'rxjs/operators'
-import { SearchOptions } from '.'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
@@ -9,13 +8,13 @@ import { memoizeObservable } from '../../../shared/src/util/memoizeObservable'
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 
 export function search(
-    options: SearchOptions,
+    query: string,
     { extensionsController }: ExtensionsControllerProps
 ): Observable<GQL.ISearchResults | ErrorLike> {
     /**
      * Emits whenever a search is executed, and whenever an extension registers a query transformer.
      */
-    return extensionsController.services.queryTransformer.transformQuery(options.query).pipe(
+    return extensionsController.services.queryTransformer.transformQuery(query).pipe(
         switchMap(query =>
             queryGraphQL(
                 gql`
@@ -146,7 +145,7 @@ export function search(
     )
 }
 
-export function fetchSearchResultStats(options: SearchOptions): Observable<GQL.ISearchResultsStats> {
+export function fetchSearchResultStats(query: string): Observable<GQL.ISearchResultsStats> {
     return queryGraphQL(
         gql`
             query SearchResultsStats($query: String!) {
@@ -158,7 +157,7 @@ export function fetchSearchResultStats(options: SearchOptions): Observable<GQL.I
                 }
             }
         `,
-        { query: options.query }
+        { query }
     ).pipe(
         map(({ data, errors }) => {
             if (!data || !data.search || !data.search.stats) {
@@ -169,7 +168,7 @@ export function fetchSearchResultStats(options: SearchOptions): Observable<GQL.I
     )
 }
 
-export function fetchSuggestions(options: SearchOptions): Observable<GQL.SearchSuggestion> {
+export function fetchSuggestions(query: string): Observable<GQL.SearchSuggestion> {
     return queryGraphQL(
         gql`
             query SearchSuggestions($query: String!) {
@@ -206,7 +205,7 @@ export function fetchSuggestions(options: SearchOptions): Observable<GQL.SearchS
                 }
             }
         `,
-        { query: options.query }
+        { query }
     ).pipe(
         mergeMap(({ data, errors }) => {
             if (!data || !data.search || !data.search.suggestions) {

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -1,6 +1,7 @@
 import * as H from 'history'
-import { buildSearchURLQuery, SearchOptions } from '.'
+import { SearchOptions } from '.'
 import * as GQL from '../../../shared/src/graphql/schema'
+import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { eventLogger } from '../tracking/eventLogger'
 
 export function submitSearch(
@@ -9,7 +10,7 @@ export function submitSearch(
     source: 'home' | 'nav' | 'repo' | 'tree' | 'filter'
 ): void {
     // Go to search results page
-    const path = '/search?' + buildSearchURLQuery(options)
+    const path = '/search?' + buildSearchURLQuery(options.query)
     eventLogger.log('SearchSubmitted', {
         code_search: {
             pattern: options.query,

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -1,24 +1,23 @@
 import * as H from 'history'
-import { SearchOptions } from '.'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { eventLogger } from '../tracking/eventLogger'
 
 export function submitSearch(
     history: H.History,
-    options: SearchOptions,
+    query: string,
     source: 'home' | 'nav' | 'repo' | 'tree' | 'filter'
 ): void {
     // Go to search results page
-    const path = '/search?' + buildSearchURLQuery(options.query)
+    const path = '/search?' + buildSearchURLQuery(query)
     eventLogger.log('SearchSubmitted', {
         code_search: {
-            pattern: options.query,
-            query: options.query,
+            pattern: query,
+            query,
             source,
         },
     })
-    history.push(path, { ...history.location.state, ...options })
+    history.push(path, { ...history.location.state, query })
 }
 
 /**

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -1,26 +1,12 @@
 import { escapeRegExp } from 'lodash'
 
-/** The options that describe a search */
-export interface SearchOptions {
-    /** The query entered by the user */
-    query: string
-}
-
 /**
- * Parses the SearchOptions out of URL search params. If neither the 'q' nor
- * 'sq' params are present, it returns undefined.
+ * Parses the query out of the URL search params (the 'q' parameter). If the 'q' parameter is not present, it
+ * returns undefined.
  */
-export function parseSearchURLQuery(query: string): SearchOptions | undefined {
+export function parseSearchURLQuery(query: string): string | undefined {
     const searchParams = new URLSearchParams(query)
-    if (!searchParams.has('q') && !searchParams.has('sq')) {
-        return undefined
-    }
-    return {
-        query: ['sq', 'q']
-            .map(param => searchParams.get(param))
-            .filter(s => s)
-            .join(' '),
-    }
+    return searchParams.get('q') || undefined
 }
 
 export function searchQueryForRepoRev(repoName: string, rev?: string): string {

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -7,18 +7,6 @@ export interface SearchOptions {
 }
 
 /**
- * Builds a URL query for given SearchOptions (without leading `?`)
- */
-export function buildSearchURLQuery(options: SearchOptions): string {
-    const searchParams = new URLSearchParams()
-    searchParams.set('q', options.query)
-    return searchParams
-        .toString()
-        .replace(/%2F/g, '/')
-        .replace(/%3A/g, ':')
-}
-
-/**
  * Parses the SearchOptions out of URL search params. If neither the 'q' nor
  * 'sq' params are present, it returns undefined.
  */

--- a/web/src/search/input/MainPage.tsx
+++ b/web/src/search/input/MainPage.tsx
@@ -232,10 +232,10 @@ export class MainPage extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
 
-        const searchOptions = parseSearchURLQuery(props.location.search)
+        const query = parseSearchURLQuery(props.location.search)
 
         this.state = {
-            userQuery: (searchOptions && searchOptions.query) || '',
+            userQuery: query || '',
             modalSearchOpen: false,
             modalSearchClosing: false,
             modalIntelligenceOpen: false,
@@ -995,12 +995,12 @@ export class MainPage extends React.Component<Props, State> {
 
     private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
-        submitSearch(this.props.history, { query: this.state.userQuery }, 'home')
+        submitSearch(this.props.history, this.state.userQuery, 'home')
     }
 
     private getPageTitle(): string | undefined {
-        const options = parseSearchURLQuery(this.props.location.search)
-        if (options && options.query) {
+        const query = parseSearchURLQuery(this.props.location.search)
+        if (query) {
             return `${limitString(this.state.userQuery, 25, true)}`
         }
         return undefined

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -19,7 +19,6 @@ import {
     toArray,
 } from 'rxjs/operators'
 import { Key } from 'ts-key-enum'
-import { SearchOptions } from '..'
 import { eventLogger } from '../../tracking/eventLogger'
 import { scrollIntoView } from '../../util'
 import { fetchSuggestions } from '../backend'
@@ -135,10 +134,10 @@ export class QueryInput extends React.Component<Props, State> {
                         if (query.length < QueryInput.SUGGESTIONS_QUERY_MIN_LENGTH) {
                             return [{ suggestions: [], selectedSuggestion: -1, loading: false }]
                         }
-                        const options: SearchOptions = {
-                            query: [this.props.prependQueryForSuggestions, this.props.value].filter(s => !!s).join(' '),
-                        }
-                        const suggestionsFetch = fetchSuggestions(options).pipe(
+                        const fullQuery = [this.props.prependQueryForSuggestions, this.props.value]
+                            .filter(s => !!s)
+                            .join(' ')
+                        const suggestionsFetch = fetchSuggestions(fullQuery).pipe(
                             map(createSuggestion),
                             toArray(),
                             map((suggestions: Suggestion[]) => ({

--- a/web/src/search/input/QueryInputForModal.tsx
+++ b/web/src/search/input/QueryInputForModal.tsx
@@ -19,7 +19,6 @@ import {
     toArray,
 } from 'rxjs/operators'
 import { Key } from 'ts-key-enum'
-import { SearchOptions } from '..'
 import { eventLogger } from '../../tracking/eventLogger'
 import { scrollIntoView } from '../../util'
 import { fetchSuggestions } from '../backend'
@@ -139,10 +138,10 @@ export class QueryInputForModal extends React.Component<Props, State> {
                         if (query.length < QueryInputForModal.SUGGESTIONS_QUERY_MIN_LENGTH) {
                             return [{ suggestions: [], selectedSuggestion: -1, loading: false }]
                         }
-                        const options: SearchOptions = {
-                            query: [this.props.prependQueryForSuggestions, this.props.value].filter(s => !!s).join(' '),
-                        }
-                        const suggestionsFetch = fetchSuggestions(options).pipe(
+                        const fullQuery = [this.props.prependQueryForSuggestions, this.props.value]
+                            .filter(s => !!s)
+                            .join(' ')
+                        const suggestionsFetch = fetchSuggestions(fullQuery).pipe(
                             map(createSuggestion),
                             toArray(),
                             map((suggestions: Suggestion[]) => ({

--- a/web/src/search/input/ScopePage.tsx
+++ b/web/src/search/input/ScopePage.tsx
@@ -236,7 +236,7 @@ export class ScopePage extends React.Component<ScopePageProps, State> {
 
     private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
-        submitSearch(this.props.history, { query: `${this.state.value} ${this.state.query}` }, 'home')
+        submitSearch(this.props.history, `${this.state.value} ${this.state.query}`, 'home')
     }
 
     private onShowMore = (event: React.MouseEvent<HTMLButtonElement>): void => {

--- a/web/src/search/input/SearchFilterChips.tsx
+++ b/web/src/search/input/SearchFilterChips.tsx
@@ -159,7 +159,7 @@ export class SearchFilterChips extends React.PureComponent<Props> {
                 value,
             },
         })
-        submitSearch(this.props.history, { query: toggleSearchFilter(this.props.query, value) }, 'filter')
+        submitSearch(this.props.history, toggleSearchFilter(this.props.query, value), 'filter')
     }
 }
 

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -37,12 +37,6 @@ export class SearchNavbarItem extends React.Component<Props> {
 
     private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
-        submitSearch(
-            this.props.history,
-            {
-                query: this.props.navbarSearchQuery,
-            },
-            'nav'
-        )
+        submitSearch(this.props.history, this.props.navbarSearchQuery, 'nav')
     }
 }

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -34,9 +34,9 @@ export class SearchPage extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
 
-        const searchOptions = parseSearchURLQuery(props.location.search)
+        const query = parseSearchURLQuery(props.location.search)
         this.state = {
-            userQuery: (searchOptions && searchOptions.query) || '',
+            userQuery: query || '',
         }
     }
 
@@ -102,12 +102,12 @@ export class SearchPage extends React.Component<Props, State> {
 
     private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
-        submitSearch(this.props.history, { query: this.state.userQuery }, 'home')
+        submitSearch(this.props.history, this.state.userQuery, 'home')
     }
 
     private getPageTitle(): string | undefined {
-        const options = parseSearchURLQuery(this.props.location.search)
-        if (options && options.query) {
+        const query = parseSearchURLQuery(this.props.location.search)
+        if (query) {
             return `${limitString(this.state.userQuery, 25, true)}`
         }
         return undefined

--- a/web/src/search/queryTelemetry.tsx
+++ b/web/src/search/queryTelemetry.tsx
@@ -1,12 +1,11 @@
-import { SearchOptions } from '.'
 import { count } from '../../../shared/src/util/strings'
 
-export function queryTelemetryData(opt: SearchOptions): { [key: string]: any } {
+export function queryTelemetryData(query: string): { [key: string]: any } {
     return {
         // 🚨 PRIVACY: never provide any private data in { code_search: { query_data: { query } } }.
-        query: opt.query ? queryStringTelemetryData(opt.query) : undefined,
-        combined: opt.query,
-        empty: !opt.query,
+        query: query ? queryStringTelemetryData(query) : undefined,
+        combined: query,
+        empty: !query,
     }
 }
 

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -9,7 +9,7 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable, Subject, Subscription } from 'rxjs'
 import { debounceTime, distinctUntilChanged, filter, first, map, skip, skipUntil } from 'rxjs/operators'
-import { buildSearchURLQuery, parseSearchURLQuery } from '..'
+import { parseSearchURLQuery } from '..'
 import { FetchFileCtx } from '../../../../shared/src/components/CodeExcerpt'
 import { FileMatch } from '../../../../shared/src/components/FileMatch'
 import { RepositoryIcon } from '../../../../shared/src/components/icons' // TODO: Switch to mdi icon
@@ -18,6 +18,7 @@ import * as GQL from '../../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { isDefined } from '../../../../shared/src/util/types'
+import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { ModalContainer } from '../../components/ModalContainer'
 import { SearchResult } from '../../components/SearchResult'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -322,7 +323,10 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                                             <li key={proposedQuery.query}>
                                                                 <Link
                                                                     className="btn btn-secondary btn-sm"
-                                                                    to={'/search?' + buildSearchURLQuery(proposedQuery)}
+                                                                    to={
+                                                                        '/search?' +
+                                                                        buildSearchURLQuery(proposedQuery.query)
+                                                                    }
                                                                 >
                                                                     {proposedQuery.query || proposedQuery.description}
                                                                 </Link>

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -249,7 +249,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                             component={
                                 <SavedQueryCreateForm
                                     authenticatedUser={this.props.authenticatedUser}
-                                    values={{ query: parsedQuery ? parsedQuery.query : '' }}
+                                    values={{ query: parsedQuery || '' }}
                                     onDidCancel={this.props.onSavedQueryModalClose}
                                     onDidCreate={this.props.onDidCreateSavedQuery}
                                     settingsCascade={this.props.settingsCascade}

--- a/web/src/search/results/SearchResultsListOld.tsx
+++ b/web/src/search/results/SearchResultsListOld.tsx
@@ -8,13 +8,14 @@ import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable } from 'rxjs'
-import { buildSearchURLQuery, parseSearchURLQuery } from '..'
+import { parseSearchURLQuery } from '..'
 import { FetchFileCtx } from '../../../../shared/src/components/CodeExcerpt'
 import { FileMatch } from '../../../../shared/src/components/FileMatch'
 import { RepositoryIcon } from '../../../../shared/src/components/icons' // TODO: Switch to mdi icon
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { ModalContainer } from '../../components/ModalContainer'
 import { eventLogger } from '../../tracking/eventLogger'
 import { SavedQueryCreateForm } from '../saved-queries/SavedQueryCreateForm'
@@ -125,7 +126,10 @@ export class SearchResultsListOld extends React.PureComponent<SearchResultsListP
                                                         <li key={proposedQuery.query}>
                                                             <Link
                                                                 className="btn btn-secondary btn-sm"
-                                                                to={'/search?' + buildSearchURLQuery(proposedQuery)}
+                                                                to={
+                                                                    '/search?' +
+                                                                    buildSearchURLQuery(proposedQuery.query)
+                                                                }
                                                             >
                                                                 {proposedQuery.query || proposedQuery.description}
                                                             </Link>

--- a/web/src/search/results/SearchResultsListOld.tsx
+++ b/web/src/search/results/SearchResultsListOld.tsx
@@ -60,7 +60,7 @@ export class SearchResultsListOld extends React.PureComponent<SearchResultsListP
                         component={
                             <SavedQueryCreateForm
                                 authenticatedUser={this.props.authenticatedUser}
-                                values={{ query: parsedQuery ? parsedQuery.query : '' }}
+                                values={{ query: parsedQuery || '' }}
                                 onDidCancel={this.props.onSavedQueryModalClose}
                                 onDidCreate={this.props.onDidCreateSavedQuery}
                                 settingsCascade={this.props.settingsCascade}

--- a/web/src/search/saved-queries/SavedQueryRow.tsx
+++ b/web/src/search/saved-queries/SavedQueryRow.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Subject, Subscription } from 'rxjs'
 import { debounceTime, map, startWith, switchMap, withLatestFrom } from 'rxjs/operators'
-import { buildSearchURLQuery } from '..'
+import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { eventLogger } from '../../tracking/eventLogger'
 import { fetchSearchResultStats } from '../backend'
 import { Sparkline } from './Sparkline'
@@ -81,7 +81,7 @@ export class SavedQueryRow extends React.PureComponent<Props, State> {
     public render(): JSX.Element | null {
         return (
             <div className={`saved-query-row ${this.props.className}`}>
-                <Link onClick={this.logEvent} to={'/search?' + buildSearchURLQuery({ query: this.props.query })}>
+                <Link onClick={this.logEvent} to={'/search?' + buildSearchURLQuery(this.props.query)}>
                     <div className="saved-query-row__row">
                         <div className="saved-query-row__row-column">
                             <div className="saved-query-row__description">

--- a/web/src/search/saved-queries/SavedQueryRow.tsx
+++ b/web/src/search/saved-queries/SavedQueryRow.tsx
@@ -49,7 +49,7 @@ export class SavedQueryRow extends React.PureComponent<Props, State> {
                     debounceTime(250),
                     withLatestFrom(propsChanges),
                     map(([v]) => v),
-                    switchMap(query => fetchSearchResultStats({ query })),
+                    switchMap(query => fetchSearchResultStats(query)),
                     map(results => ({
                         approximateResultCount: results.approximateResultCount,
                         sparkline: results.sparkline,


### PR DESCRIPTION
Removes `SearchOptions`, which used to have both `q` and `sq` properties because we used to have a separate "scope query" (`sq`) URL param. This was removed in around Jan-Feb 2018 and is no longer necessary to keep around for backcompat. Now the `SearchOptions` can just be a single string, the query itself.

Also dedupes `buildSearchURLQuery` between the web app and browser extension.

Also adds tests! :tada: 	