### PR TITLE
doc: Include snippet to obtain a certificate

### DIFF
--- a/doc/admin/site_config/all.md
+++ b/doc/admin/site_config/all.md
@@ -660,7 +660,7 @@ Additional restrictions:
 
 ### certificate (string)
 
-TLS certificate of a GitHub Enterprise instance.
+TLS certificate of a GitHub Enterprise instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`
 
 Additional restrictions:
 
@@ -768,7 +768,7 @@ Default: `"http"`
 
 ### certificate (string)
 
-TLS certificate of a GitLab instance.
+TLS certificate of a GitLab instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`
 
 Additional restrictions:
 
@@ -878,7 +878,7 @@ Default: `"http"`
 
 ### certificate (string)
 
-TLS certificate of a Bitbucket Server instance.
+TLS certificate of a Bitbucket Server instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`
 
 Additional restrictions:
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -260,7 +260,7 @@
           "pattern": "^[^<>]+$"
         },
         "certificate": {
-          "description": "TLS certificate of a GitHub Enterprise instance.",
+          "description": "TLS certificate of a GitHub Enterprise instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
           "type": "string",
           "pattern": "^-----BEGIN CERTIFICATE-----\n"
         },
@@ -334,7 +334,7 @@
           "default": "http"
         },
         "certificate": {
-          "description": "TLS certificate of a GitLab instance.",
+          "description": "TLS certificate of a GitLab instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
           "type": "string",
           "pattern": "^-----BEGIN CERTIFICATE-----\n"
         },
@@ -437,7 +437,7 @@
           "default": "http"
         },
         "certificate": {
-          "description": "TLS certificate of a Bitbucket Server instance.",
+          "description": "TLS certificate of a Bitbucket Server instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
           "type": "string",
           "pattern": "^-----BEGIN CERTIFICATE-----\n"
         },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -265,7 +265,7 @@ const SiteSchemaJSON = `{
           "pattern": "^[^<>]+$"
         },
         "certificate": {
-          "description": "TLS certificate of a GitHub Enterprise instance.",
+          "description": "TLS certificate of a GitHub Enterprise instance. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
           "type": "string",
           "pattern": "^-----BEGIN CERTIFICATE-----\n"
         },
@@ -339,7 +339,7 @@ const SiteSchemaJSON = `{
           "default": "http"
         },
         "certificate": {
-          "description": "TLS certificate of a GitLab instance.",
+          "description": "TLS certificate of a GitLab instance. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
           "type": "string",
           "pattern": "^-----BEGIN CERTIFICATE-----\n"
         },
@@ -442,7 +442,7 @@ const SiteSchemaJSON = `{
           "default": "http"
         },
         "certificate": {
-          "description": "TLS certificate of a Bitbucket Server instance.",
+          "description": "TLS certificate of a Bitbucket Server instance. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
           "type": "string",
           "pattern": "^-----BEGIN CERTIFICATE-----\n"
         },


### PR DESCRIPTION
This is used when configuring sourcegraph to connect to a remote code host which
has an untrusted certificate. I manually updated the documentation, I am unsure
if we have something which generates the docs based on the schema.

Based on this twitter discussion https://twitter.com/keegan_csmith/status/1088045259504926721
