### PR TITLE
show "Reload required" error if app JS is redeployed after user's initial page load

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -99,7 +99,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
             )}
             {!isSiteInit && <GlobalNavbar {...props} lowProfile={isSearchHomepage} />}
             {needsSiteInit && !isSiteInit && <Redirect to="/site-admin/init" />}
-            <ErrorBoundary>
+            <ErrorBoundary location={props.location}>
                 <Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                     <Switch>
                         {props.routes.map(route => {

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -205,7 +205,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
         const { children, ...props } = this.props
 
         return (
-            <ErrorBoundary>
+            <ErrorBoundary location={null}>
                 <ShortcutProvider>
                     <TelemetryContext.Provider value={eventLogger}>
                         <BrowserRouter key={0}>

--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -11,7 +11,7 @@ describe('ErrorBoundary', () => {
         expect(
             renderer
                 .create(
-                    <ErrorBoundary>
+                    <ErrorBoundary location={null}>
                         <ThrowError />
                     </ErrorBoundary>
                 )
@@ -22,7 +22,7 @@ describe('ErrorBoundary', () => {
         expect(
             renderer
                 .create(
-                    <ErrorBoundary>
+                    <ErrorBoundary location={null}>
                         <span>hello</span>
                     </ErrorBoundary>
                 )

--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -6,6 +6,11 @@ const ThrowError: React.FunctionComponent = () => {
     throw new Error('x')
 }
 
+/** Throws an error that resembles the Webpack error when chunk loading fails.  */
+const ThrowChunkError: React.FunctionComponent = () => {
+    throw new Error('Loading chunk 123 failed.')
+}
+
 describe('ErrorBoundary', () => {
     test('passes through if non-error', () =>
         expect(
@@ -24,6 +29,17 @@ describe('ErrorBoundary', () => {
                 .create(
                     <ErrorBoundary location={null}>
                         <span>hello</span>
+                    </ErrorBoundary>
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+
+    test('renders reload page if chunk error', () =>
+        expect(
+            renderer
+                .create(
+                    <ErrorBoundary location={null}>
+                        <ThrowChunkError />
                     </ErrorBoundary>
                 )
                 .toJSON()

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,7 +1,16 @@
+import H from 'history'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import React from 'react'
 import { asError } from '../../../shared/src/util/errors'
 import { HeroPage } from './HeroPage'
+
+interface Props {
+    /**
+     * The current location, or null if there is no location (such as the root component, which is above the
+     * react-router component).
+     */
+    location: H.Location | null
+}
 
 interface State {
     error?: Error
@@ -14,11 +23,19 @@ interface State {
  * Components should handle their own errors (and must not rely on this error boundary). This error
  * boundary is a last resort in case of an unexpected error.
  */
-export class ErrorBoundary extends React.PureComponent<{}, State> {
+export class ErrorBoundary extends React.PureComponent<Props, State> {
     public state: State = {}
 
     public static getDerivedStateFromError(error: any): Pick<State, 'error'> {
         return { error: asError(error) }
+    }
+
+    public componentDidUpdate(prevProps: Props): void {
+        if (prevProps.location !== this.props.location) {
+            // Reset error state when location changes, so that the user can try navigating to a different page to
+            // clear the error.
+            this.setState({ error: undefined })
+        }
     }
 
     public render(): React.ReactNode | null {

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import H from 'history'
 import ErrorIcon from 'mdi-react/ErrorIcon'
+import ReloadIcon from 'mdi-react/ReloadIcon'
 import React from 'react'
 import { asError } from '../../../shared/src/util/errors'
 import { HeroPage } from './HeroPage'
@@ -40,6 +41,26 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
 
     public render(): React.ReactNode | null {
         if (this.state.error !== undefined) {
+            if (isWebpackChunkError(this.state.error)) {
+                // "Loading chunk 123 failed" means that the JavaScript assets that correspond to the deploy
+                // version currently running are no longer available, likely because a redeploy occurred after the
+                // user initially loaded this page.
+                return (
+                    <HeroPage
+                        icon={ReloadIcon}
+                        title="Reload required"
+                        subtitle={
+                            <div className="container">
+                                <p>A new version of Sourcegraph is available.</p>
+                                <button className="btn btn-primary" onClick={this.onReloadClick}>
+                                    Reload to update
+                                </button>
+                            </div>
+                        }
+                    />
+                )
+            }
+
             return (
                 <HeroPage
                     icon={ErrorIcon}
@@ -61,4 +82,12 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
 
         return this.props.children
     }
+
+    private onReloadClick: React.MouseEventHandler<HTMLElement> = e => {
+        window.location.reload(true) // hard page reload
+    }
+}
+
+function isWebpackChunkError(err: any): boolean {
+    return typeof err.request === 'string' && err.message.startsWith('Loading chunk')
 }

--- a/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -48,3 +48,46 @@ exports[`ErrorBoundary renders error page if error 1`] = `
   hello
 </span>
 `;
+
+exports[`ErrorBoundary renders reload page if chunk error 1`] = `
+<div
+  className="hero-page "
+>
+  <div
+    className="hero-page__icon"
+  >
+    <svg
+      className="mdi-icon "
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M13,13H11V7H13M13,17H11V15H13M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+      />
+    </svg>
+  </div>
+  <div
+    className="hero-page__title"
+  >
+    Error
+  </div>
+  <div
+    className="hero-page__subtitle"
+  >
+    <div
+      className="container"
+    >
+      <p>
+        Sourcegraph encountered an unexpected error. If reloading the page doesn't fix it, contact your site admin or Sourcegraph support.
+      </p>
+      <p>
+        <code>
+          Loading chunk 123 failed.
+        </code>
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/extensions/extension/ExtensionArea.tsx
+++ b/web/src/extensions/extension/ExtensionArea.tsx
@@ -185,7 +185,7 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
             <div className="registry-extension-area area--vertical">
                 <ExtensionAreaHeader {...this.props} {...context} navItems={this.props.extensionAreaHeaderNavItems} />
                 <div className="container pt-3">
-                    <ErrorBoundary>
+                    <ErrorBoundary location={this.props.location}>
                         <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                             <Switch>
                                 {this.props.routes.map(

--- a/web/src/org/account/OrgAccountArea.tsx
+++ b/web/src/org/account/OrgAccountArea.tsx
@@ -45,7 +45,7 @@ export const OrgAccountArea: React.FunctionComponent<Props> = props => {
         <div className="org-settings-area area">
             <OrgAccountSidebar {...props} className="area__sidebar" />
             <div className="area__content">
-                <ErrorBoundary>
+                <ErrorBoundary location={props.location}>
                     <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                         <Switch>
                             <Route

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -171,7 +171,7 @@ export class OrgArea extends React.Component<Props> {
                 <OrgHeader className="area--vertical__header" {...this.props} {...transferProps} />
                 <div className="org-area__content area--vertical__content">
                     <div className="org-area__content-inner area--vertical__content-inner">
-                        <ErrorBoundary>
+                        <ErrorBoundary location={this.props.location}>
                             <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                                 <Switch>
                                     <Route

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -272,7 +272,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                     }
                     {...this.state.repoHeaderContributionsLifecycleProps}
                 />
-                <ErrorBoundary>
+                <ErrorBoundary location={this.props.location}>
                     {this.state.repoOrError.enabled || isSettingsPage ? (
                         <Switch>
                             {[

--- a/web/src/site-admin/SiteAdminArea.tsx
+++ b/web/src/site-admin/SiteAdminArea.tsx
@@ -65,7 +65,7 @@ export const SiteAdminArea = withAuthenticatedUser(
                 <div className="site-admin-area area">
                     <SiteAdminSidebar className="area__sidebar" groups={this.props.sideBarGroups} />
                     <div className="area__content">
-                        <ErrorBoundary>
+                        <ErrorBoundary location={this.props.location}>
                             <Switch>
                                 {this.props.routes.map(
                                     ({ render, path, exact, condition = () => true }) =>

--- a/web/src/user/account/UserAccountArea.tsx
+++ b/web/src/user/account/UserAccountArea.tsx
@@ -105,7 +105,7 @@ export const UserAccountArea = withAuthenticatedUser(
                         className="area__sidebar"
                     />
                     <div className="area__content">
-                        <ErrorBoundary>
+                        <ErrorBoundary location={this.props.location}>
                             <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                                 <Switch>
                                     {this.props.routes.map(

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -195,7 +195,7 @@ export class UserArea extends React.Component<UserAreaProps, UserAreaState> {
                 />
                 <div className="area--vertical__content">
                     <div className="area--vertical__content-inner">
-                        <ErrorBoundary>
+                        <ErrorBoundary location={this.props.location}>
                             <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                                 <Switch>
                                     {this.props.userAreaRoutes.map(

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -76,7 +76,7 @@ const config: webpack.Configuration = {
     output: {
         path: path.join(rootDir, 'ui', 'assets'),
         filename: 'scripts/[name].bundle.js',
-        chunkFilename: 'scripts/[id]-[chunkhash].chunk.js',
+        chunkFilename: 'scripts/[id]-[contenthash].chunk.js',
         publicPath: '/.assets/',
         globalObject: 'self',
         pathinfo: false,


### PR DESCRIPTION
- fix #1760
- also other commits to fix other related issues

In https://github.com/sourcegraph/sourcegraph/issues/1760#issuecomment-453235933 @nicksnyder recommended just removing chunking altogether. I found an easy way to retain chunking (which improves page load times significantly) without the problems I worried about at https://github.com/sourcegraph/sourcegraph/issues/1760#issuecomment-453224286. Plus, this is a more comprehensive solution. Reverting to our previous situation (with 1 main chunk and then chunks for GraphiQL (API console) and Monaco) would still cause this problem to exhibit itself after a redeploy if the user tried to navigate to the API console or the Monaco editor. Now they will be prompted to reload in all cases when it is necessary.

![screenshot from 2019-01-11 11-45-53](https://user-images.githubusercontent.com/1976/51056640-303c9600-1598-11e9-9aec-af1621c4e5b6.png)
