### PR TITLE
sort dirs/files top-bottom in columns on tree page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The Git blame information shown at the end of a line is now provided by the [Git extras extension](https://sourcegraph.com/extensions/sourcegraph/git-extras). You must add that extension to continue using this feature.
 - The `appURL` site configuration option was renamed to `externalURL`.
 - The default for `experimentalFeatures.canonicalURLRedirect` in site config was changed back to `disabled`.
+- The repository and directory pages now show all entries together instead of showing files and (sub)directories separately.
 
 ### Fixed
 

--- a/web/src/repo/TreePage.scss
+++ b/web/src/repo/TreePage.scss
@@ -14,14 +14,14 @@
 
     &__section {
         margin-bottom: 1.75rem;
+        width: 100%;
 
         &-header {
             margin-bottom: 0.125rem;
         }
 
+        max-width: 64rem;
         &-search {
-            width: 100%;
-            max-width: 48rem;
             display: flex;
             .search-help {
                 margin-left: 0.25rem;
@@ -29,24 +29,29 @@
                 margin-top: -2px;
             }
         }
-
-        &--commits,
-        &--discussions {
-            width: 100%;
-            max-width: 64rem;
-        }
     }
 
-    &__entries {
-        display: grid;
-        width: 100%;
-        grid-column-gap: 2.25rem;
+    // To avoid having empty columns (and thus the items appearing not flush with the left margin),
+    // the component only applies this class when there are >= 6 items. This number is chosen
+    // because it is greater than the maximum number of columns that will be shown and ensures that
+    // at least 1 column has more than 1 item.
+    //
+    // See also MIN_ENTRIES_FOR_COLUMN_LAYOUT.
+    &__entries--columns {
+        column-gap: 2.25rem;
+        column-width: 13rem;
 
-        &-directories {
-            grid-template-columns: repeat(auto-fill, minmax(7rem, auto));
+        @media (max-width: $media-sm) {
+            column-count: 1;
         }
-        &-files {
-            grid-template-columns: repeat(auto-fill, minmax(13rem, auto));
+        @media (max-width: $media-md) {
+            column-count: 3;
+        }
+        @media (max-width: $media-lg) {
+            column-count: 4;
+        }
+        @media (min-width: $media-lg) {
+            column-count: 5;
         }
     }
 

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -285,14 +285,9 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 </Form>
                             </section>
                             <TreeEntriesSection
-                                title="Directories"
+                                title="Files and directories"
                                 parentPath={this.props.filePath}
-                                entries={this.state.treeOrError.directories}
-                            />
-                            <TreeEntriesSection
-                                title="Files"
-                                parentPath={this.props.filePath}
-                                entries={this.state.treeOrError.files}
+                                entries={this.state.treeOrError.entries}
                             />
                             {isDiscussionsEnabled(this.props.settingsCascade) && (
                                 <div className="tree-page__section mt-2 tree-page__section--discussions">

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -54,6 +54,28 @@ const TreeEntry: React.FunctionComponent<{
     )
 }
 
+/**
+ * Use a multi-column layout for tree entries when there are at least this many. See TreePage.scss
+ * for more information.
+ */
+const MIN_ENTRIES_FOR_COLUMN_LAYOUT = 6
+
+const TreeEntriesSection: React.FunctionComponent<{
+    title: string
+    parentPath: string
+    entries: Pick<GQL.ITreeEntry, 'name' | 'isDirectory' | 'url'>[]
+}> = ({ title, parentPath, entries }) =>
+    entries.length > 0 ? (
+        <section className="tree-page__section">
+            <h3 className="tree-page__section-header">{title}</h3>
+            <div className={entries.length > MIN_ENTRIES_FOR_COLUMN_LAYOUT ? 'tree-page__entries--columns' : undefined}>
+                {entries.map((e, i) => (
+                    <TreeEntry key={i} isDir={e.isDirectory} name={e.name} parentPath={parentPath} url={e.url} />
+                ))}
+            </div>
+        </section>
+    ) : null
+
 const fetchTreeCommits = memoizeObservable(
     (args: {
         repo: GQL.ID
@@ -262,38 +284,16 @@ export class TreePage extends React.PureComponent<Props, State> {
                                     <SearchButton />
                                 </Form>
                             </section>
-                            {this.state.treeOrError.directories.length > 0 && (
-                                <section className="tree-page__section">
-                                    <h3 className="tree-page__section-header">Directories</h3>
-                                    <div className="tree-page__entries tree-page__entries-directories">
-                                        {this.state.treeOrError.directories.map((e, i) => (
-                                            <TreeEntry
-                                                key={i}
-                                                isDir={true}
-                                                name={e.name}
-                                                parentPath={this.props.filePath}
-                                                url={e.url}
-                                            />
-                                        ))}
-                                    </div>
-                                </section>
-                            )}
-                            {this.state.treeOrError.files.length > 0 && (
-                                <section className="tree-page__section">
-                                    <h3 className="tree-page__section-header">Files</h3>
-                                    <div className="tree-page__entries tree-page__entries-files">
-                                        {this.state.treeOrError.files.map((e, i) => (
-                                            <TreeEntry
-                                                key={i}
-                                                isDir={false}
-                                                name={e.name}
-                                                parentPath={this.props.filePath}
-                                                url={e.url}
-                                            />
-                                        ))}
-                                    </div>
-                                </section>
-                            )}
+                            <TreeEntriesSection
+                                title="Directories"
+                                parentPath={this.props.filePath}
+                                entries={this.state.treeOrError.directories}
+                            />
+                            <TreeEntriesSection
+                                title="Files"
+                                parentPath={this.props.filePath}
+                                entries={this.state.treeOrError.files}
+                            />
                             {isDiscussionsEnabled(this.props.settingsCascade) && (
                                 <div className="tree-page__section mt-2 tree-page__section--discussions">
                                     <h3 className="tree-page__section-header">Discussions</h3>

--- a/web/src/repo/backend.tsx
+++ b/web/src/repo/backend.tsx
@@ -275,13 +275,7 @@ export const fetchTree = memoizeObservable(
                             tree(path: $filePath) {
                                 isRoot
                                 url
-                                directories(first: $first) {
-                                    name
-                                    path
-                                    isDirectory
-                                    url
-                                }
-                                files(first: $first) {
+                                entries(first: $first) {
                                     name
                                     path
                                     isDirectory


### PR DESCRIPTION
Previously, tree entries (files and dirs) were sorted left-right, which was hard to read. Now they are sorted top-bottom, which is more familiar and easier to read.

See feedback at https://twitter.com/srcgraph/status/1078011692871757825.

This also removes the usage of CSS grid layout favor of CSS column layout. There are some edge cases, such as column sparseness on wide screens with a small number of entries. To completely fix this, it is necessary to use JavaScript (which is not worth it right now due to the added complexity).

### After

![screenshot from 2018-12-26 23-33-04](https://user-images.githubusercontent.com/1976/50467141-25162300-0967-11e9-9c30-d57fbb9609ca.png)


### Before

![screenshot from 2018-12-26 23-39-32](https://user-images.githubusercontent.com/1976/50467252-9b1a8a00-0967-11e9-933b-348a74b65d17.png)


---

### Other "after" screenshots

![screenshot from 2018-12-26 23-33-13](https://user-images.githubusercontent.com/1976/50467140-247d8c80-0967-11e9-8b0d-09058c47e1af.png)
![screenshot from 2018-12-26 23-33-50](https://user-images.githubusercontent.com/1976/50467139-23e4f600-0967-11e9-8b4d-719f0f6ef668.png)
