### PR TITLE
add app.activeWindowChanged, Window.activeEditorChanged, codeEditor.selectionChanged

### DIFF
--- a/client/browser/src/browser/storage_migrations.ts
+++ b/client/browser/src/browser/storage_migrations.ts
@@ -18,7 +18,7 @@ export function provideMigrations(area: chrome.storage.StorageArea): MigratableS
     const migrated = migrations.pipe(
         switchMap(
             migrate =>
-                new Observable(observer => {
+                new Observable<void>(observer => {
                     area.get(items => {
                         const { newItems, keysToRemove } = migrate(items as StorageItems)
                         area.remove(keysToRemove || [], () => {

--- a/client/browser/src/libs/phabricator/backend.tsx
+++ b/client/browser/src/libs/phabricator/backend.tsx
@@ -623,7 +623,7 @@ interface ResolvedDiff {
 
 export function resolveDiffRev(props: ResolveDiffOpt): Observable<ResolvedDiff> {
     // TODO: Do a proper refactor and convert all of this function call and it's deps from Promises to Observables.
-    return from<ResolvedDiff>(
+    return from(
         new Promise<ResolvedDiff>((resolve, reject) => {
             getPropsWithInfo(props)
                 .then(propsWithInfo => {

--- a/client/browser/src/platform/context.ts
+++ b/client/browser/src/platform/context.ts
@@ -1,5 +1,6 @@
-import { combineLatest, merge, ReplaySubject } from 'rxjs'
+import { combineLatest, merge, Observable, ReplaySubject } from 'rxjs'
 import { map, mergeMap, publishReplay, refCount, switchMap, take } from 'rxjs/operators'
+import { GraphQLResult } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../../shared/src/platform/context'
 import { mutateSettings, updateSettings } from '../../../../shared/src/settings/edit'
@@ -84,14 +85,15 @@ export function createPlatformContext({ urlToFile }: Pick<CodeHost, 'urlToFile'>
 
             return storage.observeSync('sourcegraphURL').pipe(
                 take(1),
-                mergeMap(url =>
-                    requestGraphQL({
-                        ctx: getContext({ repoKey: '', isRepoSpecific: false }),
-                        request,
-                        variables,
-                        url,
-                        requestMightContainPrivateInfo,
-                    })
+                mergeMap(
+                    (url: string): Observable<GraphQLResult<any>> =>
+                        requestGraphQL({
+                            ctx: getContext({ repoKey: '', isRepoSpecific: false }),
+                            request,
+                            variables,
+                            url,
+                            requestMightContainPrivateInfo,
+                        })
                 )
             )
         },

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "react-stripe-elements": "^2.0.1",
     "react-visibility-sensor": "^5.0.2",
     "reactstrap": "https://registry.npmjs.org/@sqs/reactstrap/-/reactstrap-6.5.0-tmp1.tgz",
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.4.0",
     "sanitize-html": "^1.20.0",
     "sourcegraph": "link:packages/sourcegraph-extension-api",
     "string-score": "^1.0.1",

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -431,6 +431,11 @@ declare module 'sourcegraph' {
         activeViewComponent: ViewComponent | undefined
 
         /**
+         * An event that is fired when the active view component changes.
+         */
+        activeViewComponentChanged: Subscribable<ViewComponent | undefined>
+
+        /**
          * Show a notification message to the user that does not require interaction or steal focus.
          *
          * @deprecated This API will change.
@@ -601,6 +606,13 @@ declare module 'sourcegraph' {
         readonly selections: Selection[]
 
         /**
+         * An event that is fired when the selections in this text editor change.
+         * The primary selection ({@link CodeEditor#selection}), if any selections exist,
+         * is always at index 0 of the emitted array.
+         */
+        readonly selectionsChanged: Subscribable<Selection[]>
+
+        /**
          * Add a set of decorations to this editor. If a set of decorations already exists with the given
          * {@link TextDocumentDecorationType}, they will be replaced.
          *
@@ -649,6 +661,11 @@ declare module 'sourcegraph' {
          * none has focus, the window that was most recently focused.
          */
         export const activeWindow: Window | undefined
+
+        /**
+         * An event that is fired when the currently active window changes.
+         */
+        export const activeWindowChanged: Subscribable<Window | undefined>
 
         /**
          * All application windows that are accessible by the extension.

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -433,7 +433,7 @@ declare module 'sourcegraph' {
         /**
          * An event that is fired when the active view component changes.
          */
-        activeViewComponentChanged: Subscribable<ViewComponent | undefined>
+        activeViewComponentChanges: Subscribable<ViewComponent | undefined>
 
         /**
          * Show a notification message to the user that does not require interaction or steal focus.
@@ -610,7 +610,7 @@ declare module 'sourcegraph' {
          * The primary selection ({@link CodeEditor#selection}), if any selections exist,
          * is always at index 0 of the emitted array.
          */
-        readonly selectionsChanged: Subscribable<Selection[]>
+        readonly selectionsChanges: Subscribable<Selection[]>
 
         /**
          * Add a set of decorations to this editor. If a set of decorations already exists with the given
@@ -665,7 +665,7 @@ declare module 'sourcegraph' {
         /**
          * An event that is fired when the currently active window changes.
          */
-        export const activeWindowChanged: Subscribable<Window | undefined>
+        export const activeWindowChanges: Subscribable<Window | undefined>
 
         /**
          * All application windows that are accessible by the extension.

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1224,6 +1224,12 @@ declare module 'sourcegraph' {
          * the subscription to stop reacting to the stream.
          */
         subscribe(observer?: PartialObserver<T>): Unsubscribable
+        /** @deprecated Use an observer instead of a complete callback */
+        subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable
+        /** @deprecated Use an observer instead of an error callback */
+        subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Unsubscribable
+        /** @deprecated Use an observer instead of a complete callback */
+        subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Unsubscribable
         subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable
     }
 

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -1,4 +1,5 @@
 import * as clientType from '@sourcegraph/extension-api-types'
+import { of } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { ClientCodeEditorAPI } from '../../client/api/codeEditor'
 import { Range } from '../types/range'
@@ -17,6 +18,8 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
         private proxy: ClientCodeEditorAPI,
         private documents: ExtDocuments
     ) {}
+
+    public readonly selectionsChanged = of(this.selections)
 
     public readonly type = 'CodeEditor'
 

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -19,7 +19,7 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
         private documents: ExtDocuments
     ) {}
 
-    public readonly selectionsChanged = of(this.selections)
+    public readonly selectionsChanges = of(this.selections)
 
     public readonly type = 'CodeEditor'
 

--- a/shared/src/api/extension/api/windows.ts
+++ b/shared/src/api/extension/api/windows.ts
@@ -1,4 +1,4 @@
-import { Observer } from 'rxjs'
+import { BehaviorSubject, Observer, of } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { asError } from '../../../util/errors'
 import { ClientCodeEditorAPI } from '../../client/api/codeEditor'
@@ -18,6 +18,8 @@ export interface WindowData {
  */
 class ExtWindow implements sourcegraph.Window {
     constructor(private windowsProxy: ClientWindowsAPI, private readonly textEditors: ExtCodeEditor[]) {}
+
+    public readonly activeViewComponentChanged = of(this.activeViewComponent)
 
     public get visibleViewComponents(): sourcegraph.ViewComponent[] {
         return this.textEditors
@@ -95,6 +97,8 @@ export class ExtWindows implements ExtWindowsAPI {
         private documents: ExtDocuments
     ) {}
 
+    public readonly activeWindowChanged = new BehaviorSubject<sourcegraph.Window | undefined>(this.getActive())
+
     /** @internal */
     public getActive(): sourcegraph.Window | undefined {
         return this.getAll()[0]
@@ -127,5 +131,6 @@ export class ExtWindows implements ExtWindowsAPI {
     /** @internal */
     public $acceptWindowData(allWindows: WindowData[]): void {
         this.data = allWindows
+        this.activeWindowChanged.next(this.getActive())
     }
 }

--- a/shared/src/api/extension/api/windows.ts
+++ b/shared/src/api/extension/api/windows.ts
@@ -19,7 +19,7 @@ export interface WindowData {
 class ExtWindow implements sourcegraph.Window {
     constructor(private windowsProxy: ClientWindowsAPI, private readonly textEditors: ExtCodeEditor[]) {}
 
-    public readonly activeViewComponentChanged = of(this.activeViewComponent)
+    public readonly activeViewComponentChanges = of(this.activeViewComponent)
 
     public get visibleViewComponents(): sourcegraph.ViewComponent[] {
         return this.textEditors

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -1,4 +1,4 @@
-import { Subscription, Unsubscribable } from 'rxjs'
+import { from, Subscription, Unsubscribable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { createProxy, handleRequests } from '../common/proxy'
 import { Connection, createConnection, Logger, MessageTransports } from '../protocol/jsonrpc2/connection'
@@ -185,6 +185,7 @@ function createExtensionAPI(
         },
 
         app: {
+            activeWindowChanged: windows.activeWindowChanged,
             get activeWindow(): sourcegraph.Window | undefined {
                 return windows.getActive()
             },

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -185,7 +185,7 @@ function createExtensionAPI(
         },
 
         app: {
-            activeWindowChanged: windows.activeWindowChanged,
+            activeWindowChanges: windows.activeWindowChanged,
             get activeWindow(): sourcegraph.Window | undefined {
                 return windows.getActive()
             },

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -1,4 +1,4 @@
-import { from, Subscription, Unsubscribable } from 'rxjs'
+import { Subscription, Unsubscribable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { createProxy, handleRequests } from '../common/proxy'
 import { Connection, createConnection, Logger, MessageTransports } from '../protocol/jsonrpc2/connection'

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -37,11 +37,11 @@ describe('Selections (integration)', () => {
                 roots: [],
                 visibleViewComponents: [],
             })
-            const selectionChanges = from(extensionHost.app.activeWindowChanged).pipe(
+            const selectionChanges = from(extensionHost.app.activeWindowChanges).pipe(
                 filter(isDefined),
-                switchMap(window => window.activeViewComponentChanged),
+                switchMap(window => window.activeViewComponentChanges),
                 filter(isDefined),
-                switchMap(editor => editor.selectionsChanged)
+                switchMap(editor => editor.selectionsChanges)
             )
             const selectionValues = collectSubscribableValues(selectionChanges)
             const testValues = [

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -1,0 +1,65 @@
+import { from } from 'rxjs'
+import { filter, switchMap } from 'rxjs/operators'
+import { CodeEditor, Window } from 'sourcegraph'
+import { ViewComponentData } from '../client/model'
+import { assertToJSON } from '../extension/types/testHelpers'
+import { collectSubscribableValues, integrationTestContext } from './testHelpers'
+
+const withSelections = (...selections: { start: number; end: number }[]): ViewComponentData => ({
+    type: 'textEditor',
+    item: { uri: 'foo', languageId: 'l1', text: 't1' },
+    selections: selections.map(({ start, end }) => ({
+        start: {
+            line: start,
+            character: 0,
+        },
+        end: {
+            line: end,
+            character: 0,
+        },
+        anchor: {
+            line: start,
+            character: 0,
+        },
+        active: {
+            line: end,
+            character: 0,
+        },
+        isReversed: false,
+    })),
+    isActive: true,
+})
+
+describe('Selections (integration)', () => {
+    describe('editor.selectionsChanged', () => {
+        test('reflects changes to the current selections', async () => {
+            const { model, extensionHost } = await integrationTestContext(undefined, {
+                roots: [],
+                visibleViewComponents: [],
+            })
+            const selectionChanges = from(extensionHost.app.activeWindowChanged).pipe(
+                filter((window): window is Window => window !== undefined),
+                switchMap(window => window.activeViewComponentChanged),
+                filter((editor): editor is CodeEditor => editor !== undefined),
+                switchMap(editor => editor.selectionsChanged)
+            )
+            const selectionValues = collectSubscribableValues(selectionChanges)
+            const testValues = [
+                [{ start: 3, end: 5 }],
+                [{ start: 1, end: 10 }, { start: 25, end: 40 }, { start: 56, end: 57 }],
+                [],
+            ]
+            for (const selections of testValues) {
+                model.next({
+                    ...model.value,
+                    visibleViewComponents: [withSelections(...selections)],
+                })
+                await extensionHost.internal.sync()
+            }
+            assertToJSON(
+                selectionValues.map(selections => selections.map(s => ({ start: s.start.line, end: s.end.line }))),
+                testValues
+            )
+        })
+    })
+})

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -1,6 +1,6 @@
 import { from } from 'rxjs'
 import { filter, switchMap } from 'rxjs/operators'
-import { CodeEditor, Window } from 'sourcegraph'
+import { isDefined } from '../../util/types'
 import { ViewComponentData } from '../client/model'
 import { assertToJSON } from '../extension/types/testHelpers'
 import { collectSubscribableValues, integrationTestContext } from './testHelpers'
@@ -38,9 +38,9 @@ describe('Selections (integration)', () => {
                 visibleViewComponents: [],
             })
             const selectionChanges = from(extensionHost.app.activeWindowChanged).pipe(
-                filter((window): window is Window => window !== undefined),
+                filter(isDefined),
                 switchMap(window => window.activeViewComponentChanged),
-                filter((editor): editor is CodeEditor => editor !== undefined),
+                filter(isDefined),
                 switchMap(editor => editor.selectionsChanged)
             )
             const selectionValues = collectSubscribableValues(selectionChanges)

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -56,7 +56,8 @@ const NOOP_MOCKS: Mocks = {
  * @internal
  */
 export async function integrationTestContext(
-    partialMocks: Partial<Mocks> = NOOP_MOCKS
+    partialMocks: Partial<Mocks> = NOOP_MOCKS,
+    initModel: Model = FIXTURE_MODEL
 ): Promise<
     TestContext & {
         model: Subscribable<Model> & { value: Model } & NextObserver<Model>
@@ -87,7 +88,7 @@ export async function integrationTestContext(
         )
     )
 
-    services.model.model.next(FIXTURE_MODEL)
+    services.model.model.next(initModel)
 
     await (await extensionHost.__testAPI).internal.sync()
     return {

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -19,6 +19,51 @@ describe('Windows (integration)', () => {
         })
     })
 
+    describe('app.activeWindowChanged', () => {
+        test('reflects changes to the active window', async () => {
+            const { extensionHost, model } = await integrationTestContext(undefined, {
+                roots: [],
+                visibleViewComponents: [],
+            })
+            await extensionHost.internal.sync()
+            const values = collectSubscribableValues(extensionHost.app.activeWindowChanged)
+            model.next({
+                ...model.value,
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        item: { uri: 'foo', languageId: 'l1', text: 't1' },
+                        selections: [],
+                        isActive: true,
+                    },
+                ],
+            })
+            model.next({
+                ...model.value,
+                visibleViewComponents: [],
+            })
+            await extensionHost.internal.sync()
+            model.next({
+                ...model.value,
+                visibleViewComponents: [
+                    {
+                        type: 'textEditor',
+                        item: { uri: 'bar', languageId: 'l2', text: 't2' },
+                        selections: [],
+                        isActive: true,
+                    },
+                ],
+            })
+            await extensionHost.internal.sync()
+            assertToJSON(values.map(w => w && w.activeViewComponent && w.activeViewComponent.document.uri), [
+                null,
+                'foo',
+                null,
+                'bar',
+            ])
+        })
+    })
+
     describe('app.windows', () => {
         test('lists windows', async () => {
             const { extensionHost } = await integrationTestContext()

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -26,7 +26,7 @@ describe('Windows (integration)', () => {
                 visibleViewComponents: [],
             })
             await extensionHost.internal.sync()
-            const values = collectSubscribableValues(extensionHost.app.activeWindowChanged)
+            const values = collectSubscribableValues(extensionHost.app.activeWindowChanges)
             model.next({
                 ...model.value,
                 visibleViewComponents: [

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -92,7 +92,7 @@ export class HierarchicalLocationsView extends React.PureComponent<Props, State>
                                         locationsOrError.length > 0,
                                 })
                             }),
-                            endWith({ locationsComplete: true })
+                            endWith({ ...this.state, locationsComplete: true })
                         )
                     )
                 )

--- a/web/src/util/url.test.ts
+++ b/web/src/util/url.test.ts
@@ -1,4 +1,4 @@
-import { parseBrowserRepoURL, toTreeURL } from './url'
+import { lprToSelectionsZeroIndexed, parseBrowserRepoURL, toTreeURL } from './url'
 
 /**
  * Asserts deep object equality using node's assert.deepEqual, except it (1) ignores differences in the
@@ -168,5 +168,128 @@ describe('parseBrowserRepoURL', () => {
                 character: 5,
             },
         })
+    })
+})
+
+describe('lprToSelectionsZeroIndexed', () => {
+    test('converts an LPR with only a start line', () => {
+        assertDeepStrictEqual(
+            lprToSelectionsZeroIndexed({
+                line: 5,
+            }),
+            [
+                {
+                    start: {
+                        line: 4,
+                        character: 0,
+                    },
+                    end: {
+                        line: 4,
+                        character: 0,
+                    },
+                    anchor: {
+                        line: 4,
+                        character: 0,
+                    },
+                    active: {
+                        line: 4,
+                        character: 0,
+                    },
+                    isReversed: false,
+                },
+            ]
+        )
+    })
+
+    test('converts an LPR with a line and a character', () => {
+        assertDeepStrictEqual(
+            lprToSelectionsZeroIndexed({
+                line: 5,
+                character: 45,
+            }),
+            [
+                {
+                    start: {
+                        line: 4,
+                        character: 44,
+                    },
+                    end: {
+                        line: 4,
+                        character: 44,
+                    },
+                    anchor: {
+                        line: 4,
+                        character: 44,
+                    },
+                    active: {
+                        line: 4,
+                        character: 44,
+                    },
+                    isReversed: false,
+                },
+            ]
+        )
+    })
+
+    test('converts an LPR with a start and end line', () => {
+        assertDeepStrictEqual(
+            lprToSelectionsZeroIndexed({
+                line: 12,
+                endLine: 15,
+            }),
+            [
+                {
+                    start: {
+                        line: 11,
+                        character: 0,
+                    },
+                    end: {
+                        line: 14,
+                        character: 0,
+                    },
+                    anchor: {
+                        line: 11,
+                        character: 0,
+                    },
+                    active: {
+                        line: 14,
+                        character: 0,
+                    },
+                    isReversed: false,
+                },
+            ]
+        )
+    })
+
+    test('converts an LPR with a start and end line and characters', () => {
+        assertDeepStrictEqual(
+            lprToSelectionsZeroIndexed({
+                line: 12,
+                character: 30,
+                endLine: 15,
+                endCharacter: 60,
+            }),
+            [
+                {
+                    start: {
+                        line: 11,
+                        character: 29,
+                    },
+                    end: {
+                        line: 14,
+                        character: 59,
+                    },
+                    anchor: {
+                        line: 11,
+                        character: 29,
+                    },
+                    active: {
+                        line: 14,
+                        character: 59,
+                    },
+                    isReversed: false,
+                },
+            ]
+        )
     })
 })

--- a/web/src/util/url.ts
+++ b/web/src/util/url.ts
@@ -157,8 +157,10 @@ export function lprToSelectionsZeroIndexed(lpr: LineOrPositionOrRange): Selectio
     if (range === undefined) {
         return []
     }
-    const start: Position = { line: range.start.line - 1, character: range.start.character - 1 }
-    const end: Position = { line: range.end.line - 1, character: range.end.character - 1 }
+    // `lprToRange` sets character to 0 if it's undefined. Only - 1 the character if it's not 0.
+    const characterZeroIndexed = (character: number) => (character === 0 ? character : character - 1)
+    const start: Position = { line: range.start.line - 1, character: characterZeroIndexed(range.start.character) }
+    const end: Position = { line: range.end.line - 1, character: characterZeroIndexed(range.end.character) }
     return [
         {
             start,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13088,10 +13088,10 @@ rxjs-tslint-rules@^4.12.0:
     tslib "^1.8.0"
     tsutils "^3.0.0"
 
-rxjs@^6.0.0, rxjs@^6.1.0, rxjs@^6.3.2, rxjs@^6.3.3:
-  version "6.3.3"
-  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
-  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+rxjs@^6.0.0, rxjs@^6.1.0, rxjs@^6.3.2, rxjs@^6.3.3, rxjs@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
- Fixes #2026 
- Prerequisite to merging sourcegraph/sourcegraph-git-extras#14

This pull request adds the following to the Sourcegraph extension API:
- `sourcegraph.app.activeWindowChanged`
- `Window.activeEditorChanged`
- `codeEditor.selectionChanged`

These events are backed by rxjs observables, and can be composed as such (also exemplified in tests):

```typescript
const selectionChanges = from(extensionHost.app.activeWindowChanged).pipe(
    filter((window): window is Window => window !== undefined),
    switchMap(window => window.activeViewComponentChanged),
    filter((editor): editor is CodeEditor => editor !== undefined),
    switchMap(editor => editor.selectionsChanged)
)
```

In the current implementation, all instances of `ExtWindow` and `ExtCodeEditor` exposed to extensions are recreated every time `model` emits. As a result, `activeViewComponentChanged` and `selectionsChanged` are declared using `of()`, since they will only ever have one value. This is likely to change in the future, but will not require changing the extension API.

As part of this PR, I made sure that the `Subscribable.subscribe()` overloads we declare in `sourcegraph.d.ts` were compatible with the latest RX version, 6.4.0, so that the new events could be used as `ObservableInput`.