### PR TITLE
fix: Set ffIsEnabled only auth provider is present in config

### DIFF
--- a/enterprise/cmd/frontend/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/config.go
@@ -34,8 +34,8 @@ func init() {
 					newProvidersList = append(newProvidersList, p)
 				}
 				auth.UpdateProviders(pkgName, newProvidersList)
+				ffIsEnabled = true
 			}
-			ffIsEnabled = true
 		})
 		conf.ContributeValidator(func(cfg conf.Unified) (problems []string) {
 			_, problems = parseConfig(&cfg)
@@ -50,7 +50,6 @@ func parseConfig(cfg *conf.Unified) (providers map[schema.GitHubAuthProvider]aut
 		if pr.Github == nil {
 			continue
 		}
-
 		provider, providerProblems := parseProvider(pr.Github, pr)
 		problems = append(problems, providerProblems...)
 		if provider != nil {

--- a/enterprise/cmd/frontend/auth/gitlaboauth/config.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/config.go
@@ -36,8 +36,8 @@ func init() {
 					newProvidersList = append(newProvidersList, p)
 				}
 				auth.UpdateProviders(PkgName, newProvidersList)
+				ffIsEnabled = true
 			}
-			ffIsEnabled = true
 		})
 		conf.ContributeValidator(func(cfg conf.Unified) (problems []string) {
 			_, problems = parseConfig(&cfg)


### PR DESCRIPTION
Resolves: https://github.com/sourcegraph/sourcegraph/issues/1785

When only 1 OAuth provider was enabled at a time there was an issue that the wrong provider was returned. This error surfaced because of the use of [getExactlyOneOAuthProvider](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/frontend/auth/oauth/middleware.go#L76:6) call which would attempt to redirect to the `externalURL`.

I confirmed this works for:

- 1 OAuth provider (auto-redirect still works)
- built-in + 1 OAuth
- built-in + 2 OAuth
- 2 OAuth