### PR TITLE
Enable basic-code-intel by default

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -30,11 +30,11 @@ func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settings
 	for _, extensionID := range builtinExtensionIDs {
 		extensions["extensions"][extensionID] = true
 	}
-	s, err := json.Marshal(extensions)
+	contents, err := json.Marshal(extensions)
 	if err != nil {
 		return nil, err
 	}
-	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: string(s)}
+	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: string(contents)}
 	return &settingsResolver{&settingsSubject{defaultSettings: r}, settings, nil}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -9,17 +9,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
-var builtinExtensionIDs = []string{
-	"sourcegraph/typescript",
-	"sourcegraph/python",
-	"sourcegraph/java",
-	"sourcegraph/go",
-	"sourcegraph/cpp",
-	"sourcegraph/ruby",
-	"sourcegraph/php",
-	"sourcegraph/csharp",
-	"sourcegraph/shell",
-	"sourcegraph/scala",
+var builtinExtensions = map[string]bool{
+	"sourcegraph/typescript": true,
+	"sourcegraph/python":     true,
+	"sourcegraph/java":       true,
+	"sourcegraph/go":         true,
+	"sourcegraph/cpp":        true,
+	"sourcegraph/ruby":       true,
+	"sourcegraph/php":        true,
+	"sourcegraph/csharp":     true,
+	"sourcegraph/shell":      true,
+	"sourcegraph/scala":      true,
 }
 
 const singletonDefaultSettingsGQLID = "DefaultSettings"
@@ -37,11 +37,7 @@ func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
 
 func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	extensions := map[string]map[string]bool{"extensions": {}}
-	for _, extensionID := range builtinExtensionIDs {
-		extensions["extensions"][extensionID] = true
-	}
-	contents, err := json.Marshal(extensions)
+	contents, err := json.Marshal(map[string]map[string]bool{"extensions": builtinExtensions})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -10,7 +10,6 @@ import (
 )
 
 var builtinExtensionIDs = []string{
-	"sourcegraph/basic-code-intel",
 	"sourcegraph/typescript",
 	"sourcegraph/python",
 	"sourcegraph/java",

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -1,0 +1,51 @@
+package graphqlbackend
+
+import (
+	"context"
+	"encoding/json"
+
+	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+)
+
+var builtinExtensionIDs = []string{"sourcegraph/basic-code-intel"}
+
+const singletonDefaultSettingsGQLID = "Default settings"
+
+type defaultSettingsResolver struct {
+	gqlID string
+}
+
+var singletonDefaultSettingsResolver = &defaultSettingsResolver{gqlID: singletonDefaultSettingsGQLID}
+
+func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
+	return relay.MarshalID("Default settings", defaultSettingsID)
+}
+
+func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
+
+func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
+	extensions := map[string]map[string]bool{"extensions": map[string]bool{}}
+	for _, extensionID := range builtinExtensionIDs {
+		extensions["extensions"][extensionID] = true
+	}
+	s, err := json.Marshal(extensions)
+	if err != nil {
+		return nil, err
+	}
+	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: string(s)}
+	return &settingsResolver{&settingsSubject{defaultSettings: r}, settings, nil}, nil
+}
+
+func (r *defaultSettingsResolver) SettingsURL() string { return "/nonexistent" }
+
+func (r *defaultSettingsResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
+func (r *defaultSettingsResolver) SettingsCascade() *settingsCascade {
+	return &settingsCascade{subject: &settingsSubject{defaultSettings: r}}
+}
+
+func (r *defaultSettingsResolver) ConfigurationCascade() *settingsCascade { return r.SettingsCascade() }

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -49,7 +49,7 @@ func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settings
 	return &settingsResolver{&settingsSubject{defaultSettings: r}, settings, nil}, nil
 }
 
-func (r *defaultSettingsResolver) SettingsURL() string { return "/nonexistent" }
+func (r *defaultSettingsResolver) SettingsURL() *string { return nil }
 
 func (r *defaultSettingsResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	return false, nil

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -22,7 +22,7 @@ var builtinExtensionIDs = []string{
 	"sourcegraph/scala",
 }
 
-const singletonDefaultSettingsGQLID = "Default settings"
+const singletonDefaultSettingsGQLID = "DefaultSettings"
 
 type defaultSettingsResolver struct {
 	gqlID string
@@ -31,7 +31,7 @@ type defaultSettingsResolver struct {
 var singletonDefaultSettingsResolver = &defaultSettingsResolver{gqlID: singletonDefaultSettingsGQLID}
 
 func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
-	return relay.MarshalID("Default settings", defaultSettingsID)
+	return relay.MarshalID("DefaultSettings", defaultSettingsID)
 }
 
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -9,7 +9,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
-var builtinExtensionIDs = []string{"sourcegraph/basic-code-intel"}
+var builtinExtensionIDs = []string{
+	"sourcegraph/basic-code-intel",
+	"sourcegraph/typescript",
+	"sourcegraph/python",
+	"sourcegraph/java",
+	"sourcegraph/go",
+	"sourcegraph/cpp",
+	"sourcegraph/ruby",
+	"sourcegraph/php",
+	"sourcegraph/csharp",
+	"sourcegraph/shell",
+	"sourcegraph/scala",
+}
 
 const singletonDefaultSettingsGQLID = "Default settings"
 

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -26,7 +26,7 @@ func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
 
 func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	extensions := map[string]map[string]bool{"extensions": map[string]bool{}}
+	extensions := map[string]map[string]bool{"extensions": {}}
 	for _, extensionID := range builtinExtensionIDs {
 		extensions["extensions"][extensionID] = true
 	}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -78,7 +78,7 @@ func (o *OrgResolver) DisplayName() *string {
 
 func (o *OrgResolver) URL() string { return "/organizations/" + o.org.Name }
 
-func (o *OrgResolver) SettingsURL() string { return o.URL() + "/settings" }
+func (o *OrgResolver) SettingsURL() *string { return strptr(o.URL() + "/settings") }
 
 func (o *OrgResolver) CreatedAt() string { return o.org.CreatedAt.Format(time.RFC3339) }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2597,6 +2597,29 @@ enum RepositoryOrderBy {
     REPOSITORY_CREATED_AT
 }
 
+# The default settings for the Sourcegraph instance.
+type DefaultSettings implements SettingsSubject {
+    # The opaque GraphQL ID.
+    id: ID!
+    # The latest default settings (this never changes).
+    latestSettings: Settings
+    # The URL to the default settings. This URL does not exist because you
+    # cannot edit or directly view default settings.
+    settingsURL: String!
+    # Whether the viewer can modify the subject's settings. Always false for
+    # default settings.
+    viewerCanAdminister: Boolean!
+    # The default settings, and the final merged settings.
+    #
+    # All viewers can access this field.
+    settingsCascade: SettingsCascade!
+    # DEPRECATED
+    configurationCascade: ConfigurationCascade!
+        @deprecated(
+            reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
+        )
+}
+
 # A site is an installation of Sourcegraph that consists of one or more
 # servers that share the same configuration and database.
 #
@@ -2610,16 +2633,10 @@ type Site implements SettingsSubject {
     siteID: String!
     # The site's configuration. Only visible to site admins.
     configuration: SiteConfiguration!
-    # The site's latest site-wide settings (which are the lowest-precedence
+    # The site's latest site-wide settings (which are the second-lowest-precedence
     # in the configuration cascade for a user).
     latestSettings: Settings
     # The global settings for this site, and the final merged settings.
-    #
-    # Global settings are the lowest precedence level in the settings cascade and are not merged from any other
-    # settings, so there is nothing to merge. The "final merged settings" for global settings is therefore just
-    # the global settings. that were merged to produce the final merged settings. (This is different for users,
-    # for example, whose final merged settings consist of the merger of global settings and organization
-    # settings.)
     #
     # All viewers can access this field.
     settingsCascade: SettingsCascade!

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2597,7 +2597,8 @@ enum RepositoryOrderBy {
     REPOSITORY_CREATED_AT
 }
 
-# The default settings for the Sourcegraph instance.
+# The default settings for the Sourcegraph instance. This is hardcoded in
+# Sourcegraph, but may change from release to release.
 type DefaultSettings implements SettingsSubject {
     # The opaque GraphQL ID.
     id: ID!

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2059,7 +2059,7 @@ type User implements Node & SettingsSubject {
     # The URL to the user's profile on Sourcegraph.
     url: String!
     # The URL to the user's settings.
-    settingsURL: String!
+    settingsURL: String
     # The date when the user account was created on Sourcegraph.
     createdAt: String!
     # The date when the user account was last updated on Sourcegraph.
@@ -2319,7 +2319,7 @@ type Org implements Node & SettingsSubject {
     # The URL to the organization.
     url: String!
     # The URL to the organization's settings.
-    settingsURL: String!
+    settingsURL: String
     # A list of extensions published by this organization in the extension registry.
 }
 
@@ -2605,7 +2605,7 @@ type DefaultSettings implements SettingsSubject {
     latestSettings: Settings
     # The URL to the default settings. This URL does not exist because you
     # cannot edit or directly view default settings.
-    settingsURL: String!
+    settingsURL: String
     # Whether the viewer can modify the subject's settings. Always false for
     # default settings.
     viewerCanAdminister: Boolean!
@@ -2646,7 +2646,7 @@ type Site implements SettingsSubject {
             reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
         )
     # The URL to the site's settings.
-    settingsURL: String!
+    settingsURL: String
     # Whether the viewer can reload the site (with the reloadSite mutation).
     canReloadSite: Boolean!
     # Whether the viewer can modify the subject's settings.
@@ -2771,7 +2771,7 @@ interface SettingsSubject {
     # The latest settings.
     latestSettings: Settings
     # The URL to the settings.
-    settingsURL: String!
+    settingsURL: String
     # Whether the viewer can modify the subject's settings.
     viewerCanAdminister: Boolean!
     # All settings for this subject, and the individual levels in the settings cascade (global > organization > user)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2604,7 +2604,8 @@ enum RepositoryOrderBy {
     REPOSITORY_CREATED_AT
 }
 
-# The default settings for the Sourcegraph instance.
+# The default settings for the Sourcegraph instance. This is hardcoded in
+# Sourcegraph, but may change from release to release.
 type DefaultSettings implements SettingsSubject {
     # The opaque GraphQL ID.
     id: ID!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2066,7 +2066,7 @@ type User implements Node & SettingsSubject {
     # The URL to the user's profile on Sourcegraph.
     url: String!
     # The URL to the user's settings.
-    settingsURL: String!
+    settingsURL: String
     # The date when the user account was created on Sourcegraph.
     createdAt: String!
     # The date when the user account was last updated on Sourcegraph.
@@ -2326,7 +2326,7 @@ type Org implements Node & SettingsSubject {
     # The URL to the organization.
     url: String!
     # The URL to the organization's settings.
-    settingsURL: String!
+    settingsURL: String
     # A list of extensions published by this organization in the extension registry.
 }
 
@@ -2612,7 +2612,7 @@ type DefaultSettings implements SettingsSubject {
     latestSettings: Settings
     # The URL to the default settings. This URL does not exist because you
     # cannot edit or directly view default settings.
-    settingsURL: String!
+    settingsURL: String
     # Whether the viewer can modify the subject's settings. Always false for
     # default settings.
     viewerCanAdminister: Boolean!
@@ -2653,7 +2653,7 @@ type Site implements SettingsSubject {
             reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
         )
     # The URL to the site's settings.
-    settingsURL: String!
+    settingsURL: String
     # Whether the viewer can reload the site (with the reloadSite mutation).
     canReloadSite: Boolean!
     # Whether the viewer can modify the subject's settings.
@@ -2778,7 +2778,7 @@ interface SettingsSubject {
     # The latest settings.
     latestSettings: Settings
     # The URL to the settings.
-    settingsURL: String!
+    settingsURL: String
     # Whether the viewer can modify the subject's settings.
     viewerCanAdminister: Boolean!
     # All settings for this subject, and the individual levels in the settings cascade (global > organization > user)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2604,6 +2604,29 @@ enum RepositoryOrderBy {
     REPOSITORY_CREATED_AT
 }
 
+# The default settings for the Sourcegraph instance.
+type DefaultSettings implements SettingsSubject {
+    # The opaque GraphQL ID.
+    id: ID!
+    # The latest default settings (this never changes).
+    latestSettings: Settings
+    # The URL to the default settings. This URL does not exist because you
+    # cannot edit or directly view default settings.
+    settingsURL: String!
+    # Whether the viewer can modify the subject's settings. Always false for
+    # default settings.
+    viewerCanAdminister: Boolean!
+    # The default settings, and the final merged settings.
+    #
+    # All viewers can access this field.
+    settingsCascade: SettingsCascade!
+    # DEPRECATED
+    configurationCascade: ConfigurationCascade!
+        @deprecated(
+            reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
+        )
+}
+
 # A site is an installation of Sourcegraph that consists of one or more
 # servers that share the same configuration and database.
 #
@@ -2617,16 +2640,10 @@ type Site implements SettingsSubject {
     siteID: String!
     # The site's configuration. Only visible to site admins.
     configuration: SiteConfiguration!
-    # The site's latest site-wide settings (which are the lowest-precedence
+    # The site's latest site-wide settings (which are the second-lowest-precedence
     # in the configuration cascade for a user).
     latestSettings: Settings
     # The global settings for this site, and the final merged settings.
-    #
-    # Global settings are the lowest precedence level in the settings cascade and are not merged from any other
-    # settings, so there is nothing to merge. The "final merged settings" for global settings is therefore just
-    # the global settings. that were merged to produce the final merged settings. (This is different for users,
-    # for example, whose final merged settings consist of the merger of global settings and organization
-    # settings.)
     #
     # All viewers can access this field.
     settingsCascade: SettingsCascade!

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -31,7 +31,7 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 		return mockSettingsCascadeSubjects()
 	}
 
-	subjects := []*settingsSubject{{site: singletonSiteResolver}}
+	subjects := []*settingsSubject{{defaultSettings: singletonDefaultSettingsResolver}, {site: singletonSiteResolver}}
 
 	if r.unauthenticatedActor {
 		return subjects, nil

--- a/cmd/frontend/graphqlbackend/settings_cascade_test.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade_test.go
@@ -1,6 +1,7 @@
 package graphqlbackend
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -125,6 +126,22 @@ func TestMergeSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubjects(t *testing.T) {
+	t.Run("Default settings are included", func(t *testing.T) {
+		cascade := &settingsCascade{unauthenticatedActor: true}
+		subjects, err := cascade.Subjects(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(subjects) < 1 {
+			t.Fatal("Expected at least 1 subject")
+		}
+		if subjects[0].defaultSettings == nil {
+			t.Fatal("Expected the first subject to be default settings")
+		}
+	})
 }
 
 func jsonDeepEqual(a, b string) bool {

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -136,7 +136,7 @@ func (s *settingsSubject) LatestSettings(ctx context.Context) (*settingsResolver
 	}
 }
 
-func (s *settingsSubject) SettingsURL() (string, error) {
+func (s *settingsSubject) SettingsURL() (*string, error) {
 	switch {
 	case s.defaultSettings != nil:
 		return s.defaultSettings.SettingsURL(), nil
@@ -147,7 +147,7 @@ func (s *settingsSubject) SettingsURL() (string, error) {
 	case s.user != nil:
 		return s.user.SettingsURL(), nil
 	default:
-		return "", errUnknownSettingsSubject
+		return nil, errUnknownSettingsSubject
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -81,6 +81,10 @@ func settingsSubjectsEqual(a, b api.SettingsSubject) bool {
 	return false
 }
 
+func (s *settingsSubject) ToDefaultSettings() (*defaultSettingsResolver, bool) {
+	return s.defaultSettings, s.defaultSettings != nil
+}
+
 func (s *settingsSubject) ToSite() (*siteResolver, bool) {
 	return s.site, s.site != nil
 }

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -19,9 +19,10 @@ var errUnknownSettingsSubject = errors.New("unknown settings subject")
 
 type settingsSubject struct {
 	// Exactly 1 of these fields must be set.
-	site *siteResolver
-	org  *OrgResolver
-	user *UserResolver
+	defaultSettings *defaultSettingsResolver
+	site            *siteResolver
+	org             *OrgResolver
+	user            *UserResolver
 }
 
 // settingsSubjectByID fetches the settings subject with the given ID. If the ID refers to a node
@@ -103,6 +104,8 @@ func (s *settingsSubject) toSubject() api.SettingsSubject {
 
 func (s *settingsSubject) ID() (graphql.ID, error) {
 	switch {
+	case s.defaultSettings != nil:
+		return s.defaultSettings.ID(), nil
 	case s.site != nil:
 		return s.site.ID(), nil
 	case s.org != nil:
@@ -116,6 +119,8 @@ func (s *settingsSubject) ID() (graphql.ID, error) {
 
 func (s *settingsSubject) LatestSettings(ctx context.Context) (*settingsResolver, error) {
 	switch {
+	case s.defaultSettings != nil:
+		return s.defaultSettings.LatestSettings(ctx)
 	case s.site != nil:
 		return s.site.LatestSettings(ctx)
 	case s.org != nil:
@@ -129,6 +134,8 @@ func (s *settingsSubject) LatestSettings(ctx context.Context) (*settingsResolver
 
 func (s *settingsSubject) SettingsURL() (string, error) {
 	switch {
+	case s.defaultSettings != nil:
+		return s.defaultSettings.SettingsURL(), nil
 	case s.site != nil:
 		return s.site.SettingsURL(), nil
 	case s.org != nil:
@@ -142,6 +149,8 @@ func (s *settingsSubject) SettingsURL() (string, error) {
 
 func (s *settingsSubject) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	switch {
+	case s.defaultSettings != nil:
+		return s.defaultSettings.ViewerCanAdminister(ctx)
 	case s.site != nil:
 		return s.site.ViewerCanAdminister(ctx)
 	case s.org != nil:
@@ -155,6 +164,8 @@ func (s *settingsSubject) ViewerCanAdminister(ctx context.Context) (bool, error)
 
 func (s *settingsSubject) SettingsCascade() (*settingsCascade, error) {
 	switch {
+	case s.defaultSettings != nil:
+		return s.defaultSettings.SettingsCascade(), nil
 	case s.site != nil:
 		return s.site.SettingsCascade(), nil
 	case s.org != nil:

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -96,7 +96,7 @@ func (r *siteResolver) SettingsCascade() *settingsCascade {
 
 func (r *siteResolver) ConfigurationCascade() *settingsCascade { return r.SettingsCascade() }
 
-func (r *siteResolver) SettingsURL() string { return "/site-admin/global-settings" }
+func (r *siteResolver) SettingsURL() *string { return strptr("/site-admin/global-settings") }
 
 func (r *siteResolver) CanReloadSite(ctx context.Context) bool {
 	err := backend.CheckCurrentUserIsSiteAdmin(ctx)

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -96,7 +96,7 @@ func (r *UserResolver) URL() string {
 	return "/users/" + r.user.Username
 }
 
-func (r *UserResolver) SettingsURL() string { return r.URL() + "/settings" }
+func (r *UserResolver) SettingsURL() *string { return strptr(r.URL() + "/settings") }
 
 func (r *UserResolver) CreatedAt() string {
 	return r.user.CreatedAt.Format(time.RFC3339)

--- a/doc/extensions/authoring/forking.md
+++ b/doc/extensions/authoring/forking.md
@@ -6,7 +6,7 @@ If your Sourcegraph instance is unable to connect to Sourcegraph.com (due to a f
 
 1.  Download and install the latest [src](https://github.com/sourcegraph/src-cli) (Sourcegraph CLI).
 1.  [Configure and authenticate `src`](https://github.com/sourcegraph/src-cli#authentication) with the URL and an access token for your Sourcegraph instance.
-1.  Clone the repository of the extension you want to publish: [sourcegraph-codecov](https://github.com/sourcegraph/sourcegraph-codecov) or [sourcegraph-basic-code-intel](https://github.com/sourcegraph/sourcegraph-basic-code-intel).
+1.  Clone the repository of the extension you want to publish: [sourcegraph-codecov](https://github.com/sourcegraph/sourcegraph-codecov) or [sourcegraph-typescript](https://github.com/sourcegraph/sourcegraph-typescript).
 1.  Run `npm install` in the clone directory to install dependencies.
-1.  Run `src extensions publish -extension-id $USER/$NAME` in the clone directory to publish the extension locally to your Sourcegraph instance. Replace `$USER` with your Sourcegraph username and `$NAME` with with `codecov` or `basic-code-intel`.
+1.  Run `src extensions publish -extension-id $USER/$NAME` in the clone directory to publish the extension locally to your Sourcegraph instance. Replace `$USER` with your Sourcegraph username and `$NAME` with with `codecov` or `typescript`.
 1.  Enable the extension for your Sourcegraph user account by clicking on **User menu > Extensions** in the top navigation bar and then toggling the slider to on.

--- a/doc/index.md
+++ b/doc/index.md
@@ -19,8 +19,6 @@ Run a self-hosted Sourcegraph instance in 1 command:
 
 Continue at http://localhost:7080, and see [administrator documentation](admin/index.md) for next steps.
 
-Add code intelligence (hover tooltips, jump-to-definition, find-references) for languages like [Go](https://sourcegraph.com/extensions/sourcegraph/go), [TypeScript](https://sourcegraph.com/extensions/sourcegraph/typescript), [Python](https://sourcegraph.com/extensions/sourcegraph/python), and [others](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22) by enabling the corresponding [Sourcegraph extension](extensions/index.md) on the [Sourcegraph extension registry](https://sourcegraph.com/extensions).
-
 ## Overview
 
 ### Core documentation

--- a/doc/user/code_intelligence/index.md
+++ b/doc/user/code_intelligence/index.md
@@ -7,7 +7,7 @@ Code intelligence provides advanced code navigation and cross-references for you
 - Find references
 - Symbol search
 
-Code intelligence works out of the box with all of the most popular [https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22](programming language extensions).
+Code intelligence works out of the box with all of the most popular [programming language extensions](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22).
 
 You can get more accurate (but usually slower) code intelligence by enabling a dedicated language extension and setting up the corresponding language server:
 

--- a/doc/user/code_intelligence/index.md
+++ b/doc/user/code_intelligence/index.md
@@ -7,7 +7,9 @@ Code intelligence provides advanced code navigation and cross-references for you
 - Find references
 - Symbol search
 
-## Language support
+Code intelligence works out of the box with the [sourcegraph/basic-code-intel](https://sourcegraph.com/extensions/sourcegraph/basic-code-intel) extension.
+
+You can get more accurate (but usually slower) code intelligence by enabling a dedicated language extension and setting up the corresponding language server:
 
 - [Go](https://sourcegraph.com/extensions/sourcegraph/go)
 - [TypeScript](https://sourcegraph.com/extensions/sourcegraph/typescript)

--- a/doc/user/code_intelligence/index.md
+++ b/doc/user/code_intelligence/index.md
@@ -7,7 +7,7 @@ Code intelligence provides advanced code navigation and cross-references for you
 - Find references
 - Symbol search
 
-Code intelligence works out of the box with the [sourcegraph/basic-code-intel](https://sourcegraph.com/extensions/sourcegraph/basic-code-intel) extension.
+Code intelligence works out of the box with all of the most popular [https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22](programming language extensions).
 
 You can get more accurate (but usually slower) code intelligence by enabling a dedicated language extension and setting up the corresponding language server:
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -98,7 +98,7 @@ type SettingsSubject struct {
 func (s SettingsSubject) String() string {
 	switch {
 	case s.Default:
-		return "Default settings"
+		return "DefaultSettings"
 	case s.Site:
 		return "site"
 	case s.Org != nil:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -89,13 +89,16 @@ func (r *ExternalRepoSpec) String() string {
 
 // A SettingsSubject is something that can have settings. Exactly 1 field must be nonzero.
 type SettingsSubject struct {
-	Site bool   // whether this is for global settings
-	Org  *int32 // the org's ID
-	User *int32 // the user's ID
+	Default bool   // whether this is for default settings
+	Site    bool   // whether this is for global settings
+	Org     *int32 // the org's ID
+	User    *int32 // the user's ID
 }
 
 func (s SettingsSubject) String() string {
 	switch {
+	case s.Default:
+		return "Default settings"
 	case s.Site:
 		return "site"
 	case s.Org != nil:

--- a/shared/src/settings/settings.ts
+++ b/shared/src/settings/settings.ts
@@ -37,7 +37,8 @@ export type SettingsSubject = Pick<GQL.ISettingsSubject, 'id' | 'settingsURL' | 
         | Pick<IClient, '__typename' | 'displayName'>
         | Pick<GQL.IUser, '__typename' | 'username' | 'displayName'>
         | Pick<GQL.IOrg, '__typename' | 'name' | 'displayName'>
-        | Pick<GQL.ISite, '__typename'>)
+        | Pick<GQL.ISite, '__typename'>
+        | Pick<GQL.IDefaultSettings, '__typename'>)
 
 /**
  * A cascade of settings from multiple subjects, from lowest precedence to highest precedence, and the final
@@ -227,37 +228,6 @@ export function isSettingsValid<S extends Settings>(
         settingsCascade.final !== null &&
         !isErrorLike(settingsCascade.final)
     )
-}
-
-/**
- * The conventional ordering of extension settings subject types in a list.
- */
-export const SUBJECT_TYPE_ORDER: SettingsSubject['__typename'][] = ['Client', 'User', 'Org', 'Site']
-
-export function subjectTypeHeader(nodeType: SettingsSubject['__typename']): string | null {
-    switch (nodeType) {
-        case 'Client':
-            return null
-        case 'Site':
-            return null
-        case 'Org':
-            return 'Organization:'
-        case 'User':
-            return null
-    }
-}
-
-export function subjectLabel(subject: SettingsSubject): string {
-    switch (subject.__typename) {
-        case 'Client':
-            return 'Client'
-        case 'Site':
-            return 'Everyone'
-        case 'Org':
-            return subject.name
-        case 'User':
-            return subject.username
-    }
 }
 
 /**

--- a/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
+++ b/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
@@ -31,7 +31,7 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
     private static QUERY_EXTENSIONS_ARG_EXTENSION_IDS = [
         'sourcegraph/codecov',
         'sourcegraph/code-discussions',
-        'sourcegraph/basic-code-intel',
+        'sourcegraph/typescript',
         'sourcegraph/git-extras',
     ]
 

--- a/web/src/settings/SettingsArea.tsx
+++ b/web/src/settings/SettingsArea.tsx
@@ -128,6 +128,9 @@ export class SettingsArea extends React.Component<Props, State> {
             case 'Site':
                 term = 'Global'
                 break
+            case 'DefaultSettings':
+                term = 'Default settings'
+                break
             default:
                 term = 'Unknown'
                 break


### PR DESCRIPTION
This introduces `Default settings`, which is a new level of settings at the lowest level of precedence in the settings cascade (below global settings):

- **Default settings** (new)
- Global settings (A.K.A site settings in the Go code)
- Organization settings
- User settings
- Client settings

I hard-coded in Go a list of extensions that will be enabled by default:

```
var builtinExtensionIDs = []string{
	"sourcegraph/typescript",
	"sourcegraph/python",
	"sourcegraph/java",
	"sourcegraph/go",
	"sourcegraph/cpp",
	"sourcegraph/ruby",
	"sourcegraph/php",
	"sourcegraph/csharp",
	"sourcegraph/shell",
	"sourcegraph/scala",
}
```

@dadlerj Although I asked you about DB migration earlier today, I did not end up creating one.

cc @ryan-blunden 

TODO

- [x] Add `Default settings` to the GraphQL schema
- [x] Update docs to reflect that we expect language servers to be set up later and only if basic-code-intel is not sufficient
- [x] Double check frontend code to see if it needs to be updated (e.g. browser extension)
- [x] Merge 
https://github.com/sourcegraph/sourcegraph-typescript/pull/102
- [x] Remove `/nonexistent` link