### PR TITLE
Hide "Configure external services to connect to Sourcegraph." after "other" external service is added

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -15,14 +15,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 )
 
-var externalServiceKinds = map[string]struct{}{
-	"AWSCODECOMMIT":   {},
-	"BITBUCKETSERVER": {},
-	"GITHUB":          {},
-	"GITLAB":          {},
-	"GITOLITE":        {},
-	"PHABRICATOR":     {},
-	"OTHER":           {},
+var externalServiceKinds = map[string]struct {
+	// True if the external service can host repositories.
+	codeHost bool
+}{
+	"AWSCODECOMMIT":   {codeHost: true},
+	"BITBUCKETSERVER": {codeHost: true},
+	"GITHUB":          {codeHost: true},
+	"GITLAB":          {codeHost: true},
+	"GITOLITE":        {codeHost: true},
+	"PHABRICATOR":     {codeHost: true},
+	"OTHER":           {codeHost: true},
 }
 
 func validateKind(kind string) error {

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -25,7 +25,7 @@ func (r *siteResolver) NeedsRepositoryConfiguration(ctx context.Context) (bool, 
 }
 
 func needsRepositoryConfiguration(ctx context.Context) (bool, error) {
-	kinds := []string{}
+	kinds := make([]string, 0, len(externalServiceKinds))
 	for kind, config := range externalServiceKinds {
 		if config.codeHost {
 			kinds = append(kinds, kind)

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -25,14 +25,15 @@ func (r *siteResolver) NeedsRepositoryConfiguration(ctx context.Context) (bool, 
 }
 
 func needsRepositoryConfiguration(ctx context.Context) (bool, error) {
+	kinds := []string{}
+	for kind, config := range externalServiceKinds {
+		if config.codeHost {
+			kinds = append(kinds, kind)
+		}
+	}
+
 	count, err := db.ExternalServices.Count(ctx, db.ExternalServicesListOptions{
-		Kinds: []string{
-			"AWSCODECOMMIT",
-			"BITBUCKETSERVER",
-			"GITHUB",
-			"GITLAB",
-			"GITOLITE",
-		},
+		Kinds: kinds,
 	})
 	if err != nil {
 		return false, err

--- a/web/src/site/NeedsRepositoryConfigurationAlert.tsx
+++ b/web/src/site/NeedsRepositoryConfigurationAlert.tsx
@@ -23,6 +23,6 @@ export const NeedsRepositoryConfigurationAlert: React.FunctionComponent<{ classN
             <CircleChevronRightIcon className="icon-inline site-alert__link-icon" />{' '}
             <span className="underline">Configure external services</span>
         </Link>
-        &nbsp;to connect to Sourcegraph.
+        &nbsp;to connect repositories to Sourcegraph.
     </DismissibleAlert>
 )


### PR DESCRIPTION
fixes https://github.com/sourcegraph/sourcegraph/issues/1839

Also improves the banner message.

Previously Phabricator was not included in this this, and I don't know if that was intentional or not, but it seems wrong so I also changed that. I believe that we have a customer who doesn't use it as a code host, but in general it may be used as a code host.