### PR TITLE
set overflow:auto for hover content title

### DIFF
--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -48,10 +48,8 @@
         }
         p,
         pre {
-            &:not(:last-child) {
-                margin-bottom: 0.5rem;
-                overflow: auto;
-            }
+            margin-bottom: 0.5rem;
+            overflow: auto;
             &:last-child {
                 margin-bottom: 0;
             }

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -50,6 +50,7 @@
         pre {
             &:not(:last-child) {
                 margin-bottom: 0.5rem;
+                overflow: auto;
             }
             &:last-child {
                 margin-bottom: 0;


### PR DESCRIPTION
Issue #1686 : When using the browser extension on GitHub, if the hover overlay has a long title that surpasses the box width, the entire content scrolls horizontally. However, the user would expect only the title to scroll. 

Solution: Add `overflow: auto` to the signature area (`pre`).