### PR TITLE
support category:, tag:, and #-keywords for queries to remote extension registry

### DIFF
--- a/enterprise/cmd/frontend/internal/registry/http_api.go
+++ b/enterprise/cmd/frontend/internal/registry/http_api.go
@@ -139,7 +139,9 @@ func handleRegistry(w http.ResponseWriter, r *http.Request) (err error) {
 	case urlPath == extensionsPath:
 		query := r.URL.Query().Get("q")
 		ev.AddField("query", query)
-		xs, err := registryList(r.Context(), dbExtensionsListOptions{Query: query})
+		var opt dbExtensionsListOptions
+		opt.Query, opt.Category, opt.Tag = parseExtensionQuery(query)
+		xs, err := registryList(r.Context(), opt)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The query to the remote extension registry was being treated as a literal query string and was not processed for category:, tag:, and #-keywords. This meant that self-hosted instances using those tokens in the extension registry query would not get the right results from the remote extension registry.

fix #1830

There needs to be better integration testing of fetching and merging data from the local and remote extension registries (https://github.com/sourcegraph/sourcegraph/issues/1831).