### PR TITLE
Fix #1327: make sure to pass getModeFromPath() a filePath and not a uri

### DIFF
--- a/shared/src/api/client/services/registry.ts
+++ b/shared/src/api/client/services/registry.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject, Observable, Unsubscribable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { getModeFromPath } from '../../../languages'
+import { parseRepoURI } from '../../../util/url'
 import { TextDocumentRegistrationOptions } from '../../protocol'
 import { match, TextDocumentIdentifier } from '../types/textDocument'
 
@@ -67,7 +68,7 @@ export abstract class DocumentFeatureProviderRegistry<
                             (filter ? filter(registrationOptions) : true) &&
                             match(registrationOptions.documentSelector, {
                                 uri: document.uri,
-                                languageId: getModeFromPath(document.uri),
+                                languageId: getModeFromPath(parseRepoURI(document.uri).filePath || ''),
                             })
                     )
                     .map(({ provider }) => provider)


### PR DESCRIPTION
`getModeFromPath()` misbehaves when passed a URI instead of a filePath, and may wrongly return `'plaintext'`, notably when passed a URI to a document at the root of a repository (#1327)
