### PR TITLE
Make external services token examples more clear

### DIFF
--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -14,6 +14,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 	equals := func(want ...string) func(testing.TB, []string) {
 		sort.Strings(want)
 		return func(t testing.TB, have []string) {
+			t.Helper()
 			sort.Strings(have)
 			if !reflect.DeepEqual(have, want) {
 				t.Error(pretty.Compare(have, want))
@@ -37,6 +38,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 
 	includes := func(want ...string) func(testing.TB, []string) {
 		return func(t testing.TB, have []string) {
+			t.Helper()
 			for _, err := range diff(want, have) {
 				t.Errorf("%q not found in set:\n%s", err, pretty.Sprint(have))
 			}
@@ -45,6 +47,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 
 	excludes := func(want ...string) func(testing.TB, []string) {
 		return func(t testing.TB, have []string) {
+			t.Helper()
 			for _, err := range diff(want, diff(want, have)) {
 				t.Errorf("%q found in set:\n%s", err, pretty.Sprint(have))
 			}
@@ -176,8 +179,8 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		{
 			kind:   "BITBUCKETSERVER",
 			desc:   "invalid token",
-			config: `{"token": "<foo>"}`,
-			assert: includes("token: Does not match pattern '^[^<>]+$'"),
+			config: `{"token": ""}`,
+			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
 			kind:   "BITBUCKETSERVER",
@@ -224,8 +227,8 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		{
 			kind:   "GITHUB",
 			desc:   "invalid token",
-			config: `{"token": "<foo>"}`,
-			assert: includes("token: Does not match pattern '^[^<>]+$'"),
+			config: `{"token": ""}`,
+			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
 			kind:   "GITHUB",
@@ -278,8 +281,8 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		{
 			kind:   "GITLAB",
 			desc:   "invalid token",
-			config: `{"token": "<foo>"}`,
-			assert: includes("token: Does not match pattern '^[^<>]+$'"),
+			config: `{"token": ""}`,
+			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
 			kind:   "GITLAB",
@@ -319,6 +322,12 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			desc:   "with repos",
 			config: `{"repos": [{"path": "gitolite/my/repo", "callsign": "MUX"}]}`,
 			assert: equals(`<nil>`),
+		},
+		{
+			kind:   "PHABRICATOR",
+			desc:   "invalid token",
+			config: `{"token": ""}`,
+			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
 			kind:   "PHABRICATOR",
@@ -407,8 +416,6 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.kind+"/"+tc.desc, func(t *testing.T) {
-			t.Parallel()
-
 			var have []string
 			switch e := tc.ext.validateConfig(tc.kind, tc.config).(type) {
 			case nil:

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -211,7 +211,8 @@
         },
         "token": {
           "description": "API token for the Phabricator instance.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "repos": {
           "description": "The list of repositories available on Phabricator.",
@@ -262,7 +263,7 @@
         "token": {
           "description": "A GitHub personal access token with repo and org scope.",
           "type": "string",
-          "pattern": "^[^<>]+$"
+          "minLength": 1
         },
         "certificate": {
           "description": "TLS certificate of a GitHub Enterprise instance.",
@@ -329,7 +330,7 @@
           "description":
             "A GitLab access token with \"api\" and \"sudo\" scopes. If this token does not have \"sudo\" scope, then you must set `permissions.ignore` to true.",
           "type": "string",
-          "pattern": "^[^<>]+$"
+          "minLength": 1
         },
         "gitURLType": {
           "description":
@@ -415,7 +416,7 @@
           "description":
             "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
           "type": "string",
-          "pattern": "^[^<>]+$"
+          "minLength": 1
         },
         "username": {
           "description":

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -566,7 +566,6 @@
       "description": "Connection to Git repositories for which an external service integration isn't yet available.",
       "type": "object",
       "required": ["repos"],
-      "additionalProperties": false,
       "properties": {
         "url": {
           "title": "Git clone base URL",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -571,7 +571,6 @@ const SiteSchemaJSON = `{
       "description": "Connection to Git repositories for which an external service integration isn't yet available.",
       "type": "object",
       "required": ["repos"],
-      "additionalProperties": false,
       "properties": {
         "url": {
           "title": "Git clone base URL",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -216,7 +216,8 @@ const SiteSchemaJSON = `{
         },
         "token": {
           "description": "API token for the Phabricator instance.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "repos": {
           "description": "The list of repositories available on Phabricator.",
@@ -267,7 +268,7 @@ const SiteSchemaJSON = `{
         "token": {
           "description": "A GitHub personal access token with repo and org scope.",
           "type": "string",
-          "pattern": "^[^<>]+$"
+          "minLength": 1
         },
         "certificate": {
           "description": "TLS certificate of a GitHub Enterprise instance.",
@@ -334,7 +335,7 @@ const SiteSchemaJSON = `{
           "description":
             "A GitLab access token with \"api\" and \"sudo\" scopes. If this token does not have \"sudo\" scope, then you must set ` + "`" + `permissions.ignore` + "`" + ` to true.",
           "type": "string",
-          "pattern": "^[^<>]+$"
+          "minLength": 1
         },
         "gitURLType": {
           "description":
@@ -420,7 +421,7 @@ const SiteSchemaJSON = `{
           "description":
             "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
           "type": "string",
-          "pattern": "^[^<>]+$"
+          "minLength": 1
         },
         "username": {
           "description":

--- a/web/src/site-admin/externalServices.ts
+++ b/web/src/site-admin/externalServices.ts
@@ -18,7 +18,8 @@ export const GITHUB_EXTERNAL_SERVICE: ExternalServiceMetadata = {
 
   // A token is required for access to private repos, but is also helpful for public repos
   // because it grants a higher hourly rate limit to Sourcegraph.
-  "token": "<personal access token with repo scope (https://github.com/settings/tokens/new)>",
+  // Create one with the repo scope at https://[your-github-instance]/settings/tokens/new
+  "token": "",
 
   // Sync public repositories from https://github.com by adding them to "repos".
   // (This is not necessary for GitHub Enterprise instances)
@@ -52,7 +53,10 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
   // https://docs.sourcegraph.com/admin/site_config/all#bitbucketserverconnection-object
 
   "url": "https://bitbucket.example.com",
-  "token": "<personal access token with read scope (https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add)>"
+
+  // Create a personal access token with read scope at
+  // https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add
+  "token": ""
 }`,
     },
     GITHUB_EXTERNAL_SERVICE,
@@ -65,7 +69,10 @@ export const ALL_EXTERNAL_SERVICES: ExternalServiceMetadata[] = [
   // https://docs.sourcegraph.com/admin/site_config/all#gitlabconnection-object
 
   "url": "https://gitlab.example.com",
-  "token": "<personal access token with api scope (https://[your-gitlab-hostname]/profile/personal_access_tokens)>"
+
+  // Create a personal access token with api scope at
+  // https://[your-gitlab-hostname]/profile/personal_access_tokens
+  "token": ""
 }`,
     },
     {


### PR DESCRIPTION
This PR is based on the still open #2017. Once that's merged, I'll rebase this with master.

Fixes #2042

