### PR TITLE
fix: update service kind selector on change

### DIFF
--- a/web/src/site-admin/routes.tsx
+++ b/web/src/site-admin/routes.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { eventLogger } from '../tracking/eventLogger'
 import { SiteAdminAddExternalServicePage } from './SiteAdminAddExternalServicePage'
 import { SiteAdminAllUsersPage } from './SiteAdminAllUsersPage'
 import { SiteAdminAreaRoute } from './SiteAdminArea'
@@ -40,7 +41,7 @@ export const siteAdminAreaRoutes: ReadonlyArray<SiteAdminAreaRoute> = [
     },
     {
         path: '/external-services/add',
-        render: props => <SiteAdminAddExternalServicePage {...props} />,
+        render: props => <SiteAdminAddExternalServicePage {...props} eventLogger={eventLogger} />,
         exact: true,
     },
     {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1482.

This PR contains a change to not import `eventLogger` directly and take it as a prop. This is to make it more testable. [See this PR for more info.](https://github.com/sourcegraph/sourcegraph/compare/kind-selector-test?expand=1)