### PR TITLE
show search dropdown menu with "How to search" link

### DIFF
--- a/web/src/global-styles/dropdown.scss
+++ b/web/src/global-styles/dropdown.scss
@@ -8,7 +8,7 @@ $dropdown-link-active-bg: var(--primary);
 $dropdown-link-disabled-color: var(--text-muted);
 $dropdown-header-color: var(--dropdown-header-color);
 $dropdown-item-padding-y: 0.25rem;
-$dropdown-item-padding-x: 0.75rem;
+$dropdown-item-padding-x: 0.5rem;
 $dropdown-padding-y: $dropdown-item-padding-y;
 
 @import 'bootstrap/scss/dropdown';

--- a/web/src/search/input/SearchButton.scss
+++ b/web/src/search/input/SearchButton.scss
@@ -1,6 +1,4 @@
 .search-button {
-    margin-left: 0.5rem;
-
     &__label {
         margin-left: 0.25rem;
     }

--- a/web/src/search/input/SearchButton.tsx
+++ b/web/src/search/input/SearchButton.tsx
@@ -1,13 +1,119 @@
+import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
+import HelpCircleOutlineIcon from 'mdi-react/HelpCircleOutlineIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
 import * as React from 'react'
+import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
-export class SearchButton extends React.Component {
+interface State {
+    isOpen: boolean
+}
+
+/**
+ * A search button with a dropdown with related links.
+ */
+export class SearchButton extends React.Component<{}, State> {
+    public state: State = { isOpen: false }
+
     public render(): JSX.Element | null {
+        const docsURLPrefix = window.context.sourcegraphDotComMode ? 'https://docs.sourcegraph.com' : '/help'
+
         return (
-            <button className="search-button btn btn-primary" type="submit">
-                <SearchIcon className="icon-inline" />
-                <span className="search-button__label">Search</span>
-            </button>
+            <ButtonDropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="search-button">
+                <button className="btn btn-primary rounded-0" type="submit">
+                    <SearchIcon className="icon-inline" />
+                    <span className="search-button__label">Search</span>
+                </button>
+                <DropdownToggle caret={false} className="px-1 d-flex border-0 text-muted rounded-right">
+                    <HelpCircleOutlineIcon className="icon-inline small" />
+                </DropdownToggle>
+                <DropdownMenu right={true} className="pb-0">
+                    <DropdownItem header={true}>
+                        <strong>Search reference</strong>
+                    </DropdownItem>
+                    <DropdownItem divider={true} />
+                    <DropdownItem header={true}>Finding matches:</DropdownItem>
+                    <ul className="list-unstyled px-2 mb-2">
+                        <li>
+                            <span className="text-muted small">Regexp:</span>{' '}
+                            <code>
+                                <strong>(read|write)File</strong>
+                            </code>
+                        </li>
+                        <li>
+                            <span className="text-muted small">Exact:</span>{' '}
+                            <code>
+                                "<strong>fs.open(f)</strong>"
+                            </code>
+                        </li>
+                    </ul>
+                    <DropdownItem divider={true} />
+                    <DropdownItem header={true}>Common search keywords:</DropdownItem>
+                    <ul className="list-unstyled px-2 mb-2">
+                        <li>
+                            <code>
+                                repo:<strong>my/repo</strong>
+                            </code>
+                        </li>
+                        {window.context.sourcegraphDotComMode && (
+                            <li>
+                                <code>
+                                    repo:<strong>github.com/myorg/</strong>
+                                </code>
+                            </li>
+                        )}
+                        <li>
+                            <code>
+                                file:<strong>my/file</strong>
+                            </code>
+                        </li>
+                        <li>
+                            <code>
+                                lang:<strong>javascript</strong>
+                            </code>
+                        </li>
+                    </ul>
+                    <DropdownItem divider={true} />
+                    <DropdownItem header={true}>Diff/commit search keywords:</DropdownItem>
+                    <ul className="list-unstyled px-2 mb-2">
+                        <li>
+                            <code>type:diff</code> <em className="text-muted small">or</em> <code>type:commit</code>
+                        </li>
+                        <li>
+                            <code>
+                                after:<strong>"2 weeks ago"</strong>
+                            </code>
+                        </li>
+                        <li>
+                            <code>
+                                author:<strong>alice@example.com</strong>
+                            </code>
+                        </li>
+                        <li className="text-nowrap">
+                            <code>
+                                repo:<strong>r@*refs/heads/</strong>
+                            </code>{' '}
+                            <span className="text-muted small">(all branches)</span>
+                        </li>
+                    </ul>
+                    <DropdownItem divider={true} />
+                    <a
+                        href={`${docsURLPrefix}/user/search/queries`}
+                        className="dropdown-item d-flex align-items-center"
+                        target="_blank"
+                        onClick={this.toggleIsOpen}
+                    >
+                        <ExternalLinkIcon className="icon-inline small mr-1 mb-1" /> All search keywords
+                    </a>
+                    {window.context.sourcegraphDotComMode && (
+                        <div className="p-2 alert alert-info small rounded-0 mb-0 mt-1">
+                            On Sourcegraph.com, use a <code>repo:</code> filter to narrow your search to &le;500
+                            repositories.
+                        </div>
+                    )}
+                </DropdownMenu>
+            </ButtonDropdown>
         )
     }
+
+    private toggleIsOpen = () => this.setState(prevState => ({ isOpen: !prevState.isOpen }))
 }


### PR DESCRIPTION
fix #1513 

In the future we can add more to help the user construct their query (recent searches, saved searches, quick reference, etc.).

![screenshot from 2018-12-23 14-58-28](https://user-images.githubusercontent.com/1976/50387487-45be4e80-06c3-11e9-8360-8b76b6020aa9.png)
![screenshot from 2018-12-23 14-58-23](https://user-images.githubusercontent.com/1976/50387488-45be4e80-06c3-11e9-9461-052bc639f672.png)
![screenshot from 2018-12-23 14-58-05](https://user-images.githubusercontent.com/1976/50387489-45be4e80-06c3-11e9-90e9-e77686311408.png)
