### PR TITLE
Add proposal for in-app guidance to setting up and getting value from…

### DIFF
--- a/doc/dev/plans/2019-01-14-codeintel-onboarding.md
+++ b/doc/dev/plans/2019-01-14-codeintel-onboarding.md
@@ -12,15 +12,15 @@ Today, there basically is no way to discover code intelligence unless the admin 
 
 ## Plan
 
-1) **First**, we add a post-install site alert for admins only that links them to http://sourcegraph.example.com/extensions?query=category%3A%22Programming+languages%22.
+1) **First** (3.0), we add a post-install site alert for admins only that links them to http://sourcegraph.example.com/extensions?query=category%3A%22Programming+languages%22.
 
 This would appear at the top of every page (after the admin adds repos and the "Add repositories" alert goes away) and it would say something like "Enable Sourcegraph extensions to get code intelligence for your team"
 
-2) **Second**, we add a new type of toast (using https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/web/src/marketing/Toast.tsx) for all users that appears programmatically when a user visits a new file extension (.go, .ts, etc.) that links them to the relevant extension (or basic codeintel) if they don't have it enabled. If the user is an admin, the toast would be enhanced with a link to docs on language server deployment (though no obvious page exists for this in the admin docs today, see below). 
+2) **Second** (3.1), we add a new type of toast (using https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/web/src/marketing/Toast.tsx) for all users that appears programmatically when a user visits a new file extension (.go, .ts, etc.) that links them to the relevant extension (or basic codeintel) if they don't have it enabled. If the user is an admin, the toast would be enhanced with a link to docs on language server deployment (though no obvious page exists for this in the admin docs today, see below). 
 
 These would be dismissable by language. This work would provide the foundation for future extension recommendations.
 
-3) **Third**, we enhance documentation around deployment + enablement. This means providing a "Code intelligence" page for admins in the Sourcegraph docs (i.e., on https://docs.sourcegraph.com) that provides a walkthrough for enabling language support for one or two Sourcegraph-provided languages (e.g. how to start the Go langserver). This comes on top of any documentation that appears on the extension READMEs themselves.
+3) **Third** (3.0), we enhance documentation around deployment + enablement. This means providing a "Code intelligence" page for admins in the Sourcegraph docs (i.e., on https://docs.sourcegraph.com) that provides a walkthrough for enabling language support for one or two Sourcegraph-provided languages (e.g. how to start the Go langserver). This comes on top of any documentation that appears on the extension READMEs themselves.
 
 This is necessary because of how busy/complicated the extension READMEs have already become. There are so many potential paths on those pages (e.g.: admin setup vs. user extension enablement; sourcegraph.com vs. self-hosted; 3.0 vs. 2.x; single Docker image vs. cluster, etc.). Pulling the admin setup portion out of those READMEs, and leaving them to focus on how end users (i.e., non-admins) enable the extension, would simplify and clarify them. They would, of course, link out to the docs page.
 
@@ -35,6 +35,8 @@ These would be low-risk additions. They would be released to all users as soon a
 ### Success metrics
 
 Interaction rates on Sourcegraph.com (i.e., users who click through the toast to enable code intellgience for a given language),and usage of code intelligence on self-hosted instances. 
+
+Also, where difficult to measure, direct feedback from existing, friendly customers.
 
 ### Company goals
 
@@ -52,7 +54,9 @@ TBD, pending team approval of the proposals.
 
 ## Done date
 
-Sourcegraph 3.1 (early  March).
+Documentation and site alert can be implemented by the 3.0 launch.
+
+Recommendations (toasts) would be released in 3.1 (early  March).
 
 ## Retrospective
 

--- a/doc/dev/plans/2019-01-14-codeintel-onboarding.md
+++ b/doc/dev/plans/2019-01-14-codeintel-onboarding.md
@@ -16,7 +16,7 @@ Today, there basically is no way to discover code intelligence unless the admin 
 
 This would appear at the top of every page (after the admin adds repos and the "Add repositories" alert goes away) and it would say something like "Enable Sourcegraph extensions to get code intelligence for your team"
 
-2) **Second** (3.1), we add a new type of toast (using https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/web/src/marketing/Toast.tsx) for all users that appears programmatically when a user visits a new file extension (.go, .ts, etc.) that links them to the relevant extension (or basic codeintel) if they don't have it enabled. If the user is an admin, the toast would be enhanced with a link to docs on language server deployment (though no obvious page exists for this in the admin docs today, see below). 
+2) ~~**Second** (3.1), we add a new type of toast (using https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/web/src/marketing/Toast.tsx) for all users that appears programmatically when a user visits a new file extension (.go, .ts, etc.) that links them to the relevant extension (or basic codeintel) if they don't have it enabled. If the user is an admin, the toast would be enhanced with a link to docs on language server deployment (though no obvious page exists for this in the admin docs today, see below).~~ Omitted from this proposal, but left here to preserve the numbering and correspondence with the discussion.
 
 These would be dismissable by language. This work would provide the foundation for future extension recommendations.
 

--- a/doc/dev/plans/2019-01-14-codeintel-onboarding.md
+++ b/doc/dev/plans/2019-01-14-codeintel-onboarding.md
@@ -28,8 +28,6 @@ These would be dismissable by language. This work would provide the foundation f
 - Instructions for running in Docker and Kubernetes
 - Then information specific to the language server (e.g. private dependencies)
 
-This is necessary because of how busy/complicated the extension READMEs have already become. There are so many potential paths on those pages (e.g.: admin setup vs. user extension enablement; sourcegraph.com vs. self-hosted; 3.0 vs. 2.x; single Docker image vs. cluster, etc.). Pulling the admin setup portion out of those READMEs, and leaving them to focus on how end users (i.e., non-admins) enable the extension, would simplify and clarify them. They would, of course, link out to the docs page.
-
 ### Test plan
 
 TBD. We could add an e2e test to ensure the site alert and toast appear for admins and users at the right moments.

--- a/doc/dev/plans/2019-01-14-codeintel-onboarding.md
+++ b/doc/dev/plans/2019-01-14-codeintel-onboarding.md
@@ -20,7 +20,13 @@ This would appear at the top of every page (after the admin adds repos and the "
 
 These would be dismissable by language. This work would provide the foundation for future extension recommendations.
 
-3) **Third** (3.0), we enhance documentation around deployment + enablement. This means providing a "Code intelligence" page for admins in the Sourcegraph docs (i.e., on https://docs.sourcegraph.com) that provides a walkthrough for enabling language support for one or two Sourcegraph-provided languages (e.g. how to start the Go langserver). This comes on top of any documentation that appears on the extension READMEs themselves.
+3) **Third** (3.0), we make each language extension's README follow the same format:
+
+- Table of contents
+- Image showing a hover tooltip
+- Who this README is for (admins)
+- Instructions for running in Docker and Kubernetes
+- Then information specific to the language server (e.g. private dependencies)
 
 This is necessary because of how busy/complicated the extension READMEs have already become. There are so many potential paths on those pages (e.g.: admin setup vs. user extension enablement; sourcegraph.com vs. self-hosted; 3.0 vs. 2.x; single Docker image vs. cluster, etc.). Pulling the admin setup portion out of those READMEs, and leaving them to focus on how end users (i.e., non-admins) enable the extension, would simplify and clarify them. They would, of course, link out to the docs page.
 

--- a/doc/dev/plans/2019-01-14-codeintel-onboarding.md
+++ b/doc/dev/plans/2019-01-14-codeintel-onboarding.md
@@ -1,0 +1,67 @@
+# Better in-app guidance for (1) admins to set up code intelligence and (2) users to enable it
+
+A plan to provide a more guided path in-app to enabling and getting value from code intelligence.
+
+## Background
+
+Sourcegraph has never had much onboarding, but prior to Sourcegraph 3.0.0, getting value from code intelligence was somewhat more straightforward:
+* Most language support "just worked" automatically, without the admin doing anything.
+* We used to have a **Site-admin > Code intelligence** page, which at least provided the admin with an obvious place to go if something wasn't enabled or working.
+
+Today, there basically is no way to discover code intelligence unless the admin goes searching for it in the docs (or happens across the relevant extension).
+
+## Plan
+
+1) **First**, we add a post-install site alert for admins only that links them to http://sourcegraph.example.com/extensions?query=category%3A%22Programming+languages%22.
+
+This would appear at the top of every page (after the admin adds repos and the "Add repositories" alert goes away) and it would say something like "Enable Sourcegraph extensions to get code intelligence for your team"
+
+2) **Second**, we add a new type of toast (using https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/web/src/marketing/Toast.tsx) for all users that appears programmatically when a user visits a new file extension (.go, .ts, etc.) that links them to the relevant extension (or basic codeintel) if they don't have it enabled. If the user is an admin, the toast would be enhanced with a link to docs on language server deployment (though no obvious page exists for this in the admin docs today, see below). 
+
+These would be dismissable by language. This work would provide the foundation for future extension recommendations.
+
+3) **Third**, we enhance documentation around deployment + enablement. This means providing a "Code intelligence" page for admins in the Sourcegraph docs (i.e., on https://docs.sourcegraph.com) that provides a walkthrough for enabling language support for one or two Sourcegraph-provided languages (e.g. how to start the Go langserver). This comes on top of any documentation that appears on the extension READMEs themselves.
+
+This is necessary because of how busy/complicated the extension READMEs have already become. There are so many potential paths on those pages (e.g.: admin setup vs. user extension enablement; sourcegraph.com vs. self-hosted; 3.0 vs. 2.x; single Docker image vs. cluster, etc.). Pulling the admin setup portion out of those READMEs, and leaving them to focus on how end users (i.e., non-admins) enable the extension, would simplify and clarify them. They would, of course, link out to the docs page.
+
+### Test plan
+
+TBD. We could add an e2e test to ensure the site alert and toast appear for admins and users at the right moments.
+
+### Release plan
+
+These would be low-risk additions. They would be released to all users as soon as they were available.
+
+### Success metrics
+
+Interaction rates on Sourcegraph.com (i.e., users who click through the toast to enable code intellgience for a given language),and usage of code intelligence on self-hosted instances. 
+
+### Company goals
+
+This would directly drive usage of our most popular feature, code intelligence, and would provide a much faster (and more obvious) path to value for new users. This all serves to make it much more likely that an installer would share with their teammates and grow the instance from 1 to 20 users.
+
+## Rationale
+
+There are a lot of ways we could make this easier for admins and end-users — these are just a proposal for a package of improvements, but are open to suggestions.
+
+Other ideas include different UIs for recommendations (e.g. using something other than site alerts and toasts), using emails, adding different ways to split up extension READMEs to make it easier to follow as an admin vs. as a user, etc. 
+
+## Checklist 
+
+TBD, pending team approval of the proposals.
+
+## Done date
+
+Sourcegraph 3.1 (early  March).
+
+## Retrospective
+
+[This section is completed after the project is completely done (i.e. the checklist is complete).]
+
+### Actual checklist
+
+[The checklist that was actually completed (i.e. paste the final checklist from the issue). Explain any differences from the original checklist in the plan.]
+
+### Actual done date
+
+[The date that the project was actually finished. Explain why this is earlier or later than originally planned or explain why the project was not completed.]

--- a/doc/dev/plans/2019-01-14-codeintel-onboarding.md
+++ b/doc/dev/plans/2019-01-14-codeintel-onboarding.md
@@ -60,8 +60,6 @@ TBD, pending team approval of the proposals.
 
 Documentation and site alert can be implemented by the 3.0 launch.
 
-Recommendations (toasts) would be released in 3.1 (early  March).
-
 ## Retrospective
 
 [This section is completed after the project is completely done (i.e. the checklist is complete).]


### PR DESCRIPTION
… code intelligence

Running through https://github.com/sourcegraph/sourcegraph/issues/1717 made me realize that code intel requires some very specific knowledge to get value from it. Adding in-app guidance and tweaking our doc format for codeintel could help quite a bit. 

This is a collection of three distinct proposals for discussion.

Also relevant (but not included here) is https://github.com/sourcegraph/sourcegraph/issues/1874, which could improve team-wide spreading of codeintel inside customer instances.