### PR TITLE
Fix remote repository connection checking

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -98,7 +98,7 @@ func (s *repos) Add(ctx context.Context, name api.RepoName, serviceType string) 
 	// Avoid hitting the repoupdater (and incurring a hit against our GitHub/etc. API rate
 	// limit) for repositories that don't exist or private repositories that people attempt to
 	// access.
-	gitserverRepo, err := quickGitserverRepo(ctx, name, serviceType)
+	gitserverRepo, err := quickGitserverRepo(ctx, name, &serviceType)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -98,7 +98,7 @@ func (s *repos) Add(ctx context.Context, name api.RepoName, serviceType string) 
 	// Avoid hitting the repoupdater (and incurring a hit against our GitHub/etc. API rate
 	// limit) for repositories that don't exist or private repositories that people attempt to
 	// access.
-	gitserverRepo, err := quickGitserverRepo(ctx, name, &serviceType)
+	gitserverRepo, err := quickGitserverRepo(ctx, name, serviceType)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -65,7 +65,7 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 	repo, err := db.Repos.GetByName(ctx, name)
 	if err != nil && envvar.SourcegraphDotComMode() {
 		// Automatically add repositories on Sourcegraph.com.
-		if err := s.Add(ctx, name, "github"); err != nil {
+		if err := s.AddGitHubDotComRepository(ctx, name); err != nil {
 			return nil, err
 		}
 		return db.Repos.GetByName(ctx, name)
@@ -84,21 +84,21 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 	return repo, nil
 }
 
-// Add adds the repository with the given name. The name is mapped to a repository by consulting the
+// AddGitHubDotComRepository adds the repository with the given name. The name is mapped to a repository by consulting the
 // repo-updater, which contains information about all configured code hosts and the names that they
 // handle.
-func (s *repos) Add(ctx context.Context, name api.RepoName, serviceType string) (err error) {
-	if Mocks.Repos.Add != nil {
-		return Mocks.Repos.Add(name)
+func (s *repos) AddGitHubDotComRepository(ctx context.Context, name api.RepoName) (err error) {
+	if Mocks.Repos.AddGitHubDotComRepository != nil {
+		return Mocks.Repos.AddGitHubDotComRepository(name)
 	}
 
-	ctx, done := trace(ctx, "Repos", "Add", name, &err)
+	ctx, done := trace(ctx, "Repos", "AddGitHubDotComRepository", name, &err)
 	defer done()
 
 	// Avoid hitting the repoupdater (and incurring a hit against our GitHub/etc. API rate
 	// limit) for repositories that don't exist or private repositories that people attempt to
 	// access.
-	gitserverRepo, err := quickGitserverRepo(ctx, name, serviceType)
+	gitserverRepo, err := quickGitserverRepo(ctx, name, "github.com")
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -15,14 +15,14 @@ import (
 )
 
 type MockRepos struct {
-	Get                  func(v0 context.Context, id api.RepoID) (*types.Repo, error)
-	GetByName            func(v0 context.Context, name api.RepoName) (*types.Repo, error)
-	Add                  func(name api.RepoName) error
-	List                 func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
-	GetCommit            func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error)
-	ResolveRev           func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
-	GetInventory         func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
-	GetInventoryUncached func(ctx context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
+	Get                       func(v0 context.Context, id api.RepoID) (*types.Repo, error)
+	GetByName                 func(v0 context.Context, name api.RepoName) (*types.Repo, error)
+	AddGitHubDotComRepository func(name api.RepoName) error
+	List                      func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
+	GetCommit                 func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error)
+	ResolveRev                func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
+	GetInventory              func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
+	GetInventoryUncached      func(ctx context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
 }
 
 var errRepoNotFound = &errcode.Mock{

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -86,7 +86,7 @@ func TestRepos_Add(t *testing.T) {
 		return nil
 	}
 
-	if err := s.Add(ctx, repoName, ""); err != nil {
+	if err := s.AddGitHubDotComRepository(ctx, repoName); err != nil {
 		t.Fatal(err)
 	}
 	if !calledRepoLookup {

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -86,7 +86,7 @@ func TestRepos_Add(t *testing.T) {
 		return nil
 	}
 
-	if err := s.Add(ctx, repoName); err != nil {
+	if err := s.Add(ctx, repoName, ""); err != nil {
 		t.Fatal(err)
 	}
 	if !calledRepoLookup {

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater/protocol"
@@ -75,9 +77,9 @@ func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType stri
 	lowerRepo := strings.ToLower(string(repo))
 	var hasToken func(context.Context) (bool, error)
 	switch {
-	case serviceType == "github" && strings.HasPrefix(lowerRepo, "github.com/"):
+	case serviceType == github.ServiceType && strings.HasPrefix(lowerRepo, "github.com/"):
 		hasToken = hasGitHubDotComToken
-	case serviceType == "gitlab" && strings.HasPrefix(lowerRepo, "gitlab.com/"):
+	case serviceType == gitlab.ServiceType && strings.HasPrefix(lowerRepo, "gitlab.com/"):
 		hasToken = hasGitLabDotComToken
 	default:
 		return nil, nil

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -23,9 +23,9 @@ import (
 // value), those operations will fail. This occurs when the repository isn't cloned on gitserver or
 // when an update is needed (eg in ResolveRevision).
 func CachedGitRepo(ctx context.Context, repo *types.Repo) (*gitserver.Repo, error) {
-	var serviceType *string
+	var serviceType string
 	if repo.ExternalRepo != nil {
-		serviceType = &repo.ExternalRepo.ServiceType
+		serviceType = repo.ExternalRepo.ServiceType
 	}
 	r, err := quickGitserverRepo(ctx, repo.Name, serviceType)
 	if err != nil {
@@ -40,9 +40,9 @@ func CachedGitRepo(ctx context.Context, repo *types.Repo) (*gitserver.Repo, erro
 // GitRepo returns a handle to the Git repository with the up-to-date (as of the time of this call)
 // remote URL. See CachedGitRepo for when this is necessary vs. unnecessary.
 func GitRepo(ctx context.Context, repo *types.Repo) (gitserver.Repo, error) {
-	var serviceType *string
+	var serviceType string
 	if repo.ExternalRepo != nil {
-		serviceType = &repo.ExternalRepo.ServiceType
+		serviceType = repo.ExternalRepo.ServiceType
 	}
 	gitserverRepo, err := quickGitserverRepo(ctx, repo.Name, serviceType)
 	if err != nil {
@@ -65,7 +65,7 @@ func GitRepo(ctx context.Context, repo *types.Repo) (gitserver.Repo, error) {
 	return gitserver.Repo{Name: result.Repo.Name, URL: result.Repo.VCS.URL}, nil
 }
 
-func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType *string) (*gitserver.Repo, error) {
+func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType string) (*gitserver.Repo, error) {
 	// If it is possible to 100% correctly determine it statically, use a fast path. This is
 	// used to avoid a RepoLookup call for public GitHub.com and GitLab.com repositories
 	// (especially on Sourcegraph.com), which reduces rate limit pressure significantly.
@@ -75,9 +75,9 @@ func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType *str
 	lowerRepo := strings.ToLower(string(repo))
 	var hasToken func(context.Context) (bool, error)
 	switch {
-	case serviceType != nil && *serviceType == "github" && strings.HasPrefix(lowerRepo, "github.com/"):
+	case serviceType == "github" && strings.HasPrefix(lowerRepo, "github.com/"):
 		hasToken = hasGitHubDotComToken
-	case serviceType != nil && *serviceType == "gitlab" && strings.HasPrefix(lowerRepo, "gitlab.com/"):
+	case serviceType == "gitlab" && strings.HasPrefix(lowerRepo, "gitlab.com/"):
 		hasToken = hasGitLabDotComToken
 	default:
 		return nil, nil

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -23,7 +23,7 @@ import (
 // value), those operations will fail. This occurs when the repository isn't cloned on gitserver or
 // when an update is needed (eg in ResolveRevision).
 func CachedGitRepo(ctx context.Context, repo *types.Repo) (*gitserver.Repo, error) {
-	r, err := quickGitserverRepo(ctx, repo.Name)
+	r, err := quickGitserverRepo(ctx, repo.Name, repo.ExternalRepo.ServiceType)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func CachedGitRepo(ctx context.Context, repo *types.Repo) (*gitserver.Repo, erro
 // GitRepo returns a handle to the Git repository with the up-to-date (as of the time of this call)
 // remote URL. See CachedGitRepo for when this is necessary vs. unnecessary.
 func GitRepo(ctx context.Context, repo *types.Repo) (gitserver.Repo, error) {
-	gitserverRepo, err := quickGitserverRepo(ctx, repo.Name)
+	gitserverRepo, err := quickGitserverRepo(ctx, repo.Name, repo.ExternalRepo.ServiceType)
 	if err != nil {
 		return gitserver.Repo{Name: repo.Name}, err
 	}
@@ -57,7 +57,7 @@ func GitRepo(ctx context.Context, repo *types.Repo) (gitserver.Repo, error) {
 	return gitserver.Repo{Name: result.Repo.Name, URL: result.Repo.VCS.URL}, nil
 }
 
-func quickGitserverRepo(ctx context.Context, repo api.RepoName) (*gitserver.Repo, error) {
+func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType string) (*gitserver.Repo, error) {
 	// If it is possible to 100% correctly determine it statically, use a fast path. This is
 	// used to avoid a RepoLookup call for public GitHub.com and GitLab.com repositories
 	// (especially on Sourcegraph.com), which reduces rate limit pressure significantly.
@@ -67,9 +67,9 @@ func quickGitserverRepo(ctx context.Context, repo api.RepoName) (*gitserver.Repo
 	lowerRepo := strings.ToLower(string(repo))
 	var hasToken func(context.Context) (bool, error)
 	switch {
-	case strings.HasPrefix(lowerRepo, "github.com/"):
+	case serviceType == "github" && strings.HasPrefix(lowerRepo, "github.com/"):
 		hasToken = hasGitHubDotComToken
-	case strings.HasPrefix(lowerRepo, "gitlab.com/"):
+	case serviceType == "gitlab" && strings.HasPrefix(lowerRepo, "gitlab.com/"):
 		hasToken = hasGitLabDotComToken
 	default:
 		return nil, nil


### PR DESCRIPTION
Previously, the frontend would neglect to check that the repository is associated with a GitHub external service in addition to checking that the repository hostname is `github.com` before finding an access token and looking up the repository on GitHub.com via HTTPS.

This adds a check to make sure the repository is associated with the external service before using the token from the external service.

- @nicksnyder Does this look like an appropriate change to make? You probably have a better understanding of the data model and relationships between repositories, URLs, access tokens, and external services than I do.
- @slimsag Does this actually fix the problem you saw in the issue below?

Fixes https://github.com/sourcegraph/sourcegraph/issues/1856