### PR TITLE
fix tight log loop when fetching Gitolite config and frontend is unavailable

### DIFF
--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -32,6 +32,7 @@ func RunGitoliteRepositorySyncWorker(ctx context.Context) {
 		config, err := conf.GitoliteConfigs(context.Background())
 		if err != nil {
 			log15.Error("unable to fetch Gitolite configs", "err", err)
+			time.Sleep(GetUpdateInterval())
 			continue
 		}
 


### PR DESCRIPTION
If conf.GitoliteConfigs returns an error quickly and repeatedly, then very many redundant log messages will be printed out. This occurs when the frontend is unavailable (because it is starting up) and adds useless noise to logs.