### PR TITLE
frontend: Return 401 for sign in page if redirecting

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -222,6 +222,28 @@ func serveHome(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
+func serveSignIn(w http.ResponseWriter, r *http.Request) error {
+	common, err := newCommon(w, r, "", serveError)
+	if err != nil {
+		return err
+	}
+	if common == nil {
+		return nil // request was handled
+	}
+	common.Title = "Sign in - Sourcegraph"
+
+	// If we are being redirected to another page after sign in, it means the
+	// user attempted to access something without authorization. Reflect this
+	// in the status code. This is useful when users curl / code which
+	// interacts with the Sourcegraph endpoints. Specifically this is a common
+	// issue facing extension developers interacting with the raw API.
+	if r.URL.Query().Get("returnTo") != "" {
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+
+	return renderTemplate(w, "app.html", common)
+}
+
 func serveStart(w http.ResponseWriter, r *http.Request) error {
 	common, err := newCommon(w, r, "Sourcegraph", serveError)
 	if err != nil {

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -187,7 +187,7 @@ func initRouter() {
 	router.Get(routeHome).Handler(handler(serveHome))
 	router.Get(routeStart).Handler(handler(serveStart))
 	router.Get(routeThreads).Handler(handler(serveBasicPageString("Threads - Sourcegraph")))
-	router.Get(uirouter.RouteSignIn).Handler(handler(serveBasicPageString("Sign in - Sourcegraph")))
+	router.Get(uirouter.RouteSignIn).Handler(handler(serveSignIn))
 	router.Get(uirouter.RouteSignUp).Handler(handler(serveBasicPageString("Sign up - Sourcegraph")))
 	router.Get(routeOrganizations).Handler(handler(serveBasicPageString("Organization - Sourcegraph")))
 	router.Get(routeSettings).Handler(handler(serveBasicPageString("Settings - Sourcegraph")))


### PR DESCRIPTION
If we are being redirected to another page after sign in, it means the user
attempted to access something without authorization. Reflect this in the
status code. This is useful when users curl / code which interacts with the
Sourcegraph endpoints. Specifically this is a common issue facing extension
developers interacting with the raw API.

Fixes https://github.com/sourcegraph/sourcegraph/issues/1248