### PR TITLE
in monaco editor, do not suggest completions from other words in document

### DIFF
--- a/cmd/management-console/web/src/MonacoEditor.tsx
+++ b/cmd/management-console/web/src/MonacoEditor.tsx
@@ -127,6 +127,7 @@ export class MonacoEditor extends React.Component<Props, {}> {
             scrollBeyondLastLine: false,
             quickSuggestions: true,
             quickSuggestionsDelay: 200,
+            wordBasedSuggestions: false,
             wordWrap: 'on',
             theme: 'vs-dark',
             model,

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -126,6 +126,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
                     scrollBeyondLastLine: false,
                     quickSuggestions: true,
                     quickSuggestionsDelay: 200,
+                    wordBasedSuggestions: false,
                     readOnly: this.props.readOnly,
                     wordWrap: 'on',
                 }}


### PR DESCRIPTION
fix #1790 

![screenshot from 2019-01-10 20-55-52](https://user-images.githubusercontent.com/1976/51013926-22e0c680-151a-11e9-89bb-8ca8b085cdcb.png)
