### PR TITLE
Pull "View Repository" on Sourcegraph button injection into CodeHost iterface

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -13,7 +13,7 @@ import * as H from 'history'
 import * as React from 'react'
 import { createPortal, render } from 'react-dom'
 import { animationFrameScheduler, Observable, of, Subject, Subscription } from 'rxjs'
-import { filter, map, mergeMap, observeOn, withLatestFrom } from 'rxjs/operators'
+import { catchError, filter, map, mergeMap, observeOn, tap, withLatestFrom } from 'rxjs/operators'
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 
 import { ActionItemProps } from '../../../../../shared/src/actions/ActionItem'
@@ -35,8 +35,12 @@ import {
     toURIWithPath,
     ViewStateSpec,
 } from '../../../../../shared/src/util/url'
+import { sendMessage } from '../../browser/runtime'
+import { isInPage } from '../../context'
+import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../shared/backend/errors'
 import { createLSPFromExtensions, lspViaAPIXlang, toTextDocumentIdentifier } from '../../shared/backend/lsp'
 import { ButtonProps, CodeViewToolbar } from '../../shared/components/CodeViewToolbar'
+import { resolveRev, retryWhenCloneInProgressError } from '../../shared/repo/backend'
 import { eventLogger, sourcegraphUrl, useExtensions } from '../../shared/util/context'
 import { bitbucketServerCodeHost } from '../bitbucket/code_intelligence'
 import { githubCodeHost } from '../github/code_intelligence'
@@ -109,10 +113,10 @@ interface OverlayPosition {
  */
 export type MountGetter = () => HTMLElement
 
-export interface CodeHostContext {
-    repoName: string
-    rev?: string
-}
+/**
+ * The context the code host is in on the current page.
+ */
+export type CodeHostContext = RepoSpec & Partial<RevSpec>
 
 /** Information for adding code intelligence to code views on arbitrary code hosts. */
 export interface CodeHost {
@@ -402,13 +406,35 @@ export interface ResolvedCodeView extends CodeViewWithOutSelector {
 }
 
 function handleCodeHost(codeHost: CodeHost): Subscription {
-    const { hoverifier, controllers: { platformContext, extensionsController } } = initCodeIntelligence(codeHost)
+    const {
+        hoverifier,
+        controllers: { platformContext, extensionsController },
+    } = initCodeIntelligence(codeHost)
 
     const subscriptions = new Subscription()
 
     subscriptions.add(hoverifier)
 
-    injectViewContextOnSourcegraph(sourcegraphUrl, codeHost)
+    const ensureRepoExists = (context: CodeHostContext) =>
+        resolveRev(context).pipe(
+            retryWhenCloneInProgressError(),
+            map(rev => !!rev),
+            catchError(error => {
+                if ((error as Error).name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+                    return [false]
+                }
+
+                return [true]
+            })
+        )
+
+    const openOptionsMenu = () => {
+        sendMessage({
+            type: 'openOptionsPage',
+        })
+    }
+
+    injectViewContextOnSourcegraph(sourcegraphUrl, codeHost, ensureRepoExists, isInPage ? undefined : openOptionsMenu)
 
     // Keeps track of all documents on the page since calling this function (should be once per page).
     let visibleViewComponents: ViewComponentData[] = []

--- a/client/browser/src/libs/code_intelligence/external_links.test.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent } from 'react-testing-library'
+import { of } from 'rxjs'
+import * as sinon from 'sinon'
+import { injectViewContextOnSourcegraph } from './external_links'
+
+describe('<ViewOnSourcegraphButton />', () => {
+    beforeEach(() => {
+        for (const test of document.querySelectorAll('.test')) {
+            test.remove()
+        }
+    })
+
+    it('renders a link', () => {
+        injectViewContextOnSourcegraph(
+            'https://test.com',
+            {
+                getContext: () => ({
+                    repoName: 'test',
+                }),
+                getViewContextOnSourcegraphMount: () => {
+                    const div = document.createElement('div')
+                    document.body.appendChild(div)
+                    return div
+                },
+                contextButtonClassName: 'test',
+            },
+            () => of(true),
+            undefined
+        )
+
+        const link = document.querySelector<HTMLAnchorElement>('.test')
+        expect(link).toBeInstanceOf(HTMLAnchorElement)
+        expect(link!.href).toBe('https://test.com/test')
+    })
+
+    it('renders a link with the rev when provided', () => {
+        injectViewContextOnSourcegraph(
+            'https://test.com',
+            {
+                getContext: () => ({
+                    repoName: 'test',
+                    rev: 'test',
+                }),
+                getViewContextOnSourcegraphMount: () => {
+                    const div = document.createElement('div')
+                    document.body.appendChild(div)
+                    return div
+                },
+                contextButtonClassName: 'test',
+            },
+            () => of(true),
+            undefined
+        )
+
+        const link = document.querySelector<HTMLAnchorElement>('.test')
+        expect(link).toBeInstanceOf(HTMLAnchorElement)
+        expect(link!.href).toBe('https://test.com/test@test')
+    })
+
+    it('renders configure sourcegraph button when pointing at sourcegraph.com', () => {
+        const configureClickSpy = sinon.spy()
+
+        injectViewContextOnSourcegraph(
+            'https://sourcegraph.com',
+            {
+                getContext: () => ({
+                    repoName: 'test',
+                    rev: 'test',
+                }),
+                getViewContextOnSourcegraphMount: () => {
+                    const div = document.createElement('div')
+                    document.body.appendChild(div)
+                    return div
+                },
+                contextButtonClassName: 'test',
+            },
+            () => of(false),
+            configureClickSpy
+        )
+
+        const link = document.querySelector<HTMLAnchorElement>('.test')
+        expect(link).toBeInstanceOf(HTMLAnchorElement)
+        expect(link!.textContent).toBe('Configure Sourcegraph')
+
+        fireEvent.click(link!)
+        expect(configureClickSpy.calledOnce).toBe(true)
+    })
+
+    it('still renders "View Repository" if repo doesn\'t exist and its not pointed at .com', () => {
+        const configureClickSpy = sinon.spy()
+
+        injectViewContextOnSourcegraph(
+            'https://test.com',
+            {
+                getContext: () => ({
+                    repoName: 'test',
+                    rev: 'test',
+                }),
+                getViewContextOnSourcegraphMount: () => {
+                    const div = document.createElement('div')
+                    document.body.appendChild(div)
+                    return div
+                },
+                contextButtonClassName: 'test',
+            },
+            () => of(false),
+            configureClickSpy
+        )
+
+        const link = document.querySelector<HTMLAnchorElement>('.test')
+        expect(link).toBeInstanceOf(HTMLAnchorElement)
+        expect(link!.textContent).toBe('View Repository')
+    })
+})

--- a/client/browser/src/libs/code_intelligence/external_links.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import { render } from 'react-dom'
+import { Button } from '../../shared/components/Button'
+import { CodeHost, CodeHostContext } from './code_intelligence'
+
+interface ViewOnSourcegraphButtonProps {
+    context: CodeHostContext
+    sourcegraphUrl: string
+    className?: string
+}
+
+class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonProps> {
+    public render(): React.ReactNode {
+        return (
+            <Button
+                url={this.getURL()}
+                label="View Repository"
+                ariaLabel="View repository on Sourcegraph"
+                className={`open-on-sourcegraph ${this.props.className || ''}`}
+            />
+        )
+    }
+
+    private getURL(): string {
+        const rev = this.props.context.rev ? `@${this.props.context.rev}` : ''
+
+        return `${this.props.sourcegraphUrl}/${this.props.context.repoName}${rev}`
+    }
+}
+
+export function injectViewContextOnSourcegraph(
+    sourcegraphUrl: string,
+    {
+        getContext,
+        getViewContextOnSourcegraphMount,
+        contextButtonClassName,
+    }: Pick<CodeHost, 'getContext' | 'getViewContextOnSourcegraphMount' | 'contextButtonClassName'>
+): void {
+    if (!getContext || !getViewContextOnSourcegraphMount) {
+        return
+    }
+
+    const mount = getViewContextOnSourcegraphMount()
+
+    render(
+        <ViewOnSourcegraphButton
+            context={getContext()}
+            className={contextButtonClassName}
+            sourcegraphUrl={sourcegraphUrl}
+        />,
+        mount
+    )
+}

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -21,6 +21,7 @@ import {
 } from './dom_functions'
 import { getCommandPaletteMount, getGlobalDebugMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './file_info'
+import { createOpenOnSourcegraphIfNotExists } from './inject'
 import { createCodeViewToolbarMount, getFileContainers, parseURL } from './util'
 
 const toolbarButtonProps = {
@@ -159,6 +160,9 @@ export const githubCodeHost: CodeHost = {
     name: 'github',
     codeViews: [searchResultCodeView, commentSnippetCodeView],
     codeViewResolver,
+    getContext: parseURL,
+    getViewContextOnSourcegraphMount: createOpenOnSourcegraphIfNotExists,
+    contextButtonClassName: 'btn btn-sm tooltipped tooltipped-s',
     check: checkIsGithub,
     getOverlayMount,
     getCommandPaletteMount,

--- a/client/browser/src/libs/github/inject.tsx
+++ b/client/browser/src/libs/github/inject.tsx
@@ -2,13 +2,8 @@ import mermaid from 'mermaid'
 import * as React from 'react'
 import { render } from 'react-dom'
 import { TelemetryContext } from '../../../../../shared/src/telemetry/telemetryContext'
-import storage from '../../browser/storage'
 import { Alerts } from '../../shared/components/Alerts'
-import { ConfigureSourcegraphButton } from '../../shared/components/ConfigureSourcegraphButton'
-import { ContextualSourcegraphButton } from '../../shared/components/ContextualSourcegraphButton'
-import { ServerAuthButton } from '../../shared/components/ServerAuthButton'
 import { SymbolsDropdownContainer } from '../../shared/components/SymbolsDropdownContainer'
-import { WithResolvedRev } from '../../shared/components/WithResolvedRev'
 import { eventLogger, inlineSymbolSearchEnabled, renderMermaidGraphsEnabled } from '../../shared/util/context'
 import { getFileContainers, parseURL } from './util'
 
@@ -36,7 +31,6 @@ export async function injectGitHubApplication(marker: HTMLElement): Promise<void
 
 async function inject(): Promise<void> {
     injectServerBanner()
-    injectOpenOnSourcegraphButton()
 
     injectMermaid()
 
@@ -74,42 +68,6 @@ function injectServerBanner(): void {
         </TelemetryContext.Provider>,
         mount
     )
-}
-
-/**
- * Appends an Open on Sourcegraph button to the GitHub DOM.
- * The button is only rendered on a repo homepage after the "find file" button.
- */
-function injectOpenOnSourcegraphButton(): void {
-    storage.getSync(items => {
-        const container = createOpenOnSourcegraphIfNotExists()
-
-        if (items.featureFlags.useExtensions) {
-            container.classList.add('use-extensions')
-        }
-
-        const pageheadActions = document.querySelector('.pagehead-actions')
-        if (!pageheadActions || !pageheadActions.children.length) {
-            return
-        }
-        pageheadActions.insertBefore(container, pageheadActions.children[0])
-        if (container) {
-            const { repoName, rev } = parseURL()
-            if (repoName) {
-                render(
-                    <WithResolvedRev
-                        component={ContextualSourcegraphButton}
-                        repoName={repoName}
-                        rev={rev}
-                        defaultBranch={'HEAD'}
-                        notFoundComponent={ConfigureSourcegraphButton}
-                        requireAuthComponent={ServerAuthButton}
-                    />,
-                    container
-                )
-            }
-        }
-    })
 }
 
 function injectMermaid(): void {
@@ -223,7 +181,7 @@ function injectInlineSearch(): void {
 
 const OPEN_ON_SOURCEGRAPH_ID = 'open-on-sourcegraph'
 
-function createOpenOnSourcegraphIfNotExists(): HTMLElement {
+export function createOpenOnSourcegraphIfNotExists(): HTMLElement {
     let container = document.getElementById(OPEN_ON_SOURCEGRAPH_ID)
     if (container) {
         container.remove()
@@ -231,5 +189,13 @@ function createOpenOnSourcegraphIfNotExists(): HTMLElement {
 
     container = document.createElement('li')
     container.id = OPEN_ON_SOURCEGRAPH_ID
+
+    const pageheadActions = document.querySelector('.pagehead-actions')
+    if (!pageheadActions || !pageheadActions.children.length) {
+        throw new Error('Unable to find page actions (GitHub)')
+    }
+
+    pageheadActions.insertAdjacentElement('afterbegin', container)
+
     return container
 }

--- a/client/browser/src/libs/options/Menu.scss
+++ b/client/browser/src/libs/options/Menu.scss
@@ -13,4 +13,10 @@
     &__no-border {
         border-top: none;
     }
+
+    &--full {
+        max-width: 400px;
+        margin: 8rem auto;
+        box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.15);
+    }
 }

--- a/client/browser/src/libs/options/Menu.tsx
+++ b/client/browser/src/libs/options/Menu.tsx
@@ -23,6 +23,9 @@ const withSentry = (flags: OptionsMenuProps['featureFlags']) => flags.filter(({ 
 const withOutSentry = (flags: OptionsMenuProps['featureFlags']) =>
     flags.filter(({ key }) => key !== 'allowErrorReporting')
 
+const isFullPage = (): boolean =>
+    !new URLSearchParams(window.location.search).get('popup')
+
 export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
     sourcegraphURL,
     onURLChange,
@@ -32,7 +35,7 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
     featureFlags,
     ...props
 }) => (
-    <div className="options-menu">
+    <div className={`options-menu ${isFullPage() ? 'options-menu--full' : ''}`}>
         <OptionsHeader {...props} className="options-menu__section options-menu__no-border" />
         <ServerURLForm
             {...props}

--- a/client/browser/src/shared/backend/errors.tsx
+++ b/client/browser/src/shared/backend/errors.tsx
@@ -93,6 +93,7 @@ export class NoSourcegraphURLError extends Error {
 export const ERPRIVATEREPOPUBLICSOURCEGRAPHCOM = 'ERPRIVATEREPOPUBLICSOURCEGRAPHCOM'
 export class PrivateRepoPublicSourcegraphComError extends Error {
     public readonly code = ERPRIVATEREPOPUBLICSOURCEGRAPHCOM
+    public readonly name = ERPRIVATEREPOPUBLICSOURCEGRAPHCOM
     constructor(graphQLName: string) {
         super(
             `A ${graphQLName} GraphQL request to the public Sourcegraph.com was blocked because the current repository is private.`


### PR DESCRIPTION
This PR moves the injection of the "View repository on Sourcegraph" functionality into the CodeHost interface. Its a complete re-implementation of the feature to be abstract from the code host. It's an optional property in the interface.

Closes https://github.com/sourcegraph/sourcegraph/issues/656.