### PR TITLE
doc: add access token debugging instructions for GitLab

### DIFF
--- a/doc/integration/gitlab.md
+++ b/doc/integration/gitlab.md
@@ -12,6 +12,16 @@ Sourcegraph supports syncing repositories from GitLab.com, GitLab CE, and GitLab
 
 By default, it adds every GitLab project where the token's user is a member. If you wish to limit the set of repositories that is indexed by Sourcegraph, the recommended way is to create a Sourcegraph "bot" user, which is just a normal user account with the desired access scope. For instance, if you wanted to add all internal GitLab projects to Sourcegraph, you could create a user "sourcegraph-bot" and give it no explicit access to any GitLab repositories.
 
+### Debugging
+
+You can test your access token's permissions by running a cURL command against the GitLab API. This is the same API and the same project list used by Sourcegraph. 
+
+Replace `$ACCESS_TOKEN` with the access token you are providing to Sourcegraph, and `$GITLAB_HOSTNAME` with your GitLab hostname:
+
+```
+curl -H 'Private-Token: $ACCESS_TOKEN' -XGET 'https://$GITLAB_HOSTNAME/api/v4/projects'
+```
+
 ### Repository permissions
 
 By default, all Sourcegraph users can view all repositories. To configure Sourcegraph to use GitLab's per-user repository permissions, see "[Repository permissions](../admin/repo/permissions.md)".


### PR DESCRIPTION
The user that reported https://github.com/sourcegraph/sourcegraph/issues/1537 described this information as extremely helpful for setting up an access token that works company-wide.