### PR TITLE
Replace GitLab sudo-token-based authz impl with OAuth-based impl

### DIFF
--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -248,7 +248,7 @@ func newGitLabConnection(config *schema.GitLabConnection) (*gitlabConnection, er
 	return &gitlabConnection{
 		config:  config,
 		baseURL: baseURL,
-		client:  gitlab.NewClient(baseURL, config.Token, "", transport),
+		client:  gitlab.NewClientProvider(baseURL, transport).GetPATClient(config.Token),
 	}, nil
 }
 

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -51,8 +51,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 
 	// Try every verified email in succession until the first that succeeds
 	var data extsvc.ExternalAccountData
-	data.SetAccountData(ghUser)
-	data.SetAuthData(token)
+	githubsvc.SetExternalAccountData(&data, ghUser, token)
 	var (
 		firstSafeErrMsg string
 		firstErr        error

--- a/enterprise/cmd/frontend/auth/gitlaboauth/login.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/login.go
@@ -78,5 +78,5 @@ func gitlabClientFromAuthURL(authURL, oauthToken string) (*gitlab.Client, error)
 	baseURL.Path = ""
 	baseURL.RawQuery = ""
 	baseURL.Fragment = ""
-	return gitlab.NewClient(baseURL, "", oauthToken, nil), nil
+	return gitlab.NewClientProvider(baseURL, nil).GetOAuthClient(oauthToken), nil
 }

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -35,8 +35,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 	}
 
 	var data extsvc.ExternalAccountData
-	data.SetAccountData(gUser)
-	data.SetAuthData(token)
+	gitlab.SetExternalAccountData(&data, gUser, token)
 
 	userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, auth.GetAndSaveUserOp{
 		UserProps: db.NewUser{

--- a/enterprise/cmd/frontend/internal/authz/authz_gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/authz_gitlab.go
@@ -61,13 +61,19 @@ func gitlabProvider(cfg *conf.Unified, gl *schema.GitLabConnection) (authz.Provi
 		return nil, fmt.Errorf("Could not parse URL for GitLab instance %q: %s", gl.Url, err)
 	}
 
+	// Check that there is a GitLab authn provider corresponding to this GitLab instance
 	foundAuthProvider := false
 	for _, authnProvider := range cfg.Critical.AuthProviders {
 		if authnProvider.Gitlab == nil {
 			continue
 		}
-		authProviderURL, err := url.Parse(authnProvider.Gitlab.Url)
+		authnURL := authnProvider.Gitlab.Url
+		if authnURL == "" {
+			authnURL = "https://gitlab.com"
+		}
+		authProviderURL, err := url.Parse(authnURL)
 		if err != nil {
+			// Ignore the error here, because the authn provider is responsible for its own validation
 			continue
 		}
 		if authProviderURL.Hostname() == glURL.Hostname() {

--- a/enterprise/cmd/frontend/internal/authz/authz_gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/authz_gitlab.go
@@ -2,18 +2,14 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	permgl "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz/gitlab"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
-	"github.com/sourcegraph/sourcegraph/pkg/env"
 	"github.com/sourcegraph/sourcegraph/schema"
-	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 func init() {
@@ -70,52 +66,14 @@ func gitlabProvider(cfg *conf.Unified, gl *schema.GitLabConnection) (authz.Provi
 		return nil, err
 	}
 
-	op := permgl.GitLabAuthzProviderOp{
+	return NewGitLabProvider(permgl.GitLabOAuthAuthzProviderOp{
 		BaseURL:   glURL,
-		SudoToken: gl.Token,
-		AuthnConfigID: auth.ProviderConfigID{
-			ID:   gl.Authorization.AuthnProvider.ConfigID,
-			Type: gl.Authorization.AuthnProvider.Type,
-		},
-		GitLabProvider: gl.Authorization.AuthnProvider.GitlabProvider,
-		CacheTTL:       ttl,
-		MockCache:      nil,
-	}
-	if gl.Authorization.AuthnProvider.ConfigID == "" {
-		// Note: In the future when we support sign-in via GitLab, we can check if that is
-		// enabled and instead fall back to that.
-		if env.InsecureDev {
-			log15.Warn("Using username matching for debugging purposes, because `authz.authnProvider.configID` in the config was empty. This should ONLY occur in a development build.")
-			op.UseNativeUsername = true
-		} else {
-			return nil, errors.New("`authz.authnProvider.configID` was empty. No users will be granted access to these repositories.")
-		}
-	} else if gl.Authorization.AuthnProvider.Type == "" {
-		return nil, errors.New("`authz.authnProvider.type` was not specified, which means GitLab users cannot be resolved.")
-	} else if gl.Authorization.AuthnProvider.GitlabProvider == "" {
-		return nil, errors.New("`authz.authnProvider.gitlabProvider` was not specified, which means GitLab users cannot be resolved.")
-	} else {
-		// Best-effort determine if the authz.authnConfigID field refers to an item in auth.provider
-		found := false
-		for _, p := range cfg.Critical.AuthProviders {
-			if p.Openidconnect != nil && p.Openidconnect.ConfigID == gl.Authorization.AuthnProvider.ConfigID && p.Openidconnect.Type == gl.Authorization.AuthnProvider.Type {
-				found = true
-				break
-			}
-			if p.Saml != nil && p.Saml.ConfigID == gl.Authorization.AuthnProvider.ConfigID && p.Saml.Type == gl.Authorization.AuthnProvider.Type {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, fmt.Errorf("Could not find item in `auth.providers` with config ID %q and type %q", gl.Authorization.AuthnProvider.ConfigID, gl.Authorization.AuthnProvider.Type)
-		}
-	}
-
-	return NewGitLabProvider(op), nil
+		CacheTTL:  ttl,
+		MockCache: nil,
+	}), nil
 }
 
 // NewGitLabProvider is a mockable constructor for new GitLabAuthzProvider instances.
-var NewGitLabProvider = func(op permgl.GitLabAuthzProviderOp) authz.Provider {
+var NewGitLabProvider = func(op permgl.GitLabOAuthAuthzProviderOp) authz.Provider {
 	return permgl.NewProvider(op)
 }

--- a/enterprise/cmd/frontend/internal/authz/authz_gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/authz_gitlab.go
@@ -61,6 +61,24 @@ func gitlabProvider(cfg *conf.Unified, gl *schema.GitLabConnection) (authz.Provi
 		return nil, fmt.Errorf("Could not parse URL for GitLab instance %q: %s", gl.Url, err)
 	}
 
+	foundAuthProvider := false
+	for _, authnProvider := range cfg.Critical.AuthProviders {
+		if authnProvider.Gitlab == nil {
+			continue
+		}
+		authProviderURL, err := url.Parse(authnProvider.Gitlab.Url)
+		if err != nil {
+			continue
+		}
+		if authProviderURL.Hostname() == glURL.Hostname() {
+			foundAuthProvider = true
+			break
+		}
+	}
+	if !foundAuthProvider {
+		return nil, fmt.Errorf("Did not find authentication provider matching %q", gl.Url)
+	}
+
 	ttl, err := parseTTL(gl.Authorization.Ttl)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/authz/github/cache.go
+++ b/enterprise/cmd/frontend/internal/authz/github/cache.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// pcache describes the shape of the repo permissions cache that Provider uses internally.
-type pcache interface {
+// cache describes the shape of the repo permissions cache that Provider uses internally.
+type cache interface {
 	GetMulti(keys ...string) [][]byte
 	SetMulti(keyvals ...[2]string)
 	Get(key string) ([]byte, bool)

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -21,10 +21,10 @@ type Provider struct {
 	client   *github.Client
 	codeHost *github.CodeHost
 	cacheTTL time.Duration
-	cache    pcache
+	cache    cache
 }
 
-func NewProvider(githubURL *url.URL, baseToken string, cacheTTL time.Duration, mockCache pcache) *Provider {
+func NewProvider(githubURL *url.URL, baseToken string, cacheTTL time.Duration, mockCache cache) *Provider {
 	apiURL, _ := github.APIRoot(githubURL)
 	client := github.NewClient(apiURL, baseToken, nil)
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
@@ -1,0 +1,18 @@
+package gitlab
+
+import "time"
+
+type pcache interface {
+	Get(key string) ([]byte, bool)
+	Set(key string, b []byte)
+	Delete(key string)
+}
+
+type cacheVal struct {
+	// ProjIDs is the set of project IDs to which a GitLab user has access.
+	ProjIDs map[int]struct{} `json:"repos"`
+
+	// TTL is the ttl of the cache entry. This must be checked for equality in case the TTL has
+	// changed (and the cache entry should therefore be invalidated).
+	TTL time.Duration `json:"ttl"`
+}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
@@ -2,7 +2,7 @@ package gitlab
 
 import "time"
 
-type pcache interface {
+type cache interface {
 	Get(key string) ([]byte, bool)
 	Set(key string, b []byte)
 	Delete(key string)

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -1,4 +1,3 @@
-// Package gitlab contains an authorization provider for GitLab.
 package gitlab
 
 import (
@@ -10,7 +9,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -20,77 +18,37 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-type pcache interface {
-	Get(key string) ([]byte, bool)
-	Set(key string, b []byte)
-	Delete(key string)
+// TODO: this should replace the old sudo-token-based auth method
+
+var _ authz.Provider = ((*GitLabOAuthAuthzProvider)(nil))
+
+type GitLabOAuthAuthzProvider struct {
+	clientProvider *gitlab.ClientProvider
+	clientURL      *url.URL
+	codeHost       *gitlab.CodeHost
+	cache          pcache
+	cacheTTL       time.Duration
 }
 
-// GitLabAuthzProvider is an implementation of AuthzProvider that provides repository permissions as
-// determined from a GitLab instance API. For documentation of specific fields, see the docstrings
-// of GitLabAuthzProviderOp.
-type GitLabAuthzProvider struct {
-	client            *gitlab.Client
-	clientURL         *url.URL
-	codeHost          *gitlab.CodeHost
-	gitlabProvider    string
-	authnConfigID     auth.ProviderConfigID
-	useNativeUsername bool
-	cache             pcache
-	cacheTTL          time.Duration
-}
-
-var _ authz.Provider = ((*GitLabAuthzProvider)(nil))
-
-type cacheVal struct {
-	// ProjIDs is the set of project IDs to which a GitLab user has access.
-	ProjIDs map[int]struct{} `json:"repos"`
-
-	// TTL is the ttl of the cache entry. This must be checked for equality in case the TTL has
-	// changed (and the cache entry should therefore be invalidated).
-	TTL time.Duration `json:"ttl"`
-}
-
-type GitLabAuthzProviderOp struct {
+type GitLabOAuthAuthzProviderOp struct {
 	// BaseURL is the URL of the GitLab instance.
 	BaseURL *url.URL
 
-	// AuthnConfigID identifies the authn provider to use to lookup users on the GitLab instance.
-	// This should be the authn provider that's used to sign into the GitLab instance.
-	AuthnConfigID auth.ProviderConfigID
-
-	// GitLabProvider is the id of the authn provider to GitLab. It will be used in the
-	// `users?extern_uid=$uid&provider=$provider` API query.
-	GitLabProvider string
-
-	// SudoToken is an access token with sudo *and* api scope.
-	//
-	// 🚨 SECURITY: This value contains secret information that must not be shown to non-site-admins.
-	SudoToken string
-
 	// CacheTTL is the TTL of cached permissions lists from the GitLab API.
 	CacheTTL time.Duration
-
-	// UseNativeUsername, if true, maps Sourcegraph users to GitLab users using username equivalency
-	// instead of the authn provider user ID. This is *very* insecure (Sourcegraph usernames can be
-	// changed at the user's will) and should only be used in development environments.
-	UseNativeUsername bool
 
 	// MockCache, if non-nil, replaces the default Redis-based cache with the supplied cache mock.
 	// Should only be used in tests.
 	MockCache pcache
 }
 
-func NewProvider(op GitLabAuthzProviderOp) *GitLabAuthzProvider {
-	p := &GitLabAuthzProvider{
-		client:            gitlab.NewClient(op.BaseURL, op.SudoToken, "", nil),
-		clientURL:         op.BaseURL,
-		codeHost:          gitlab.NewCodeHost(op.BaseURL),
-		cache:             op.MockCache,
-		authnConfigID:     op.AuthnConfigID,
-		gitlabProvider:    op.GitLabProvider,
-		cacheTTL:          op.CacheTTL,
-		useNativeUsername: op.UseNativeUsername,
+func NewProvider(op GitLabOAuthAuthzProviderOp) *GitLabOAuthAuthzProvider {
+	p := &GitLabOAuthAuthzProvider{
+		clientProvider: gitlab.NewClientProvider(op.BaseURL, nil),
+		clientURL:      op.BaseURL,
+		codeHost:       gitlab.NewCodeHost(op.BaseURL),
+		cache:          op.MockCache,
+		cacheTTL:       op.CacheTTL,
 	}
 	if p.cache == nil {
 		p.cache = rcache.NewWithTTL(fmt.Sprintf("gitlabAuthz:%s", op.BaseURL.String()), int(math.Ceil(op.CacheTTL.Seconds())))
@@ -98,28 +56,19 @@ func NewProvider(op GitLabAuthzProviderOp) *GitLabAuthzProvider {
 	return p
 }
 
-func (p *GitLabAuthzProvider) Validate() (problems []string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if _, _, err := p.client.ListProjects(ctx, "projects?sudo=1"); err != nil {
-		if err == ctx.Err() {
-			problems = append(problems, fmt.Sprintf("GitLab API did not respond within 5s (%s)", err.Error()))
-		} else if !gitlab.IsNotFound(err) {
-			problems = append(problems, "access token did not have sufficient privileges, requires scopes \"sudo\" and \"api\"")
-		}
-	}
-	return problems
+func (p *GitLabOAuthAuthzProvider) Validate() (problems []string) {
+	return nil
 }
 
-func (p *GitLabAuthzProvider) ServiceID() string {
+func (p *GitLabOAuthAuthzProvider) ServiceID() string {
 	return p.codeHost.ServiceID()
 }
 
-func (p *GitLabAuthzProvider) ServiceType() string {
+func (p *GitLabOAuthAuthzProvider) ServiceType() string {
 	return p.codeHost.ServiceType()
 }
 
-func (p *GitLabAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (map[api.RepoName]map[authz.Perm]bool, error) {
+func (p *GitLabOAuthAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (map[api.RepoName]map[authz.Perm]bool, error) {
 	accountID := "" // empty means public / unauthenticated to the code host
 	if account != nil && account.ServiceID == p.codeHost.ServiceID() && account.ServiceType == p.codeHost.ServiceType() {
 		accountID = account.AccountID
@@ -131,7 +80,13 @@ func (p *GitLabAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.Ext
 		accessibleRepos = r
 	} else {
 		var err error
-		accessibleRepos, err = p.fetchUserAccessList(ctx, accountID)
+
+		_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+		if err != nil {
+			return nil, err
+		}
+
+		accessibleRepos, err = p.fetchUserAccessList(ctx, accountID, tok.AccessToken)
 		if err != nil {
 			return nil, err
 		}
@@ -165,100 +120,17 @@ func (p *GitLabAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.Ext
 	return perms, nil
 }
 
-func (p *GitLabAuthzProvider) Repos(ctx context.Context, repos map[authz.Repo]struct{}) (mine map[authz.Repo]struct{}, others map[authz.Repo]struct{}) {
+func (p *GitLabOAuthAuthzProvider) Repos(ctx context.Context, repos map[authz.Repo]struct{}) (mine map[authz.Repo]struct{}, others map[authz.Repo]struct{}) {
 	return authz.GetCodeHostRepos(p.codeHost, repos)
 }
 
-func (p *GitLabAuthzProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
-	if user == nil {
-		return nil, nil
-	}
-
-	var glUser *gitlab.User
-	if p.useNativeUsername {
-		glUser, err = p.fetchAccountByUsername(ctx, user.Username)
-	} else {
-		// resolve the GitLab account using the authn provider (specified by p.AuthnConfigID)
-		authnProvider := getProviderByConfigID(p.authnConfigID)
-		if authnProvider == nil {
-			return nil, nil
-		}
-		var authnAcct *extsvc.ExternalAccount
-		for _, acct := range current {
-			if acct.ServiceID == authnProvider.CachedInfo().ServiceID && acct.ServiceType == authnProvider.ConfigID().Type {
-				authnAcct = acct
-				break
-			}
-		}
-		if authnAcct == nil {
-			return nil, nil
-		}
-		glUser, err = p.fetchAccountByExternalUID(ctx, authnAcct.AccountID)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if glUser == nil {
-		return nil, nil
-	}
-
-	jsonGLUser, err := json.Marshal(glUser)
-	if err != nil {
-		return nil, err
-	}
-	accountData := json.RawMessage(jsonGLUser)
-	glExternalAccount := extsvc.ExternalAccount{
-		UserID: user.ID,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
-			ServiceType: p.codeHost.ServiceType(),
-			ServiceID:   p.codeHost.ServiceID(),
-			AccountID:   strconv.Itoa(int(glUser.ID)),
-		},
-		ExternalAccountData: extsvc.ExternalAccountData{
-			AccountData: &accountData,
-		},
-	}
-	return &glExternalAccount, nil
-}
-
-func (p *GitLabAuthzProvider) fetchAccountByExternalUID(ctx context.Context, uid string) (*gitlab.User, error) {
-	q := make(url.Values)
-	q.Add("extern_uid", uid)
-	q.Add("provider", p.gitlabProvider)
-	q.Add("per_page", "2")
-	glUsers, _, err := p.client.ListUsers(ctx, "users?"+q.Encode())
-	if err != nil {
-		return nil, err
-	}
-	if len(glUsers) >= 2 {
-		return nil, fmt.Errorf("failed to determine unique GitLab user for query %q", q.Encode())
-	}
-	if len(glUsers) == 0 {
-		return nil, nil
-	}
-	return glUsers[0], nil
-}
-
-func (p *GitLabAuthzProvider) fetchAccountByUsername(ctx context.Context, username string) (*gitlab.User, error) {
-	q := make(url.Values)
-	q.Add("username", username)
-	q.Add("per_page", "2")
-	glUsers, _, err := p.client.ListUsers(ctx, "users?"+q.Encode())
-	if err != nil {
-		return nil, err
-	}
-	if len(glUsers) >= 2 {
-		return nil, fmt.Errorf("failed to determine unique GitLab user for query %q", q.Encode())
-	}
-	if len(glUsers) == 0 {
-		return nil, nil
-	}
-	return glUsers[0], nil
+func (p *GitLabOAuthAuthzProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+	return nil, nil
 }
 
 // getCachedAccessList returns the list of repositories accessible to a user from the cache and
 // whether the cache entry exists.
-func (p *GitLabAuthzProvider) getCachedAccessList(accountID string) (map[int]struct{}, bool) {
+func (p *GitLabOAuthAuthzProvider) getCachedAccessList(accountID string) (map[int]struct{}, bool) {
 	// TODO(beyang): trigger best-effort fetch in background if ttl is getting close (but avoid dup refetches)
 
 	cachedReposB, exists := p.cache.Get(accountID)
@@ -277,24 +149,16 @@ func (p *GitLabAuthzProvider) getCachedAccessList(accountID string) (map[int]str
 }
 
 // fetchUserAccessList fetches the list of project IDs that are readable to a user from the GitLab API.
-func (p *GitLabAuthzProvider) fetchUserAccessList(ctx context.Context, glUserID string) (map[int]struct{}, error) {
-	q := make(url.Values)
-	if glUserID != "" {
-		q.Add("sudo", glUserID)
-	} else {
-		q.Add("visibility", "public")
-	}
-	q.Add("per_page", "100")
-
+func (p *GitLabOAuthAuthzProvider) fetchUserAccessList(ctx context.Context, glUserID, oauthTok string) (map[int]struct{}, error) {
 	projIDs := make(map[int]struct{})
 	var iters = 0
-	var pageURL = "projects?" + q.Encode()
+	var pageURL = fmt.Sprintf("projects?%s", url.Values(map[string][]string{"per_page": []string{"100"}}).Encode())
 	for {
 		if iters >= 100 && iters%100 == 0 {
 			log15.Warn("Excessively many GitLab API requests to fetch complete user authz list", "iters", iters, "gitlabUserID", glUserID, "host", p.clientURL.String())
 		}
 
-		projs, nextPageURL, err := p.client.ListProjects(ctx, pageURL)
+		projs, nextPageURL, err := p.clientProvider.GetOAuthClient(oauthTok).ListProjects(ctx, pageURL)
 		if err != nil {
 			return nil, err
 		}
@@ -310,5 +174,3 @@ func (p *GitLabAuthzProvider) fetchUserAccessList(ctx context.Context, glUserID 
 	}
 	return projIDs, nil
 }
-
-var getProviderByConfigID = auth.GetProviderByConfigID

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -18,8 +18,6 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-// TODO: this should replace the old sudo-token-based auth method
-
 var _ authz.Provider = ((*GitLabOAuthAuthzProvider)(nil))
 
 type GitLabOAuthAuthzProvider struct {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -24,7 +24,7 @@ type GitLabOAuthAuthzProvider struct {
 	clientProvider *gitlab.ClientProvider
 	clientURL      *url.URL
 	codeHost       *gitlab.CodeHost
-	cache          pcache
+	cache          cache
 	cacheTTL       time.Duration
 }
 
@@ -37,7 +37,7 @@ type GitLabOAuthAuthzProviderOp struct {
 
 	// MockCache, if non-nil, replaces the default Redis-based cache with the supplied cache mock.
 	// Should only be used in tests.
-	MockCache pcache
+	MockCache cache
 }
 
 func NewProvider(op GitLabOAuthAuthzProviderOp) *GitLabOAuthAuthzProvider {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -1,3 +1,5 @@
+// Package gitlab contains an authorization provider for GitLab that uses GitLab OAuth
+// authenetication.
 package gitlab
 
 import (

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -79,11 +79,7 @@ func (p *GitLabOAuthAuthzProvider) RepoPerms(ctx context.Context, account *extsv
 	if r, exists := p.getCachedAccessList(accountID); exists {
 		accessibleRepos = r
 	} else {
-		var (
-			err         error
-			accessToken string
-		)
-
+		var accessToken string
 		if account != nil {
 			_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
 			if err != nil {
@@ -92,6 +88,7 @@ func (p *GitLabOAuthAuthzProvider) RepoPerms(ctx context.Context, account *extsv
 			accessToken = tok.AccessToken
 		}
 
+		var err error
 		accessibleRepos, err = p.fetchUserAccessList(ctx, accountID, accessToken)
 		if err != nil {
 			return nil, err

--- a/pkg/extsvc/gitlab/client.go
+++ b/pkg/extsvc/gitlab/client.go
@@ -61,14 +61,17 @@ func NewClientProvider(baseURL *url.URL, transport http.RoundTripper) *ClientPro
 	}
 }
 
+// GetPATClient returns a client authenticated by the personal access token.
 func (p *ClientProvider) GetPATClient(personalAccessToken string) *Client {
 	return p.getClient(fmt.Sprintf("pat::%s", personalAccessToken), personalAccessToken, "")
 }
 
+// GetOAuthClient returns a client authenticated by the OAuth token.
 func (p *ClientProvider) GetOAuthClient(oauthToken string) *Client {
 	return p.getClient(fmt.Sprintf("oauth::%s", oauthToken), "", oauthToken)
 }
 
+// GetClient returns an unauthenticated client.
 func (p *ClientProvider) GetClient() *Client {
 	return p.getClient("", "", "")
 }

--- a/pkg/extsvc/gitlab/client.go
+++ b/pkg/extsvc/gitlab/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -22,25 +23,23 @@ import (
 
 var requestCounter = metrics.NewRequestCounter("gitlab", "Total number of requests sent to the GitLab API.")
 
-// Client is a GitLab API client.
-type Client struct {
-	baseURL *url.URL // base URL of GitLab; e.g., https://gitlab.com or https://gitlab.example.com
+// ClientProvider creates GitLab API clients. Each client has separate authentication creds and a
+// separate cache, but they share an underlying HTTP client and rate limiter. Callers who want a simple
+// unauthenticated API client should use `NewClientProvider(baseURL, transport).GetClient()`.
+type ClientProvider struct {
+	// baseURL is the base URL of GitLab; e.g., https://gitlab.com or https://gitlab.example.com
+	baseURL *url.URL
 
-	personalAccessToken string // a personal access token to authenticate requests, if set
-	oauthToken          string // an OAuth bearer token, if set
+	// httpClient is the underlying the HTTP client to use
+	httpClient *http.Client
 
-	httpClient *http.Client // the HTTP client to use
+	gitlabClients   map[string]*Client
+	gitlabClientsMu sync.Mutex
 
 	RateLimit *ratelimit.Monitor // the API rate limit monitor
-
-	projCache *rcache.Cache
 }
 
-// NewClient creates a new GitLab API client with an optional personal access token to authenticate requests.
-//
-// The URL must point to the base URL of the GitLab instance. This is https://gitlab.com for GitLab.com and
-// http[s]://[gitlab-hostname] for self-hosted GitLab instances.
-func NewClient(baseURL *url.URL, personalAccessToken, oauthToken string, transport http.RoundTripper) *Client {
+func NewClientProvider(baseURL *url.URL, transport http.RoundTripper) *ClientProvider {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
@@ -54,24 +53,70 @@ func NewClient(baseURL *url.URL, personalAccessToken, oauthToken string, transpo
 		return category
 	})
 
+	return &ClientProvider{
+		baseURL:       baseURL.ResolveReference(&url.URL{Path: path.Join(baseURL.Path, "api/v4") + "/"}),
+		httpClient:    &http.Client{Transport: transport},
+		gitlabClients: make(map[string]*Client),
+		RateLimit:     &ratelimit.Monitor{},
+	}
+}
+
+func (p *ClientProvider) GetPATClient(personalAccessToken string) *Client {
+	return p.getClient(fmt.Sprintf("pat::%s", personalAccessToken), personalAccessToken, "")
+}
+
+func (p *ClientProvider) GetOAuthClient(oauthToken string) *Client {
+	return p.getClient(fmt.Sprintf("oauth::%s", oauthToken), "", oauthToken)
+}
+
+func (p *ClientProvider) GetClient() *Client {
+	return p.getClient("", "", "")
+}
+
+func (p *ClientProvider) getClient(key, personalAccessToken, oauthToken string) *Client {
+	p.gitlabClientsMu.Lock()
+	defer p.gitlabClientsMu.Unlock()
+
+	if c, ok := p.gitlabClients[key]; ok {
+		return c
+	}
+
+	c := p.newClient(p.baseURL, personalAccessToken, oauthToken, p.httpClient, p.RateLimit)
+	p.gitlabClients[key] = c
+	return c
+}
+
+type Client struct {
+	baseURL             *url.URL
+	httpClient          *http.Client
+	projCache           *rcache.Cache
+	personalAccessToken string // a personal access token to authenticate requests, if set
+	oauthToken          string // an OAuth bearer token, if set
+	RateLimit           *ratelimit.Monitor
+}
+
+// newClient creates a new GitLab API client with an optional personal access token to authenticate requests.
+//
+// The URL must point to the base URL of the GitLab instance. This is https://gitlab.com for GitLab.com and
+// http[s]://[gitlab-hostname] for self-hosted GitLab instances.
+func (p *ClientProvider) newClient(baseURL *url.URL, personalAccessToken, oauthToken string, httpClient *http.Client, rateLimit *ratelimit.Monitor) *Client {
+	// Cache for GitLab project metadata.
 	var cacheTTL time.Duration
 	if isGitLabDotComURL(baseURL) && personalAccessToken == "" && oauthToken == "" {
 		cacheTTL = 10 * time.Minute // cache for longer when unauthenticated
 	} else {
 		cacheTTL = 30 * time.Second
 	}
-
-	// Cache for GitLab project metadata.
 	key := sha256.Sum256([]byte(personalAccessToken + ":" + oauthToken + ":" + baseURL.String()))
 	projCache := rcache.NewWithTTL("gl_proj:"+base64.URLEncoding.EncodeToString(key[:]), int(cacheTTL/time.Second))
 
 	return &Client{
-		baseURL:             baseURL.ResolveReference(&url.URL{Path: path.Join(baseURL.Path, "api/v4") + "/"}),
+		baseURL:             baseURL,
+		httpClient:          httpClient,
+		projCache:           projCache,
 		personalAccessToken: personalAccessToken,
 		oauthToken:          oauthToken,
-		httpClient:          &http.Client{Transport: transport},
-		RateLimit:           &ratelimit.Monitor{},
-		projCache:           projCache,
+		RateLimit:           rateLimit,
 	}
 }
 

--- a/pkg/extsvc/gitlab/client.go
+++ b/pkg/extsvc/gitlab/client.go
@@ -91,7 +91,7 @@ type Client struct {
 	httpClient          *http.Client
 	projCache           *rcache.Cache
 	personalAccessToken string // a personal access token to authenticate requests, if set
-	oauthToken          string // an OAuth bearer token, if set
+	OAuthToken          string // an OAuth bearer token, if set
 	RateLimit           *ratelimit.Monitor
 }
 
@@ -115,7 +115,7 @@ func (p *ClientProvider) newClient(baseURL *url.URL, personalAccessToken, oauthT
 		httpClient:          httpClient,
 		projCache:           projCache,
 		personalAccessToken: personalAccessToken,
-		oauthToken:          oauthToken,
+		OAuthToken:          oauthToken,
 		RateLimit:           rateLimit,
 	}
 }
@@ -131,8 +131,8 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 	if c.personalAccessToken != "" {
 		req.Header.Set("Private-Token", c.personalAccessToken) // https://docs.gitlab.com/ee/api/README.html#personal-access-tokens
 	}
-	if c.oauthToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.oauthToken))
+	if c.OAuthToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.OAuthToken))
 	}
 
 	var resp *http.Response

--- a/pkg/extsvc/gitlab/mock.go
+++ b/pkg/extsvc/gitlab/mock.go
@@ -5,10 +5,10 @@ import (
 )
 
 // MockListProjects, if non-nil, will be called instead of every invocation of Client.ListProjects.
-var MockListProjects func(ctx context.Context, urlStr string) (proj []*Project, nextPageURL *string, err error)
+var MockListProjects func(c *Client, ctx context.Context, urlStr string) (proj []*Project, nextPageURL *string, err error)
 
 // MockListUsers, if non-nil, will be called instead of Client.ListUsers
-var MockListUsers func(ctx context.Context, urlStr string) (users []*User, nextPageURL *string, err error)
+var MockListUsers func(c *Client, ctx context.Context, urlStr string) (users []*User, nextPageURL *string, err error)
 
 // MockGetUser, if non-nil, will be called instead of Client.GetUser
-var MockGetUser func(ctx context.Context, id string) (*User, error)
+var MockGetUser func(c *Client, ctx context.Context, id string) (*User, error)

--- a/pkg/extsvc/gitlab/projects.go
+++ b/pkg/extsvc/gitlab/projects.go
@@ -176,7 +176,7 @@ func (c *Client) getProjectFromAPI(ctx context.Context, id int, pathWithNamespac
 // ListProjects lists GitLab projects.
 func (c *Client) ListProjects(ctx context.Context, urlStr string) (projs []*Project, nextPageURL *string, err error) {
 	if MockListProjects != nil {
-		return MockListProjects(ctx, urlStr)
+		return MockListProjects(c, ctx, urlStr)
 	}
 
 	req, err := http.NewRequest("GET", urlStr, nil)

--- a/pkg/extsvc/gitlab/projects_test.go
+++ b/pkg/extsvc/gitlab/projects_test.go
@@ -45,7 +45,7 @@ func newTestClient(t *testing.T) *Client {
 	return &Client{
 		baseURL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
 		httpClient: &http.Client{},
-		RateLimit:  &ratelimit.Monitor{},
+		rateLimit:  &ratelimit.Monitor{},
 		projCache:  rcache.NewWithTTL("__test__gl_proj", 1000),
 	}
 }

--- a/pkg/extsvc/gitlab/projects_test.go
+++ b/pkg/extsvc/gitlab/projects_test.go
@@ -45,7 +45,7 @@ func newTestClient(t *testing.T) *Client {
 	return &Client{
 		baseURL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
 		httpClient: &http.Client{},
-		rateLimit:  &ratelimit.Monitor{},
+		RateLimit:  &ratelimit.Monitor{},
 		projCache:  rcache.NewWithTTL("__test__gl_proj", 1000),
 	}
 }

--- a/pkg/extsvc/gitlab/user.go
+++ b/pkg/extsvc/gitlab/user.go
@@ -5,6 +5,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// GetExternalAccountData returns the deserialized user and token from the external account data
+// JSON blob in a typesafe way.
 func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *oauth2.Token, err error) {
 	var (
 		u User
@@ -26,6 +28,7 @@ func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *o
 	return usr, tok, nil
 }
 
+// SetExternalAccountData sets the user and token into the external account data blob.
 func SetExternalAccountData(data *extsvc.ExternalAccountData, user *User, token *oauth2.Token) {
 	data.SetAccountData(user)
 	data.SetAuthData(token)

--- a/pkg/extsvc/gitlab/user.go
+++ b/pkg/extsvc/gitlab/user.go
@@ -1,0 +1,32 @@
+package gitlab
+
+import (
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
+	"golang.org/x/oauth2"
+)
+
+func GetExternalAccountData(data *extsvc.ExternalAccountData) (usr *User, tok *oauth2.Token, err error) {
+	var (
+		u User
+		t oauth2.Token
+	)
+
+	if data.AccountData != nil {
+		if err := data.GetAccountData(&u); err != nil {
+			return nil, nil, err
+		}
+		usr = &u
+	}
+	if data.AuthData != nil {
+		if err := data.GetAuthData(&t); err != nil {
+			return nil, nil, err
+		}
+		tok = &t
+	}
+	return usr, tok, nil
+}
+
+func SetExternalAccountData(data *extsvc.ExternalAccountData, user *User, token *oauth2.Token) {
+	data.SetAccountData(user)
+	data.SetAuthData(token)
+}

--- a/pkg/extsvc/gitlab/users.go
+++ b/pkg/extsvc/gitlab/users.go
@@ -26,7 +26,7 @@ type Identity struct {
 
 func (c *Client) ListUsers(ctx context.Context, urlStr string) (users []*User, nextPageURL *string, err error) {
 	if MockListUsers != nil {
-		return MockListUsers(ctx, urlStr)
+		return MockListUsers(c, ctx, urlStr)
 	}
 
 	req, err := http.NewRequest("GET", urlStr, nil)
@@ -48,7 +48,7 @@ func (c *Client) ListUsers(ctx context.Context, urlStr string) (users []*User, n
 
 func (c *Client) GetUser(ctx context.Context, id string) (*User, error) {
 	if MockGetUser != nil {
-		return MockGetUser(ctx, id)
+		return MockGetUser(c, ctx, id)
 	}
 
 	var urlStr string

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -79,12 +79,6 @@ func (v *AuthProviders) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"builtin", "saml", "openidconnect", "http-header", "github", "gitlab"})
 }
 
-// AuthnProvider description: Identifies the authentication provider to use to identify users to GitLab.
-type AuthnProvider struct {
-	ConfigID       string `json:"configID"`
-	GitlabProvider string `json:"gitlabProvider"`
-	Type           string `json:"type"`
-}
 type BitbucketServerConnection struct {
 	Certificate                 string `json:"certificate,omitempty"`
 	ExcludePersonalRepositories bool   `json:"excludePersonalRepositories,omitempty"`
@@ -184,8 +178,7 @@ type GitLabAuthProvider struct {
 
 // GitLabAuthorization description: If non-null, enforces GitLab repository permissions. This requires that the value of `token` be an access token with "sudo" and "api" scopes.
 type GitLabAuthorization struct {
-	AuthnProvider AuthnProvider `json:"authnProvider"`
-	Ttl           string        `json:"ttl,omitempty"`
+	Ttl string `json:"ttl,omitempty"`
 }
 type GitLabConnection struct {
 	Authorization               *GitLabAuthorization `json:"authorization,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -366,29 +366,7 @@
         "If non-null, enforces GitLab repository permissions. This requires that the value of `token` be an access token with \"sudo\" and \"api\" scopes.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["authnProvider"],
       "properties": {
-        "authnProvider": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["configID", "type", "gitlabProvider"],
-          "description": "Identifies the authentication provider to use to identify users to GitLab.",
-          "properties": {
-            "configID": {
-              "type": "string",
-              "description": "The value of the `configID` field of the targeted authentication provider."
-            },
-            "type": {
-              "type": "string",
-              "description": "The `type` field of the targeted authentication provider."
-            },
-            "gitlabProvider": {
-              "type": "string",
-              "description":
-                "The provider name that identifies the authentication provider to GitLab. This is the name passed to the `?provider=` query parameter in calls to the GitLab Users API."
-            }
-          }
-        },
         "ttl": {
           "description":
             "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -371,29 +371,7 @@ const SiteSchemaJSON = `{
         "If non-null, enforces GitLab repository permissions. This requires that the value of ` + "`" + `token` + "`" + ` be an access token with \"sudo\" and \"api\" scopes.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["authnProvider"],
       "properties": {
-        "authnProvider": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["configID", "type", "gitlabProvider"],
-          "description": "Identifies the authentication provider to use to identify users to GitLab.",
-          "properties": {
-            "configID": {
-              "type": "string",
-              "description": "The value of the ` + "`" + `configID` + "`" + ` field of the targeted authentication provider."
-            },
-            "type": {
-              "type": "string",
-              "description": "The ` + "`" + `type` + "`" + ` field of the targeted authentication provider."
-            },
-            "gitlabProvider": {
-              "type": "string",
-              "description":
-                "The provider name that identifies the authentication provider to GitLab. This is the name passed to the ` + "`" + `?provider=` + "`" + ` query parameter in calls to the GitLab Users API."
-            }
-          }
-        },
         "ttl": {
           "description":
             "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",


### PR DESCRIPTION
Previous GitLab authz implementation required a sudo token. This replaces that implementation with one that uses a GitLab OAuth app, instead, which is consistent with what we already do for GitHub.

Old GitLab authz:
* Requires sudo-scoped access token, which increased setup friction, because this requires admin permissions
* Required a SSO authentication provider to be set in `auth.providers` (this would be the same SSO provider used to sign into the GitLab instance and would require their GitLab instance use SSO, as well)

New GitLab authz:
* Requires creating a GitLab OAuth app (any user can do this)
* Requires GitLab be set as an authentication provider in `auth.providers`

Fixes https://github.com/sourcegraph/sourcegraph/issues/1813