### PR TITLE
store non-resolved input revision for workspace roots

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -476,7 +476,7 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                         // All the currently open documents, which are all now considered inactive.
                         ...visibleViewComponents.map(c => ({ ...c, isActive: false })),
                     ]
-                    const roots: Model['roots'] = [{ uri: toRootURI(info) }]
+                    const roots: Model['roots'] = [{ uri: toRootURI(info), inputRevision: info.rev || '' }]
 
                     // When codeView is a diff, add BASE too.
                     if (baseContent! && info.baseRepoName && info.baseCommitID && info.baseFilePath) {
@@ -503,6 +503,7 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                                 repoName: info.baseRepoName,
                                 commitID: info.baseCommitID,
                             }),
+                            inputRevision: info.baseRev || '',
                         })
                     }
 

--- a/shared/src/api/client/model.ts
+++ b/shared/src/api/client/model.ts
@@ -17,6 +17,25 @@ export interface ViewComponentData {
 }
 
 /**
+ * A workspace root with additional metadata that is not exposed to extensions.
+ */
+export interface WorkspaceRootWithMetadata extends WorkspaceRoot {
+    /**
+     * The original input Git revision that the user requested. The {@link WorkspaceRoot#uri} value will contain
+     * the Git commit SHA resolved from the input revision, but it is useful to also know the original revision
+     * (e.g., to construct URLs for the user that don't result in them navigating from a branch view to a commit
+     * SHA view).
+     *
+     * For example, if the user is viewing the web page https://github.com/alice/myrepo/blob/master/foo.js (note
+     * that the URL contains a Git revision "master"), the input revision is "master".
+     *
+     * The empty string is a valid value (meaning that the default should be used, such as "HEAD" in Git) and is
+     * distinct from undefined. If undefined, the Git commit SHA from {@link WorkspaceRoot#uri} should be used.
+     */
+    inputRevision?: string
+}
+
+/**
  * A description of the model represented by the Sourcegraph extension client application.
  *
  * This models the state of editor-like tools that display documents, allow selections and scrolling
@@ -26,7 +45,7 @@ export interface Model {
     /**
      * The currently open workspace roots (typically a single repository).
      */
-    readonly roots: WorkspaceRoot[] | null
+    readonly roots: WorkspaceRootWithMetadata[] | null
 
     /**
      * The view components that are currently visible. Each text document is represented as being in its own

--- a/shared/src/util/url.test.ts
+++ b/shared/src/util/url.test.ts
@@ -1,4 +1,11 @@
-import { buildSearchURLQuery, makeRepoURI, parseHash, parseRepoURI, toPrettyBlobURL } from './url'
+import {
+    buildSearchURLQuery,
+    makeRepoURI,
+    parseHash,
+    parseRepoURI,
+    toPrettyBlobURL,
+    withWorkspaceRootInputRevision,
+} from './url'
 
 /**
  * Asserts deep object equality using node's assert.deepEqual, except it (1) ignores differences in the
@@ -233,6 +240,36 @@ describe('util/url', () => {
             )
         })
     })
+})
+
+describe('withWorkspaceRootInputRevision', () => {
+    test('uses input revision for URI inside root with input revision', () =>
+        expect(
+            withWorkspaceRootInputRevision([{ uri: 'git://r?c', inputRevision: 'v' }], parseRepoURI('git://r?c#f'))
+        ).toEqual(parseRepoURI('git://r?v#f')))
+
+    test('does not change URI outside root (different repoName)', () =>
+        expect(
+            withWorkspaceRootInputRevision([{ uri: 'git://r?c', inputRevision: 'v' }], parseRepoURI('git://r2?c#f'))
+        ).toEqual(parseRepoURI('git://r2?c#f')))
+
+    test('does not change URI outside root (different rev)', () =>
+        expect(
+            withWorkspaceRootInputRevision([{ uri: 'git://r?c', inputRevision: 'v' }], parseRepoURI('git://r?c2#f'))
+        ).toEqual(parseRepoURI('git://r?c2#f')))
+
+    test('uses empty string input revision (treats differently from undefined)', () =>
+        expect(
+            withWorkspaceRootInputRevision([{ uri: 'git://r?c', inputRevision: '' }], parseRepoURI('git://r?c#f'))
+        ).toEqual({ ...parseRepoURI('git://r?c#f'), rev: '' }))
+
+    test('does not change URI if root has undefined input revision', () =>
+        expect(
+            withWorkspaceRootInputRevision(
+                [{ uri: 'git://r?c', inputRevision: undefined }],
+                parseRepoURI('git://r?c#f')
+            )
+        ).toEqual(parseRepoURI('git://r?c#f')))
 })
 
 describe('buildSearchURLQuery', () => {

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -1,4 +1,3 @@
-import { WorkspaceRoot } from '@sourcegraph/extension-api-types'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import * as React from 'react'
@@ -6,6 +5,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import { Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators'
 import { redirectToExternalHost } from '.'
+import { WorkspaceRootWithMetadata } from '../../../shared/src/api/client/model'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
@@ -149,7 +149,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
             this.revResolves
                 .pipe(
                     map(resolvedRevOrError => {
-                        let roots: WorkspaceRoot[] | null = null
+                        let roots: WorkspaceRootWithMetadata[] | null = null
                         if (resolvedRevOrError && !isErrorLike(resolvedRevOrError)) {
                             roots = [
                                 {
@@ -157,6 +157,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                                         repoName: this.state.repoName,
                                         rev: resolvedRevOrError.commitID,
                                     }),
+                                    inputRevision: this.state.rev || '',
                                 },
                             ]
                         }


### PR DESCRIPTION
This makes it so that the original input revision (e.g., a branch name) for each workspace root is stored. Previously only the full Git commit SHA was available (in the workspace root URI).

This is a prerequisite to avoid navigating the user from a URL with a branch name to a URL with a full Git commit SHA when they perform actions such as go-to-definition.


<!-- Remember to update the changelog for user-facing changes. -->