### PR TITLE
Bump jsonx to fix a panic when parsing JSONC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/sourcegraph/godockerize v0.0.0-20181126200657-4f825419611b
 	github.com/sourcegraph/gosyntect v0.0.0-20180604231642-c01be3625b10
 	github.com/sourcegraph/httpcache v0.0.0-20160524185540-16db777d8ebe
-	github.com/sourcegraph/jsonx v0.0.0-20190114102935-8db49c873df2
+	github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614
 	github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff
 	github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e
 	github.com/stvp/tempredis v0.0.0-20190104202742-b82af8480203 // indirect

--- a/go.sum
+++ b/go.sum
@@ -444,6 +444,8 @@ github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd h1:NPk22RvonOjkN
 github.com/sourcegraph/jsonx v0.0.0-20180801091521-5a4ae5eb18cd/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/jsonx v0.0.0-20190114102935-8db49c873df2 h1:09VKHYUnrQS7FW1JLQvOHbNWu8xytRRll0QAfD40wKM=
 github.com/sourcegraph/jsonx v0.0.0-20190114102935-8db49c873df2/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
+github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614 h1:MrlKMpoGse4bCneDoK/c+ZbPGqOP5Hme5ulatc8smbQ=
+github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce h1:TP4fl7kMJdB4LKqVkME7tqyFwWiOuNyEefiVCBdGJIE=
 github.com/sourcegraph/zoekt v0.0.0-20181115082148-dacbbfd8c3ce/go.mod h1:f1Qnbu4glSRTb9A/H7qLv4AhudFf3eStkDbpyb21KYQ=
 github.com/spf13/afero v1.1.0 h1:bopulORc2JeYaxfHLvJa5NzxviA9PoWhpiiJkru7Ji4=


### PR DESCRIPTION
Previously, updating site config to a string of length 1 with content of `/` would cause a panic in the jsonx library, crashing the Sourcegraph instance. Patched in https://github.com/sourcegraph/jsonx/pull/4