### PR TITLE
Fix: close button in hovers overlapping text

### DIFF
--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -19,7 +19,7 @@
         right: 0;
         padding: 0.25rem;
         border-radius: 0;
-        background: transparent;
+        background: var(--body-bg);
         z-index: 1;
         border: none;
         opacity: 0;


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1935. 

Rather than adding padding as suggested in the issue, which would force us to make the close button use non-absolute positioning to affect any change, I just made the background for the close button match the background of the card. This makes it not look broken when it collides with text. @francisschmaltz I think this is a good fix, lmk if you think otherwise/have a better suggestion.

Before: 
![image](https://user-images.githubusercontent.com/16265452/51632248-ab406d80-1f03-11e9-9f6a-4a9d871a8de2.png)

After: 
![image](https://user-images.githubusercontent.com/16265452/51632203-9237bc80-1f03-11e9-99b0-60a881c91bdb.png)
