### PR TITLE
activation status in pings

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -103,21 +103,23 @@ func updateURL(ctx context.Context) string {
 		logFunc("db.Users.Count failed", "error", err)
 	}
 	q.Set("totalUsers", strconv.Itoa(totalUsers))
-	totalRepos, err := db.Repos.Count(ctx, db.ReposListOptions{})
+	totalRepos, err := db.Repos.Count(ctx, db.ReposListOptions{Enabled: true, Disabled: true})
+	hasRepos := totalRepos > 0
 	if err != nil {
 		logFunc("db.Repos.Count failed", "error", err)
 	}
-	q.Set("repos", strconv.FormatBool(totalRepos > 0))
+	q.Set("repos", strconv.FormatBool(hasRepos))
 	searchOccurred, err := usagestats.HasSearchOccurred()
 	if err != nil {
 		logFunc("usagestats.HasSearchOccurred failed", "error", err)
 	}
-	q.Set("searched", strconv.FormatBool(searchOccurred))
-	codeIntelOccurred, err := usagestats.HasCodeIntelOccurred()
+	// Searches only count if repos have been added.
+	q.Set("searched", strconv.FormatBool(hasRepos && searchOccurred))
+	findRefsOccurred, err := usagestats.HasFindRefsOccurred()
 	if err != nil {
-		logFunc("usagestats.HasCodeIntelOccurred failed", "error", err)
+		logFunc("usagestats.HasFindRefsOccurred failed", "error", err)
 	}
-	q.Set("codeIntel", strconv.FormatBool(codeIntelOccurred))
+	q.Set("refs", strconv.FormatBool(findRefsOccurred))
 	if act, err := getSiteActivityJSON(); err != nil {
 		logFunc("getSiteActivityJSON failed", "error", err)
 	} else {

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -90,6 +90,9 @@ func updateURL(ctx context.Context) string {
 	q.Set("site", siteid.Get())
 	q.Set("auth", strings.Join(authProviderTypes(), ","))
 	q.Set("deployType", conf.DeployType())
+	q.Set("hasExtURL", strconv.FormatBool(conf.UsingExternalURL()))
+	q.Set("signup", strconv.FormatBool(conf.IsBuiltinSignupAllowed()))
+
 	count, err := usagestats.GetUsersActiveTodayCount()
 	if err != nil {
 		logFunc("usagestats.GetUsersActiveTodayCount failed", "error", err)
@@ -100,6 +103,21 @@ func updateURL(ctx context.Context) string {
 		logFunc("db.Users.Count failed", "error", err)
 	}
 	q.Set("totalUsers", strconv.Itoa(totalUsers))
+	totalRepos, err := db.Repos.Count(ctx, db.ReposListOptions{})
+	if err != nil {
+		logFunc("db.Repos.Count failed", "error", err)
+	}
+	q.Set("repos", strconv.FormatBool(totalRepos > 0))
+	searchOccurred, err := usagestats.HasSearchOccurred()
+	if err != nil {
+		logFunc("usagestats.HasSearchOccurred failed", "error", err)
+	}
+	q.Set("searched", strconv.FormatBool(searchOccurred))
+	codeIntelOccurred, err := usagestats.HasCodeIntelOccurred()
+	if err != nil {
+		logFunc("usagestats.HasCodeIntelOccurred failed", "error", err)
+	}
+	q.Set("codeIntel", strconv.FormatBool(codeIntelOccurred))
 	if act, err := getSiteActivityJSON(); err != nil {
 		logFunc("getSiteActivityJSON failed", "error", err)
 	} else {

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -143,12 +143,17 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 	q := r.URL.Query()
 	clientSiteID := q.Get("site")
 	authProviders := q.Get("auth")
+	builtinSignupAllowed := q.Get("signup")
+	hasExtURL := q.Get("hasExtURL")
 	uniqueUsers := q.Get("u")
 	activity := q.Get("act")
 	initialAdminEmail := q.Get("initAdmin")
 	hasCodeIntelligence := q.Get("codeintel")
 	deployType := q.Get("deployType")
 	totalUsers := q.Get("totalUsers")
+	everRepos := q.Get("repos")
+	everSearched := q.Get("searched")
+	everCodeIntel := q.Get("codeIntel")
 
 	// Log update check.
 	var clientAddr string
@@ -174,8 +179,13 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		"site_activity": %s,
 		"installer_email": "%s",
 		"auth_providers": "%s",
+		"builtin_signup_allowed", "%s",
 		"deploy_type": "%s",
 		"total_user_accounts": "%s",
+		"has_external_url", "%s",
+		"ever_added_repos", "%s",
+		"ever_searched", "%s",
+		"ever_code_intel", "%s",
 		"timestamp": "%s"
 	}`,
 		clientAddr,
@@ -187,8 +197,13 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		activity,
 		initialAdminEmail,
 		authProviders,
+		builtinSignupAllowed,
 		deployType,
 		totalUsers,
+		hasExtURL,
+		everRepos,
+		everSearched,
+		everCodeIntel,
 		time.Now().UTC().Format(time.RFC3339),
 	)
 

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -150,9 +150,9 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 	initialAdminEmail := q.Get("initAdmin")
 	deployType := q.Get("deployType")
 	totalUsers := q.Get("totalUsers")
-	everRepos := q.Get("repos")
+	hasRepos := q.Get("repos")
 	everSearched := q.Get("searched")
-	everCodeIntel := q.Get("codeIntel")
+	everFindRefs := q.Get("refs")
 
 	// Log update check.
 	var clientAddr string
@@ -181,9 +181,9 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		"deploy_type": "%s",
 		"total_user_accounts": "%s",
 		"has_external_url", "%s",
-		"ever_added_repos", "%s",
+		"has_repos", "%s",
 		"ever_searched", "%s",
-		"ever_code_intel", "%s",
+		"ever_find_refs", "%s",
 		"timestamp": "%s"
 	}`,
 		clientAddr,
@@ -198,9 +198,9 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		deployType,
 		totalUsers,
 		hasExtURL,
-		everRepos,
+		hasRepos,
 		everSearched,
-		everCodeIntel,
+		everFindRefs,
 		time.Now().UTC().Format(time.RFC3339),
 	)
 

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -148,7 +148,6 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 	uniqueUsers := q.Get("u")
 	activity := q.Get("act")
 	initialAdminEmail := q.Get("initAdmin")
-	hasCodeIntelligence := q.Get("codeintel")
 	deployType := q.Get("deployType")
 	totalUsers := q.Get("totalUsers")
 	everRepos := q.Get("repos")
@@ -175,7 +174,6 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		"remote_site_id": "%s",
 		"has_update": "%s",
 		"unique_users_today": "%s",
-		"has_code_intelligence": "%s",
 		"site_activity": %s,
 		"installer_email": "%s",
 		"auth_providers": "%s",
@@ -193,7 +191,6 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		clientSiteID,
 		strconv.FormatBool(hasUpdate),
 		uniqueUsers,
-		hasCodeIntelligence,
 		activity,
 		initialAdminEmail,
 		authProviders,

--- a/cmd/frontend/internal/pkg/usagestats/usage_stats.go
+++ b/cmd/frontend/internal/pkg/usagestats/usage_stats.go
@@ -441,13 +441,19 @@ func LogActivity(isAuthenticated bool, userID int32, userCookieID string, event 
 	// Regardless of authentication status,
 	switch event {
 	case "SEARCHQUERY":
-		logSearchOccurred()
+		if err := logSearchOccurred(); err != nil {
+			return err
+		}
 	case "CODEINTEL":
 		// TODO(Dan): differentiate between go to def and find refs
-		logFindRefsOccurred()
+		if err := logFindRefsOccurred(); err != nil {
+			return err
+		}
 	case "CODEINTELINTEGRATION":
 		// TODO(Dan): differentiate between go to def and find refs
-		logFindRefsOccurred()
+		if err := logFindRefsOccurred(); err != nil {
+			return err
+		}
 	}
 
 	// If the user isn't authenticated, return at this point and don't record user-level properties.

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -4,10 +4,14 @@ Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and
 
 - Sourcegraph version string
 - Deployment type (single-node or Kubernetes cluster)
+- Whether the instance is deployed on localhost (true/false)
 - Randomly generated site identifier
 - The email address of the initial site installer (or if deleted, the first active site admin), to know who to contact regarding sales, product updates, and policy updates
 - Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, or SAML)
-- Whether code intelligence is enabled
+- Whether new user signup is allowed (true/false)
+- Whether a repository has ever been added (true/false)
+- Whether a code search has ever been executed (true/false)
+- Whether code intelligence has ever been used (true/false)
 - Total count of existing user accounts
 - Aggregate counts of current daily, weekly, and monthly users
 - Aggregate counts of current users using code host integrations

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -284,6 +284,21 @@ func readSrcGitServers() []string {
 	return strings.Fields(v)
 }
 
+func UsingExternalURL() bool {
+	url := Get().Critical.ExternalURL
+	return !(url == "" || strings.HasPrefix(url, "http://localhost") || strings.HasPrefix(url, "https://localhost") || strings.HasPrefix(url, "http://127.0.0.1") || strings.HasPrefix(url, "https://127.0.0.1"))
+}
+
 func IsExternalURLSecure() bool {
 	return strings.HasPrefix(Get().Critical.ExternalURL, "https:")
+}
+
+func IsBuiltinSignupAllowed() bool {
+	provs := Get().Critical.AuthProviders
+	for _, prov := range provs {
+		if prov.Builtin != nil {
+			return prov.Builtin.AllowSignup
+		}
+	}
+	return false
 }

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -286,8 +286,7 @@ func readSrcGitServers() []string {
 
 func UsingExternalURL() bool {
 	url := Get().Critical.ExternalURL
-	// CI:LOCALHOST_OK
-	return !(url == "" || strings.HasPrefix(url, "http://localhost") || strings.HasPrefix(url, "https://localhost") || strings.HasPrefix(url, "http://127.0.0.1") || strings.HasPrefix(url, "https://127.0.0.1"))
+	return !(url == "" || strings.HasPrefix(url, "http://localhost") || strings.HasPrefix(url, "https://localhost") || strings.HasPrefix(url, "http://127.0.0.1") || strings.HasPrefix(url, "https://127.0.0.1")) // CI:LOCALHOST_OK
 }
 
 func IsExternalURLSecure() bool {

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -286,6 +286,7 @@ func readSrcGitServers() []string {
 
 func UsingExternalURL() bool {
 	url := Get().Critical.ExternalURL
+	// CI:LOCALHOST_OK
 	return !(url == "" || strings.HasPrefix(url, "http://localhost") || strings.HasPrefix(url, "https://localhost") || strings.HasPrefix(url, "http://127.0.0.1") || strings.HasPrefix(url, "https://127.0.0.1"))
 }
 

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -40,6 +40,7 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                 <ul>
                     <li>Sourcegraph version string</li>
                     <li>Deployment type (Docker, Kubernetes, or dev build)</li>
+                    <li>Whether the instance is deployed on localhost (true/false)</li>
                     <li>Randomly generated site identifier</li>
                     <li>
                         The email address of the initial site installer (or if deleted, the first active site admin), to
@@ -49,7 +50,10 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                         Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, or
                         SAML)
                     </li>
-                    <li>Whether code intelligence is enabled</li>
+                    <li>Whether new user signup is allowed (true/false)</li>
+                    <li>Whether a repository has ever been added (true/false)</li>
+                    <li>Whether a code search has ever been executed (true/false)</li>
+                    <li>Whether code intelligence has ever been used (true/false)</li>
                     <li>Total count of existing user accounts</li>
                     <li>Aggregate counts of current daily, weekly, and monthly users</li>
                     <li>Aggregate counts of current users using code host integrations</li>


### PR DESCRIPTION
~WIP, needs testing~. Initial items for https://github.com/sourcegraph/sourcegraph/issues/2024

Needs to differentiate between go-to-def and find-refs per convo here https://docs.google.com/a/sourcegraph.com/document/d/1P7uMHtOeYK1IwMj-1WtKspo16v8C_Mevj3qe1cX_kGY/edit?disco=AAAACjsSStE

Probably not currently the best way to record "did ever search" or "did ever do find refs" in redis, need to discuss what the ideal future activation dataset in pings is so this PR prepares us for that.

<!-- Remember to update the changelog for user-facing changes. -->

@sqs this is currently working, except find-refs isn't differentiated from go-to-def. We can merge this now, though, before 3.0, and while we'll potentially capture slightly too many that have used find-refs (since go-to-defs will also count), this can be fixed before 3.0.1.

Edit: looks like 3.0 is already tagged 🙁 this will have to get in in 3.0.1. Still ready for review, I will try to do the find-refs/go-to-def differentiation in a separate PR

