### PR TITLE
improve extension registry list UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The repository settings mirroring page now shows when a repo is next scheduled for an update (requires experiment `"updateScheduler2": "enabled"`).
 - Configured repositories are periodically scheduled for updates using a new algorithm. You can disable the new algorithm with the following site configuration: `"experimentalFeatures": { "updateScheduler2": "disabled" }`. If you do so, please file a public issue to describe why you needed to disable it.
 - When using HTTP header authentication, [`stripUsernameHeaderPrefix`](https://docs.sourcegraph.com/admin/auth/#username-header-prefixes) field lets an admin specify a prefix to strip from the HTTP auth header when converting the header value to a username.
-- Sourcegraph extensions whose title begins with `WIP:` or `[WIP]` are considered [work-in-progress extensions](https://docs.sourcegraph.com/extensions/authoring/creating_and_publishing#work-in-progress-wip-extensions) and are indicated as such to avoid users accidentally using them.
+- Sourcegraph extensions whose package.json contains `"wip": true` are considered [work-in-progress extensions](https://docs.sourcegraph.com/extensions/authoring/publishing#wip-extensions) and are indicated as such to avoid users accidentally using them.
 - Information about user survey submissions and a chart showing weekly active users is now displayed on the site admin Overview page.
 - A new GraphQL API field `UserEmail.isPrimary` was added that indicates whether an email is the user's primary email.
 - The filters bar in the search results page can now display filters from extensions.
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The `appURL` site configuration option was renamed to `externalURL`.
 - The default for `experimentalFeatures.canonicalURLRedirect` in site config was changed back to `disabled`.
 - The repository and directory pages now show all entries together instead of showing files and (sub)directories separately.
+- Extensions no longer can specify titles (in the `title` property in the `package.json` extension manifest). Their extension ID (such as `alice/myextension`) is used.
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -111,7 +111,6 @@ type RegistryExtension interface {
 // ExtensionManifest is the interface for the GraphQL type ExtensionManifest.
 type ExtensionManifest interface {
 	Raw() string
-	Title() (*string, error)
 	Description() (*string, error)
 	BundleURL() (*string, error)
 }

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -45,7 +45,6 @@ type RegistryExtensionConnectionArgs struct {
 	Publisher              *graphql.ID
 	Local                  bool
 	Remote                 bool
-	IncludeWIP             bool
 	PrioritizeExtensionIDs *[]string
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2977,6 +2977,14 @@ type ExtensionRegistry {
         # Returns only extensions from this publisher.
         publisher: ID
         # Returns only extensions matching the query.
+        #
+        # The following keywords are supported:
+        #
+        # - category:"C" - include only extensions in the given category.
+        # - tag:"T" - include only extensions in the given tag.
+        # - #wip - include WIP extensions.
+        #
+        # WIP extensions are excluded by default. Use #wip to include them.
         query: String
         # Include extensions from the local registry.
         local: Boolean = true
@@ -2987,8 +2995,6 @@ type ExtensionRegistry {
         # Typically, the client passes the list of added and enabled extension IDs in this parameter so that the
         # results include those extensions first (which is typically what the user prefers).
         prioritizeExtensionIDs: [String!]
-        # Include WIP (work-in-progress) extensions.
-        includeWIP: Boolean = true
     ): RegistryExtensionConnection!
     # A list of publishers with at least 1 extension in the registry.
     publishers(

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2982,7 +2982,6 @@ type ExtensionRegistry {
         #
         # - category:"C" - include only extensions in the given category.
         # - tag:"T" - include only extensions in the given tag.
-        # - #wip - include WIP extensions.
         #
         # The following keywords are ignored by the server (so that the frontend can post-process the result set to
         # implement the keywords):
@@ -2990,8 +2989,6 @@ type ExtensionRegistry {
         # - #installed - include only installed extensions.
         # - #enabled - include only enabled extensions.
         # - #disabled - include only disabled extensions.
-        #
-        # WIP extensions are excluded by default. Use #wip to include them.
         query: String
         # Include extensions from the local registry.
         local: Boolean = true

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3133,8 +3133,6 @@ type RegistryExtension implements Node {
 type ExtensionManifest {
     # The raw JSON contents of the manifest.
     raw: String!
-    # The title specified in the manifest, if any.
-    title: String
     # The description specified in the manifest, if any.
     description: String
     # The URL to the bundled JavaScript source code for the extension, if any.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2984,6 +2984,13 @@ type ExtensionRegistry {
         # - tag:"T" - include only extensions in the given tag.
         # - #wip - include WIP extensions.
         #
+        # The following keywords are ignored by the server (so that the frontend can post-process the result set to
+        # implement the keywords):
+        #
+        # - #installed - include only installed extensions.
+        # - #enabled - include only enabled extensions.
+        # - #disabled - include only disabled extensions.
+        #
         # WIP extensions are excluded by default. Use #wip to include them.
         query: String
         # Include extensions from the local registry.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3140,8 +3140,6 @@ type RegistryExtension implements Node {
 type ExtensionManifest {
     # The raw JSON contents of the manifest.
     raw: String!
-    # The title specified in the manifest, if any.
-    title: String
     # The description specified in the manifest, if any.
     description: String
     # The URL to the bundled JavaScript source code for the extension, if any.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2984,6 +2984,14 @@ type ExtensionRegistry {
         # Returns only extensions from this publisher.
         publisher: ID
         # Returns only extensions matching the query.
+        #
+        # The following keywords are supported:
+        #
+        # - category:"C" - include only extensions in the given category.
+        # - tag:"T" - include only extensions in the given tag.
+        # - #wip - include WIP extensions.
+        #
+        # WIP extensions are excluded by default. Use #wip to include them.
         query: String
         # Include extensions from the local registry.
         local: Boolean = true
@@ -2994,8 +3002,6 @@ type ExtensionRegistry {
         # Typically, the client passes the list of added and enabled extension IDs in this parameter so that the
         # results include those extensions first (which is typically what the user prefers).
         prioritizeExtensionIDs: [String!]
-        # Include WIP (work-in-progress) extensions.
-        includeWIP: Boolean = true
     ): RegistryExtensionConnection!
     # A list of publishers with at least 1 extension in the registry.
     publishers(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2991,6 +2991,13 @@ type ExtensionRegistry {
         # - tag:"T" - include only extensions in the given tag.
         # - #wip - include WIP extensions.
         #
+        # The following keywords are ignored by the server (so that the frontend can post-process the result set to
+        # implement the keywords):
+        #
+        # - #installed - include only installed extensions.
+        # - #enabled - include only enabled extensions.
+        # - #disabled - include only disabled extensions.
+        #
         # WIP extensions are excluded by default. Use #wip to include them.
         query: String
         # Include extensions from the local registry.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2989,7 +2989,6 @@ type ExtensionRegistry {
         #
         # - category:"C" - include only extensions in the given category.
         # - tag:"T" - include only extensions in the given tag.
-        # - #wip - include WIP extensions.
         #
         # The following keywords are ignored by the server (so that the frontend can post-process the result set to
         # implement the keywords):
@@ -2997,8 +2996,6 @@ type ExtensionRegistry {
         # - #installed - include only installed extensions.
         # - #enabled - include only enabled extensions.
         # - #disabled - include only disabled extensions.
-        #
-        # WIP extensions are excluded by default. Use #wip to include them.
         query: String
         # Include extensions from the local registry.
         local: Boolean = true

--- a/cmd/frontend/registry/extension_connection_graphql.go
+++ b/cmd/frontend/registry/extension_connection_graphql.go
@@ -82,16 +82,6 @@ func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]gr
 			}
 			remote = append(remote, xs...)
 		}
-		// Filter out WIP extensions from the remote extensions list if WIP extensions are excluded.
-		if !r.args.IncludeWIP {
-			keep := remote[:0]
-			for _, x := range remote {
-				if !IsWorkInProgressExtension(x.Manifest) {
-					keep = append(keep, x)
-				}
-			}
-			remote = keep
-		}
 
 		r.registryExtensions = make([]graphqlbackend.RegistryExtension, len(local)+len(remote))
 		copy(r.registryExtensions, local)

--- a/cmd/frontend/registry/extension_manifest.go
+++ b/cmd/frontend/registry/extension_manifest.go
@@ -36,17 +36,6 @@ func (r *extensionManifest) parse() (*schema.SourcegraphExtensionManifest, error
 
 func (r *extensionManifest) Raw() string { return r.raw }
 
-func (r *extensionManifest) Title() (*string, error) {
-	parsed, err := r.parse()
-	if parsed == nil || err != nil {
-		return nil, err
-	}
-	if parsed.Title == "" {
-		return nil, nil
-	}
-	return &parsed.Title, nil
-}
-
 func (r *extensionManifest) Description() (*string, error) {
 	parsed, err := r.parse()
 	if parsed == nil || err != nil {

--- a/cmd/frontend/registry/extensions_test.go
+++ b/cmd/frontend/registry/extensions_test.go
@@ -188,14 +188,17 @@ func TestGetExtensionByExtensionID(t *testing.T) {
 
 func TestIsWorkInProgressExtension(t *testing.T) {
 	tests := map[*string]bool{
-		nil:                           true,
-		strptr(`{`):                   false,
-		strptr(`{}`):                  false,
-		strptr(`{"title":null}`):      false,
-		strptr(`{"title":""}`):        false,
-		strptr(`{"title":"a b"}`):     false,
-		strptr(`{"title":"WIP: a"}`):  true,
-		strptr(`{"title":"[WIP] a"}`): true,
+		nil:                                        true,
+		strptr(`{`):                                false,
+		strptr(`{}`):                               false,
+		strptr(`{"title":null}`):                   false,
+		strptr(`{"title":""}`):                     false,
+		strptr(`{"title":"a b"}`):                  false,
+		strptr(`{"title":"WIP: a"}`):               true,
+		strptr(`{"title":"[WIP] a"}`):              true,
+		strptr(`{"wip": true, "title":"a"}`):       true,
+		strptr(`{"wip": false, "title":"a"}`):      false,
+		strptr(`{"wip": false, "title":"WIP: a"}`): true,
 	}
 	for manifest, want := range tests {
 		got := IsWorkInProgressExtension(manifest)

--- a/doc/extensions/authoring/manifest.md
+++ b/doc/extensions/authoring/manifest.md
@@ -7,7 +7,6 @@ Sourcegraph extensions use a `package.json` file for metadata and configuration.
 Name | Required | Type | Details
 ---- |:--------:| ---- | -------
 `name` | ✔️ | `string` | Extension identifier: all lowercase, alphanumeric with hyphens and underscores.
-`title` | ✔️ | `string`| The name displayed in the extension registry. Can be used to indicate a [work-in-progress extension](publishing.md#wip-extensions).
 `description` | ✔️ | `string` | The extension's description, which summarizes the extension's purpose and features.
 `version` | | `string` | [Semantic versioning](https://semver.org/) format.
 `publisher` | ✔️ | `string` | Your [Sourcegraph username](development_environment.md#sourcegraph-com-account-and-the-sourcegraph-cli) (or the name of an organization you're a member of)
@@ -22,6 +21,7 @@ Name | Required | Type | Details
 `repository` | | `object` | npm field for the repository location.
 `categories` | | `string[]` | Categories that describe this extension, from the predefined set [`Programming languages`](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22), `Linters`, `Code analysis`, `External services`, `Reports and stats`, `Other`.
 `tags` | | `string[]` | Arbitrary tags that describe this extension.
+`wip` | | `boolean`| Indicates that this is a [work-in-progress extension](publishing.md#wip-extensions).
 
 See the [npm package.json documentation](https://docs.npmjs.com/creating-a-package-json-file) for other fields.
 
@@ -41,7 +41,6 @@ Here is an example `package.json` created by the [Sourcegraph extension creator]
 ```json
 {
   "name": "my-extension",
-  "title": "WIP: My extension",
   "description": "An awesome Sourcegraph extension",
   "publisher": "your-sourcegraph-username",
   "repository": {

--- a/doc/extensions/authoring/publishing.md
+++ b/doc/extensions/authoring/publishing.md
@@ -25,12 +25,11 @@ Your extension will need to be published to Sourcegraph.com or an Enterprise ins
 
 ### WIP extensions
 
-An extension with no published releases, or whose title begins with `WIP:` or `[WIP]`, is considered a work-in-progress (WIP) extension. WIP extensions:
+An extension with no published releases, or whose `package.json` extension manifest has a `"wip": true` property, is considered a work-in-progress (WIP) extension. WIP extensions:
 
-- Are not shown in the initial list of extensions on the extension registry. (They are only shown when the user has typed in a query).
-- Are sorted last on the list of extensions when there is a query (unless the user has already added the WIP extension).
-- Have a red "Work in progress" badge on the extension card in the list.
-- Have a red "Work in progress" badge on the extension's page.
+- are sorted last on the list of extensions (unless the user has previously enabled the WIP extension);
+- have a red "WIP" badge on the extension card in the list; and
+- have a red "WIP" badge on the extension's page.
 
 You can use WIP extensions for testing in-development extensions, as well as new versions of an existing extension.
 
@@ -40,7 +39,7 @@ When iterating on your extension, each code change requires republishing. You ca
 
 To set this up:
 
-1. If the extension is in use, add a `wip-` prefix to the current name and a `WIP:` or `[WIP]` to the title.
+1. If the extension is in use, add a `wip-` prefix to the current name (so that you don't publish your work-in-progress changes to users that rely on the extension) and set `"wip": true"` in the extension manifest.
 
 1. In a terminal window, run `npm run serve` in your extension's directory to run the Parcel dev server. Wait until it reports that it's listening on http://localhost:1234 (or another port number).
 

--- a/doc/extensions/authoring/publishing.md
+++ b/doc/extensions/authoring/publishing.md
@@ -27,6 +27,7 @@ Your extension will need to be published to Sourcegraph.com or an Enterprise ins
 
 An extension with no published releases, or whose `package.json` extension manifest has a `"wip": true` property, is considered a work-in-progress (WIP) extension. WIP extensions:
 
+- are not shown when searching for extensions unless the "Include WIP extensions" option is selected;
 - are sorted last on the list of extensions (unless the user has previously enabled the WIP extension);
 - have a red "WIP" badge on the extension card in the list; and
 - have a red "WIP" badge on the extension's page.

--- a/doc/extensions/authoring/publishing.md
+++ b/doc/extensions/authoring/publishing.md
@@ -27,7 +27,6 @@ Your extension will need to be published to Sourcegraph.com or an Enterprise ins
 
 An extension with no published releases, or whose `package.json` extension manifest has a `"wip": true` property, is considered a work-in-progress (WIP) extension. WIP extensions:
 
-- are not shown when searching for extensions unless the "Include WIP extensions" option is selected;
 - are sorted last on the list of extensions (unless the user has previously enabled the WIP extension);
 - have a red "WIP" badge on the extension card in the list; and
 - have a red "WIP" badge on the extension's page.

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
@@ -102,6 +102,10 @@ func parseExtensionQuery(q string) (text, category, tag string, includeWIP bool)
 			tag = unquoteValue(strings.TrimPrefix(tok, "tag:"))
 		} else if tok == "#wip" {
 			includeWIP = true
+		} else if tok == "#installed" || tok == "#enabled" || tok == "#disabled" {
+			// Ignore so that the client can implement these in post-processing. Add #wip if these
+			// tokens are encountered because that is usually the user's intent.
+			includeWIP = true
 		} else {
 			textTokens = append(textTokens, tok)
 		}

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
@@ -42,35 +42,31 @@ func TestToDBExtensionsListOptions(t *testing.T) {
 	}{
 		"empty": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{},
-			want: dbExtensionsListOptions{ExcludeWIP: true},
+			want: dbExtensionsListOptions{},
 		},
 		"Query simple": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr("q")},
-			want: dbExtensionsListOptions{Query: "q", ExcludeWIP: true},
+			want: dbExtensionsListOptions{Query: "q"},
 		},
 		"Query category quoted": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b category:"C🚀" c`)},
-			want: dbExtensionsListOptions{Query: "a b c", Category: "C🚀", ExcludeWIP: true},
+			want: dbExtensionsListOptions{Query: "a b c", Category: "C🚀"},
 		},
 		"Query category unquoted": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b category:C c`)},
-			want: dbExtensionsListOptions{Query: "a b c", Category: "C", ExcludeWIP: true},
+			want: dbExtensionsListOptions{Query: "a b c", Category: "C"},
 		},
 		"Query multiple categories": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a category:"C🚀" b category:"DD" c`)},
-			want: dbExtensionsListOptions{Query: "a b c", Category: "DD", ExcludeWIP: true},
+			want: dbExtensionsListOptions{Query: "a b c", Category: "DD"},
 		},
 		"Query tag": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b tag:"T🚀" c`)},
-			want: dbExtensionsListOptions{Query: "a b c", Tag: "T🚀", ExcludeWIP: true},
-		},
-		"Query include WIP": {
-			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b #wip c`)},
-			want: dbExtensionsListOptions{Query: "a b c", ExcludeWIP: false},
+			want: dbExtensionsListOptions{Query: "a b c", Tag: "T🚀"},
 		},
 		"PrioritizeExensionIDs": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{PrioritizeExtensionIDs: strarrayptr([]string{"a", "b"})},
-			want: dbExtensionsListOptions{PrioritizeExtensionIDs: []string{"a", "b"}, ExcludeWIP: true},
+			want: dbExtensionsListOptions{PrioritizeExtensionIDs: []string{"a", "b"}},
 		},
 	}
 	for name, test := range tests {

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
@@ -64,6 +64,10 @@ func TestToDBExtensionsListOptions(t *testing.T) {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b tag:"T🚀" c`)},
 			want: dbExtensionsListOptions{Query: "a b c", Tag: "T🚀", ExcludeWIP: true},
 		},
+		"Query include WIP": {
+			args: graphqlbackend.RegistryExtensionConnectionArgs{Query: strptr(`a b #wip c`)},
+			want: dbExtensionsListOptions{Query: "a b c", ExcludeWIP: false},
+		},
 		"PrioritizeExensionIDs": {
 			args: graphqlbackend.RegistryExtensionConnectionArgs{PrioritizeExtensionIDs: strarrayptr([]string{"a", "b"})},
 			want: dbExtensionsListOptions{PrioritizeExtensionIDs: []string{"a", "b"}, ExcludeWIP: true},

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -186,7 +186,6 @@ type dbExtensionsListOptions struct {
 	Category               string // matches the latest release's manifest's categories array
 	Tag                    string // matches the latest release's manifest's tags array
 	PrioritizeExtensionIDs []string
-	ExcludeWIP             bool // exclude extensions marked as WIP
 	*db.LimitOffset
 }
 
@@ -219,9 +218,6 @@ func (o dbExtensionsListOptions) sqlConditions() []*sqlf.Query {
 	}
 	if o.Tag != "" {
 		conds = append(conds, sqlf.Sprintf(`CASE WHEN rer.manifest IS NOT NULL THEN (rer.manifest->>'tags')::jsonb @> to_json(%s::text)::jsonb ELSE false END`, o.Tag))
-	}
-	if o.ExcludeWIP {
-		conds = append(conds, sqlf.Sprintf("NOT (%s)", extensionIsWIPExpr))
 	}
 	if len(conds) == 0 {
 		conds = append(conds, sqlf.Sprintf("TRUE"))

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -263,7 +263,7 @@ func TestRegistryExtensions(t *testing.T) {
 		}
 	})
 
-	t.Run("List ExcludeWIP and sort non-WIP first", func(t *testing.T) {
+	t.Run("List sort non-WIP first", func(t *testing.T) {
 		// xwip1 is a WIP extension because its title begins with "WIP:".
 		xwip1 := createAndGet(t, user.ID, 0, "wiptest1")
 		_, err := dbReleases{}.Create(ctx, &dbRelease{
@@ -326,10 +326,7 @@ func TestRegistryExtensions(t *testing.T) {
 		xnonwip2.NonCanonicalIsWorkInProgress = false
 
 		// The non-WIP extension should be sorted first.
-		testList(t, dbExtensionsListOptions{ExcludeWIP: false, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 5}}, []*dbExtension{xnonwip1, xnonwip2, xwip1, xwip2, xwip3})
-
-		// The WIP extension should be excluded.
-		testList(t, dbExtensionsListOptions{ExcludeWIP: true, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 3}}, []*dbExtension{xnonwip1, xnonwip2})
+		testList(t, dbExtensionsListOptions{Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 5}}, []*dbExtension{xnonwip1, xnonwip2, xwip1, xwip2, xwip3})
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -281,10 +281,24 @@ func TestRegistryExtensions(t *testing.T) {
 		// xwip2 is a WIP extension because it has no published releases.
 		xwip2 := createAndGet(t, user.ID, 0, "wiptest2")
 
-		// xnonwip is a non-WIP extension.
-		xnonwip := createAndGet(t, user.ID, 0, "wiptest3")
+		// xwip3 is a WIP extension because it has a "wip": true property.
+		xwip3 := createAndGet(t, user.ID, 0, "wiptest3")
 		_, err = dbReleases{}.Create(ctx, &dbRelease{
-			RegistryExtensionID: xnonwip.ID,
+			RegistryExtensionID: xwip3.ID,
+			CreatorUserID:       user.ID,
+			ReleaseTag:          "release",
+			Manifest:            `{"wip": true}`,
+			Bundle:              strptr(""),
+			SourceMap:           strptr(""),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// xnonwip1 is a non-WIP extension.
+		xnonwip1 := createAndGet(t, user.ID, 0, "wiptest4")
+		_, err = dbReleases{}.Create(ctx, &dbRelease{
+			RegistryExtensionID: xnonwip1.ID,
 			CreatorUserID:       user.ID,
 			ReleaseTag:          "release",
 			Manifest:            `{"title": "x"}`,
@@ -294,13 +308,28 @@ func TestRegistryExtensions(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		xnonwip.NonCanonicalIsWorkInProgress = false
+		xnonwip1.NonCanonicalIsWorkInProgress = false
+
+		// xnonwip2 is a non-WIP extension because its wip property is not true.
+		xnonwip2 := createAndGet(t, user.ID, 0, "wiptest5")
+		_, err = dbReleases{}.Create(ctx, &dbRelease{
+			RegistryExtensionID: xnonwip2.ID,
+			CreatorUserID:       user.ID,
+			ReleaseTag:          "release",
+			Manifest:            `{"wip": 123}`,
+			Bundle:              strptr(""),
+			SourceMap:           strptr(""),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		xnonwip2.NonCanonicalIsWorkInProgress = false
 
 		// The non-WIP extension should be sorted first.
-		testList(t, dbExtensionsListOptions{ExcludeWIP: false, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 3}}, []*dbExtension{xnonwip, xwip1, xwip2})
+		testList(t, dbExtensionsListOptions{ExcludeWIP: false, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 5}}, []*dbExtension{xnonwip1, xnonwip2, xwip1, xwip2, xwip3})
 
 		// The WIP extension should be excluded.
-		testList(t, dbExtensionsListOptions{ExcludeWIP: true, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 3}}, []*dbExtension{xnonwip})
+		testList(t, dbExtensionsListOptions{ExcludeWIP: true, Query: "wiptest", LimitOffset: &db.LimitOffset{Limit: 3}}, []*dbExtension{xnonwip1, xnonwip2})
 	})
 }
 
@@ -362,10 +391,14 @@ func TestRegistryExtensions_ListCount(t *testing.T) {
 	createAndGet(t, "xnomanifest", ``) // create extension without manifest to ensure it is not matched
 	createAndGet(t, "xinvalidmanifest", `123`)
 	createAndGet(t, "xinvalidtitle", `{"title": 123}`)
+	createAndGet(t, "xinvaliddescription", `{"description": 123}`)
 	createAndGet(t, "xinvalidcategoriestags", `{"title": "invalidcategories", "categories": 123, "tags": 123}`)
-	x1 := createAndGet(t, "x", `{"title": "foo", "categories": ["mycategory1", "Mycategory2"], "tags": ["t1", "T2"], "xyz": 1}`)
+	x1 := createAndGet(t, "x", `{"title": "foo1", "description": "foo2", "categories": ["mycategory1", "Mycategory2"], "tags": ["t1", "T2"], "xyz": 1}`)
 	t.Run("by title", func(t *testing.T) {
 		testListCount(t, dbExtensionsListOptions{Query: "foo"}, []*dbExtension{x1})
+		// BACKCOMPAT: match on title even though extension manifests no longer have a title property.
+		testListCount(t, dbExtensionsListOptions{Query: "foo1"}, []*dbExtension{x1})
+		testListCount(t, dbExtensionsListOptions{Query: "foo2"}, []*dbExtension{x1})
 		// Ensure it's not just searching the full JSON manifest.
 		testListCount(t, dbExtensionsListOptions{Query: "xyz"}, nil)
 		// Ensure it's not matching on category.

--- a/schema/extension_schema.go
+++ b/schema/extension_schema.go
@@ -14,7 +14,7 @@ type SourcegraphExtensionManifest struct {
 	Icon             string                  `json:"icon,omitempty"`
 	Readme           string                  `json:"readme,omitempty"`
 	Repository       *ExtensionRepository    `json:"repository,omitempty"`
-	Title            string                  `json:"title,omitempty"`
+	Wip              bool                    `json:"wip,omitempty"`
 	Url              string                  `json:"url"`
 }
 

--- a/shared/src/components/Path.test.tsx
+++ b/shared/src/components/Path.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Path } from './Path'
+
+describe('Path', () => {
+    test('no path components', () => {
+        expect(renderer.create(<Path path="" />).toJSON()).toMatchSnapshot()
+    })
+
+    test('1 path component', () => {
+        expect(renderer.create(<Path path="a" />).toJSON()).toMatchSnapshot()
+    })
+
+    test('2 path components', () => {
+        expect(renderer.create(<Path path="a/b" />).toJSON()).toMatchSnapshot()
+    })
+
+    test('3 path components', () => {
+        expect(renderer.create(<Path path="a/b/c" />).toJSON()).toMatchSnapshot()
+    })
+})

--- a/shared/src/components/Path.tsx
+++ b/shared/src/components/Path.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+/**
+ * Displays a "/"-separated path with the last path component bolded.
+ */
+export const Path: React.FunctionComponent<{ path: string }> = ({ path }) => {
+    if (path === '') {
+        return null
+    }
+    const parts = path.split('/')
+    return (
+        <>
+            {parts.length > 1 ? <span className="text-muted">{parts.slice(0, -1).join('/')}/</span> : ''}
+            <strong>{parts[parts.length - 1]}</strong>
+        </>
+    )
+}

--- a/shared/src/components/__snapshots__/Path.test.tsx.snap
+++ b/shared/src/components/__snapshots__/Path.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Path 1 path component 1`] = `
+Array [
+  "",
+  <strong>
+    a
+  </strong>,
+]
+`;
+
+exports[`Path 2 path components 1`] = `
+Array [
+  <span
+    className="text-muted"
+  >
+    a
+    /
+  </span>,
+  <strong>
+    b
+  </strong>,
+]
+`;
+
+exports[`Path 3 path components 1`] = `
+Array [
+  <span
+    className="text-muted"
+  >
+    a/b
+    /
+  </span>,
+  <strong>
+    c
+  </strong>,
+]
+`;
+
+exports[`Path no path components 1`] = `null`;

--- a/shared/src/extensions/extensionManifest.ts
+++ b/shared/src/extensions/extensionManifest.ts
@@ -10,13 +10,13 @@ import { parseJSONCOrError } from '../util/jsonc'
 export interface ExtensionManifest
     extends Pick<
         ExtensionManifestSchema,
-        | 'title'
         | 'description'
         | 'repository'
         | 'categories'
         | 'tags'
         | 'readme'
         | 'url'
+        | 'icon'
         | 'activationEvents'
         | 'contributes'
     > {}
@@ -34,9 +34,6 @@ export function parseExtensionManifestOrError(input: string): ExtensionManifest 
             return new Error('invalid extension manifest: must be a JSON object')
         }
         const problems: string[] = []
-        if (value.title && typeof value.title !== 'string') {
-            problems.push('"title" property must be a string')
-        }
         if (value.repository) {
             if (!isPlainObject(value.repository)) {
                 problems.push('"repository" property must be an object')
@@ -80,6 +77,9 @@ export function parseExtensionManifestOrError(input: string): ExtensionManifest 
             if (!isPlainObject(value.contributes)) {
                 problems.push('"contributes" property must be an object')
             }
+        }
+        if (value.icon && typeof value.icon !== 'string') {
+            problems.push('"icon" property must be a string')
         }
         if (problems.length > 0) {
             return new Error(`invalid extension manifest: ${problems.join(', ')}`)

--- a/shared/src/extensions/helpers.ts
+++ b/shared/src/extensions/helpers.ts
@@ -74,10 +74,6 @@ export function queryConfiguredRegistryExtensions(
             {
                 first: extensionIDs.length,
                 prioritizeExtensionIDs: extensionIDs,
-
-                // Include WIP extensions because some of the extensionIDs might be WIP, and we want them all to be
-                // returned.
-                query: '#wip',
             } as GQL.IExtensionsOnExtensionRegistryArguments,
             false
         )

--- a/shared/src/extensions/helpers.ts
+++ b/shared/src/extensions/helpers.ts
@@ -74,6 +74,10 @@ export function queryConfiguredRegistryExtensions(
             {
                 first: extensionIDs.length,
                 prioritizeExtensionIDs: extensionIDs,
+
+                // Include WIP extensions because some of the extensionIDs might be WIP, and we want them all to be
+                // returned.
+                query: '#wip',
             } as GQL.IExtensionsOnExtensionRegistryArguments,
             false
         )

--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -7,10 +7,6 @@
   "additionalProperties": true,
   "required": ["activationEvents", "publisher"],
   "properties": {
-    "title": {
-      "description": "The title of the extension. If not specified, the extension ID is used.",
-      "type": "string"
-    },
     "description": {
       "description":
         "The extension's description, which summarizes the extension's purpose and features. It should not exceed a few sentences.",

--- a/shared/src/schema/extension.schema.ts
+++ b/shared/src/schema/extension.schema.ts
@@ -34,7 +34,6 @@ export const EXTENSION_CATEGORIES = array([
 export type ExtensionCategory = typeof EXTENSION_CATEGORIES[number]
 
 export interface ExtensionManifest {
-    title?: string
     description?: string
     readme?: string
     url: string

--- a/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
+++ b/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable, Subscription } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
+import { Path } from '../../../../../shared/src/components/Path'
 import { gql } from '../../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../../shared/src/graphql/schema'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
@@ -59,8 +60,8 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
             this.state.extensionsOrError === LOADING
                 ? Array(ExtensionsExploreSection.QUERY_EXTENSIONS_ARG_FIRST).fill(LOADING)
                 : isErrorLike(this.state.extensionsOrError)
-                    ? this.state.extensionsOrError
-                    : this.state.extensionsOrError.nodes
+                ? this.state.extensionsOrError
+                : this.state.extensionsOrError.nodes
 
         return (
             <div className="extensions-explore-section">
@@ -79,7 +80,7 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
                                 <div key={i} className="col-md-6 col-lg-3 mb-2">
                                     {extension === LOADING ? (
                                         <ExtensionsExploreSectionExtensionCard
-                                            title="⋯"
+                                            extensionID="⋯"
                                             // Spacer to reduce loading jitter.
                                             description={
                                                 <>
@@ -90,10 +91,7 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
                                         />
                                     ) : (
                                         <ExtensionsExploreSectionExtensionCard
-                                            title={
-                                                (extension.manifest && extension.manifest.title) ||
-                                                extension.extensionIDWithoutRegistry
-                                            }
+                                            extensionID={<Path path={extension.extensionIDWithoutRegistry} />}
                                             description={
                                                 (extension.manifest && extension.manifest.description) || undefined
                                             }
@@ -105,7 +103,8 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
                         </div>
                         <div className="text-right mt-1">
                             <Link to="/extensions">
-                                View all extensions<ChevronRightIcon className="icon-inline" />
+                                View all extensions
+                                <ChevronRightIcon className="icon-inline" />
                             </Link>
                         </div>
                     </>
@@ -127,7 +126,6 @@ function queryExtensions(
                             extensionIDWithoutRegistry
                             url
                             manifest {
-                                title
                                 description
                             }
                         }

--- a/web/src/enterprise/extensions/explore/ExtensionsExploreSectionExtensionCard.tsx
+++ b/web/src/enterprise/extensions/explore/ExtensionsExploreSectionExtensionCard.tsx
@@ -5,10 +5,10 @@ import { LinkOrSpan } from '../../../../../shared/src/components/LinkOrSpan'
  * An extension card shown in {@link ExtensionsExploreSection}.
  */
 export const ExtensionsExploreSectionExtensionCard: React.FunctionComponent<{
-    title: string
+    extensionID: string | React.ReactFragment
     description?: string | React.ReactFragment
     url?: string
-}> = ({ title, description = '', url }) => (
+}> = ({ extensionID: title, description = '', url }) => (
     <LinkOrSpan
         to={url}
         className="card bg-secondary border-primary card-link text-white"
@@ -18,7 +18,7 @@ export const ExtensionsExploreSectionExtensionCard: React.FunctionComponent<{
         style={{ backgroundImage: 'linear-gradient(116deg, #0c1e41, #171941)' }}
     >
         <div className="card-body">
-            <h2 className="h6 font-weight-bold mb-0 text-truncate">{title}</h2>
+            <h2 className="h6 font-weight-normal mb-0 text-truncate">{title}</h2>
             {description && <p className="card-text mt-1 small">{description}</p>}
         </div>
     </LinkOrSpan>

--- a/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -76,10 +76,6 @@ class RegistryExtensionNodeSiteAdminRow extends React.PureComponent<
                         <Link className="font-weight-bold" to={this.props.node.url}>
                             {this.props.node.extensionID}
                         </Link>{' '}
-                        {this.props.node.manifest &&
-                            this.props.node.manifest.title && (
-                                <span className="text-muted">({this.props.node.manifest.title})</span>
-                            )}
                         <div className="text-muted small">
                             <RegistryExtensionSourceBadge extension={this.props.node} showText={true} />
                             {this.props.node.updatedAt && (
@@ -99,17 +95,15 @@ class RegistryExtensionNodeSiteAdminRow extends React.PureComponent<
                                 Manage
                             </Link>
                         )}
-                        {!this.props.node.isLocal &&
-                            this.props.node.remoteURL &&
-                            this.props.node.registryName && (
-                                <a
-                                    href={this.props.node.remoteURL}
-                                    className="btn btn-link text-info btn-sm ml-1"
-                                    title={`View extension on ${this.props.node.registryName}`}
-                                >
-                                    Visit
-                                </a>
-                            )}
+                        {!this.props.node.isLocal && this.props.node.remoteURL && this.props.node.registryName && (
+                            <a
+                                href={this.props.node.remoteURL}
+                                className="btn btn-link text-info btn-sm ml-1"
+                                title={`View extension on ${this.props.node.registryName}`}
+                            >
+                                Visit
+                            </a>
+                        )}
                         {this.props.node.viewerCanAdminister && (
                             <button
                                 className="btn btn-outline-danger btn-sm ml-1"

--- a/web/src/extensions/ExtensionCard.scss
+++ b/web/src/extensions/ExtensionCard.scss
@@ -1,5 +1,4 @@
 .extension-card {
-    min-height: 9rem;
     background-color: var(--extension-card-bg);
     flex: 1;
 

--- a/web/src/extensions/ExtensionCard.test.tsx
+++ b/web/src/extensions/ExtensionCard.test.tsx
@@ -20,14 +20,14 @@ describe('ExtensionCard', () => {
                             node={{
                                 id: 'x/y',
                                 manifest: {
-                                    title: 't',
                                     activationEvents: ['*'],
                                     description: 'd',
                                     url: 'https://example.com',
                                     icon: 'data:image/png,abcd',
                                 },
                                 registryExtension: {
-                                    id: 'x/y',
+                                    id: 'abcd1234',
+                                    extensionIDWithoutRegistry: 'x/y',
                                     url: 'extensions/x/y',
                                     isWorkInProgress: false,
                                     viewerCanAdminister: false,

--- a/web/src/extensions/ExtensionCard.tsx
+++ b/web/src/extensions/ExtensionCard.tsx
@@ -2,6 +2,7 @@ import WarningIcon from 'mdi-react/WarningIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { LinkOrSpan } from '../../../shared/src/components/LinkOrSpan'
+import { Path } from '../../../shared/src/components/Path'
 import { ConfiguredRegistryExtension, isExtensionEnabled } from '../../../shared/src/extensions/extension'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { SettingsSubject } from '../../../shared/src/graphql/schema'
@@ -17,7 +18,10 @@ import { ExtensionToggle } from './ExtensionToggle'
 interface Props extends SettingsCascadeProps, PlatformContextProps {
     node: Pick<
         ConfiguredRegistryExtension<
-            Pick<GQL.IRegistryExtension, 'id' | 'isWorkInProgress' | 'viewerCanAdminister' | 'url'>
+            Pick<
+                GQL.IRegistryExtension,
+                'id' | 'extensionIDWithoutRegistry' | 'isWorkInProgress' | 'viewerCanAdminister' | 'url'
+            >
         >,
         'id' | 'manifest' | 'registryExtension'
     >
@@ -54,16 +58,24 @@ export class ExtensionCard extends React.PureComponent<Props> {
                                 /^data:image\/png(;base64)?,/.test(manifest.icon) && (
                                     <img className="extension-card__icon mr-2" src={manifest.icon} />
                                 )}
-                            <div>
-                                <h4 className="card-title extension-card__body-title mb-0">
-                                    {manifest && manifest.title ? manifest.title : node.id}
-                                </h4>
-                                <div className="extension-card__body-text d-inline-block mt-1">
+                            <div className="text-truncate">
+                                <div className="d-flex align-items-center">
+                                    <h4 className="card-title extension-card__body-title mb-0 mr-1 text-truncate font-weight-normal">
+                                        <Path
+                                            path={
+                                                node.registryExtension
+                                                    ? node.registryExtension.extensionIDWithoutRegistry
+                                                    : node.id
+                                            }
+                                        />
+                                    </h4>
                                     {node.registryExtension && node.registryExtension.isWorkInProgress && (
                                         <WorkInProgressBadge
                                             viewerCanAdminister={node.registryExtension.viewerCanAdminister}
                                         />
                                     )}
+                                </div>
+                                <div className="mt-1">
                                     {node.manifest ? (
                                         isErrorLike(node.manifest) ? (
                                             <span className="text-danger small" title={node.manifest.message}>
@@ -71,7 +83,9 @@ export class ExtensionCard extends React.PureComponent<Props> {
                                             </span>
                                         ) : (
                                             node.manifest.description && (
-                                                <span className="text-muted">{node.manifest.description}</span>
+                                                <div className="text-muted text-truncate">
+                                                    {node.manifest.description}
+                                                </div>
                                             )
                                         )
                                     ) : (

--- a/web/src/extensions/ExtensionToggle.test.tsx
+++ b/web/src/extensions/ExtensionToggle.test.tsx
@@ -13,9 +13,8 @@ describe('ExtensionToggle', () => {
         // tslint:disable-next-line:no-object-literal-type-assertion
         subject: { __typename: 'User', id: 'u', viewerCanAdminister: true } as SettingsSubject,
     }
-    const EXTENSION: Pick<ConfiguredRegistryExtension, 'id' | 'manifest'> = {
+    const EXTENSION: Pick<ConfiguredRegistryExtension, 'id'> = {
         id: 'x/y',
-        manifest: { activationEvents: ['*'], title: 't', url: 'https://example.com' },
     }
 
     test('extension not present in settings', () => {

--- a/web/src/extensions/ExtensionToggle.tsx
+++ b/web/src/extensions/ExtensionToggle.tsx
@@ -11,7 +11,7 @@ import { isExtensionAdded } from './extension/extension'
 
 interface Props extends SettingsCascadeProps, PlatformContextProps {
     /** The extension that this element is for. */
-    extension: Pick<ConfiguredRegistryExtension, 'id' | 'manifest'>
+    extension: Pick<ConfiguredRegistryExtension, 'id'>
 }
 
 /**
@@ -42,7 +42,7 @@ export class ExtensionToggle extends React.PureComponent<Props> {
 
                         if (
                             !isExtensionAdded(this.props.settingsCascade.final, this.props.extension.id) &&
-                            !confirmAddExtension(this.props.extension.id, this.props.extension.manifest)
+                            !confirmAddExtension(this.props.extension.id)
                         ) {
                             return EMPTY
                         }
@@ -98,21 +98,9 @@ export class ExtensionToggle extends React.PureComponent<Props> {
 /**
  * Shows a modal confirmation prompt to the user confirming whether to add an extension.
  */
-function confirmAddExtension(
-    extensionID: string,
-    extensionManifest?: ConfiguredRegistryExtension['manifest']
-): boolean {
-    // Either `"title" (id)` (if there is a title in the manifest) or else just `id`. It is
-    // important to show the ID because it indicates who the publisher is and allows
-    // disambiguation from other similarly titled extensions.
-    let displayName: string
-    if (extensionManifest && !isErrorLike(extensionManifest) && extensionManifest.title) {
-        displayName = `${JSON.stringify(extensionManifest.title)} (${extensionID})`
-    } else {
-        displayName = extensionID
-    }
+function confirmAddExtension(extensionID: string): boolean {
     return confirm(
-        `Add Sourcegraph extension ${displayName}?\n\nIt can:\n- Read repositories and files you view using Sourcegraph\n- Read and change your Sourcegraph settings`
+        `Add Sourcegraph extension ${extensionID}?\n\nIt can:\n- Read repositories and files you view using Sourcegraph\n- Read and change your Sourcegraph settings`
     )
 }
 

--- a/web/src/extensions/ExtensionsList.test.tsx
+++ b/web/src/extensions/ExtensionsList.test.tsx
@@ -1,0 +1,30 @@
+import { applyExtensionsQuery } from './ExtensionsList'
+
+describe('applyExtensionsQuery', () => {
+    test('#installed', () =>
+        expect(
+            applyExtensionsQuery('#installed', { extensions: { a: true, b: false } }, [
+                { extensionID: 'a' },
+                { extensionID: 'b' },
+                { extensionID: 'c' },
+            ]).map(({ extensionID }) => extensionID)
+        ).toEqual(['a', 'b']))
+
+    test('#enabled', () =>
+        expect(
+            applyExtensionsQuery('#enabled', { extensions: { a: true, b: false } }, [
+                { extensionID: 'a' },
+                { extensionID: 'b' },
+                { extensionID: 'c' },
+            ]).map(({ extensionID }) => extensionID)
+        ).toEqual(['a']))
+
+    test('#disabled', () =>
+        expect(
+            applyExtensionsQuery('#disabled', { extensions: { a: true, b: false } }, [
+                { extensionID: 'a' },
+                { extensionID: 'b' },
+                { extensionID: 'c' },
+            ]).map(({ extensionID }) => extensionID)
+        ).toEqual(['b']))
+})

--- a/web/src/extensions/ExtensionsList.tsx
+++ b/web/src/extensions/ExtensionsList.tsx
@@ -12,6 +12,7 @@ import { SettingsCascadeProps, SettingsSubject } from '../../../shared/src/setti
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { queryGraphQL } from '../backend/graphql'
 import { Form } from '../components/Form'
+import { extensionsQuery } from './extension/extension'
 import { ExtensionCard } from './ExtensionCard'
 import { ExtensionsQueryInputToolbar } from './ExtensionsQueryInputToolbar'
 
@@ -208,9 +209,17 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                         )}
                         {this.state.data.resultOrError.extensions.length === 0 ? (
                             this.state.data.query ? (
-                                <span className="text-muted">
-                                    No extensions matching <strong>{this.state.data.query}</strong>
-                                </span>
+                                <div className="text-muted">
+                                    <p>
+                                        No extensions match <strong>{this.state.data.query}</strong>.
+                                    </p>
+                                    {!this.state.data.query.includes(extensionsQuery({ wip: true })) && (
+                                        <p className="small">
+                                            Looking for a WIP extension? Select{' '}
+                                            <strong>Options &gt; Include WIP extensions</strong>.
+                                        </p>
+                                    )}
+                                </div>
                             ) : (
                                 this.props.emptyElement || <span className="text-muted">No extensions found</span>
                             )
@@ -255,11 +264,7 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                         gql`
                             query RegistryExtensions($query: String, $prioritizeExtensionIDs: [String!]!) {
                                 extensionRegistry {
-                                    extensions(
-                                        query: $query
-                                        prioritizeExtensionIDs: $prioritizeExtensionIDs
-                                        includeWIP: true
-                                    ) {
+                                    extensions(query: $query, prioritizeExtensionIDs: $prioritizeExtensionIDs) {
                                         nodes {
                                             ...RegistryExtensionFields
                                         }

--- a/web/src/extensions/ExtensionsList.tsx
+++ b/web/src/extensions/ExtensionsList.tsx
@@ -214,15 +214,7 @@ export class ExtensionsList extends React.PureComponent<Props, State> {
                         {this.state.data.resultOrError.extensions.length === 0 ? (
                             this.state.data.query ? (
                                 <div className="text-muted">
-                                    <p>
-                                        No extensions match <strong>{this.state.data.query}</strong>.
-                                    </p>
-                                    {!this.state.data.query.includes(extensionsQuery({ wip: true })) && (
-                                        <p className="small">
-                                            Looking for a WIP extension? Select{' '}
-                                            <strong>Options &gt; Include WIP extensions</strong>.
-                                        </p>
-                                    )}
+                                    No extensions match <strong>{this.state.data.query}</strong>.
                                 </div>
                             ) : (
                                 this.props.emptyElement || <span className="text-muted">No extensions found</span>

--- a/web/src/extensions/ExtensionsList.tsx
+++ b/web/src/extensions/ExtensionsList.tsx
@@ -47,7 +47,6 @@ export const registryExtensionFragment = gql`
         name
         manifest {
             raw
-            title
             description
         }
         createdAt

--- a/web/src/extensions/ExtensionsQueryInputToolbar.test.tsx
+++ b/web/src/extensions/ExtensionsQueryInputToolbar.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { EXTENSION_CATEGORIES } from '../../../shared/src/schema/extension.schema'
+import { extensionsQuery } from './extension/extension'
+import { ExtensionsQueryInputToolbar } from './ExtensionsQueryInputToolbar'
+
+describe('ExtensionsQueryInputToolbar', () => {
+    test('renders', () => {
+        expect(
+            // tslint:disable-next-line:jsx-no-lambda
+            renderer.create(<ExtensionsQueryInputToolbar query="q" onQueryChange={() => void 0} />).toJSON()
+        ).toMatchSnapshot()
+    })
+
+    test('shows category in query as selected', () => {
+        expect(
+            renderer
+                .create(
+                    <ExtensionsQueryInputToolbar
+                        query={extensionsQuery({ category: EXTENSION_CATEGORIES[0] })}
+                        // tslint:disable-next-line:jsx-no-lambda
+                        onQueryChange={() => void 0}
+                    />
+                )
+                .toJSON()
+        ).toMatchSnapshot()
+    })
+})

--- a/web/src/extensions/ExtensionsQueryInputToolbar.tsx
+++ b/web/src/extensions/ExtensionsQueryInputToolbar.tsx
@@ -55,6 +55,20 @@ export class ExtensionsQueryInputToolbar extends React.PureComponent<Props, Stat
                     <DropdownMenu right={true}>
                         <DropdownItem
                             // tslint:disable-next-line:jsx-no-lambda
+                            onClick={() => this.props.onQueryChange(extensionsQuery({ enabled: true }))}
+                            disabled={this.props.query.includes(extensionsQuery({ enabled: true }))}
+                        >
+                            Show enabled extensions
+                        </DropdownItem>
+                        <DropdownItem
+                            // tslint:disable-next-line:jsx-no-lambda
+                            onClick={() => this.props.onQueryChange(extensionsQuery({ disabled: true }))}
+                            disabled={this.props.query.includes(extensionsQuery({ disabled: true }))}
+                        >
+                            Show disabled extensions
+                        </DropdownItem>
+                        <DropdownItem
+                            // tslint:disable-next-line:jsx-no-lambda
                             onClick={() =>
                                 this.props.onQueryChange(this.props.query + ' ' + extensionsQuery({ wip: true }))
                             }

--- a/web/src/extensions/ExtensionsQueryInputToolbar.tsx
+++ b/web/src/extensions/ExtensionsQueryInputToolbar.tsx
@@ -67,15 +67,6 @@ export class ExtensionsQueryInputToolbar extends React.PureComponent<Props, Stat
                         >
                             Show disabled extensions
                         </DropdownItem>
-                        <DropdownItem
-                            // tslint:disable-next-line:jsx-no-lambda
-                            onClick={() =>
-                                this.props.onQueryChange(this.props.query + ' ' + extensionsQuery({ wip: true }))
-                            }
-                            disabled={this.props.query.includes(extensionsQuery({ wip: true }))}
-                        >
-                            Include WIP extensions
-                        </DropdownItem>
                     </DropdownMenu>
                 </ButtonDropdown>
             </>

--- a/web/src/extensions/ExtensionsQueryInputToolbar.tsx
+++ b/web/src/extensions/ExtensionsQueryInputToolbar.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
+import { EXTENSION_CATEGORIES } from '../../../shared/src/schema/extension.schema'
+import { extensionsQuery } from './extension/extension'
+
+interface Props {
+    /** The current extensions registry list query. */
+    query: string
+
+    /** Called when the query changes as a result of user interaction with this component. */
+    onQueryChange: (query: string) => void
+}
+
+interface State {
+    /** Whether the categories dropdown is open. */
+    isOpen: boolean
+}
+
+/**
+ * Displays buttons to be rendered alongside the extension registry list query input field.
+ */
+export class ExtensionsQueryInputToolbar extends React.PureComponent<Props, State> {
+    public state: State = { isOpen: false }
+
+    public render(): JSX.Element | null {
+        return (
+            <>
+                <ButtonDropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen}>
+                    <DropdownToggle caret={true}>Category</DropdownToggle>
+                    <DropdownMenu right={true}>
+                        {EXTENSION_CATEGORIES.map((c, i) => (
+                            <DropdownItem
+                                key={i}
+                                // tslint:disable-next-line:jsx-no-lambda
+                                onClick={() => this.props.onQueryChange(extensionsQuery({ category: c }))}
+                                disabled={this.props.query === extensionsQuery({ category: c })}
+                            >
+                                {c}
+                            </DropdownItem>
+                        ))}
+                    </DropdownMenu>
+                </ButtonDropdown>
+            </>
+        )
+    }
+
+    private toggleIsOpen = () => this.setState(prevState => ({ isOpen: !prevState.isOpen }))
+}

--- a/web/src/extensions/ExtensionsQueryInputToolbar.tsx
+++ b/web/src/extensions/ExtensionsQueryInputToolbar.tsx
@@ -11,21 +11,27 @@ interface Props {
     onQueryChange: (query: string) => void
 }
 
+type DropdownMenuID = 'categories' | 'options'
+
 interface State {
-    /** Whether the categories dropdown is open. */
-    isOpen: boolean
+    /** Which dropdown is open (if any). */
+    open?: DropdownMenuID
 }
 
 /**
  * Displays buttons to be rendered alongside the extension registry list query input field.
  */
 export class ExtensionsQueryInputToolbar extends React.PureComponent<Props, State> {
-    public state: State = { isOpen: false }
+    public state: State = {}
 
     public render(): JSX.Element | null {
         return (
             <>
-                <ButtonDropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen}>
+                <ButtonDropdown
+                    isOpen={this.state.open === 'categories'}
+                    // tslint:disable-next-line:jsx-no-lambda
+                    toggle={() => this.toggleIsOpen('categories')}
+                >
                     <DropdownToggle caret={true}>Category</DropdownToggle>
                     <DropdownMenu right={true}>
                         {EXTENSION_CATEGORIES.map((c, i) => (
@@ -39,10 +45,29 @@ export class ExtensionsQueryInputToolbar extends React.PureComponent<Props, Stat
                             </DropdownItem>
                         ))}
                     </DropdownMenu>
+                </ButtonDropdown>{' '}
+                <ButtonDropdown
+                    isOpen={this.state.open === 'options'}
+                    // tslint:disable-next-line:jsx-no-lambda
+                    toggle={() => this.toggleIsOpen('options')}
+                >
+                    <DropdownToggle caret={true}>Options</DropdownToggle>
+                    <DropdownMenu right={true}>
+                        <DropdownItem
+                            // tslint:disable-next-line:jsx-no-lambda
+                            onClick={() =>
+                                this.props.onQueryChange(this.props.query + ' ' + extensionsQuery({ wip: true }))
+                            }
+                            disabled={this.props.query.includes(extensionsQuery({ wip: true }))}
+                        >
+                            Include WIP extensions
+                        </DropdownItem>
+                    </DropdownMenu>
                 </ButtonDropdown>
             </>
         )
     }
 
-    private toggleIsOpen = () => this.setState(prevState => ({ isOpen: !prevState.isOpen }))
+    private toggleIsOpen = (menu: DropdownMenuID) =>
+        this.setState(prevState => ({ open: prevState.open === menu ? undefined : menu }))
 }

--- a/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
@@ -18,20 +18,34 @@ exports[`ExtensionCard renders 1`] = `
           className="extension-card__icon mr-2"
           src="data:image/png,abcd"
         />
-        <div>
-          <h4
-            className="card-title extension-card__body-title mb-0"
-          >
-            t
-          </h4>
+        <div
+          className="text-truncate"
+        >
           <div
-            className="extension-card__body-text d-inline-block mt-1"
+            className="d-flex align-items-center"
           >
-            <span
-              className="text-muted"
+            <h4
+              className="card-title extension-card__body-title mb-0 mr-1 text-truncate font-weight-normal"
+            >
+              <span
+                className="text-muted"
+              >
+                x
+                /
+              </span>
+              <strong>
+                y
+              </strong>
+            </h4>
+          </div>
+          <div
+            className="mt-1"
+          >
+            <div
+              className="text-muted text-truncate"
             >
               d
-            </span>
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
@@ -1,0 +1,190 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExtensionsQueryInputToolbar renders 1`] = `
+<div
+  className="search-button btn-group"
+  onKeyDown={[Function]}
+>
+  <button
+    aria-expanded={false}
+    aria-haspopup={true}
+    aria-label={null}
+    className="dropdown-toggle btn btn-secondary"
+    onClick={[Function]}
+    type="button"
+  >
+    Category
+  </button>
+  <div
+    aria-hidden={true}
+    className="dropdown-menu dropdown-menu-right"
+    role="menu"
+    tabIndex="-1"
+  >
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Programming languages
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Linters
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Code analysis
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      External services
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Reports and stats
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Other
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Demos
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ExtensionsQueryInputToolbar shows category in query as selected 1`] = `
+<div
+  className="search-button btn-group"
+  onKeyDown={[Function]}
+>
+  <button
+    aria-expanded={false}
+    aria-haspopup={true}
+    aria-label={null}
+    className="dropdown-toggle btn btn-secondary"
+    onClick={[Function]}
+    type="button"
+  >
+    Category
+  </button>
+  <div
+    aria-hidden={true}
+    className="dropdown-menu dropdown-menu-right"
+    role="menu"
+    tabIndex="-1"
+  >
+    <button
+      className="disabled dropdown-item"
+      disabled={true}
+      onClick={[Function]}
+      tabIndex="-1"
+      type="button"
+    >
+      Programming languages
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Linters
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Code analysis
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      External services
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Reports and stats
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Other
+    </button>
+    <button
+      className="dropdown-item"
+      disabled={false}
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="0"
+      type="button"
+    >
+      Demos
+    </button>
+  </div>
+</div>
+`;

--- a/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
@@ -123,6 +123,26 @@ Array [
         tabIndex="0"
         type="button"
       >
+        Show enabled extensions
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Show disabled extensions
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
         Include WIP extensions
       </button>
     </div>
@@ -244,6 +264,26 @@ Array [
       role="menu"
       tabIndex="-1"
     >
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Show enabled extensions
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Show disabled extensions
+      </button>
       <button
         className="dropdown-item"
         disabled={false}

--- a/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
@@ -135,16 +135,6 @@ Array [
       >
         Show disabled extensions
       </button>
-      <button
-        className="dropdown-item"
-        disabled={false}
-        onClick={[Function]}
-        role="menuitem"
-        tabIndex="0"
-        type="button"
-      >
-        Include WIP extensions
-      </button>
     </div>
   </div>,
 ]
@@ -283,16 +273,6 @@ Array [
         type="button"
       >
         Show disabled extensions
-      </button>
-      <button
-        className="dropdown-item"
-        disabled={false}
-        onClick={[Function]}
-        role="menuitem"
-        tabIndex="0"
-        type="button"
-      >
-        Include WIP extensions
       </button>
     </div>
   </div>,

--- a/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionsQueryInputToolbar.test.tsx.snap
@@ -1,190 +1,260 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ExtensionsQueryInputToolbar renders 1`] = `
-<div
-  className="search-button btn-group"
-  onKeyDown={[Function]}
->
-  <button
-    aria-expanded={false}
-    aria-haspopup={true}
-    aria-label={null}
-    className="dropdown-toggle btn btn-secondary"
-    onClick={[Function]}
-    type="button"
-  >
-    Category
-  </button>
+Array [
   <div
-    aria-hidden={true}
-    className="dropdown-menu dropdown-menu-right"
-    role="menu"
-    tabIndex="-1"
+    className="btn-group"
+    onKeyDown={[Function]}
   >
     <button
-      className="dropdown-item"
-      disabled={false}
+      aria-expanded={false}
+      aria-haspopup={true}
+      aria-label={null}
+      className="dropdown-toggle btn btn-secondary"
       onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
       type="button"
     >
-      Programming languages
+      Category
     </button>
+    <div
+      aria-hidden={true}
+      className="dropdown-menu dropdown-menu-right"
+      role="menu"
+      tabIndex="-1"
+    >
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Programming languages
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Linters
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Code analysis
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        External services
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Reports and stats
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Other
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Demos
+      </button>
+    </div>
+  </div>,
+  " ",
+  <div
+    className="btn-group"
+    onKeyDown={[Function]}
+  >
     <button
-      className="dropdown-item"
-      disabled={false}
+      aria-expanded={false}
+      aria-haspopup={true}
+      aria-label={null}
+      className="dropdown-toggle btn btn-secondary"
       onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
       type="button"
     >
-      Linters
+      Options
     </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
+    <div
+      aria-hidden={true}
+      className="dropdown-menu dropdown-menu-right"
+      role="menu"
+      tabIndex="-1"
     >
-      Code analysis
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      External services
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      Reports and stats
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      Other
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      Demos
-    </button>
-  </div>
-</div>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Include WIP extensions
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ExtensionsQueryInputToolbar shows category in query as selected 1`] = `
-<div
-  className="search-button btn-group"
-  onKeyDown={[Function]}
->
-  <button
-    aria-expanded={false}
-    aria-haspopup={true}
-    aria-label={null}
-    className="dropdown-toggle btn btn-secondary"
-    onClick={[Function]}
-    type="button"
-  >
-    Category
-  </button>
+Array [
   <div
-    aria-hidden={true}
-    className="dropdown-menu dropdown-menu-right"
-    role="menu"
-    tabIndex="-1"
+    className="btn-group"
+    onKeyDown={[Function]}
   >
     <button
-      className="disabled dropdown-item"
-      disabled={true}
+      aria-expanded={false}
+      aria-haspopup={true}
+      aria-label={null}
+      className="dropdown-toggle btn btn-secondary"
       onClick={[Function]}
+      type="button"
+    >
+      Category
+    </button>
+    <div
+      aria-hidden={true}
+      className="dropdown-menu dropdown-menu-right"
+      role="menu"
       tabIndex="-1"
-      type="button"
     >
-      Programming languages
-    </button>
+      <button
+        className="disabled dropdown-item"
+        disabled={true}
+        onClick={[Function]}
+        tabIndex="-1"
+        type="button"
+      >
+        Programming languages
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Linters
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Code analysis
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        External services
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Reports and stats
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Other
+      </button>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Demos
+      </button>
+    </div>
+  </div>,
+  " ",
+  <div
+    className="btn-group"
+    onKeyDown={[Function]}
+  >
     <button
-      className="dropdown-item"
-      disabled={false}
+      aria-expanded={false}
+      aria-haspopup={true}
+      aria-label={null}
+      className="dropdown-toggle btn btn-secondary"
       onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
       type="button"
     >
-      Linters
+      Options
     </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
+    <div
+      aria-hidden={true}
+      className="dropdown-menu dropdown-menu-right"
+      role="menu"
+      tabIndex="-1"
     >
-      Code analysis
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      External services
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      Reports and stats
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      Other
-    </button>
-    <button
-      className="dropdown-item"
-      disabled={false}
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="0"
-      type="button"
-    >
-      Demos
-    </button>
-  </div>
-</div>
+      <button
+        className="dropdown-item"
+        disabled={false}
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+        type="button"
+      >
+        Include WIP extensions
+      </button>
+    </div>
+  </div>,
+]
 `;

--- a/web/src/extensions/extension/ExtensionArea.tsx
+++ b/web/src/extensions/extension/ExtensionArea.tsx
@@ -43,7 +43,6 @@ export const registryExtensionFragment = gql`
         name
         manifest {
             raw
-            title
             description
         }
         createdAt

--- a/web/src/extensions/extension/ExtensionAreaHeader.scss
+++ b/web/src/extensions/extension/ExtensionAreaHeader.scss
@@ -6,9 +6,4 @@
         width: 8rem;
         height: 8rem;
     }
-    &__icon-chevron {
-        margin-left: -0.5rem;
-        margin-right: -0.5rem;
-        margin-bottom: -0.15rem;
-    }
 }

--- a/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -1,6 +1,7 @@
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import * as React from 'react'
 import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
+import { Path } from '../../../../shared/src/components/Path'
 import { isExtensionEnabled } from '../../../../shared/src/extensions/extension'
 import { ExtensionManifest } from '../../../../shared/src/schema/extension.schema'
 import { isErrorLike } from '../../../../shared/src/util/errors'
@@ -53,18 +54,19 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                                         <img className="extension-area-header__icon mr-2" src={manifest.icon} />
                                     )}
                                 <div>
-                                    <div className="d-flex align-items-center">
-                                        <h2 className="mb-0">
-                                            <Link to="/extensions" className="extensions-nav-link">
-                                                Extensions
-                                            </Link>{' '}
-                                            <ChevronRightIcon className="icon-inline extension-area-header__icon-chevron" />{' '}
-                                            {(manifest && manifest.title) || props.extension.id}
-                                        </h2>
-                                    </div>
-                                    {manifest && manifest.title && (
-                                        <div className="text-muted">{props.extension.id}</div>
-                                    )}
+                                    <h2 className="d-flex align-items-center mb-0 font-weight-normal">
+                                        <Link to="/extensions" className="extensions-nav-link">
+                                            Extensions
+                                        </Link>
+                                        <ChevronRightIcon className="icon-inline extension-area-header__icon-chevron" />{' '}
+                                        <Path
+                                            path={
+                                                props.extension.registryExtension
+                                                    ? props.extension.registryExtension.extensionIDWithoutRegistry
+                                                    : props.extension.id
+                                            }
+                                        />
+                                    </h2>
                                     {manifest && (manifest.description || isWorkInProgress) && (
                                         <p className="mt-1 mb-0">
                                             {isWorkInProgress && (

--- a/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -8,7 +8,7 @@ import { ExtensionCategory } from '../../../../shared/src/schema/extension.schem
 import { isErrorLike } from '../../../../shared/src/util/errors'
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
-import { extensionIDPrefix, validCategories } from './extension'
+import { extensionIDPrefix, extensionsQuery, urlToExtensionsQuery, validCategories } from './extension'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionREADME } from './RegistryExtensionREADME'
 
@@ -58,7 +58,7 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                                 {categories.map((c, i) => (
                                     <li key={i} className="list-inline-item mb-2 small">
                                         <Link
-                                            to={`/extensions?query=category:${encodeURIComponent('"' + c + '"')}`}
+                                            to={urlToExtensionsQuery(extensionsQuery({ category: c }))}
                                             className="rounded border p-1"
                                         >
                                             {c}
@@ -78,7 +78,7 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                                     {this.props.extension.manifest.tags.map((t, i) => (
                                         <li key={i} className="list-inline-item mb-2 small">
                                             <Link
-                                                to={`/extensions?query=tag:${encodeURIComponent(JSON.stringify(t))}`}
+                                                to={urlToExtensionsQuery(extensionsQuery({ tag: t }))}
                                                 className="rounded border p-1"
                                             >
                                                 {truncate(t, { length: 24 })}

--- a/web/src/extensions/extension/RegistryExtensionREADME.tsx
+++ b/web/src/extensions/extension/RegistryExtensionREADME.tsx
@@ -14,15 +14,14 @@ const PublishNewManifestAlert: React.FunctionComponent<{
 }> = ({ extension, text, buttonLabel, alertClass }) => (
     <div className={`alert ${alertClass}`}>
         {text}
-        {extension.registryExtension &&
-            extension.registryExtension.viewerCanAdminister && (
-                <>
-                    <br />
-                    <Link className="mt-3 btn btn-primary" to={`${extension.registryExtension.url}/-/releases/new`}>
-                        {buttonLabel}
-                    </Link>
-                </>
-            )}
+        {extension.registryExtension && extension.registryExtension.viewerCanAdminister && (
+            <>
+                <br />
+                <Link className="mt-3 btn btn-primary" to={`${extension.registryExtension.url}/-/releases/new`}>
+                    {buttonLabel}
+                </Link>
+            </>
+        )}
     </div>
 )
 
@@ -49,15 +48,12 @@ export const ExtensionREADME: React.FunctionComponent<{
 
     if (!manifest || !manifest.readme) {
         return (
-            <>
-                {manifest && manifest.title && <h2>{manifest.title}</h2>}
-                <PublishNewManifestAlert
-                    extension={extension}
-                    alertClass="alert-info"
-                    text={`This extension has no README.`}
-                    buttonLabel="Add README and publish new release"
-                />
-            </>
+            <PublishNewManifestAlert
+                extension={extension}
+                alertClass="alert-info"
+                text={`This extension has no README.`}
+                buttonLabel="Add README and publish new release"
+            />
         )
     }
 

--- a/web/src/extensions/extension/WorkInProgressBadge.tsx
+++ b/web/src/extensions/extension/WorkInProgressBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 /**
- * Shows a "Work in progress" badge for extensions.
+ * Shows a "WIP" badge for extensions.
  */
 export const WorkInProgressBadge: React.FunctionComponent<{ viewerCanAdminister: boolean }> = ({
     viewerCanAdminister,
@@ -11,9 +11,9 @@ export const WorkInProgressBadge: React.FunctionComponent<{ viewerCanAdminister:
         data-tooltip={
             viewerCanAdminister
                 ? 'Remove "WIP" from the title when this extension is ready for use.'
-                : 'This extension is still under development and is not ready for use.'
+                : 'Work in progress (not ready for use)'
         }
     >
-        Work in progress
+        WIP
     </span>
 )

--- a/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         >
           <a
             className="rounded border p-1"
-            href="/extensions?query=category:%22Other%22"
+            href="/extensions?query=category%3AOther"
             onClick={[Function]}
           >
             Other
@@ -45,7 +45,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         >
           <a
             className="rounded border p-1"
-            href="/extensions?query=category:%22Programming%20languages%22"
+            href="/extensions?query=category%3A%22Programming+languages%22"
             onClick={[Function]}
           >
             Programming languages
@@ -67,7 +67,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         >
           <a
             className="rounded border p-1"
-            href="/extensions?query=tag:%22T1%22"
+            href="/extensions?query=tag%3AT1"
             onClick={[Function]}
           >
             T1
@@ -78,7 +78,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         >
           <a
             className="rounded border p-1"
-            href="/extensions?query=tag:%22T2%22"
+            href="/extensions?query=tag%3AT2"
             onClick={[Function]}
           >
             T2

--- a/web/src/extensions/extension/extension.test.ts
+++ b/web/src/extensions/extension/extension.test.ts
@@ -1,4 +1,4 @@
-import { validCategories } from './extension'
+import { extensionsQuery, urlToExtensionsQuery, validCategories } from './extension'
 
 describe('validCategories', () => {
     test('selects only known categories, sorts, and dedupes', () =>
@@ -12,4 +12,16 @@ describe('validCategories', () => {
     test('returns undefined for empty', () => expect(validCategories([])).toEqual(undefined))
 
     test('returns undefined when no categories are known', () => expect(validCategories(['x'])).toEqual(undefined))
+})
+
+describe('extensionsQuery', () => {
+    test('category (unquoted)', () => expect(extensionsQuery({ category: 'c' })).toBe('category:c'))
+    test('category (quoted)', () => expect(extensionsQuery({ category: 'c c' })).toBe('category:"c c"'))
+    test('tag (unquoted)', () => expect(extensionsQuery({ tag: 't' })).toBe('tag:t'))
+    test('tag (quoted)', () => expect(extensionsQuery({ tag: 't t' })).toBe('tag:"t t"'))
+    test('none', () => expect(extensionsQuery({})).toBe(''))
+})
+
+describe('urlToExtensionsQuery', () => {
+    test('generates', () => expect(urlToExtensionsQuery('foo bar')).toBe('/extensions?query=foo+bar'))
 })

--- a/web/src/extensions/extension/extension.test.ts
+++ b/web/src/extensions/extension/extension.test.ts
@@ -19,6 +19,7 @@ describe('extensionsQuery', () => {
     test('category (quoted)', () => expect(extensionsQuery({ category: 'c c' })).toBe('category:"c c"'))
     test('tag (unquoted)', () => expect(extensionsQuery({ tag: 't' })).toBe('tag:t'))
     test('tag (quoted)', () => expect(extensionsQuery({ tag: 't t' })).toBe('tag:"t t"'))
+    test('wip', () => expect(extensionsQuery({ wip: true })).toBe('#wip'))
     test('none', () => expect(extensionsQuery({})).toBe(''))
 })
 

--- a/web/src/extensions/extension/extension.test.ts
+++ b/web/src/extensions/extension/extension.test.ts
@@ -19,7 +19,6 @@ describe('extensionsQuery', () => {
     test('category (quoted)', () => expect(extensionsQuery({ category: 'c c' })).toBe('category:"c c"'))
     test('tag (unquoted)', () => expect(extensionsQuery({ tag: 't' })).toBe('tag:t'))
     test('tag (quoted)', () => expect(extensionsQuery({ tag: 't t' })).toBe('tag:"t t"'))
-    test('wip', () => expect(extensionsQuery({ wip: true })).toBe('#wip'))
     test('none', () => expect(extensionsQuery({})).toBe(''))
 })
 

--- a/web/src/extensions/extension/extension.ts
+++ b/web/src/extensions/extension/extension.ts
@@ -66,7 +66,21 @@ export function validCategories(categories: ExtensionManifest['categories']): Ex
  * Constructs the extensions query given the options (for use in the query input field in the extension registry
  * list page).
  */
-export function extensionsQuery({ category, tag, wip }: { category?: string; tag?: string; wip?: boolean }): string {
+export function extensionsQuery({
+    category,
+    tag,
+    wip,
+    installed,
+    enabled,
+    disabled,
+}: {
+    category?: string
+    tag?: string
+    wip?: boolean
+    installed?: boolean
+    enabled?: boolean
+    disabled?: boolean
+}): string {
     const parts: string[] = []
     if (category) {
         parts.push(`category:${quoteIfNeeded(category)}`)
@@ -76,6 +90,15 @@ export function extensionsQuery({ category, tag, wip }: { category?: string; tag
     }
     if (wip) {
         parts.push('#wip')
+    }
+    if (installed) {
+        parts.push('#installed')
+    }
+    if (enabled) {
+        parts.push('#enabled')
+    }
+    if (disabled) {
+        parts.push('#disabled')
     }
     return parts.join(' ')
 }

--- a/web/src/extensions/extension/extension.ts
+++ b/web/src/extensions/extension/extension.ts
@@ -69,14 +69,12 @@ export function validCategories(categories: ExtensionManifest['categories']): Ex
 export function extensionsQuery({
     category,
     tag,
-    wip,
     installed,
     enabled,
     disabled,
 }: {
     category?: string
     tag?: string
-    wip?: boolean
     installed?: boolean
     enabled?: boolean
     disabled?: boolean
@@ -87,9 +85,6 @@ export function extensionsQuery({
     }
     if (tag) {
         parts.push(`tag:${quoteIfNeeded(tag)}`)
-    }
-    if (wip) {
-        parts.push('#wip')
     }
     if (installed) {
         parts.push('#installed')

--- a/web/src/extensions/extension/extension.ts
+++ b/web/src/extensions/extension/extension.ts
@@ -66,13 +66,16 @@ export function validCategories(categories: ExtensionManifest['categories']): Ex
  * Constructs the extensions query given the options (for use in the query input field in the extension registry
  * list page).
  */
-export function extensionsQuery({ category, tag }: { category?: string; tag?: string }): string {
+export function extensionsQuery({ category, tag, wip }: { category?: string; tag?: string; wip?: boolean }): string {
     const parts: string[] = []
     if (category) {
         parts.push(`category:${quoteIfNeeded(category)}`)
     }
     if (tag) {
         parts.push(`tag:${quoteIfNeeded(tag)}`)
+    }
+    if (wip) {
+        parts.push('#wip')
     }
     return parts.join(' ')
 }

--- a/web/src/extensions/extension/extension.ts
+++ b/web/src/extensions/extension/extension.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../shared/src/schema/extension.schema'
 import { Settings } from '../../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { quoteIfNeeded } from '../../search'
 
 /** Pattern for valid extension names. */
 export const EXTENSION_NAME_VALID_PATTERN = '^[a-zA-Z0-9](?:[a-zA-Z0-9]|[_.-](?=[a-zA-Z0-9]))*$'
@@ -59,4 +60,29 @@ export function validCategories(categories: ExtensionManifest['categories']): Ex
         categories.filter((c): c is ExtensionCategory => EXTENSION_CATEGORIES.includes(c as ExtensionCategory)).sort()
     )
     return validCategories.length === 0 ? undefined : validCategories
+}
+
+/**
+ * Constructs the extensions query given the options (for use in the query input field in the extension registry
+ * list page).
+ */
+export function extensionsQuery({ category, tag }: { category?: string; tag?: string }): string {
+    const parts: string[] = []
+    if (category) {
+        parts.push(`category:${quoteIfNeeded(category)}`)
+    }
+    if (tag) {
+        parts.push(`tag:${quoteIfNeeded(tag)}`)
+    }
+    return parts.join(' ')
+}
+
+/**
+ * Constructs the URL to the extensions list with the given query string (which can be constructed using
+ * {@link extensionsQuery}).
+ */
+export function urlToExtensionsQuery(query: string): string {
+    const params = new URLSearchParams()
+    params.set('query', query)
+    return `/extensions?${params.toString()}`
 }


### PR DESCRIPTION
See commit messages for more details.

- Add categories and enabled/disabled filters to extension registry list.
- Remove extension titles; always use the extension ID. See the relevant commit message in this PR for the reason.
- Remove complexity around WIP extensions since #1508 will reduce the need for WIP extensions overall. (There were bugs here anyway; remote WIP extensions were still being shown even if `includeWIP=false` in the GraphQL query.)

Ready to review.




![screenshot from 2019-01-02 03-22-17](https://user-images.githubusercontent.com/1976/50589966-a412cc00-0e3d-11e9-8d7b-68f3c483872d.png)
![screenshot from 2019-01-02 03-22-06](https://user-images.githubusercontent.com/1976/50589968-a412cc00-0e3d-11e9-81b6-f9598c851df8.png)
