### PR TITLE
clean up usage of Sourcegraph extensions API (controller, platform context) in client/browser

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -24,17 +24,18 @@ import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import {
     FileSpec,
+    PositionSpec,
     RepoSpec,
     ResolvedRevSpec,
     RevSpec,
     toPrettyBlobURL,
     toRootURI,
     toURIWithPath,
+    ViewStateSpec,
 } from '../../../../../shared/src/util/url'
 import {
     createJumpURLFetcher,
     createLSPFromExtensions,
-    JumpURLLocation,
     lspViaAPIXlang,
     toTextDocumentIdentifier,
 } from '../../shared/backend/lsp'
@@ -159,8 +160,10 @@ export interface CodeHost {
      */
     getGlobalDebugMount?: MountGetter
 
-    /** Build the J2D url from the location. */
-    buildJumpURLLocation?: (def: JumpURLLocation) => string
+    /** Construct the URL to the specified file. */
+    urlToFile?: (
+        location: RepoSpec & RevSpec & FileSpec & Partial<PositionSpec> & Partial<ViewStateSpec> & { part?: DiffPart }
+    ) => string
 }
 
 export interface FileInfo {
@@ -244,7 +247,7 @@ function initCodeIntelligence(
 
     const relativeElement = document.body
 
-    const fetchJumpURL = createJumpURLFetcher(fetchDefinition, codeHost.buildJumpURLLocation || toPrettyBlobURL)
+    const fetchJumpURL = createJumpURLFetcher(fetchDefinition, location => platformContext.urlToFile(location))
 
     const containerComponentUpdates = new Subject<void>()
 

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -20,31 +20,37 @@ import { createPlatformContext } from '../../platform/context'
 import { GlobalDebug } from '../../shared/components/GlobalDebug'
 import { ShortcutProvider } from '../../shared/components/ShortcutProvider'
 import { getGlobalDebugMount } from '../github/extensions'
-import { MountGetter } from './code_intelligence'
+import { CodeHost } from './code_intelligence'
 
 /**
- * Initializes extensions for a page. It creates the controllers and injects the command palette.
+ * Initializes extensions for a page. It creates the {@link PlatformContext} and extensions controller.
+ *
+ * If the "Use extensions" feature flag is enabled (or always for Sourcegraph.com), it injects the command palette.
+ * If extensions are not supported by the associated Sourcegraph instance, the extensions controller will behave as
+ * though no individual extensions are enabled, which makes it effectively a noop.
  */
-export function initializeExtensions(
-    getCommandPaletteMount: MountGetter
-): PlatformContextProps & ExtensionsControllerProps {
+export function initializeExtensions({
+    getCommandPaletteMount,
+}: Pick<CodeHost, 'getCommandPaletteMount'>): PlatformContextProps & ExtensionsControllerProps {
     const platformContext = createPlatformContext()
     const extensionsController = createExtensionsController(platformContext)
     const history = H.createBrowserHistory()
 
-    render(
-        <ShortcutProvider>
-            <CommandListPopoverButton
-                extensionsController={extensionsController}
-                menu={ContributableMenu.CommandPalette}
-                platformContext={platformContext}
-                autoFocus={false}
-                location={history.location}
-            />
-            <Notifications extensionsController={extensionsController} />
-        </ShortcutProvider>,
-        getCommandPaletteMount()
-    )
+    if (getCommandPaletteMount) {
+        render(
+            <ShortcutProvider>
+                <CommandListPopoverButton
+                    extensionsController={extensionsController}
+                    menu={ContributableMenu.CommandPalette}
+                    platformContext={platformContext}
+                    autoFocus={false}
+                    location={history.location}
+                />
+                <Notifications extensionsController={extensionsController} />
+            </ShortcutProvider>,
+            getCommandPaletteMount()
+        )
+    }
 
     render(
         <GlobalDebug

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -31,8 +31,9 @@ import { CodeHost } from './code_intelligence'
  */
 export function initializeExtensions({
     getCommandPaletteMount,
-}: Pick<CodeHost, 'getCommandPaletteMount'>): PlatformContextProps & ExtensionsControllerProps {
-    const platformContext = createPlatformContext()
+    urlToFile,
+}: Pick<CodeHost, 'getCommandPaletteMount' | 'urlToFile'>): PlatformContextProps & ExtensionsControllerProps {
+    const platformContext = createPlatformContext({ urlToFile })
     const extensionsController = createExtensionsController(platformContext)
     const history = H.createBrowserHistory()
 

--- a/client/browser/src/platform/context.ts
+++ b/client/browser/src/platform/context.ts
@@ -5,8 +5,10 @@ import { PlatformContext } from '../../../../shared/src/platform/context'
 import { mutateSettings, updateSettings } from '../../../../shared/src/settings/edit'
 import { EMPTY_SETTINGS_CASCADE, gqlToCascade } from '../../../../shared/src/settings/settings'
 import { LocalStorageSubject } from '../../../../shared/src/util/LocalStorageSubject'
+import { toPrettyBlobURL } from '../../../../shared/src/util/url'
 import * as runtime from '../browser/runtime'
 import storage from '../browser/storage'
+import { CodeHost } from '../libs/code_intelligence'
 import { getContext } from '../shared/backend/context'
 import { requestGraphQL } from '../shared/backend/graphql'
 import { sendLSPHTTPRequests } from '../shared/backend/lsp'
@@ -17,7 +19,7 @@ import { editClientSettings, fetchViewerSettings, mergeCascades, storageSettings
 /**
  * Creates the {@link PlatformContext} for the browser extension.
  */
-export function createPlatformContext(): PlatformContext {
+export function createPlatformContext({ urlToFile }: Pick<CodeHost, 'urlToFile'>): PlatformContext {
     // TODO: support listening for changes to sourcegraphUrl
     const sourcegraphLanguageServerURL = new URL(sourcegraphUrl)
     sourcegraphLanguageServerURL.pathname = '.api/xlang'
@@ -105,6 +107,14 @@ export function createPlatformContext(): PlatformContext {
                 )
             )
             return blobURL
+        },
+        urlToFile: location => {
+            if (urlToFile) {
+                // Construct URL to file on code host, if possible.
+                return urlToFile(location)
+            }
+            // Otherwise fall back to linking to Sourcegraph (with an absolute URL).
+            return `${sourcegraphUrl}${toPrettyBlobURL(location)}`
         },
         sourcegraphURL: sourcegraphUrl,
         clientApplication: 'other',

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -9,7 +9,6 @@ import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { toURIWithPath } from '../../../../../shared/src/util/url'
 import { FileInfo } from '../../libs/code_intelligence'
-import { SimpleProviderFns } from '../backend/lsp'
 import { fetchCurrentUser, fetchSite } from '../backend/server'
 import { OpenOnSourcegraph } from './OpenOnSourcegraph'
 
@@ -19,7 +18,7 @@ export interface ButtonProps {
     iconStyle?: React.CSSProperties
 }
 
-interface CodeViewToolbarProps extends Partial<PlatformContextProps>, Partial<ExtensionsControllerProps>, FileInfo {
+interface CodeViewToolbarProps extends PlatformContextProps, ExtensionsControllerProps, FileInfo {
     onEnabledChange?: (enabled: boolean) => void
 
     buttonProps: ButtonProps
@@ -27,7 +26,6 @@ interface CodeViewToolbarProps extends Partial<PlatformContextProps>, Partial<Ex
         listItemClass?: string
         actionItemClass?: string
     }
-    simpleProviderFns: SimpleProviderFns
     location: H.Location
 }
 
@@ -57,25 +55,22 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                 style={{ display: 'inline-flex', verticalAlign: 'middle', alignItems: 'center' }}
             >
                 <ul className={`nav ${this.props.platformContext ? 'pr-1' : ''}`}>
-                    {this.props.extensionsController &&
-                        this.props.platformContext && (
-                            <ActionsNavItems
-                                menu={ContributableMenu.EditorTitle}
-                                extensionsController={this.props.extensionsController}
-                                platformContext={this.props.platformContext}
-                                listItemClass="BtnGroup"
-                                actionItemClass="btn btn-sm tooltipped tooltipped-n BtnGroup-item"
-                                location={this.props.location}
-                                scope={{
-                                    type: 'textEditor',
-                                    item: {
-                                        uri: toURIWithPath(this.props),
-                                        languageId: getModeFromPath(this.props.filePath) || 'could not determine mode',
-                                    },
-                                    selections: [],
-                                }}
-                            />
-                        )}
+                    <ActionsNavItems
+                        menu={ContributableMenu.EditorTitle}
+                        extensionsController={this.props.extensionsController}
+                        platformContext={this.props.platformContext}
+                        listItemClass="BtnGroup"
+                        actionItemClass="btn btn-sm tooltipped tooltipped-n BtnGroup-item"
+                        location={this.props.location}
+                        scope={{
+                            type: 'textEditor',
+                            item: {
+                                uri: toURIWithPath(this.props),
+                                languageId: getModeFromPath(this.props.filePath) || 'could not determine mode',
+                            },
+                            selections: [],
+                        }}
+                    />
                 </ul>
                 {this.props.baseCommitID &&
                     this.props.baseHasFileContents && (

--- a/shared/src/platform/context.ts
+++ b/shared/src/platform/context.ts
@@ -4,6 +4,7 @@ import { MessageTransports } from '../api/protocol/jsonrpc2/connection'
 import { GraphQLResult } from '../graphql/graphql'
 import * as GQL from '../graphql/schema'
 import { Settings, SettingsCascadeOrError } from '../settings/settings'
+import { FileSpec, PositionSpec, RepoSpec, RevSpec, ViewStateSpec } from '../util/url'
 
 /**
  * Platform-specific data and methods shared by multiple Sourcegraph components.
@@ -93,6 +94,14 @@ export interface PlatformContext {
      * https:// URL for the extension's bundle or a blob: URI for it.
      */
     getScriptURLForExtension(bundleURL: string): string | Promise<string>
+
+    /**
+     * Constructs the URL (possibly relative or absolute) to the file with the specified options.
+     *
+     * @param location The specific repository, revision, file, position, and view state to generate the URL for.
+     * @return The URL to the file with the specified options.
+     */
+    urlToFile(location: RepoSpec & RevSpec & FileSpec & Partial<PositionSpec> & Partial<ViewStateSpec>): string
 
     /**
      * The URL to the Sourcegraph site that the user's session is associated with. This refers to

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -8,6 +8,7 @@ import { PlatformContext } from '../../../shared/src/platform/context'
 import { mutateSettings, updateSettings } from '../../../shared/src/settings/edit'
 import { gqlToCascade } from '../../../shared/src/settings/settings'
 import { LocalStorageSubject } from '../../../shared/src/util/LocalStorageSubject'
+import { toPrettyBlobURL } from '../../../shared/src/util/url'
 import { requestGraphQL } from '../backend/graphql'
 import { Tooltip } from '../components/tooltip/Tooltip'
 import { fetchViewerSettings } from '../user/settings/backend'
@@ -63,6 +64,7 @@ export function createPlatformContext(): PlatformContext {
                 return () => worker.terminate()
             })
         },
+        urlToFile: toPrettyBlobURL,
         getScriptURLForExtension: bundleURL => bundleURL,
         sourcegraphURL: window.context.externalURL,
         clientApplication: 'sourcegraph',


### PR DESCRIPTION
See individual commits.

---

reuse browser extension `CodeHost#{buildJumpURLLocation => urlToFile}` in PlatformContext

The purpose of this commit is to reduce the differences between how the web app and browser extension construct URLs to files.

- Add `PlatformContext#urlToFile`
- Rename `CodeHost#{buildJumpURLLocation => urlToFile}`
- Use `CodeHost#urlToFile` to populate `PlatformContext#urlToFile` in the browser extension
- Use `toPrettyBlobURL` for `PlatformContext#urlToFile` in the web app


---

always use extensionsController/platformContext in browser extension

This shrinks the delta between code paths in the browser extension for "Use extensions" and non-"Use extensions". It makes it so that the platformContext and extensionsController are always instantiated.

This change is tested to be backwards-compatible with Sourcegraph 2.10. In older Sourcegraph versions with extensions not enabled by default (2.10-2.11 inclusive), the user settings will not contain any extensions, and so the extensions controller will effectively be a noop. It is useful to still call it (even if it's a noop) to shrink the delta between the 2 code paths.