### PR TITLE
reenable browser extension e2e tests

### DIFF
--- a/client/browser/package.json
+++ b/client/browser/package.json
@@ -18,7 +18,7 @@
     "stylelint": "stylelint 'app/**/*.scss'",
     "clean": "rm -rf build/ dist/ *.zip *.xpi .checksum",
     "test": "jest --testPathIgnorePatterns e2e",
-    "test-e2e": "cross-env OVERRIDE_AUTH_SECRET=sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ jest --coverage=false e2e",
+    "test-e2e": "cross-env OVERRIDE_AUTH_SECRET=sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ jest --forceExit --detectOpenHandles --coverage=false e2e",
     "storybook": "start-storybook -s ./src/extension/assets -c ./config/storybook -p 6006",
     "build-storybook": "build-storybook -c ./config/storybook"
   },


### PR DESCRIPTION
The build steps for the browser extension e2e tests were commented out in 1567da237f37824fad6238e6388fb0fca233d76e (2018 Nov 20) by @ijsnow. This reenables them (and makes it possible to run them by pushing to `bext/e2e` without releasing).

@ijsnow Why did you disable these? They appear to pass (although after the tests pass, the process hangs in CI, possibly due to some other issue). See https://buildkite.com/sourcegraph/sourcegraph/builds/25662#800d7c44-72a9-422b-a73b-4fb5c703dc79 for an example of the hang.