### PR TITLE
Revert to PostgreSQL 9.6 for 3.0 release

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repo
     echo "http://dl-cdn.alpinelinux.org/alpine/v3.6/community" >> /etc/apk/repositories
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache 'postgresql-contrib=11.1-r0' 'postgresql=11.1-r0' 'redis=3.2.12-r0' bind-tools ca-certificates git@edge mailcap nginx openssh-client su-exec tini
+RUN apk add --no-cache 'postgresql-contrib=9.6.10-r0' 'postgresql=9.6.10-r0' 'redis=3.2.12-r0' bind-tools ca-certificates git@edge mailcap nginx openssh-client su-exec tini
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:d74791c /syntect_server /usr/local/bin/

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -39,7 +39,7 @@ Sourcegraph has the following dependencies:
 - [make](https://www.gnu.org/software/make/)
 - [Docker](https://docs.docker.com/engine/installation/) (v1.8 or higher)
   - For macOS we recommend using Docker for Mac instead of `docker-machine`
-- [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides) (v11.1.0)
+- [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides) (v9.6.0)
 - [Redis](http://redis.io/) (v3.0.7 or higher)
 - [Yarn](https://yarnpkg.com) (v1.10.1 or higher)
 - [nginx](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/) (v1.14 or higher)
@@ -59,7 +59,7 @@ This is a streamlined setup for Mac machines.
     brew cask install docker
     ```
 
-3.  Install Go, Node, PostgreSQL 11, Redis, Git, and nginx with the following command:
+3.  Install Go, Node, PostgreSQL 9.6, Redis, Git, and nginx with the following command:
 
     ```
     brew install go node redis postgresql@11 git gnu-sed nginx
@@ -68,7 +68,7 @@ This is a streamlined setup for Mac machines.
 4.  Configure PostgreSQL and Redis to start automatically
 
     ```
-    brew services start postgresql@11
+    brew services start postgresql@9.6
     brew services start redis
     ```
 

--- a/doc/dev/postgresql.md
+++ b/doc/dev/postgresql.md
@@ -7,7 +7,7 @@ on the filesystem.
 
 ## Version requirements
 
-You must use PostgreSQL 11.1 for development.
+You must use PostgreSQL 9.6 for development.
 
 For Ubuntu 18.04, you will need to add a repository source. Use the
 [PostgreSQL.org official repo and instructions.](https://www.postgresql.org/download/linux/ubuntu/)


### PR DESCRIPTION
This commit reverts to Postgres 9.6 for the 3.0 release.

We didn't manage to finish everything on time so we'll continue
this work after 3.0 is released.
