### PR TITLE
search: improve commit search title, small style fixes

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -365,7 +365,7 @@ func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *gitCommit
 	repoURL := commitResolver.Repository().URL()
 	url := commitResolver.URL()
 
-	return fmt.Sprintf("[%s](%s) &nbsp; [%s](%s) &nbsp; [%s](%s)", repoName, repoURL, author, url, message, url)
+	return fmt.Sprintf("[%s](%s) › [%s](%s): [%s](%s)", repoName, repoURL, author, url, message, url)
 }
 
 func commitSubject(message string) string {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -71,7 +71,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			},
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
 			icon:        "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
-			label:       "[repo](/repo) &nbsp; [](/repo/-/commit/c1) &nbsp; [](/repo/-/commit/c1)",
+			label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
 			url:         "/repo/-/commit/c1",
 			detail:      "[`c1` one day ago](/repo/-/commit/c1)",
 			matches:     []*searchResultMatchResolver{&searchResultMatchResolver{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},

--- a/web/src/components/SearchResultMatch.scss
+++ b/web/src/components/SearchResultMatch.scss
@@ -66,6 +66,13 @@
             background-color: transparent;
             padding: 0;
         }
+
+        p,
+        li {
+            code {
+                display: inline;
+            }
+        }
     }
 
     &__code-excerpt {
@@ -97,15 +104,6 @@
         top: 50%;
         transform: translateY(-50%);
         left: 50%;
-    }
-
-    code.language-diff & {
-        font-style: italic;
-        tr:first-child {
-            td.code:first-child {
-                background-color: red;
-            }
-        }
     }
 
     .theme-light & {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1366. Also gets rid of an unused style + adds a new style for code in rendered markdown results. 

Ran the new title by @francisschmaltz