### PR TITLE
Prevent empty settings from being stored

### DIFF
--- a/cmd/frontend/db/settings.go
+++ b/cmd/frontend/db/settings.go
@@ -20,6 +20,10 @@ func (o *settings) CreateIfUpToDate(ctx context.Context, subject api.SettingsSub
 		return Mocks.Settings.CreateIfUpToDate(ctx, subject, lastID, authorUserID, contents)
 	}
 
+	if contents == "" {
+		return nil, fmt.Errorf("the empty string is not valid JSONC (you can clear the settings by entering an empty JSON object: {})")
+	}
+
 	// Validate JSON syntax before saving.
 	if _, errs := jsonx.Parse(contents, jsonx.ParseOptions{Comments: true, TrailingCommas: true}); len(errs) > 0 {
 		return nil, fmt.Errorf("invalid settings JSON: %v", errs)

--- a/cmd/frontend/db/settings.go
+++ b/cmd/frontend/db/settings.go
@@ -20,10 +20,6 @@ func (o *settings) CreateIfUpToDate(ctx context.Context, subject api.SettingsSub
 		return Mocks.Settings.CreateIfUpToDate(ctx, subject, lastID, authorUserID, contents)
 	}
 
-	if contents == "" {
-		return nil, fmt.Errorf("the empty string is not valid JSONC (you can clear the settings by entering an empty JSON object: {})")
-	}
-
 	// Validate JSON syntax before saving.
 	if _, errs := jsonx.Parse(contents, jsonx.ParseOptions{Comments: true, TrailingCommas: true}); len(errs) > 0 {
 		return nil, fmt.Errorf("invalid settings JSON: %v", errs)

--- a/cmd/frontend/db/settings_test.go
+++ b/cmd/frontend/db/settings_test.go
@@ -23,10 +23,10 @@ func TestSettings_ListAll(t *testing.T) {
 	}
 
 	// Try creating both with non-nil author and nil author.
-	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user1.ID}, nil, &user1.ID, ""); err != nil {
+	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user1.ID}, nil, &user1.ID, "{}"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user2.ID}, nil, nil, ""); err != nil {
+	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user2.ID}, nil, nil, "{}"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -401,10 +401,10 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// Create settings for the user, and for another user authored by this user.
-			if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user.ID}, nil, &user.ID, ""); err != nil {
+			if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user.ID}, nil, &user.ID, "{}"); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &otherUser.ID}, nil, &user.ID, ""); err != nil {
+			if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &otherUser.ID}, nil, &user.ID, "{}"); err != nil {
 				t.Fatal(err)
 			}
 

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -185,9 +185,9 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return false, err
 	}
-    if args.Input == "" {
-        return false, fmt.Errorf("the empty string is not valid site configuration (you can clear the site configuration by entering an empty JSON object: {})")
-    }
+	if args.Input == "" {
+		return false, fmt.Errorf("the empty string is not valid site configuration (you can clear the site configuration by entering an empty JSON object: {})")
+	}
 	prev := globals.ConfigurationServerFrontendOnly.Raw()
 	prev.Site = args.Input
 	// TODO(slimsag): future: actually pass lastID through to prevent race conditions

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -185,6 +185,9 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return false, err
 	}
+    if args.Input == "" {
+        return false, fmt.Errorf("the empty string is not valid site configuration (you can clear the site configuration by entering an empty JSON object: {})")
+    }
 	prev := globals.ConfigurationServerFrontendOnly.Raw()
 	prev.Site = args.Input
 	// TODO(slimsag): future: actually pass lastID through to prevent race conditions

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -185,6 +185,9 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return false, err
 	}
+	if args.Input == "" {
+		return false, fmt.Errorf("the empty string is not valid site configuration (you can clear the site configuration by entering an empty JSON object: {})")
+	}
 	prev := globals.ConfigurationServerFrontendOnly.Raw()
 	prev.Site = args.Input
 	// TODO(slimsag): future: actually pass lastID through to prevent race conditions

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -185,9 +185,6 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return false, err
 	}
-	if args.Input == "" {
-		return false, fmt.Errorf("the empty string is not valid site configuration (you can clear the site configuration by entering an empty JSON object: {})")
-	}
 	prev := globals.ConfigurationServerFrontendOnly.Raw()
 	prev.Site = args.Input
 	// TODO(slimsag): future: actually pass lastID through to prevent race conditions

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/sourcegraph/godockerize v0.0.0-20181126200657-4f825419611b
 	github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10
 	github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe
-	github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd
+	github.com/sourcegraph/jsonx v0.0.0-20190114094009-4b3eb4946c82
 	github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff
 	github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e
 	github.com/stvp/tempredis v0.0.0-20190104202742-b82af8480203 // indirect

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/sourcegraph/godockerize v0.0.0-20181126200657-4f825419611b
 	github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10
 	github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe
-	github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd
+	github.com/sourcegraph/jsonx v0.0.0-20190114102935-8db49c873df2
 	github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff
 	github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e
 	github.com/stvp/tempredis v0.0.0-20190104202742-b82af8480203 // indirect

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/sourcegraph/godockerize v0.0.0-20181126200657-4f825419611b
 	github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10
 	github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe
-	github.com/sourcegraph/jsonx v0.0.0-20190114094009-4b3eb4946c82
+	github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd
 	github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff
 	github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e
 	github.com/stvp/tempredis v0.0.0-20190104202742-b82af8480203 // indirect

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,6 @@ github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe h1:JAHsmn5ix
 github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe/go.mod h1:0AJ8DDXVNSPaIhEfFiCg9TqPt9YgLf+umcJSUjuG9SA=
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd h1:NPk22RvonOjkNI4JgKJbOnGJrRT2C6Bg35LVtbrIULM=
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
-github.com/sourcegraph/jsonx v0.0.0-20190114094009-4b3eb4946c82 h1:LLma5i1ja6kJaPkZI5B4nUZjPvavlc/U9zP8vHQmAgE=
-github.com/sourcegraph/jsonx v0.0.0-20190114094009-4b3eb4946c82/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce h1:TP4fl7kMJdB4LKqVkME7tqyFwWiOuNyEefiVCBdGJIE=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce/go.mod h1:f1Qnbu4glSRTb9A/H7qLv4AhudFf3eStkDbpyb21KYQ=
 github.com/spf13/afero v1.1.0 h1:bopulORc2JeYaxfHLvJa5NzxviA9PoWhpiiJkru7Ji4=

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,8 @@ github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe h1:JAHsmn5ix
 github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe/go.mod h1:0AJ8DDXVNSPaIhEfFiCg9TqPt9YgLf+umcJSUjuG9SA=
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd h1:NPk22RvonOjkNI4JgKJbOnGJrRT2C6Bg35LVtbrIULM=
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
+github.com/sourcegraph/jsonx v0.0.0-20190114102935-8db49c873df2 h1:09VKHYUnrQS7FW1JLQvOHbNWu8xytRRll0QAfD40wKM=
+github.com/sourcegraph/jsonx v0.0.0-20190114102935-8db49c873df2/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce h1:TP4fl7kMJdB4LKqVkME7tqyFwWiOuNyEefiVCBdGJIE=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce/go.mod h1:f1Qnbu4glSRTb9A/H7qLv4AhudFf3eStkDbpyb21KYQ=
 github.com/spf13/afero v1.1.0 h1:bopulORc2JeYaxfHLvJa5NzxviA9PoWhpiiJkru7Ji4=

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,8 @@ github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe h1:JAHsmn5ix
 github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe/go.mod h1:0AJ8DDXVNSPaIhEfFiCg9TqPt9YgLf+umcJSUjuG9SA=
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd h1:NPk22RvonOjkNI4JgKJbOnGJrRT2C6Bg35LVtbrIULM=
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
+github.com/sourcegraph/jsonx v0.0.0-20190114094009-4b3eb4946c82 h1:LLma5i1ja6kJaPkZI5B4nUZjPvavlc/U9zP8vHQmAgE=
+github.com/sourcegraph/jsonx v0.0.0-20190114094009-4b3eb4946c82/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce h1:TP4fl7kMJdB4LKqVkME7tqyFwWiOuNyEefiVCBdGJIE=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce/go.mod h1:f1Qnbu4glSRTb9A/H7qLv4AhudFf3eStkDbpyb21KYQ=
 github.com/spf13/afero v1.1.0 h1:bopulORc2JeYaxfHLvJa5NzxviA9PoWhpiiJkru7Ji4=

--- a/pkg/jsonc/jsonc.go
+++ b/pkg/jsonc/jsonc.go
@@ -14,9 +14,6 @@ func Unmarshal(text string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	if len(data) == 0 {
-		return fmt.Errorf("the empty string is not valid jsonc")
-	}
 	return json.Unmarshal(data, v)
 }
 

--- a/pkg/jsonc/jsonc.go
+++ b/pkg/jsonc/jsonc.go
@@ -15,7 +15,7 @@ func Unmarshal(text string, v interface{}) error {
 		return err
 	}
 	if len(data) == 0 {
-		return nil
+		return fmt.Errorf("the empty string is not valid jsonc")
 	}
 	return json.Unmarshal(data, v)
 }

--- a/pkg/jsonc/jsonc.go
+++ b/pkg/jsonc/jsonc.go
@@ -14,6 +14,9 @@ func Unmarshal(text string, v interface{}) error {
 	if err != nil {
 		return err
 	}
+	if len(data) == 0 {
+		return fmt.Errorf("the empty string is not valid jsonc")
+	}
 	return json.Unmarshal(data, v)
 }
 


### PR DESCRIPTION
The empty string is valid jsonx (validated by https://github.com/sourcegraph/jsonx), but not valid jsonc. Consumers of settings using either of these jsonc-parser packages produce `undefined` when parsing the empty string:

- https://www.npmjs.com/package/@sqs/jsonc-parser
- https://www.npmjs.com/package/jsonc-parser

This change prevents the empty string from being stored as settings.

![image](https://user-images.githubusercontent.com/1387653/51094607-59f5e880-1763-11e9-9992-56ba9a524e2f.png)

- Fixes https://github.com/sourcegraph/sourcegraph/issues/1784
- Fixes https://github.com/sourcegraph/sourcegraph/issues/1645