### PR TITLE
define constants true, false, undefined, null in extension expr lang

### DIFF
--- a/shared/src/api/client/context/expr/evaluator.test.ts
+++ b/shared/src/api/client/context/expr/evaluator.test.ts
@@ -19,6 +19,8 @@ describe('evaluate', () => {
         'a != b': false,
         'a + b == c': true,
         x: 'y',
+        'd === false': false,
+        'd !== false': true,
         '!a': false,
         '!!a': true,
         'a && c': 2,

--- a/shared/src/api/client/context/expr/evaluator.ts
+++ b/shared/src/api/client/context/expr/evaluator.ts
@@ -111,6 +111,16 @@ function exec(node: Expression, context: ComputedContext): any {
     }
 
     if ('Identifier' in node) {
+        switch (node.Identifier) {
+            case 'true':
+                return true
+            case 'false':
+                return false
+            case 'undefined':
+                return undefined
+            case 'null':
+                return null
+        }
         return context.get(node.Identifier)
     }
 


### PR DESCRIPTION
Previously, if you had a `when` or other extension expression such as `x === false` (or using any of the other constants above), the behavior would be unexpected. There was no identifier named `false`, so `false` would actually be `undefined`. This caused problems when you wanted to have a setting default to `true` and used a check like `config.mysetting !== false`. As a temporary workaround until this is merged and released, you can use `config.mysetting !== (0==1)` because `0==1` evaluates to `false` not `undefined`.