### PR TITLE
server: Add certbot for letsencrypt

### DIFF
--- a/cmd/server/dockerfile.go
+++ b/cmd/server/dockerfile.go
@@ -5,7 +5,7 @@ package main
 
 //docker:install docker
 
-//docker:install nginx
+//docker:install nginx certbot
 
 // make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
 // alpine doesn't require explicit locale-file generation


### PR DESCRIPTION
Bundling in certbot makes it easier for users to setup letsencrypt
integration. However, this does increase our image size by
80meg. Alternatively users can link a volume and use the certbot
container. Both are pretty complicated as is, and much less nice than what we
used to offer with the builtin integration.

I am considering we just remove letsencrypt support due to how complicated
this is getting, and instead encourage users to run a special proxy to do
it. For example we used to use caddy as a proxy for an internal service and it
would take care of letsencrypt certs.