### PR TITLE
more specific error message when connection closed

### DIFF
--- a/shared/src/api/protocol/jsonrpc2/connection.ts
+++ b/shared/src/api/protocol/jsonrpc2/connection.ts
@@ -560,7 +560,10 @@ function _createConnection(transports: MessageTransports, logger: Logger): Conne
 
     function throwIfClosedOrUnsubscribed(): void {
         if (isClosed()) {
-            throw new ConnectionError(ConnectionErrors.Closed, 'Connection is closed.')
+            throw new ConnectionError(
+                ConnectionErrors.Closed,
+                'Extension host connection unexpectedly closed. Reload the page to resolve.'
+            )
         }
         if (isUnsubscribed()) {
             throw new ConnectionError(ConnectionErrors.Unsubscribed, 'Connection is unsubscribed.')


### PR DESCRIPTION
The extension host connection occasionally gets closed. [The one reproducible case I've found for this is rare](https://github.com/sourcegraph/sourcegraph/issues/1228#issuecomment-459127220) and is actually most likely seen during our local development than in the wild. Because of this, I've opted to just update the error message with the required action to resolve the issue.

Closes https://github.com/sourcegraph/sourcegraph/issues/1228.