### PR TITLE
support extension categories/tags and searching by them

### DIFF
--- a/doc/extensions/authoring/manifest.md
+++ b/doc/extensions/authoring/manifest.md
@@ -20,7 +20,8 @@ Name | Required | Type | Details
 `scripts` | ✔️ | `object` | npm's scripts with Sourcegraph specific entries such as `sourcegraph:prepublish`.
 `browserslist` | | `string` | Modern list of browsers for build tools to target when transpiling.
 `repository` | | `object` | npm field for the repository location.
-`categories` | | `string[]` | Categories that describe this extension, from the set [`Programming languages`](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22), `Linters`, `Code analysis`, `External services`, `Reports and stats`, `Other`.
+`categories` | | `string[]` | Categories that describe this extension, from the predefined set [`Programming languages`](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22), `Linters`, `Code analysis`, `External services`, `Reports and stats`, `Other`.
+`tags` | | `string[]` | Arbitrary tags that describe this extension.
 
 See the [npm package.json documentation](https://docs.npmjs.com/creating-a-package-json-file) for other fields.
 
@@ -48,6 +49,7 @@ Here is an example `package.json` created by the [Sourcegraph extension creator]
     "url": "https://github.com/example/repo"
   },
   "categories": ["Programming languages"],
+  "tags": ["awesome"],
   "activationEvents": [
     "*"
   ],

--- a/doc/extensions/authoring/manifest.md
+++ b/doc/extensions/authoring/manifest.md
@@ -20,6 +20,7 @@ Name | Required | Type | Details
 `scripts` | ✔️ | `object` | npm's scripts with Sourcegraph specific entries such as `sourcegraph:prepublish`.
 `browserslist` | | `string` | Modern list of browsers for build tools to target when transpiling.
 `repository` | | `object` | npm field for the repository location.
+`categories` | | `string[]` | Categories that describe this extension, from the set `Programming languages`, `Linters`, `Code analysis`, `External services`, `Reports and stats`, `Other`.
 
 See the [npm package.json documentation](https://docs.npmjs.com/creating-a-package-json-file) for other fields.
 
@@ -42,6 +43,11 @@ Here is an example `package.json` created by the [Sourcegraph extension creator]
   "title": "WIP: My extension",
   "description": "An awesome Sourcegraph extension",
   "publisher": "your-sourcegraph-username",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/example/repo"
+  },
+  "categories": ["Programming languages"],
   "activationEvents": [
     "*"
   ],

--- a/doc/extensions/authoring/manifest.md
+++ b/doc/extensions/authoring/manifest.md
@@ -20,7 +20,7 @@ Name | Required | Type | Details
 `scripts` | ✔️ | `object` | npm's scripts with Sourcegraph specific entries such as `sourcegraph:prepublish`.
 `browserslist` | | `string` | Modern list of browsers for build tools to target when transpiling.
 `repository` | | `object` | npm field for the repository location.
-`categories` | | `string[]` | Categories that describe this extension, from the set `Programming languages`, `Linters`, `Code analysis`, `External services`, `Reports and stats`, `Other`.
+`categories` | | `string[]` | Categories that describe this extension, from the set [`Programming languages`](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22), `Linters`, `Code analysis`, `External services`, `Reports and stats`, `Other`.
 
 See the [npm package.json documentation](https://docs.npmjs.com/creating-a-package-json-file) for other fields.
 

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"strings"
+	"unicode"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
@@ -56,13 +57,46 @@ func toDBExtensionsListOptions(args graphqlbackend.RegistryExtensionConnectionAr
 		opt.Publisher.OrgID = p.orgID
 	}
 	if args.Query != nil {
-		opt.Query = *args.Query
+		opt.Query, opt.Category = parseExtensionQuery(*args.Query)
 	}
 	if args.PrioritizeExtensionIDs != nil {
 		opt.PrioritizeExtensionIDs = *args.PrioritizeExtensionIDs
 	}
 	opt.ExcludeWIP = !args.IncludeWIP
 	return opt, nil
+}
+
+// parseExtensionQuery parses an extension registry query consisting of terms and a single operator
+// `category:"My category"`.
+//
+// This is an intentionally simple, unoptimized parser.
+func parseExtensionQuery(q string) (text, category string) {
+	// Tokenize.
+	var lastQuote rune
+	tokens := strings.FieldsFunc(q, func(c rune) bool {
+		switch {
+		case c == lastQuote:
+			lastQuote = rune(0)
+			return false
+		case lastQuote != rune(0):
+			return false
+		case c == '"' || c == '\'':
+			lastQuote = c
+			return false
+		default:
+			return unicode.IsSpace(c)
+		}
+	})
+
+	var textTokens []string
+	for _, tok := range tokens {
+		if strings.HasPrefix(tok, "category:") {
+			category = strings.Trim(strings.TrimPrefix(tok, "category:"), `"'`)
+		} else {
+			textTokens = append(textTokens, tok)
+		}
+	}
+	return strings.Join(textTokens, " "), category
 }
 
 // filterStripLocalExtensionIDs filters to local extension IDs and strips the

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
@@ -57,7 +57,7 @@ func toDBExtensionsListOptions(args graphqlbackend.RegistryExtensionConnectionAr
 		opt.Publisher.OrgID = p.orgID
 	}
 	if args.Query != nil {
-		opt.Query, opt.Category = parseExtensionQuery(*args.Query)
+		opt.Query, opt.Category, opt.Tag = parseExtensionQuery(*args.Query)
 	}
 	if args.PrioritizeExtensionIDs != nil {
 		opt.PrioritizeExtensionIDs = *args.PrioritizeExtensionIDs
@@ -66,11 +66,11 @@ func toDBExtensionsListOptions(args graphqlbackend.RegistryExtensionConnectionAr
 	return opt, nil
 }
 
-// parseExtensionQuery parses an extension registry query consisting of terms and a single operator
-// `category:"My category"`.
+// parseExtensionQuery parses an extension registry query consisting of terms and the operators
+// `category:"My category"` and `tag:"mytag"`.
 //
 // This is an intentionally simple, unoptimized parser.
-func parseExtensionQuery(q string) (text, category string) {
+func parseExtensionQuery(q string) (text, category, tag string) {
 	// Tokenize.
 	var lastQuote rune
 	tokens := strings.FieldsFunc(q, func(c rune) bool {
@@ -92,11 +92,13 @@ func parseExtensionQuery(q string) (text, category string) {
 	for _, tok := range tokens {
 		if strings.HasPrefix(tok, "category:") {
 			category = strings.Trim(strings.TrimPrefix(tok, "category:"), `"'`)
+		} else if strings.HasPrefix(tok, "tag:") {
+			tag = strings.Trim(strings.TrimPrefix(tok, "tag:"), `"'`)
 		} else {
 			textTokens = append(textTokens, tok)
 		}
 	}
-	return strings.Join(textTokens, " "), category
+	return strings.Join(textTokens, " "), category, tag
 }
 
 // filterStripLocalExtensionIDs filters to local extension IDs and strips the

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
@@ -60,6 +60,10 @@ func TestToDBExtensionsListOptions(t *testing.T) {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a category:"C🚀" b category:"DD" c`)},
 			want: dbExtensionsListOptions{Query: "a b c", Category: "DD", ExcludeWIP: true},
 		},
+		"Query tag": {
+			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b tag:"T🚀" c`)},
+			want: dbExtensionsListOptions{Query: "a b c", Tag: "T🚀", ExcludeWIP: true},
+		},
 		"PrioritizeExensionIDs": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{PrioritizeExtensionIDs: strarrayptr([]string{"a", "b"})},
 			want: dbExtensionsListOptions{PrioritizeExtensionIDs: []string{"a", "b"}, ExcludeWIP: true},

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
@@ -48,6 +48,18 @@ func TestToDBExtensionsListOptions(t *testing.T) {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr("q")},
 			want: dbExtensionsListOptions{Query: "q", ExcludeWIP: true},
 		},
+		"Query category quoted": {
+			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b category:"C🚀" c`)},
+			want: dbExtensionsListOptions{Query: "a b c", Category: "C🚀", ExcludeWIP: true},
+		},
+		"Query category unquoted": {
+			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b category:C c`)},
+			want: dbExtensionsListOptions{Query: "a b c", Category: "C", ExcludeWIP: true},
+		},
+		"Query multiple categories": {
+			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a category:"C🚀" b category:"DD" c`)},
+			want: dbExtensionsListOptions{Query: "a b c", Category: "DD", ExcludeWIP: true},
+		},
 		"PrioritizeExensionIDs": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{PrioritizeExtensionIDs: strarrayptr([]string{"a", "b"})},
 			want: dbExtensionsListOptions{PrioritizeExtensionIDs: []string{"a", "b"}, ExcludeWIP: true},

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -184,6 +184,7 @@ type dbExtensionsListOptions struct {
 	Publisher              dbPublisher
 	Query                  string // matches the extension ID and latest release's manifest's title
 	Category               string // matches the latest release's manifest's categories array
+	Tag                    string // matches the latest release's manifest's tags array
 	PrioritizeExtensionIDs []string
 	ExcludeWIP             bool // exclude extensions marked as WIP
 	*db.LimitOffset
@@ -211,6 +212,9 @@ func (o dbExtensionsListOptions) sqlConditions() []*sqlf.Query {
 	}
 	if o.Category != "" {
 		conds = append(conds, sqlf.Sprintf(`CASE WHEN rer.manifest IS NOT NULL THEN (rer.manifest->>'categories')::jsonb @> to_json(%s::text)::jsonb ELSE false END`, o.Category))
+	}
+	if o.Tag != "" {
+		conds = append(conds, sqlf.Sprintf(`CASE WHEN rer.manifest IS NOT NULL THEN (rer.manifest->>'tags')::jsonb @> to_json(%s::text)::jsonb ELSE false END`, o.Tag))
 	}
 	if o.ExcludeWIP {
 		conds = append(conds, sqlf.Sprintf("NOT (%s)", extensionIsWIPExpr))

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -302,7 +302,7 @@ func (dbExtensions) Update(ctx context.Context, id int32, name *string) error {
 	}
 
 	res, err := dbconn.Global.ExecContext(ctx,
-		"UPDATE registry_extensions SET name=COALESCE($2, name),  updated_at=now() WHERE id=$1 AND deleted_at IS NULL",
+		"UPDATE registry_extensions SET name=COALESCE($2, name), updated_at=now() WHERE id=$1 AND deleted_at IS NULL",
 		id, name,
 	)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -362,11 +362,22 @@ func TestRegistryExtensions_ListCount(t *testing.T) {
 	createAndGet(t, "xnomanifest", ``) // create extension without manifest to ensure it is not matched
 	createAndGet(t, "xinvalidmanifest", `123`)
 	createAndGet(t, "xinvalidtitle", `{"title": 123}`)
-	x1 := createAndGet(t, "x", `{"title": "foo", "xyz": 1}`)
+	createAndGet(t, "xinvalidcategories", `{"title": "invalidcategories", "categories": 123}`) // invalid categories
+	x1 := createAndGet(t, "x", `{"title": "foo", "categories": ["mycategory1", "Mycategory2"], "xyz": 1}`)
 	t.Run("by title", func(t *testing.T) {
 		testListCount(t, dbExtensionsListOptions{Query: "foo"}, []*dbExtension{x1})
 		// Ensure it's not just searching the full JSON manifest.
 		testListCount(t, dbExtensionsListOptions{Query: "xyz"}, nil)
+		// Ensure it's not matching on category.
+		testListCount(t, dbExtensionsListOptions{Query: "mycategory1"}, nil)
+		testListCount(t, dbExtensionsListOptions{Query: "Mycategory2"}, nil)
+	})
+	t.Run("by category", func(t *testing.T) {
+		testListCount(t, dbExtensionsListOptions{Category: "mycategory1"}, []*dbExtension{x1})
+		testListCount(t, dbExtensionsListOptions{Category: "Mycategory2"}, []*dbExtension{x1})
+		testListCount(t, dbExtensionsListOptions{Category: "mycategory2"}, nil) // case-sensitive
+		testListCount(t, dbExtensionsListOptions{Category: "mycateg"}, nil)     // no partial matches
+		testListCount(t, dbExtensionsListOptions{Category: "othercategory"}, nil)
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -35,7 +35,7 @@ var registryExtensionNamesForTests = []struct {
 	{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", false},
 }
 
-func TestRegistryExtensions_validUsernames(t *testing.T) {
+func TestRegistryExtensions_validNames(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -362,8 +362,8 @@ func TestRegistryExtensions_ListCount(t *testing.T) {
 	createAndGet(t, "xnomanifest", ``) // create extension without manifest to ensure it is not matched
 	createAndGet(t, "xinvalidmanifest", `123`)
 	createAndGet(t, "xinvalidtitle", `{"title": 123}`)
-	createAndGet(t, "xinvalidcategories", `{"title": "invalidcategories", "categories": 123}`) // invalid categories
-	x1 := createAndGet(t, "x", `{"title": "foo", "categories": ["mycategory1", "Mycategory2"], "xyz": 1}`)
+	createAndGet(t, "xinvalidcategoriestags", `{"title": "invalidcategories", "categories": 123, "tags": 123}`)
+	x1 := createAndGet(t, "x", `{"title": "foo", "categories": ["mycategory1", "Mycategory2"], "tags": ["t1", "T2"], "xyz": 1}`)
 	t.Run("by title", func(t *testing.T) {
 		testListCount(t, dbExtensionsListOptions{Query: "foo"}, []*dbExtension{x1})
 		// Ensure it's not just searching the full JSON manifest.
@@ -378,6 +378,13 @@ func TestRegistryExtensions_ListCount(t *testing.T) {
 		testListCount(t, dbExtensionsListOptions{Category: "mycategory2"}, nil) // case-sensitive
 		testListCount(t, dbExtensionsListOptions{Category: "mycateg"}, nil)     // no partial matches
 		testListCount(t, dbExtensionsListOptions{Category: "othercategory"}, nil)
+	})
+	t.Run("by tag", func(t *testing.T) {
+		testListCount(t, dbExtensionsListOptions{Tag: "t1"}, []*dbExtension{x1})
+		testListCount(t, dbExtensionsListOptions{Tag: "T2"}, []*dbExtension{x1})
+		testListCount(t, dbExtensionsListOptions{Tag: "t2"}, nil) // case-sensitive
+		testListCount(t, dbExtensionsListOptions{Tag: "t"}, nil)  // no partial matches
+		testListCount(t, dbExtensionsListOptions{Tag: "t3"}, nil)
 	})
 }
 

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -4,7 +4,7 @@
 const config = {
   collectCoverage: true,
   coverageDirectory: '<rootDir>/coverage',
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   preset: 'ts-jest/presets/js-with-ts',
   roots: ['<rootDir>/src'],
   transform: { '^.+\\.[jt]sx?$': 'ts-jest' },

--- a/shared/src/extensions/extensionManifest.test.ts
+++ b/shared/src/extensions/extensionManifest.test.ts
@@ -15,4 +15,8 @@ describe('parseExtensionManifestOrError', () => {
         const value = parseExtensionManifestOrError('{"url":"a"}')
         expect(isErrorLike(value)).toBeTruthy()
     })
+    test('invalid categories', () => {
+        const value = parseExtensionManifestOrError('{"categories":[1]}')
+        expect(isErrorLike(value)).toBeTruthy()
+    })
 })

--- a/shared/src/extensions/extensionManifest.test.ts
+++ b/shared/src/extensions/extensionManifest.test.ts
@@ -19,4 +19,8 @@ describe('parseExtensionManifestOrError', () => {
         const value = parseExtensionManifestOrError('{"categories":[1]}')
         expect(isErrorLike(value)).toBeTruthy()
     })
+    test('invalid tags', () => {
+        const value = parseExtensionManifestOrError('{"tags":[1]}')
+        expect(isErrorLike(value)).toBeTruthy()
+    })
 })

--- a/shared/src/extensions/extensionManifest.ts
+++ b/shared/src/extensions/extensionManifest.ts
@@ -10,7 +10,15 @@ import { parseJSONCOrError } from '../util/jsonc'
 export interface ExtensionManifest
     extends Pick<
         ExtensionManifestSchema,
-        'title' | 'description' | 'repository' | 'categories' | 'readme' | 'url' | 'activationEvents' | 'contributes'
+        | 'title'
+        | 'description'
+        | 'repository'
+        | 'categories'
+        | 'tags'
+        | 'readme'
+        | 'url'
+        | 'activationEvents'
+        | 'contributes'
     > {}
 
 /**
@@ -46,6 +54,9 @@ export function parseExtensionManifestOrError(input: string): ExtensionManifest 
             (!Array.isArray(value.categories) || !value.categories.every(c => typeof c === 'string'))
         ) {
             problems.push('"categories" property must be an array of strings')
+        }
+        if (value.tags && (!Array.isArray(value.tags) || !value.tags.every(c => typeof c === 'string'))) {
+            problems.push('"tags" property must be an array of strings')
         }
         if (value.description && typeof value.description !== 'string') {
             problems.push('"description" property must be a string')

--- a/shared/src/extensions/extensionManifest.ts
+++ b/shared/src/extensions/extensionManifest.ts
@@ -9,9 +9,9 @@ import { parseJSONCOrError } from '../util/jsonc'
  */
 export interface ExtensionManifest
     extends Pick<
-            ExtensionManifestSchema,
-            'title' | 'description' | 'repository' | 'readme' | 'url' | 'activationEvents' | 'contributes'
-        > {}
+        ExtensionManifestSchema,
+        'title' | 'description' | 'repository' | 'categories' | 'readme' | 'url' | 'activationEvents' | 'contributes'
+    > {}
 
 /**
  * Parses and validates the extension manifest. If parsing or validation fails, an error value is returned (not
@@ -40,6 +40,12 @@ export function parseExtensionManifestOrError(input: string): ExtensionManifest 
                     problems.push('"repository" property "url" must be a string')
                 }
             }
+        }
+        if (
+            value.categories &&
+            (!Array.isArray(value.categories) || !value.categories.every(c => typeof c === 'string'))
+        ) {
+            problems.push('"categories" property must be an array of strings')
         }
         if (value.description && typeof value.description !== 'string') {
             problems.push('"description" property must be a string')

--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -59,6 +59,11 @@
         ]
       }
     },
+    "tags": {
+      "description": "Arbitrary tags that describe this extension.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "activationEvents": {
       "description":
         "A list of events that cause this extension to be activated. '*' means that it will always be activated.",

--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -43,6 +43,22 @@
         }
       }
     },
+    "categories": {
+      "description": "The categories that describe this extension, to help users browsing the extension registry to discover this extension.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Programming languages",
+          "Linters",
+          "Code analysis",
+          "External services",
+          "Reports and stats",
+          "Other",
+          "Demos"
+        ]
+      }
+    },
     "activationEvents": {
       "description":
         "A list of events that cause this extension to be activated. '*' means that it will always be activated.",

--- a/shared/src/schema/extension.schema.ts
+++ b/shared/src/schema/extension.schema.ts
@@ -49,6 +49,7 @@ export interface ExtensionManifest {
      */
     categories?: (ExtensionCategory | string)[]
 
+    tags?: string[]
     icon?: string
     activationEvents: string[]
     contributes?: Contributions & { configuration?: { [key: string]: any } }

--- a/shared/src/schema/extension.schema.ts
+++ b/shared/src/schema/extension.schema.ts
@@ -10,6 +10,29 @@ import { Contributions } from '../api/protocol/contribution'
  * manually duplicate it for now.
  */
 
+ /**
+  * The set of known categories in the extension registry.
+  *
+  * Keep this in sync with <extension.schema.json>'s #/categories/items/enum set.
+  *
+  * This uses a typed array instead of a TypeScript enum to avoid needing to define redundant identifiers for each
+  * string constant (e.g., `ProgrammingLanguages = 'Programming languages'`).
+  */
+export const EXTENSION_CATEGORIES = array([
+  'Programming languages',
+  'Linters',
+  'Code analysis',
+  'External services',
+  'Reports and stats',
+  'Other',
+  'Demos',
+])
+
+/**
+ * The set of known categories in the extension registry.
+ */
+export type ExtensionCategory = typeof EXTENSION_CATEGORIES[number]
+
 export interface ExtensionManifest {
     title?: string
     description?: string
@@ -19,7 +42,19 @@ export interface ExtensionManifest {
         type?: string
         url: string
     }
+
+    /**
+     * The element type includes `string` because this value has not been validated. Use {@link knownCategories} to
+     * filter to only known {@link ExtensionCategory} values.
+     */
+    categories?: (ExtensionCategory | string)[]
+
     icon?: string
     activationEvents: string[]
     contributes?: Contributions & { configuration?: { [key: string]: any } }
+}
+
+/** TypeScript helper for making an array type with constant string union elements, not just string[]. */
+function array<T extends string>(a: T[]): T[] {
+    return a;
 }

--- a/web/src/extensions/extension/ExtensionAreaHeader.scss
+++ b/web/src/extensions/extension/ExtensionAreaHeader.scss
@@ -1,11 +1,6 @@
 .extension-area-header {
     padding-top: 0.5rem;
 
-    .container {
-        padding-left: 0;
-        padding-right: 0;
-    }
-
     &__icon {
         display: block;
         width: 8rem;

--- a/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
@@ -7,7 +7,6 @@ import { ConfiguredRegistryExtension } from '../../../../shared/src/extensions/e
 import extensionSchemaJSON from '../../../../shared/src/schema/extension.schema.json'
 import { PageTitle } from '../../components/PageTitle'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../settings/DynamicallyImportedMonacoSettingsEditor'
-import { eventLogger } from '../../tracking/eventLogger'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 
 export const ExtensionNoManifestAlert: React.FunctionComponent<{
@@ -56,10 +55,6 @@ export class RegistryExtensionManifestPage extends React.PureComponent<Props, St
     }
 
     public state: State = { viewMode: RegistryExtensionManifestPage.getViewMode() }
-
-    public componentDidMount(): void {
-        eventLogger.logViewEvent('RegistryExtensionManifest')
-    }
 
     public render(): JSX.Element | null {
         return (

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -21,6 +21,7 @@ describe('RegistryExtensionOverviewPage', () => {
                                     url: 'https://example.com',
                                     activationEvents: ['*'],
                                     categories: ['Programming languages', 'Other'],
+                                    tags: ['T1', 'T2'],
                                     readme: '**A**',
                                     repository: {
                                         url: 'https://github.com/foo/bar',

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -1,0 +1,34 @@
+import { flatten } from 'lodash'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { RegistryExtensionOverviewPage } from './RegistryExtensionOverviewPage'
+
+describe('RegistryExtensionOverviewPage', () => {
+    describe('categories', () => {
+        test('filters out unrecognized categories', () => {
+            const x = renderer.create(
+                <RegistryExtensionOverviewPage
+                    extension={{
+                        id: 'x',
+                        rawManifest: '',
+                        manifest: {
+                            url: 'https://example.com',
+                            activationEvents: ['*'],
+                            categories: ['Programming languages', 'invalid', 'Other'],
+                        },
+                    }}
+                />
+            ).root
+            expect(
+                flatten(
+                    x
+                        .findAll(
+                            ({ props: { className } }) =>
+                                className && className.includes('registry-extension-overview-page__categories')
+                        )
+                        .map(c => flatten(c.children.map(c => (typeof c === 'string' ? c : c.children))))
+                )
+            ).toEqual(['Other', 'Programming languages' /* no 'invalid' */])
+        })
+    })
+})

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -1,5 +1,5 @@
 import maxDate from 'date-fns/max'
-import { isObject } from 'lodash'
+import { isObject, truncate } from 'lodash'
 import GithubCircleIcon from 'mdi-react/GithubCircleIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
@@ -68,6 +68,26 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                             </ul>
                         </div>
                     )}
+                    {this.props.extension.manifest &&
+                        !isErrorLike(this.props.extension.manifest) &&
+                        this.props.extension.manifest.tags &&
+                        this.props.extension.manifest.tags.length > 0 && (
+                            <div className="mb-3">
+                                <h3>Tags</h3>
+                                <ul className="list-inline registry-extension-overview-page__tags">
+                                    {this.props.extension.manifest.tags.map((t, i) => (
+                                        <li key={i} className="list-inline-item mb-2 small">
+                                            <Link
+                                                to={`/extensions?query=tag:${encodeURIComponent(JSON.stringify(t))}`}
+                                                className="rounded border p-1"
+                                            >
+                                                {truncate(t, { length: 24 })}
+                                            </Link>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
                     <small className="text-muted">
                         <dl className="border-top pt-2">
                             {this.props.extension.registryExtension &&

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -129,7 +129,7 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                                 {repositoryURL && (
                                     <div className="d-flex">
                                         {repositoryURL.hostname === 'github.com' && (
-                                            <GithubCircleIcon className="icon-inline" />
+                                            <GithubCircleIcon className="icon-inline mr-1" />
                                         )}
                                         <a
                                             href={repositoryURL.href}

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -52,12 +52,17 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                 </div>
                 <div className="col-md-4">
                     {categories && (
-                        <div className="mb-2">
+                        <div className="mb-3">
                             <h3>Categories</h3>
                             <ul className="list-inline registry-extension-overview-page__categories">
                                 {categories.map((c, i) => (
-                                    <li key={i} className="list-inline-item rounded border p-1 mb-1 small">
-                                        {c}
+                                    <li key={i} className="list-inline-item mb-2 small">
+                                        <Link
+                                            to={`/extensions?query=category:${encodeURIComponent('"' + c + '"')}`}
+                                            className="rounded border p-1"
+                                        >
+                                            {c}
+                                        </Link>
                                     </li>
                                 ))}
                             </ul>

--- a/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RegistryExtensionOverviewPage renders 1`] = `
+<div
+  className="registry-extension-overview-page row"
+>
+  <div
+    className="col-md-8"
+  >
+    <div
+      className="markdown undefined"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p><strong>A</strong></p>
+",
+        }
+      }
+    />
+  </div>
+  <div
+    className="col-md-4"
+  >
+    <div
+      className="mb-2"
+    >
+      <h3>
+        Categories
+      </h3>
+      <ul
+        className="list-inline registry-extension-overview-page__categories"
+      >
+        <li
+          className="list-inline-item mb-1 small"
+        >
+          <a
+            className="rounded border p-1"
+            href="/extensions?query=category:%22Other%22"
+            onClick={[Function]}
+          >
+            Other
+          </a>
+        </li>
+        <li
+          className="list-inline-item mb-1 small"
+        >
+          <a
+            className="rounded border p-1"
+            href="/extensions?query=category:%22Programming%20languages%22"
+            onClick={[Function]}
+          >
+            Programming languages
+          </a>
+        </li>
+      </ul>
+    </div>
+    <small
+      className="text-muted"
+    >
+      <dl
+        className="border-top pt-2"
+      >
+        <dt
+          className="border-top pt-2"
+        >
+          Extension ID
+        </dt>
+        <dd>
+          x
+        </dd>
+        <dt
+          className="border-top pt-2"
+        >
+          Resources
+        </dt>
+        <dd
+          className="border-bottom pb-2"
+        >
+          <a
+            className="d-block"
+            href="https://example.com"
+            rel="nofollow"
+            target="_blank"
+          >
+            Source code (JavaScript)
+          </a>
+          <div
+            className="d-flex"
+          >
+            <svg
+              className="mdi-icon icon-inline mr-1"
+              fill="currentColor"
+              height={24}
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M12,2C6.48,2 2,6.48 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12C22,6.48 17.52,2 12,2Z"
+              />
+            </svg>
+            <a
+              className="d-block"
+              href="https://github.com/foo/bar"
+              rel="nofollow noreferrer noopener"
+              target="_blank"
+            >
+              Repository
+            </a>
+          </div>
+        </dd>
+      </dl>
+    </small>
+  </div>
+</div>
+`;

--- a/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
     className="col-md-4"
   >
     <div
-      className="mb-2"
+      className="mb-3"
     >
       <h3>
         Categories
@@ -30,7 +30,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         className="list-inline registry-extension-overview-page__categories"
       >
         <li
-          className="list-inline-item mb-1 small"
+          className="list-inline-item mb-2 small"
         >
           <a
             className="rounded border p-1"
@@ -41,7 +41,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
           </a>
         </li>
         <li
-          className="list-inline-item mb-1 small"
+          className="list-inline-item mb-2 small"
         >
           <a
             className="rounded border p-1"
@@ -49,6 +49,39 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
             onClick={[Function]}
           >
             Programming languages
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div
+      className="mb-3"
+    >
+      <h3>
+        Tags
+      </h3>
+      <ul
+        className="list-inline registry-extension-overview-page__tags"
+      >
+        <li
+          className="list-inline-item mb-2 small"
+        >
+          <a
+            className="rounded border p-1"
+            href="/extensions?query=tag:%22T1%22"
+            onClick={[Function]}
+          >
+            T1
+          </a>
+        </li>
+        <li
+          className="list-inline-item mb-2 small"
+        >
+          <a
+            className="rounded border p-1"
+            href="/extensions?query=tag:%22T2%22"
+            onClick={[Function]}
+          >
+            T2
           </a>
         </li>
       </ul>

--- a/web/src/extensions/extension/extension.test.ts
+++ b/web/src/extensions/extension/extension.test.ts
@@ -1,0 +1,15 @@
+import { validCategories } from './extension'
+
+describe('validCategories', () => {
+    test('selects only known categories, sorts, and dedupes', () =>
+        expect(validCategories(['Programming languages', 'Other', 'x', 'Other'])).toEqual([
+            'Other',
+            'Programming languages',
+        ]))
+
+    test('returns undefined for undefined', () => expect(validCategories(undefined)).toEqual(undefined))
+
+    test('returns undefined for empty', () => expect(validCategories([])).toEqual(undefined))
+
+    test('returns undefined when no categories are known', () => expect(validCategories(['x'])).toEqual(undefined))
+})

--- a/web/src/extensions/extension/extension.ts
+++ b/web/src/extensions/extension/extension.ts
@@ -1,4 +1,10 @@
+import { uniq } from 'lodash'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import {
+    EXTENSION_CATEGORIES,
+    ExtensionCategory,
+    ExtensionManifest,
+} from '../../../../shared/src/schema/extension.schema'
 import { Settings } from '../../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 
@@ -38,4 +44,19 @@ export function toExtensionID(publisher: string | RegistryPublisher, name: strin
 /** Reports whether the given extension is mentioned (enabled or disabled) in the settings. */
 export function isExtensionAdded(settings: Settings | ErrorLike | null, extensionID: string): boolean {
     return !!settings && !isErrorLike(settings) && !!settings.extensions && extensionID in settings.extensions
+}
+
+/**
+ * @param categories The (unvalidated) categories defined on the extension.
+ * @returns An array that is the subset of {@link categories} consisting only of known categories, sorted and with
+ * duplicates removed.
+ */
+export function validCategories(categories: ExtensionManifest['categories']): ExtensionCategory[] | undefined {
+    if (!categories || categories.length === 0) {
+        return undefined
+    }
+    const validCategories = uniq(
+        categories.filter((c): c is ExtensionCategory => EXTENSION_CATEGORIES.includes(c as ExtensionCategory)).sort()
+    )
+    return validCategories.length === 0 ? undefined : validCategories
 }


### PR DESCRIPTION
Extension manifests can now have `categories` and `tags` properties (both `string[]`). See updated docs in this PR.

The extension registry search now supports search queries containing `category:"C"` and `tag:"T"`, such as `category:"Programming languages"`. This query matches extensions that list `Programming languages` as a category in their extension manifest. Any additional query terms will be matched against the title and extension ID (as they normally would be).

fix #1494