### PR TITLE
frontend: include the rest of URL paramters when handling renamed repositories

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -122,7 +122,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 				// was renamed to "github.com/moby/moby" -> redirect the user now.
 				err = handlerutil.RedirectToNewRepoName(w, r, e.NewRepo)
 				if err != nil {
-					return nil, errors.Wrap(err, "when sending repo redirect response")
+					return nil, errors.Wrap(err, "when sending renamed repository redirect response")
 				}
 
 				return nil, nil

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -120,7 +120,11 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 			if e, ok := err.(*handlerutil.URLMovedError); ok {
 				// The repository has been renamed, e.g. "github.com/docker/docker"
 				// was renamed to "github.com/moby/moby" -> redirect the user now.
-				http.Redirect(w, r, "/"+string(e.NewRepo), http.StatusMovedPermanently)
+				err = handlerutil.RedirectToNewRepoName(w, r, e.NewRepo)
+				if err != nil {
+					return nil, errors.Wrap(err, "when sending repo redirect response")
+				}
+
 				return nil, nil
 			}
 			if e, ok := err.(backend.ErrRepoSeeOther); ok {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2049

Previously when handling repository redirects, our API would only respond with the link to the base repository page and ignored all the other request parameters. This PR fixes that behavior through the use of `handlerutil.RedirectToNewRepoName`:

https://github.com/sourcegraph/sourcegraph/blob/037947175957ac02bf867595dacb1455ed6fdc76/cmd/frontend/internal/pkg/handlerutil/repo.go#L61-L80

---

Before:

```
github.com/foo/Bar@123456/-/blob/main.go -> github.com/foo/bar
```

After:

```
github.com/foo/Bar@123456/-/blob/main.go -> github.com/foo/bar@123456/-/blob/main.go
```