### PR TITLE
Set timeout to focus input after DOM rendering

### DIFF
--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -86,6 +86,7 @@ export class CommandList extends React.PureComponent<Props, State> {
         )
 
         // Only focus input after it has been rendered in the DOM
+        // Workaround for Firefox and Safari where preventScroll isn't compatible
         setTimeout(() => {
             this.setState({ autoFocus: true })
         })

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -33,6 +33,8 @@ interface State {
 
     /** Recently invoked actions, which should be sorted first in the list. */
     recentActions: string[] | null
+
+    autoFocus?: boolean
 }
 
 /** Displays a list of commands contributed by extensions for a specific menu. */
@@ -82,6 +84,11 @@ export class CommandList extends React.PureComponent<Props, State> {
                 .getContributions()
                 .subscribe(contributions => this.setState({ contributions }))
         )
+
+        // Only focus input after it has been rendered in the DOM
+        setTimeout(() => {
+            this.setState({ autoFocus: true })
+        })
     }
 
     public componentDidUpdate(_prevProps: Props, prevState: State): void {
@@ -118,7 +125,7 @@ export class CommandList extends React.PureComponent<Props, State> {
                         </label>
                         <input
                             id="command-list__input"
-                            ref={input => input && input.focus({ preventScroll: true })}
+                            ref={input => input && this.state.autoFocus && input.focus({ preventScroll: true })}
                             type="text"
                             className="form-control px-2 py-1 rounded-0"
                             value={this.state.input}


### PR DESCRIPTION
This fixes #631 for Safari and Firefox, where opening the command pallet scrolled the page to the bottom. This was caused by setting the autofocus attribute on the input element. The input was not yet rendered into the DOM because of it being inside a popover, which lead to the unintended scroll. Chrome accepts passing in the parameter `preventScroll: true` (introduced in this PR: https://github.com/sourcegraph/sourcegraph/pull/1767). However, this is not compatible with Safari or Firefox: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Browser_compatibility.

## Solution
Manually focus the rendered input element after the popover has opened by setting a timeout to wait for the input to be rendered in the DOM. This is a workaround solution as the library we use `Popper.js` doesn't support callbacks to get notified when the popover has finished rendering. There was an issue about it on GitHub ([FezVrasta/popper.js#412](https://github.com/FezVrasta/popper.js/issues/412)) but they didn't implement it.
