### PR TITLE
symbols: add healthz endpoint

### DIFF
--- a/cmd/symbols/internal/symbols/service.go
+++ b/cmd/symbols/internal/symbols/service.go
@@ -79,8 +79,20 @@ func (s *Service) Handler() http.Handler {
 	}
 
 	mux := http.NewServeMux()
+
 	mux.HandleFunc("/search", s.handleSearch)
+	mux.HandleFunc("/healthz", s.handleHealthCheck)
+
 	return mux
+}
+
+func (s *Service) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte("Ok"))
+	if err != nil {
+		log.Printf("failed to write response to health check, err: %s", err)
+	}
 }
 
 // watchAndEvict is a loop which periodically checks the size of the cache and


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/1202

This PR adds a simple health checkpoint to the symbols service. After this is merged, I will open a PR in https://github.com/sourcegraph/deploy-sourcegraph that adds the health check to the symbols deployment. 

I haven't tested this in a K8s environment yet. However, I think it's okay to open this PR since the change is simple.  

---

We currently use the healthz endpoint as both a health/liveness check for `frontend` here: 

https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/e330905a9e932888899206a545762f1ee4a65860/base/frontend/sourcegraph-frontend.Deployment.yaml#L188-L204

While looking at https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+healthz+language:go though, it wasn't clear to me if / how that endpoint actually ensures that `frontend` is healthy/contactable (i.e. Are we sure that `frontend` is always healthy / able to field requests if `/healthz` returns a valid response? It seems like `healthz` will always return `"Ok"` no matter the circumstance). 

**Similarly to `frontend`'s implementation, the `healthz` endpoint for the symbols service in this PR doesn't do any extra validation/verification about the health of the service.**



 