### PR TITLE
In browser extension, make all GraphQL api requests from background page

### DIFF
--- a/client/browser/src/browser/runtime.ts
+++ b/client/browser/src/browser/runtime.ts
@@ -18,6 +18,7 @@ export interface Message {
         | 'fetched-files'
         | 'repo-closed'
         | 'createBlobURL'
+        | 'requestGraphQL'
     payload?: any
 }
 

--- a/client/browser/src/extension/scripts/background.tsx
+++ b/client/browser/src/extension/scripts/background.tsx
@@ -15,6 +15,7 @@ import { featureFlagDefaults, FeatureFlags } from '../../browser/types'
 import initializeCli from '../../libs/cli'
 import { initSentry } from '../../libs/sentry'
 import { createBlobURLForBundle, createExtensionHostWorker } from '../../platform/worker'
+import { requestGraphQL } from '../../shared/backend/graphql'
 import { resolveClientConfiguration } from '../../shared/backend/server'
 import { DEFAULT_SOURCEGRAPH_URL, setSourcegraphUrl } from '../../shared/util/context'
 import { assertEnv } from '../envAssertion'
@@ -288,6 +289,12 @@ runtime.onMessage((message, _, cb) => {
                 .catch(err => {
                     throw new Error(`Unable to create blob url for bundle ${message.payload} error: ${err}`)
                 })
+            return true
+        case 'requestGraphQL':
+            requestGraphQL(message.payload)
+                .toPromise()
+                .then(result => cb && cb({ result }))
+                .catch(err => cb && cb({ err }))
             return true
     }
 


### PR DESCRIPTION
Fixes #1945

Makes sure all GraphQL API requests are sent from the background page, so as to bypass CORS restrictions when running on private code hosts with the public Sourcegraph instance. This allows us to run extensions on private code hosts without needing a private Sourcegraph instance.
