### PR TITLE
[WIP] Implement stackoverflow git service/package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
 	golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2
 	golang.org/x/time v0.0.0-20190104202802-85acf8d2951c
-	golang.org/x/tools v0.0.0-20190108222858-421f03a57a64
+	golang.org/x/tools v0.0.0-20190114222345-bf090417da8b
 	google.golang.org/api v0.1.0 // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 	gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
 	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
+	github.com/google/go-cmp v0.2.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0
 	github.com/google/uuid v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,8 @@ golang.org/x/tools v0.0.0-20181117154741-2ddaf7f79a09/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181220024903-92cdcd90bf52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190108222858-421f03a57a64 h1:9Y3iftuqayHi0EqSzJ3MrPoNIHHcIvicTPdfepyP5tE=
 golang.org/x/tools v0.0.0-20190108222858-421f03a57a64/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190114222345-bf090417da8b h1:qMK98NmNCRVDIYFycQ5yVRkvgDUFfdP8Ip4KqmDEB7g=
+golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20180921000521-920bb1beccf7/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181015145326-625cd1887957/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/stackexchange-api-proxy/README.md
+++ b/stackexchange-api-proxy/README.md
@@ -1,0 +1,57 @@
+# Stack Exchange API Proxy
+
+This package imeplements a proxy for the StackExchange API (v2.2) principally
+for StackOverflow.
+
+The package fetches questions, and answers using the API and will
+deterministically dump them into flat files in a Git repository which is used
+as a pseudo repo/stub/similar to facilitate code search.
+
+The Git lock file can be used to prevent concurrent access, and all mutation
+operations will force creation of a new commit. The commit timestamp can be
+used to optimize for the smallest delta when re-fetching against the
+StackExchange API.
+
+The API docs note:
+
+> A useful trick to poll for updates is to sort by activity, with a minimum
+> date of the last time you polled.  –
+> https://api.stackexchange.com/docs/answers-by-ids
+
+## Package Usage
+
+In order to check if a URL is part of the StackExchange network an initial
+pre-flight call to check the URL against an allow list must be made, this will
+return an initial set of `url.Values` as the StackExchange API expects a
+`&site=stackoverflow` in the URL query parameters.
+
+    values, supported := se.IsAllowedURL("http://stackoverflow.com/")
+    #=> {site: stackoverflow}, true
+
+    values, supported := se.IsAllowedURL("http://example.com/")
+    #=> {}, false
+
+This call makes no network requests. The allow-list is hard-coded in a Go file.
+It is not necessary to store the first value as the same API is used
+internally, so most calls to IsAllowedURL will look like:
+
+    if _, supported := se.IsAllowedURL("http://example.com/"); supported {
+      // ...
+    } else {
+        w.WriteHeader(http.StatusPreconditionFailed)
+        fmt.Fprintf(w, "URL %q is not supported by this service", "http://example.com/")
+    }
+
+Subsequent API calls can look like this:
+
+  d := time.Now().Add(50 * time.Millisecond)
+  ctx, cancel := context.WithDeadline(context.Background(), d)
+  defer cancel()
+
+  client := se.Client()
+  client.FetchUpdate(ctx, "https://stackoverflow.com/questions/18390852/go-concurrency-and-channel-confusion")
+
+Note: StackExchange's API has relatively conservative rate limits, and this
+package does not yet support passing authentication tokens. This should be
+simple enough to add using "functional options" to `se.Client(...)` as
+described by Dave Cheney.

--- a/stackexchange-api-proxy/se.go
+++ b/stackexchange-api-proxy/se.go
@@ -1,0 +1,46 @@
+package se
+
+import (
+	"net/url"
+	"regexp"
+)
+
+var allowListPatterns = map[string]*regexp.Regexp{
+	"stackverflow": regexp.MustCompile("^(|www.)stackoverflow.com$"),
+}
+
+// IsAllowedURL takes a URL string and tries to parse it
+// with url.Parse. Upon success the host part of the URL
+// will be compared with an allow list.
+//
+// Malformed URLs return false without proporgating an
+// error, callers who are not certian if they even have
+// a valid URL are advised to use url.Parse and consult
+// the url.error.Op field.
+//
+// The naive looping search may cause a problem if the
+// allow list grows significantly, this should be instrumented
+// if the allow list grows
+func IsAllowedURL(s string) (*url.Values, bool) {
+
+	parsedURL, err := url.Parse(s)
+	if err != nil {
+		return nil, false
+	}
+
+	var anyMatch bool
+	var matchedSite string
+	for sn, re := range allowListPatterns {
+		if match := re.MatchString(parsedURL.Hostname()); match {
+			anyMatch = true
+			matchedSite = sn
+			break
+		}
+	}
+
+	if anyMatch == false {
+		return nil, false
+	}
+
+	return &url.Values{"site": []string{matchedSite}}, true
+}

--- a/stackexchange-api-proxy/se_api_types.go
+++ b/stackexchange-api-proxy/se_api_types.go
@@ -2,57 +2,50 @@ package se
 
 // Complete API docs at https://api.stackexchange.com/docs/
 
-// User mirrors https://api.stackexchange.com/docs/types/user
-type User struct {
-	Reputation   int    `json:"reputation"`
-	UserID       int    `json:"user_id"`
-	UserType     string `json:"user_type"`
-	AcceptRate   int    `json:"accept_rate"`
-	ProfileImage string `json:"profile_image"`
-	DisplayName  string `json:"display_name"`
-	Link         string `json:"link"`
-}
+// These types are written to be extremely slimmed-down and use an aggressive
+// filter which fetches only the bare minimum data to populate a git repository
+// for the purposes of code indexing.
+//
+// According to the documentation filters are immutable and aggressively cached
+// on StackExchange's side the filter that is used it based on the following
+// API call:
+//
+// https://api.stackexchange.com/docs/create-filter#include=.items%3B.backoff%3B.quota_max%3B.quota_remaining%3Bquestion.body_markdown%3Banswer.body_markdown%3Bquestion.question_id%3Banswer.answer_id%3Bquestion.last_activity_date%3Banswer.last_activity_date%3Bquestion.answers%3B.error_id%3B.error_name%3B.error_message&base=none&unsafe=false&filter=default&run=true
+//
+// From the docs:
+//
+// > It is not expected that many applications will call this method
+// > at runtime, filters should be pre-calculated and "baked in" in
+// > the common cases. Furthermore, there are a number of built-in
+// > filters which cover common use cases.
 
-// Answer mirrors https://api.stackexchange.com/docs/types/answer
+// FilterID is closely bound to the URL in the doc block
+// above, do not change it without ensuring that it matches
+// that which is emit by the link above.
+const FilterID = "!*T0B4iEq2Y9dRWeCGhAfJ_2wl_Q2"
+
+// Answer https://api.stackexchange.com/docs/types/answer
 type Answer struct {
-	Owner            User   `json:"owner"`
-	IsAccepted       bool   `json:"is_accepted"`
-	Score            int    `json:"score"`
 	LastActivityDate int    `json:"last_activity_date"`
-	CreationDate     int    `json:"creation_date"`
 	AnswerID         int    `json:"answer_id"`
-	QuestionID       int    `json:"question_id"`
-	Body             string `json:"body"`
+	BodyMarkdown     string `json:"body_markdown"`
 }
 
-// Question mirrors https://api.stackexchange.com/docs/types/question
+// Question https://api.stackexchange.com/docs/types/question
 type Question struct {
-	Tags             []string `json:"tags"`
-	Owner            User     `json:"owner"`
-	IsAnswered       bool     `json:"is_answered"`
-	ViewCount        int      `json:"view_count"`
-	AcceptedAnswerID int      `json:"accepted_answer_id"`
-	AnswerCount      int      `json:"answer_count"`
-	Score            int      `json:"score"`
 	LastActivityDate int      `json:"last_activity_date"`
-	CreationDate     int      `json:"creation_date"`
 	QuestionID       int      `json:"question_id"`
-	Link             string   `json:"link"`
-	Title            string   `json:"title"`
+	BodyMarkdown     string   `json:"body_markdown"`
+	Answers          []Answer `json:"answers"`
 }
 
-// AnswersResp mirrors https://api.stackexchange.com/docs/answers
-type AnswersResp struct {
-	Items          []Answer `json:"items"`
-	HasMore        bool     `json:"has_more"`
-	QuotaMax       int      `json:"quota_max"`
-	QuotaRemaining int      `json:"quota_remaining"`
-}
-
-// QuestionsResp mirrors https://api.stackexchange.com/docs/questions
+// ResponseWrapper mirrors https://api.stackexchange.com/docs/wrapper
 type QuestionsResp struct {
 	Questions      []Question `json:"items"`
-	HasMore        bool       `json:"has_more"`
 	QuotaMax       int        `json:"quota_max"`
 	QuotaRemaining int        `json:"quota_remaining"`
+
+	ErrorID      int    `json:"error_id"`
+	ErrorName    string `json:"error_name"`
+	ErrorMessage string `json:"error_message"`
 }

--- a/stackexchange-api-proxy/se_api_types.go
+++ b/stackexchange-api-proxy/se_api_types.go
@@ -1,0 +1,58 @@
+package se
+
+// Complete API docs at https://api.stackexchange.com/docs/
+
+// User mirrors https://api.stackexchange.com/docs/types/user
+type User struct {
+	Reputation   int    `json:"reputation"`
+	UserID       int    `json:"user_id"`
+	UserType     string `json:"user_type"`
+	AcceptRate   int    `json:"accept_rate"`
+	ProfileImage string `json:"profile_image"`
+	DisplayName  string `json:"display_name"`
+	Link         string `json:"link"`
+}
+
+// Answer mirrors https://api.stackexchange.com/docs/types/answer
+type Answer struct {
+	Owner            User   `json:"owner"`
+	IsAccepted       bool   `json:"is_accepted"`
+	Score            int    `json:"score"`
+	LastActivityDate int    `json:"last_activity_date"`
+	CreationDate     int    `json:"creation_date"`
+	AnswerID         int    `json:"answer_id"`
+	QuestionID       int    `json:"question_id"`
+	Body             string `json:"body"`
+}
+
+// Question mirrors https://api.stackexchange.com/docs/types/question
+type Question struct {
+	Tags             []string `json:"tags"`
+	Owner            User     `json:"owner"`
+	IsAnswered       bool     `json:"is_answered"`
+	ViewCount        int      `json:"view_count"`
+	AcceptedAnswerID int      `json:"accepted_answer_id"`
+	AnswerCount      int      `json:"answer_count"`
+	Score            int      `json:"score"`
+	LastActivityDate int      `json:"last_activity_date"`
+	CreationDate     int      `json:"creation_date"`
+	QuestionID       int      `json:"question_id"`
+	Link             string   `json:"link"`
+	Title            string   `json:"title"`
+}
+
+// AnswersResp mirrors https://api.stackexchange.com/docs/answers
+type AnswersResp struct {
+	Items          []Answer `json:"items"`
+	HasMore        bool     `json:"has_more"`
+	QuotaMax       int      `json:"quota_max"`
+	QuotaRemaining int      `json:"quota_remaining"`
+}
+
+// QuestionsResp mirrors https://api.stackexchange.com/docs/questions
+type QuestionsResp struct {
+	Questions      []Question `json:"items"`
+	HasMore        bool       `json:"has_more"`
+	QuotaMax       int        `json:"quota_max"`
+	QuotaRemaining int        `json:"quota_remaining"`
+}

--- a/stackexchange-api-proxy/se_test.go
+++ b/stackexchange-api-proxy/se_test.go
@@ -1,9 +1,11 @@
 package se
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -68,4 +70,26 @@ func Test_IsAllowedURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_FetchUpdate(t *testing.T) {
+
+	var c = Client{
+		allowList:   defaultAllowListPatterns,
+		lockTimeout: 50 * time.Millisecond,
+	}
+
+	t.Run("locking", func(t *testing.T) {
+		t.Run("errs with a lock contnetion error on time", func(t *testing.T) {
+
+			t.Skip("needs configurable workdir before I can write lockfiles to disk")
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			go c.FetchUpdate(ctx, "http://stackoverflow.com/...")
+			c.FetchUpdate(ctx, "http://stackoverflow.com/...")
+		})
+	})
+
 }

--- a/stackexchange-api-proxy/se_test.go
+++ b/stackexchange-api-proxy/se_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -51,22 +53,18 @@ func Test_IsAllowedURL(t *testing.T) {
 			vals, allowed := IsAllowedURL(tc.urlStr)
 			if allowed != tc.allowed {
 				t.Fatalf("Expected %t to equal %t when checking if %q is allowed.", allowed, tc.allowed, tc.urlStr)
-				t.Failed()
 			}
 			if cmp.Diff(vals, tc.vals) != "" {
 				t.Fatalf("Expected %#v to equal %#v when checking if %q is allowed.", vals, tc.vals, tc.urlStr)
-				t.Failed()
 			}
 		})
 		t.Run(fmt.Sprintf("custom client %s", tc.urlStr), func(t *testing.T) {
 			vals, allowed := Client{allowList: DefaultAllowListPatterns}.IsAllowedURL(tc.urlStr)
 			if allowed != tc.allowed {
 				t.Fatalf("Expected %t to equal %t when checking if %q is allowed.", allowed, tc.allowed, tc.urlStr)
-				t.Failed()
 			}
 			if cmp.Diff(vals, tc.vals) != "" {
 				t.Fatalf("Expected %#v to equal %#v when checking if %q is allowed.", vals, tc.vals, tc.urlStr)
-				t.Failed()
 			}
 		})
 	}
@@ -74,18 +72,67 @@ func Test_IsAllowedURL(t *testing.T) {
 
 func Test_FetchUpdate(t *testing.T) {
 
-	var c, _ = NewClient(SpecifyLockWaitTimeout(50 * time.Millisecond))
+	t.Run("allow-list", func(t *testing.T) {
+		var c, _ = NewClient(SpecifyAllowList(AllowList{})) // empty allow-list
+		err := c.FetchUpdate(context.Background(), "http://www.example.com/")
+		if err != ErrURLNotAllowed {
+			t.Fatalf("Expected all urls to be disallowed and return ErrURLNotAllowed, got %q", err)
+		}
+	})
+
+	t.Run("unparsable URL", func(t *testing.T) {
+		t.Skip("can't find anything that Go won't parse!")
+		var c, _ = NewClient(SpecifyAllowList(AllowList{"helloworld": regexp.MustCompile(".*")}))
+		err := c.FetchUpdate(context.Background(), "hello::::world") // non-integer ports are disallowed by http spec
+		if err == nil {
+			t.Fatalf("Expected string to return an error propagated from url.Parse, got nil")
+		}
+		if seErr, ok := err.(Error); !ok {
+			t.Fatalf("Expected string to return an error propagated from url.Parse, got nil")
+		} else {
+			if seErr.Op != "parse-url" {
+				t.Fatalf("Expected string to return an error propagated from url.Parse with .Op set to 'parse-url'")
+			}
+		}
+	})
 
 	t.Run("locking", func(t *testing.T) {
-		t.Run("errs with a lock contnetion error on time", func(t *testing.T) {
+		t.Run("errs with a lock contention error on time", func(t *testing.T) {
 
-			t.Skip("needs configurable workdir before I can write lockfiles to disk")
+			// Pre-lock a mutex, guarantees no race conditions
+			// in trying to get and hold a lock whilst firing a second
+			// request to the same URL resource.
+			var alreadyLockedMutex = &sync.Mutex{}
+			alreadyLockedMutex.Lock()
+			defer alreadyLockedMutex.Unlock()
+
+			var artificallyShortLockWaitTimeout = 50 * time.Millisecond
+			var c, _ = NewClient(
+				SpecifyLockWaitTimeout(artificallyShortLockWaitTimeout),
+				SpecifyLockMechanism(func(u url.URL) sync.Locker {
+					return alreadyLockedMutex
+				}),
+			)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
-			go c.FetchUpdate(ctx, "http://stackoverflow.com/...")
-			c.FetchUpdate(ctx, "http://stackoverflow.com/...")
+			// start one we care about, and time it..
+			start := time.Now()
+			err := c.FetchUpdate(ctx, "http://stackoverflow.com/...")
+			elapsed := time.Since(start)
+
+			if err != ErrTimeoutLocking {
+				t.Fatalf("Expected err to be %s got %s", ErrTimeoutLocking, err)
+			}
+
+			// Grace period of double the wait timeout. Observed was 5-7ms
+			// overhead through, presumably the locking and scheduling of
+			// goroutines and the use of select{}
+			if elapsed > artificallyShortLockWaitTimeout*2 {
+				t.Fatalf("Lock wait time was configured at %s but elapsed time was %s, must be a mistake in the locking code", artificallyShortLockWaitTimeout, elapsed)
+			}
+
 		})
 	})
 

--- a/stackexchange-api-proxy/se_test.go
+++ b/stackexchange-api-proxy/se_test.go
@@ -90,3 +90,13 @@ func Test_FetchUpdate(t *testing.T) {
 	})
 
 }
+
+// TODO: This test could be much more comprehensive, this is just a
+// big sanity check.
+func Test_NewClient(t *testing.T) {
+	var c1, _ = NewClient()
+	var c2, _ = NewClient(SpecifyLockWaitTimeout(c1.lockWaitTimeout * 2))
+	if c1.lockWaitTimeout == c2.lockWaitTimeout {
+		t.Fatalf("Expected %s to equal %s when checking whether client optionsFns were applied correctly.", c1.lockWaitTimeout, c2.lockWaitTimeout)
+	}
+}

--- a/stackexchange-api-proxy/se_test.go
+++ b/stackexchange-api-proxy/se_test.go
@@ -1,0 +1,61 @@
+package se
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_IsAllowedURL(t *testing.T) {
+
+	t.Parallel()
+
+	var cases = []struct {
+		urlStr  string
+		vals    *url.Values
+		allowed bool
+	}{
+		{
+			urlStr:  "http://example.com",
+			vals:    nil,
+			allowed: false,
+		},
+		{
+			urlStr:  "http://stackoverflow.com",
+			vals:    &url.Values{"site": []string{"stackoverflow"}},
+			allowed: true,
+		},
+		{
+			urlStr:  "http://www.stackoverflow.com",
+			vals:    &url.Values{"site": []string{"stackoverflow"}},
+			allowed: true,
+		},
+		{
+			urlStr:  "http://maliciousstackoverflow.com",
+			vals:    nil,
+			allowed: false,
+		},
+		{
+			urlStr:  "http://www.stackexchange.com",
+			vals:    nil,
+			allowed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s", tc.urlStr), func(t *testing.T) {
+			vals, allowed := IsAllowedURL(tc.urlStr)
+			if allowed != tc.allowed {
+				t.Fatalf("Expected %t to equal %t when checking if %q is allowed.", allowed, tc.allowed, tc.urlStr)
+				t.Failed()
+			}
+			if cmp.Diff(vals, tc.vals) != "" {
+				t.Fatalf("Expected %#v to equal %#v when checking if %q is allowed.", vals, tc.vals, tc.urlStr)
+				t.Failed()
+			}
+		})
+	}
+
+}

--- a/stackexchange-api-proxy/se_test.go
+++ b/stackexchange-api-proxy/se_test.go
@@ -45,7 +45,7 @@ func Test_IsAllowedURL(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf("%s", tc.urlStr), func(t *testing.T) {
+		t.Run(fmt.Sprintf("simple client %s", tc.urlStr), func(t *testing.T) {
 			vals, allowed := IsAllowedURL(tc.urlStr)
 			if allowed != tc.allowed {
 				t.Fatalf("Expected %t to equal %t when checking if %q is allowed.", allowed, tc.allowed, tc.urlStr)
@@ -56,6 +56,16 @@ func Test_IsAllowedURL(t *testing.T) {
 				t.Failed()
 			}
 		})
+		t.Run(fmt.Sprintf("custom client %s", tc.urlStr), func(t *testing.T) {
+			vals, allowed := Client{allowList: defaultAllowListPatterns}.IsAllowedURL(tc.urlStr)
+			if allowed != tc.allowed {
+				t.Fatalf("Expected %t to equal %t when checking if %q is allowed.", allowed, tc.allowed, tc.urlStr)
+				t.Failed()
+			}
+			if cmp.Diff(vals, tc.vals) != "" {
+				t.Fatalf("Expected %#v to equal %#v when checking if %q is allowed.", vals, tc.vals, tc.urlStr)
+				t.Failed()
+			}
+		})
 	}
-
 }

--- a/stackexchange-api-proxy/se_test.go
+++ b/stackexchange-api-proxy/se_test.go
@@ -59,7 +59,7 @@ func Test_IsAllowedURL(t *testing.T) {
 			}
 		})
 		t.Run(fmt.Sprintf("custom client %s", tc.urlStr), func(t *testing.T) {
-			vals, allowed := Client{allowList: defaultAllowListPatterns}.IsAllowedURL(tc.urlStr)
+			vals, allowed := Client{allowList: DefaultAllowListPatterns}.IsAllowedURL(tc.urlStr)
 			if allowed != tc.allowed {
 				t.Fatalf("Expected %t to equal %t when checking if %q is allowed.", allowed, tc.allowed, tc.urlStr)
 				t.Failed()
@@ -74,10 +74,7 @@ func Test_IsAllowedURL(t *testing.T) {
 
 func Test_FetchUpdate(t *testing.T) {
 
-	var c = Client{
-		allowList:   defaultAllowListPatterns,
-		lockTimeout: 50 * time.Millisecond,
-	}
+	var c, _ = NewClient(SpecifyLockWaitTimeout(50 * time.Millisecond))
 
 	t.Run("locking", func(t *testing.T) {
 		t.Run("errs with a lock contnetion error on time", func(t *testing.T) {


### PR DESCRIPTION
I took the first steps in implementing a Stack~Overflow~Exchange client in this branch to begin to address https://github.com/sourcegraph/sourcegraph/issues/423.

I have considered that a possible way to feed this machine would be to have the browser extension recognise StackExchange family URLs and forward them to this service, and have the service populate and track Git assets for those pages as quickly as possible, hence I have coded extremely defensively so far.

The README sketches out a little where I intend to take the solution, I plan to at least get as far as having this package create Git repositories containing the information extracted from StackExchange pages where a code block can be identified in the question or any of the answers. (subject to concerns such as identifying the language, etc)

I understand that the discussion in #423 talked about having the browser extension do this parsing and analysis since they already have the DOM and can avoid API rate limit constraints. I'm operating so far on the assumption that even if such a browser extension feature exists, something server-side should still refresh code samples (so we still need an API wrapper for SO/SE anyway) - and that even on the server-side, we can consider whether registering as an app, and/or talking with SO about increased rate limits would be feasible. 

There's always the option to add a lot of TLS and borrow the user's auth token, if that would work? I would like to try that with my own tokens though before committing to anything.