### PR TITLE
Loading unpacked extensions

### DIFF
--- a/client/browser/src/browser/ExtensionStorageSubject.ts
+++ b/client/browser/src/browser/ExtensionStorageSubject.ts
@@ -3,11 +3,11 @@ import storage from './storage'
 import { StorageItems } from './types'
 
 /**
- * An RxJS subject that is backed by an extension storage item
+ * An RxJS subject that is backed by an extension storage item.
  */
 export class ExtensionStorageSubject<T extends keyof StorageItems> extends Observable<StorageItems[T]>
     implements NextObserver<StorageItems[T]>, Pick<BehaviorSubject<StorageItems[T]>, 'value'> {
-    constructor(private key: T, private defaultValue: StorageItems[T]) {
+    constructor(private key: T, defaultValue: StorageItems[T]) {
         super(subscriber => {
             subscriber.next(this.value)
             return storage.observeLocal(this.key).subscribe(item => {
@@ -15,11 +15,12 @@ export class ExtensionStorageSubject<T extends keyof StorageItems> extends Obser
                 subscriber.next(item)
             })
         })
+        this.value = defaultValue
     }
 
     public next(value: StorageItems[T]): void {
         storage.setLocal({ [this.key]: value })
     }
 
-    public value = this.defaultValue
+    public value: StorageItems[T]
 }

--- a/client/browser/src/browser/ExtensionStorageSubject.ts
+++ b/client/browser/src/browser/ExtensionStorageSubject.ts
@@ -1,0 +1,25 @@
+import { BehaviorSubject, NextObserver, Observable } from 'rxjs'
+import storage from './storage'
+import { StorageItems } from './types'
+
+/**
+ * An RxJS subject that is backed by an extension storage item
+ */
+export class ExtensionStorageSubject<T extends keyof StorageItems> extends Observable<StorageItems[T]>
+    implements NextObserver<StorageItems[T]>, Pick<BehaviorSubject<StorageItems[T]>, 'value'> {
+    constructor(private key: T, private defaultValue: StorageItems[T]) {
+        super(subscriber => {
+            subscriber.next(this.value)
+            return storage.observeLocal(this.key).subscribe(item => {
+                this.value = item
+                subscriber.next(item)
+            })
+        })
+    }
+
+    public next(value: StorageItems[T]): void {
+        storage.setLocal({ [this.key]: value })
+    }
+
+    public value = this.defaultValue
+}

--- a/client/browser/src/browser/types.ts
+++ b/client/browser/src/browser/types.ts
@@ -82,6 +82,7 @@ export interface StorageItems {
      * Overrides settings from Sourcegraph.
      */
     clientSettings: string
+    unpackedExtensionURL: string
 }
 
 interface ClientConfigurationDetails {
@@ -110,6 +111,7 @@ export const defaultStorageItems: StorageItems = {
         },
     },
     clientSettings: '',
+    unpackedExtensionURL: '',
 }
 
 export type StorageChange = { [key in keyof StorageItems]: chrome.storage.StorageChange }

--- a/client/browser/src/browser/types.ts
+++ b/client/browser/src/browser/types.ts
@@ -82,7 +82,7 @@ export interface StorageItems {
      * Overrides settings from Sourcegraph.
      */
     clientSettings: string
-    unpackedExtensionURL: string
+    sideloadedExtensionURL: string | null
 }
 
 interface ClientConfigurationDetails {
@@ -111,7 +111,7 @@ export const defaultStorageItems: StorageItems = {
         },
     },
     clientSettings: '',
-    unpackedExtensionURL: '',
+    sideloadedExtensionURL: '',
 }
 
 export type StorageChange = { [key in keyof StorageItems]: chrome.storage.StorageChange }

--- a/client/browser/src/platform/context.ts
+++ b/client/browser/src/platform/context.ts
@@ -132,7 +132,7 @@ export function createPlatformContext({ urlToFile }: Pick<CodeHost, 'urlToFile'>
         sourcegraphURL: sourcegraphUrl,
         clientApplication: 'other',
         traceExtensionHostCommunication: new LocalStorageSubject<boolean>('traceExtensionHostCommunication', false),
-        unpackedExtensionURL: new ExtensionStorageSubject('unpackedExtensionURL', ''),
+        sideloadedExtensionURL: new ExtensionStorageSubject('sideloadedExtensionURL', null),
     }
     return context
 }

--- a/client/browser/src/platform/context.ts
+++ b/client/browser/src/platform/context.ts
@@ -6,6 +6,7 @@ import { mutateSettings, updateSettings } from '../../../../shared/src/settings/
 import { EMPTY_SETTINGS_CASCADE, gqlToCascade } from '../../../../shared/src/settings/settings'
 import { LocalStorageSubject } from '../../../../shared/src/util/LocalStorageSubject'
 import { toPrettyBlobURL } from '../../../../shared/src/util/url'
+import { ExtensionStorageSubject } from '../browser/ExtensionStorageSubject'
 import * as runtime from '../browser/runtime'
 import storage from '../browser/storage'
 import { isInPage } from '../context'
@@ -131,6 +132,7 @@ export function createPlatformContext({ urlToFile }: Pick<CodeHost, 'urlToFile'>
         sourcegraphURL: sourcegraphUrl,
         clientApplication: 'other',
         traceExtensionHostCommunication: new LocalStorageSubject<boolean>('traceExtensionHostCommunication', false),
+        unpackedExtensionURL: new ExtensionStorageSubject('unpackedExtensionURL', ''),
     }
     return context
 }

--- a/shared/src/api/client/services.test.ts
+++ b/shared/src/api/client/services.test.ts
@@ -1,4 +1,4 @@
-import { NEVER } from 'rxjs'
+import { BehaviorSubject, NEVER } from 'rxjs'
 import { Services } from './services'
 
 describe('Services', () => {
@@ -10,6 +10,7 @@ describe('Services', () => {
             queryGraphQL: () => NEVER,
             getScriptURLForExtension: scriptURL => scriptURL,
             clientApplication: 'sourcegraph',
+            sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
         })
     })
 })

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -23,7 +23,12 @@ export class Services {
     constructor(
         private platformContext: Pick<
             PlatformContext,
-            'settings' | 'updateSettings' | 'queryGraphQL' | 'getScriptURLForExtension' | 'clientApplication'
+            | 'settings'
+            | 'updateSettings'
+            | 'queryGraphQL'
+            | 'getScriptURLForExtension'
+            | 'clientApplication'
+            | 'sideloadedExtensionURL'
         >
     ) {}
 

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -17,8 +17,8 @@ class TestExtensionsService extends ExtensionsService {
             enabledExtensions: ConfiguredExtension[],
             model: Pick<Model, 'visibleViewComponents'>
         ) => ConfiguredExtension[],
-        unpackedExtensionUrl: Subscribable<string>,
-        fetchUnpackedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
+        sideloadedExtensionURL: Subscribable<string | null>,
+        fetchSideloadedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
     ) {
         super(
             {
@@ -26,14 +26,14 @@ class TestExtensionsService extends ExtensionsService {
                     throw new Error('not implemented')
                 },
                 getScriptURLForExtension: scriptURL => scriptURL,
+                sideloadedExtensionURL,
             },
             model,
             settingsService,
             extensionActivationFilter,
-            fetchUnpackedExtension
+            fetchSideloadedExtension
         )
         this.configuredExtensions = of(mockConfiguredExtensions)
-        this.unpackedExtensionURL = unpackedExtensionUrl as any
     }
 }
 
@@ -107,7 +107,7 @@ describe('activeExtensions', () => {
             } as Record<string, ExecutableExtension[]>)
         ))
 
-    test('fetches an unpacked extension and adds it to the set of registry extensions', () => {
+    test('fetches a sideloaded extension and adds it to the set of registry extensions', () => {
         scheduler().run(({ cold, expectObservable }) => {
             expectObservable(
                 from(
@@ -150,7 +150,7 @@ describe('activeExtensions', () => {
         })
     })
 
-    test('still returns registry extensions even if fetching an unpacked extension fails', () => {
+    test('still returns registry extensions even if fetching a sideloaded extension fails', () => {
         scheduler().run(({ cold, expectObservable }) => {
             expectObservable(
                 from(

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -37,8 +37,7 @@ class TestExtensionsService extends ExtensionsService {
     }
 }
 
-/* tslint:disable-next-line */
-describe.only('activeExtensions', () => {
+describe('activeExtensions', () => {
     test('emits an empty set', () =>
         scheduler().run(({ cold, expectObservable }) =>
             expectObservable(

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -1,4 +1,4 @@
-import { NEVER, NextObserver, of, Subscribable, throwError } from 'rxjs'
+import { BehaviorSubject, NEVER, NextObserver, of, Subscribable, throwError } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { PlatformContext } from '../../platform/context'
@@ -32,9 +32,14 @@ interface TestContext {
 
 interface Mocks
     extends Pick<
-            PlatformContext,
-            'settings' | 'updateSettings' | 'queryGraphQL' | 'getScriptURLForExtension' | 'clientApplication'
-        > {}
+        PlatformContext,
+        | 'settings'
+        | 'updateSettings'
+        | 'queryGraphQL'
+        | 'getScriptURLForExtension'
+        | 'clientApplication'
+        | 'sideloadedExtensionURL'
+    > {}
 
 const NOOP_MOCKS: Mocks = {
     settings: NEVER,
@@ -42,6 +47,7 @@ const NOOP_MOCKS: Mocks = {
     queryGraphQL: () => throwError(new Error('Mocks#queryGraphQL not implemented')),
     getScriptURLForExtension: scriptURL => scriptURL,
     clientApplication: 'sourcegraph',
+    sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
 }
 
 /**

--- a/shared/src/extensions/ExtensionStatus.tsx
+++ b/shared/src/extensions/ExtensionStatus.tsx
@@ -20,6 +20,7 @@ interface State {
 
     /** Whether to log traces of communication with extensions. */
     traceExtensionHostCommunication?: boolean
+    unpackedExtensionURL?: string
 }
 
 export class ExtensionStatus extends React.PureComponent<Props, State> {
@@ -53,7 +54,16 @@ export class ExtensionStatus extends React.PureComponent<Props, State> {
                     switchMap(({ traceExtensionHostCommunication }) => traceExtensionHostCommunication),
                     map(traceExtensionHostCommunication => ({ traceExtensionHostCommunication }))
                 )
-                .subscribe(stateUpdate => this.setState(stateUpdate))
+                .subscribe(stateUpdate => this.setState({ ...this.state, ...stateUpdate }))
+        )
+
+        this.subscriptions.add(
+            platformContext
+                .pipe(
+                    switchMap(({ unpackedExtensionURL }) => unpackedExtensionURL),
+                    map(unpackedExtensionURL => ({ unpackedExtensionURL }))
+                )
+                .subscribe(unpackedExtensionURL => this.setState({ ...this.state, ...unpackedExtensionURL }))
         )
 
         this.componentUpdates.next(this.props)
@@ -104,12 +114,29 @@ export class ExtensionStatus extends React.PureComponent<Props, State> {
                         title="Toggle extension trace logging to devtools console"
                     />
                 </div>
+                <div className="card-body border-top">
+                    <label htmlFor="extension-status__unpackedurl" className="mr-2 mb-0">
+                        Load unpacked extension
+                    </label>
+                    <div>
+                        <input
+                            type="text"
+                            id="extension-status__unpackedurl"
+                            onChange={this.onUnpackedURLChange}
+                            value={this.state.unpackedExtensionURL || ''}
+                        />
+                    </div>
+                </div>
             </div>
         )
     }
 
     private onToggleTrace = () => {
         this.props.platformContext.traceExtensionHostCommunication.next(!this.state.traceExtensionHostCommunication)
+    }
+
+    private onUnpackedURLChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        this.props.platformContext.unpackedExtensionURL.next(e.target.value || '')
     }
 }
 

--- a/shared/src/extensions/ExtensionStatus.tsx
+++ b/shared/src/extensions/ExtensionStatus.tsx
@@ -103,7 +103,7 @@ export class ExtensionStatus extends React.PureComponent<Props, State> {
                         <LoadingSpinner className="icon-inline" /> Loading extensions...
                     </span>
                 )}
-                <div className="card-body border-top d-flex justify-content-end align-items-center">
+                <div className="card-body border-top d-flex justify-content-start align-items-center">
                     <label htmlFor="extension-status__trace" className="mr-2 mb-0">
                         Log to devtools console{' '}
                     </label>
@@ -115,14 +115,14 @@ export class ExtensionStatus extends React.PureComponent<Props, State> {
                     />
                 </div>
                 <div className="card-body border-top">
-                    <label htmlFor="extension-status__unpackedurl" className="mr-2 mb-0">
-                        Load unpacked extension
-                    </label>
-                    <div>
+                    <div className="form-group">
+                        <label htmlFor="extension-status__unpackedurl">Load unpacked extension</label>
                         <input
                             type="text"
                             id="extension-status__unpackedurl"
+                            className="form-control"
                             onChange={this.onUnpackedURLChange}
+                            placeholder="URL"
                             value={this.state.unpackedExtensionURL || ''}
                         />
                     </div>

--- a/shared/src/extensions/ExtensionStatus.tsx
+++ b/shared/src/extensions/ExtensionStatus.tsx
@@ -122,7 +122,7 @@ export class ExtensionStatus extends React.PureComponent<Props, State> {
                             id="extension-status__unpackedurl"
                             className="form-control"
                             onChange={this.onUnpackedURLChange}
-                            placeholder="URL"
+                            placeholder="URL to extension's package.json"
                             value={this.state.unpackedExtensionURL || ''}
                         />
                     </div>

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -82,14 +82,10 @@ export function createController(context: PlatformContext): Controller {
             }),
             share()
         ),
-        context.traceExtensionHostCommunication,
-        context.unpackedExtensionURL
+        context.traceExtensionHostCommunication
     ).pipe(
-        tap(([connection, trace, unpackedExtensionURL]) => {
+        tap(([connection, trace]) => {
             connection.trace(trace ? new BrowserConsoleTracer('') : null)
-            if (unpackedExtensionURL) {
-                services.extensions.unpackedExtensionURL.next(unpackedExtensionURL)
-            }
         }),
         map(([connection]) => connection),
         distinctUntilChanged()

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -88,7 +88,7 @@ export function createController(context: PlatformContext): Controller {
         tap(([connection, trace, unpackedExtensionURL]) => {
             connection.trace(trace ? new BrowserConsoleTracer('') : null)
             if (unpackedExtensionURL) {
-                services.extensions.unpackedExtension.next(unpackedExtensionURL)
+                services.extensions.unpackedExtensionURL.next(unpackedExtensionURL)
             }
         }),
         map(([connection]) => connection),

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -82,9 +82,15 @@ export function createController(context: PlatformContext): Controller {
             }),
             share()
         ),
-        context.traceExtensionHostCommunication
+        context.traceExtensionHostCommunication,
+        context.unpackedExtensionURL
     ).pipe(
-        tap(([connection, trace]) => connection.trace(trace ? new BrowserConsoleTracer('') : null)),
+        tap(([connection, trace, unpackedExtensionURL]) => {
+            connection.trace(trace ? new BrowserConsoleTracer('') : null)
+            if (unpackedExtensionURL) {
+                services.extensions.unpackedExtension.next(unpackedExtensionURL)
+            }
+        }),
         map(([connection]) => connection),
         distinctUntilChanged()
     )

--- a/shared/src/platform/context.ts
+++ b/shared/src/platform/context.ts
@@ -121,7 +121,11 @@ export interface PlatformContext {
      */
     traceExtensionHostCommunication: Subscribable<boolean> & NextObserver<boolean>
 
-    unpackedExtensionURL: Subscribable<string> & NextObserver<string>
+    /**
+     * The URL to the Parcel dev server for a single extension.
+     * Used for extension development purposes, to run an extension that isn't on the registry.
+     */
+    sideloadedExtensionURL: Subscribable<string | null> & NextObserver<string | null>
 }
 
 /**

--- a/shared/src/platform/context.ts
+++ b/shared/src/platform/context.ts
@@ -120,6 +120,8 @@ export interface PlatformContext {
      * Whether to log all messages sent between the client and the extension host.
      */
     traceExtensionHostCommunication: Subscribable<boolean> & NextObserver<boolean>
+
+    unpackedExtensionURL: Subscribable<string> & NextObserver<string>
 }
 
 /**

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -65,7 +65,7 @@ export function createPlatformContext(): PlatformContext {
         sourcegraphURL: window.context.externalURL,
         clientApplication: 'sourcegraph',
         traceExtensionHostCommunication: new LocalStorageSubject<boolean>('traceExtensionHostCommunication', false),
-        unpackedExtensionURL: new LocalStorageSubject<string>('unpackedExtensionURL', ''),
+        sideloadedExtensionURL: new LocalStorageSubject<string | null>('sideloadedExtensionURL', null),
     }
     return context
 }

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -65,6 +65,7 @@ export function createPlatformContext(): PlatformContext {
         sourcegraphURL: window.context.externalURL,
         clientApplication: 'sourcegraph',
         traceExtensionHostCommunication: new LocalStorageSubject<boolean>('traceExtensionHostCommunication', false),
+        unpackedExtensionURL: new LocalStorageSubject<string>('unpackedExtensionURL', ''),
     }
     return context
 }


### PR DESCRIPTION
closes #489 

This PR adds the ability to load locally served Sourcegraph extensions. Review by commit.

The URL to an unpacked extension can be set using the debug palette:

![image](https://user-images.githubusercontent.com/1741180/50605077-753e3980-0ec1-11e9-8ac5-c3548ea4cb8f.png)


In the browser extension, the unpacked extension url is stored in `chrome.storage.local`. This is done to avoid reading & fetching a URL from localStorage that may have been set by other scripts.

In the webapp, the value is read from localStorage.

By using localStorage/chrome.storage.local rather than settings, and only allowing one unpacked extension, we avoid usage of this feature to circumvent the "private extensions registry is a premium feature" restriction.

TODO:
- [x] styling
- [x] tests