### PR TITLE
More comments in external service default configs

### DIFF
--- a/web/src/site-admin/externalServices.ts
+++ b/web/src/site-admin/externalServices.ts
@@ -10,7 +10,7 @@ export const GITHUB_EXTERNAL_SERVICE: ExternalServiceMetadata = {
     kind: GQL.ExternalServiceKind.GITHUB,
     displayName: 'GitHub',
     defaultConfig: `{
-  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Use Ctrl+Space for completion, and hover over JSON properties for documentation.
   // Configuration options are documented here:
   // https://docs.sourcegraph.com/admin/site_config/all#githubconnection-object
 
@@ -34,7 +34,7 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.AWSCODECOMMIT,
         displayName: 'AWS CodeCommit',
         defaultConfig: `{
-  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Use Ctrl+Space for completion, and hover over JSON properties for documentation.
   // Configuration options are documented here:
   // https://docs.sourcegraph.com/admin/site_config/all#awscodecommitconnection-object
 
@@ -47,7 +47,7 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.BITBUCKETSERVER,
         displayName: 'Bitbucket Server',
         defaultConfig: `{
-  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Use Ctrl+Space for completion, and hover over JSON properties for documentation.
   // Configuration options are documented here:
   // https://docs.sourcegraph.com/admin/site_config/all#bitbucketserverconnection-object
 
@@ -60,7 +60,7 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.GITLAB,
         displayName: 'GitLab',
         defaultConfig: `{
-  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Use Ctrl+Space for completion, and hover over JSON properties for documentation.
   // Configuration options are documented here:
   // https://docs.sourcegraph.com/admin/site_config/all#gitlabconnection-object
 
@@ -72,7 +72,7 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.GITOLITE,
         displayName: 'Gitolite',
         defaultConfig: `{
-  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Use Ctrl+Space for completion, and hover over JSON properties for documentation.
   // Configuration options are documented here:
   // https://docs.sourcegraph.com/admin/site_config/all#gitoliteconnection-object
 
@@ -84,7 +84,7 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.PHABRICATOR,
         displayName: 'Phabricator',
         defaultConfig: `{
-  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Use Ctrl+Space for completion, and hover over JSON properties for documentation.
   // Configuration options are documented here:
   // https://docs.sourcegraph.com/admin/site_config/all#phabricatorconnection-object
 

--- a/web/src/site-admin/externalServices.ts
+++ b/web/src/site-admin/externalServices.ts
@@ -10,11 +10,22 @@ export const GITHUB_EXTERNAL_SERVICE: ExternalServiceMetadata = {
     kind: GQL.ExternalServiceKind.GITHUB,
     displayName: 'GitHub',
     defaultConfig: `{
+  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Configuration options are documented here:
+  // https://docs.sourcegraph.com/admin/site_config/all#githubconnection-object
+
   "url": "https://github.com",
 
   // A token is required for access to private repos, but is also helpful for public repos
   // because it grants a higher hourly rate limit to Sourcegraph.
-  "token": "<personal access token with repo scope (https://github.com/settings/tokens/new)>"
+  "token": "<personal access token with repo scope (https://github.com/settings/tokens/new)>",
+
+  // Sync public repositories from https://github.com by adding them to "repos".
+  // (This is not necessary for GitHub Enterprise instances)
+  // "repos": [
+  //     "sourcegraph/sourcegraph"
+  // ]
+
 }`,
 }
 
@@ -23,6 +34,10 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.AWSCODECOMMIT,
         displayName: 'AWS CodeCommit',
         defaultConfig: `{
+  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Configuration options are documented here:
+  // https://docs.sourcegraph.com/admin/site_config/all#awscodecommitconnection-object
+
   "region": "",
   "accessKeyID": "",
   "secretAccessKey": ""
@@ -32,6 +47,10 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.BITBUCKETSERVER,
         displayName: 'Bitbucket Server',
         defaultConfig: `{
+  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Configuration options are documented here:
+  // https://docs.sourcegraph.com/admin/site_config/all#bitbucketserverconnection-object
+
   "url": "https://bitbucket.example.com",
   "token": "<personal access token with read scope (https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add)>"
 }`,
@@ -41,6 +60,10 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.GITLAB,
         displayName: 'GitLab',
         defaultConfig: `{
+  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Configuration options are documented here:
+  // https://docs.sourcegraph.com/admin/site_config/all#gitlabconnection-object
+
   "url": "https://gitlab.example.com",
   "token": "<personal access token with api scope (https://[your-gitlab-hostname]/profile/personal_access_tokens)>"
 }`,
@@ -49,6 +72,10 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.GITOLITE,
         displayName: 'Gitolite',
         defaultConfig: `{
+  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Configuration options are documented here:
+  // https://docs.sourcegraph.com/admin/site_config/all#gitoliteconnection-object
+
   "prefix": "gitolite.example.com/",
   "host": "git@gitolite.example.com"
 }`,
@@ -57,6 +84,10 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
         kind: GQL.ExternalServiceKind.PHABRICATOR,
         displayName: 'Phabricator',
         defaultConfig: `{
+  // Hover over fields for documentation and Ctrl+Space for auto-completion.
+  // Configuration options are documented here:
+  // https://docs.sourcegraph.com/admin/site_config/all#phabricatorconnection-object
+
   "url": "https://phabricator.example.com",
   "token": "",
   "repos": []


### PR DESCRIPTION
- Inline "Hover over fields for documentation and Ctrl+Space for auto-completion.". Not sure if this is overkill, but @dadlerj didn't seem to see the message below the editor.
- Added link to specific configuration options for each external service type
- Specifically added a comment to GitHub about syncing public repos (since that is a common case).