### PR TITLE
add safe update process to roadmap

### DIFF
--- a/doc/dev/roadmap/index.md
+++ b/doc/dev/roadmap/index.md
@@ -39,6 +39,7 @@ Release date: T.B.D.
 - [Java language support via extension](https://github.com/sourcegraph/sourcegraph/issues/1400)
 - [Python dependency fetching and cross repository references](https://github.com/sourcegraph/sourcegraph/issues/1401)
 - [Onboarding flow for site admins](https://github.com/sourcegraph/sourcegraph/issues/975)
+- [Safe update process](TODO(tomas))
 - Other items T.B.D.
 
 <small>[All 3.1 issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+org%3Asourcegraph+milestone%3A3.1)</small>

--- a/doc/dev/roadmap/index.md
+++ b/doc/dev/roadmap/index.md
@@ -39,7 +39,6 @@ Release date: T.B.D.
 - [Java language support via extension](https://github.com/sourcegraph/sourcegraph/issues/1400)
 - [Python dependency fetching and cross repository references](https://github.com/sourcegraph/sourcegraph/issues/1401)
 - [Onboarding flow for site admins](https://github.com/sourcegraph/sourcegraph/issues/975)
-- Safe update process
 - Other items T.B.D.
 
 <small>[All 3.1 issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+org%3Asourcegraph+milestone%3A3.1)</small>
@@ -81,6 +80,7 @@ Other
 - [Browser authorization flow for clients](https://github.com/sourcegraph/sourcegraph/pull/528)
 - Enhanced notification preferences
 - API access logging
+- Safe update process
 
 ---
 

--- a/doc/dev/roadmap/index.md
+++ b/doc/dev/roadmap/index.md
@@ -39,7 +39,7 @@ Release date: T.B.D.
 - [Java language support via extension](https://github.com/sourcegraph/sourcegraph/issues/1400)
 - [Python dependency fetching and cross repository references](https://github.com/sourcegraph/sourcegraph/issues/1401)
 - [Onboarding flow for site admins](https://github.com/sourcegraph/sourcegraph/issues/975)
-- [Safe update process](TODO(tomas))
+- Safe update process
 - Other items T.B.D.
 
 <small>[All 3.1 issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+org%3Asourcegraph+milestone%3A3.1)</small>


### PR DESCRIPTION
Assigned to @tsenart based on the discussion at https://sourcegraph.slack.com/archives/C07KZF47K/p1548268483384600. This PR is the right place to discuss whether this improvement should be prioritized.

I originally created this PR and added it under 3.1, but I decided to move it to the "Future" section to stay focused. If anyone would like to propose doing it for 3.1 because they think it is important and/or easy, make the case here on this PR.