### PR TITLE
rename from backcompat name to CountGoImporters

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -11,32 +11,29 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
-// TODO!(sqs): This file contains backcompat stubs for definitions that were removed in the
-// migration to using Sourcegraph extensions for language support.
-
-var MockBackcompatBackendDefsTotalRefs func(ctx context.Context, repo api.RepoName) (int, error)
+var MockCountGoImporters func(ctx context.Context, repo api.RepoName) (int, error)
 
 // 100 MiB cache, no age-based eviction
 var httpClient = &http.Client{Transport: httpcache.NewTransport(lrucache.New(100*1024*1024, 0))}
 
-type GDDOResponse struct {
-	Results []GDDOResult `json:"results"`
-}
-
-type GDDOResult struct {
-	Path string `json:"path"`
-}
-
-func BackcompatBackendDefsTotalRefs(ctx context.Context, repo api.RepoName) (int, error) {
-	if MockBackcompatBackendDefsTotalRefs != nil {
-		return MockBackcompatBackendDefsTotalRefs(ctx, repo)
+// CountGoImporters returns the number of Go importers for the repository. This is a special case
+// used only on Sourcegraph.com for repository badges.
+//
+// TODO: The import path is not always the same as the repository name.
+func CountGoImporters(ctx context.Context, repo api.RepoName) (int, error) {
+	if MockCountGoImporters != nil {
+		return MockCountGoImporters(ctx, repo)
 	}
 	// Assumes the import path is the same as the repo name - not always true!
 	response, err := httpClient.Get("https://api.godoc.org/importers/" + string(repo))
 	if err != nil {
 		return 0, err
 	}
-	var result *GDDOResponse
+	var result struct {
+		Results []struct {
+			Path string
+		}
+	}
 	bytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return 0, err

--- a/cmd/frontend/internal/app/badge.go
+++ b/cmd/frontend/internal/app/badge.go
@@ -18,7 +18,7 @@ import (
 
 // NOTE: Keep in sync with services/backend/httpapi/repo_shield.go
 func badgeValue(r *http.Request) (int, error) {
-	totalRefs, err := backend.BackcompatBackendDefsTotalRefs(r.Context(), routevar.ToRepo(mux.Vars(r)))
+	totalRefs, err := backend.CountGoImporters(r.Context(), routevar.ToRepo(mux.Vars(r)))
 	if err != nil {
 		return 0, errors.Wrap(err, "Defs.TotalRefs")
 	}

--- a/cmd/frontend/internal/httpapi/repo_shield.go
+++ b/cmd/frontend/internal/httpapi/repo_shield.go
@@ -12,7 +12,7 @@ import (
 
 // NOTE: Keep in sync with services/backend/httpapi/repo_shield.go
 func badgeValue(r *http.Request) (int, error) {
-	totalRefs, err := backend.BackcompatBackendDefsTotalRefs(r.Context(), routevar.ToRepo(mux.Vars(r)))
+	totalRefs, err := backend.CountGoImporters(r.Context(), routevar.ToRepo(mux.Vars(r)))
 	if err != nil {
 		return 0, errors.Wrap(err, "Defs.TotalRefs")
 	}

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -51,7 +51,7 @@ func TestRepoShield(t *testing.T) {
 		}
 		return "aed", nil
 	}
-	backend.MockBackcompatBackendDefsTotalRefs = func(ctx context.Context, source api.RepoName) (int, error) {
+	backend.MockCountGoImporters = func(ctx context.Context, source api.RepoName) (int, error) {
 		if source != "github.com/gorilla/mux" {
 			t.Error("wrong repo source to TotalRefs")
 		}


### PR DESCRIPTION
This removes a `TODO!(sqs)` from the code and updates the name. The filename backcompat.go only made sense in the migration away from lsp-proxy; now that the migration is complete, it is not accurate to call this backcompat anymore.