### PR TITLE
suppress log noise from config fetching when frontend is temp unavailable

### DIFF
--- a/pkg/api/internal_client.go
+++ b/pkg/api/internal_client.go
@@ -267,7 +267,13 @@ func (c *internalClient) ReposListEnabled(ctx context.Context) ([]RepoName, erro
 	return names, err
 }
 
+// MockInternalClientConfiguration mocks (*internalClient).Configuration.
+var MockInternalClientConfiguration func() (conftypes.RawUnified, error)
+
 func (c *internalClient) Configuration(ctx context.Context) (conftypes.RawUnified, error) {
+	if MockInternalClientConfiguration != nil {
+		return MockInternalClientConfiguration()
+	}
 	var cfg conftypes.RawUnified
 	err := c.postInternal(ctx, "configuration", nil, &cfg)
 	return cfg, err

--- a/pkg/conf/client_test.go
+++ b/pkg/conf/client_test.go
@@ -1,0 +1,58 @@
+package conf
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/conf/conftypes"
+)
+
+func TestClient_continuouslyUpdate(t *testing.T) {
+	t.Run("suppresses errors due to temporarily unreachable frontend", func(t *testing.T) {
+		api.MockInternalClientConfiguration = func() (conftypes.RawUnified, error) {
+			return conftypes.RawUnified{}, &url.Error{
+				Op:  "Post",
+				URL: "https://example.com",
+				Err: &net.OpError{Op: "dial"},
+			}
+		}
+		defer func() { api.MockInternalClientConfiguration = nil }()
+
+		var client client
+		var logMessages []string
+		done := make(chan struct{})
+		sleeps := 0
+		const delayBeforeUnreachableLog = 150 * time.Millisecond // assumes first loop iter executes within this time period
+		go client.continuouslyUpdate(&continuousUpdateOptions{
+			delayBeforeUnreachableLog: delayBeforeUnreachableLog,
+			log: func(format string, v ...interface{}) {
+				logMessages = append(logMessages, fmt.Sprintf(format, v...))
+			},
+			sleep: func() {
+				switch sleeps {
+				case 0:
+					if len(logMessages) > 0 {
+						t.Errorf("got log messages (below), want no log before delayBeforeUnreachableLog\n\n%s", strings.Join(logMessages, "\n"))
+					}
+					time.Sleep(delayBeforeUnreachableLog)
+					sleeps++
+				case 1:
+					if len(logMessages) != 1 {
+						t.Errorf("got %d log messages, want exactly 1 log after delayBeforeUnreachableLog", len(logMessages))
+					}
+
+					// Exit goroutine after this test is done.
+					close(done)
+					runtime.Goexit()
+				}
+			},
+		})
+		<-done
+	})
+}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -90,7 +90,7 @@ func init() {
 	// The default client is started in InitConfigurationServerFrontendOnly in
 	// the case of server mode.
 	if mode == modeClient {
-		go defaultClient.continuouslyUpdate()
+		go defaultClient.continuouslyUpdate(nil)
 		close(configurationServerFrontendOnlyInitialized)
 	}
 }
@@ -117,7 +117,7 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 	// and instead only relies on the DB.
 	defaultClient.passthrough = source
 
-	go defaultClient.continuouslyUpdate()
+	go defaultClient.continuouslyUpdate(nil)
 	configurationServerFrontendOnly = server
 	close(configurationServerFrontendOnlyInitialized)
 	return server


### PR DESCRIPTION
When starting up Sourcegraph (sourcegraph/server, the cluster, and the dev server), there is a lot of logspam before it shows the "Sourcegraph is ready at" message. This will make users think that there is an error, when in reality it's *usually* just that the other services are waiting for the frontend to be ready (which can take a few seconds when it needs to migrate the DB).

A slightly better fix might be for the frontend to immediately start listening for conf requests when it starts up (even before DB migration is done). Then the delayBeforeUnreachableLog could be lowered from its current default of 15s, and actual errors would be printed sooner. That is more complex and is not necessary right now.

fix #1826