### PR TITLE
Improve styling of errors in the root of the file tree

### DIFF
--- a/web/src/repo/RepoRevSidebar.tsx
+++ b/web/src/repo/RepoRevSidebar.tsx
@@ -78,11 +78,13 @@ export class RepoRevSidebar extends React.PureComponent<Props, State> {
             )
         }
 
+        const STORAGE_KEY = 'repo-rev-sidebar'
+
         return (
             <Resizable
                 className="repo-rev-container__sidebar-resizable"
                 handlePosition="right"
-                storageKey="repo-rev-sidebar"
+                storageKey={STORAGE_KEY}
                 defaultSize={256 /* px */}
                 element={
                     <TabsWithLocalStorageViewStatePersistence
@@ -117,6 +119,7 @@ export class RepoRevSidebar extends React.PureComponent<Props, State> {
                             scrollRootSelector="#explorer"
                             activePath={this.props.filePath}
                             activePathIsDir={this.props.isDir}
+                            sizeKey={`Resizable:${STORAGE_KEY}`}
                         />
                         <RepoRevSidebarSymbols
                             key="symbols"

--- a/web/src/tree/Tree.scss
+++ b/web/src/tree/Tree.scss
@@ -53,6 +53,12 @@
         margin: 0;
     }
 
+    &__row-alert-root {
+        display: block;
+        padding: 0.75rem 1.25rem;
+        white-space: pre-wrap;
+    }
+
     &__row-icon {
         color: #ffffff !important; // override link color
         // stylelint-disable-next-line declaration-property-unit-whitelist

--- a/web/src/tree/Tree.scss
+++ b/web/src/tree/Tree.scss
@@ -49,14 +49,9 @@
 
     &__row-alert {
         display: block;
-        padding: 0.25rem 0;
-        margin: 0;
-    }
-
-    &__row-alert-root {
-        display: block;
         padding: 0.75rem 1.25rem;
         white-space: pre-wrap;
+        margin-bottom: 0;
     }
 
     &__row-icon {

--- a/web/src/tree/Tree.tsx
+++ b/web/src/tree/Tree.tsx
@@ -19,6 +19,8 @@ interface Props extends AbsoluteRepo {
 
     /** Whether the active path is a directory (including the root directory). False if it is a file. */
     activePathIsDir: boolean
+    /** The localStorage key that stores the current size of the (resizable) RepoRevSidebar. */
+    sizeKey: string
 }
 
 interface State {
@@ -246,6 +248,7 @@ export class Tree extends React.PureComponent<Props, State> {
                     selectedNode={this.state.selectedNode}
                     setChildNodes={this.setChildNode}
                     setActiveNode={this.setActiveNode}
+                    sizeKey={this.props.sizeKey}
                 />
             </div>
         )

--- a/web/src/tree/TreeRoot.tsx
+++ b/web/src/tree/TreeRoot.tsx
@@ -19,7 +19,6 @@ import { AbsoluteRepo } from '../../../shared/src/util/url'
 import { fetchTreeEntries } from '../repo/backend'
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeNode } from './Tree'
-import { treePadding } from './util'
 import { hasSingleChild, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
 
 const maxEntries = 2500
@@ -155,7 +154,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
             <>
                 {isErrorLike(treeOrError) ? (
                     <div
-                        className="tree__row tree__row-alert-root alert alert-danger"
+                        className="tree__row tree__row-alert alert alert-danger"
                         // tslint:disable-next-line:jsx-ban-props (needed because of dynamic styling)
                         style={errorWidth(localStorage.getItem(this.props.sizeKey) ? this.props.sizeKey : undefined)}
                     >

--- a/web/src/tree/TreeRoot.tsx
+++ b/web/src/tree/TreeRoot.tsx
@@ -41,6 +41,7 @@ export interface TreeRootProps extends AbsoluteRepo {
     onToggleExpand: (path: string, expanded: boolean, node: TreeNode) => void
     setChildNodes: (node: TreeNode, index: number) => void
     setActiveNode: (node: TreeNode) => void
+    sizeKey: string
 }
 
 const LOADING: 'loading' = 'loading'
@@ -151,41 +152,45 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
         }
 
         return (
-            <table className="tree-layer" tabIndex={0}>
-                <tbody>
-                    <tr>
-                        <td className="tree__cell">
-                            {treeOrError === LOADING ? (
-                                <div className="tree__row-loader">
-                                    <LoadingSpinner className="icon-inline tree-page__entries-loader" />
-                                    Loading tree
-                                </div>
-                            ) : isErrorLike(treeOrError) ? (
-                                <div
-                                    className="tree__row tree__row-alert alert alert-danger"
-                                    // tslint:disable-next-line:jsx-ban-props (needed because of dynamic styling)
-                                    style={treePadding(this.props.depth, true)}
-                                >
-                                    Error loading tree: {treeOrError.message}
-                                </div>
-                            ) : (
-                                treeOrError && (
-                                    <ChildTreeLayer
-                                        {...this.props}
-                                        parent={this.node}
-                                        depth={-1 as number}
-                                        entries={treeOrError.entries}
-                                        singleChildTreeEntry={singleChildTreeEntry}
-                                        childrenEntries={singleChildTreeEntry.children}
-                                        onHover={this.fetchChildContents}
-                                        setChildNodes={this.setChildNode}
-                                    />
-                                )
-                            )}
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <>
+                {isErrorLike(treeOrError) ? (
+                    <div
+                        className="tree__row tree__row-alert-root alert alert-danger"
+                        // tslint:disable-next-line:jsx-ban-props (needed because of dynamic styling)
+                        style={errorWidth(localStorage.getItem(this.props.sizeKey) ? this.props.sizeKey : undefined)}
+                    >
+                        Error loading tree: {treeOrError.message}
+                    </div>
+                ) : (
+                    <table className="tree-layer" tabIndex={0}>
+                        <tbody>
+                            <tr>
+                                <td className="tree__cell">
+                                    {treeOrError === LOADING ? (
+                                        <div className="tree__row-loader">
+                                            <LoadingSpinner className="icon-inline tree-page__entries-loader" />
+                                            Loading tree
+                                        </div>
+                                    ) : (
+                                        treeOrError && (
+                                            <ChildTreeLayer
+                                                {...this.props}
+                                                parent={this.node}
+                                                depth={-1 as number}
+                                                entries={treeOrError.entries}
+                                                singleChildTreeEntry={singleChildTreeEntry}
+                                                childrenEntries={singleChildTreeEntry.children}
+                                                onHover={this.fetchChildContents}
+                                                setChildNodes={this.setChildNode}
+                                            />
+                                        )
+                                    )}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                )}
+            </>
         )
     }
     /**
@@ -200,3 +205,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
         this.node.childNodes[index] = node
     }
 }
+
+const errorWidth = (width?: string) => ({
+    width: width ? `${width}px` : 'auto',
+})


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1963

Now looks like this:
![image](https://user-images.githubusercontent.com/16265452/51873406-e2eb5300-2311-11e9-8277-9601685b39fb.png)
![image](https://user-images.githubusercontent.com/16265452/51873643-da474c80-2312-11e9-8349-470e59779feb.png)
