### PR TITLE
Fix link to styleguide in the documentation dir.

### DIFF
--- a/doc/dev/style.md
+++ b/doc/dev/style.md
@@ -8,7 +8,7 @@ and [Effective Go](http://golang.org/doc/effective_go.html).
 
 # English
 
-See https://sourcegraph.com/github.com/sourcegraph/about/-/blob/website/STYLEGUIDE.md.
+See https://sourcegraph.com/github.com/sourcegraph/about/-/blob/STYLEGUIDE.md.
 
 # Code
 


### PR DESCRIPTION
Minor correction - it appears the `website/STYLEGUIDE.md` in the github.com/sourcegraph/about repository was moved in https://github.com/sourcegraph/about/pull/19 (https://github.com/sourcegraph/about/commit/2ec613e0257d4ccaba01029879f81afb7a195ded#diff-ba2dc84c4bcbe54f368b6c7d3bc1b13e).


It looks like there is a check for some broken links in some circumstances in `./dev/check/*.sh` but not for this kind of defect.

Not sure where best to add a check for this, and in any case the request to `curl -v https://sourcegraph.com/github.com/sourcegraph/about/-/blob/website/STYLEGUIDE.md` returns `200 HTTP/2 OK` so an automated check would be unlikely to catch this without upstream changes.