### PR TITLE
use React error boundaries to avoid blank pages upon unexpected errors

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -6,6 +6,7 @@ import { ResizablePanel } from '../../shared/src/panel/Panel'
 import { PlatformContextProps } from '../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../shared/src/settings/settings'
 import { parseHash } from '../../shared/src/util/url'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { GlobalContributions } from './contributions'
 import { ExploreSectionDescriptor } from './explore/ExploreArea'
 import { ExtensionAreaRoute } from './extensions/extension/ExtensionArea'
@@ -92,34 +93,38 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                 isSiteAdmin={!!props.authenticatedUser && props.authenticatedUser.siteAdmin}
                 settingsCascade={props.settingsCascade}
             />
-            {!needsSiteInit &&
-                !isSiteInit &&
-                !!props.authenticatedUser && <IntegrationsToast history={props.history} />}
+            {!needsSiteInit && !isSiteInit && !!props.authenticatedUser && (
+                <IntegrationsToast history={props.history} />
+            )}
             {!isSiteInit && <GlobalNavbar {...props} lowProfile={isSearchHomepage} />}
             {needsSiteInit && !isSiteInit && <Redirect to="/site-admin/init" />}
-            <Switch>
-                {props.routes.map((route, i) => {
-                    const isFullWidth = !route.forceNarrowWidth
-                    return (
-                        <Route
-                            {...route}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            component={undefined}
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <div
-                                    className={[
-                                        'layout__app-router-container',
-                                        `layout__app-router-container--${isFullWidth ? 'full-width' : 'restricted'}`,
-                                    ].join(' ')}
-                                >
-                                    {route.render({ ...props, ...routeComponentProps })}
-                                </div>
-                            )}
-                        />
-                    )
-                })}
-            </Switch>
+            <ErrorBoundary>
+                <Switch>
+                    {props.routes.map((route, i) => {
+                        const isFullWidth = !route.forceNarrowWidth
+                        return (
+                            <Route
+                                {...route}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                component={undefined}
+                                // tslint:disable-next-line:jsx-no-lambda
+                                render={routeComponentProps => (
+                                    <div
+                                        className={[
+                                            'layout__app-router-container',
+                                            `layout__app-router-container--${
+                                                isFullWidth ? 'full-width' : 'restricted'
+                                            }`,
+                                        ].join(' ')}
+                                    >
+                                        {route.render({ ...props, ...routeComponentProps })}
+                                    </div>
+                                )}
+                            />
+                        )
+                    })}
+                </Switch>
+            </ErrorBoundary>
             {parseHash(props.location.hash).viewState && (
                 <ResizablePanel
                     repoName={`git://${parseBrowserRepoURL(props.location.pathname).repoName}`}

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -1,5 +1,4 @@
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import ServerIcon from 'mdi-react/ServerIcon'
 import * as React from 'react'
 import { Route } from 'react-router'
@@ -18,6 +17,7 @@ import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '../../shared/src/s
 import { TelemetryContext } from '../../shared/src/telemetry/telemetryContext'
 import { isErrorLike } from '../../shared/src/util/errors'
 import { authenticatedUser } from './auth'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { FeedbackText } from './components/FeedbackText'
 import { HeroPage } from './components/HeroPage'
 import { RouterLinkOrAnchor } from './components/RouterLinkOrAnchor'
@@ -173,10 +173,6 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
     }
 
     public render(): React.ReactFragment | null {
-        if (this.state.error) {
-            return <HeroPage icon={AlertCircleIcon} title={'Something happened'} subtitle={this.state.error.message} />
-        }
-
         if (window.pageError && window.pageError.statusCode !== 404) {
             const statusCode = window.pageError.statusCode
             const statusText = window.pageError.statusText
@@ -209,38 +205,40 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
         const { children, ...props } = this.props
 
         return (
-            <ShortcutProvider>
-                <TelemetryContext.Provider value={eventLogger}>
-                    <BrowserRouter key={0}>
-                        <Route
-                            path="/"
-                            // tslint:disable-next-line:jsx-no-lambda RouteProps.render is an exception
-                            render={routeComponentProps => (
-                                <Layout
-                                    {...props}
-                                    {...routeComponentProps}
-                                    authenticatedUser={authenticatedUser}
-                                    viewerSubject={this.state.viewerSubject}
-                                    settingsCascade={this.state.settingsCascade}
-                                    // Theme
-                                    isLightTheme={this.state.isLightTheme}
-                                    onThemeChange={this.onThemeChange}
-                                    isMainPage={this.state.isMainPage}
-                                    onMainPage={this.onMainPage}
-                                    // Search query
-                                    navbarSearchQuery={this.state.navbarSearchQuery}
-                                    onNavbarQueryChange={this.onNavbarQueryChange}
-                                    // Extensions
-                                    platformContext={this.state.platformContext}
-                                    extensionsController={this.state.extensionsController}
-                                />
-                            )}
-                        />
-                    </BrowserRouter>
-                    <Tooltip key={1} />
-                    <Notifications key={2} extensionsController={this.state.extensionsController} />
-                </TelemetryContext.Provider>
-            </ShortcutProvider>
+            <ErrorBoundary>
+                <ShortcutProvider>
+                    <TelemetryContext.Provider value={eventLogger}>
+                        <BrowserRouter key={0}>
+                            <Route
+                                path="/"
+                                // tslint:disable-next-line:jsx-no-lambda RouteProps.render is an exception
+                                render={routeComponentProps => (
+                                    <Layout
+                                        {...props}
+                                        {...routeComponentProps}
+                                        authenticatedUser={authenticatedUser}
+                                        viewerSubject={this.state.viewerSubject}
+                                        settingsCascade={this.state.settingsCascade}
+                                        // Theme
+                                        isLightTheme={this.state.isLightTheme}
+                                        onThemeChange={this.onThemeChange}
+                                        isMainPage={this.state.isMainPage}
+                                        onMainPage={this.onMainPage}
+                                        // Search query
+                                        navbarSearchQuery={this.state.navbarSearchQuery}
+                                        onNavbarQueryChange={this.onNavbarQueryChange}
+                                        // Extensions
+                                        platformContext={this.state.platformContext}
+                                        extensionsController={this.state.extensionsController}
+                                    />
+                                )}
+                            />
+                        </BrowserRouter>
+                        <Tooltip key={1} />
+                        <Notifications key={2} extensionsController={this.state.extensionsController} />
+                    </TelemetryContext.Provider>
+                </ShortcutProvider>
+            </ErrorBoundary>
         )
     }
 

--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { ErrorBoundary } from './ErrorBoundary'
+
+const ThrowError: React.FunctionComponent = () => {
+    throw new Error('x')
+}
+
+describe('ErrorBoundary', () => {
+    test('passes through if non-error', () =>
+        expect(
+            renderer
+                .create(
+                    <ErrorBoundary>
+                        <ThrowError />
+                    </ErrorBoundary>
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+
+    test('renders error page if error', () =>
+        expect(
+            renderer
+                .create(
+                    <ErrorBoundary>
+                        <span>hello</span>
+                    </ErrorBoundary>
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+})

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import ErrorIcon from 'mdi-react/ErrorIcon'
+import React from 'react'
+import { asError, ErrorLike } from '../../../shared/src/util/errors'
+import { HeroPage } from './HeroPage'
+
+interface State {
+    error?: ErrorLike
+}
+
+/**
+ * A [React error boundary](https://reactjs.org/docs/error-boundaries.html) that catches errors from
+ * its children. If an error occurs, it displays a nice error page instead of a blank page.
+ *
+ * Components should handle their own errors (and must not rely on this error boundary). This error
+ * boundary is a last resort in case of an unexpected error.
+ */
+export class ErrorBoundary extends React.PureComponent<{}, State> {
+    public state: State = {}
+
+    public static getDerivedStateFromError(error: any): Pick<State, 'error'> {
+        return { error: asError(error) }
+    }
+
+    public render(): React.ReactNode | null {
+        if (this.state.error !== undefined) {
+            return (
+                <HeroPage
+                    icon={ErrorIcon}
+                    title="Error"
+                    subtitle={
+                        <div className="container">
+                            <p>
+                                Sourcegraph encountered an unexpected error. If reloading the page doesn't fix it,
+                                contact your site admin or Sourcegraph support.
+                            </p>
+                            <p>Open your browser's JavaScript console for details.</p>
+                        </div>
+                    }
+                />
+            )
+        }
+
+        return this.props.children
+    }
+}

--- a/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorBoundary passes through if non-error 1`] = `
+<div
+  className="hero-page "
+>
+  <div
+    className="hero-page__icon"
+  >
+    <svg
+      className="mdi-icon "
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M13,13H11V7H13M13,17H11V15H13M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+      />
+    </svg>
+  </div>
+  <div
+    className="hero-page__title"
+  >
+    Error
+  </div>
+  <div
+    className="hero-page__subtitle"
+  >
+    <div
+      className="container"
+    >
+      <p>
+        Sourcegraph encountered an unexpected error. If reloading the page doesn't fix it, contact your site admin or Sourcegraph support.
+      </p>
+      <p>
+        Open your browser's JavaScript console for details.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ErrorBoundary renders error page if error 1`] = `
+<span>
+  hello
+</span>
+`;

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -11,6 +11,7 @@ import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../backend/graphql'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { SettingsArea } from '../../settings/SettingsArea'
 import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
@@ -169,69 +170,71 @@ export class OrgArea extends React.Component<Props> {
                 <OrgHeader className="area--vertical__header" {...this.props} {...transferProps} />
                 <div className="org-area__content area--vertical__content">
                     <div className="org-area__content-inner area--vertical__content-inner">
-                        <Switch>
-                            <Route
-                                path={this.props.match.url}
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                exact={true}
-                                // tslint:disable-next-line:jsx-no-lambda
-                                render={routeComponentProps => (
-                                    <OrgOverviewPage {...routeComponentProps} {...transferProps} />
-                                )}
-                            />
-                            <Route
-                                path={`${this.props.match.url}/members`}
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                exact={true}
-                                // tslint:disable-next-line:jsx-no-lambda
-                                render={routeComponentProps => (
-                                    <OrgMembersPage {...routeComponentProps} {...transferProps} />
-                                )}
-                            />
-                            <Route
-                                path={`${this.props.match.url}/settings`}
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                exact={true}
-                                // tslint:disable-next-line:jsx-no-lambda
-                                render={routeComponentProps => (
-                                    <SettingsArea
-                                        {...routeComponentProps}
-                                        {...transferProps}
-                                        subject={transferProps.org}
-                                        isLightTheme={this.props.isLightTheme}
-                                        extraHeader={
-                                            <>
-                                                {transferProps.authenticatedUser &&
-                                                    transferProps.org.viewerCanAdminister &&
-                                                    !transferProps.org.viewerIsMember && (
-                                                        <SiteAdminAlert className="sidebar__alert">
-                                                            Viewing settings for{' '}
-                                                            <strong>{transferProps.org.name}</strong>
-                                                        </SiteAdminAlert>
-                                                    )}
-                                                <p>
-                                                    Organization settings apply to all members. User settings override
-                                                    organization settings.
-                                                </p>
-                                            </>
-                                        }
-                                    />
-                                )}
-                            />
-                            <Route
-                                path={`${this.props.match.url}/account`}
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                // tslint:disable-next-line:jsx-no-lambda
-                                render={routeComponentProps => (
-                                    <OrgAccountArea
-                                        {...routeComponentProps}
-                                        {...transferProps}
-                                        isLightTheme={this.props.isLightTheme}
-                                    />
-                                )}
-                            />
-                            <Route key="hardcoded-key" component={NotFoundPage} />
-                        </Switch>
+                        <ErrorBoundary>
+                            <Switch>
+                                <Route
+                                    path={this.props.match.url}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    exact={true}
+                                    // tslint:disable-next-line:jsx-no-lambda
+                                    render={routeComponentProps => (
+                                        <OrgOverviewPage {...routeComponentProps} {...transferProps} />
+                                    )}
+                                />
+                                <Route
+                                    path={`${this.props.match.url}/members`}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    exact={true}
+                                    // tslint:disable-next-line:jsx-no-lambda
+                                    render={routeComponentProps => (
+                                        <OrgMembersPage {...routeComponentProps} {...transferProps} />
+                                    )}
+                                />
+                                <Route
+                                    path={`${this.props.match.url}/settings`}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    exact={true}
+                                    // tslint:disable-next-line:jsx-no-lambda
+                                    render={routeComponentProps => (
+                                        <SettingsArea
+                                            {...routeComponentProps}
+                                            {...transferProps}
+                                            subject={transferProps.org}
+                                            isLightTheme={this.props.isLightTheme}
+                                            extraHeader={
+                                                <>
+                                                    {transferProps.authenticatedUser &&
+                                                        transferProps.org.viewerCanAdminister &&
+                                                        !transferProps.org.viewerIsMember && (
+                                                            <SiteAdminAlert className="sidebar__alert">
+                                                                Viewing settings for{' '}
+                                                                <strong>{transferProps.org.name}</strong>
+                                                            </SiteAdminAlert>
+                                                        )}
+                                                    <p>
+                                                        Organization settings apply to all members. User settings
+                                                        override organization settings.
+                                                    </p>
+                                                </>
+                                            }
+                                        />
+                                    )}
+                                />
+                                <Route
+                                    path={`${this.props.match.url}/account`}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    // tslint:disable-next-line:jsx-no-lambda
+                                    render={routeComponentProps => (
+                                        <OrgAccountArea
+                                            {...routeComponentProps}
+                                            {...transferProps}
+                                            isLightTheme={this.props.isLightTheme}
+                                        />
+                                    )}
+                                />
+                                <Route key="hardcoded-key" component={NotFoundPage} />
+                            </Switch>
+                        </ErrorBoundary>
                     </div>
                 </div>
             </div>

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -12,6 +12,7 @@ import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { makeRepoURI } from '../../../shared/src/util/url'
+import { ErrorBoundary } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { searchQueryForRepoRev } from '../search'
 import { queryUpdates } from '../search/input/QueryInput'
@@ -271,113 +272,115 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                     }
                     {...this.state.repoHeaderContributionsLifecycleProps}
                 />
-                {this.state.repoOrError.enabled || isSettingsPage ? (
-                    <Switch>
-                        {[
-                            '',
-                            `@${this.state.rawRev}`, // must exactly match how the rev was encoded in the URL
-                            '/-/blob',
-                            '/-/tree',
-                            '/-/commits',
-                        ].map(routePath => (
+                <ErrorBoundary>
+                    {this.state.repoOrError.enabled || isSettingsPage ? (
+                        <Switch>
+                            {[
+                                '',
+                                `@${this.state.rawRev}`, // must exactly match how the rev was encoded in the URL
+                                '/-/blob',
+                                '/-/tree',
+                                '/-/commits',
+                            ].map(routePath => (
+                                <Route
+                                    path={`${repoMatchURL}${routePath}`}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    exact={routePath === ''}
+                                    // tslint:disable-next-line:jsx-no-lambda
+                                    render={routeComponentProps => (
+                                        <RepoRevContainer
+                                            {...routeComponentProps}
+                                            {...transferProps}
+                                            routes={this.props.repoRevContainerRoutes}
+                                            rev={this.state.rev || ''}
+                                            resolvedRevOrError={this.state.resolvedRevOrError}
+                                            onResolvedRevOrError={this.onResolvedRevOrError}
+                                            // must exactly match how the rev was encoded in the URL
+                                            routePrefix={`${repoMatchURL}${
+                                                this.state.rawRev ? `@${this.state.rawRev}` : ''
+                                            }`}
+                                        />
+                                    )}
+                                />
+                            ))}
                             <Route
-                                path={`${repoMatchURL}${routePath}`}
+                                path={`${repoMatchURL}/-/commit/:revspec+`}
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                exact={routePath === ''}
                                 // tslint:disable-next-line:jsx-no-lambda
                                 render={routeComponentProps => (
-                                    <RepoRevContainer
+                                    <RepositoryGitDataContainer repoName={this.state.repoName}>
+                                        <RepositoryCommitPage
+                                            {...routeComponentProps}
+                                            {...transferProps}
+                                            onDidUpdateExternalLinks={this.onDidUpdateExternalLinks}
+                                        />
+                                    </RepositoryGitDataContainer>
+                                )}
+                            />
+                            <Route
+                                path={`${repoMatchURL}/-/branches`}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                // tslint:disable-next-line:jsx-no-lambda
+                                render={routeComponentProps => (
+                                    <RepositoryGitDataContainer repoName={this.state.repoName}>
+                                        <RepositoryBranchesArea {...routeComponentProps} {...transferProps} />
+                                    </RepositoryGitDataContainer>
+                                )}
+                            />
+                            <Route
+                                path={`${repoMatchURL}/-/tags`}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                // tslint:disable-next-line:jsx-no-lambda
+                                render={routeComponentProps => (
+                                    <RepositoryGitDataContainer repoName={this.state.repoName}>
+                                        <RepositoryReleasesArea {...routeComponentProps} {...transferProps} />
+                                    </RepositoryGitDataContainer>
+                                )}
+                            />
+                            <Route
+                                path={`${repoMatchURL}/-/compare/:spec*`}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                // tslint:disable-next-line:jsx-no-lambda
+                                render={routeComponentProps => (
+                                    <RepositoryGitDataContainer repoName={this.state.repoName}>
+                                        <RepositoryCompareArea {...routeComponentProps} {...transferProps} />
+                                    </RepositoryGitDataContainer>
+                                )}
+                            />
+                            <Route
+                                path={`${repoMatchURL}/-/stats`}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                // tslint:disable-next-line:jsx-no-lambda
+                                render={routeComponentProps => (
+                                    <RepositoryGitDataContainer repoName={this.state.repoName}>
+                                        <RepositoryStatsArea {...routeComponentProps} {...transferProps} />
+                                    </RepositoryGitDataContainer>
+                                )}
+                            />
+                            <Route
+                                path={`${repoMatchURL}/-/settings`}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                // tslint:disable-next-line:jsx-no-lambda
+                                render={routeComponentProps => (
+                                    <RepoSettingsArea
                                         {...routeComponentProps}
                                         {...transferProps}
-                                        routes={this.props.repoRevContainerRoutes}
-                                        rev={this.state.rev || ''}
-                                        resolvedRevOrError={this.state.resolvedRevOrError}
-                                        onResolvedRevOrError={this.onResolvedRevOrError}
-                                        // must exactly match how the rev was encoded in the URL
-                                        routePrefix={`${repoMatchURL}${
-                                            this.state.rawRev ? `@${this.state.rawRev}` : ''
-                                        }`}
+                                        onDidUpdateRepository={this.onDidUpdateRepository}
                                     />
                                 )}
                             />
-                        ))}
-                        <Route
-                            path={`${repoMatchURL}/-/commit/:revspec+`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryCommitPage
-                                        {...routeComponentProps}
-                                        {...transferProps}
-                                        onDidUpdateExternalLinks={this.onDidUpdateExternalLinks}
-                                    />
-                                </RepositoryGitDataContainer>
-                            )}
+                            <Route key="hardcoded-key" component={RepoPageNotFound} />
+                        </Switch>
+                    ) : (
+                        <RepositoryErrorPage
+                            repo={this.state.repoOrError.name}
+                            repoID={this.state.repoOrError.id}
+                            error="disabled"
+                            viewerCanAdminister={viewerCanAdminister}
+                            onDidUpdateRepository={this.onDidUpdateRepository}
                         />
-                        <Route
-                            path={`${repoMatchURL}/-/branches`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryBranchesArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/tags`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryReleasesArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/compare/:spec*`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryCompareArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/stats`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryStatsArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/settings`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepoSettingsArea
-                                    {...routeComponentProps}
-                                    {...transferProps}
-                                    onDidUpdateRepository={this.onDidUpdateRepository}
-                                />
-                            )}
-                        />
-                        <Route key="hardcoded-key" component={RepoPageNotFound} />
-                    </Switch>
-                ) : (
-                    <RepositoryErrorPage
-                        repo={this.state.repoOrError.name}
-                        repoID={this.state.repoOrError.id}
-                        error="disabled"
-                        viewerCanAdminister={viewerCanAdminister}
-                        onDidUpdateRepository={this.onDidUpdateRepository}
-                    />
-                )}
+                    )}
+                </ErrorBoundary>
             </div>
         )
     }

--- a/web/src/site-admin/SiteAdminArea.tsx
+++ b/web/src/site-admin/SiteAdminArea.tsx
@@ -5,6 +5,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
+import { ErrorBoundary } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { RouteDescriptor } from '../util/contributions'
 import { SiteAdminSidebar, SiteAdminSideBarGroups } from './SiteAdminSidebar'
@@ -64,24 +65,26 @@ export const SiteAdminArea = withAuthenticatedUser(
                 <div className="site-admin-area area">
                     <SiteAdminSidebar className="area__sidebar" groups={this.props.sideBarGroups} />
                     <div className="area__content">
-                        <Switch>
-                            {this.props.routes.map(
-                                ({ render, path, exact, condition = () => true }) =>
-                                    condition(context) && (
-                                        <Route
-                                            // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                            key="hardcoded-key"
-                                            path={this.props.match.url + path}
-                                            exact={exact}
-                                            // tslint:disable-next-line:jsx-no-lambda RouteProps.render is an exception
-                                            render={routeComponentProps =>
-                                                render({ ...context, ...routeComponentProps })
-                                            }
-                                        />
-                                    )
-                            )}
-                            <Route component={NotFoundPage} />
-                        </Switch>
+                        <ErrorBoundary>
+                            <Switch>
+                                {this.props.routes.map(
+                                    ({ render, path, exact, condition = () => true }) =>
+                                        condition(context) && (
+                                            <Route
+                                                // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                                key="hardcoded-key"
+                                                path={this.props.match.url + path}
+                                                exact={exact}
+                                                // tslint:disable-next-line:jsx-no-lambda RouteProps.render is an exception
+                                                render={routeComponentProps =>
+                                                    render({ ...context, ...routeComponentProps })
+                                                }
+                                            />
+                                        )
+                                )}
+                                <Route component={NotFoundPage} />
+                            </Switch>
+                        </ErrorBoundary>
                     </div>
                 </div>
             )

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -11,6 +11,7 @@ import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../backend/graphql'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { RouteDescriptor } from '../../util/contributions'
 import { UserAccountAreaRoute } from '../account/UserAccountArea'
@@ -193,23 +194,25 @@ export class UserArea extends React.Component<UserAreaProps, UserAreaState> {
                 />
                 <div className="area--vertical__content">
                     <div className="area--vertical__content-inner">
-                        <Switch>
-                            {this.props.userAreaRoutes.map(
-                                ({ path, exact, render, condition = () => true }) =>
-                                    condition(context) && (
-                                        <Route
-                                            path={this.props.match.url + path}
-                                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                            exact={exact}
-                                            // tslint:disable-next-line:jsx-no-lambda
-                                            render={routeComponentProps =>
-                                                render({ ...context, ...routeComponentProps })
-                                            }
-                                        />
-                                    )
-                            )}
-                            <Route key="hardcoded-key" component={NotFoundPage} />
-                        </Switch>
+                        <ErrorBoundary>
+                            <Switch>
+                                {this.props.userAreaRoutes.map(
+                                    ({ path, exact, render, condition = () => true }) =>
+                                        condition(context) && (
+                                            <Route
+                                                path={this.props.match.url + path}
+                                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                                exact={exact}
+                                                // tslint:disable-next-line:jsx-no-lambda
+                                                render={routeComponentProps =>
+                                                    render({ ...context, ...routeComponentProps })
+                                                }
+                                            />
+                                        )
+                                )}
+                                <Route key="hardcoded-key" component={NotFoundPage} />
+                            </Switch>
+                        </ErrorBoundary>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
If a React component throws an error during rendering, previously the entire page would be blank. This commit introduces [React error boundaries](https://reactjs.org/docs/error-boundaries.html) so that the error is confined and a nice(r) error page is displayed.

This is NOT intended to handle errors that can be anticipated. Components must do their own error handling. It is just a better worst-case when an error is not handled correctly.

fix #659

![screenshot from 2018-12-30 06-45-07](https://user-images.githubusercontent.com/1976/50547486-e9e25100-0bff-11e9-9e01-85cdbf70803f.png)
![screenshot from 2018-12-30 06-43-16](https://user-images.githubusercontent.com/1976/50547487-ec44ab00-0bff-11e9-85b8-f7903ad3a1fe.png)
![screenshot from 2018-12-30 06-41-51](https://user-images.githubusercontent.com/1976/50547489-eea70500-0bff-11e9-9e56-2831bf5471a8.png)
![screenshot from 2018-12-30 06-41-38](https://user-images.githubusercontent.com/1976/50547490-efd83200-0bff-11e9-934a-1c1cbec8b29e.png)
