### PR TITLE
Faster GitLab authz

### DIFF
--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -154,7 +154,7 @@ func GetGitLabRepository(ctx context.Context, args protocol.RepoLookupArgs) (rep
 		if err != nil {
 			return nil, true, err
 		}
-		proj, err := conn.client.GetProject(ctx, id, "")
+		proj, err := conn.client.GetProject(ctx, gitlab.GetProjectOp{ID: id})
 		if proj != nil {
 			repo = ghrepoToRepoInfo(proj, conn)
 		}
@@ -164,7 +164,7 @@ func GetGitLabRepository(ctx context.Context, args protocol.RepoLookupArgs) (rep
 	if args.Repo != "" {
 		// Look up by repository name.
 		pathWithNamespace := strings.TrimPrefix(strings.ToLower(string(args.Repo)), conn.baseURL.Hostname()+"/")
-		proj, err := conn.client.GetProject(ctx, 0, pathWithNamespace)
+		proj, err := conn.client.GetProject(ctx, gitlab.GetProjectOp{PathWithNamespace: pathWithNamespace})
 		if proj != nil {
 			repo = ghrepoToRepoInfo(proj, conn)
 		}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/cache.go
@@ -1,6 +1,12 @@
 package gitlab
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
+)
 
 type cache interface {
 	Get(key string) ([]byte, bool)
@@ -8,11 +14,76 @@ type cache interface {
 	Delete(key string)
 }
 
-type cacheVal struct {
-	// ProjIDs is the set of project IDs to which a GitLab user has access.
-	ProjIDs map[int]struct{} `json:"repos"`
+func userRepoCacheKey(gitlabAccountID string, gitlabProjID int) string {
+	return fmt.Sprintf("userRepo:%s:%d", gitlabAccountID, gitlabProjID) // GitLab account IDs cannot have ':'
+}
 
-	// TTL is the ttl of the cache entry. This must be checked for equality in case the TTL has
-	// changed (and the cache entry should therefore be invalidated).
-	TTL time.Duration `json:"ttl"`
+type userRepoCacheVal struct {
+	// Read is whether or not the repository can be read by the user specified in the key
+	Read bool
+
+	TTL time.Duration
+}
+
+func cacheGetUserRepo(c cache, gitlabAccountID string, gitlabProjID int, ttl time.Duration) (v userRepoCacheVal, exists bool) {
+	k := userRepoCacheKey(gitlabAccountID, gitlabProjID)
+	b, exists := c.Get(k)
+	if !exists {
+		return userRepoCacheVal{}, false
+	}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		c.Delete(k)
+		return userRepoCacheVal{}, false
+	}
+	if v.TTL != ttl {
+		c.Delete(k)
+		return userRepoCacheVal{}, false
+	}
+	return v, true
+}
+
+func cacheSetUserRepo(c cache, gitlabAccountID string, gitlabProjID int, v userRepoCacheVal) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	c.Set(userRepoCacheKey(gitlabAccountID, gitlabProjID), b)
+	return nil
+}
+
+func repoVisibilityCacheKey(gitlabProjID int) string {
+	return fmt.Sprintf("visibility:%d", gitlabProjID)
+}
+
+type repoVisibilityCacheVal struct {
+	Visibility gitlab.Visibility
+	TTL        time.Duration
+}
+
+func cacheGetRepoVisibility(c cache, gitlabProjID int, ttl time.Duration) (v repoVisibilityCacheVal, exists bool) {
+	k := repoVisibilityCacheKey(gitlabProjID)
+	b, exists := c.Get(k)
+	if !exists {
+		return repoVisibilityCacheVal{}, false
+	}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		c.Delete(k)
+		return repoVisibilityCacheVal{}, false
+	}
+	if v.TTL != ttl {
+		c.Delete(k)
+		return repoVisibilityCacheVal{}, false
+	}
+	return v, true
+}
+
+func cacheSetRepoVisibility(c cache, gitlabProjID int, v repoVisibilityCacheVal) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	c.Set(repoVisibilityCacheKey(gitlabProjID), b)
+	return nil
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -1,0 +1,237 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/schema"
+	"golang.org/x/oauth2"
+)
+
+// mockGitLab is a mock for the GitLab client that can be used by tests. Instantiating a mockGitLab
+// instance itself does nothing, but its methods can be used to replace the mock functions (e.g.,
+// MockListProjects).
+//
+// We prefer to do it this way, instead of defining an interface for the GitLab client, because this
+// preserves the ability to jump-to-def around the actual implementation.
+type mockGitLab struct {
+	t *testing.T
+
+	// projs is a map of all projects on the instance, keyed by project ID
+	projs map[int]*gitlab.Project
+
+	// privateGuest is a map from GitLab user ID to list of metadata-accessible private project IDs on GitLab
+	privateGuest map[string][]int
+
+	// privateRepo is a map from GitLab user ID to list of repo-content-accessible private project IDs on GitLab.
+	// Projects in each list are also metadata-accessible.
+	privateRepo map[string][]int
+
+	// oauthToks is a map from OAuth token to GitLab user account ID
+	oauthToks map[string]string
+
+	// madeGetProject records what GetProject calls have been made. It's a map from oauth token -> GetProjectOp -> count.
+	madeGetProject map[string]map[gitlab.GetProjectOp]int
+
+	// madeListTree recores what ListTree calls have been made. It's a map from oauth token -> ListTreeOp -> count.
+	madeListTree map[string]map[gitlab.ListTreeOp]int
+}
+
+// newMockGitLab returns a new mockGitLab instance
+func newMockGitLab(
+	t *testing.T, publicProjs []int, internalProjs []int, privateProjs map[int][2][]string, // privateProjs maps from { projID -> [ guestUserIDs, contentUserIDs ] }
+	oauthToks map[string]string,
+) mockGitLab {
+	projs := make(map[int]*gitlab.Project)
+	privateGuest := make(map[string][]int)
+	privateRepo := make(map[string][]int)
+	for _, p := range publicProjs {
+		projs[p] = &gitlab.Project{Visibility: gitlab.Public, ProjectCommon: gitlab.ProjectCommon{ID: p}}
+	}
+	for _, p := range internalProjs {
+		projs[p] = &gitlab.Project{Visibility: gitlab.Internal, ProjectCommon: gitlab.ProjectCommon{ID: p}}
+	}
+	for p, userAccess := range privateProjs {
+		projs[p] = &gitlab.Project{Visibility: gitlab.Private, ProjectCommon: gitlab.ProjectCommon{ID: p}}
+
+		guestUsers, contentUsers := userAccess[0], userAccess[1]
+		for _, u := range guestUsers {
+			privateGuest[u] = append(privateGuest[u], p)
+		}
+		for _, u := range contentUsers {
+			privateRepo[u] = append(privateRepo[u], p)
+		}
+	}
+	return mockGitLab{
+		t:              t,
+		projs:          projs,
+		privateGuest:   privateGuest,
+		privateRepo:    privateRepo,
+		oauthToks:      oauthToks,
+		madeGetProject: map[string]map[gitlab.GetProjectOp]int{},
+		madeListTree:   map[string]map[gitlab.ListTreeOp]int{},
+	}
+}
+
+func (m *mockGitLab) GetProject(c *gitlab.Client, ctx context.Context, op gitlab.GetProjectOp) (*gitlab.Project, error) {
+	if _, ok := m.madeGetProject[c.OAuthToken]; !ok {
+		m.madeGetProject[c.OAuthToken] = map[gitlab.GetProjectOp]int{}
+	}
+	m.madeGetProject[c.OAuthToken][op]++
+
+	proj, ok := m.projs[op.ID]
+	if !ok {
+		return nil, gitlab.ErrNotFound
+	}
+	if proj.Visibility == gitlab.Public {
+		return proj, nil
+	}
+	if c.OAuthToken != "" && proj.Visibility == gitlab.Internal {
+		return proj, nil
+	}
+
+	acctID := m.oauthToks[c.OAuthToken]
+	for _, accessibleProjID := range append(m.privateGuest[acctID], m.privateRepo[acctID]...) {
+		if accessibleProjID == op.ID {
+			return proj, nil
+		}
+	}
+
+	return nil, gitlab.ErrNotFound
+}
+
+func (m *mockGitLab) ListTree(c *gitlab.Client, ctx context.Context, op gitlab.ListTreeOp) ([]*gitlab.Tree, error) {
+	if _, ok := m.madeListTree[c.OAuthToken]; !ok {
+		m.madeListTree[c.OAuthToken] = map[gitlab.ListTreeOp]int{}
+	}
+	m.madeListTree[c.OAuthToken][op]++
+
+	ret := []*gitlab.Tree{
+		{
+			ID:   "123",
+			Name: "file.txt",
+			Type: "blob",
+			Path: "dir/file.txt",
+			Mode: "100644",
+		},
+	}
+
+	proj, ok := m.projs[op.ProjID]
+	if !ok {
+		return nil, gitlab.ErrNotFound
+	}
+	if proj.Visibility == gitlab.Public {
+		return ret, nil
+	}
+	if c.OAuthToken != "" && proj.Visibility == gitlab.Internal {
+		return ret, nil
+	}
+
+	acctID := m.oauthToks[c.OAuthToken]
+	for _, accessibleProjID := range m.privateRepo[acctID] {
+		if accessibleProjID == op.ProjID {
+			return ret, nil
+		}
+	}
+
+	return nil, gitlab.ErrNotFound
+}
+
+type mockCache map[string]string
+
+func (m mockCache) Get(key string) ([]byte, bool) {
+	v, ok := m[key]
+	return []byte(v), ok
+}
+func (m mockCache) Set(key string, b []byte) {
+	m[key] = string(b)
+}
+func (m mockCache) Delete(key string) {
+	delete(m, key)
+}
+
+func getIntOrDefault(str string, def int) (int, error) {
+	if str == "" {
+		return def, nil
+	}
+	return strconv.Atoi(str)
+}
+
+func acct(userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.ExternalAccount {
+	var data extsvc.ExternalAccountData
+	gitlab.SetExternalAccountData(&data, &gitlab.User{
+		ID: userID,
+	}, &oauth2.Token{
+		AccessToken: oauthTok,
+	})
+	return &extsvc.ExternalAccount{
+		UserID: userID,
+		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+			ServiceType: serviceType,
+			ServiceID:   serviceID,
+			AccountID:   accountID,
+		},
+		ExternalAccountData: data,
+	}
+}
+
+func repo(uri, serviceType, serviceID, id string) authz.Repo {
+	return authz.Repo{
+		RepoName: api.RepoName(uri),
+		ExternalRepoSpec: api.ExternalRepoSpec{
+			ID:          id,
+			ServiceType: serviceType,
+			ServiceID:   serviceID,
+		},
+	}
+}
+
+type mockAuthnProvider struct {
+	configID  auth.ProviderConfigID
+	serviceID string
+}
+
+func (m mockAuthnProvider) ConfigID() auth.ProviderConfigID {
+	return m.configID
+}
+
+func (m mockAuthnProvider) Config() schema.AuthProviders {
+	return schema.AuthProviders{
+		Gitlab: &schema.GitLabAuthProvider{
+			Type: m.configID.Type,
+			Url:  m.configID.ID,
+		},
+	}
+}
+
+func (m mockAuthnProvider) CachedInfo() *auth.ProviderInfo {
+	return &auth.ProviderInfo{ServiceID: m.serviceID}
+}
+
+func (m mockAuthnProvider) Refresh(ctx context.Context) error {
+	panic("should not be called")
+}
+
+func mustURL(t *testing.T, u string) *url.URL {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}
+
+func asJSON(t *testing.T, v interface{}) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/common_test.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
-	"strconv"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/schema"
 	"golang.org/x/oauth2"
 )
 
@@ -158,13 +155,6 @@ func (m mockCache) Delete(key string) {
 	delete(m, key)
 }
 
-func getIntOrDefault(str string, def int) (int, error) {
-	if str == "" {
-		return def, nil
-	}
-	return strconv.Atoi(str)
-}
-
 func acct(userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.ExternalAccount {
 	var data extsvc.ExternalAccountData
 	gitlab.SetExternalAccountData(&data, &gitlab.User{
@@ -192,32 +182,6 @@ func repo(uri, serviceType, serviceID, id string) authz.Repo {
 			ServiceID:   serviceID,
 		},
 	}
-}
-
-type mockAuthnProvider struct {
-	configID  auth.ProviderConfigID
-	serviceID string
-}
-
-func (m mockAuthnProvider) ConfigID() auth.ProviderConfigID {
-	return m.configID
-}
-
-func (m mockAuthnProvider) Config() schema.AuthProviders {
-	return schema.AuthProviders{
-		Gitlab: &schema.GitLabAuthProvider{
-			Type: m.configID.Type,
-			Url:  m.configID.ID,
-		},
-	}
-}
-
-func (m mockAuthnProvider) CachedInfo() *auth.ProviderInfo {
-	return &auth.ProviderInfo{ServiceID: m.serviceID}
-}
-
-func (m mockAuthnProvider) Refresh(ctx context.Context) error {
-	panic("should not be called")
 }
 
 func mustURL(t *testing.T, u string) *url.URL {

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab.go
@@ -4,13 +4,14 @@ package gitlab
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -68,61 +69,6 @@ func (p *GitLabOAuthAuthzProvider) ServiceType() string {
 	return p.codeHost.ServiceType()
 }
 
-func (p *GitLabOAuthAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (map[api.RepoName]map[authz.Perm]bool, error) {
-	accountID := "" // empty means public / unauthenticated to the code host
-	if account != nil && account.ServiceID == p.codeHost.ServiceID() && account.ServiceType == p.codeHost.ServiceType() {
-		accountID = account.AccountID
-	}
-
-	myRepos, _ := p.Repos(ctx, repos)
-	var accessibleRepos map[int]struct{}
-	if r, exists := p.getCachedAccessList(accountID); exists {
-		accessibleRepos = r
-	} else {
-		var accessToken string
-		if account != nil {
-			_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
-			if err != nil {
-				return nil, err
-			}
-			accessToken = tok.AccessToken
-		}
-
-		var err error
-		accessibleRepos, err = p.fetchUserAccessList(ctx, accountID, accessToken)
-		if err != nil {
-			return nil, err
-		}
-
-		accessibleReposB, err := json.Marshal(cacheVal{
-			ProjIDs: accessibleRepos,
-			TTL:     p.cacheTTL,
-		})
-		if err != nil {
-			return nil, err
-		}
-		p.cache.Set(accountID, accessibleReposB)
-	}
-
-	perms := make(map[api.RepoName]map[authz.Perm]bool)
-	for repo := range myRepos {
-		perms[repo.RepoName] = map[authz.Perm]bool{}
-
-		projID, err := strconv.Atoi(repo.ExternalRepoSpec.ID)
-		if err != nil {
-			log15.Warn("couldn't parse GitLab proj ID as int while computing permissions", "id", repo.ExternalRepoSpec.ID)
-			continue
-		}
-		_, isAccessible := accessibleRepos[projID]
-		if !isAccessible {
-			continue
-		}
-		perms[repo.RepoName][authz.Read] = true
-	}
-
-	return perms, nil
-}
-
 func (p *GitLabOAuthAuthzProvider) Repos(ctx context.Context, repos map[authz.Repo]struct{}) (mine map[authz.Repo]struct{}, others map[authz.Repo]struct{}) {
 	return authz.GetCodeHostRepos(p.codeHost, repos)
 }
@@ -131,49 +77,156 @@ func (p *GitLabOAuthAuthzProvider) FetchAccount(ctx context.Context, user *types
 	return nil, nil
 }
 
-// getCachedAccessList returns the list of repositories accessible to a user from the cache and
-// whether the cache entry exists.
-func (p *GitLabOAuthAuthzProvider) getCachedAccessList(accountID string) (map[int]struct{}, bool) {
-	// TODO(beyang): trigger best-effort fetch in background if ttl is getting close (but avoid dup refetches)
-
-	cachedReposB, exists := p.cache.Get(accountID)
-	if !exists {
-		return nil, false
+func (p *GitLabOAuthAuthzProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (
+	map[api.RepoName]map[authz.Perm]bool, error,
+) {
+	accountID := "" // empty means public / unauthenticated to the code host
+	if account != nil && account.ServiceID == p.codeHost.ServiceID() && account.ServiceType == p.codeHost.ServiceType() {
+		accountID = account.AccountID
 	}
-	var r cacheVal
-	if err := json.Unmarshal(cachedReposB, &r); err != nil || r.TTL == 0 || r.TTL > p.cacheTTL {
+
+	perms := map[api.RepoName]map[authz.Perm]bool{}
+
+	remaining, _ := p.Repos(ctx, repos)
+	nextRemaining := map[authz.Repo]struct{}{}
+
+	// Check cached visibility
+	for repo := range remaining {
+		projID, err := strconv.Atoi(repo.ExternalRepoSpec.ID)
 		if err != nil {
-			log15.Warn("Failed to unmarshal repo perm cache entry", "err", err.Error())
+			return nil, errors.Wrap(err, "GitLab repo external ID did not parse to int")
 		}
-		p.cache.Delete(accountID)
-		return nil, false
+		vis, exists := cacheGetRepoVisibility(p.cache, projID, p.cacheTTL)
+		if !exists {
+			nextRemaining[repo] = struct{}{}
+			continue
+		}
+		switch v := vis.Visibility; {
+		case v == gitlab.Public:
+			fallthrough
+		case v == gitlab.Internal && accountID != "":
+			perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: true}
+			continue
+		}
+		nextRemaining[repo] = struct{}{}
 	}
-	return r.ProjIDs, true
-}
 
-// fetchUserAccessList fetches the list of project IDs that are readable to a user from the GitLab API.
-func (p *GitLabOAuthAuthzProvider) fetchUserAccessList(ctx context.Context, glUserID, oauthTok string) (map[int]struct{}, error) {
-	projIDs := make(map[int]struct{})
-	var iters = 0
-	var pageURL = fmt.Sprintf("projects?%s", url.Values(map[string][]string{"per_page": {"100"}}).Encode())
-	for {
-		if iters >= 100 && iters%100 == 0 {
-			log15.Warn("Excessively many GitLab API requests to fetch complete user authz list", "iters", iters, "gitlabUserID", glUserID, "host", p.clientURL.String())
+	if len(nextRemaining) == 0 { // shortcut
+		return perms, nil
+	}
+
+	// Check cached user repos
+	if accountID != "" {
+		remaining, nextRemaining = nextRemaining, map[authz.Repo]struct{}{}
+		for repo := range remaining {
+			projID, err := strconv.Atoi(repo.ExternalRepoSpec.ID)
+			if err != nil {
+				return nil, errors.Wrap(err, "GitLab repo external ID did not parse to int")
+			}
+			userRepo, exists := cacheGetUserRepo(p.cache, accountID, projID, p.cacheTTL)
+			if !exists {
+				nextRemaining[repo] = struct{}{}
+				continue
+			}
+			perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: userRepo.Read}
 		}
 
-		projs, nextPageURL, err := p.clientProvider.GetOAuthClient(oauthTok).ListProjects(ctx, pageURL)
+		if len(nextRemaining) == 0 { // shortcut
+			return perms, nil
+		}
+	}
+
+	// Fetch and update cache
+	var accessToken string
+	if account != nil {
+		_, tok, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
 		if err != nil {
 			return nil, err
 		}
-		for _, proj := range projs {
-			projIDs[proj.ID] = struct{}{}
-		}
-
-		if nextPageURL == nil {
-			break
-		}
-		pageURL = *nextPageURL
-		iters++
+		accessToken = tok.AccessToken
 	}
-	return projIDs, nil
+	for repo := range remaining {
+		projID, err := strconv.Atoi(repo.ExternalRepoSpec.ID)
+		if err != nil {
+			return nil, errors.Wrap(err, "GitLab repo external ID did not parse to int")
+		}
+		isAccessible, vis, isContentAccessible, err := p.fetchProjVis(ctx, accessToken, projID)
+		if err != nil {
+			log15.Error("Failed to fetch visibility for GitLab project", "projectID", projID, "gitlabHost", p.codeHost.BaseURL().String(), "error", err)
+			continue
+		}
+		if isAccessible {
+			// Set perms
+			perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: true}
+
+			// Update visibility cache
+			err := cacheSetRepoVisibility(p.cache, projID, repoVisibilityCacheVal{Visibility: vis, TTL: p.cacheTTL})
+			if err != nil {
+				return nil, errors.Wrap(err, "could not set cached repo visibility")
+			}
+
+			// Update userRepo cache if the visibility is private
+			if vis == gitlab.Private {
+				err := cacheSetUserRepo(p.cache, accountID, projID, userRepoCacheVal{Read: isContentAccessible, TTL: p.cacheTTL})
+				if err != nil {
+					return nil, errors.Wrap(err, "could not set cached user repo")
+				}
+			}
+		} else if accountID != "" {
+			// A repo is private if it is not accessible to an authenticated user
+			err := cacheSetRepoVisibility(p.cache, projID, repoVisibilityCacheVal{Visibility: gitlab.Private, TTL: p.cacheTTL})
+			if err != nil {
+				return nil, errors.Wrap(err, "could not set cached repo visibility")
+			}
+			err = cacheSetUserRepo(p.cache, accountID, projID, userRepoCacheVal{Read: false, TTL: p.cacheTTL})
+			if err != nil {
+				return nil, errors.Wrap(err, "could not set cached user repo")
+			}
+		}
+	}
+	return perms, nil
+}
+
+// fetchRepoVisibility fetches a repository's visibility with usr's credentials. It returns:
+// - whether the project is accessible to the user,
+// - the visibility if the repo is accessible (otherwise this is empty),
+// - whether the repository contents are accessible to usr, and
+// - any error encountered in fetching (not including an error due to the repository not being visible);
+//   if the error is non-nil, all other return values should be disregraded
+func (p *GitLabOAuthAuthzProvider) fetchProjVis(ctx context.Context, accessToken string, projID int) (
+	isAccessible bool, vis gitlab.Visibility, isContentAccessible bool, err error,
+) {
+	proj, err := p.clientProvider.GetOAuthClient(accessToken).GetProject(ctx, gitlab.GetProjectOp{
+		ID:       projID,
+		CommonOp: gitlab.CommonOp{NoCache: true},
+	})
+	if err != nil {
+		if errCode := gitlab.HTTPErrorCode(err); errCode == http.StatusNotFound {
+			return false, "", false, nil
+		}
+		return false, "", false, err
+	}
+
+	// If we get here, the project is accessible to the user (user has at least "Guest" permissions
+	// on the project).
+
+	if proj.Visibility == gitlab.Public || proj.Visibility == gitlab.Internal {
+		// All authenticated users can read the contents of all internal/public projects
+		// (https://docs.gitlab.com/ee/user/permissions.html).
+		return true, proj.Visibility, true, nil
+	}
+
+	// If project visibility is private and its accessible to user, we still need to check if the user
+	// can read the repository contents (i.e., does not merely have "Guest" permissions).
+
+	if _, err := p.clientProvider.GetOAuthClient(accessToken).ListTree(ctx, gitlab.ListTreeOp{
+		ProjID:   projID,
+		CommonOp: gitlab.CommonOp{NoCache: true},
+	}); err != nil {
+		if errCode := gitlab.HTTPErrorCode(err); errCode == http.StatusNotFound {
+			return true, proj.Visibility, false, nil
+		}
+		return false, "", false, err
+	}
+	return true, proj.Visibility, true, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_new_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_new_test.go
@@ -1,0 +1,5 @@
+package gitlab
+
+// Test cases
+// - User without access should be cached (don't refetch repo every time if user can't access)
+// - User without access is just granted access

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_new_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_new_test.go
@@ -1,5 +1,0 @@
-package gitlab
-
-// Test cases
-// - User without access should be cached (don't refetch repo every time if user can't access)
-// - User without access is just granted access

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_test.go
@@ -2,47 +2,62 @@ package gitlab
 
 import (
 	"context"
-	"encoding/json"
-	"net/url"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/oauth2"
 )
 
 func Test_GitLab_RepoPerms(t *testing.T) {
+	// Mock the following scenario:
+	// - public projects begin with 99
+	// - internal projects begin with 98
+	// - private projects begin with the digit of the user that owns them (other users may have access)
+	// - u1 owns its own repositories and nothing else
+	// - u2 owns its own repos and has guest access to u1's
+	// - u3 owns its own repos and has full access to u1's and guest access to u2's
 	gitlabMock := newMockGitLab(t,
-		[]int{ // Repos
-			11, // gitlab.mine/bl/repo-1
-			12, // gitlab.mine/bl/repo-2
-			13, // gitlab.mine/bl/repo-3
-			21, // gitlab.mine/kl/repo-1
-			22, // gitlab.mine/kl/repo-2
-			23, // gitlab.mine/kl/repo-3
-			31, // gitlab.mine/org/repo-1
-			32, // gitlab.mine/org/repo-2
-			33, // gitlab.mine/org/repo-3
-			41, // gitlab.mine/public/repo-1
+		[]int{ // public projects
+			991,
 		},
-		map[string][]int{ // GitLab user IDs to repo IDs
-			"101":    {11, 12, 13, 31, 32, 33, 41},
-			"201":    {21, 22, 23, 31, 32, 33, 41},
-			"PUBLIC": {41},
+		[]int{ // internal projects
+			981,
 		},
-		map[string]string{ // GitLab OAuth tokens to GitLab user IDs
-			"oauth101": "101",
-			"oauth201": "201",
+		map[int][2][]string{ // private projects
+			10: [2][]string{
+				[]string{ // guests
+					"u2",
+				},
+				[]string{ // content ("full access")
+					"u1",
+					"u3",
+				},
+			},
+			20: [2][]string{
+				[]string{
+					"u3",
+				},
+				[]string{
+					"u2",
+				},
+			},
+			30: [2][]string{
+				[]string{},
+				[]string{"u3"},
+			},
 		},
-		1)
-	gitlab.MockListProjects = gitlabMock.ListProjects
+		map[string]string{
+			"oauth-u1": "u1",
+			"oauth-u2": "u2",
+			"oauth-u3": "u3",
+		},
+	)
+	gitlab.MockGetProject = gitlabMock.GetProject
+	gitlab.MockListTree = gitlabMock.ListTree
 
 	tests := []GitLab_RepoPerms_Test{
 		{
@@ -52,128 +67,78 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 			},
 			calls: []GitLab_RepoPerms_call{
 				{
-					description: "bl user has expected perms",
-					account:     acct(1, "gitlab", "https://gitlab.mine/", "101", "oauth101"),
+					description: "u1 user has expected perms",
+					account:     acct(1, "gitlab", "https://gitlab.mine/", "u1", "oauth-u1"),
 					repos: map[authz.Repo]struct{}{
-						repo("bl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "11"):                 {},
-						repo("bl/repo-2", gitlab.ServiceType, "other", "12"):                                {},
-						repo("gitlab.mine/bl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "999"):    {},
-						repo("kl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "21"):                 {},
-						repo("kl/repo-2", gitlab.ServiceType, "other", "22"):                                {},
-						repo("gitlab.mine/kl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "998"):    {},
-						repo("org/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "31"):                {},
-						repo("org/repo-2", gitlab.ServiceType, "other", "32"):                               {},
-						repo("gitlab.mine/org/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "997"):   {},
-						repo("gitlab.mine/public/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "41"): {},
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
 					},
 					expPerms: map[api.RepoName]map[authz.Perm]bool{
-						"bl/repo-1":                 {authz.Read: true},
-						"gitlab.mine/bl/repo-3":     {},
-						"kl/repo-1":                 {},
-						"gitlab.mine/kl/repo-3":     {},
-						"org/repo-1":                {authz.Read: true},
-						"gitlab.mine/org/repo-3":    {},
-						"gitlab.mine/public/repo-1": {authz.Read: true},
+						"u1/repo1":       {authz.Read: true},
+						"internal/repo1": {authz.Read: true},
+						"public/repo1":   {authz.Read: true},
 					},
 				},
 				{
-					description: "kl user has expected perms",
-					account:     acct(2, "gitlab", "https://gitlab.mine/", "201", "oauth201"),
+					description: "u2 user has expected perms",
+					account:     acct(2, "gitlab", "https://gitlab.mine/", "u2", "oauth-u2"),
 					repos: map[authz.Repo]struct{}{
-						repo("bl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "11"):                 {},
-						repo("bl/repo-2", gitlab.ServiceType, "other", "12"):                                {},
-						repo("gitlab.mine/bl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "999"):    {},
-						repo("kl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "21"):                 {},
-						repo("kl/repo-2", gitlab.ServiceType, "other", "22"):                                {},
-						repo("gitlab.mine/kl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "998"):    {},
-						repo("org/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "31"):                {},
-						repo("org/repo-2", gitlab.ServiceType, "other", "32"):                               {},
-						repo("gitlab.mine/org/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "997"):   {},
-						repo("gitlab.mine/public/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "41"): {},
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
 					},
 					expPerms: map[api.RepoName]map[authz.Perm]bool{
-						"bl/repo-1":                 {},
-						"gitlab.mine/bl/repo-3":     {},
-						"kl/repo-1":                 {authz.Read: true},
-						"gitlab.mine/kl/repo-3":     {},
-						"org/repo-1":                {authz.Read: true},
-						"gitlab.mine/org/repo-3":    {},
-						"gitlab.mine/public/repo-1": {authz.Read: true},
+						"u2/repo1":       {authz.Read: true},
+						"internal/repo1": {authz.Read: true},
+						"public/repo1":   {authz.Read: true},
 					},
 				},
 				{
-					description: "unknown user has access to public only",
-					account:     acct(3, "gitlab", "https://gitlab.mine/", "999", "oauth999"),
+					description: "other user has expected perms (internal and public)",
+					account:     acct(4, "gitlab", "https://gitlab.mine/", "other", "oauth-other"),
 					repos: map[authz.Repo]struct{}{
-						repo("bl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "11"):                 {},
-						repo("bl/repo-2", gitlab.ServiceType, "other", "12"):                                {},
-						repo("gitlab.mine/bl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "999"):    {},
-						repo("kl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "21"):                 {},
-						repo("kl/repo-2", gitlab.ServiceType, "other", "22"):                                {},
-						repo("gitlab.mine/kl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "998"):    {},
-						repo("org/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "31"):                {},
-						repo("org/repo-2", gitlab.ServiceType, "other", "32"):                               {},
-						repo("gitlab.mine/org/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "997"):   {},
-						repo("gitlab.mine/public/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "41"): {},
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
 					},
 					expPerms: map[api.RepoName]map[authz.Perm]bool{
-						"bl/repo-1":                 {},
-						"gitlab.mine/bl/repo-3":     {},
-						"kl/repo-1":                 {},
-						"gitlab.mine/kl/repo-3":     {},
-						"org/repo-1":                {},
-						"gitlab.mine/org/repo-3":    {},
-						"gitlab.mine/public/repo-1": {authz.Read: true},
+						"internal/repo1": {authz.Read: true},
+						"public/repo1":   {authz.Read: true},
 					},
 				},
 				{
-					description: "unauthenticated user has access to public only",
+					description: "no token means only public repos",
+					account:     acct(4, "gitlab", "https://gitlab.mine/", "no-token", ""),
+					repos: map[authz.Repo]struct{}{
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
+					},
+					expPerms: map[api.RepoName]map[authz.Perm]bool{
+						"public/repo1": {authz.Read: true},
+					},
+				},
+				{
+					description: "unauthenticated means only public repos",
 					account:     nil,
 					repos: map[authz.Repo]struct{}{
-						repo("bl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "11"):                 {},
-						repo("bl/repo-2", gitlab.ServiceType, "other", "12"):                                {},
-						repo("gitlab.mine/bl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "999"):    {},
-						repo("kl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "21"):                 {},
-						repo("kl/repo-2", gitlab.ServiceType, "other", "22"):                                {},
-						repo("gitlab.mine/kl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "998"):    {},
-						repo("org/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "31"):                {},
-						repo("org/repo-2", gitlab.ServiceType, "other", "32"):                               {},
-						repo("gitlab.mine/org/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "997"):   {},
-						repo("gitlab.mine/public/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "41"): {},
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
 					},
 					expPerms: map[api.RepoName]map[authz.Perm]bool{
-						"bl/repo-1":                 {},
-						"gitlab.mine/bl/repo-3":     {},
-						"kl/repo-1":                 {},
-						"gitlab.mine/kl/repo-3":     {},
-						"org/repo-1":                {},
-						"gitlab.mine/org/repo-3":    {},
-						"gitlab.mine/public/repo-1": {authz.Read: true},
-					},
-				},
-				{
-					description: "user with no oauth token has access to public only",
-					account:     acct(2, "gitlab", "https://gitlab.mine/", "201", ""),
-					repos: map[authz.Repo]struct{}{
-						repo("bl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "11"):                 {},
-						repo("bl/repo-2", gitlab.ServiceType, "other", "12"):                                {},
-						repo("gitlab.mine/bl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "999"):    {},
-						repo("kl/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "21"):                 {},
-						repo("kl/repo-2", gitlab.ServiceType, "other", "22"):                                {},
-						repo("gitlab.mine/kl/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "998"):    {},
-						repo("org/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "31"):                {},
-						repo("org/repo-2", gitlab.ServiceType, "other", "32"):                               {},
-						repo("gitlab.mine/org/repo-3", gitlab.ServiceType, "https://gitlab.mine/", "997"):   {},
-						repo("gitlab.mine/public/repo-1", gitlab.ServiceType, "https://gitlab.mine/", "41"): {},
-					},
-					expPerms: map[api.RepoName]map[authz.Perm]bool{
-						"bl/repo-1":                 {},
-						"gitlab.mine/bl/repo-3":     {},
-						"kl/repo-1":                 {},
-						"gitlab.mine/kl/repo-3":     {},
-						"org/repo-1":                {},
-						"gitlab.mine/org/repo-3":    {},
-						"gitlab.mine/public/repo-1": {authz.Read: true},
+						"public/repo1": {authz.Read: true},
 					},
 				},
 			},
@@ -181,6 +146,123 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		test.run(t)
+	}
+}
+
+func Test_GitLab_RepoPerms_cache(t *testing.T) {
+	gitlabMock := newMockGitLab(t,
+		[]int{ // public projects
+			991,
+		},
+		[]int{ // internal projects
+			981,
+		},
+		map[int][2][]string{ // private projects
+			10: [2][]string{
+				[]string{ // guests
+					"u2",
+				},
+				[]string{ // content ("full access")
+					"u1",
+				},
+			},
+		},
+		map[string]string{
+			"oauth-u1": "u1",
+			"oauth-u2": "u2",
+			"oauth-u3": "u3",
+		},
+	)
+	gitlab.MockGetProject = gitlabMock.GetProject
+	gitlab.MockListTree = gitlabMock.ListTree
+
+	ctx := context.Background()
+	authzProvider := NewProvider(GitLabOAuthAuthzProviderOp{
+		BaseURL:   mustURL(t, "https://gitlab.mine"),
+		MockCache: make(mockCache),
+		CacheTTL:  3 * time.Hour,
+	})
+
+	// Initial request for private repo
+	if _, err := authzProvider.RepoPerms(ctx,
+		acct(1, gitlab.ServiceType, "https://gitlab.mine/", "u1", "oauth-u1"),
+		map[authz.Repo]struct{}{
+			repo("10", "gitlab", "https://gitlab.mine/", "10"): {},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
+		"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+	}; !reflect.DeepEqual(exp, actual) {
+		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
+	}
+	if actual, exp := gitlabMock.madeListTree, map[string]map[gitlab.ListTreeOp]int{
+		"oauth-u1": map[gitlab.ListTreeOp]int{{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+	}; !reflect.DeepEqual(exp, actual) {
+		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
+	}
+
+	// Exact same request
+	if _, err := authzProvider.RepoPerms(ctx,
+		acct(1, gitlab.ServiceType, "https://gitlab.mine/", "u1", "oauth-u1"),
+		map[authz.Repo]struct{}{
+			repo("10", "gitlab", "https://gitlab.mine/", "10"): {},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
+		"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+	}; !reflect.DeepEqual(exp, actual) {
+		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
+	}
+	if actual, exp := gitlabMock.madeListTree, map[string]map[gitlab.ListTreeOp]int{
+		"oauth-u1": map[gitlab.ListTreeOp]int{{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+	}; !reflect.DeepEqual(exp, actual) {
+		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
+	}
+
+	// Different request, on internal repo
+	if _, err := authzProvider.RepoPerms(ctx,
+		acct(2, gitlab.ServiceType, "https://gitlab.mine/", "u2", "oauth-u2"),
+		map[authz.Repo]struct{}{
+			repo("981", "gitlab", "https://gitlab.mine/", "981"): {},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
+		"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		"oauth-u2": map[gitlab.GetProjectOp]int{{ID: 981, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+	}; !reflect.DeepEqual(exp, actual) {
+		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
+	}
+
+	// Bypass cache when ttl changed
+	authzProvider.cacheTTL = 1 * time.Hour
+
+	// Make initial request twice again, expect cache miss the first time around
+	if _, err := authzProvider.RepoPerms(ctx,
+		acct(1, gitlab.ServiceType, "https://gitlab.mine/", "u1", "oauth-u1"),
+		map[authz.Repo]struct{}{
+			repo("10", "gitlab", "https://gitlab.mine/", "10"): {},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
+			"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 2},
+			"oauth-u2": map[gitlab.GetProjectOp]int{{ID: 981, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		}; !reflect.DeepEqual(exp, actual) {
+			t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
+		}
+		if actual, exp := gitlabMock.madeListTree, map[string]map[gitlab.ListTreeOp]int{
+			"oauth-u1": map[gitlab.ListTreeOp]int{{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 2},
+		}; !reflect.DeepEqual(exp, actual) {
+			t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
+		}
 	}
 }
 
@@ -222,121 +304,6 @@ func (g GitLab_RepoPerms_Test) run(t *testing.T) {
 				t.Errorf("expected %s, but got %s", asJSON(t, c.expPerms), asJSON(t, perms))
 			}
 		}
-	}
-}
-
-func Test_GitLab_RepoPerms_cache(t *testing.T) {
-	gitlabMock := newMockGitLab(t, []int{}, map[string][]int{}, map[string]string{}, 1)
-	gitlab.MockListProjects = gitlabMock.ListProjects
-
-	ctx := context.Background()
-	authzProvider := NewProvider(GitLabOAuthAuthzProviderOp{
-		BaseURL:   mustURL(t, "https://gitlab.mine"),
-		MockCache: make(mockCache),
-		CacheTTL:  3 * time.Hour,
-	})
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "bl", "oauth_bl"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if exp := map[string]map[string]int{
-		"projects?per_page=100": {"oauth_bl": 1},
-	}; !reflect.DeepEqual(gitlabMock.madeProjectReqs, exp) {
-		t.Errorf("Unexpected cache behavior. Expected underying requests to be %v, but got %v", exp, gitlabMock.madeProjectReqs)
-	}
-
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "bl", "oauth_bl"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if exp := map[string]map[string]int{
-		"projects?per_page=100": {"oauth_bl": 1},
-	}; !reflect.DeepEqual(gitlabMock.madeProjectReqs, exp) {
-		t.Errorf("Unexpected cache behavior. Expected underying requests to be %v, but got %v", exp, gitlabMock.madeProjectReqs)
-	}
-
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "kl", "oauth_kl"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if exp := map[string]map[string]int{
-		"projects?per_page=100": {"oauth_bl": 1, "oauth_kl": 1},
-	}; !reflect.DeepEqual(gitlabMock.madeProjectReqs, exp) {
-		t.Errorf("Unexpected cache behavior. Expected underying requests to be %v, but got %v", exp, gitlabMock.madeProjectReqs)
-	}
-
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "kl", "oauth_kl"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if exp := map[string]map[string]int{
-		"projects?per_page=100": {"oauth_bl": 1, "oauth_kl": 1},
-	}; !reflect.DeepEqual(gitlabMock.madeProjectReqs, exp) {
-		t.Errorf("Unexpected cache behavior. Expected underying requests to be %v, but got %v", exp, gitlabMock.madeProjectReqs)
-	}
-}
-
-// Test_GitLab_RepoPerms_cache_ttl tests the behavior of overwriting cache entries when the TTL changes
-func Test_GitLab_RepoPerms_cache_ttl(t *testing.T) {
-	gitlabMock := newMockGitLab(t,
-		[]int{
-			11, // gitlab.mine/bl/repo-1
-		},
-		map[string][]int{
-			"101": {11},
-		},
-		map[string]string{
-			"oauth101": "101",
-		}, 1)
-	gitlab.MockListProjects = gitlabMock.ListProjects
-
-	cache := make(mockCache)
-	ctx := context.Background()
-	authzProvider := NewProvider(GitLabOAuthAuthzProviderOp{
-		BaseURL:   mustURL(t, "https://gitlab.mine"),
-		MockCache: cache,
-	})
-	if expCache := mockCache(map[string]string{}); !reflect.DeepEqual(cache, expCache) {
-		t.Errorf("expected cache to be %+v, but was %+v", expCache, cache)
-	}
-
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "101", "oauth101"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if expCache := mockCache(map[string]string{"101": `{"repos":{"11":{}},"ttl":0}`}); !reflect.DeepEqual(cache, expCache) {
-		t.Errorf("expected cache to be %+v, but was %+v", expCache, cache)
-	}
-
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "101", "oauth101"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if expCache := mockCache(map[string]string{"101": `{"repos":{"11":{}},"ttl":0}`}); !reflect.DeepEqual(cache, expCache) {
-		t.Errorf("expected cache to be %+v, but was %+v", expCache, cache)
-	}
-
-	authzProvider.cacheTTL = time.Hour * 5
-
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "101", "oauth101"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if expCache := mockCache(map[string]string{"101": `{"repos":{"11":{}},"ttl":18000000000000}`}); !reflect.DeepEqual(cache, expCache) {
-		t.Errorf("expected cache to be %+v, but was %+v", expCache, cache)
-	}
-
-	authzProvider.cacheTTL = time.Second * 5
-
-	// Use lower TTL
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "101", "oauth101"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if expCache := mockCache(map[string]string{"101": `{"repos":{"11":{}},"ttl":5000000000}`}); !reflect.DeepEqual(cache, expCache) {
-		t.Errorf("expected cache to be %+v, but was %+v", expCache, cache)
-	}
-
-	authzProvider.cacheTTL = time.Second * 60
-
-	// Increase in TTL doesn't overwrite cache entry
-	if _, err := authzProvider.RepoPerms(ctx, acct(1, gitlab.ServiceType, "https://gitlab.mine/", "101", "oauth101"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if expCache := mockCache(map[string]string{"101": `{"repos":{"11":{}},"ttl":5000000000}`}); !reflect.DeepEqual(cache, expCache) {
-		t.Errorf("expected cache to be %+v, but was %+v", expCache, cache)
 	}
 }
 
@@ -404,210 +371,4 @@ func (g GitLab_Repos_Test) run(t *testing.T) {
 			t.Errorf("For input %v, expected others to be %v, but got %v", c.repos, c.expOthers, others)
 		}
 	}
-}
-
-// mockGitLab is a mock for the GitLab client that can be used by tests. Instantiating a mockGitLab
-// instance itself does nothing, but its methods can be used to replace the mock functions (e.g.,
-// MockListProjects).
-//
-// We prefer to do it this way, instead of defining an interface for the GitLab client, because this
-// preserves the ability to jump-to-def around the actual implementation.
-type mockGitLab struct {
-	t *testing.T
-
-	// acls is a map from GitLab user ID to list of accessible project IDs on GitLab
-	// Publicly accessible projects are keyed by the special "PUBLIC" key
-	acls map[string][]int
-
-	// projs is a map of all projects on the instance, keyed by project ID
-	projs map[int]*gitlab.Project
-
-	// oauthToks is a map from OAuth token to GitLab user account ID
-	oauthToks map[string]string
-
-	// maxPerPage returns the max per_page value for the instance
-	maxPerPage int
-
-	// madeProjectReqs records how many ListProjects requests were made by url string and oauth
-	// token
-	madeProjectReqs map[string]map[string]int
-}
-
-// newMockGitLab returns a new mockGitLab instance with the specified projects (projIDs), ACLs (acls
-// maps from user account ID to list of project IDs), and OAuth tokens (oauthToks maps OAuth token
-// to user ID).
-func newMockGitLab(t *testing.T, projIDs []int, acls map[string][]int, oauthToks map[string]string, maxPerPage int) mockGitLab {
-	projs := make(map[int]*gitlab.Project)
-	for _, p := range projIDs {
-		projs[p] = &gitlab.Project{ProjectCommon: gitlab.ProjectCommon{ID: p}}
-	}
-	return mockGitLab{
-		t:          t,
-		projs:      projs,
-		acls:       acls,
-		oauthToks:  oauthToks,
-		maxPerPage: maxPerPage,
-	}
-}
-
-func (m *mockGitLab) ListProjects(c *gitlab.Client, ctx context.Context, urlStr string) (proj []*gitlab.Project, nextPageURL *string, err error) {
-	if m.madeProjectReqs == nil {
-		m.madeProjectReqs = make(map[string]map[string]int)
-	}
-	if m.madeProjectReqs[urlStr] == nil {
-		m.madeProjectReqs[urlStr] = make(map[string]int)
-	}
-	m.madeProjectReqs[urlStr][c.OAuthToken]++
-
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		m.t.Fatalf("could not parse ListProjects urlStr %q: %s", urlStr, err)
-	}
-	acceptedQ := map[string]struct{}{"page": {}, "per_page": {}}
-	for k := range u.Query() {
-		if _, ok := acceptedQ[k]; !ok {
-			m.t.Fatalf("mockGitLab unable to handle urlStr %q", urlStr)
-		}
-	}
-
-	acctID := m.oauthToks[c.OAuthToken]
-	var repoIDs []int
-	if acctID == "" {
-		repoIDs = m.acls["PUBLIC"]
-	} else {
-		repoIDs = m.acls[acctID]
-	}
-
-	allProjs := make([]*gitlab.Project, len(repoIDs))
-	for i, repoID := range repoIDs {
-		proj, ok := m.projs[repoID]
-		if !ok {
-			m.t.Fatalf("Dangling project reference in mockGitLab: %d", repoID)
-		}
-		allProjs[i] = proj
-	}
-
-	// pagination
-	perPage, err := getIntOrDefault(u.Query().Get("per_page"), m.maxPerPage)
-	if err != nil {
-		return nil, nil, err
-	}
-	if perPage > m.maxPerPage {
-		perPage = m.maxPerPage
-	}
-	page, err := getIntOrDefault(u.Query().Get("page"), 1)
-	if err != nil {
-		return nil, nil, err
-	}
-	p := page - 1
-	var (
-		pagedProjs []*gitlab.Project
-	)
-	if perPage*p > len(allProjs)-1 {
-		pagedProjs = nil
-	} else if perPage*(p+1) > len(allProjs)-1 {
-		pagedProjs = allProjs[perPage*p:]
-	} else {
-		pagedProjs = allProjs[perPage*p : perPage*(p+1)]
-		if perPage*(p+1) <= len(allProjs)-1 {
-			newU := *u
-			q := u.Query()
-			q.Set("page", strconv.Itoa(page+1))
-			newU.RawQuery = q.Encode()
-			s := newU.String()
-			nextPageURL = &s
-		}
-	}
-	return pagedProjs, nextPageURL, nil
-}
-
-type mockCache map[string]string
-
-func (m mockCache) Get(key string) ([]byte, bool) {
-	v, ok := m[key]
-	return []byte(v), ok
-}
-func (m mockCache) Set(key string, b []byte) {
-	m[key] = string(b)
-}
-func (m mockCache) Delete(key string) {
-	delete(m, key)
-}
-
-func getIntOrDefault(str string, def int) (int, error) {
-	if str == "" {
-		return def, nil
-	}
-	return strconv.Atoi(str)
-}
-
-func acct(userID int32, serviceType, serviceID, accountID, oauthTok string) *extsvc.ExternalAccount {
-	var data extsvc.ExternalAccountData
-	gitlab.SetExternalAccountData(&data, &gitlab.User{
-		ID: userID,
-	}, &oauth2.Token{
-		AccessToken: oauthTok,
-	})
-	return &extsvc.ExternalAccount{
-		UserID: userID,
-		ExternalAccountSpec: extsvc.ExternalAccountSpec{
-			ServiceType: serviceType,
-			ServiceID:   serviceID,
-			AccountID:   accountID,
-		},
-		ExternalAccountData: data,
-	}
-}
-
-func repo(uri, serviceType, serviceID, id string) authz.Repo {
-	return authz.Repo{
-		RepoName: api.RepoName(uri),
-		ExternalRepoSpec: api.ExternalRepoSpec{
-			ID:          id,
-			ServiceType: serviceType,
-			ServiceID:   serviceID,
-		},
-	}
-}
-
-type mockAuthnProvider struct {
-	configID  auth.ProviderConfigID
-	serviceID string
-}
-
-func (m mockAuthnProvider) ConfigID() auth.ProviderConfigID {
-	return m.configID
-}
-
-func (m mockAuthnProvider) Config() schema.AuthProviders {
-	return schema.AuthProviders{
-		Gitlab: &schema.GitLabAuthProvider{
-			Type: m.configID.Type,
-			Url:  m.configID.ID,
-		},
-	}
-}
-
-func (m mockAuthnProvider) CachedInfo() *auth.ProviderInfo {
-	return &auth.ProviderInfo{ServiceID: m.serviceID}
-}
-
-func (m mockAuthnProvider) Refresh(ctx context.Context) error {
-	panic("should not be called")
-}
-
-func mustURL(t *testing.T, u string) *url.URL {
-	parsed, err := url.Parse(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return parsed
-}
-
-func asJSON(t *testing.T, v interface{}) string {
-	b, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(b)
 }

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_test.go
@@ -28,26 +28,26 @@ func Test_GitLab_RepoPerms(t *testing.T) {
 			981,
 		},
 		map[int][2][]string{ // private projects
-			10: [2][]string{
-				[]string{ // guests
+			10: {
+				{ // guests
 					"u2",
 				},
-				[]string{ // content ("full access")
+				{ // content ("full access")
 					"u1",
 					"u3",
 				},
 			},
-			20: [2][]string{
-				[]string{
+			20: {
+				{
 					"u3",
 				},
-				[]string{
+				{
 					"u2",
 				},
 			},
-			30: [2][]string{
-				[]string{},
-				[]string{"u3"},
+			30: {
+				{},
+				{"u3"},
 			},
 		},
 		map[string]string{
@@ -158,11 +158,11 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 			981,
 		},
 		map[int][2][]string{ // private projects
-			10: [2][]string{
-				[]string{ // guests
+			10: {
+				{ // guests
 					"u2",
 				},
-				[]string{ // content ("full access")
+				{ // content ("full access")
 					"u1",
 				},
 			},
@@ -193,12 +193,12 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 		t.Fatal(err)
 	}
 	if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
-		"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		"oauth-u1": {{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
 	}; !reflect.DeepEqual(exp, actual) {
 		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 	}
 	if actual, exp := gitlabMock.madeListTree, map[string]map[gitlab.ListTreeOp]int{
-		"oauth-u1": map[gitlab.ListTreeOp]int{{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		"oauth-u1": {{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
 	}; !reflect.DeepEqual(exp, actual) {
 		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 	}
@@ -213,12 +213,12 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 		t.Fatal(err)
 	}
 	if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
-		"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		"oauth-u1": {{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
 	}; !reflect.DeepEqual(exp, actual) {
 		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 	}
 	if actual, exp := gitlabMock.madeListTree, map[string]map[gitlab.ListTreeOp]int{
-		"oauth-u1": map[gitlab.ListTreeOp]int{{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		"oauth-u1": {{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
 	}; !reflect.DeepEqual(exp, actual) {
 		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 	}
@@ -233,8 +233,8 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 		t.Fatal(err)
 	}
 	if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
-		"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
-		"oauth-u2": map[gitlab.GetProjectOp]int{{ID: 981, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		"oauth-u1": {{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+		"oauth-u2": {{ID: 981, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
 	}; !reflect.DeepEqual(exp, actual) {
 		t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 	}
@@ -253,13 +253,13 @@ func Test_GitLab_RepoPerms_cache(t *testing.T) {
 	}
 	for i := 0; i < 2; i++ {
 		if actual, exp := gitlabMock.madeGetProject, map[string]map[gitlab.GetProjectOp]int{
-			"oauth-u1": map[gitlab.GetProjectOp]int{{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 2},
-			"oauth-u2": map[gitlab.GetProjectOp]int{{ID: 981, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
+			"oauth-u1": {{ID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 2},
+			"oauth-u2": {{ID: 981, CommonOp: gitlab.CommonOp{NoCache: true}}: 1},
 		}; !reflect.DeepEqual(exp, actual) {
 			t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 		}
 		if actual, exp := gitlabMock.madeListTree, map[string]map[gitlab.ListTreeOp]int{
-			"oauth-u1": map[gitlab.ListTreeOp]int{{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 2},
+			"oauth-u1": {{ProjID: 10, CommonOp: gitlab.CommonOp{NoCache: true}}: 2},
 		}; !reflect.DeepEqual(exp, actual) {
 			t.Errorf("Unexpected cache behavior. Expected %v, but got %v", exp, actual)
 		}

--- a/pkg/extsvc/gitlab/client.go
+++ b/pkg/extsvc/gitlab/client.go
@@ -39,6 +39,10 @@ type ClientProvider struct {
 	RateLimit *ratelimit.Monitor // the API rate limit monitor
 }
 
+type CommonOp struct {
+	NoCache bool
+}
+
 func NewClientProvider(baseURL *url.URL, transport http.RoundTripper) *ClientProvider {
 	if transport == nil {
 		transport = http.DefaultTransport
@@ -63,11 +67,17 @@ func NewClientProvider(baseURL *url.URL, transport http.RoundTripper) *ClientPro
 
 // GetPATClient returns a client authenticated by the personal access token.
 func (p *ClientProvider) GetPATClient(personalAccessToken string) *Client {
+	if personalAccessToken == "" {
+		return p.getClient("", "", "")
+	}
 	return p.getClient(fmt.Sprintf("pat::%s", personalAccessToken), personalAccessToken, "")
 }
 
 // GetOAuthClient returns a client authenticated by the OAuth token.
 func (p *ClientProvider) GetOAuthClient(oauthToken string) *Client {
+	if oauthToken == "" {
+		return p.getClient("", "", "")
+	}
 	return p.getClient(fmt.Sprintf("oauth::%s", oauthToken), "", oauthToken)
 }
 

--- a/pkg/extsvc/gitlab/mock.go
+++ b/pkg/extsvc/gitlab/mock.go
@@ -12,3 +12,9 @@ var MockListUsers func(c *Client, ctx context.Context, urlStr string) (users []*
 
 // MockGetUser, if non-nil, will be called instead of Client.GetUser
 var MockGetUser func(c *Client, ctx context.Context, id string) (*User, error)
+
+// MockGetProject, if non-nil, will be called instead of Client.GetProject
+var MockGetProject func(c *Client, ctx context.Context, op GetProjectOp) (*Project, error)
+
+// MockListTree, if non-nil, will be called instead of Client.ListTree
+var MockListTree func(c *Client, ctx context.Context, op ListTreeOp) ([]*Tree, error)

--- a/pkg/extsvc/gitlab/projects.go
+++ b/pkg/extsvc/gitlab/projects.go
@@ -47,12 +47,9 @@ func (p Project) RequiresAuthentication() bool {
 func idCacheKey(id int) string                                  { return "1:" + strconv.Itoa(id) }
 func pathWithNamespaceCacheKey(pathWithNamespace string) string { return "1:" + pathWithNamespace }
 
-// GetProjectMock is set by tests to mock (*Client).GetProject.
-var GetProjectMock func(ctx context.Context, op GetProjectOp) (*Project, error)
-
 // MockGetProject_Return is called by tests to mock (*Client).GetProject.
 func MockGetProject_Return(returns *Project) {
-	GetProjectMock = func(context.Context, GetProjectOp) (*Project, error) {
+	MockGetProject = func(*Client, context.Context, GetProjectOp) (*Project, error) {
 		return returns, nil
 	}
 }
@@ -69,8 +66,8 @@ func (c *Client) GetProject(ctx context.Context, op GetProjectOp) (*Project, err
 		panic("invalid args (specify exactly one of id and pathWithNamespace)")
 	}
 
-	if GetProjectMock != nil {
-		return GetProjectMock(ctx, op)
+	if MockGetProject != nil {
+		return MockGetProject(c, ctx, op)
 	}
 
 	var key string

--- a/pkg/extsvc/gitlab/projects.go
+++ b/pkg/extsvc/gitlab/projects.go
@@ -17,8 +17,8 @@ type Visibility string
 
 const (
 	Public   Visibility = "public"
-	Private             = "private"
-	Internal            = "internal"
+	Private  Visibility = "private"
+	Internal Visibility = "internal"
 )
 
 // Project is a GitLab project (equivalent to a GitHub repository).

--- a/pkg/extsvc/gitlab/repositories.go
+++ b/pkg/extsvc/gitlab/repositories.go
@@ -1,0 +1,58 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+type Tree struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Path string `json:"path"`
+	Mode string `json:"mode"`
+}
+
+type ListTreeOp struct {
+	ProjID                int
+	ProjPathWithNamespace string
+	CommonOp
+}
+
+var ListTreeMock func(ctx context.Context, op ListTreeOp) ([]*Tree, error)
+
+// ListTree lists the repository tree of the specified project. The underlying GitLab API has more
+// options, but for now, we only support non-recursive queries of the root directory. Requests
+// results are not cached by the client at the moment (i.e., setting op.NoCache to true does not
+// alter behavior).
+func (c *Client) ListTree(ctx context.Context, op ListTreeOp) ([]*Tree, error) {
+	if ListTreeMock != nil {
+		return ListTreeMock(ctx, op)
+	}
+
+	if op.ProjID != 0 && op.ProjPathWithNamespace != "" {
+		return nil, errors.New("invalid args (specify exactly one of id and projPathWithNamespace")
+	}
+
+	return c.listTreeFromAPI(ctx, op.ProjID, op.ProjPathWithNamespace)
+}
+
+func (c *Client) listTreeFromAPI(ctx context.Context, projID int, projPathWithNamespace string) (tree []*Tree, err error) {
+	var projSpecifier string
+	if projID != 0 {
+		projSpecifier = strconv.Itoa(projID)
+	} else {
+		projSpecifier = url.PathEscape(projPathWithNamespace)
+	}
+	req, err := http.NewRequest("GET", fmt.Sprintf("projects/%s/repository/tree", projSpecifier), nil)
+	if err != nil {
+		return nil, err
+	}
+	_, err = c.do(ctx, req, &tree)
+	return tree, err
+}

--- a/pkg/extsvc/gitlab/repositories.go
+++ b/pkg/extsvc/gitlab/repositories.go
@@ -31,8 +31,8 @@ var ListTreeMock func(ctx context.Context, op ListTreeOp) ([]*Tree, error)
 // results are not cached by the client at the moment (i.e., setting op.NoCache to true does not
 // alter behavior).
 func (c *Client) ListTree(ctx context.Context, op ListTreeOp) ([]*Tree, error) {
-	if ListTreeMock != nil {
-		return ListTreeMock(ctx, op)
+	if MockListTree != nil {
+		return MockListTree(c, ctx, op)
 	}
 
 	if op.ProjID != 0 && op.ProjPathWithNamespace != "" {

--- a/pkg/extsvc/gitlab/repositories_test.go
+++ b/pkg/extsvc/gitlab/repositories_test.go
@@ -1,0 +1,81 @@
+package gitlab
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestListTree(t *testing.T) {
+	mock := mockHTTPResponseBody{
+		responseBody: `
+[
+  {
+    "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+    "name": "html",
+    "type": "tree",
+    "path": "files/html",
+    "mode": "040000"
+  },
+  {
+    "id": "4535904260b1082e14f867f7a24fd8c21495bde3",
+    "name": "images",
+    "type": "tree",
+    "path": "files/images",
+    "mode": "040000"
+  }
+]
+`}
+	c := newTestClient(t)
+	c.httpClient.Transport = &mock
+
+	want := []*Tree{
+		{
+			ID:   "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+			Name: "html",
+			Type: "tree",
+			Path: "files/html",
+			Mode: "040000",
+		},
+		{
+			ID:   "4535904260b1082e14f867f7a24fd8c21495bde3",
+			Name: "images",
+			Type: "tree",
+			Path: "files/images",
+			Mode: "040000",
+		},
+	}
+
+	// Test first fetch (cache empty)
+	tree, err := c.ListTree(context.Background(), ListTreeOp{ProjPathWithNamespace: "n1/n2/r"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tree == nil {
+		t.Error("tree == nil")
+	}
+	if mock.count != 1 {
+		t.Errorf("mock.count == %d, expected to miss cache once", mock.count)
+	}
+	if !reflect.DeepEqual(tree, want) {
+		t.Errorf("got tree %+v, want %+v", tree, &want)
+	}
+
+	// Note: since caching is not currently implemented for this endpoint, we don't test it
+
+	// Test the `NoCache: true` option
+	tree, err = c.ListTree(context.Background(), ListTreeOp{ProjPathWithNamespace: "n1/n2/r", CommonOp: CommonOp{NoCache: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tree == nil {
+		t.Error("tree == nil")
+	}
+	if mock.count != 2 {
+		t.Errorf("mock.count == %d, expected to miss cache once", mock.count)
+	}
+	if !reflect.DeepEqual(tree, want) {
+		t.Errorf("got tree %+v, want %+v", tree, &want)
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2007

The first commit makes the actual change. Subsequent commits update unit tests.

This makes GitLab permissions fetching use the same general strategy as we use for GitHub. GitLab has 3 levels of project (a GitLab project is analogous to a GitHub repo): public, internal, and private. Public projects are accessible to anyone, including unauthenticated requests. Internal projs are accessible to any authenticated user. Private projs are subject to permissions. We cache the following pieces of information:
* Which projs are public
* Which projs are internal
* For each user, a list of private projs that the user has access to (not just "Guest"-level access, but can actually read the repository contents)

This results in much better performance, because we don't have to block on fetching a user's entire list of accessible projects. Instead, we make at most 2 API requests for each project being accessed, the first to determine if the project is public/internal (`GetProject`), the second to determine if a private project is accessible to the current user (`ListTree`).