### PR TITLE
support typed property values in Context

### DIFF
--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -20,11 +20,17 @@ export function applyContextUpdate(base: Context, update: Context): Context {
 }
 
 /**
- * Context is an arbitrary, immutable set of key-value pairs.
+ * Context is an arbitrary, immutable set of key-value pairs. Its value can be any JSON object.
+ *
+ * @template T If you have a value with a property of type T that is not one of the primitive types listed below
+ * (or Context), you can use Context<T> to hold that value. T must be a value that can be represented by a JSON
+ * object.
  */
-export interface Context {
-    [key: string]: string | number | boolean | Context | null
-}
+export interface Context<T = never>
+    extends Record<
+            string,
+            string | number | boolean | null | Context | T | (string | number | boolean | null | Context | T)[]
+        > {}
 
 export type ContributionScope =
     | (Pick<ViewComponentData, 'type' | 'selections'> & {
@@ -42,7 +48,7 @@ export type ContributionScope =
 export function getComputedContextProperty(
     model: Model,
     settings: SettingsCascadeOrError,
-    context: Context,
+    context: Context<any>,
     key: string,
     scope?: ContributionScope
 ): any {

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -44,7 +44,7 @@ export class ContributionRegistry {
     public constructor(
         private model: Subscribable<Model>,
         private settingsService: Pick<SettingsService, 'data'>,
-        private context: Subscribable<Context>
+        private context: Subscribable<Context<any>>
     ) {}
 
     /** Register contributions and return an unsubscribable that deregisters the contributions. */
@@ -80,17 +80,26 @@ export class ContributionRegistry {
      * Returns an observable that emits all contributions (merged) evaluated in the current model (with the
      * optional scope). It emits whenever there is any change.
      *
+     * @template T Extra allowed property value types for the {@link Context} value. See {@link Context}'s `T` type
+     * parameter for more information.
      * @param extraContext Extra context values to use when computing the contributions. Properties in this object
      * shadow (take precedence over) properties in the global context for this computation.
      */
-    public getContributions(scope?: ContributionScope | undefined, extraContext?: Context): Observable<Contributions> {
+    public getContributions<T>(
+        scope?: ContributionScope | undefined,
+        extraContext?: Context<T>
+    ): Observable<Contributions> {
         return this.getContributionsFromEntries(this._entries, scope, extraContext)
     }
 
-    protected getContributionsFromEntries(
+    /**
+     * @template T Extra allowed property value types for the {@link Context} value. See {@link Context}'s `T` type
+     * parameter for more information.
+     */
+    protected getContributionsFromEntries<T>(
         entries: Observable<ContributionsEntry[]>,
         scope: ContributionScope | undefined,
-        extraContext?: Context,
+        extraContext?: Context<T>,
         logWarning = (...args: any[]) => console.log(...args)
     ): Observable<Contributions> {
         return combineLatest(


### PR DESCRIPTION
This allows the context (which is used for `when` expressions and other expressions in an extension manifest) to contain properties whose value is a TypeScript type other than the primitive types (or Context itself). This is useful when, for example, you have a `TextDocumentPositionParams` value that is the value of a context property; using `Context<TextDocumentPositionParams>` makes it typecheck.

There is no user-facing behavior change. This is just a change to types, not impl code.

Part of #1313 but useful by itself.