### PR TITLE
fix popover link triggering open

### DIFF
--- a/shared/src/components/PopoverButton.tsx
+++ b/shared/src/components/PopoverButton.tsx
@@ -74,6 +74,9 @@ export class PopoverButton extends React.PureComponent<Props, State> {
                 toggle={this.toggleVisibility}
                 target={this.rootRef}
                 className={`popover-button2__popover ${this.props.popoverClassName || ''}`}
+                // This popover is manually triggered. Must remove default "click" trigger so that
+                // in link mode (this.props.link), only caret (not link) opens the popover.
+                trigger=""
             >
                 {isOpen && <Shortcut ordered={['Escape']} onMatch={this.toggleVisibility} ignoreInput={true} />}
                 {this.props.popoverElement}

--- a/web/src/components/PopoverButton.tsx
+++ b/web/src/components/PopoverButton.tsx
@@ -91,6 +91,9 @@ export class PopoverButton extends React.PureComponent<Props, State> {
                 toggle={this.onPopoverVisibilityToggle}
                 target={this.rootRef}
                 className={`popover-button__popover ${this.props.popoverClassName || ''}`}
+                // This popover is manually triggered. Must remove default "click" trigger so that
+                // in link mode (this.props.link), only caret (not link) opens the popover.
+                trigger=""
             >
                 {this.props.popoverElement}
             </Popover>
@@ -124,7 +127,7 @@ export class PopoverButton extends React.PureComponent<Props, State> {
         )
     }
 
-    private onClickLink = (e: React.MouseEvent<HTMLElement>): void => {
+    private onClickLink = (): void => {
         this.setState({ open: false })
     }
 


### PR DESCRIPTION
The repo popover has 2 parts: `repolink caret`. Clicking on the repolink part of the repo popover button should NOT open the popover. Upgrading reactstrap changed (broke) this behavior. This commit adds the necessary props to reactstrap's Popover to revert to the previous correct behavior.