### PR TITLE
fix link in "Search your own code" alert on search results pages

### DIFF
--- a/web/src/marketing/ServerBanner.tsx
+++ b/web/src/marketing/ServerBanner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { DismissibleAlert } from '../components/DismissibleAlert'
 import { eventLogger } from '../tracking/eventLogger'
 
 const onClickInstall = (): void => {
@@ -6,10 +7,12 @@ const onClickInstall = (): void => {
 }
 
 export const ServerBanner = () => (
-    <div className="alert alert-secondary">
-        Search your private and internal code.{' '}
-        <a href="https://about.sourcegraph.com" onClick={onClickInstall}>
-            Set up a self-hosted Sourcegraph instance.
-        </a>
-    </div>
+    <DismissibleAlert partialStorageKey="set-up-self-hosted" className="alert alert-info">
+        <span>
+            Search your private and internal code.{' '}
+            <a href="https://docs.sourcegraph.com/#quickstart" onClick={onClickInstall}>
+                Set up a self-hosted Sourcegraph instance.
+            </a>
+        </span>
+    </DismissibleAlert>
 )

--- a/web/src/search/results/SearchResultsInfoBar.scss
+++ b/web/src/search/results/SearchResultsInfoBar.scss
@@ -4,7 +4,6 @@
     justify-content: space-between;
     color: #93a9c8;
     padding-bottom: 0.25rem;
-    padding-left: 0.625rem;
 
     .mdi-icon {
         margin-right: 0.125rem;


### PR DESCRIPTION
The intent of this is to communicate that Sourcegraph.com does not search your private code. The link needs to point to the `docker run` command and the docs (not https://about.sourcegraph.com, which contains different content now).

Also makes this alert dismissible.

![screenshot from 2019-01-15 06-08-45](https://user-images.githubusercontent.com/1976/51179835-4003f500-188c-11e9-9312-3b7e38aafdcb.png)
![screenshot from 2019-01-15 06-08-38](https://user-images.githubusercontent.com/1976/51179836-409c8b80-188c-11e9-99fc-6484a278ba24.png)
