### PR TITLE
Prevent blank (whitespace-only) settings from being stored

### DIFF
--- a/cmd/frontend/db/settings.go
+++ b/cmd/frontend/db/settings.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"strings"
 	"context"
 	"database/sql"
 	"fmt"
@@ -20,8 +21,8 @@ func (o *settings) CreateIfUpToDate(ctx context.Context, subject api.SettingsSub
 		return Mocks.Settings.CreateIfUpToDate(ctx, subject, lastID, authorUserID, contents)
 	}
 
-	if contents == "" {
-		return nil, fmt.Errorf("the empty string is not valid JSONC (you can clear the settings by entering an empty JSON object: {})")
+	if strings.TrimSpace(contents) == "" {
+		return nil, fmt.Errorf("blank settings are invalid (you can clear the settings by entering an empty JSON object: {})")
 	}
 
 	// Validate JSON syntax before saving.

--- a/cmd/frontend/db/settings.go
+++ b/cmd/frontend/db/settings.go
@@ -1,10 +1,10 @@
 package db
 
 import (
-	"strings"
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -185,8 +186,8 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return false, err
 	}
-	if args.Input == "" {
-		return false, fmt.Errorf("the empty string is not valid site configuration (you can clear the site configuration by entering an empty JSON object: {})")
+	if strings.TrimSpace(args.Input) == "" {
+		return false, fmt.Errorf("blank site configuration is invalid (you can clear the site configuration by entering an empty JSON object: {})")
 	}
 	prev := globals.ConfigurationServerFrontendOnly.Raw()
 	prev.Site = args.Input

--- a/pkg/jsonc/jsonc.go
+++ b/pkg/jsonc/jsonc.go
@@ -3,6 +3,7 @@ package jsonc
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/sourcegraph/jsonx"
 )
@@ -14,8 +15,8 @@ func Unmarshal(text string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	if len(data) == 0 {
-		return fmt.Errorf("the empty string is not valid jsonc")
+	if strings.TrimSpace(text) == "" {
+		return fmt.Errorf("blank input is invalid jsonc")
 	}
 	return json.Unmarshal(data, v)
 }


### PR DESCRIPTION
Essentially a continuation of https://github.com/sourcegraph/sourcegraph/pull/1863