### PR TITLE
support noop actions, display as non-clickable in ActionItem

### DIFF
--- a/shared/src/actions/ActionItem.test.tsx
+++ b/shared/src/actions/ActionItem.test.tsx
@@ -35,6 +35,18 @@ describe('ActionItem', () => {
         expect(component.toJSON()).toMatchSnapshot()
     })
 
+    test('noop command', () => {
+        const component = renderer.create(
+            <ActionItem
+                action={{ id: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                location={history.location}
+                extensionsController={NOOP_EXTENSIONS_CONTROLLER}
+                platformContext={NOOP_PLATFORM_CONTEXT}
+            />
+        )
+        expect(component.toJSON()).toMatchSnapshot()
+    })
+
     test('title element', () => {
         const component = renderer.create(
             <ActionItem

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -160,6 +160,20 @@ export class ActionItem extends React.PureComponent<Props, State> {
             tooltip = this.props.action.description
         }
 
+        const variantClassName = this.props.variant === 'actionItem' ? 'action-item--variant-action-item' : ''
+
+        // Simple display if the action is a noop.
+        if (!this.props.action.command) {
+            return (
+                <span
+                    data-tooltip={tooltip}
+                    className={`action-item ${this.props.className || ''} ${variantClassName}`}
+                >
+                    {content}
+                </span>
+            )
+        }
+
         const showLoadingSpinner = this.props.showLoadingSpinnerDuringExecution && this.state.actionOrError === LOADING
 
         return (
@@ -175,7 +189,7 @@ export class ActionItem extends React.PureComponent<Props, State> {
                 }
                 className={`action-item ${this.props.className || ''} ${
                     showLoadingSpinner ? 'action-item--loading' : ''
-                } ${this.props.variant === 'actionItem' ? 'action-item--variant-action-item' : ''}`}
+                } ${variantClassName}`}
                 // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
                 // it as a button that executes the command.
                 to={
@@ -198,6 +212,12 @@ export class ActionItem extends React.PureComponent<Props, State> {
 
     public runAction = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
         const action = (isAltEvent(e) && this.props.altAction) || this.props.action
+
+        if (!action.command) {
+            // Unexpectedly arrived here; noop actions should not have event handlers that trigger
+            // this.
+            return
+        }
 
         // Record action ID (but not args, which might leak sensitive data).
         this.context.log(action.id)

--- a/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -48,6 +48,21 @@ exports[`ActionItem non-actionItem variant 1`] = `
 </a>
 `;
 
+exports[`ActionItem noop command 1`] = `
+<span
+  className="action-item  "
+  data-tooltip="d"
+>
+  <img
+    className="icon-inline"
+    src="u"
+  />
+   
+  g: 
+  t
+</span>
+`;
+
 exports[`ActionItem render as link for "open" command 1`] = `
 <a
   className="action-item    "

--- a/shared/src/api/protocol/contribution.ts
+++ b/shared/src/api/protocol/contribution.ts
@@ -34,22 +34,26 @@ export interface ActionContribution {
     id: string
 
     /**
-     * The command that this action invokes. It can refer to a command registered by the same extension or any
-     * other extension, or to a builtin command.
+     * The command that this action invokes. It can refer to a command registered by the same
+     * extension or any other extension, or to a builtin command. If it is undefined, the action is
+     * a noop.
      *
      * See "[Builtin commands](../../../../doc/extensions/authoring/builtin_commands.md)" (online at
-     * https://docs.sourcegraph.com/extensions/authoring/builtin_commands) for documentation on builtin client
-     * commands.
+     * https://docs.sourcegraph.com/extensions/authoring/builtin_commands) for documentation on
+     * builtin client commands.
      *
-     * Extensions: The command must be registered (unless it is a builtin command). Extensions can register
-     * commands using {@link sourcegraph.commands.registerCommand}.
+     * Extensions: The command must be registered (unless it is a builtin command). Extensions can
+     * register commands using {@link sourcegraph.commands.registerCommand}.
      *
-     * Clients: All clients must implement the builtin commands as specified in the documentation above.
+     * Clients: All clients must implement the builtin commands as specified in the documentation
+     * above. If the command is undefined (which means the action is a noop), the action should be
+     * displayed in such a way that avoids suggesting it can be clicked/activated (e.g., there
+     * should not be any hover or active state on the button).
      *
      * @see ActionContributionClientCommandOpen
      * @see ActionContributionClientCommandUpdateConfiguration
      */
-    command: string
+    command?: string
 
     /**
      * Optional arguments to pass to the extension when the action is invoked.


### PR DESCRIPTION
An ActionItem that is a noop action is useful when it only displays information and does not have any action associated with it (such as a "fuzzy" indicator on refs that come from imprecise analysis, such as basic-code-intel's providers).