### PR TITLE
server: Fix SSH cloning

### DIFF
--- a/cmd/server/dockerfile.go
+++ b/cmd/server/dockerfile.go
@@ -1,5 +1,7 @@
 package main
 
+//docker:run apk update && apk upgrade
+
 //docker:install curl
 //docker:run curl -o /usr/local/bin/syntect_server https://storage.googleapis.com/sourcegraph-artifacts/syntect_server/f85a9897d3c23ef84eb219516efdbb2d && chmod +x /usr/local/bin/syntect_server
 


### PR DESCRIPTION
This commit fixes SSH cloning in the server alpine image by ensuring it
has the latest updates installed, which seemed to fix it.

Fixes #1917

```
/ # apk upgrade
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.10.1-r0 -> 2.10.3-r1)
Executing busybox-1.28.4-r2.trigger
Continuing the upgrade transaction with new apk-tools:
(1/10) Upgrading musl (1.1.19-r10 -> 1.1.20-r3)
(2/10) Upgrading busybox (1.28.4-r2 -> 1.29.3-r9)
Executing busybox-1.29.3-r9.post-upgrade
(3/10) Upgrading alpine-baselayout (3.1.0-r0 -> 3.1.0-r2)
Executing alpine-baselayout-3.1.0-r2.pre-upgrade
Executing alpine-baselayout-3.1.0-r2.post-upgrade
(4/10) Installing ca-certificates-cacert (20180924-r3)
(5/10) Installing libtls-standalone (2.7.4-r6)
(6/10) Upgrading ssl_client (1.28.4-r2 -> 1.29.3-r9)
(7/10) Upgrading libressl2.7-libcrypto (2.7.4-r0 -> 2.7.4-r2)
(8/10) Upgrading musl-utils (1.1.19-r10 -> 1.1.20-r3)
(9/10) Upgrading libressl2.7-libssl (2.7.4-r0 -> 2.7.4-r2)
(10/10) Purging libressl2.7-libtls (2.7.4-r0)
Executing busybox-1.29.3-r9.trigger
Executing ca-certificates-20180924-r3.trigger
OK: 318 MiB in 60 packages
```