### PR TITLE
Fix private code host detection

### DIFF
--- a/client/browser/src/context.ts
+++ b/client/browser/src/context.ts
@@ -46,6 +46,14 @@ export const isOptions = ctx.scriptEnv === ScriptEnv.Options
 export const isExtension = ctx.appEnv === AppEnv.Extension
 export const isInPage = !isExtension
 
+export const isPublicCodeHost = ((): boolean => {
+    if (!isContent) {
+        return false
+    }
+    const { hostname } = window.location
+    return ['github.com', 'gitlab.com', 'bitbucket.org'].includes(hostname)
+})()
+
 export const isPhabricator = Boolean(document.querySelector('.phabricator-wordmark'))
 
 export default ctx

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -22,7 +22,7 @@ import {
 import { getCommandPaletteMount, getGlobalDebugMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './file_info'
 import { createOpenOnSourcegraphIfNotExists } from './inject'
-import { createCodeViewToolbarMount, getFileContainers, isGitHubEnterprise, parseURL } from './util'
+import { createCodeViewToolbarMount, getFileContainers, parseURL } from './util'
 
 const toolbarButtonProps = {
     className: 'btn btn-sm tooltipped tooltipped-n',
@@ -138,8 +138,10 @@ function checkIsGithub(): boolean {
     const href = window.location.href
 
     const isGithub = /^https?:\/\/(www.)?github.com/.test(href)
+    const ogSiteName = document.head!.querySelector(`meta[property='og:site_name']`) as HTMLMetaElement
+    const isGitHubEnterprise = ogSiteName ? ogSiteName.content === 'GitHub Enterprise' : false
 
-    return isGithub || isGitHubEnterprise()
+    return isGithub || isGitHubEnterprise
 }
 
 const getOverlayMount = () => {

--- a/client/browser/src/libs/github/util.tsx
+++ b/client/browser/src/libs/github/util.tsx
@@ -401,8 +401,3 @@ export function parseGitHubHash(hash: string): { startLine: number; endLine?: nu
     const endLine = m[2] ? parseInt(m[2], 10) : undefined
     return { startLine, endLine }
 }
-
-export function isGitHubEnterprise(): boolean {
-    const ogSiteName = document.head!.querySelector(`meta[property='og:site_name']`) as HTMLMetaElement
-    return ogSiteName ? ogSiteName.content === 'GitHub Enterprise' : false
-}

--- a/client/browser/src/shared/util/context.tsx
+++ b/client/browser/src/shared/util/context.tsx
@@ -1,6 +1,6 @@
 import * as runtime from '../../browser/runtime'
 import storage from '../../browser/storage'
-import { isPhabricator } from '../../context'
+import { isPhabricator, isPublicCodeHost } from '../../context'
 import { EventLogger } from '../tracking/EventLogger'
 
 export const DEFAULT_SOURCEGRAPH_URL = 'https://sourcegraph.com'
@@ -79,6 +79,10 @@ export function isPrivateRepository(): boolean {
     if (isPhabricator) {
         return true
     }
+    if (!isPublicCodeHost) {
+        return true
+    }
+    // @TODO(lguychard) this is github-specific and should not be in /shared
     const header = document.querySelector('.repohead-details-container')
     if (!header) {
         return false


### PR DESCRIPTION
60de302 fixed an issue on hosted Github Enterprise + public Sourcegraph whereby we failed to resolve code views because graphQL requests stemming, for example, from `ensureRevisionsAreCloned()`, would fail with `"repository not found"` instead of  `ERPRIVATEREPOPUBLICSOURCEGRAPHCOM`. This meant that extensions could not work.

I failed to anticipate that the same issue would occur on hosted Gitlab & Bitbucket. This PR reverts 60de302 and fixes the issue for all code hosts by returning `true` in `isPrivateRepository()` when we're not on a known public code host (gitlab.com, github.com, bitbucket.org).