### PR TITLE
Fix Phabricator script

### DIFF
--- a/client/browser/gulpfile.ts
+++ b/client/browser/gulpfile.ts
@@ -18,7 +18,7 @@ export function watch(): ChildProcess {
     })
 }
 
-const PHABRICATOR_EXTENSION_FILES = path.join(__dirname, './build/phabricator/**')
+const PHABRICATOR_EXTENSION_FILES = path.join(__dirname, './build/phabricator/dist/**')
 
 /**
  * Copies the phabricator extension over to the ui/assets folder so they can be served by the webapp. The package

--- a/client/browser/src/browser/types.ts
+++ b/client/browser/src/browser/types.ts
@@ -25,13 +25,6 @@ export interface FeatureFlags {
      */
     newInject: boolean
     /**
-     * Enable the use of Sourcegraph extensions.
-     *
-     * @duration temporary - to be removed by @chris when extensions are stable and out of
-     * beta.
-     */
-    useExtensions: boolean
-    /**
      * Enable inline symbol search by typing `!symbolQueryText` inside of GitHub PR comments (requires reload after toggling).
      *
      * @duration temporary - needs feedback from users.
@@ -49,7 +42,6 @@ export interface FeatureFlags {
 export const featureFlagDefaults: FeatureFlags = {
     newInject: false,
     renderMermaidGraphsEnabled: true,
-    useExtensions: false,
     inlineSymbolSearchEnabled: true,
     allowErrorReporting: false,
 }

--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -18,7 +18,6 @@ import {
     setInlineSymbolSearchEnabled,
     setRenderMermaidGraphsEnabled,
     setSourcegraphUrl,
-    setUseExtensions,
 } from '../../shared/util/context'
 import { featureFlags } from '../../shared/util/featureFlags'
 import { assertEnv } from '../envAssertion'
@@ -120,8 +119,6 @@ function injectApplication(): void {
                 window.addEventListener('unload', () => subscriptions.unsubscribe())
             }
         }
-
-        setUseExtensions(items.featureFlags.useExtensions === undefined ? false : items.featureFlags.useExtensions)
     }
 
     storage.getSync(handleGetStorage)

--- a/client/browser/src/extension/scripts/options.tsx
+++ b/client/browser/src/extension/scripts/options.tsx
@@ -19,7 +19,7 @@ assertEnv('OPTIONS')
 
 initSentry('options')
 
-type State = Pick<FeatureFlags, 'useExtensions' | 'allowErrorReporting'> & { sourcegraphURL: string | null }
+type State = Pick<FeatureFlags, 'allowErrorReporting'> & { sourcegraphURL: string | null }
 
 const keyIsFeatureFlag = (key: string): key is keyof FeatureFlags =>
     !!Object.keys(featureFlagDefaults).find(k => key === k)
@@ -34,14 +34,14 @@ const toggleFeatureFlag = (key: string) => {
 }
 
 class Options extends React.Component<{}, State> {
-    public state: State = { sourcegraphURL: null, useExtensions: false, allowErrorReporting: false }
+    public state: State = { sourcegraphURL: null, allowErrorReporting: false }
 
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            storage.observeSync('featureFlags').subscribe(({ allowErrorReporting, useExtensions }) => {
-                this.setState({ allowErrorReporting, useExtensions })
+            storage.observeSync('featureFlags').subscribe(({ allowErrorReporting }) => {
+                this.setState({ allowErrorReporting })
             })
         )
 
@@ -77,10 +77,7 @@ class Options extends React.Component<{}, State> {
             fetchAccessTokenIDs,
 
             toggleFeatureFlag,
-            featureFlags: [
-                { key: 'useExtensions', value: this.state.useExtensions },
-                { key: 'allowErrorReporting', value: this.state.allowErrorReporting },
-            ],
+            featureFlags: [{ key: 'allowErrorReporting', value: this.state.allowErrorReporting }],
         }
 
         return <OptionsContainer {...props} />

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -38,10 +38,10 @@ import {
 import { sendMessage } from '../../browser/runtime'
 import { isInPage } from '../../context'
 import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../shared/backend/errors'
-import { createLSPFromExtensions, lspViaAPIXlang, toTextDocumentIdentifier } from '../../shared/backend/lsp'
+import { createLSPFromExtensions, toTextDocumentIdentifier } from '../../shared/backend/lsp'
 import { ButtonProps, CodeViewToolbar } from '../../shared/components/CodeViewToolbar'
 import { resolveRev, retryWhenCloneInProgressError } from '../../shared/repo/backend'
-import { eventLogger, sourcegraphUrl, useExtensions } from '../../shared/util/context'
+import { eventLogger, sourcegraphUrl } from '../../shared/util/context'
 import { bitbucketServerCodeHost } from '../bitbucket/code_intelligence'
 import { githubCodeHost } from '../github/code_intelligence'
 import { gitlabCodeHost } from '../gitlab/code_intelligence'
@@ -250,8 +250,7 @@ function initCodeIntelligence(
         extensionsController,
     }: PlatformContextProps & ExtensionsControllerProps = initializeExtensions(codeHost)
 
-    const shouldUseExtensions = useExtensions || sourcegraphUrl === 'https://sourcegraph.com'
-    const { getHover } = shouldUseExtensions ? createLSPFromExtensions(extensionsController) : lspViaAPIXlang
+    const { getHover } = createLSPFromExtensions(extensionsController)
 
     /** Emits when the close button was clicked */
     const closeButtonClicks = new Subject<MouseEvent>()

--- a/client/browser/src/libs/options/Menu.tsx
+++ b/client/browser/src/libs/options/Menu.tsx
@@ -4,6 +4,11 @@ import * as React from 'react'
 import { OptionsHeader, OptionsHeaderProps } from './Header'
 import { ServerURLForm, ServerURLFormProps } from './ServerURLForm'
 
+interface ConfigurableFeatureFlag {
+    key: string
+    value: boolean
+}
+
 export interface OptionsMenuProps
     extends OptionsHeaderProps,
         Pick<ServerURLFormProps, Exclude<keyof ServerURLFormProps, 'value' | 'onChange' | 'onSubmit'>> {
@@ -13,15 +18,14 @@ export interface OptionsMenuProps
 
     isSettingsOpen?: boolean
     toggleFeatureFlag: (key: string) => void
-    featureFlags: { key: string; value: boolean }[]
+    featureFlags?: ConfigurableFeatureFlag[]
 }
 
 const buildFeatureFlagToggleHandler = (key: string, handler: OptionsMenuProps['toggleFeatureFlag']) => () =>
     handler(key)
 
-const withSentry = (flags: OptionsMenuProps['featureFlags']) => flags.filter(({ key }) => key === 'allowErrorReporting')
-const withOutSentry = (flags: OptionsMenuProps['featureFlags']) =>
-    flags.filter(({ key }) => key !== 'allowErrorReporting')
+const withSentry = (flags: ConfigurableFeatureFlag[]) => flags.filter(({ key }) => key === 'allowErrorReporting')
+const withOutSentry = (flags: ConfigurableFeatureFlag[]) => flags.filter(({ key }) => key !== 'allowErrorReporting')
 
 const isFullPage = (): boolean =>
     !new URLSearchParams(window.location.search).get('popup')
@@ -44,47 +48,49 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
             onSubmit={onURLSubmit}
             className="options-menu__section"
         />
-        {isSettingsOpen && (
-            <div className="options-menu__section">
-                <label>Configuration</label>
-                <div>
-                    {withSentry(featureFlags).map(({ key, value }) => (
-                        <div className="form-check" key={key}>
-                            <label className="form-check-label">
-                                <input
-                                    id={key}
-                                    onClick={buildFeatureFlagToggleHandler(key, toggleFeatureFlag)}
-                                    className="form-check-input"
-                                    type="checkbox"
-                                    checked={value}
-                                />{' '}
-                                {upperFirst(lowerCase(key))}
-                            </label>
-                        </div>
-                    ))}
+        {isSettingsOpen &&
+            featureFlags && (
+                <div className="options-menu__section">
+                    <label>Configuration</label>
+                    <div>
+                        {withSentry(featureFlags).map(({ key, value }) => (
+                            <div className="form-check" key={key}>
+                                <label className="form-check-label">
+                                    <input
+                                        id={key}
+                                        onClick={buildFeatureFlagToggleHandler(key, toggleFeatureFlag)}
+                                        className="form-check-input"
+                                        type="checkbox"
+                                        checked={value}
+                                    />{' '}
+                                    {upperFirst(lowerCase(key))}
+                                </label>
+                            </div>
+                        ))}
+                    </div>
                 </div>
-            </div>
-        )}
-        {isSettingsOpen && (
-            <div className="options-menu__section">
-                <label>Experimental configuration</label>
-                <div>
-                    {withOutSentry(featureFlags).map(({ key, value }) => (
-                        <div className="form-check" key={key}>
-                            <label className="form-check-label">
-                                <input
-                                    id={key}
-                                    onClick={buildFeatureFlagToggleHandler(key, toggleFeatureFlag)}
-                                    className="form-check-input"
-                                    type="checkbox"
-                                    checked={value}
-                                />{' '}
-                                {upperFirst(lowerCase(key))}
-                            </label>
-                        </div>
-                    ))}
+            )}
+        {isSettingsOpen &&
+            featureFlags && (
+                <div className="options-menu__section">
+                    <label>Experimental configuration</label>
+                    <div>
+                        {withOutSentry(featureFlags).map(({ key, value }) => (
+                            <div className="form-check" key={key}>
+                                <label className="form-check-label">
+                                    <input
+                                        id={key}
+                                        onClick={buildFeatureFlagToggleHandler(key, toggleFeatureFlag)}
+                                        className="form-check-input"
+                                        type="checkbox"
+                                        checked={value}
+                                    />{' '}
+                                    {upperFirst(lowerCase(key))}
+                                </label>
+                            </div>
+                        ))}
+                    </div>
                 </div>
-            </div>
-        )}
+            )}
     </div>
 )

--- a/client/browser/src/libs/phabricator/backend.tsx
+++ b/client/browser/src/libs/phabricator/backend.tsx
@@ -268,6 +268,7 @@ const createPhabricatorRepo = memoizeObservable(
             addPhabricatorRepo(callsign: $callsign, uri: $repoName, url: $phabricatorURL) { alwaysNil }
         }`,
             variables: options,
+            retry: false,
         }).pipe(
             map(({ data, errors }) => {
                 if (!data || (errors && errors.length > 0)) {

--- a/client/browser/src/libs/phabricator/dom_functions.ts
+++ b/client/browser/src/libs/phabricator/dom_functions.ts
@@ -1,5 +1,4 @@
 import { DOMFunctions } from '@sourcegraph/codeintellify'
-import { CodeView } from '../code_intelligence'
 
 const getLineNumberCell = (codeElement: HTMLElement) => {
     let elem: HTMLElement | null = codeElement
@@ -94,25 +93,12 @@ export const diffDomFunctions: DOMFunctions = {
 export const diffusionDOMFns: DOMFunctions = {
     getCodeElementFromTarget: target => target.closest('td'),
     getCodeElementFromLineNumber: (codeView, line) => {
-        const lineAnchor = codeView.querySelector(`[data-n="${line}"]`)
-        if (!lineAnchor) {
-            return null
-        }
-        const lineCell = lineAnchor.closest('th')
-        if (!lineCell) {
-            return null
+        const row = codeView.querySelector(`tr:nth-of-type(${line})`)
+        if (!row) {
+            throw new Error(`unable to find row ${line} from code view`)
         }
 
-        let codeElement = lineCell as HTMLElement | null
-        while (
-            codeElement !== null &&
-            codeElement.tagName !== 'TD' &&
-            !codeElement.classList.contains('phabricator-source-code')
-        ) {
-            codeElement = lineCell.nextElementSibling as HTMLElement | null
-        }
-
-        return codeElement
+        return row.querySelector<HTMLElement>('td')
     },
     getLineNumberFromCodeElement: codeElement => {
         let lineCell = codeElement as HTMLElement | null
@@ -129,18 +115,9 @@ export const diffusionDOMFns: DOMFunctions = {
 
         const lineAnchor = lineCell.querySelector('a')
         if (!lineAnchor) {
-            throw new Error('could not find line number cell from code element')
+            throw new Error('could not find line number anchor from code element')
         }
-        const lineNumberStr = lineAnchor.dataset.n
-        if (!lineNumberStr) {
-            throw new Error('could not get line number from line number cell')
-        }
-
-        return parseInt(lineNumberStr, 10)
+        return parseInt(lineAnchor.textContent || '', 10)
     },
     isFirstCharacterDiffIndicator: () => false,
-}
-
-export const getLineRanges: CodeView['getLineRanges'] = () => {
-    throw new Error('TODO: implement')
 }

--- a/client/browser/src/libs/phabricator/scrape.ts
+++ b/client/browser/src/libs/phabricator/scrape.ts
@@ -1,0 +1,28 @@
+export function getFilepathFromFileForDiff(fileContainer: HTMLElement): { filePath: string; baseFilePath?: string } {
+    const filePath = fileContainer.children[3].textContent as string
+    const metas = fileContainer.querySelectorAll('.differential-meta-notice')
+    let baseFilePath: string | undefined
+    const movedFilePrefix = 'This file was moved from '
+    for (const meta of metas) {
+        let metaText = meta.textContent!
+        if (metaText.startsWith(movedFilePrefix)) {
+            metaText = metaText.substr(0, metaText.length - 1) // remove trailing '.'
+            baseFilePath = metaText.split(movedFilePrefix)[1]
+            break
+        }
+    }
+    return { filePath, baseFilePath }
+}
+
+export function getFilePathFromFileForRevision(codeView: HTMLElement): string {
+    const filePathContainer = document.querySelector('.differential-file-icon-header')
+    if (!filePathContainer) {
+        throw new Error('Unable to find file path container for revision code view')
+    }
+
+    if (!filePathContainer.textContent) {
+        throw new Error('`textContent` is undefined for revision file path container')
+    }
+
+    return filePathContainer.textContent
+}

--- a/client/browser/src/libs/phabricator/util.tsx
+++ b/client/browser/src/libs/phabricator/util.tsx
@@ -439,22 +439,6 @@ export function getPhabricatorState(
     })
 }
 
-export function getFilepathFromFile(fileContainer: HTMLElement): { filePath: string; baseFilePath?: string } {
-    const filePath = fileContainer.children[3].textContent as string
-    const metas = fileContainer.querySelectorAll('.differential-meta-notice')
-    let baseFilePath: string | undefined
-    const movedFilePrefix = 'This file was moved from '
-    for (const meta of metas) {
-        let metaText = meta.textContent!
-        if (metaText.startsWith(movedFilePrefix)) {
-            metaText = metaText.substr(0, metaText.length - 1) // remove trailing '.'
-            baseFilePath = metaText.split(movedFilePrefix)[1]
-            break
-        }
-    }
-    return { filePath, baseFilePath }
-}
-
 /**
  * This hacks javelin Stratcom to ignore command + click actions on sg-clickable tokens.
  * Without this, two windows open when a user command + clicks on a token.

--- a/client/browser/src/libs/sentry/index.ts
+++ b/client/browser/src/libs/sentry/index.ts
@@ -35,7 +35,6 @@ export function initSentry(script: 'content' | 'options' | 'background'): void {
         Sentry.configureScope(async scope => {
             scope.setTag('script', script)
             scope.setTag('extension_version', getExtensionVersionSync())
-            scope.setTag('extensions', flags.useExtensions ? 'enabled' : 'disabled')
 
             const codeHosts: CodeHost[] = [bitbucketServerCodeHost, githubCodeHost, gitlabCodeHost, phabricatorCodeHost]
             for (const { check, name } of codeHosts) {

--- a/client/browser/src/platform/settings.ts
+++ b/client/browser/src/platform/settings.ts
@@ -1,6 +1,6 @@
 import { applyEdits, parse as parseJSONC } from '@sqs/jsonc-parser'
 import { setProperty } from '@sqs/jsonc-parser/lib/edit'
-import { Observable } from 'rxjs'
+import { Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { SettingsEdit } from '../../../../shared/src/api/client/services/settings'
 import { gql, graphQLContent } from '../../../../shared/src/graphql/graphql'
@@ -13,6 +13,7 @@ import {
 } from '../../../../shared/src/settings/settings'
 import { createAggregateError, isErrorLike } from '../../../../shared/src/util/errors'
 import storage, { StorageItems } from '../browser/storage'
+import { isInPage } from '../context'
 import { getContext } from '../shared/backend/context'
 import { queryGraphQL } from '../shared/backend/graphql'
 import { sourcegraphUrl } from '../shared/util/context'
@@ -20,25 +21,27 @@ import { sourcegraphUrl } from '../shared/util/context'
 /**
  * The settings cascade consisting solely of client settings.
  */
-export const storageSettingsCascade: Observable<SettingsCascade> = storage.observeSync('clientSettings').pipe(
-    map(clientSettingsString => parseJSONC(clientSettingsString || '')),
-    map(clientSettings => ({
-        subjects: [
-            {
-                subject: {
-                    id: 'Client',
-                    settingsURL: 'N/A',
-                    viewerCanAdminister: true,
-                    __typename: 'Client',
-                    displayName: 'Client',
-                } as SettingsSubject,
-                settings: clientSettings,
-                lastID: null,
-            },
-        ],
-        final: clientSettings || {},
-    }))
-)
+export const storageSettingsCascade: Observable<SettingsCascade> = isInPage
+    ? of({ subjects: [], final: {} })
+    : storage.observeSync('clientSettings').pipe(
+          map(clientSettingsString => parseJSONC(clientSettingsString || '')),
+          map(clientSettings => ({
+              subjects: [
+                  {
+                      subject: {
+                          id: 'Client',
+                          settingsURL: 'N/A',
+                          viewerCanAdminister: true,
+                          __typename: 'Client',
+                          displayName: 'Client',
+                      } as SettingsSubject,
+                      settings: clientSettings,
+                      lastID: null,
+                  },
+              ],
+              final: clientSettings || {},
+          }))
+      )
 
 /**
  * Merge two settings cascades (used to merge viewer settings and client settings).

--- a/client/browser/src/platform/worker.ts
+++ b/client/browser/src/platform/worker.ts
@@ -1,0 +1,15 @@
+import { ajax } from 'rxjs/ajax'
+import ExtensionHostWorker from 'worker-loader?inline!../../../../shared/src/api/extension/main.worker.ts'
+
+export function createExtensionHostWorker(): ExtensionHostWorker {
+    return new ExtensionHostWorker()
+}
+
+export async function createBlobURLForBundle(bundleURL: string): Promise<string> {
+    const req = await ajax({
+        url: bundleURL,
+        crossDomain: true,
+        responseType: 'blob',
+    }).toPromise()
+    return window.URL.createObjectURL(req.response)
+}

--- a/client/browser/src/shared/backend/headers.tsx
+++ b/client/browser/src/shared/backend/headers.tsx
@@ -20,7 +20,9 @@ export function getHeaders(
     useToken = true
 ): Observable<{ [name: string]: string } | undefined> {
     if (isPhabricator && isInPage) {
-        return of(undefined)
+        return of({
+            'X-Requested-With': `Sourcegraph - ${getPlatformName()} v${getExtensionVersionSync()}`,
+        })
     }
 
     return of(url).pipe(

--- a/client/browser/src/shared/backend/lsp.tsx
+++ b/client/browser/src/shared/backend/lsp.tsx
@@ -1,24 +1,11 @@
 import { Location } from '@sourcegraph/extension-api-types'
-import { from, Observable, of, OperatorFunction, throwError } from 'rxjs'
-import { ajax, AjaxResponse } from 'rxjs/ajax'
-import { catchError, map, switchMap, tap } from 'rxjs/operators'
+import { from, Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
 import { TextDocumentIdentifier } from '../../../../../shared/src/api/client/types/textDocument'
 import { TextDocumentPositionParams } from '../../../../../shared/src/api/protocol'
 import { Controller } from '../../../../../shared/src/extensions/controller'
-import { getModeFromPath } from '../../../../../shared/src/languages'
-import {
-    AbsoluteRepo,
-    AbsoluteRepoFilePosition,
-    FileSpec,
-    makeRepoURI,
-    RepoSpec,
-    ResolvedRevSpec,
-} from '../../../../../shared/src/util/url'
-import { canFetchForURL, DEFAULT_SOURCEGRAPH_URL, repoUrlCache, sourcegraphUrl } from '../util/context'
-import { memoizeObservable } from '../util/memoize'
-import { normalizeAjaxError, NoSourcegraphURLError } from './errors'
-import { getHeaders } from './headers'
+import { AbsoluteRepoFilePosition, FileSpec, RepoSpec, ResolvedRevSpec } from '../../../../../shared/src/util/url'
 
 export interface LSPRequest {
     method: string
@@ -28,195 +15,13 @@ export interface LSPRequest {
 /** LSP proxy error code for unsupported modes */
 export const EMODENOTFOUND = -32000
 
-/**
- * Modes that are known to not be supported because the server replied with a mode not found error
- */
-const unsupportedModes = new Set<string>()
-
 export function isEmptyHover(hover: HoverMerged | null): boolean {
     return !hover || !hover.contents || (Array.isArray(hover.contents) && hover.contents.length === 0)
 }
 
-const request = (url: string, method: string, requests: any[]): Observable<AjaxResponse> =>
-    getHeaders(url).pipe(
-        switchMap(headers =>
-            ajax({
-                method: 'POST',
-                url: `${url}/.api/xlang/${method || ''}`,
-                headers,
-                crossDomain: true,
-                withCredentials: !(headers && headers.authorization),
-                body: JSON.stringify(requests),
-                async: true,
-            })
-        )
-    )
-
-export function sendLSPHTTPRequests(requests: any[], url: string = sourcegraphUrl): Observable<any[]> {
-    const sendTo = (urlsToTry: string[]): Observable<AjaxResponse> => {
-        if (urlsToTry.length === 0) {
-            return throwError(new NoSourcegraphURLError())
-        }
-
-        const urlToTry = urlsToTry[0]
-        const urlPathHint = requests[1] && requests[1].method
-
-        return request(urlToTry, urlPathHint, requests).pipe(
-            // Workaround for https://github.com/ReactiveX/rxjs/issues/3606
-            tap(response => {
-                if (response.status === 0) {
-                    throw Object.assign(new Error('Ajax status 0'), response)
-                }
-            }),
-            catchError(err => {
-                if (urlsToTry.length === 1) {
-                    // We don't have any fallbacks left, so throw the most recent error.
-                    throw err
-                } else {
-                    return sendTo(urlsToTry.slice(1))
-                }
-            }),
-            catchError<AjaxResponse, never>(err => {
-                normalizeAjaxError(err)
-                throw err
-            })
-        )
-    }
-
-    return sendTo([url, DEFAULT_SOURCEGRAPH_URL].filter(url => canFetchForURL(url))).pipe(
-        map(({ response }) => response)
-    )
-}
-
-function wrapLSP(req: LSPRequest, ctx: AbsoluteRepo, path: string): any[] {
-    return [
-        {
-            id: 0,
-            method: 'initialize',
-            params: {
-                rootUri: `git://${ctx.repoName}?${ctx.commitID}`,
-                initializationOptions: { mode: `${getModeFromPath(path)}` },
-            },
-        },
-        {
-            id: 1,
-            ...req,
-        },
-        {
-            id: 2,
-            method: 'shutdown',
-        },
-        {
-            // id not included on 'exit' requests
-            method: 'exit',
-        },
-    ]
-}
-
-/**
- * Inspects a response from LSP Proxy and throws an exception if the response
- * has an error. This is intended to be used in rxjs: pipe(...throwIfError)
- */
-const extractLSPResponse: OperatorFunction<AjaxResponse, any> = source =>
-    source.pipe(
-        tap(ajaxResponse => {
-            // Workaround for https://github.com/ReactiveX/rxjs/issues/3606
-            if (ajaxResponse.status === 0) {
-                throw Object.assign(new Error('Ajax status 0'), ajaxResponse)
-            }
-        }),
-        catchError(err => {
-            normalizeAjaxError(err)
-            throw err
-        }),
-        map<AjaxResponse, any[]>(({ response }) => response),
-        tap(lspResponses => {
-            for (const lspResponse of lspResponses) {
-                if (lspResponse && lspResponse.error) {
-                    throw Object.assign(new Error(lspResponse.error.message), lspResponse.error, {
-                        responses: lspResponses,
-                    })
-                }
-            }
-        }),
-        map(lspResponses => lspResponses[1] && lspResponses[1].result)
-    )
-
-const getHover = memoizeObservable((pos: AbsoluteRepoFilePosition): Observable<HoverMerged | null> => {
-    const mode = getModeFromPath(pos.filePath)
-    if (!mode || unsupportedModes.has(mode)) {
-        return of({ contents: [] })
-    }
-
-    const body = wrapLSP(
-        {
-            method: 'textDocument/hover',
-            params: {
-                textDocument: {
-                    uri: `git://${pos.repoName}?${pos.commitID}#${pos.filePath}`,
-                },
-                position: {
-                    character: pos.position.character! - 1,
-                    line: pos.position.line - 1,
-                },
-            },
-        },
-        pos,
-        pos.filePath
-    )
-
-    const url = repoUrlCache[pos.repoName] || sourcegraphUrl
-    if (!url) {
-        throw new Error('Error fetching hover: No URL found.')
-    }
-    if (!canFetchForURL(url)) {
-        return of(null)
-    }
-
-    return request(url, 'textDocument/hover', body).pipe(extractLSPResponse)
-}, makeRepoURI)
-
-const fetchDefinition = memoizeObservable((pos: AbsoluteRepoFilePosition): Observable<Location | Location[] | null> => {
-    const mode = getModeFromPath(pos.filePath)
-    if (!mode || unsupportedModes.has(mode)) {
-        return of([])
-    }
-
-    const body = wrapLSP(
-        {
-            method: 'textDocument/definition',
-            params: {
-                textDocument: {
-                    uri: `git://${pos.repoName}?${pos.commitID}#${pos.filePath}`,
-                },
-                position: {
-                    character: pos.position.character! - 1,
-                    line: pos.position.line - 1,
-                },
-            },
-        },
-        pos,
-        pos.filePath
-    )
-
-    const url = repoUrlCache[pos.repoName] || sourcegraphUrl
-    if (!url) {
-        throw new Error('Error fetching definition: No URL found.')
-    }
-    if (!canFetchForURL(url)) {
-        return of([])
-    }
-    return request(url, 'textDocument/definition', body).pipe(extractLSPResponse)
-}, makeRepoURI)
-
 interface SimpleProviderFns {
     getHover: (pos: AbsoluteRepoFilePosition) => Observable<HoverMerged | null>
     fetchDefinition: (pos: AbsoluteRepoFilePosition) => Observable<Location | Location[] | null>
-}
-
-export const lspViaAPIXlang: SimpleProviderFns = {
-    getHover,
-    fetchDefinition,
 }
 
 export const toTextDocumentIdentifier = (pos: RepoSpec & ResolvedRevSpec & FileSpec): TextDocumentIdentifier => ({

--- a/client/browser/src/shared/util/context.tsx
+++ b/client/browser/src/shared/util/context.tsx
@@ -14,8 +14,6 @@ export let renderMermaidGraphsEnabled = false
 
 export let inlineSymbolSearchEnabled = false
 
-export let useExtensions = false
-
 interface UrlCache {
     [key: string]: string
 }
@@ -27,7 +25,6 @@ if (window.SG_ENV === 'EXTENSION') {
         sourcegraphUrl = items.sourcegraphURL
         renderMermaidGraphsEnabled = items.featureFlags.renderMermaidGraphsEnabled
         inlineSymbolSearchEnabled = items.featureFlags.inlineSymbolSearchEnabled
-        useExtensions = items.featureFlags.useExtensions
     })
 }
 
@@ -49,10 +46,6 @@ export function setRenderMermaidGraphsEnabled(enabled: boolean): void {
 
 export function setInlineSymbolSearchEnabled(enabled: boolean): void {
     inlineSymbolSearchEnabled = enabled
-}
-
-export function setUseExtensions(value: boolean): void {
-    useExtensions = value
 }
 
 export function getPlatformName():

--- a/client/browser/stories/options/Menu.tsx
+++ b/client/browser/stories/options/Menu.tsx
@@ -32,7 +32,6 @@ storiesOf('Options - OptionsMenu', module)
                 onURLChange={action('Sourcegraph URL changed')}
                 onURLSubmit={action('New Sourcegraph URL submitted')}
                 onSettingsClick={action('Settings clicked')}
-                featureFlags={[{ key: 'useExtensions', value: true }]}
                 isSettingsOpen={true}
                 toggleFeatureFlag={action('Feture flag toggled')}
             />

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -142,6 +142,7 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 		// to the incoming header URL. Otherwise use the configured CORS origin.
 		headerOrigin := r.Header.Get("Origin")
 		isExtensionRequest := (headerOrigin == devExtension || headerOrigin == prodExtension) && !conf.Get().DisableBrowserExtension
+
 		if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" || isExtensionRequest {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -47,7 +47,7 @@ export class ExtensionsService {
      * Most callers should use {@link ExtensionsService#activeExtensions}.
      */
     private get enabledExtensions(): Subscribable<ConfiguredExtension[]> {
-        return combineLatest(from(this.settingsService.data), this.configuredExtensions).pipe(
+        return combineLatest(from(this.settingsService.data), from(this.configuredExtensions)).pipe(
             map(([settings, configuredExtensions]) =>
                 configuredExtensions.filter(x => isExtensionEnabled(settings.final, x.id))
             )
@@ -74,7 +74,7 @@ export class ExtensionsService {
         // Extensions that have been activated (including extensions with zero "activationEvents" that evaluate to
         // true currently).
         const activatedExtensionIDs: string[] = []
-        return combineLatest(from(this.model), this.enabledExtensions).pipe(
+        return combineLatest(from(this.model).pipe(), from(this.enabledExtensions).pipe()).pipe(
             tap(([model, enabledExtensions]) => {
                 const activeExtensions = this.extensionActivationFilter(enabledExtensions, model)
                 for (const x of activeExtensions) {

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -74,7 +74,7 @@ export class ExtensionsService {
         // Extensions that have been activated (including extensions with zero "activationEvents" that evaluate to
         // true currently).
         const activatedExtensionIDs: string[] = []
-        return combineLatest(from(this.model).pipe(), from(this.enabledExtensions).pipe()).pipe(
+        return combineLatest(from(this.model), this.enabledExtensions).pipe(
             tap(([model, enabledExtensions]) => {
                 const activeExtensions = this.extensionActivationFilter(enabledExtensions, model)
                 for (const x of activeExtensions) {

--- a/shared/src/commands/commands.ts
+++ b/shared/src/commands/commands.ts
@@ -14,7 +14,7 @@ import { PlatformContext } from '../platform/context'
  */
 export function registerBuiltinClientCommands(
     { settings: settingsService, commands: commandRegistry, textDocumentLocations }: Services,
-    context: Pick<PlatformContext, 'queryGraphQL' | 'backcompatQueryLSP'>
+    context: Pick<PlatformContext, 'queryGraphQL'>
 ): Unsubscribable {
     const subscription = new Subscription()
 
@@ -88,17 +88,6 @@ export function registerBuiltinClientCommands(
                 // extension) to check that parameter and prevent the request
                 // from being sent to Sourcegraph.com.
                 from(context.queryGraphQL(query, variables, true)).toPromise(),
-        })
-    )
-
-    /**
-     * Sends a batched LSP request to the Sourcegraph LSP gateway API and returns the result. The request is
-     * performed with the privileges of the current user.
-     */
-    subscription.add(
-        commandRegistry.registerCommand({
-            command: 'queryLSP',
-            run: requests => from(context.backcompatQueryLSP(requests)).toPromise(),
         })
     )
 

--- a/shared/src/platform/context.ts
+++ b/shared/src/platform/context.ts
@@ -56,18 +56,6 @@ export interface PlatformContext {
     ): Subscribable<GraphQLResult<R>>
 
     /**
-     * Sends a batch of LSP requests to the Sourcegraph LSP gateway API and returns the result.
-     *
-     * @todo This only remains for backcompat in the browser extension's communication with old Sourcegraph
-     * instances pre-3.0.
-     * @param requests An array of LSP requests (with methods `initialize`, the (optional) request, `shutdown`,
-     *                 `exit`).
-     * @return Observable that emits the result and then completes, or an error if the request fails. The value is
-     *         an array of LSP responses.
-     */
-    backcompatQueryLSP(requests: object[]): Subscribable<object[]>
-
-    /**
      * Forces the currently displayed tooltip, if any, to update its contents.
      */
     forceUpdateTooltip(): void

--- a/web/gulpfile.ts
+++ b/web/gulpfile.ts
@@ -37,6 +37,7 @@ export async function webpackDevServer(): Promise<void> {
         contentBase: './ui/assets',
         stats: WEBPACK_STATS_OPTIONS,
         noInfo: false,
+        disableHostCheck: true,
         proxy: {
             '/': {
                 target: 'http://localhost:3081',

--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -1,4 +1,4 @@
-import { concat, Observable, ReplaySubject, throwError } from 'rxjs'
+import { concat, Observable, ReplaySubject } from 'rxjs'
 import { map, publishReplay, refCount } from 'rxjs/operators'
 import ExtensionHostWorker from 'worker-loader!../../../shared/src/api/extension/main.worker.ts'
 import { createWebWorkerMessageTransports } from '../../../shared/src/api/protocol/jsonrpc2/transports/webWorker'
@@ -50,10 +50,6 @@ export function createPlatformContext(): PlatformContext {
                     ${request}
                 `,
                 variables
-            ),
-        backcompatQueryLSP: () =>
-            throwError(
-                'queryLSP is no longer implemented; extensions must manage their own connection to a language server'
             ),
         forceUpdateTooltip: () => Tooltip.forceUpdate(),
         createExtensionHost: () => {


### PR DESCRIPTION
This PR fixes the in page Phabricator script by:

1. Modifying extension host code to not rely on browser extension APIs.
2. Removing backwards compatibility support for LSP requests.
3. Fixing Diffusion `CodeView` implementation
4. Adding revision `CodeView` implementation

Closes https://github.com/sourcegraph/sourcegraph/issues/1411.