### PR TITLE
allow contributing actions to location results

### DIFF
--- a/doc/extensions/authoring/contributions.md
+++ b/doc/extensions/authoring/contributions.md
@@ -23,6 +23,7 @@ A menu is an existing part of the user interface (of Sourcegraph or any other in
 * `directory/page`: A section on all pages showing a directory listing. Sometimes known as a "tree page" on code hosts.
 * `global/nav`: The global navigation bar, shown at the top of every page.
 * `panel/toolbar`: The toolbar on the panel, which is used to show references, definitions, commit history, and other information related to a file or a token/position in a file.
+* `location/title`: The title bar of a location result (such as a reference result in the panel shown in response to a "Find references" action).
 * `help`: The help menu or page.
 
 The set of available menus is defined in the `menus` property in [`extension.schema.json`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/shared/src/schema/extension.schema.json).

--- a/packages/@sourcegraph/extension-api-types/src/location.d.ts
+++ b/packages/@sourcegraph/extension-api-types/src/location.d.ts
@@ -63,4 +63,12 @@ export interface Location {
 
     /** An optional range within the document. */
     readonly range?: Range
+
+    /**
+     * Additional data associated with this location. The context data is available to actions
+     * contributed to the `location` menu. It allows extensions to contribute custom actions to
+     * locations shown in (e.g.) the references panel, such as an indicator that the location is
+     * an imprecise match or is on another branch.
+     */
+    readonly context?: ContextValues
 }

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -312,12 +312,23 @@ declare module 'sourcegraph' {
         range?: Range
 
         /**
+         * Additional data associated with this location. The context data is available to actions
+         * contributed to the `location` menu. It allows extensions to contribute custom actions to
+         * locations shown in (e.g.) the references panel, such as an indicator that the location is
+         * an imprecise match or is on another branch.
+         */
+        readonly context?: Readonly<ContextValues>
+
+        /**
          * Creates a new location object.
+         *
+         * The argument values must not be mutated after the constructor is called.
          *
          * @param uri The resource identifier.
          * @param rangeOrPosition The range or position. Positions will be converted to an empty range.
+         * @param context Optional context data associated with this location.
          */
-        constructor(uri: URI, rangeOrPosition?: Range | Position)
+        constructor(uri: URI, rangeOrPosition?: Range | Position, context?: ContextValues)
     }
 
     /**

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -218,6 +218,27 @@ describe('getComputedContextProperty', () => {
             ))
     })
 
+    describe('location', () => {
+        test('scoped context shadows outer context', () =>
+            expect(
+                getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, { a: 1 }, 'a', {
+                    type: 'location',
+                    location: { uri: 'x', context: { a: 2 } },
+                })
+            ).toBe(2))
+
+        test('provides location.uri', () =>
+            expect(
+                getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, {}, 'location.uri', {
+                    type: 'location',
+                    location: { uri: 'x' },
+                })
+            ).toBe('x'))
+
+        test('returns null for location.uri when there is no location', () =>
+            expect(getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, {}, 'location.uri')).toBe(null))
+    })
+
     test('falls back to the context entries', () => {
         expect(getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, { x: 1 }, 'x')).toBe(1)
         expect(getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, {}, 'y')).toBe(undefined)

--- a/shared/src/api/extension/api/types.test.ts
+++ b/shared/src/api/extension/api/types.test.ts
@@ -1,0 +1,16 @@
+import { Location } from '../types/location'
+import { Position } from '../types/position'
+import { Range } from '../types/range'
+import { URI } from '../types/uri'
+import { fromLocation } from './types'
+
+describe('fromLocation', () => {
+    test('converts to location', () =>
+        expect(
+            fromLocation(new Location(URI.parse('x'), new Range(new Position(1, 2), new Position(3, 4)), { a: 1 }))
+        ).toEqual({
+            uri: 'x',
+            range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+            context: { a: 1 },
+        }))
+})

--- a/shared/src/api/extension/api/types.ts
+++ b/shared/src/api/extension/api/types.ts
@@ -21,6 +21,7 @@ export function fromLocation(location: sourcegraph.Location): clientType.Locatio
     return {
         uri: location.uri.toString(),
         range: fromRange(location.range),
+        context: location.context,
     }
 }
 

--- a/shared/src/api/extension/types/location.test.ts
+++ b/shared/src/api/extension/types/location.test.ts
@@ -9,10 +9,17 @@ describe('Location', () => {
         assertToJSON(new Location(URI.file('u.ts'), new Position(3, 4)), {
             uri: URI.parse('file://u.ts').toJSON(),
             range: { start: { line: 3, character: 4 }, end: { line: 3, character: 4 } },
+            context: undefined,
         })
         assertToJSON(new Location(URI.file('u.ts'), new Range(1, 2, 3, 4)), {
             uri: URI.parse('file://u.ts').toJSON(),
             range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+            context: undefined,
+        })
+        assertToJSON(new Location(URI.file('u.ts'), new Range(1, 2, 3, 4), { a: 1 }), {
+            uri: URI.parse('file://u.ts').toJSON(),
+            range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+            context: { a: 1 },
         })
     })
 })

--- a/shared/src/api/extension/types/location.ts
+++ b/shared/src/api/extension/types/location.ts
@@ -14,12 +14,13 @@ export class Location implements sourcegraph.Location {
         return Range.isRange((thing as Location).range) && URI.isURI((thing as Location).uri)
     }
 
-    public uri: sourcegraph.URI
     public range?: sourcegraph.Range
 
-    constructor(uri: sourcegraph.URI, rangeOrPosition?: sourcegraph.Range | sourcegraph.Position) {
-        this.uri = uri
-
+    constructor(
+        public readonly uri: sourcegraph.URI,
+        rangeOrPosition?: sourcegraph.Range | sourcegraph.Position,
+        public readonly context?: sourcegraph.ContextValues
+    ) {
         if (!rangeOrPosition) {
             // that's OK
         } else if (rangeOrPosition instanceof Range) {
@@ -35,6 +36,7 @@ export class Location implements sourcegraph.Location {
         return {
             uri: this.uri,
             range: this.range,
+            context: this.context,
         }
     }
 }

--- a/shared/src/api/protocol/contribution.ts
+++ b/shared/src/api/protocol/contribution.ts
@@ -207,6 +207,11 @@ export enum ContributableMenu {
     /** The panel toolbar. */
     PanelToolbar = 'panel/toolbar',
 
+    /**
+     * The title bar of a location result, such as a reference or definition location in the panel.
+     */
+    LocationTitle = 'location/title',
+
     /** The help menu in the application. */
     Help = 'help',
 }

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import VisibilitySensor from 'react-visibility-sensor'
 import { combineLatest, Observable, Subject, Subscription } from 'rxjs'
 import { filter, switchMap } from 'rxjs/operators'
+import { ActionContribution } from '../api/protocol'
 import { highlightNode } from '../util/dom'
 import { Repo } from '../util/url'
 
@@ -20,12 +21,16 @@ interface Props extends Repo {
     // How many extra lines to show in the excerpt before/after the ref.
     context?: number
     highlightRanges: HighlightRange[]
+
+    /** The actions (if any) for each line. */
+    actions?: { line: number; actions: ActionContribution }[]
+
     className?: string
     isLightTheme: boolean
     fetchHighlightedFileLines: (ctx: FetchFileCtx, force?: boolean) => Observable<string[]>
 }
 
-interface HighlightRange {
+export interface HighlightRange {
     /**
      * The 0-based line number that this highlight appears in
      */

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -57,6 +57,11 @@ interface Props {
      */
     showAllMatches: boolean
 
+    /**
+     * An extra React fragment to render in the header.
+     */
+    extraHeader?: React.ReactFragment
+
     isLightTheme: boolean
 
     allExpanded?: boolean
@@ -91,12 +96,17 @@ export class FileMatch extends React.PureComponent<Props> {
         }))
 
         const title = (
-            <RepoFileLink
-                repoName={result.repository.name}
-                repoURL={result.repository.url}
-                filePath={result.file.path}
-                fileURL={result.file.url}
-            />
+            <div className="d-flex align-items-center justify-content-between">
+                <div>
+                    <RepoFileLink
+                        repoName={result.repository.name}
+                        repoURL={result.repository.url}
+                        filePath={result.file.path}
+                        fileURL={result.file.url}
+                    />
+                </div>
+                {this.props.extraHeader ? <div>{this.props.extraHeader}</div> : null}
+            </div>
         )
 
         let containerProps: ResultContainerProps

--- a/shared/src/panel/Panel.tsx
+++ b/shared/src/panel/Panel.tsx
@@ -83,6 +83,7 @@ export class Panel extends React.PureComponent<Props, State> {
                                       location={this.props.location}
                                       isLightTheme={this.props.isLightTheme}
                                       extensionsController={this.props.extensionsController}
+                                      platformContext={this.props.platformContext}
                                       settingsCascade={this.props.settingsCascade}
                                       fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
                                   />

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -1,5 +1,6 @@
 import { Location } from '@sourcegraph/extension-api-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import * as H from 'history'
 import * as React from 'react'
 import { Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, endWith, map, startWith, switchMap, tap } from 'rxjs/operators'
@@ -8,6 +9,7 @@ import { RepositoryIcon } from '../../components/icons' // TODO: Switch to mdi i
 import { RepoLink } from '../../components/RepoLink'
 import { Resizable } from '../../components/Resizable'
 import { ExtensionsControllerProps } from '../../extensions/controller'
+import { PlatformContextProps } from '../../platform/context'
 import { SettingsCascadeProps } from '../../settings/settings'
 import { ErrorLike, isErrorLike } from '../../util/errors'
 import { asError } from '../../util/errors'
@@ -16,7 +18,7 @@ import { registerPanelToolbarContributions } from './contributions'
 import { FileLocations, FileLocationsError, FileLocationsNotFound } from './FileLocations'
 import { groupLocations } from './locations'
 
-interface Props extends ExtensionsControllerProps, SettingsCascadeProps {
+interface Props extends ExtensionsControllerProps, PlatformContextProps, SettingsCascadeProps {
     /**
      * The observable that emits the locations.
      */
@@ -36,6 +38,8 @@ interface Props extends ExtensionsControllerProps, SettingsCascadeProps {
     onSelectLocation?: () => void
 
     className?: string
+
+    location: H.Location
 
     isLightTheme: boolean
 
@@ -240,6 +244,9 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
                     icon={RepositoryIcon}
                     isLightTheme={this.props.isLightTheme}
                     fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
+                    location={this.props.location}
+                    extensionsController={this.props.extensionsController}
+                    platformContext={this.props.platformContext}
                 />
             </div>
         )

--- a/shared/src/panel/views/PanelView.tsx
+++ b/shared/src/panel/views/PanelView.tsx
@@ -6,12 +6,13 @@ import { PanelViewWithComponent, ViewProviderRegistrationOptions } from '../../a
 import { FetchFileCtx } from '../../components/CodeExcerpt'
 import { Markdown } from '../../components/Markdown'
 import { ExtensionsControllerProps } from '../../extensions/controller'
+import { PlatformContextProps } from '../../platform/context'
 import { SettingsCascadeProps } from '../../settings/settings'
 import { createLinkClickHandler } from '../../util/linkClickHandler'
 import { EmptyPanelView } from './EmptyPanelView'
 import { HierarchicalLocationsView } from './HierarchicalLocationsView'
 
-interface Props extends ExtensionsControllerProps, SettingsCascadeProps {
+interface Props extends ExtensionsControllerProps, PlatformContextProps, SettingsCascadeProps {
     panelView: PanelViewWithComponent & Pick<ViewProviderRegistrationOptions, 'id'>
     repoName?: string
     history: H.History
@@ -38,17 +39,18 @@ export class PanelView extends React.PureComponent<Props, State> {
                     </div>
                 )}
                 {this.props.panelView.reactElement}
-                {this.props.panelView.locationProvider &&
-                    this.props.repoName && (
-                        <HierarchicalLocationsView
-                            locations={this.props.panelView.locationProvider}
-                            defaultGroup={this.props.repoName}
-                            isLightTheme={this.props.isLightTheme}
-                            fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
-                            extensionsController={this.props.extensionsController}
-                            settingsCascade={this.props.settingsCascade}
-                        />
-                    )}
+                {this.props.panelView.locationProvider && this.props.repoName && (
+                    <HierarchicalLocationsView
+                        locations={this.props.panelView.locationProvider}
+                        defaultGroup={this.props.repoName}
+                        isLightTheme={this.props.isLightTheme}
+                        fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
+                        location={this.props.location}
+                        extensionsController={this.props.extensionsController}
+                        platformContext={this.props.platformContext}
+                        settingsCascade={this.props.settingsCascade}
+                    />
+                )}
                 {!this.props.panelView.content &&
                     !this.props.panelView.reactElement &&
                     !this.props.panelView.locationProvider && <EmptyPanelView className="mt-3" />}


### PR DESCRIPTION
This lets extensions' location providers (definition/reference/etc. providers) associate context data with each location, and also contribute actions that are shown selectively in the file title for location matches shown in the panel.

Together, these new features allow the basic-code-intel extension to add "Fuzzy" badges to defs/refs in the panel. This fixes https://github.com/sourcegraph/sourcegraph/issues/1174.

It would also enable things like:

- Showing a "source" badge on cross-repository reference results explaining how the reference was found (eg by looking up dependents on npm)
- Showing the type of reference (eg denoting some references as "Assignments", some as "Calls", some as "References", etc.)
- Adding an action to "hide" or "always ignore" the reference
- Adding an action to add the match to a saved list
- Adding an action for users to say "This was useful" or "This was not useful" (eg for a code examples extension)

See https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/10 for an example of how extensions can use this new API.

## Screenshot (note the <kbd>Fuzzy</kbd> badge in the panel)

![screenshot from 2019-01-03 23-03-24](https://user-images.githubusercontent.com/1976/50677385-684b4400-0fae-11e9-9728-5fe341dd8220.png)
