### PR TITLE
DON'T MERGE: test fix for external service kind selector

### DIFF
--- a/shared/src/testing/router.tsx
+++ b/shared/src/testing/router.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+// tslint:disable-next-line:ban-imports
+import { MemoryRouter, Route, RouteComponentProps } from 'react-router'
+
+export interface WithRouterProviderProps<T> {
+    children(routerProps: RouteComponentProps<T>): React.ReactNode
+}
+
+export class WithRouterProvider<T = undefined> extends React.Component<WithRouterProviderProps<T>, {}> {
+    public render(): React.ReactNode {
+        return (
+            <MemoryRouter>
+                <Route path="/" render={this.renderComposedComponent} />
+            </MemoryRouter>
+        )
+    }
+
+    private renderComposedComponent = (routerProps: RouteComponentProps<T>): React.ReactNode =>
+        this.props.children(routerProps)
+}

--- a/web/src/site-admin/SiteAdminAddExternalServicePage.test.tsx
+++ b/web/src/site-admin/SiteAdminAddExternalServicePage.test.tsx
@@ -1,0 +1,33 @@
+import { noop } from 'lodash'
+import * as React from 'react'
+import { cleanup, fireEvent, render } from 'react-testing-library'
+
+import { WithRouterProvider } from '../../../shared/src/testing/router'
+import { SiteAdminAddExternalServicePage } from './SiteAdminAddExternalServicePage'
+
+describe('SiteAdminAddExternalServicePage', () => {
+    afterEach(cleanup)
+
+    it('updates the kind selector after change', () => {
+        const { container } = render(
+            <WithRouterProvider>
+                {({ history, location }) => (
+                    <SiteAdminAddExternalServicePage
+                        history={history}
+                        location={location}
+                        isLightTheme={true}
+                        eventLogger={{
+                            log: noop,
+                            logViewEvent: noop,
+                        }}
+                    />
+                )}
+            </WithRouterProvider>
+        )
+
+        const kindInput = container.querySelector<HTMLSelectElement>('#external-service-page-form-kind')!
+        fireEvent.change(kindInput, { target: { value: 'GITOLITE' } })
+
+        expect(kindInput.value).toBe('GITOLITE')
+    })
+})

--- a/web/src/site-admin/routes.tsx
+++ b/web/src/site-admin/routes.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { eventLogger } from '../tracking/eventLogger'
 import { SiteAdminAddExternalServicePage } from './SiteAdminAddExternalServicePage'
 import { SiteAdminAllUsersPage } from './SiteAdminAllUsersPage'
 import { SiteAdminAreaRoute } from './SiteAdminArea'
@@ -40,7 +41,7 @@ export const siteAdminAreaRoutes: ReadonlyArray<SiteAdminAreaRoute> = [
     },
     {
         path: '/external-services/add',
-        render: props => <SiteAdminAddExternalServicePage {...props} />,
+        render: props => <SiteAdminAddExternalServicePage {...props} eventLogger={eventLogger} />,
         exact: true,
     },
     {


### PR DESCRIPTION
I tried writing a test for the fix for [this issue](https://github.com/sourcegraph/sourcegraph/issues/1482) to show an example of how to write tests for react components with `react-testing-library` but this proved difficult.

I had to make `eventLogger` a prop for this component because a transient import from `eventLogger` accesses something on `window.context` which is not defined in `jest` and typescript was getting angry when I just tried to polyfill `window.context` in jest. This change makes the component more modular anyways so that's good. 

Once that was solved, I ran into an issue complaining about not being able to find the `monaco-editor` module. This is likely due to the magic we're doing around loading it for performance. We'll probably have to [use webpack with jest](https://jestjs.io/docs/en/webpack) to map the module like we do in our build process. This will likely slow down jest but will be a requirement if we want to test components using the monaco editor.

I'll open issues for the takeaways from this experience.