### PR TITLE
Update GHE API URL to `/api/v3`

### DIFF
--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -123,11 +122,6 @@ func derefInt64(i *int64) int64 {
 func (s *sessionIssuerHelper) getVerifiedEmails(ctx context.Context, token *oauth2.Token) (verifiedEmails []string) {
 	apiURL, _ := githubsvc.APIRoot(s.BaseURL())
 
-	if apiURL.String() != defaultAPI {
-		// Append /v3 to GHE API
-		var appURLV3 = apiURL.String() + "/v3"
-		apiURL, _ = url.Parse(appURLV3)
-	}
 	ghClient := githubsvc.NewClient(apiURL, "", nil)
 	emails, err := ghClient.GetAuthenticatedUserEmails(ctx, token.AccessToken)
 	if err != nil {
@@ -137,11 +131,11 @@ func (s *sessionIssuerHelper) getVerifiedEmails(ctx context.Context, token *oaut
 
 	for _, email := range emails {
 
-		// GitHub Enterprise does not authorize emails. Continue anyways.
-		if email.Primary && apiURL.String() != defaultAPI {
-			verifiedEmails = append([]string{email.Email}, verifiedEmails...)
-			continue
-		}
+		// // GitHub Enterprise does not authorize emails. Continue anyways.
+		// if email.Primary && apiURL.String() != defaultAPI {
+		// 	verifiedEmails = append([]string{email.Email}, verifiedEmails...)
+		// 	continue
+		// }
 		if !email.Verified {
 			continue
 		}

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -24,7 +24,6 @@ type sessionIssuerHelper struct {
 	clientID    string
 	allowSignup bool
 }
-var defaultAPI = "https://api.github.com/" // Default GitHub API URL
 
 func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2.Token) (actr *actor.Actor, safeErrMsg string, err error) {
 	ghUser, err := github.UserFromContext(ctx)
@@ -121,7 +120,6 @@ func derefInt64(i *int64) int64 {
 // it will be the first email in the returned list. It only checks the first 100 user emails.
 func (s *sessionIssuerHelper) getVerifiedEmails(ctx context.Context, token *oauth2.Token) (verifiedEmails []string) {
 	apiURL, _ := githubsvc.APIRoot(s.BaseURL())
-
 	ghClient := githubsvc.NewClient(apiURL, "", nil)
 	emails, err := ghClient.GetAuthenticatedUserEmails(ctx, token.AccessToken)
 	if err != nil {
@@ -130,12 +128,6 @@ func (s *sessionIssuerHelper) getVerifiedEmails(ctx context.Context, token *oaut
 	}
 
 	for _, email := range emails {
-
-		// // GitHub Enterprise does not authorize emails. Continue anyways.
-		// if email.Primary && apiURL.String() != defaultAPI {
-		// 	verifiedEmails = append([]string{email.Email}, verifiedEmails...)
-		// 	continue
-		// }
 		if !email.Verified {
 			continue
 		}

--- a/pkg/extsvc/github/client.go
+++ b/pkg/extsvc/github/client.go
@@ -375,7 +375,7 @@ func APIRoot(baseURL *url.URL) (apiURL *url.URL, githubDotCom bool) {
 	}
 	// GitHub Enterprise
 	if baseURL.Path == "" || baseURL.Path == "/" {
-		return baseURL.ResolveReference(&url.URL{Path: "/api"}), false
+		return baseURL.ResolveReference(&url.URL{Path: "/api/v3"}), false
 	}
 	return baseURL.ResolveReference(&url.URL{Path: "api"}), false
 }

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -265,7 +265,7 @@ func convertRestRepo(restRepo restRepository) *Repository {
 // https://developer.github.com/v3/repos/#list-all-public-repositories
 func (c *Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) ([]*Repository, error) {
 	var restRepos []restRepository
-	path := "v3/repositories"
+	path := "repositories"
 	if sinceRepoID > 0 {
 		path += "?per_page=100&since=" + strconv.FormatInt(sinceRepoID, 10)
 	}
@@ -318,12 +318,7 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 // return. Pages are 1-indexed (so the first call should be for page 1).
 func (c *Client) ListViewerRepositories(ctx context.Context, token string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	var restRepos []restRepository
-	var path string
-	if c.githubDotCom {
-		path = fmt.Sprintf("user/repos?sort=pushed&page=%d&per_page=100", page)
-	} else {
-		path = fmt.Sprintf("v3/user/repos?sort=pushed&page=%d&per_page=100", page)
-	}
+	path := fmt.Sprintf("user/repos?sort=pushed&page=%d&per_page=100", page)
 	if err := c.requestGet(ctx, token, path, &restRepos); err != nil {
 		return nil, false, 1, err
 	}
@@ -347,12 +342,7 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 		"q":    []string{searchString},
 		"page": []string{strconv.Itoa(page)},
 	}
-	var path string
-	if c.githubDotCom {
-		path = "search/repositories?" + urlValues.Encode()
-	} else {
-		path = "v3/search/repositories?" + urlValues.Encode()
-	}
+	path := "search/repositories?" + urlValues.Encode()
 	var response restSearchResponse
 	if err := c.requestGet(ctx, "", path, &response); err != nil {
 		return nil, false, 1, err


### PR DESCRIPTION
This changes the GHE API URL to include `/v3` so that packages do not have to specify it on their own and API URLs can match across GitHub.com and GHE instances. Also resolves https://github.com/sourcegraph/sourcegraph/issues/1376