### PR TITLE
use code splitting to speed up initial page load

### DIFF
--- a/doc/dev/web_app.md
+++ b/doc/dev/web_app.md
@@ -46,6 +46,22 @@ Their purpose is to reexport symbols from a number of other files to make import
 - Avoid styling the children of your components. This couples your component to the implementation of the child
 - Order your rules so that layout rules (that describe how the component is laid out to its parents) come first, then rules that describe the layout of its children, and finally visual details.
 
+## Code splitting
+
+[Code splitting](https://reactjs.org/docs/code-splitting.html) refers to the practice of bundling the frontend code into multiple JavaScript files, each with a subset of the frontend code, so that the client only needs to download and parse/run the code necessary for the page they are viewing. We use the [react-router code splitting technique](https://reactjs.org/docs/code-splitting.html#route-based-code-splitting) to accomplish this.
+
+When adding a new route (and new components), you can opt into code splitting for it by referring to a lazy-loading reference to the component (instead of a static import binding of the component). To create the lazy-loading reference to the component, use `React.lazy`, as in:
+
+``` typescript
+const MyComponent = React.lazy(async () => ({
+    default: (await import('./path/to/MyComponent)).MyComponent,
+}))
+```
+
+If you don't do this (and just use a normal `import`), it will still work, but it will increase the initial bundle size for all users.
+
+(It is necessary to return the component as the `default` property of an object because `React.lazy` is hard-coded to look there for it. We could avoid this extra work by using default exports, but we chose not to use default exports ([reasons](https://blog.neufund.org/why-we-have-banned-default-exports-and-you-should-do-the-same-d51fdc2cf2ad)).)
+
 ### Theming
 
 Theming is done through toggling top-level CSS classes `theme-light` and `theme-dark`.
@@ -74,13 +90,13 @@ You can run unit tests via `yarn test` (to run all) or `yarn test --watch` (to r
 
 _🚨  Until the follow up work in https://github.com/sourcegraph/sourcegraph/issues/976 is completed, our E2E tests will be disabled in CI. **Before merging your PR, you should manually run e2e tests against a local instancing by running `./dev/enterprise/start.sh` in one terminal tab and `yarn run test-e2e` in another one**. Additionally, some E2E tests depend on the Go language server. Currently, that language server is in a transition state and can't be run on its own. Until @chrismwendt finishes up his work on that project, all tests that rely on Go code intelligence are skipped.🚨_
 
-E2E tests are for the whole app: JS, CSS, and backend. 
+E2E tests are for the whole app: JS, CSS, and backend.
 
 These tests require hitting a backend like https://sourcegraph.com or https://sourcegraph.sgdev.org (default `SOURCEGRAPH_BASE_URL=http://localhost:3080`). E2E tests send messages to a chrome debugger port (9222), telling chrome to do things like "go to this URL" and "click on this selector" and "execute this JavaScript in the page".
 
 You can run E2E tests via `cd web && yarn run test-e2e`. This command will automatically start a headless chrome process; to prevent that, set the environment variable `SKIP_LAUNCH_CHROME=t`. See "[Testing](testing.md)" for more information.
 
-#### E2E caveats 
+#### E2E caveats
 
 - don't overdo them; they are the tip of the testing pyramid and the mass of tests should be at lower layers
 - avoid coupling your tests too tightly to the implementation (e.g. with strict selectors that are coupled to the DOM structure), or we will have many test failures

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import React, { Suspense } from 'react'
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 import { ExtensionsControllerProps } from '../../shared/src/extensions/controller'
 import * as GQL from '../../shared/src/graphql/schema'
@@ -99,31 +100,33 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
             {!isSiteInit && <GlobalNavbar {...props} lowProfile={isSearchHomepage} />}
             {needsSiteInit && !isSiteInit && <Redirect to="/site-admin/init" />}
             <ErrorBoundary>
-                <Switch>
-                    {props.routes.map((route, i) => {
-                        const isFullWidth = !route.forceNarrowWidth
-                        return (
-                            <Route
-                                {...route}
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                component={undefined}
-                                // tslint:disable-next-line:jsx-no-lambda
-                                render={routeComponentProps => (
-                                    <div
-                                        className={[
-                                            'layout__app-router-container',
-                                            `layout__app-router-container--${
-                                                isFullWidth ? 'full-width' : 'restricted'
-                                            }`,
-                                        ].join(' ')}
-                                    >
-                                        {route.render({ ...props, ...routeComponentProps })}
-                                    </div>
-                                )}
-                            />
-                        )
-                    })}
-                </Switch>
+                <Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
+                    <Switch>
+                        {props.routes.map(route => {
+                            const isFullWidth = !route.forceNarrowWidth
+                            return (
+                                <Route
+                                    {...route}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    component={undefined}
+                                    // tslint:disable-next-line:jsx-no-lambda
+                                    render={routeComponentProps => (
+                                        <div
+                                            className={[
+                                                'layout__app-router-container',
+                                                `layout__app-router-container--${
+                                                    isFullWidth ? 'full-width' : 'restricted'
+                                                }`,
+                                            ].join(' ')}
+                                        >
+                                            {route.render({ ...props, ...routeComponentProps })}
+                                        </div>
+                                    )}
+                                />
+                            )
+                        })}
+                    </Switch>
+                </Suspense>
             </ErrorBoundary>
             {parseHash(props.location.hash).viewState && (
                 <ResizablePanel

--- a/web/src/enterprise/explore/exploreSections.tsx
+++ b/web/src/enterprise/explore/exploreSections.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { ExploreSectionDescriptor } from '../../explore/ExploreArea'
 import { exploreSections } from '../../explore/exploreSections'
-import { ExtensionsExploreSection } from '../extensions/explore/ExtensionsExploreSection'
+const ExtensionsExploreSection = React.lazy(async () => ({
+    default: (await import('../extensions/explore/ExtensionsExploreSection')).ExtensionsExploreSection,
+}))
 
 export const enterpriseExploreSections: ReadonlyArray<ExploreSectionDescriptor> = [
     { render: props => <ExtensionsExploreSection {...props} /> },

--- a/web/src/enterprise/extensions/extension/routes.tsx
+++ b/web/src/enterprise/extensions/extension/routes.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { ExtensionAreaRoute } from '../../../extensions/extension/ExtensionArea'
 import { extensionAreaRoutes } from '../../../extensions/extension/routes'
-import { RegistryExtensionManagePage } from './RegistryExtensionManagePage'
-import { RegistryExtensionNewReleasePage } from './RegistryExtensionNewReleasePage'
+const RegistryExtensionManagePage = React.lazy(async () => ({
+    default: (await import('./RegistryExtensionManagePage')).RegistryExtensionManagePage,
+}))
+const RegistryExtensionNewReleasePage = React.lazy(async () => ({
+    default: (await import('./RegistryExtensionNewReleasePage')).RegistryExtensionNewReleasePage,
+}))
 
 export const enterpriseExtensionAreaRoutes: ReadonlyArray<ExtensionAreaRoute> = [
     ...extensionAreaRoutes,

--- a/web/src/enterprise/extensions/routes.tsx
+++ b/web/src/enterprise/extensions/routes.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ExtensionsAreaRoute } from '../../extensions/ExtensionsArea'
 import { extensionsAreaRoutes } from '../../extensions/routes'
-import { RegistryArea } from './registry/RegistryArea'
+const RegistryArea = React.lazy(async () => ({ default: (await import('./registry/RegistryArea')).RegistryArea }))
 
 export const enterpriseExtensionsAreaRoutes: ReadonlyArray<ExtensionsAreaRoute> = [
     extensionsAreaRoutes[0],

--- a/web/src/enterprise/routes.tsx
+++ b/web/src/enterprise/routes.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { LayoutRouteProps, routes } from '../routes'
-import { NewProductSubscriptionPageOrRedirectUser } from './user/productSubscriptions/NewProductSubscriptionPageOrRedirectUser'
+const NewProductSubscriptionPageOrRedirectUser = React.lazy(async () => ({
+    default: (await import('./user/productSubscriptions/NewProductSubscriptionPageOrRedirectUser'))
+        .NewProductSubscriptionPageOrRedirectUser,
+}))
 
 export const enterpriseRoutes: ReadonlyArray<LayoutRouteProps> = [
     {

--- a/web/src/enterprise/site-admin/overviewComponents.ts
+++ b/web/src/enterprise/site-admin/overviewComponents.ts
@@ -1,7 +1,10 @@
+import React from 'react'
 import { siteAdminOverviewComponents } from '../../site-admin/overviewComponents'
-import { ProductSubscriptionStatus } from './productSubscription/ProductSubscriptionStatus'
+const ProductSubscriptionStatus = React.lazy(async () => ({
+    default: (await import('./productSubscription/ProductSubscriptionStatus')).ProductSubscriptionStatus,
+}))
 
-export const enterpriseSiteAdminOverviewComponents: ReadonlyArray<React.ComponentType> = [
+export const enterpriseSiteAdminOverviewComponents: ReadonlyArray<React.ComponentType<any>> = [
     ...siteAdminOverviewComponents,
     ProductSubscriptionStatus,
 ]

--- a/web/src/enterprise/site-admin/routes.tsx
+++ b/web/src/enterprise/site-admin/routes.tsx
@@ -1,15 +1,36 @@
 import React from 'react'
 import { siteAdminAreaRoutes } from '../../site-admin/routes'
 import { SiteAdminAreaRoute } from '../../site-admin/SiteAdminArea'
-import { SiteAdminProductCustomersPage } from './dotcom/customers/SiteAdminCustomersPage'
-import { SiteAdminCreateProductSubscriptionPage } from './dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage'
-import { SiteAdminProductLicensesPage } from './dotcom/productSubscriptions/SiteAdminProductLicensesPage'
-import { SiteAdminProductSubscriptionPage as SiteAdminDotcomProductSubscriptionPage } from './dotcom/productSubscriptions/SiteAdminProductSubscriptionPage'
-import { SiteAdminProductSubscriptionsPage } from './dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage'
-import { SiteAdminProductSubscriptionPage } from './productSubscription/SiteAdminProductSubscriptionPage'
-import { SiteAdminAuthenticationProvidersPage } from './SiteAdminAuthenticationProvidersPage'
-import { SiteAdminExternalAccountsPage } from './SiteAdminExternalAccountsPage'
-import { SiteAdminRegistryExtensionsPage } from './SiteAdminRegistryExtensionsPage'
+const SiteAdminProductCustomersPage = React.lazy(async () => ({
+    default: (await import('./dotcom/customers/SiteAdminCustomersPage')).SiteAdminProductCustomersPage,
+}))
+const SiteAdminCreateProductSubscriptionPage = React.lazy(async () => ({
+    default: (await import('./dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage'))
+        .SiteAdminCreateProductSubscriptionPage,
+}))
+const SiteAdminProductLicensesPage = React.lazy(async () => ({
+    default: (await import('./dotcom/productSubscriptions/SiteAdminProductLicensesPage')).SiteAdminProductLicensesPage,
+}))
+const SiteAdminDotcomProductSubscriptionPage = React.lazy(async () => ({
+    default: (await import('./dotcom/productSubscriptions/SiteAdminProductSubscriptionPage'))
+        .SiteAdminProductSubscriptionPage,
+}))
+const SiteAdminProductSubscriptionsPage = React.lazy(async () => ({
+    default: (await import('./dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage'))
+        .SiteAdminProductSubscriptionsPage,
+}))
+const SiteAdminProductSubscriptionPage = React.lazy(async () => ({
+    default: (await import('./productSubscription/SiteAdminProductSubscriptionPage')).SiteAdminProductSubscriptionPage,
+}))
+const SiteAdminAuthenticationProvidersPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminAuthenticationProvidersPage')).SiteAdminAuthenticationProvidersPage,
+}))
+const SiteAdminExternalAccountsPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminExternalAccountsPage')).SiteAdminExternalAccountsPage,
+}))
+const SiteAdminRegistryExtensionsPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminRegistryExtensionsPage')).SiteAdminRegistryExtensionsPage,
+}))
 
 export const enterpriseSiteAdminAreaRoutes: ReadonlyArray<SiteAdminAreaRoute> = [
     ...siteAdminAreaRoutes,

--- a/web/src/enterprise/user/account/routes.tsx
+++ b/web/src/enterprise/user/account/routes.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { userAccountAreaRoutes } from '../../../user/account/routes'
 import { UserAccountAreaRoute } from '../../../user/account/UserAccountArea'
-import { UserAccountExternalAccountsPage } from './UserAccountExternalAccountsPage'
+const UserAccountExternalAccountsPage = React.lazy(async () => ({
+    default: (await import('./UserAccountExternalAccountsPage')).UserAccountExternalAccountsPage,
+}))
 
 export const enterpriseUserAccountAreaRoutes: ReadonlyArray<UserAccountAreaRoute> = [
     ...userAccountAreaRoutes,

--- a/web/src/enterprise/user/routes.tsx
+++ b/web/src/enterprise/user/routes.tsx
@@ -2,10 +2,22 @@ import React from 'react'
 import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute } from '../../user/area/UserArea'
 import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
-import { UserSubscriptionsEditProductSubscriptionPage } from './productSubscriptions/UserSubscriptionsEditProductSubscriptionPage'
-import { UserSubscriptionsNewProductSubscriptionPage } from './productSubscriptions/UserSubscriptionsNewProductSubscriptionPage'
-import { UserSubscriptionsProductSubscriptionPage } from './productSubscriptions/UserSubscriptionsProductSubscriptionPage'
-import { UserSubscriptionsProductSubscriptionsPage } from './productSubscriptions/UserSubscriptionsProductSubscriptionsPage'
+const UserSubscriptionsEditProductSubscriptionPage = React.lazy(async () => ({
+    default: (await import('./productSubscriptions/UserSubscriptionsEditProductSubscriptionPage'))
+        .UserSubscriptionsEditProductSubscriptionPage,
+}))
+const UserSubscriptionsNewProductSubscriptionPage = React.lazy(async () => ({
+    default: (await import('./productSubscriptions/UserSubscriptionsNewProductSubscriptionPage'))
+        .UserSubscriptionsNewProductSubscriptionPage,
+}))
+const UserSubscriptionsProductSubscriptionPage = React.lazy(async () => ({
+    default: (await import('./productSubscriptions/UserSubscriptionsProductSubscriptionPage'))
+        .UserSubscriptionsProductSubscriptionPage,
+}))
+const UserSubscriptionsProductSubscriptionsPage = React.lazy(async () => ({
+    default: (await import('./productSubscriptions/UserSubscriptionsProductSubscriptionsPage'))
+        .UserSubscriptionsProductSubscriptionsPage,
+}))
 
 export const enterpriseUserAreaRoutes: ReadonlyArray<UserAreaRoute> = [
     ...userAreaRoutes,

--- a/web/src/explore/exploreSections.tsx
+++ b/web/src/explore/exploreSections.tsx
@@ -1,11 +1,23 @@
 import React from 'react'
 import { isDiscussionsEnabled } from '../discussions'
-import { DiscussionsExploreSection } from '../discussions/explore/DiscussionsExploreSection'
-import { ExtensionViewsExploreSection } from '../extensions/explore/ExtensionViewsExploreSection'
-import { IntegrationsExploreSection } from '../integrations/explore/IntegrationsExploreSection'
-import { RepositoriesExploreSection } from '../repo/explore/RepositoriesExploreSection'
-import { SavedSearchesExploreSection } from '../search/saved-queries/explore/SavedSearchesExploreSection'
-import { SiteUsageExploreSection } from '../usageStatistics/explore/SiteUsageExploreSection'
+const DiscussionsExploreSection = React.lazy(async () => ({
+    default: (await import('../discussions/explore/DiscussionsExploreSection')).DiscussionsExploreSection,
+}))
+const ExtensionViewsExploreSection = React.lazy(async () => ({
+    default: (await import('../extensions/explore/ExtensionViewsExploreSection')).ExtensionViewsExploreSection,
+}))
+const IntegrationsExploreSection = React.lazy(async () => ({
+    default: (await import('../integrations/explore/IntegrationsExploreSection')).IntegrationsExploreSection,
+}))
+const RepositoriesExploreSection = React.lazy(async () => ({
+    default: (await import('../repo/explore/RepositoriesExploreSection')).RepositoriesExploreSection,
+}))
+const SavedSearchesExploreSection = React.lazy(async () => ({
+    default: (await import('../search/saved-queries/explore/SavedSearchesExploreSection')).SavedSearchesExploreSection,
+}))
+const SiteUsageExploreSection = React.lazy(async () => ({
+    default: (await import('../usageStatistics/explore/SiteUsageExploreSection')).SiteUsageExploreSection,
+}))
 import { ExploreSectionDescriptor } from './ExploreArea'
 
 export const exploreSections: ReadonlyArray<ExploreSectionDescriptor> = [

--- a/web/src/extensions/extension/routes.tsx
+++ b/web/src/extensions/extension/routes.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 import { ExtensionAreaRoute } from './ExtensionArea'
-import { RegistryExtensionContributionsPage } from './RegistryExtensionContributionsPage'
-import { RegistryExtensionManifestPage } from './RegistryExtensionManifestPage'
-import { RegistryExtensionOverviewPage } from './RegistryExtensionOverviewPage'
+const RegistryExtensionContributionsPage = React.lazy(async () => ({
+    default: (await import('./RegistryExtensionContributionsPage')).RegistryExtensionContributionsPage,
+}))
+const RegistryExtensionManifestPage = React.lazy(async () => ({
+    default: (await import('./RegistryExtensionManifestPage')).RegistryExtensionManifestPage,
+}))
+const RegistryExtensionOverviewPage = React.lazy(async () => ({
+    default: (await import('./RegistryExtensionOverviewPage')).RegistryExtensionOverviewPage,
+}))
 
 export const extensionAreaRoutes: ReadonlyArray<ExtensionAreaRoute> = [
     {

--- a/web/src/extensions/routes.tsx
+++ b/web/src/extensions/routes.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
-import { ExtensionArea } from './extension/ExtensionArea'
 import { ExtensionsAreaRoute } from './ExtensionsArea'
-import { ExtensionsOverviewPage } from './ExtensionsOverviewPage'
+const ExtensionArea = React.lazy(async () => ({ default: (await import('./extension/ExtensionArea')).ExtensionArea }))
+const ExtensionsOverviewPage = React.lazy(async () => ({
+    default: (await import('./ExtensionsOverviewPage')).ExtensionsOverviewPage,
+}))
 
 export const extensionsAreaRoutes: ReadonlyArray<ExtensionsAreaRoute> = [
     {

--- a/web/src/integrations/explore/IntegrationsExploreSection.tsx
+++ b/web/src/integrations/explore/IntegrationsExploreSection.tsx
@@ -26,38 +26,37 @@ const DATA: { title: string; description: string; url: string; backgroundImage: 
     },
 ]
 
+interface Props {}
+
 /**
  * An explore section that shows integrations.
  */
-export class IntegrationsExploreSection extends React.PureComponent {
-    public render(): JSX.Element | null {
-        return (
-            <div className="integrations-explore-section">
-                <h2>Popular integrations</h2>
-                <div className="row">
-                    {DATA.map(({ title, description, url, backgroundImage }, i) => (
-                        <div key={i} className="col-md-4 mb-2 mb-md-0">
-                            <a
-                                href={url}
-                                target="_blank"
-                                className="card rounded border-white card-link text-white"
-                                // tslint:disable-next-line:jsx-ban-props
-                                style={{ backgroundImage }}
-                            >
-                                <div className="card-body">
-                                    <h2 className="card-title h6 font-weight-bold mb-0">{title}</h2>
-                                    <p className="card-text">{description}</p>
-                                </div>
-                            </a>
+export const IntegrationsExploreSection: React.FunctionComponent<Props> = () => (
+    <div className="integrations-explore-section">
+        <h2>Popular integrations</h2>
+        <div className="row">
+            {DATA.map(({ title, description, url, backgroundImage }, i) => (
+                <div key={i} className="col-md-4 mb-2 mb-md-0">
+                    <a
+                        href={url}
+                        target="_blank"
+                        className="card rounded border-white card-link text-white"
+                        // tslint:disable-next-line:jsx-ban-props
+                        style={{ backgroundImage }}
+                    >
+                        <div className="card-body">
+                            <h2 className="card-title h6 font-weight-bold mb-0">{title}</h2>
+                            <p className="card-text">{description}</p>
                         </div>
-                    ))}
+                    </a>
                 </div>
-                <div className="text-right mt-3">
-                    <Link to="/help/integration" target="_blank">
-                        View all integrations<ChevronRightIcon className="icon-inline" />
-                    </Link>
-                </div>
-            </div>
-        )
-    }
-}
+            ))}
+        </div>
+        <div className="text-right mt-3">
+            <Link to="/help/integration" target="_blank">
+                View all integrations
+                <ChevronRightIcon className="icon-inline" />
+            </Link>
+        </div>
+    </div>
+)

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -3,13 +3,17 @@ import { Redirect, RouteComponentProps } from 'react-router'
 import { getModeFromPath } from '../../../shared/src/languages'
 import { isLegacyFragment, parseHash } from '../../../shared/src/util/url'
 import { formatHash } from '../util/url'
-import { BlobPage } from './blob/BlobPage'
-import { RepositoryCommitsPage } from './commits/RepositoryCommitsPage'
-import { FilePathBreadcrumb } from './FilePathBreadcrumb'
+const BlobPage = React.lazy(async () => ({ default: (await import('./blob/BlobPage')).BlobPage }))
+const RepositoryCommitsPage = React.lazy(async () => ({
+    default: (await import('./commits/RepositoryCommitsPage')).RepositoryCommitsPage,
+}))
+const FilePathBreadcrumb = React.lazy(async () => ({
+    default: (await import('./FilePathBreadcrumb')).FilePathBreadcrumb,
+}))
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
 import { RepoRevContainerContext, RepoRevContainerRoute } from './RepoRevContainer'
-import { RepoRevSidebar } from './RepoRevSidebar'
-import { TreePage } from './TreePage'
+const RepoRevSidebar = React.lazy(async () => ({ default: (await import('./RepoRevSidebar')).RepoRevSidebar }))
+const TreePage = React.lazy(async () => ({ default: (await import('./TreePage')).TreePage }))
 
 /** Dev feature flag to make benchmarking the file tree in isolation easier. */
 const hideRepoRevContent = localStorage.getItem('hideRepoRevContent')

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -1,29 +1,51 @@
 import * as React from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
-import { APIConsole } from './api/APIConsole'
-import { ResetPasswordPage } from './auth/ResetPasswordPage'
-import { SignInPage } from './auth/SignInPage'
-import { SignUpPage } from './auth/SignUpPage'
-import { DiscussionsPage } from './discussions/DiscussionsPage'
-import { DocSitePage } from './docSite/DocSitePage'
-import { ExploreArea } from './explore/ExploreArea'
-import { ExtensionsArea } from './extensions/ExtensionsArea'
 import { LayoutProps } from './Layout'
-import { SurveyPage } from './marketing/SurveyPage'
-import { OpenPage } from './open/OpenPage'
-import { OrgsArea } from './org/OrgsArea'
-import { RepoContainer } from './repo/RepoContainer'
 import { parseSearchURLQuery } from './search'
-import { MainPage } from './search/input/MainPage'
-import { ScopePage } from './search/input/ScopePage'
-import { SearchPage } from './search/input/SearchPage'
-import { SearchResults } from './search/results/SearchResults'
-import { SavedQueriesPage } from './search/saved-queries/SavedQueries'
-import { SiteAdminArea } from './site-admin/SiteAdminArea'
-import { SiteInitPage } from './site-admin/SiteInitPage'
-import { RedirectToUserPage } from './user/account/RedirectToUserPage'
-import { RedirectToUserSettings } from './user/account/RedirectToUserSettings'
-import { UserArea } from './user/area/UserArea'
+const MainPage = React.lazy(async () => ({
+    default: (await import('./search/input/MainPage')).MainPage,
+}))
+const SearchPage = React.lazy(async () => ({
+    default: (await import('./search/input/SearchPage')).SearchPage,
+}))
+const SearchResults = React.lazy(async () => ({
+    default: (await import('./search/results/SearchResults')).SearchResults,
+}))
+const SavedQueriesPage = React.lazy(async () => ({
+    default: (await import('./search/saved-queries/SavedQueries')).SavedQueriesPage,
+}))
+const SiteAdminArea = React.lazy(async () => ({
+    default: (await import('./site-admin/SiteAdminArea')).SiteAdminArea,
+}))
+const UserArea = React.lazy(async () => ({
+    default: (await import('./user/area/UserArea')).UserArea,
+}))
+const APIConsole = React.lazy(async () => ({ default: (await import('./api/APIConsole')).APIConsole }))
+const ResetPasswordPage = React.lazy(async () => ({
+    default: (await import('./auth/ResetPasswordPage')).ResetPasswordPage,
+}))
+const SignInPage = React.lazy(async () => ({ default: (await import('./auth/SignInPage')).SignInPage }))
+const SignUpPage = React.lazy(async () => ({ default: (await import('./auth/SignUpPage')).SignUpPage }))
+const DiscussionsPage = React.lazy(async () => ({
+    default: (await import('./discussions/DiscussionsPage')).DiscussionsPage,
+}))
+const DocSitePage = React.lazy(async () => ({ default: (await import('./docSite/DocSitePage')).DocSitePage }))
+const ExploreArea = React.lazy(async () => ({ default: (await import('./explore/ExploreArea')).ExploreArea }))
+const ExtensionsArea = React.lazy(async () => ({
+    default: (await import('./extensions/ExtensionsArea')).ExtensionsArea,
+}))
+const SurveyPage = React.lazy(async () => ({ default: (await import('./marketing/SurveyPage')).SurveyPage }))
+const OpenPage = React.lazy(async () => ({ default: (await import('./open/OpenPage')).OpenPage }))
+const OrgsArea = React.lazy(async () => ({ default: (await import('./org/OrgsArea')).OrgsArea }))
+const RepoContainer = React.lazy(async () => ({ default: (await import('./repo/RepoContainer')).RepoContainer }))
+const ScopePage = React.lazy(async () => ({ default: (await import('./search/input/ScopePage')).ScopePage }))
+const SiteInitPage = React.lazy(async () => ({ default: (await import('./site-admin/SiteInitPage')).SiteInitPage }))
+const RedirectToUserPage = React.lazy(async () => ({
+    default: (await import('./user/account/RedirectToUserPage')).RedirectToUserPage,
+}))
+const RedirectToUserSettings = React.lazy(async () => ({
+    default: (await import('./user/account/RedirectToUserSettings')).RedirectToUserSettings,
+}))
 
 export interface LayoutRouteComponentProps extends RouteComponentProps<any>, LayoutProps {}
 

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -240,22 +240,19 @@ export function isStandaloneCodeEditor(
     return editor.getEditorType() === monaco.editor.EditorType.ICodeEditor
 }
 
-export function toMonacoEdits(
+function toMonacoEdits(
     model: monaco.editor.IModel,
     edits: jsonc.Edit[]
 ): monaco.editor.IIdentifiedSingleEditOperation[] {
-    return edits.map(
-        (edit, i) =>
-            ({
-                identifier: { major: model.getVersionId(), minor: i },
-                range: monaco.Range.fromPositions(
-                    model.getPositionAt(edit.offset),
-                    model.getPositionAt(edit.offset + edit.length)
-                ),
-                forceMoveMarkers: true,
-                text: edit.content,
-            } as monaco.editor.IIdentifiedSingleEditOperation)
-    )
+    return edits.map((edit, i) => ({
+        identifier: { major: model.getVersionId(), minor: i },
+        range: monaco.Range.fromPositions(
+            model.getPositionAt(edit.offset),
+            model.getPositionAt(edit.offset + edit.length)
+        ),
+        forceMoveMarkers: true,
+        text: edit.content,
+    }))
 }
 
 /**

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -3,12 +3,14 @@ import { Subscription } from 'rxjs'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 
+interface Props {}
+
 interface State {}
 
 /**
  * A page displaying information about telemetry pings for the site.
  */
-export class SiteAdminPingsPage extends React.Component<{}, State> {
+export class SiteAdminPingsPage extends React.Component<Props, State> {
     public state: State = {}
 
     private subscriptions = new Subscription()
@@ -57,7 +59,8 @@ export class SiteAdminPingsPage extends React.Component<{}, State> {
                         To disable pings (for customers only),{' '}
                         <a href="https://about.sourcegraph.com/contact/" target="_blank">
                             contact support
-                        </a>.
+                        </a>
+                        .
                     </p>
                 )}
             </div>

--- a/web/src/site-admin/routes.tsx
+++ b/web/src/site-admin/routes.tsx
@@ -1,21 +1,49 @@
 import React from 'react'
 import { eventLogger } from '../tracking/eventLogger'
-import { SiteAdminAddExternalServicePage } from './SiteAdminAddExternalServicePage'
-import { SiteAdminAllUsersPage } from './SiteAdminAllUsersPage'
 import { SiteAdminAreaRoute } from './SiteAdminArea'
-import { SiteAdminConfigurationPage } from './SiteAdminConfigurationPage'
-import { SiteAdminCreateUserPage } from './SiteAdminCreateUserPage'
-import { SiteAdminExternalServicePage } from './SiteAdminExternalServicePage'
-import { SiteAdminExternalServicesPage } from './SiteAdminExternalServicesPage'
-import { SiteAdminOrgsPage } from './SiteAdminOrgsPage'
-import { SiteAdminOverviewPage } from './SiteAdminOverviewPage'
-import { SiteAdminPingsPage } from './SiteAdminPingsPage'
-import { SiteAdminRepositoriesPage } from './SiteAdminRepositoriesPage'
-import { SiteAdminSettingsPage } from './SiteAdminSettingsPage'
-import { SiteAdminSurveyResponsesPage } from './SiteAdminSurveyResponsesPage'
-import { SiteAdminTokensPage } from './SiteAdminTokensPage'
-import { SiteAdminUpdatesPage } from './SiteAdminUpdatesPage'
-import { SiteAdminUsageStatisticsPage } from './SiteAdminUsageStatisticsPage'
+const SiteAdminAddExternalServicePage = React.lazy(async () => ({
+    default: (await import('./SiteAdminAddExternalServicePage')).SiteAdminAddExternalServicePage,
+}))
+const SiteAdminAllUsersPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminAllUsersPage')).SiteAdminAllUsersPage,
+}))
+const SiteAdminConfigurationPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminConfigurationPage')).SiteAdminConfigurationPage,
+}))
+const SiteAdminCreateUserPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminCreateUserPage')).SiteAdminCreateUserPage,
+}))
+const SiteAdminExternalServicePage = React.lazy(async () => ({
+    default: (await import('./SiteAdminExternalServicePage')).SiteAdminExternalServicePage,
+}))
+const SiteAdminExternalServicesPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminExternalServicesPage')).SiteAdminExternalServicesPage,
+}))
+const SiteAdminOrgsPage = React.lazy(async () => ({ default: (await import('./SiteAdminOrgsPage')).SiteAdminOrgsPage }))
+const SiteAdminOverviewPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminOverviewPage')).SiteAdminOverviewPage,
+}))
+const SiteAdminPingsPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminPingsPage')).SiteAdminPingsPage,
+}))
+const SiteAdminRepositoriesPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminRepositoriesPage')).SiteAdminRepositoriesPage,
+}))
+const SiteAdminSettingsPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminSettingsPage')).SiteAdminSettingsPage,
+}))
+const SiteAdminSurveyResponsesPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminSurveyResponsesPage')).SiteAdminSurveyResponsesPage,
+}))
+const SiteAdminTokensPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminTokensPage')).SiteAdminTokensPage,
+}))
+const SiteAdminUpdatesPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminUpdatesPage')).SiteAdminUpdatesPage,
+}))
+const SiteAdminUsageStatisticsPage = React.lazy(async () => ({
+    default: (await import('./SiteAdminUsageStatisticsPage')).SiteAdminUsageStatisticsPage,
+}))
 
 export const siteAdminAreaRoutes: ReadonlyArray<SiteAdminAreaRoute> = [
     {

--- a/web/src/user/account/routes.tsx
+++ b/web/src/user/account/routes.tsx
@@ -1,10 +1,20 @@
 import React from 'react'
 import { UserAccountAreaRoute } from './UserAccountArea'
-import { UserAccountCreateAccessTokenPage } from './UserAccountCreateAccessTokenPage'
-import { UserAccountEmailsPage } from './UserAccountEmailsPage'
-import { UserAccountPasswordPage } from './UserAccountPasswordPage'
-import { UserAccountProfilePage } from './UserAccountProfilePage'
-import { UserAccountTokensPage } from './UserAccountTokensPage'
+const UserAccountCreateAccessTokenPage = React.lazy(async () => ({
+    default: (await import('./UserAccountCreateAccessTokenPage')).UserAccountCreateAccessTokenPage,
+}))
+const UserAccountEmailsPage = React.lazy(async () => ({
+    default: (await import('./UserAccountEmailsPage')).UserAccountEmailsPage,
+}))
+const UserAccountPasswordPage = React.lazy(async () => ({
+    default: (await import('./UserAccountPasswordPage')).UserAccountPasswordPage,
+}))
+const UserAccountProfilePage = React.lazy(async () => ({
+    default: (await import('./UserAccountProfilePage')).UserAccountProfilePage,
+}))
+const UserAccountTokensPage = React.lazy(async () => ({
+    default: (await import('./UserAccountTokensPage')).UserAccountTokensPage,
+}))
 
 export const userAccountAreaRoutes: ReadonlyArray<UserAccountAreaRoute> = [
     // Render empty page if no settings page selected

--- a/web/src/user/area/routes.tsx
+++ b/web/src/user/area/routes.tsx
@@ -1,9 +1,18 @@
 import React from 'react'
-import { SettingsArea } from '../../settings/SettingsArea'
 import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
-import { UserAccountArea } from '../account/UserAccountArea'
 import { UserAreaRoute } from './UserArea'
-import { UserOverviewPage } from './UserOverviewPage'
+
+const UserOverviewPage = React.lazy(async () => ({
+    default: (await import('./UserOverviewPage')).UserOverviewPage,
+}))
+
+const SettingsArea = React.lazy(async () => ({
+    default: (await import('../../settings/SettingsArea')).SettingsArea,
+}))
+
+const UserAccountArea = React.lazy(async () => ({
+    default: (await import('../account/UserAccountArea')).UserAccountArea,
+}))
 
 export const userAreaRoutes: ReadonlyArray<UserAreaRoute> = [
     {
@@ -23,12 +32,11 @@ export const userAreaRoutes: ReadonlyArray<UserAreaRoute> = [
                 isLightTheme={props.isLightTheme}
                 extraHeader={
                     <>
-                        {props.authenticatedUser &&
-                            props.user.id !== props.authenticatedUser.id && (
-                                <SiteAdminAlert className="sidebar__alert">
-                                    Viewing settings for <strong>{props.user.username}</strong>
-                                </SiteAdminAlert>
-                            )}
+                        {props.authenticatedUser && props.user.id !== props.authenticatedUser.id && (
+                            <SiteAdminAlert className="sidebar__alert">
+                                Viewing settings for <strong>{props.user.username}</strong>
+                            </SiteAdminAlert>
+                        )}
                         <p>User settings override global and organization settings.</p>
                     </>
                 }


### PR DESCRIPTION
Uses the [react-router code splitting technique](https://reactjs.org/docs/code-splitting.html#route-based-code-splitting) to reduce the initial bundle size by ~50%. This is intended to make the initial page load faster for users. (It is possible that it makes it slower in some cases because the client now needs to load multiple JS files, possibly in serial. In most cases, we expect there to be a net benefit.)

As a secondary benefit, it speeds up the initial bundle compilation time in local development.

Codemod for one-time migration of static imports to React.lazy imports, change `import` to `ximport` and run:

```
codemod --extensions tsx -d web/src "ximport \{([^}]+)\} from ('[^']+')" 'const \1 = React.lazy(async () => ({ default: (await import(\2)).\1 }))'
````