### PR TITLE
fix syntax highlighting not being registered

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -16,6 +16,7 @@ import * as React from 'react'
 import { createPortal, render } from 'react-dom'
 import { animationFrameScheduler, Observable, of, Subject, Subscription } from 'rxjs'
 import { filter, map, mergeMap, observeOn, withLatestFrom } from 'rxjs/operators'
+import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 
 import { HoverMerged } from '@sourcegraph/codeintellify/lib/types'
 import { Model, ViewComponentData } from '../../../../../shared/src/api/client/model'
@@ -48,6 +49,8 @@ import { gitlabCodeHost } from '../gitlab/code_intelligence'
 import { phabricatorCodeHost } from '../phabricator/code_intelligence'
 import { findCodeViews, getContentOfCodeView } from './code_views'
 import { applyDecorations, initializeExtensions } from './extensions'
+
+registerHighlightContributions()
 
 /**
  * Defines a type of code view a given code host can have. It tells us how to

--- a/shared/src/highlight/contributions.ts
+++ b/shared/src/highlight/contributions.ts
@@ -1,25 +1,42 @@
-// Load only a subset of the highlight.js languages
+// tslint:disable:no-submodule-imports Avoid loading grammars for unused languages.
 import { registerLanguage } from 'highlight.js/lib/highlight'
-registerLanguage('go', require('highlight.js/lib/languages/go'))
-registerLanguage('javascript', require('highlight.js/lib/languages/javascript'))
-registerLanguage('typescript', require('highlight.js/lib/languages/typescript'))
-registerLanguage('java', require('highlight.js/lib/languages/java'))
-registerLanguage('python', require('highlight.js/lib/languages/python'))
-registerLanguage('php', require('highlight.js/lib/languages/php'))
-registerLanguage('bash', require('highlight.js/lib/languages/bash'))
-registerLanguage('clojure', require('highlight.js/lib/languages/clojure'))
-registerLanguage('cpp', require('highlight.js/lib/languages/cpp'))
-registerLanguage('cs', require('highlight.js/lib/languages/cs'))
-registerLanguage('css', require('highlight.js/lib/languages/css'))
-registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'))
-registerLanguage('elixir', require('highlight.js/lib/languages/elixir'))
-registerLanguage('haskell', require('highlight.js/lib/languages/haskell'))
-registerLanguage('html', require('highlight.js/lib/languages/xml'))
-registerLanguage('lua', require('highlight.js/lib/languages/lua'))
-registerLanguage('ocaml', require('highlight.js/lib/languages/ocaml'))
-registerLanguage('r', require('highlight.js/lib/languages/r'))
-registerLanguage('ruby', require('highlight.js/lib/languages/ruby'))
-registerLanguage('rust', require('highlight.js/lib/languages/rust'))
-registerLanguage('swift', require('highlight.js/lib/languages/swift'))
-registerLanguage('markdown', require('highlight.js/lib/languages/markdown'))
-registerLanguage('diff', require('highlight.js/lib/languages/diff'))
+
+let registered = false
+
+/**
+ * Registers syntax highlighters for commonly used languages.
+ *
+ * This function must be called exactly once. A function is used instead of having the registerLanguage calls be
+ * side effects of importing this module to prevent this module from being omitted from production builds due to
+ * tree-shaking.
+ */
+export function registerHighlightContributions(): void {
+    if (registered) {
+        // Don't double-register these. (There is no way to unregister them.)
+        return
+    }
+    registered = true
+    registerLanguage('go', require('highlight.js/lib/languages/go'))
+    registerLanguage('javascript', require('highlight.js/lib/languages/javascript'))
+    registerLanguage('typescript', require('highlight.js/lib/languages/typescript'))
+    registerLanguage('java', require('highlight.js/lib/languages/java'))
+    registerLanguage('python', require('highlight.js/lib/languages/python'))
+    registerLanguage('php', require('highlight.js/lib/languages/php'))
+    registerLanguage('bash', require('highlight.js/lib/languages/bash'))
+    registerLanguage('clojure', require('highlight.js/lib/languages/clojure'))
+    registerLanguage('cpp', require('highlight.js/lib/languages/cpp'))
+    registerLanguage('cs', require('highlight.js/lib/languages/cs'))
+    registerLanguage('css', require('highlight.js/lib/languages/css'))
+    registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'))
+    registerLanguage('elixir', require('highlight.js/lib/languages/elixir'))
+    registerLanguage('haskell', require('highlight.js/lib/languages/haskell'))
+    registerLanguage('html', require('highlight.js/lib/languages/xml'))
+    registerLanguage('lua', require('highlight.js/lib/languages/lua'))
+    registerLanguage('ocaml', require('highlight.js/lib/languages/ocaml'))
+    registerLanguage('r', require('highlight.js/lib/languages/r'))
+    registerLanguage('ruby', require('highlight.js/lib/languages/ruby'))
+    registerLanguage('rust', require('highlight.js/lib/languages/rust'))
+    registerLanguage('swift', require('highlight.js/lib/languages/swift'))
+    registerLanguage('markdown', require('highlight.js/lib/languages/markdown'))
+    registerLanguage('diff', require('highlight.js/lib/languages/diff'))
+}

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -6,6 +6,7 @@ import { ResizablePanel } from '../../shared/src/panel/Panel'
 import { PlatformContextProps } from '../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../shared/src/settings/settings'
 import { parseHash } from '../../shared/src/util/url'
+import { GlobalContributions } from './contributions'
 import { ExploreSectionDescriptor } from './explore/ExploreArea'
 import { ExtensionAreaRoute } from './extensions/extension/ExtensionArea'
 import { ExtensionAreaHeaderNavItem } from './extensions/extension/ExtensionAreaHeader'
@@ -131,6 +132,12 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                     fetchHighlightedFileLines={fetchHighlightedFileLines}
                 />
             )}
+            <GlobalContributions
+                key={3}
+                extensionsController={props.extensionsController}
+                platformContext={props.platformContext}
+                history={props.history}
+            />
             <GlobalDebug {...props} />
         </div>
     )

--- a/web/src/contributions.ts
+++ b/web/src/contributions.ts
@@ -1,0 +1,30 @@
+import H from 'history'
+import React from 'react'
+import { Subscription } from 'rxjs'
+import { ExtensionsControllerProps } from '../../shared/src/extensions/controller'
+import { registerHighlightContributions } from '../../shared/src/highlight/contributions'
+import { PlatformContextProps } from '../../shared/src/platform/context'
+
+interface Props extends ExtensionsControllerProps, PlatformContextProps {
+    history: H.History
+}
+
+/**
+ * A component that registers global contributions. It is implemented as a React component so that its
+ * registrations use the React lifecycle.
+ */
+export class GlobalContributions extends React.Component<Props> {
+    private subscriptions = new Subscription()
+
+    public componentDidMount(): void {
+        registerHighlightContributions() // no way to unregister these
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    public render(): JSX.Element | null {
+        return null
+    }
+}

--- a/web/src/enterprise/main.tsx
+++ b/web/src/enterprise/main.tsx
@@ -5,8 +5,6 @@
 
 import '../polyfills'
 
-import '../../../shared/src/highlight/contributions'
-
 import React from 'react'
 import { render } from 'react-dom'
 import { keybindings } from '../keybindings'

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,8 +5,6 @@
 
 import './polyfills'
 
-import '../../shared/src/highlight/contributions'
-
 import React from 'react'
 import { render } from 'react-dom'
 import { exploreSections } from './explore/exploreSections'


### PR DESCRIPTION
- prevents the contributions file (which contains no exported definitions and only has side effects) from being tree-shaked out of the production build
- imports the syntax highlighting contributions in the browser extension

fix #1418