### PR TITLE
all: Remove env.Version

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/db/globalstatedb"
-	"github.com/sourcegraph/sourcegraph/pkg/env"
 	"github.com/sourcegraph/sourcegraph/pkg/version"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -103,7 +102,7 @@ func (r *siteResolver) CanReloadSite(ctx context.Context) bool {
 	return canReloadSite && err == nil
 }
 
-func (r *siteResolver) BuildVersion() string { return env.Version }
+func (r *siteResolver) BuildVersion() string { return version.Version() }
 
 func (r *siteResolver) ProductVersion() string { return version.Version() }
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/db/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
+	"github.com/sourcegraph/sourcegraph/pkg/version"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -137,7 +138,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		CSRFToken:           csrfToken,
 		UserAgentIsBot:      isBot(req.UserAgent()),
 		AssetsRoot:          assetsutil.URL("").String(),
-		Version:             env.Version,
+		Version:             version.Version(),
 		IsAuthenticatedUser: actor.IsAuthenticated(),
 		SentryDSN:           sentryDSNFrontend,
 		Debug:               env.InsecureDev,

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -22,8 +22,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
-	"github.com/sourcegraph/sourcegraph/pkg/env"
 	tracepkg "github.com/sourcegraph/sourcegraph/pkg/trace"
+	"github.com/sourcegraph/sourcegraph/pkg/version"
 )
 
 // newExternalHTTPHandler creates and returns the HTTP handler that serves the app and API pages to
@@ -80,7 +80,7 @@ func healthCheckMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz", "/__version":
-			fmt.Fprintf(w, env.Version)
+			fmt.Fprintf(w, version.Version())
 		default:
 			next.ServeHTTP(w, r)
 		}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/processrestart"
 	"github.com/sourcegraph/sourcegraph/pkg/sysreq"
 	"github.com/sourcegraph/sourcegraph/pkg/tracer"
+	"github.com/sourcegraph/sourcegraph/pkg/version"
 	"github.com/sourcegraph/sourcegraph/pkg/vfsutil"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -106,7 +107,7 @@ func Main() error {
 	if len(os.Args) >= 2 {
 		switch os.Args[1] {
 		case "help", "-h", "--help":
-			log.Printf("Version: %s", env.Version)
+			log.Printf("Version: %s", version.Version())
 			log.Print()
 
 			env.PrintHelp()

--- a/cmd/frontend/internal/pkg/handlerutil/error_reporting.go
+++ b/cmd/frontend/internal/pkg/handlerutil/error_reporting.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
 	"github.com/sourcegraph/sourcegraph/pkg/trace"
+	"github.com/sourcegraph/sourcegraph/pkg/version"
 )
 
 var ravenClient *raven.Client
@@ -29,7 +30,7 @@ func init() {
 		ravenClient.DropHandler = func(pkt *raven.Packet) {
 			log.Println("WARNING: dropped error report because buffer is full:", pkt)
 		}
-		ravenClient.SetRelease(env.Version)
+		ravenClient.SetRelease(version.Version())
 	}
 }
 

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -18,6 +18,6 @@ RUN apk add --no-cache 'postgresql-contrib=9.6.10-r0' 'postgresql=9.6.10-r0' 're
 COPY --from=sourcegraph/syntect_server:d74791c /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 
-ENV GO111MODULES=on LANG=en_US.utf8 VERSION=$VERSION
+ENV GO111MODULES=on LANG=en_US.utf8
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/server"]
 COPY * /usr/local/bin/

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -23,7 +23,6 @@ var env = expvar.NewMap("env")
 var (
 	// MyName represents the name of the current process.
 	MyName, envVarName = findName()
-	Version            = Get("VERSION", "dev", "the version of the packaged app, usually set by Dockerfile")
 	LogLevel           = Get("SRC_LOG_LEVEL", "dbug", "upper log level to restrict log output to (dbug, info, warn, error, crit)")
 	LogFormat          = Get("SRC_LOG_FORMAT", "logfmt", "log format (logfmt, condensed)")
 	InsecureDev, _     = strconv.ParseBool(Get("INSECURE_DEV", "false", "Running in insecure dev (local laptop) mode"))

--- a/pkg/eventlogger/event_logger.go
+++ b/pkg/eventlogger/event_logger.go
@@ -8,7 +8,7 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/sourcegraph/sourcegraph/pkg/api"
-	"github.com/sourcegraph/sourcegraph/pkg/env"
+	"github.com/sourcegraph/sourcegraph/pkg/version"
 
 	"github.com/google/uuid"
 	"golang.org/x/net/context"
@@ -46,7 +46,7 @@ type eventLogger struct {
 // new returns a new EventLogger client
 func new() *eventLogger {
 	environment := "production"
-	if env.Version == "dev" {
+	if version.Version() == "dev" {
 		environment = "development"
 	}
 	return &eventLogger{


### PR DESCRIPTION
env.Version is broken since our switch to Dockerfiles. It was also always the
same value as version.Version before the breakage, so we can just remove our
use of it.

Fixes https://github.com/sourcegraph/sourcegraph/issues/2130