### PR TITLE
Change launch.sh to run yarn online for management console

### DIFF
--- a/dev/launch.sh
+++ b/dev/launch.sh
@@ -110,7 +110,7 @@ export PATH="$PWD/.bin:$PWD/node_modules/.bin:$PATH"
 
 # Management console webapp
 [ -n "${OFFLINE-}" ] || {
-    pushd ./cmd/management-console/web && yarn --offline --no-progress && popd
+    pushd ./cmd/management-console/web && yarn  --no-progress && popd
 }
 
 printf >&2 "\nStarting all binaries...\n\n"


### PR DESCRIPTION
Changes `launch.sh` to run yarn online for management console.