### PR TITLE
redirect back to repositories overview after deleting repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue where the site admin is redirected to the start page instead of being redirected to the repositories overview page after deleting a repo.
+
 ### Removed
 
 ## 3.0.0-beta

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -130,7 +130,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
             .toPromise()
             .then(() => {
                 this.repoUpdates.next()
-                this.props.history.push('/')
+                this.props.history.push('/site-admin/repositories')
             })
     }
 }


### PR DESCRIPTION
The issue: When deleting a repository, the site admin would get redirected to the search page. 
A better user experience would be to be redirected to the repositories overview.

Solution: This PR fixes #1921 by redirecting back to repositories overview after deleting a repo.