### PR TITLE
Add `workspace.activeTextDocument` to the extensions API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - When searching, a filter button `case:yes` will now appear when relevant. This helps discovery and makes it easier to use our case-sensitive search syntax.
 - Extensions can now report progress in the UI through the `withProgress()` extension API.
 - When calling `editor.setDecorations()`, extensions must now provide an instance of `TextDocumentDecorationType` as first argument. This helps gracefully displaying decorations from several extensions.
+- Added `workspace.activeTextDocument` in the extensions API
 
 ### Changed
 

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -720,8 +720,20 @@ declare module 'sourcegraph' {
 
         /**
          * An event that is fired when a new text document is opened.
+         *
+         * @deprecated this is deprecated and will be removed soon, use {@link activeTextDocument} instead.
          */
         export const onDidOpenTextDocument: Subscribable<TextDocument>
+
+        /**
+         * An event fired when the active text document changes.
+         * The active text document is the text document open in the
+         * {@link activeViewComponent} of the {@link activeWindow}, if any.
+         *
+         * This event fires on subscription with the currently active text document,
+         * or `null` if there is none.
+         */
+        export const activeTextDocument: Subcribable<TextDocument | null>
 
         /**
          * The root directories of the workspace, if any.

--- a/shared/src/api/client/api/documents.ts
+++ b/shared/src/api/client/api/documents.ts
@@ -2,7 +2,7 @@ import { Observable, Subscription } from 'rxjs'
 import { createProxyAndHandleRequests } from '../../common/proxy'
 import { ExtDocumentsAPI } from '../../extension/api/documents'
 import { Connection } from '../../protocol/jsonrpc2/connection'
-import { TextDocumentItem } from '../types/textDocument'
+import { ViewComponentData } from '../model'
 import { SubscriptionMap } from './common'
 
 /** @internal */
@@ -11,12 +11,12 @@ export class ClientDocuments {
     private registrations = new SubscriptionMap()
     private proxy: ExtDocumentsAPI
 
-    constructor(connection: Connection, modelTextDocuments: Observable<TextDocumentItem[] | null>) {
+    constructor(connection: Connection, modelViewComponents: Observable<ViewComponentData[] | null>) {
         this.proxy = createProxyAndHandleRequests('documents', connection, this)
 
         this.subscriptions.add(
-            modelTextDocuments.subscribe(docs => {
-                this.proxy.$acceptDocumentData(docs || [])
+            modelViewComponents.subscribe(editors => {
+                this.proxy.$acceptEditorData(editors || [])
             })
         )
 

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -94,10 +94,7 @@ export function createExtensionHostClientConnection(
         new ClientDocuments(
             connection,
             from(services.model.model).pipe(
-                map(
-                    ({ visibleViewComponents }) =>
-                        visibleViewComponents && visibleViewComponents.map(({ item }) => item)
-                ),
+                map(({ visibleViewComponents }) => visibleViewComponents),
                 distinctUntilChanged()
             )
         )

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -199,6 +199,7 @@ function createExtensionAPI(
             get textDocuments(): sourcegraph.TextDocument[] {
                 return documents.getAll()
             },
+            activeTextDocument: documents.activeTextDocument,
             onDidOpenTextDocument: documents.onDidOpenTextDocument,
             get roots(): ReadonlyArray<sourcegraph.WorkspaceRoot> {
                 return roots.getAll()

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -54,4 +54,68 @@ describe('Documents (integration)', () => {
             expect(values).toEqual([{ uri: 'file:///f2', languageId: 'l2', text: 't2' }] as TextDocument[])
         })
     })
+
+    describe('workspace.activeTextDocument', () => {
+        test('emits `null` on subscription if there is no active text document', async () => {
+            const { extensionHost } = await integrationTestContext(undefined, {
+                roots: [],
+                visibleViewComponents: [],
+            })
+            const values = collectSubscribableValues(extensionHost.workspace.activeTextDocument)
+            expect(values).toEqual([null])
+        })
+
+        test('emits the active text document on subscription if there is one', async () => {
+            const { model, extensionHost } = await integrationTestContext(undefined, {
+                roots: [],
+                visibleViewComponents: [],
+            })
+            model.next({
+                ...model.value,
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        item: { uri: 'file:///f1', languageId: 'l1', text: 't1' },
+                        selections: [],
+                        isActive: false,
+                    },
+                    {
+                        type: 'textEditor',
+                        item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
+                        selections: [],
+                        isActive: true,
+                    },
+                ],
+            })
+            await extensionHost.internal.sync()
+            const values = collectSubscribableValues(extensionHost.workspace.activeTextDocument)
+            expect(values.pop()).toEqual({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
+        })
+
+        test('emits null when all viewComponents are closed', async () => {
+            const { model, extensionHost } = await integrationTestContext(undefined, {
+                roots: [],
+                visibleViewComponents: [],
+            })
+            const values = collectSubscribableValues(extensionHost.workspace.activeTextDocument)
+            model.next({
+                ...model.value,
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        item: { uri: 'file:///f1', languageId: 'l1', text: 't1' },
+                        selections: [],
+                        isActive: true,
+                    },
+                ],
+            })
+            await extensionHost.internal.sync()
+            model.next({
+                ...model.value,
+                visibleViewComponents: [],
+            })
+            await extensionHost.internal.sync()
+            expect(values).toEqual([null, { uri: 'file:///f1', languageId: 'l1', text: 't1' }, null])
+        })
+    })
 })

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -32,9 +32,9 @@ interface TestContext {
 
 interface Mocks
     extends Pick<
-            PlatformContext,
-            'settings' | 'updateSettings' | 'queryGraphQL' | 'getScriptURLForExtension' | 'clientApplication'
-        > {}
+        PlatformContext,
+        'settings' | 'updateSettings' | 'queryGraphQL' | 'getScriptURLForExtension' | 'clientApplication'
+    > {}
 
 const NOOP_MOCKS: Mocks = {
     settings: NEVER,
@@ -50,7 +50,8 @@ const NOOP_MOCKS: Mocks = {
  * @internal
  */
 export async function integrationTestContext(
-    partialMocks: Partial<Mocks> = NOOP_MOCKS
+    partialMocks: Partial<Mocks> = NOOP_MOCKS,
+    initialModel: Model = FIXTURE_MODEL
 ): Promise<
     TestContext & {
         model: Subscribable<Model> & { value: Model } & NextObserver<Model>
@@ -81,7 +82,7 @@ export async function integrationTestContext(
         )
     )
 
-    services.model.model.next(FIXTURE_MODEL)
+    services.model.model.next(initialModel)
 
     await (await extensionHost.__testAPI).internal.sync()
     return {


### PR DESCRIPTION
Added this to address the shortcomings of `onDidOpenTextDocument`, most notably its racy behaviour: the event may fire before extension activation, making it impossible to reliably react to the currently open text document upon extension activation, which is how extension authors expect to use it.