### PR TITLE
improve search help button and query input UI component

### DIFF
--- a/web/src/search/input/MainPage.scss
+++ b/web/src/search/input/MainPage.scss
@@ -549,7 +549,7 @@ body.main-page {
             font-size: 20px;
             font-weight: 400;
             letter-spacing: 0.05rem;
-            .search-button {
+            .search-button > .btn-primary {
                 margin-left: 3rem;
                 padding-left: 2rem;
                 padding-right: 2rem;

--- a/web/src/search/input/MainPage.scss
+++ b/web/src/search/input/MainPage.scss
@@ -549,8 +549,7 @@ body.main-page {
             font-size: 20px;
             font-weight: 400;
             letter-spacing: 0.05rem;
-            .search-button > .btn-primary {
-                margin-left: 3rem;
+            .search-button > .search-button__btn {
                 padding-left: 2rem;
                 padding-right: 2rem;
                 margin-right: 0;

--- a/web/src/search/input/MainPage.tsx
+++ b/web/src/search/input/MainPage.tsx
@@ -648,7 +648,7 @@ export class MainPage extends React.Component<Props, State> {
                                         autoFocus={'cursor-at-end'}
                                         hasGlobalQueryBehavior={true}
                                     />
-                                    <SearchButton />
+                                    <SearchButton noHelp={true} noLabel={true} />
                                 </div>
                             </Form>
                         </div>

--- a/web/src/search/input/QueryInput.scss
+++ b/web/src/search/input/QueryInput.scss
@@ -4,6 +4,12 @@
     flex: 1 1 auto;
     position: relative;
 
+    &__input {
+        // Right side is flush with SearchButton.
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
     &__suggestions {
         position: absolute;
         width: 100%;

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -282,7 +282,7 @@ export class QueryInput extends React.Component<Props, State> {
         return (
             <div className="query-input2">
                 <input
-                    className="form-control query-input2__input"
+                    className="form-control query-input2__input rounded-left"
                     value={this.props.value}
                     autoFocus={this.props.autoFocus === true}
                     onChange={this.onInputChange}

--- a/web/src/search/input/QueryInputForModal.scss
+++ b/web/src/search/input/QueryInputForModal.scss
@@ -4,6 +4,12 @@
     width: 100%;
     position: relative;
 
+    &__input {
+        // Right side is flush with SearchButton.
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
     &__suggestions {
         position: absolute;
         width: 100%;

--- a/web/src/search/input/SearchButton.scss
+++ b/web/src/search/input/SearchButton.scss
@@ -1,4 +1,10 @@
 .search-button {
+    &__btn {
+        // Left side is flush with QueryInput.
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
     &__label {
         margin-left: 0.25rem;
     }

--- a/web/src/search/input/SearchButton.tsx
+++ b/web/src/search/input/SearchButton.tsx
@@ -4,6 +4,14 @@ import SearchIcon from 'mdi-react/SearchIcon'
 import * as React from 'react'
 import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
+interface Props {
+    /** Hide the "help" icon and dropdown. */
+    noHelp?: boolean
+
+    /** Never show the "Search" button label. */
+    noLabel?: boolean
+}
+
 interface State {
     isOpen: boolean
 }
@@ -11,7 +19,7 @@ interface State {
 /**
  * A search button with a dropdown with related links.
  */
-export class SearchButton extends React.Component<{}, State> {
+export class SearchButton extends React.Component<Props, State> {
     public state: State = { isOpen: false }
 
     public render(): JSX.Element | null {
@@ -21,96 +29,101 @@ export class SearchButton extends React.Component<{}, State> {
             <ButtonDropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="search-button">
                 <button className="btn btn-primary rounded-0" type="submit">
                     <SearchIcon className="icon-inline" />
-                    <span className="search-button__label">Search</span>
+                    {!this.props.noLabel && <span className="search-button__label">Search</span>}
                 </button>
-                <DropdownToggle caret={false} className="px-1 d-flex border-0 text-muted rounded-right">
-                    <HelpCircleOutlineIcon className="icon-inline small" />
-                </DropdownToggle>
-                <DropdownMenu right={true} className="pb-0">
-                    <DropdownItem header={true}>
-                        <strong>Search reference</strong>
-                    </DropdownItem>
-                    <DropdownItem divider={true} />
-                    <DropdownItem header={true}>Finding matches:</DropdownItem>
-                    <ul className="list-unstyled px-2 mb-2">
-                        <li>
-                            <span className="text-muted small">Regexp:</span>{' '}
-                            <code>
-                                <strong>(read|write)File</strong>
-                            </code>
-                        </li>
-                        <li>
-                            <span className="text-muted small">Exact:</span>{' '}
-                            <code>
-                                "<strong>fs.open(f)</strong>"
-                            </code>
-                        </li>
-                    </ul>
-                    <DropdownItem divider={true} />
-                    <DropdownItem header={true}>Common search keywords:</DropdownItem>
-                    <ul className="list-unstyled px-2 mb-2">
-                        <li>
-                            <code>
-                                repo:<strong>my/repo</strong>
-                            </code>
-                        </li>
-                        {window.context.sourcegraphDotComMode && (
-                            <li>
-                                <code>
-                                    repo:<strong>github.com/myorg/</strong>
-                                </code>
-                            </li>
-                        )}
-                        <li>
-                            <code>
-                                file:<strong>my/file</strong>
-                            </code>
-                        </li>
-                        <li>
-                            <code>
-                                lang:<strong>javascript</strong>
-                            </code>
-                        </li>
-                    </ul>
-                    <DropdownItem divider={true} />
-                    <DropdownItem header={true}>Diff/commit search keywords:</DropdownItem>
-                    <ul className="list-unstyled px-2 mb-2">
-                        <li>
-                            <code>type:diff</code> <em className="text-muted small">or</em> <code>type:commit</code>
-                        </li>
-                        <li>
-                            <code>
-                                after:<strong>"2 weeks ago"</strong>
-                            </code>
-                        </li>
-                        <li>
-                            <code>
-                                author:<strong>alice@example.com</strong>
-                            </code>
-                        </li>
-                        <li className="text-nowrap">
-                            <code>
-                                repo:<strong>r@*refs/heads/</strong>
-                            </code>{' '}
-                            <span className="text-muted small">(all branches)</span>
-                        </li>
-                    </ul>
-                    <DropdownItem divider={true} />
-                    <a
-                        href={`${docsURLPrefix}/user/search/queries`}
-                        className="dropdown-item d-flex align-items-center"
-                        target="_blank"
-                        onClick={this.toggleIsOpen}
-                    >
-                        <ExternalLinkIcon className="icon-inline small mr-1 mb-1" /> All search keywords
-                    </a>
-                    {window.context.sourcegraphDotComMode && (
-                        <div className="p-2 alert alert-info small rounded-0 mb-0 mt-1">
-                            On Sourcegraph.com, use a <code>repo:</code> filter to narrow your search to &le;500
-                            repositories.
-                        </div>
-                    )}
-                </DropdownMenu>
+                {!this.props.noHelp && (
+                    <>
+                        <DropdownToggle caret={false} className="px-1 d-flex border-0 text-muted rounded-right">
+                            <HelpCircleOutlineIcon className="icon-inline small" />
+                        </DropdownToggle>
+                        <DropdownMenu right={true} className="pb-0">
+                            <DropdownItem header={true}>
+                                <strong>Search reference</strong>
+                            </DropdownItem>
+                            <DropdownItem divider={true} />
+                            <DropdownItem header={true}>Finding matches:</DropdownItem>
+                            <ul className="list-unstyled px-2 mb-2">
+                                <li>
+                                    <span className="text-muted small">Regexp:</span>{' '}
+                                    <code>
+                                        <strong>(read|write)File</strong>
+                                    </code>
+                                </li>
+                                <li>
+                                    <span className="text-muted small">Exact:</span>{' '}
+                                    <code>
+                                        "<strong>fs.open(f)</strong>"
+                                    </code>
+                                </li>
+                            </ul>
+                            <DropdownItem divider={true} />
+                            <DropdownItem header={true}>Common search keywords:</DropdownItem>
+                            <ul className="list-unstyled px-2 mb-2">
+                                <li>
+                                    <code>
+                                        repo:<strong>my/repo</strong>
+                                    </code>
+                                </li>
+                                {window.context.sourcegraphDotComMode && (
+                                    <li>
+                                        <code>
+                                            repo:<strong>github.com/myorg/</strong>
+                                        </code>
+                                    </li>
+                                )}
+                                <li>
+                                    <code>
+                                        file:<strong>my/file</strong>
+                                    </code>
+                                </li>
+                                <li>
+                                    <code>
+                                        lang:<strong>javascript</strong>
+                                    </code>
+                                </li>
+                            </ul>
+                            <DropdownItem divider={true} />
+                            <DropdownItem header={true}>Diff/commit search keywords:</DropdownItem>
+                            <ul className="list-unstyled px-2 mb-2">
+                                <li>
+                                    <code>type:diff</code> <em className="text-muted small">or</em>{' '}
+                                    <code>type:commit</code>
+                                </li>
+                                <li>
+                                    <code>
+                                        after:<strong>"2 weeks ago"</strong>
+                                    </code>
+                                </li>
+                                <li>
+                                    <code>
+                                        author:<strong>alice@example.com</strong>
+                                    </code>
+                                </li>
+                                <li className="text-nowrap">
+                                    <code>
+                                        repo:<strong>r@*refs/heads/</strong>
+                                    </code>{' '}
+                                    <span className="text-muted small">(all branches)</span>
+                                </li>
+                            </ul>
+                            <DropdownItem divider={true} />
+                            <a
+                                href={`${docsURLPrefix}/user/search/queries`}
+                                className="dropdown-item d-flex align-items-center"
+                                target="_blank"
+                                onClick={this.toggleIsOpen}
+                            >
+                                <ExternalLinkIcon className="icon-inline small mr-1 mb-1" /> All search keywords
+                            </a>
+                            {window.context.sourcegraphDotComMode && (
+                                <div className="p-2 alert alert-info small rounded-0 mb-0 mt-1">
+                                    On Sourcegraph.com, use a <code>repo:</code> filter to narrow your search to &le;500
+                                    repositories.
+                                </div>
+                            )}
+                        </DropdownMenu>
+                    </>
+                )}
             </ButtonDropdown>
         )
     }

--- a/web/src/search/input/SearchButton.tsx
+++ b/web/src/search/input/SearchButton.tsx
@@ -2,7 +2,7 @@ import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import HelpCircleOutlineIcon from 'mdi-react/HelpCircleOutlineIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
 import * as React from 'react'
-import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
+import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 interface Props {
     /** Hide the "help" icon and dropdown. */
@@ -26,105 +26,111 @@ export class SearchButton extends React.Component<Props, State> {
         const docsURLPrefix = window.context.sourcegraphDotComMode ? 'https://docs.sourcegraph.com' : '/help'
 
         return (
-            <ButtonDropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="search-button">
-                <button className="btn btn-primary rounded-0" type="submit">
+            <div className="search-button d-flex">
+                <button className="btn btn-primary search-button__btn" type="submit">
                     <SearchIcon className="icon-inline" />
                     {!this.props.noLabel && <span className="search-button__label">Search</span>}
                 </button>
-                {!this.props.noHelp && (
-                    <>
-                        <DropdownToggle caret={false} className="px-1 d-flex border-0 text-muted rounded-right">
-                            <HelpCircleOutlineIcon className="icon-inline small" />
-                        </DropdownToggle>
-                        <DropdownMenu right={true} className="pb-0">
-                            <DropdownItem header={true}>
-                                <strong>Search reference</strong>
-                            </DropdownItem>
-                            <DropdownItem divider={true} />
-                            <DropdownItem header={true}>Finding matches:</DropdownItem>
-                            <ul className="list-unstyled px-2 mb-2">
-                                <li>
-                                    <span className="text-muted small">Regexp:</span>{' '}
-                                    <code>
-                                        <strong>(read|write)File</strong>
-                                    </code>
-                                </li>
-                                <li>
-                                    <span className="text-muted small">Exact:</span>{' '}
-                                    <code>
-                                        "<strong>fs.open(f)</strong>"
-                                    </code>
-                                </li>
-                            </ul>
-                            <DropdownItem divider={true} />
-                            <DropdownItem header={true}>Common search keywords:</DropdownItem>
-                            <ul className="list-unstyled px-2 mb-2">
-                                <li>
-                                    <code>
-                                        repo:<strong>my/repo</strong>
-                                    </code>
-                                </li>
-                                {window.context.sourcegraphDotComMode && (
+                <Dropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="d-flex">
+                    {!this.props.noHelp && (
+                        <>
+                            <DropdownToggle
+                                tag="span"
+                                caret={false}
+                                className="px-2 btn btn-link d-flex align-items-center"
+                            >
+                                <HelpCircleOutlineIcon className="icon-inline small" />
+                            </DropdownToggle>
+                            <DropdownMenu right={true} className="pb-0">
+                                <DropdownItem header={true}>
+                                    <strong>Search reference</strong>
+                                </DropdownItem>
+                                <DropdownItem divider={true} />
+                                <DropdownItem header={true}>Finding matches:</DropdownItem>
+                                <ul className="list-unstyled px-2 mb-2">
                                     <li>
+                                        <span className="text-muted small">Regexp:</span>{' '}
                                         <code>
-                                            repo:<strong>github.com/myorg/</strong>
+                                            <strong>(read|write)File</strong>
                                         </code>
                                     </li>
+                                    <li>
+                                        <span className="text-muted small">Exact:</span>{' '}
+                                        <code>
+                                            "<strong>fs.open(f)</strong>"
+                                        </code>
+                                    </li>
+                                </ul>
+                                <DropdownItem divider={true} />
+                                <DropdownItem header={true}>Common search keywords:</DropdownItem>
+                                <ul className="list-unstyled px-2 mb-2">
+                                    <li>
+                                        <code>
+                                            repo:<strong>my/repo</strong>
+                                        </code>
+                                    </li>
+                                    {window.context.sourcegraphDotComMode && (
+                                        <li>
+                                            <code>
+                                                repo:<strong>github.com/myorg/</strong>
+                                            </code>
+                                        </li>
+                                    )}
+                                    <li>
+                                        <code>
+                                            file:<strong>my/file</strong>
+                                        </code>
+                                    </li>
+                                    <li>
+                                        <code>
+                                            lang:<strong>javascript</strong>
+                                        </code>
+                                    </li>
+                                </ul>
+                                <DropdownItem divider={true} />
+                                <DropdownItem header={true}>Diff/commit search keywords:</DropdownItem>
+                                <ul className="list-unstyled px-2 mb-2">
+                                    <li>
+                                        <code>type:diff</code> <em className="text-muted small">or</em>{' '}
+                                        <code>type:commit</code>
+                                    </li>
+                                    <li>
+                                        <code>
+                                            after:<strong>"2 weeks ago"</strong>
+                                        </code>
+                                    </li>
+                                    <li>
+                                        <code>
+                                            author:<strong>alice@example.com</strong>
+                                        </code>
+                                    </li>
+                                    <li className="text-nowrap">
+                                        <code>
+                                            repo:<strong>r@*refs/heads/</strong>
+                                        </code>{' '}
+                                        <span className="text-muted small">(all branches)</span>
+                                    </li>
+                                </ul>
+                                <DropdownItem divider={true} />
+                                <a
+                                    href={`${docsURLPrefix}/user/search/queries`}
+                                    className="dropdown-item d-flex align-items-center"
+                                    target="_blank"
+                                    onClick={this.toggleIsOpen}
+                                >
+                                    <ExternalLinkIcon className="icon-inline small mr-1 mb-1" /> All search keywords
+                                </a>
+                                {window.context.sourcegraphDotComMode && (
+                                    <div className="p-2 alert alert-info small rounded-0 mb-0 mt-1">
+                                        On Sourcegraph.com, use a <code>repo:</code> filter to narrow your search to
+                                        &le;500 repositories.
+                                    </div>
                                 )}
-                                <li>
-                                    <code>
-                                        file:<strong>my/file</strong>
-                                    </code>
-                                </li>
-                                <li>
-                                    <code>
-                                        lang:<strong>javascript</strong>
-                                    </code>
-                                </li>
-                            </ul>
-                            <DropdownItem divider={true} />
-                            <DropdownItem header={true}>Diff/commit search keywords:</DropdownItem>
-                            <ul className="list-unstyled px-2 mb-2">
-                                <li>
-                                    <code>type:diff</code> <em className="text-muted small">or</em>{' '}
-                                    <code>type:commit</code>
-                                </li>
-                                <li>
-                                    <code>
-                                        after:<strong>"2 weeks ago"</strong>
-                                    </code>
-                                </li>
-                                <li>
-                                    <code>
-                                        author:<strong>alice@example.com</strong>
-                                    </code>
-                                </li>
-                                <li className="text-nowrap">
-                                    <code>
-                                        repo:<strong>r@*refs/heads/</strong>
-                                    </code>{' '}
-                                    <span className="text-muted small">(all branches)</span>
-                                </li>
-                            </ul>
-                            <DropdownItem divider={true} />
-                            <a
-                                href={`${docsURLPrefix}/user/search/queries`}
-                                className="dropdown-item d-flex align-items-center"
-                                target="_blank"
-                                onClick={this.toggleIsOpen}
-                            >
-                                <ExternalLinkIcon className="icon-inline small mr-1 mb-1" /> All search keywords
-                            </a>
-                            {window.context.sourcegraphDotComMode && (
-                                <div className="p-2 alert alert-info small rounded-0 mb-0 mt-1">
-                                    On Sourcegraph.com, use a <code>repo:</code> filter to narrow your search to &le;500
-                                    repositories.
-                                </div>
-                            )}
-                        </DropdownMenu>
-                    </>
-                )}
-            </ButtonDropdown>
+                            </DropdownMenu>
+                        </>
+                    )}
+                </Dropdown>
+            </div>
         )
     }
 


### PR DESCRIPTION
See commits.

cc @felixfbecker this makes the search help an icon instead of a button

![screenshot from 2019-01-03 17-58-18](https://user-images.githubusercontent.com/1976/50670578-720a8280-0f81-11e9-8758-747641039702.png)
![screenshot from 2019-01-03 17-57-28](https://user-images.githubusercontent.com/1976/50670580-72a31900-0f81-11e9-88b4-b2f1351c613c.png)
![screenshot from 2019-01-03 17-57-06](https://user-images.githubusercontent.com/1976/50670582-733baf80-0f81-11e9-9e89-51a9302d3b67.png)
![screenshot from 2019-01-03 17-57-01](https://user-images.githubusercontent.com/1976/50670583-73d44600-0f81-11e9-8ee1-14e05c2c7018.png)
