### PR TITLE
repo-updater: Make new scheduler conform to DisableAutoGitUpdates semantics

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -112,9 +112,8 @@ func main() {
 
 	// Start other repos updates scheduler relay thread.
 	go func() {
-		newScheduler := conf.UpdateScheduler2Enabled()
 		for repo := range synced {
-			if newScheduler {
+			if conf.UpdateScheduler2Enabled() {
 				repos.Scheduler.UpdateOnce(repo.Name, repo.VCS.URL)
 			} else {
 				repos.UpdateOnce(ctx, repo.Name, repo.VCS.URL)

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -113,7 +113,9 @@ func main() {
 	// Start other repos updates scheduler relay thread.
 	go func() {
 		for repo := range synced {
-			if conf.UpdateScheduler2Enabled() {
+			if conf.Get().DisableAutoGitUpdates {
+				continue
+			} else if conf.UpdateScheduler2Enabled() {
 				repos.Scheduler.UpdateOnce(repo.Name, repo.VCS.URL)
 			} else {
 				repos.UpdateOnce(ctx, repo.Name, repo.VCS.URL)

--- a/cmd/repo-updater/repos/conf.go
+++ b/cmd/repo-updater/repos/conf.go
@@ -7,11 +7,9 @@ import (
 )
 
 func GetUpdateInterval() time.Duration {
-	if v := conf.Get().RepoListUpdateInterval; v == 0 { //  default to 1 minute
-		return 1 * time.Minute
-	} else if v == -1 { // sentinel for zero
-		return 0
-	} else {
-		return time.Duration(v) * time.Minute
+	v := conf.Get().RepoListUpdateInterval
+	if v == 0 { //  default to 1 minute
+		v = 1
 	}
+	return time.Duration(v) * time.Minute
 }

--- a/cmd/repo-updater/repos/reposlist.go
+++ b/cmd/repo-updater/repos/reposlist.go
@@ -739,16 +739,12 @@ func (c schedulerConfig) scheduler() string {
 // RunRepositorySyncWorker runs the worker that syncs repositories from external code hosts to Sourcegraph
 func RunRepositorySyncWorker(ctx context.Context) {
 	var (
-		mu   sync.Mutex
 		have schedulerConfig
 		stop context.CancelFunc
 	)
 
 	conf.Watch(func() {
 		c := conf.Get()
-
-		mu.Lock()
-		defer mu.Unlock()
 
 		want := schedulerConfig{
 			running:               true,

--- a/cmd/repo-updater/repos/reposlist.go
+++ b/cmd/repo-updater/repos/reposlist.go
@@ -765,6 +765,10 @@ func RunRepositorySyncWorker(ctx context.Context) {
 			log15.Info("stopped previous scheduler")
 		}
 
+		// We setup a separate sub-context so that we can reuse the original
+		// parent context every time we're starting up the newly configured
+		// scheduler. If we'd assign to ctx it'd only be usable up until the
+		// we'd call stop.
 		var ctx2 context.Context
 		if ctx2, stop = context.WithCancel(ctx); want.newSchedulerEnabled {
 			// this metric doesn't apply to the new scheduler

--- a/cmd/repo-updater/repos/reposlist.go
+++ b/cmd/repo-updater/repos/reposlist.go
@@ -786,8 +786,11 @@ func RunRepositorySyncWorker(ctx context.Context) {
 			"auto-git-updates", want.autoGitUpdatesEnabled,
 		)
 
+		// We converged to the desired configuration.
+		have = want
+
 		// Assigning stop to _ makes go-lint not report a false positive context leak.
-		have, _ = want, stop
+		_ = stop
 	})
 }
 

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -81,12 +81,6 @@ func newUpdateScheduler() *updateScheduler {
 	}
 }
 
-// run starts scheduled repo updates.
-func (s *updateScheduler) run(ctx context.Context) {
-	go s.runScheduleLoop(ctx)
-	go s.runUpdateLoop(ctx)
-}
-
 // runScheduleLoop starts the loop that schedules updates by enqueuing them into the updateQueue.
 func (s *updateScheduler) runScheduleLoop(ctx context.Context) {
 	for {

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -953,7 +953,7 @@ func verifyScheduleRecording(t *testing.T, s *updateScheduler, timeAfterFuncDela
 	}
 }
 
-func TestUpdateScheduler_runScheduleLoop(t *testing.T) {
+func TestUpdateScheduler_runSchedule(t *testing.T) {
 	a := &configuredRepo2{Name: "a", URL: "a.com"}
 	b := &configuredRepo2{Name: "b", URL: "b.com"}
 	c := &configuredRepo2{Name: "c", URL: "c.com"}
@@ -1064,29 +1064,9 @@ func TestUpdateScheduler_runScheduleLoop(t *testing.T) {
 
 			s := newUpdateScheduler()
 
-			// unbuffer the wakeup channel
-			s.schedule.wakeup = make(chan struct{})
-
 			setupInitialSchedule(s, test.initialSchedule)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			done := make(chan struct{})
-			go func() {
-				s.runScheduleLoop(ctx)
-				close(done)
-			}()
-
-			// Let the goroutine do a single loop.
-			s.schedule.wakeup <- struct{}{}
-
-			// Cancel after the first loop.
-			// This doesn't race with the wakeup notification because the channel is not buffered.
-			cancel()
-
-			// Wait for the goroutine to exit so we can verify the final state.
-			<-done
+			s.runSchedule()
 
 			verifySchedule(t, s, test.finalSchedule)
 			verifyQueue(t, s, test.finalQueue)

--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -91,36 +91,26 @@ func createEnableUpdateRepos(ctx context.Context, source string, repoChan <-chan
 			return
 		}
 
-		if c.DisableAutoGitUpdates {
-			return
-		}
-
-		if newScheduler {
+		if !newScheduler {
+			newList[string(createdRepo.Name)] = configuredRepo{url: op.URL, enabled: createdRepo.Enabled}
+		} else if !c.DisableAutoGitUpdates {
 			newMap[createdRepo.Name] = &configuredRepo2{
 				Name:    createdRepo.Name,
 				URL:     op.URL,
 				Enabled: createdRepo.Enabled,
 			}
-			return
 		}
-
-		newList[string(createdRepo.Name)] = configuredRepo{url: op.URL, enabled: createdRepo.Enabled}
 	}
 
 	for repo := range repoChan {
 		do(repo)
 	}
 
-	if c.DisableAutoGitUpdates {
-		return
-	}
-
-	if newScheduler {
+	if !newScheduler {
+		repos.updateSource(source, newList)
+	} else if !c.DisableAutoGitUpdates {
 		Scheduler.updateSource(source, newMap)
-		return
 	}
-
-	repos.updateSource(source, newList)
 }
 
 // setUserinfoBestEffort adds the username and password to rawurl. If user is


### PR DESCRIPTION
This commit makes the new scheduler conform to the semantics of the
`DisableAutoGitUpdates` configuration setting.

Every time either the configured scheduler or DisableAutoGitUpdates
changes, we stop the previous scheduler and start the desired one with the
correct configuration.

This code is unfortunately very hard to unit test as it stands and, after
some attempts to refactor it, it became clear that I wouldn't be able to
finish in time for cutting 3.0.

We'll be working to make all of repo-update more testable in the coming
weeks and months, and this will certainly be addressed then.

Fixes #1982
