### PR TITLE
command palette placeholder "Run Sourcegraph action..."

### DIFF
--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -137,7 +137,7 @@ export class CommandList extends React.PureComponent<Props, State> {
                             type="text"
                             className="form-control px-2 py-1 rounded-0"
                             value={this.state.input}
-                            placeholder="Command..."
+                            placeholder="Run Sourcegraph action..."
                             spellCheck={false}
                             autoCorrect="off"
                             autoComplete="off"


### PR DESCRIPTION
This makes it clearer what it does, especially when it's injected on other sites in the browser extension.