### PR TITLE
Remove docker.sock from the quickstart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The default for `experimentalFeatures.canonicalURLRedirect` in site config was changed back to `disabled`.
 - The repository and directory pages now show all entries together instead of showing files and (sub)directories separately.
 - Extensions no longer can specify titles (in the `title` property in the `package.json` extension manifest). Their extension ID (such as `alice/myextension`) is used.
+- Sourcegraph no longer requires access to `/var/run/docker.sock`.
 
 ### Fixed
 

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -34,5 +34,4 @@ docker run "$@" \
  -e DEBUG=t \
  --volume $DATA/config:/etc/sourcegraph \
  --volume $DATA/data:/var/opt/sourcegraph \
- -v /var/run/docker.sock:/var/run/docker.sock \
  $IMAGE

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -38,7 +38,7 @@ If you're just starting out, we recommend [installing Sourcegraph locally](index
   - sed -i -e 's/4096/40960/g' /etc/sysconfig/docker
   - service docker start
   - usermod -a -G docker ec2-user
-  - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph --volume /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.13.5' ]
+  - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.13.5' ]
   ```
 
 - Select **Next: ...** until you get to the **Configure Security Group** page, then add the default **HTTP** rule (port range "80", source "0.0.0.0/0, ::/0")

--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -30,7 +30,7 @@ If you're just starting out, we recommend [installing Sourcegraph locally](index
   runcmd:
   - mkdir -p /root/.sourcegraph/config
   - mkdir -p /root/.sourcegraph/data
-  - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph --volume /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.13.5' ]
+  - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.13.5' ]
   ```
 
 - Launch your instance, then navigate to its IP address.

--- a/doc/admin/install/docker/google_cloud.md
+++ b/doc/admin/install/docker/google_cloud.md
@@ -31,7 +31,7 @@ If you're just starting out, we recommend [installing Sourcegraph locally](index
   sudo apt-get install -y docker-ce
   mkdir -p /root/.sourcegraph/config
   mkdir -p /root/.sourcegraph/data
-  docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph --volume /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.13.5
+  docker run -d --publish 80:7080 --publish 443:7443 --publish 2633:2633 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.13.5
   ```
 
 - Create your VM, then navigate to its public IP address.

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -11,7 +11,6 @@ docker run \
   --publish 7080:7080 --publish 2633:2633 --rm \
   --volume ~/.sourcegraph/config:/etc/sourcegraph \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
   sourcegraph/server:2.13.5
 ```
 

--- a/doc/admin/tls_ssl.md
+++ b/doc/admin/tls_ssl.md
@@ -24,7 +24,7 @@ acme: authorization error for example.com: 403 urn:acme:error:unauthorized:
 Cannot negotiate ALPN protocol "acme-tls/1" for tls-alpn-01 challenge;
 challenge "http-01" failed with error: acme: authorization error for example.com:
 403 urn:acme:error:unauthorized: Invalid response from
-http://example.com/.well-known/acme-challenge/gHyMI48MrfLg: ... 
+http://example.com/.well-known/acme-challenge/gHyMI48MrfLg: ...
 
 ...
 
@@ -52,7 +52,7 @@ For single-server Docker image deployments, add the following lines to your site
   // ...
   "tlsCert": "-----BEGIN CERTIFICATE-----\nMIIFdTCCBF2gAWiB...",
   "tlsKey": "-----BEGIN RSA PRIVATE KEY-----\nMII...",
-  "externalURL": "https://example.com:3443" 
+  "externalURL": "https://example.com:3443"
   // Must begin with "https"; replace with the public IP or hostname of your machine
   // ...
 }
@@ -65,7 +65,6 @@ docker run \
   --publish 443:7443 --rm \
   --volume ~/.sourcegraph/config:/etc/sourcegraph \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
   sourcegraph/server:2.13.5
 ```
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -13,7 +13,6 @@ docker run \
   --publish 7080:7080 --publish 2633:2633 --rm \
   --volume ~/.sourcegraph/config:/etc/sourcegraph \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
   sourcegraph/server:2.13.5
 ```
 


### PR DESCRIPTION
⚠️ **Do not merge until 3.0 is released**

Sourcegraph 3.0 will not manage Docker containers, which was the only reason why `docker.sock` had to be mounted.