### PR TITLE
inline symbol search trigger is now `@!`

### DIFF
--- a/client/browser/src/shared/components/SymbolsDropdownContainer.tsx
+++ b/client/browser/src/shared/components/SymbolsDropdownContainer.tsx
@@ -286,7 +286,7 @@ export class SymbolsDropdownContainer extends React.Component<Props, State> {
     private extractSymbolQueries(text: string): SymbolQuery[] {
         const out: SymbolQuery[] = []
 
-        const symbolAutoCompleteRegexp = /!(\w[^\s]*)/g
+        const symbolAutoCompleteRegexp = /@!(\w[^\s]*)/g
 
         let match = symbolAutoCompleteRegexp.exec(text)
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/1201.

Inline symbol search is now `@!` rather than `!`.