### PR TITLE
fix #1736: hide PopoverButton when clicking elsewhere on the page

### DIFF
--- a/shared/src/components/PopoverButton.tsx
+++ b/shared/src/components/PopoverButton.tsx
@@ -60,8 +60,18 @@ export class PopoverButton extends React.PureComponent<Props, State> {
 
     public componentWillReceiveProps(props: Props): void {
         if (props.hideOnChange !== this.props.hideOnChange) {
-            this.setState({ open: false })
+            this.hide()
         }
+    }
+
+    public componentDidMount(): void {
+        window.addEventListener('mousedown', this.onClickOutside)
+        window.addEventListener('touchstart', this.onClickOutside)
+    }
+
+    public componentWillUnmount(): void {
+        window.removeEventListener('mousedown', this.onClickOutside)
+        window.removeEventListener('touchstart', this.onClickOutside)
     }
 
     public render(): React.ReactFragment {
@@ -97,7 +107,7 @@ export class PopoverButton extends React.PureComponent<Props, State> {
                             : 'popover-button2__container'
                     }
                     to={this.props.link}
-                    onClick={this.props.link ? this.onClickLink : this.toggleVisibility}
+                    onClick={this.props.link ? this.hide : this.toggleVisibility}
                 >
                     {this.props.children}{' '}
                     {!this.props.link && <MenuDownIcon className="icon-inline popover-button2__icon" />}
@@ -121,9 +131,13 @@ export class PopoverButton extends React.PureComponent<Props, State> {
         )
     }
 
-    private onClickLink = (e: React.MouseEvent<HTMLElement>): void => {
-        this.setState({ open: false })
+    public onClickOutside = (e: MouseEvent | TouchEvent) => {
+        if (this.rootRef && !this.rootRef.contains(e.target as HTMLElement)) {
+            this.hide()
+        }
     }
+
+    private hide = () => this.setState({ open: false })
 
     private setRootRef = (e: HTMLElement | null) => (this.rootRef = e)
 

--- a/web/src/components/PopoverButton.tsx
+++ b/web/src/components/PopoverButton.tsx
@@ -69,17 +69,21 @@ export class PopoverButton extends React.PureComponent<Props, State> {
 
     public componentDidMount(): void {
         window.addEventListener('keydown', this.onGlobalKeyDown)
+        window.addEventListener('mousedown', this.onClickOutside)
+        window.addEventListener('touchstart', this.onClickOutside)
     }
 
     public componentWillReceiveProps(props: Props): void {
         if (props.hideOnChange !== this.props.hideOnChange) {
-            this.setState({ open: false })
+            this.hide()
         }
     }
 
     public componentWillUnmount(): void {
         this.subscriptions.unsubscribe()
         window.removeEventListener('keydown', this.onGlobalKeyDown)
+        window.removeEventListener('mousedown', this.onClickOutside)
+        window.removeEventListener('touchstart', this.onClickOutside)
     }
 
     public render(): React.ReactFragment {
@@ -110,7 +114,7 @@ export class PopoverButton extends React.PureComponent<Props, State> {
                         this.props.link ? 'popover-button__btn popover-button__btn--link' : 'popover-button__container'
                     }
                     to={this.props.link}
-                    onClick={this.props.link ? this.onClickLink : this.onPopoverVisibilityToggle}
+                    onClick={this.props.link ? this.hide : this.onPopoverVisibilityToggle}
                 >
                     {this.props.children}{' '}
                     {!this.props.link && <MenuDownIcon className="icon-inline popover-button__icon" />}
@@ -129,14 +133,12 @@ export class PopoverButton extends React.PureComponent<Props, State> {
         )
     }
 
-    private onClickLink = (): void => {
-        this.setState({ open: false })
-    }
+    private hide = () => this.setState({ open: false })
 
     private onGlobalKeyDown = (event: KeyboardEvent) => {
         if (event.key === Key.Escape) {
             // Always close the popover when Escape is pressed, even when in an input.
-            this.setState({ open: false })
+            this.hide()
             return
         }
 
@@ -154,6 +156,12 @@ export class PopoverButton extends React.PureComponent<Props, State> {
         ) {
             event.preventDefault()
             this.onPopoverVisibilityToggle()
+        }
+    }
+
+    private onClickOutside = (e: MouseEvent | TouchEvent) => {
+        if (this.rootRef && !this.rootRef.contains(e.target as HTMLElement)) {
+            this.hide()
         }
     }
 


### PR DESCRIPTION
Previously `PopoverButton` stayed open even when clicking elsewhere on the page. This was an issue on the webapp (#1736), but also in the browser extension in cases like this:

![image](https://user-images.githubusercontent.com/1741180/51126835-69893600-1824-11e9-83d1-e0b916269d3e.png)