### PR TITLE
Add UI for explaining move to management console #1617

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,7 @@ github.com/gchaincl/sqlhooks v1.1.0 h1:c/JqKEQFqiqnV8D7b834AT5gyrOsFvxdmBWJPAgXV
 github.com/gchaincl/sqlhooks v1.1.0/go.mod h1:kvcSeiqN3dMcwlPcJIeNNqIvrUpk+G0mmXDv5qPF5IU=
 github.com/getsentry/raven-go v0.0.0-20180903072508-084a9de9eb03 h1:G/9fPivTr5EiyqE9OlW65iMRUxFXMGRHgZFGo50uG8Q=
 github.com/getsentry/raven-go v0.0.0-20180903072508-084a9de9eb03/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
+github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -177,6 +178,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekf
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 h1:u4bArs140e9+AfE52mFHOXVFnOSBJBRlzTHrOPLOIhE=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20190104202712-c65c006176ff h1:laFPSS7u3jCEedwKqc3g8kbxG07Q3TVXNq8qHzgd+vg=
 github.com/golang/groupcache v0.0.0-20190104202712-c65c006176ff/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
@@ -255,6 +257,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/slothfs v0.0.0-20170112234537-ecdd255f653d/go.mod h1:kzvK/MFjZSNdFgc1tCZML3E1nVvnB4/npSKEuvMoECU=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/zoekt v0.0.0-20180530125106-8e284ca7e964/go.mod h1:rq17mlD02KZEKl5IJj0kPYUrH5dBVi/J5Ipcgnxvm94=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
@@ -381,6 +384,7 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20180702182724-07a764486eb1 h1:gmB1XmLjI0RXG8rJCP0PK6g8rwhX8COSGFTiOgJ4Wx4=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20180702182724-07a764486eb1/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
+github.com/opentracing-contrib/go-stdlib v0.0.0-20190104202730-77df8e8e70b4 h1:EhSaxex5Xvzs0xfbrCeaUfF8/jrY4yEm/v5b+HMYF5A=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190104202730-77df8e8e70b4/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -537,6 +541,7 @@ golang.org/x/crypto v0.0.0-20180403160946-b2aa35443fbc/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180505025534-4ec37c66abab/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b h1:2b9XGzhjiYsYPnKXoEfL7klWZQIt8IfyRCz62gCqqlQ=
 golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190104202753-ff983b9c42bc h1:q4DTZDq44Ue0CR1CnaidNPfdpaDNTMMXrf5IIWZy2UQ=
 golang.org/x/crypto v0.0.0-20190104202753-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -578,6 +583,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2IVY3KZs6p9mix0ziNYJM=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190104202802-85acf8d2951c h1:Bj+bnC2UNaTz6nj5p0/mwzBAFZFV7caoTXgb7veN3MQ=
 golang.org/x/time v0.0.0-20190104202802-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180826000951-f6ba57429505/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
@@ -82,13 +82,8 @@ export class SiteAdminAuthenticationProvidersPage extends React.Component<Props>
                 <p>
                     Authentication providers allow users to sign into Sourcegraph. See{' '}
                     <a href="https://docs.sourcegraph.com/admin/auth">authentication documentation</a> about configuring
-                    single-sign-on (SSO) via SAML and OpenID Connect.
+                    single-sign-on (SSO) via SAML and OpenID Connect. Configure authentication providers in the management console.
                 </p>
-                <div>
-                    <Link to="/site-admin/configuration" className="btn btn-secondary">
-                        <SettingsIcon className="icon-inline" /> Configure auth providers
-                    </Link>
-                </div>
                 <FilteredAuthProviderConnection
                     className="mt-3"
                     listClassName="list-group list-group-flush"

--- a/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -314,10 +314,6 @@ export class SiteAdminAllUsersPage extends React.Component<Props, State> {
                     <Link to="/site-admin/users/new" className="btn btn-primary">
                         <AddIcon className="icon-inline" /> Create user account
                     </Link>
-                    &nbsp;
-                    <Link to="/site-admin/configuration" className="btn btn-secondary">
-                        <SettingsIcon className="icon-inline" /> Configure SSO
-                    </Link>
                 </div>
                 <FilteredUserConnection
                     className="mt-3"

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -257,6 +257,9 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                     View and edit the Sourcegraph site configuration. See{' '}
                     <Link to="/help/admin/site_config">documentation</Link> for more information.
                 </p>
+				<div className="alert alert-primary mb-2">
+					Core configuration has moved. <Link to="/help/admin/site_config">Learn more</Link> about the management console.
+				</div>
                 <div className="site-admin-configuration-page__alerts">{alerts}</div>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
                 {this.state.site &&
@@ -264,7 +267,6 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                         <div>
                             <DynamicallyImportedMonacoSettingsEditor
                                 value={contents || ''}
-                                actions={siteConfigActions}
                                 jsonSchemaId="site.schema.json#"
                                 extraSchemas={EXTRA_SCHEMAS}
                                 onDirtyChange={this.onDirtyChange}

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -12,6 +12,7 @@ import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchSite, reloadSite, updateSiteConfiguration } from './backend'
 import { siteConfigActions } from './configHelpers'
+import { SiteAdminManagementConsolePassword } from './SiteAdminManagementConsolePassword'
 
 interface Props extends RouteComponentProps<any> {
     isLightTheme: boolean
@@ -257,9 +258,9 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                     View and edit the Sourcegraph site configuration. See{' '}
                     <Link to="/help/admin/site_config">documentation</Link> for more information.
                 </p>
-				<div className="alert alert-primary mb-2">
-					Core configuration has moved. <Link to="/help/admin/site_config">Learn more</Link> about the management console.
-				</div>
+				<div className="mb-3">
+                    <SiteAdminManagementConsolePassword />
+                </div>
                 <div className="site-admin-configuration-page__alerts">{alerts}</div>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
                 {this.state.site &&

--- a/web/src/site-admin/SiteAdminManagementConsolePassword.tsx
+++ b/web/src/site-admin/SiteAdminManagementConsolePassword.tsx
@@ -78,7 +78,7 @@ export class SiteAdminManagementConsolePassword extends React.Component<Props, S
             <>
                 <div className="card">
                     <div className="card-header alert-warning">
-                        <KeyVariantIcon /> Save your management console password!
+                        <KeyVariantIcon /> Core configuration has moved to the mangement console.
                     </div>
                     <div className="card-body">
                         Your management console password has been automatically generated for you. <br />

--- a/web/src/site-admin/SiteAdminOverviewPage.tsx
+++ b/web/src/site-admin/SiteAdminOverviewPage.tsx
@@ -152,9 +152,6 @@ export class SiteAdminOverviewPage extends React.Component<Props, State> {
                                         <Link to="/site-admin/users/new" className="btn btn-primary btn-sm">
                                             <AddIcon className="icon-inline" /> Create user account
                                         </Link>
-                                        <Link to="/site-admin/configuration" className="btn btn-secondary btn-sm">
-                                            <SettingsIcon className="icon-inline" /> Configure SSO
-                                        </Link>
                                         <Link to="/site-admin/users" className="btn btn-secondary btn-sm">
                                             <OpenInNewIcon className="icon-inline" /> View all
                                         </Link>

--- a/web/src/site-admin/configHelpers.ts
+++ b/web/src/site-admin/configHelpers.ts
@@ -69,11 +69,5 @@ export const settingsActions: EditorAction[] = [
 ]
 
 export const siteConfigActions: EditorAction[] = [
-    {
-        id: 'sourcegraph.site.addGSuiteOIDCAuthProvider',
-        label: 'Add G Suite user auth',
-        run: addGSuiteOIDCAuthProvider,
-    },
-    { id: 'sourcegraph.site.addSAMLAUthProvider', label: 'Add SAML user auth', run: addSAMLAuthProvider },
-    { id: 'sourcegraph.site.addLicenseKey', label: 'Add license key', run: addLicenseKey },
+
 ]


### PR DESCRIPTION
Create a UI that explains the move to management console for core configuration and gives users explanation of missing config. #1617

- Removes option to configure auth providers in auth UI
- Shows notification on site-admin and site-admin configuration pages
- Removes references to configure auth providers in configuration page.


![screen shot 2019-01-07 at 1 34 46 pm](https://user-images.githubusercontent.com/11583013/50794880-43daba80-1281-11e9-8a6b-4231293525ce.png)
![screen shot 2019-01-07 at 1 34 57 pm](https://user-images.githubusercontent.com/11583013/50794881-43daba80-1281-11e9-8133-c7422423bba1.png)
![screen shot 2019-01-07 at 1 36 56 pm](https://user-images.githubusercontent.com/11583013/50794893-4fc67c80-1281-11e9-81e1-b080cd0c67ae.png)