### PR TITLE
Replace code discussions and typescript entries with datadog for top extensions list

### DIFF
--- a/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
+++ b/web/src/enterprise/extensions/explore/ExtensionsExploreSection.tsx
@@ -30,8 +30,7 @@ export class ExtensionsExploreSection extends React.PureComponent<Props, State> 
      */
     private static QUERY_EXTENSIONS_ARG_EXTENSION_IDS = [
         'sourcegraph/codecov',
-        'sourcegraph/code-discussions',
-        'sourcegraph/typescript',
+        'sourcegraph/datadog-metrics',
         'sourcegraph/git-extras',
     ]
 


### PR DESCRIPTION
Code discussions is considered experimental and the typescript lang extension is enabled by default in Sourcegraph 3.0

<!-- Remember to update the changelog for user-facing changes. -->
