### PR TITLE
handle empty selection in and add test for modelToTextDocumentPositionParams

### DIFF
--- a/shared/src/api/client/model.test.ts
+++ b/shared/src/api/client/model.test.ts
@@ -1,0 +1,84 @@
+import { modelToTextDocumentPositionParams } from './model'
+
+describe('modelToTextDocumentPositionParams', () => {
+    test('null if visibleViewComponents is empty', () => {
+        expect(modelToTextDocumentPositionParams({ visibleViewComponents: null })).toBeNull()
+        expect(modelToTextDocumentPositionParams({ visibleViewComponents: [] })).toBeNull()
+    })
+
+    test('null if no visibleViewComponents are active', () => {
+        expect(
+            modelToTextDocumentPositionParams({
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        isActive: false,
+                        selections: [],
+                        item: { uri: 'u', text: 't', languageId: 'l' },
+                    },
+                ],
+            })
+        ).toBeNull()
+    })
+
+    test('null if active visibleViewComponents has no selection', () => {
+        expect(
+            modelToTextDocumentPositionParams({
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        isActive: true,
+                        selections: [],
+                        item: { uri: 'u', text: 't', languageId: 'l' },
+                    },
+                ],
+            })
+        ).toBeNull()
+    })
+
+    test('null if active visibleViewComponents has empty selection', () => {
+        expect(
+            modelToTextDocumentPositionParams({
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        isActive: true,
+                        selections: [
+                            {
+                                start: { line: 3, character: -1 },
+                                end: { line: 3, character: -1 },
+                                anchor: { line: 3, character: -1 },
+                                active: { line: 3, character: -1 },
+                                isReversed: false,
+                            },
+                        ],
+                        item: { uri: 'u', text: 't', languageId: 'l' },
+                    },
+                ],
+            })
+        ).toBeNull()
+    })
+
+    test('equivalent params', () => {
+        expect(
+            modelToTextDocumentPositionParams({
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        isActive: true,
+                        selections: [
+                            {
+                                start: { line: 3, character: 2 },
+                                end: { line: 3, character: 5 },
+                                anchor: { line: 3, character: 2 },
+                                active: { line: 3, character: 5 },
+                                isReversed: false,
+                            },
+                        ],
+                        item: { uri: 'u', text: 't', languageId: 'l' },
+                    },
+                ],
+            })
+        ).toEqual({ textDocument: { uri: 'u', text: 't', languageId: 'l' }, position: { line: 3, character: 2 } })
+    })
+})

--- a/shared/src/api/client/model.ts
+++ b/shared/src/api/client/model.ts
@@ -56,11 +56,13 @@ export function modelToTextDocumentPositionParams({
         return null
     }
     const sel = activeViewComponent.selections[0]
+    if (!sel) {
+        return null
+    }
     // TODO(sqs): Return null for empty selections (but currently all selected tokens are treated as an empty
-    // selection at the beginning of the token, so this would break a lot of things).
-    //
-    // HACK(sqs): Character === -1 means that the whole line is selected (this is a bug in the caller, but it is
-    // useful here).
+    // selection at the beginning of the token, so this would break a lot of things, so we only do this for empty
+    // selections when the start character is -1). HACK(sqs): Character === -1 means that the whole line is
+    // selected (this is a bug in the caller, but it is useful here).
     const isEmpty =
         sel.start.line === sel.end.line && sel.start.character === sel.end.character && sel.start.character === -1
     if (isEmpty) {


### PR DESCRIPTION
The previous bug in (not) handling empty selections (length == 0) caused some exceptions in the JS devtools console that were harmless but distracting. This fixes that, and it also adds tests.