### PR TITLE
Don't get file contents from the DOM

### DIFF
--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -2,7 +2,7 @@ import { AdjustmentDirection, DOMFunctions, PositionAdjuster } from '@sourcegrap
 import { of } from 'rxjs'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
 import { CodeHost, CodeViewResolver, CodeViewWithOutSelector } from '../code_intelligence'
-import { diffDOMFunctions, getLineRanges, singleFileDOMFunctions } from './dom_functions'
+import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { resolveDiffFileInfo, resolveFileInfo } from './file_info'
 
 const createToolbarMount = (codeView: HTMLElement) => {
@@ -62,7 +62,6 @@ const singleFileCodeView: CodeViewWithOutSelector = {
     getToolbarMount: createToolbarMount,
     dom: singleFileDOMFunctions,
     resolveFileInfo,
-    getLineRanges,
     adjustPosition: createPositionAdjuster(singleFileDOMFunctions),
     toolbarButtonProps: {
         className: 'aui-button',

--- a/client/browser/src/libs/bitbucket/dom_functions.ts
+++ b/client/browser/src/libs/bitbucket/dom_functions.ts
@@ -39,18 +39,6 @@ export const singleFileDOMFunctions: DOMFunctions = {
     },
 }
 
-export const getLineRanges = (codeView: HTMLElement) => {
-    const first = codeView.querySelector<HTMLElement>('div.line:first-of-type')!
-    const last = codeView.querySelector<HTMLElement>('div.line:last-of-type')!
-
-    return [
-        {
-            start: singleFileDOMFunctions.getLineNumberFromCodeElement(first),
-            end: singleFileDOMFunctions.getLineNumberFromCodeElement(last),
-        },
-    ]
-}
-
 export const diffDOMFunctions: DOMFunctions = {
     getCodeElementFromTarget: singleFileDOMFunctions.getCodeElementFromTarget,
     getLineNumberFromCodeElement: codeElement => {

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -461,7 +461,7 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                         item: {
                             uri: toURIWithPath(info),
                             languageId: getModeFromPath(info.filePath) || 'could not determine mode',
-                            text: info.content,
+                            text: info.content!,
                         },
                         selections: [],
                         isActive: true,

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -13,7 +13,7 @@ import * as H from 'history'
 import * as React from 'react'
 import { createPortal, render } from 'react-dom'
 import { animationFrameScheduler, Observable, of, Subject, Subscription } from 'rxjs'
-import { catchError, filter, map, mergeMap, observeOn, withLatestFrom } from 'rxjs/operators'
+import { catchError, filter, map, mergeMap, observeOn, switchMap, withLatestFrom } from 'rxjs/operators'
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 
 import { ActionItemProps } from '../../../../../shared/src/actions/ActionItem'
@@ -46,7 +46,7 @@ import { bitbucketServerCodeHost } from '../bitbucket/code_intelligence'
 import { githubCodeHost } from '../github/code_intelligence'
 import { gitlabCodeHost } from '../gitlab/code_intelligence'
 import { phabricatorCodeHost } from '../phabricator/code_intelligence'
-import { findCodeViews, getContentOfCodeView } from './code_views'
+import { fetchFileContents, findCodeViews } from './code_views'
 import { applyDecorations, initializeExtensions } from './extensions'
 import { injectViewContextOnSourcegraph } from './external_links'
 
@@ -83,17 +83,6 @@ export interface CodeView {
     toolbarButtonProps?: ButtonProps
 
     isDiff?: boolean
-
-    /** Gets the 1-indexed range of the code view */
-    getLineRanges?: (
-        codeView: HTMLElement,
-        part?: DiffPart
-    ) => {
-        /** The first line shown in the code view. */
-        start: number
-        /** The last line shown in the code view. */
-        end: number
-    }[]
 }
 
 export type CodeViewWithOutSelector = Pick<CodeView, Exclude<keyof CodeView, 'selector'>>
@@ -445,149 +434,127 @@ function handleCodeHost(codeHost: CodeHost): Subscription {
                 mergeMap(({ codeView, resolveFileInfo, ...rest }) =>
                     resolveFileInfo(codeView).pipe(map(info => ({ info, codeView, ...rest })))
                 ),
+                switchMap(({ info, ...rest }) =>
+                    fetchFileContents(info).pipe(map(infoWithContents => ({ info: infoWithContents, ...rest })))
+                ),
                 observeOn(animationFrameScheduler)
             )
-            .subscribe(
-                ({
-                    codeView,
-                    info,
-                    isDiff,
-                    getLineRanges,
-                    dom,
-                    adjustPosition,
-                    getToolbarMount,
-                    toolbarButtonProps,
-                }) => {
-                    const originalDOM = dom
-                    dom = {
-                        ...dom,
-                        // If any parent element has the sourcegraph-extension-element
-                        // class then that element does not have any code. We
-                        // must check for "any parent element" because extensions
-                        // create their DOM changes before the blob is tokenized
-                        // into multiple elements.
-                        getCodeElementFromTarget: (target: HTMLElement): HTMLElement | null =>
-                            target.closest('.sourcegraph-extension-element') !== null
-                                ? null
-                                : originalDOM.getCodeElementFromTarget(target),
-                    }
+            .subscribe(({ codeView, info, dom, adjustPosition, getToolbarMount, toolbarButtonProps }) => {
+                const originalDOM = dom
+                dom = {
+                    ...dom,
+                    // If any parent element has the sourcegraph-extension-element
+                    // class then that element does not have any code. We
+                    // must check for "any parent element" because extensions
+                    // create their DOM changes before the blob is tokenized
+                    // into multiple elements.
+                    getCodeElementFromTarget: (target: HTMLElement): HTMLElement | null =>
+                        target.closest('.sourcegraph-extension-element') !== null
+                            ? null
+                            : originalDOM.getCodeElementFromTarget(target),
+                }
 
-                    let content = info.content
-                    let baseContent = info.baseContent
-
-                    if (!content) {
-                        if (!getLineRanges) {
-                            throw new Error('Must either provide a line range getter or provide file contents')
-                        }
-
-                        const contents = getContentOfCodeView(codeView, { isDiff, getLineRanges, dom })
-
-                        content = contents.content
-                        baseContent = contents.baseContent
-                    }
-
-                    visibleViewComponents = [
-                        // Either a normal file, or HEAD when codeView is a diff
-                        {
-                            type: 'textEditor',
-                            item: {
-                                uri: toURIWithPath(info),
-                                languageId: getModeFromPath(info.filePath) || 'could not determine mode',
-                                text: content!,
-                            },
-                            selections: [],
-                            isActive: true,
+                visibleViewComponents = [
+                    // Either a normal file, or HEAD when codeView is a diff
+                    {
+                        type: 'textEditor',
+                        item: {
+                            uri: toURIWithPath(info),
+                            languageId: getModeFromPath(info.filePath) || 'could not determine mode',
+                            text: info.content,
                         },
-                        // All the currently open documents, which are all now considered inactive.
-                        ...visibleViewComponents.map(c => ({ ...c, isActive: false })),
-                    ]
-                    const roots: Model['roots'] = [{ uri: toRootURI(info), inputRevision: info.rev || '' }]
+                        selections: [],
+                        isActive: true,
+                    },
+                    // All the currently open documents, which are all now considered inactive.
+                    ...visibleViewComponents.map(c => ({ ...c, isActive: false })),
+                ]
+                const roots: Model['roots'] = [{ uri: toRootURI(info), inputRevision: info.rev || '' }]
 
-                    // When codeView is a diff, add BASE too.
-                    if (baseContent! && info.baseRepoName && info.baseCommitID && info.baseFilePath) {
-                        visibleViewComponents.push({
-                            type: 'textEditor',
-                            item: {
-                                uri: toURIWithPath({
-                                    repoName: info.baseRepoName,
-                                    commitID: info.baseCommitID,
-                                    filePath: info.baseFilePath,
-                                }),
-                                languageId: getModeFromPath(info.filePath) || 'could not determine mode',
-                                text: baseContent!,
-                            },
-                            // There is no notion of a selection on code hosts yet, so this is empty.
-                            //
-                            // TODO: Support interpreting GitHub #L1-2, etc., URL fragments as selections (and
-                            // similar on other code hosts), or find some other way to get this info.
-                            selections: [],
-                            isActive: false,
-                        })
-                        roots.push({
-                            uri: toRootURI({
+                // When codeView is a diff, add BASE too.
+                if (info.baseContent && info.baseRepoName && info.baseCommitID && info.baseFilePath) {
+                    visibleViewComponents.push({
+                        type: 'textEditor',
+                        item: {
+                            uri: toURIWithPath({
                                 repoName: info.baseRepoName,
                                 commitID: info.baseCommitID,
+                                filePath: info.baseFilePath,
                             }),
-                            inputRevision: info.baseRev || '',
-                        })
-                    }
-
-                    let decoratedLines: number[] = []
-                    if (!info.baseCommitID) {
-                        extensionsController.services.textDocumentDecoration
-                            .getDecorations(toTextDocumentIdentifier(info))
-                            .subscribe(decorations => {
-                                decoratedLines = applyDecorations(dom, codeView, decorations || [], decoratedLines)
-                            })
-                    }
-
-                    extensionsController.services.model.model.next({ roots, visibleViewComponents })
-
-                    const resolveContext: ContextResolver<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec> = ({
-                        part,
-                    }) => ({
-                        repoName: part === 'base' ? info.baseRepoName || info.repoName : info.repoName,
-                        commitID: part === 'base' ? info.baseCommitID! : info.commitID,
-                        filePath: part === 'base' ? info.baseFilePath || info.filePath : info.filePath,
-                        rev: part === 'base' ? info.baseRev || info.baseCommitID! : info.rev || info.commitID,
+                            languageId: getModeFromPath(info.filePath) || 'could not determine mode',
+                            text: info.baseContent,
+                        },
+                        // There is no notion of a selection on code hosts yet, so this is empty.
+                        //
+                        // TODO: Support interpreting GitHub #L1-2, etc., URL fragments as selections (and
+                        // similar on other code hosts), or find some other way to get this info.
+                        selections: [],
+                        isActive: false,
                     })
-
-                    subscriptions.add(
-                        hoverifier.hoverify({
-                            dom,
-                            positionEvents: of(codeView).pipe(findPositionsFromEvents(dom)),
-                            resolveContext,
-                            adjustPosition,
-                        })
-                    )
-
-                    codeView.classList.add('sg-mounted')
-
-                    if (!getToolbarMount) {
-                        return
-                    }
-
-                    const mount = getToolbarMount(codeView)
-
-                    render(
-                        <TelemetryContext.Provider value={eventLogger}>
-                            <CodeViewToolbar
-                                {...info}
-                                platformContext={platformContext}
-                                extensionsController={extensionsController}
-                                buttonProps={
-                                    toolbarButtonProps || {
-                                        className: '',
-                                        style: {},
-                                    }
-                                }
-                                location={H.createLocation(window.location)}
-                            />
-                        </TelemetryContext.Provider>,
-                        mount
-                    )
+                    roots.push({
+                        uri: toRootURI({
+                            repoName: info.baseRepoName,
+                            commitID: info.baseCommitID,
+                        }),
+                        inputRevision: info.baseRev || '',
+                    })
                 }
-            )
+
+                let decoratedLines: number[] = []
+                if (!info.baseCommitID) {
+                    extensionsController.services.textDocumentDecoration
+                        .getDecorations(toTextDocumentIdentifier(info))
+                        .subscribe(decorations => {
+                            decoratedLines = applyDecorations(dom, codeView, decorations || [], decoratedLines)
+                        })
+                }
+
+                extensionsController.services.model.model.next({ roots, visibleViewComponents })
+
+                const resolveContext: ContextResolver<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec> = ({
+                    part,
+                }) => ({
+                    repoName: part === 'base' ? info.baseRepoName || info.repoName : info.repoName,
+                    commitID: part === 'base' ? info.baseCommitID! : info.commitID,
+                    filePath: part === 'base' ? info.baseFilePath || info.filePath : info.filePath,
+                    rev: part === 'base' ? info.baseRev || info.baseCommitID! : info.rev || info.commitID,
+                })
+
+                subscriptions.add(
+                    hoverifier.hoverify({
+                        dom,
+                        positionEvents: of(codeView).pipe(findPositionsFromEvents(dom)),
+                        resolveContext,
+                        adjustPosition,
+                    })
+                )
+
+                codeView.classList.add('sg-mounted')
+
+                if (!getToolbarMount) {
+                    return
+                }
+
+                const mount = getToolbarMount(codeView)
+
+                render(
+                    <TelemetryContext.Provider value={eventLogger}>
+                        <CodeViewToolbar
+                            {...info}
+                            platformContext={platformContext}
+                            extensionsController={extensionsController}
+                            buttonProps={
+                                toolbarButtonProps || {
+                                    className: '',
+                                    style: {},
+                                }
+                            }
+                            location={H.createLocation(window.location)}
+                        />
+                    </TelemetryContext.Provider>,
+                    mount
+                )
+            })
     )
 
     return subscriptions

--- a/client/browser/src/libs/code_intelligence/code_views.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.ts
@@ -1,10 +1,9 @@
 import { propertyIsDefined } from '@sourcegraph/codeintellify/lib/helpers'
-import { last, range } from 'lodash'
-import { from, merge, Observable, of, Subject } from 'rxjs'
-import { filter, map, mergeMap } from 'rxjs/operators'
+import { from, merge, Observable, of, Subject, zip } from 'rxjs'
+import { catchError, filter, map, mergeMap } from 'rxjs/operators'
 
-import { DiffPart } from '@sourcegraph/codeintellify'
-import { CodeHost, CodeView, ResolvedCodeView } from './code_intelligence'
+import { fetchBlobContentLines } from '../../shared/repo/backend'
+import { CodeHost, FileInfo, ResolvedCodeView } from './code_intelligence'
 
 /**
  * Emits a ResolvedCodeView when it's DOM element is on or about to be on the page.
@@ -132,35 +131,33 @@ export interface CodeViewContent {
     baseContent?: string
 }
 
-export const getContentOfCodeView = (
-    codeView: HTMLElement,
-    info: Pick<CodeView, 'dom' | 'isDiff' | 'getLineRanges'>
-): CodeViewContent => {
-    const getContent = (part?: DiffPart): string => {
-        const lines = new Map<number, string>()
-        let min = 1
-        let max = 1
+export const fetchFileContents = (info: FileInfo) => {
+    const fetchingBaseFile = info.baseCommitID
+        ? fetchBlobContentLines({
+              repoName: info.repoName,
+              filePath: info.baseFilePath || info.filePath,
+              commitID: info.baseCommitID,
+          })
+        : of(null)
 
-        for (const { start, end } of info.getLineRanges!(codeView, part)) {
-            for (const line of range(start, end + 1)) {
-                min = Math.min(min, line)
-                max = Math.max(max, line)
+    const fetchingHeadFile = fetchBlobContentLines({
+        repoName: info.repoName,
+        filePath: info.filePath,
+        commitID: info.commitID,
+    })
 
-                const codeElement = info.dom.getCodeElementFromLineNumber(codeView, line, part)
-                if (codeElement) {
-                    lines.set(line, codeElement.textContent || '')
-                }
-            }
-        }
+    return zip(fetchingBaseFile, fetchingHeadFile).pipe(
+        map(([baseFileContent, headFileContent]) => ({
+            ...info,
+            baseContent: baseFileContent ? baseFileContent.join('\n') : undefined,
+            content: headFileContent.join('\n'),
+            headHasFileContents: headFileContent.length > 0,
+            baseHasFileContents: baseFileContent ? baseFileContent.length > 0 : undefined,
+        })),
+        catchError(error => {
+            console.log(error)
 
-        return range(min, max + 1)
-            .map(line => lines.get(line) || '\n')
-            .map(content => (last(content) === '\n' ? content : `${content}\n`))
-            .join('')
-    }
-
-    return {
-        content: getContent(info.isDiff ? 'head' : undefined),
-        baseContent: info.isDiff ? getContent('base') : undefined,
-    }
+            return [info]
+        })
+    )
 }

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -12,13 +12,7 @@ import {
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { toAbsoluteBlobURL } from '../../shared/util/url'
 import { CodeHost, CodeView, CodeViewResolver, CodeViewWithOutSelector } from '../code_intelligence'
-import {
-    diffDomFunctions,
-    getDiffLineRanges,
-    getLineRanges,
-    searchCodeSnippetDOMFunctions,
-    singleFileDOMFunctions,
-} from './dom_functions'
+import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { getCommandPaletteMount, getGlobalDebugMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './file_info'
 import { createOpenOnSourcegraphIfNotExists } from './inject'
@@ -34,7 +28,6 @@ const diffCodeView: CodeViewWithOutSelector = {
     getToolbarMount: createCodeViewToolbarMount,
     resolveFileInfo: resolveDiffFileInfo,
     toolbarButtonProps,
-    getLineRanges: getDiffLineRanges,
     isDiff: true,
 }
 
@@ -48,7 +41,6 @@ const singleFileCodeView: CodeViewWithOutSelector = {
     getToolbarMount: createCodeViewToolbarMount,
     resolveFileInfo,
     toolbarButtonProps,
-    getLineRanges,
     isDiff: false,
 }
 
@@ -94,7 +86,6 @@ const searchResultCodeView: CodeView = {
     adjustPosition: adjustPositionForSnippet,
     resolveFileInfo: resolveSnippetFileInfo,
     toolbarButtonProps,
-    getLineRanges,
     isDiff: false,
 }
 
@@ -104,7 +95,6 @@ const commentSnippetCodeView: CodeView = {
     resolveFileInfo: resolveSnippetFileInfo,
     adjustPosition: adjustPositionForSnippet,
     toolbarButtonProps,
-    getLineRanges,
     isDiff: false,
 }
 

--- a/client/browser/src/libs/github/dom_functions.ts
+++ b/client/browser/src/libs/github/dom_functions.ts
@@ -1,5 +1,4 @@
 import { DiffPart, DOMFunctions } from '@sourcegraph/codeintellify'
-import { CodeView } from '../code_intelligence'
 import { isDomSplitDiff } from './util'
 
 const getDiffCodePart = (codeElement: HTMLElement): DiffPart => {
@@ -186,76 +185,4 @@ export const searchCodeSnippetDOMFunctions: DOMFunctions = {
 
         return parseInt(cell.firstElementChild!.textContent!, 10)
     },
-}
-
-export const getLineRanges: CodeView['getLineRanges'] = codeView => {
-    const firstLine = codeView.querySelector<HTMLTableRowElement>('tr:first-of-type td.blob-code')
-    if (!firstLine) {
-        throw new Error('Unable to determine start line of code view')
-    }
-
-    const lastLine = codeView.querySelector<HTMLTableRowElement>('tr:last-of-type td.blob-code')
-    if (!lastLine) {
-        throw new Error('Unable to determine start line of code view')
-    }
-
-    const getLineNumber = (line: HTMLElement) => {
-        const codeElement = singleFileDOMFunctions.getCodeElementFromTarget(line)!
-
-        return singleFileDOMFunctions.getLineNumberFromCodeElement(codeElement)
-    }
-
-    return [
-        {
-            start: getLineNumber(firstLine),
-            end: getLineNumber(lastLine),
-        },
-    ]
-}
-
-export const getDiffLineRanges: CodeView['getLineRanges'] = (codeView, part) => {
-    const ranges: { start: number; end: number }[] = []
-
-    let start: number | null = null
-    let end: number | null = null
-
-    for (const row of codeView.querySelectorAll<HTMLTableRowElement>('tr')) {
-        const isCode =
-            !row.classList.contains('js-expandable-line') &&
-            !row.classList.contains('js-inline-comments-container') &&
-            !row.querySelector('[data-line-number="..."]')
-
-        if (isCode) {
-            const line = row.querySelector<HTMLElement>(
-                `td${isDomSplitDiff() ? `:nth-of-type(${part === 'base' ? 2 : 4})` : '.blob-code'}`
-            )
-
-            if (
-                !line ||
-                line.classList.contains('empty-cell') ||
-                line.classList.contains(part === 'base' ? 'blob-code-addition' : 'blob-code-deletion')
-            ) {
-                // Empty row
-                continue
-            }
-
-            const numCell = row.querySelector<HTMLElement>(`td:nth-of-type(${getLineNumberElementIndex(part!) + 1})`)!
-
-            const num = parseInt(numCell.dataset.lineNumber!, 10)
-            if (start === null) {
-                start = num
-            } else {
-                end = num
-            }
-        } else if (start && end) {
-            ranges.push({ start, end })
-        }
-
-        if (!isCode) {
-            start = null
-            end = null
-        }
-    }
-
-    return ranges
 }

--- a/client/browser/src/libs/gitlab/code_intelligence.ts
+++ b/client/browser/src/libs/gitlab/code_intelligence.ts
@@ -1,10 +1,5 @@
 import { CodeHost, CodeViewResolver, CodeViewWithOutSelector } from '../code_intelligence'
-import {
-    diffDOMFunctions,
-    diffFileGetLineRanges,
-    singleFileDOMFunctions,
-    singleFileGetLineRanges,
-} from './dom_functions'
+import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { getCommandPaletteMount } from './extensions'
 import { resolveCommitFileInfo, resolveDiffFileInfo, resolveFileInfo } from './file_info'
 import { getPageInfo, GitLabPageKind } from './scrape'
@@ -54,7 +49,6 @@ const singleFileCodeView: CodeViewWithOutSelector = {
     getToolbarMount: createToolbarMount,
     resolveFileInfo,
     toolbarButtonProps,
-    getLineRanges: singleFileGetLineRanges,
 }
 
 const mergeRequestCodeView: CodeViewWithOutSelector = {
@@ -63,7 +57,6 @@ const mergeRequestCodeView: CodeViewWithOutSelector = {
     getToolbarMount: createToolbarMount,
     resolveFileInfo: resolveDiffFileInfo,
     toolbarButtonProps,
-    getLineRanges: diffFileGetLineRanges,
 }
 
 const commitCodeView: CodeViewWithOutSelector = {
@@ -72,7 +65,6 @@ const commitCodeView: CodeViewWithOutSelector = {
     getToolbarMount: createToolbarMount,
     resolveFileInfo: resolveCommitFileInfo,
     toolbarButtonProps,
-    getLineRanges: diffFileGetLineRanges,
 }
 
 const resolveCodeView = (codeView: HTMLElement): CodeViewWithOutSelector => {

--- a/client/browser/src/libs/gitlab/dom_functions.ts
+++ b/client/browser/src/libs/gitlab/dom_functions.ts
@@ -1,5 +1,4 @@
 import { DOMFunctions } from '@sourcegraph/codeintellify'
-import { CodeView } from '../code_intelligence'
 
 export const singleFileDOMFunctions: DOMFunctions = {
     getCodeElementFromTarget: target => target.closest('span.line') as HTMLElement | null,
@@ -67,66 +66,4 @@ export const diffDOMFunctions: DOMFunctions = {
         return row.querySelector<HTMLElement>(selector)
     },
     getDiffCodePart,
-}
-
-export const singleFileGetLineRanges: CodeView['getLineRanges'] = codeView => {
-    const firstLine = codeView.querySelector<HTMLTableRowElement>('.line:first-of-type')
-    if (!firstLine) {
-        throw new Error('Unable to determine start line of code view')
-    }
-
-    const lastLine = codeView.querySelector<HTMLTableRowElement>('.line:last-of-type')
-    if (!lastLine) {
-        throw new Error('Unable to determine start line of code view')
-    }
-
-    const getLineNumber = (line: HTMLElement) => {
-        const codeElement = singleFileDOMFunctions.getCodeElementFromTarget(line)!
-
-        return singleFileDOMFunctions.getLineNumberFromCodeElement(codeElement)
-    }
-
-    return [
-        {
-            start: getLineNumber(firstLine),
-            end: getLineNumber(lastLine),
-        },
-    ]
-}
-
-export const diffFileGetLineRanges: CodeView['getLineRanges'] = (codeView, part) => {
-    const ranges: { start: number; end: number }[] = []
-
-    let start: number | null = null
-    let end: number | null = null
-
-    for (const row of codeView.querySelectorAll<HTMLTableRowElement>('tr')) {
-        const isCode = row.firstElementChild && !row.firstElementChild.classList.contains('js-unfold')
-
-        if (isCode) {
-            const line = row.querySelector<HTMLElement>(`td.${part === 'base' ? 'left-side' : 'right-side'} span.line`)!
-            if (!line) {
-                // Empty row
-                continue
-            }
-
-            const codeElement = diffDOMFunctions.getCodeElementFromTarget(line)!
-
-            const num = diffDOMFunctions.getLineNumberFromCodeElement(codeElement)
-            if (start === null) {
-                start = num
-            } else {
-                end = num
-            }
-        } else if (start && end) {
-            ranges.push({ start, end })
-        }
-
-        if (!isCode) {
-            start = null
-            end = null
-        }
-    }
-
-    return ranges
 }


### PR DESCRIPTION
We no longer want to retrieve file contents for extensions by scraping the DOM. This is because it's notoriously buggy, hard to maintain and comes with [major performance problems when looking at large files or PRs with a lot of files.](https://github.com/sourcegraph/sourcegraph/issues/2000). This PR removes DOM scraping and uses Sourcegraph instances to fetch the file contents. 

This means if you are using a Sourcegraph extension that requires file contents, the file must be in a repository on Sourcegraph.com or your own private Sourcegraph instance. @sqs, @ryan-blunden is there any particular way we'd like to communicate this to users? Note that extensions, like Codecov that don't need file contents still work as expected without a Sourcegraph instance containing private repos.

[See this slack conversation for more context.](https://sourcegraph.slack.com/archives/CCLF4R6EM/p1548369521128500)

Closes https://github.com/sourcegraph/sourcegraph/issues/2000.