### PR TITLE
Fix: misaligned icon on view file button on GitLab

### DIFF
--- a/client/browser/src/shared/components/Button.tsx
+++ b/client/browser/src/shared/components/Button.tsx
@@ -21,7 +21,7 @@ export const Button: React.FunctionComponent<Props> = (props: Props) => (
         onClick={props.onClick}
         target={props.target}
     >
-        <SourcegraphIcon style={props.iconStyle || { marginTop: '-1px', paddingRight: '4px', fontSize: '18px' }} />
+        <SourcegraphIcon style={props.iconStyle || { marginTop: '-1px', paddingRight: '4px', fontSize: '18px', verticalAlign: 'text-top' }} />
         {props.label}
     </a>
 )

--- a/client/browser/src/shared/components/Button.tsx
+++ b/client/browser/src/shared/components/Button.tsx
@@ -21,7 +21,7 @@ export const Button: React.FunctionComponent<Props> = (props: Props) => (
         onClick={props.onClick}
         target={props.target}
     >
-        <SourcegraphIcon style={props.iconStyle || { marginTop: '-1px', paddingRight: '4px', fontSize: '18px', verticalAlign: 'text-top' }} />
+        <SourcegraphIcon style={props.iconStyle || { marginTop: '-1px', paddingRight: '4px', fontSize: '18px', position: 'static' }} />
         {props.label}
     </a>
 )

--- a/client/browser/src/shared/components/Button.tsx
+++ b/client/browser/src/shared/components/Button.tsx
@@ -21,7 +21,9 @@ export const Button: React.FunctionComponent<Props> = (props: Props) => (
         onClick={props.onClick}
         target={props.target}
     >
-        <SourcegraphIcon style={props.iconStyle || { marginTop: '-1px', paddingRight: '4px', fontSize: '18px', position: 'static' }} />
+        <SourcegraphIcon
+            style={props.iconStyle || { marginTop: '-1px', paddingRight: '4px', fontSize: '18px', position: 'static' }}
+        />
         {props.label}
     </a>
 )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1842

The icon was getting set to be relative positioned due to a style from GitLab.