### PR TITLE
ci: only build non-frontend images when pushing to "docker-images/"

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -326,10 +326,10 @@ func main() {
 		addDockerImageStep(branch[20:], false)
 
 	case strings.HasPrefix(branch, "docker-images/"):
-		addDockerImageStep(branch[14:], true)
-		pipeline.AddWait()
 		// Only deploy images that aren't auto deployed from master.
 		if branch != "docker-images/server" && branch != "docker-images/frontend" {
+			addDockerImageStep(branch[14:], true)
+			pipeline.AddWait()
 			addDeploySteps()
 		}
 	}


### PR DESCRIPTION
Both `sourcegraph/server` and `sourcegraph/frontend` should *not* be built when pushing to `docker-images/*` so that we don't accidentally push an outdated frontend / server version under the `"insiders"` tag.