### PR TITLE
search: significantly improve the performance of file search suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ## 3.0.1
 
+### Changed
+
+- Significantly optimized how file search suggestions are provided when using indexed search (cluster deployments).
+
 ### Postgres 11.1
 
 Both the `sourcegraph/server` image and the [Kubernetes deployment](https://github.com/sourcegraph/deploy-sourcegraph) manifests ship with Postgres `11.1`.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -500,7 +500,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		return nil, nil
 	}
 
-	p, err := r.getPatternInfo(true)
+	p, err := r.getPatternInfo(&getPatternInfoOptions{forceFileSearch: true})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -520,7 +520,8 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 	}
 
 	var suggestions []*searchSuggestionResolver
-	for assumedScore, result := range fileResults {
+	for i, result := range fileResults {
+		assumedScore := len(fileResults) - i // Greater score is first, so we inverse the index.
 		suggestions = append(suggestions, newSearchResultResolver(result.File(), assumedScore))
 	}
 	return suggestions, nil

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -11,12 +11,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/felixfbecker/stringscore"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
 	searchquerytypes "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/types"
@@ -25,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
 	"github.com/sourcegraph/sourcegraph/pkg/inventory/filelang"
-	"github.com/sourcegraph/sourcegraph/pkg/pathmatch"
 	"github.com/sourcegraph/sourcegraph/pkg/trace"
 	"github.com/sourcegraph/sourcegraph/pkg/vcs"
 	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
@@ -492,7 +489,7 @@ func optimizeRepoPatternWithHeuristics(repoPattern string) string {
 }
 
 func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*searchSuggestionResolver, error) {
-	repoRevisions, _, _, overLimit, err := r.resolveRepositories(ctx, nil)
+	repos, _, _, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -503,38 +500,30 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		return nil, nil
 	}
 
-	includePatterns, excludePatterns := r.query.RegexpPatterns(query.FieldFile)
-	excludePattern := unionRegExps(excludePatterns)
-	pathOptions := pathmatch.CompileOptions{
-		RegExp:        true,
-		CaseSensitive: r.query.IsCaseSensitive(),
-	}
-
-	// Treat all default terms as though they had `file:` before them (to make it easy for users to
-	// jump to files by just typing their name).
-	for _, v := range r.query.Values(query.FieldDefault) {
-		includePatterns = append(includePatterns, asString(v))
-	}
-
-	matchPath, err := pathmatch.CompilePathPatterns(includePatterns, excludePattern, pathOptions)
+	p, err := r.getPatternInfo(true)
 	if err != nil {
-		return nil, &badRequestError{err}
+		return nil, err
+	}
+	args := search.Args{
+		Pattern:         p,
+		Repos:           repos,
+		Query:           r.query,
+		UseFullDeadline: r.searchTimeoutFieldSet(),
+	}
+	if err := args.Pattern.Validate(); err != nil {
+		return nil, err
 	}
 
-	matcher := matcher{match: matchPath.MatchPath}
-
-	// Rank matches if include patterns are specified.
-	if len(includePatterns) > 0 {
-		scorerQueryParts := make([]string, len(includePatterns))
-		for i, includePattern := range includePatterns {
-			// Try to extract the text-only (non-regexp) part of the query to
-			// pass to stringscore, which doesn't use regexps. This is best-effort.
-			scorerQueryParts[i] = strings.TrimSuffix(strings.TrimPrefix(strings.Replace(includePattern, `\`, "", -1), "^"), "$")
-		}
-		matcher.scorerQuery = strings.Join(scorerQueryParts, " ")
+	fileResults, _, err := searchFilesInRepos(ctx, &args)
+	if err != nil {
+		return nil, err
 	}
 
-	return searchTree(ctx, matcher, repoRevisions, limit)
+	var suggestions []*searchSuggestionResolver
+	for assumedScore, result := range fileResults {
+		suggestions = append(suggestions, newSearchResultResolver(result.File(), assumedScore))
+	}
+	return suggestions, nil
 }
 
 func unionRegExps(patterns []string) string {
@@ -610,127 +599,6 @@ func (r *searchSuggestionResolver) ToSymbol() (*symbolResolver, bool) {
 	return res, ok
 }
 
-// A matcher describes how to filter and score results (for repos and files).
-// Exactly one of (query) and (match, scoreQuery) must be set.
-type matcher struct {
-	query string // query to match using stringscore algorithm
-
-	match       func(path string) bool // func that returns true if the item matches
-	scorerQuery string                 // effective query to use in stringscore algorithm
-}
-
-// searchTree searches the specified repositories for files and dirs whose name matches the matcher.
-func searchTree(ctx context.Context, matcher matcher, repos []*search.RepositoryRevisions, limit int) ([]*searchSuggestionResolver, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	var (
-		resMu sync.Mutex
-		res   []*searchSuggestionResolver
-	)
-	done := make(chan error, len(repos))
-	for _, repoRev := range repos {
-		if len(repoRev.Revs) >= 2 {
-			return nil, errMultipleRevsNotSupported
-		}
-
-		go func(repoRev search.RepositoryRevisions) {
-			fileResults, err := searchTreeForRepo(ctx, matcher, repoRev, limit, true)
-			if err != nil {
-				done <- err
-				return
-			}
-			resMu.Lock()
-			res = append(res, fileResults...)
-			resMu.Unlock()
-			done <- nil
-		}(*repoRev)
-	}
-	for range repos {
-		if err := <-done; err != nil {
-			// TODO collect error
-			if errors.Cause(err) != context.Canceled {
-				log15.Warn("searchFiles error", "err", err)
-			}
-		}
-	}
-	return res, nil
-}
-
-var mockSearchFilesForRepo func(matcher matcher, repoRevs search.RepositoryRevisions, limit int, includeDirs bool) ([]*searchSuggestionResolver, error)
-
-// searchTreeForRepo searches the specified repository for files whose name matches
-// the matcher
-func searchTreeForRepo(ctx context.Context, matcher matcher, repoRevs search.RepositoryRevisions, limit int, includeDirs bool) (res []*searchSuggestionResolver, err error) {
-	if mockSearchFilesForRepo != nil {
-		return mockSearchFilesForRepo(matcher, repoRevs, limit, includeDirs)
-	}
-
-	if len(repoRevs.Revs) == 0 {
-		return nil, nil // no revs to search
-	}
-
-	repoResolver := &repositoryResolver{repo: repoRevs.Repo}
-	commitResolver, err := repoResolver.Commit(ctx, &repositoryCommitArgs{Rev: repoRevs.RevSpecs()[0]}) // TODO(sqs): search all revspecs
-	if err != nil {
-		return nil, err
-	}
-	if vcs.IsCloneInProgress(err) {
-		// TODO report a cloning repo
-		return res, nil
-	}
-	if commitResolver == nil {
-		// TODO(sqs): this means the repository is empty or the revision did not resolve - in either case,
-		// there no tree entries here, but maybe we should handle this better
-		return nil, nil
-	}
-	treeResolver, err := commitResolver.Tree(ctx, &struct {
-		Path      string
-		Recursive bool
-	}{Path: ""})
-	if err != nil {
-		return nil, err
-	}
-	entries, err := treeResolver.Entries(ctx, &gitTreeEntryConnectionArgs{
-		ConnectionArgs: graphqlutil.ConnectionArgs{First: nil},
-		Recursive:      true,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var scorerQuery string
-	if matcher.query != "" {
-		scorerQuery = matcher.query
-	} else {
-		scorerQuery = matcher.scorerQuery
-	}
-
-	scorer := newScorer(scorerQuery)
-	for _, entryResolver := range entries {
-		if !includeDirs {
-			if entryResolver.IsDirectory() {
-				continue
-			}
-		}
-
-		score := scorer.calcScore(entryResolver)
-		if score <= 0 && matcher.scorerQuery != "" && matcher.match(entryResolver.path) {
-			score = 1 // minimum to ensure everything included by match.match is included
-		}
-		if score > 0 {
-			res = append(res, newSearchResultResolver(entryResolver, score))
-		}
-	}
-
-	sortSearchSuggestions(res)
-	if len(res) > limit {
-		res = res[:limit]
-	}
-
-	return res, nil
-}
-
 // newSearchResultResolver returns a new searchResultResolver wrapping the
 // given result.
 //
@@ -750,123 +618,6 @@ func newSearchResultResolver(result interface{}, score int) *searchSuggestionRes
 	default:
 		panic("never here")
 	}
-}
-
-// scorer is a structure for holding some scorer state that can be shared
-// across calcScore calls for the same query string.
-type scorer struct {
-	query      string
-	queryEmpty bool
-	queryParts []string
-}
-
-// newScorer returns a scorer to be used for calculating sort scores of results
-// against the specified query.
-func newScorer(query string) *scorer {
-	return &scorer{
-		query:      query,
-		queryEmpty: strings.TrimSpace(query) == "",
-		queryParts: splitNoEmpty(query, "/"),
-	}
-}
-
-// score values to add to different types of results to e.g. get forks lower in
-// search results, etc.
-const (
-	// Files > Repos > Forks
-	scoreBumpFile = 1 * (math.MaxInt32 / 16)
-	scoreBumpRepo = 0 * (math.MaxInt32 / 16)
-	scoreBumpFork = -10
-)
-
-// calcScore calculates and assigns the sorting score to the given result.
-//
-// A panic occurs if the type of result is not a valid search result resolver type.
-func (s *scorer) calcScore(result interface{}) int {
-	var score int
-	if s.queryEmpty {
-		// If no query, then it will show *all* results; score must be nonzero in order to
-		// have scoreBump* constants applied.
-		score = 1
-	}
-
-	switch r := result.(type) {
-	case *repositoryResolver:
-		if !s.queryEmpty {
-			score = postfixFuzzyAlignScore(splitNoEmpty(string(r.repo.Name), "/"), s.queryParts)
-		}
-		// Push forks down
-		if r.repo.Fork {
-			score += scoreBumpFork
-		}
-		if score > 0 {
-			score += scoreBumpRepo
-		}
-		return score
-
-	case *gitTreeEntryResolver:
-		if !s.queryEmpty {
-			pathParts := splitNoEmpty(r.path, "/")
-			score = postfixFuzzyAlignScore(pathParts, s.queryParts)
-		}
-		if score > 0 {
-			score += scoreBumpFile
-		}
-		return score
-
-	default:
-		panic("never here")
-	}
-}
-
-// postfixFuzzyAlignScore is used to calculate how well a targets component
-// matches a query from the back. It rewards consecutive alignment as well as
-// aligning to the right. For example for the query "a/b" we get the
-// following ranking:
-//
-//   /a/b == /x/a/b
-//   /a/b/x
-//   /a/x/b
-//
-// The following will get zero score
-//
-//   /x/b
-//   /ab/
-func postfixFuzzyAlignScore(targetParts, queryParts []string) int {
-	total := 0
-	consecutive := true
-	queryIdx := len(queryParts) - 1
-	for targetIdx := len(targetParts) - 1; targetIdx >= 0 && queryIdx >= 0; targetIdx-- {
-		score := stringscore.Score(targetParts[targetIdx], queryParts[queryIdx])
-		if score <= 0 {
-			consecutive = false
-			continue
-		}
-		// Consecutive and align bonus
-		if consecutive {
-			score *= 2
-		}
-		consecutive = true
-		total += score
-		queryIdx--
-	}
-	// Did not match whole of queryIdx
-	if queryIdx >= 0 {
-		return 0
-	}
-	return total
-}
-
-// splitNoEmpty is like strings.Split except empty strings are removed.
-func splitNoEmpty(s, sep string) []string {
-	split := strings.Split(s, sep)
-	res := make([]string, 0, len(split))
-	for _, part := range split {
-		if part != "" {
-			res = append(res, part)
-		}
-	}
-	return res
 }
 
 func sortSearchSuggestions(s []*searchSuggestionResolver) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -228,7 +228,7 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 				t.Fatal(err)
 			}
 			sr := searchResolver{query: query}
-			p, err := sr.getPatternInfo()
+			p, err := sr.getPatternInfo(false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -228,7 +228,7 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 				t.Fatal(err)
 			}
 			sr := searchResolver{query: query}
-			p, err := sr.getPatternInfo(false)
+			p, err := sr.getPatternInfo(nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -86,6 +86,8 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		hasOnlyEmptyRepoField := len(r.query.Values(query.FieldRepo)) > 0 && allEmptyStrings(r.query.RegexpPatterns(query.FieldRepo)) && len(r.query.Fields) == 1
 		hasRepoOrFileFields := len(r.query.Values(query.FieldRepoGroup)) > 0 || len(r.query.Values(query.FieldRepo)) > 0 || len(r.query.Values(query.FieldFile)) > 0
 		if !hasOnlyEmptyRepoField && hasRepoOrFileFields && len(r.query.Values(query.FieldDefault)) <= 1 {
+			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			defer cancel()
 			return r.suggestFilePaths(ctx, maxSearchSuggestions)
 		}
 		return nil, nil

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -99,7 +99,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return nil, err
 		}
 
-		p, err := r.getPatternInfo()
+		p, err := r.getPatternInfo(false)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -99,7 +99,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return nil, err
 		}
 
-		p, err := r.getPatternInfo(false)
+		p, err := r.getPatternInfo(nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -167,18 +167,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 					results.results = results.results[:*args.First]
 				}
 				for i, res := range results.results {
-					entryResolver := &gitTreeEntryResolver{
-						path: res.fileMatch.JPath,
-						commit: &gitCommitResolver{
-							oid:      gitObjectID(res.fileMatch.commitID),
-							inputRev: res.fileMatch.inputRev,
-							// NOTE(sqs): Omits other commit fields to avoid needing to fetch them
-							// (which would make it slow). This gitCommitResolver will return empty
-							// values for all other fields.
-							repo: &repositoryResolver{repo: res.fileMatch.repo},
-						},
-						stat: createFileInfo(res.fileMatch.JPath, false),
-					}
+					entryResolver := res.fileMatch.File()
 					suggestions = append(suggestions, newSearchResultResolver(entryResolver, len(results.results)-i))
 				}
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -140,8 +140,8 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			if want := "foo"; args.Pattern.Pattern != want {
-				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
+			if args.Pattern.Pattern != "." && args.Pattern.Pattern != "foo" {
+				t.Errorf("got %q, want %q", args.Pattern.Pattern, `"foo" or "."`)
 			}
 			return []*fileMatchResolver{
 				{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", repo: &types.Repo{Name: "repo3"}, commitID: "rev"},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -71,6 +71,9 @@ func (fm *fileMatchResolver) Key() string {
 }
 
 func (fm *fileMatchResolver) File() *gitTreeEntryResolver {
+	// NOTE(sqs): Omits other commit fields to avoid needing to fetch them
+	// (which would make it slow). This gitCommitResolver will return empty
+	// values for all other fields.
 	return &gitTreeEntryResolver{
 		commit: &gitCommitResolver{
 			repo:     &repositoryResolver{repo: fm.repo},


### PR DESCRIPTION
This change significantly improves the performance and code quality of the
implementation providing file search _suggestions_.

It reduces IO load on gitserver, but primarily removes load from repo-updater and redis which occurred due to a bug in the old implementation trying to update all repositories involved in the search.

Fixes #2089

### How?

Most importantly, the old implementation issued requests erroneously which caused repo-updater, redis, and gitserver more IO load than was optimal. You can read more about this in the linked issue above.

File search suggestions now also benefit from the same zoekt indexing that we do for search otherwise, because we are now using the same code path that provides actual search results.

In `sourcegraph/server` instances, which do not use indexed search by default, performance is roughly identical to before.

### Code quality gains

Prior to this change file search suggestions were provided by an entirely separate code path. This old code path was responsible for listing all files in every repository your query matched, then matching those files against your search query. In contrast, after this change:

1. File search suggestions are provided by the same code-path which provides text search results.
2. Because the code-path is the same, you no longer get different ordering in search suggestions compared to when you actually run the query.

### Change in fuzzy matching behavior / more consistent matching

Before this change, you could type `src/http.go` (internally converted to `file:src/http.go`) and get fuzzy suggestions matching `src/net/http/http.go` even though your query was missing the `net/http` part of the path.

After this change, you must type a substring match, or use regex. i.e. `src/http.go` will now not fuzzy match / provide any suggestions, but these would:

- `http.go`
- `http/http.go`
- `net/http/http.go`
- `src/net/http/http.go`
- `src.*http.go`

The prior behavior was better in some regards because it acted more like your editor quick file open panel. However, the inconsistency with the results you would get when running your query was also bad. For example:

1. Visit https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.0.0
2. Type `file:dev/main.go` in the search input and you will see two suggestions.
3. Actually press enter and run the query, you will recieve no results!

We now have consistency and a shared implementation. In the future, we could gain this behavior back by changing the `file:` match operator to do fuzzy editor-like matching, instead of (or in addition to) using regex. However, it is unclear to me if doing that would be worth it or if this behavior is generally good enough (I suspect it is).
