### PR TITLE
manual autofocus of command pallet input to prevent scroll to bottom of page, fixes #631

### DIFF
--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -47,7 +47,6 @@ export function initializeExtensions({
                         extensionsController={extensionsController}
                         menu={ContributableMenu.CommandPalette}
                         platformContext={platformContext}
-                        autoFocus={false}
                         location={history.location}
                     />
                     <Notifications extensionsController={extensionsController} />

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -21,14 +21,7 @@ interface Props extends ExtensionsControllerProps, PlatformContextProps {
     /** Called when the user has selected an item in the list. */
     onSelect?: () => void
 
-    /**
-     * Whether the text input should have autofocus.
-     *
-     * When used in the browser extension, this sometimes results in the page being scrolled to the bottom in the
-     * web browser because it attempts to autofocus (and scroll to reveal) before the element is attached to the
-     * correct position. Therefore this should be set to true only in the Sourcegraph web app (or unless you're
-     * confident that it works otherwise and have tested it, in which case you should update this comment).
-     */
+    /** Whether the text input should have autofocus. */
     autoFocus: boolean
 
     location: H.Location
@@ -95,9 +88,12 @@ export class CommandList extends React.PureComponent<Props, State> {
                 .subscribe(contributions => this.setState({ contributions }))
         )
 
-        setTimeout(() => {
-            this.setState({ autoFocus: true })
-        })
+        // Only focus input after it has been rendered in the DOM
+        if (this.props.autoFocus) {
+            setTimeout(() => {
+                this.setState({ autoFocus: true })
+            })
+        }
     }
 
     public componentDidUpdate(_prevProps: Props, prevState: State): void {
@@ -134,6 +130,7 @@ export class CommandList extends React.PureComponent<Props, State> {
                         </label>
                         <input
                             id="command-list__input"
+                            ref={input => input && this.state.autoFocus && input.focus()}
                             type="text"
                             className="form-control px-2 py-1 rounded-0"
                             value={this.state.input}
@@ -141,7 +138,6 @@ export class CommandList extends React.PureComponent<Props, State> {
                             spellCheck={false}
                             autoCorrect="off"
                             autoComplete="off"
-                            autoFocus={this.props.autoFocus || this.state.autoFocus}
                             onChange={this.onInputChange}
                             onKeyDown={this.onInputKeyDown}
                         />

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -21,9 +21,6 @@ interface Props extends ExtensionsControllerProps, PlatformContextProps {
     /** Called when the user has selected an item in the list. */
     onSelect?: () => void
 
-    /** Whether the text input should have autofocus. */
-    autoFocus: boolean
-
     location: H.Location
 }
 
@@ -89,11 +86,9 @@ export class CommandList extends React.PureComponent<Props, State> {
         )
 
         // Only focus input after it has been rendered in the DOM
-        if (this.props.autoFocus) {
-            setTimeout(() => {
-                this.setState({ autoFocus: true })
-            })
-        }
+        setTimeout(() => {
+            this.setState({ autoFocus: true })
+        })
     }
 
     public componentDidUpdate(_prevProps: Props, prevState: State): void {

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -33,8 +33,6 @@ interface State {
 
     /** Recently invoked actions, which should be sorted first in the list. */
     recentActions: string[] | null
-
-    autoFocus?: boolean
 }
 
 /** Displays a list of commands contributed by extensions for a specific menu. */
@@ -84,11 +82,6 @@ export class CommandList extends React.PureComponent<Props, State> {
                 .getContributions()
                 .subscribe(contributions => this.setState({ contributions }))
         )
-
-        // Only focus input after it has been rendered in the DOM
-        setTimeout(() => {
-            this.setState({ autoFocus: true })
-        })
     }
 
     public componentDidUpdate(_prevProps: Props, prevState: State): void {
@@ -125,7 +118,7 @@ export class CommandList extends React.PureComponent<Props, State> {
                         </label>
                         <input
                             id="command-list__input"
-                            ref={input => input && this.state.autoFocus && input.focus()}
+                            ref={input => input && input.focus({ preventScroll: true })}
                             type="text"
                             className="form-control px-2 py-1 rounded-0"
                             value={this.state.input}

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -97,7 +97,6 @@ export class NavLinks extends React.PureComponent<Props> {
                     extensionsController={this.props.extensionsController}
                     platformContext={this.props.platformContext}
                     toggleVisibilityKeybinding={this.props.keybindings.commandPalette}
-                    autoFocus={true}
                     location={this.props.location}
                 />
                 {this.props.authenticatedUser && (

--- a/web/src/search/input/MainPage.scss
+++ b/web/src/search/input/MainPage.scss
@@ -58,7 +58,6 @@ body.main-page {
     $media-md: 768px;
     $media-lg: 992px;
     width: 100%;
-    display: block;
 
     &__logo {
         flex: 0 0 auto;

--- a/web/src/search/input/MainPage.scss
+++ b/web/src/search/input/MainPage.scss
@@ -58,6 +58,7 @@ body.main-page {
     $media-md: 768px;
     $media-lg: 992px;
     width: 100%;
+    display: block;
 
     &__logo {
         flex: 0 0 auto;


### PR DESCRIPTION
This fixes #631, where opening the command pallet scrolled the page to the bottom. This was caused by setting the autofocus attribute on the input element. The input was not yet rendered into the DOM because of being inside a popover, which lead to the unintended scroll.

## Solution

Manually focus the rendered input element after the popover has opened.