### PR TITLE
Fix: clicking inside repo popover would dismiss popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed resolving of git clone URLs with `git+` prefix through the GraphQL API
 - Fixed an issue where the graphql Repositories endpoint would order by a field which was not indexed. Times on Sourcegraph.com went from 10s to 200ms.
 - Fixed an issue where whitespace was not handled properly in environment variable lists (`SYMBOLS_URL`, `SEARCHER_URL`).
+- Fixed an issue where clicking inside the repository popover or clicking "Show more" would dismiss the popover.
 
 ### Removed
 

--- a/web/src/components/PopoverButton.tsx
+++ b/web/src/components/PopoverButton.tsx
@@ -116,10 +116,12 @@ export class PopoverButton extends React.PureComponent<Props, State> {
                     {!this.props.link && <MenuDownIcon className="icon-inline popover-button__icon" />}
                 </LinkOrSpan>
                 {this.props.link ? (
-                    <button className="popover-button__anchor btn-icon" onClick={this.onPopoverVisibilityToggle}>
-                        <MenuDownIcon className="icon-inline popover-button__icon popover-button__icon--outside" />
+                    <>
+                        <button className="popover-button__anchor btn-icon" onClick={this.onPopoverVisibilityToggle}>
+                            <MenuDownIcon className="icon-inline popover-button__icon popover-button__icon--outside" />
+                        </button>
                         {popoverAnchor}
-                    </button>
+                    </>
                 ) : (
                     popoverAnchor
                 )}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1735.