### PR TITLE
dedupe repo display names in file matches with mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- File match search results now show full repo name if there are results from
+  mirrors on different code hosts (e.g. github.com/sourcegraph/sourcegraph and gitlab.com/sourcegraph/sourcegraph)
+
 ### Fixed
 
 ### Removed

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -38,6 +38,12 @@ interface Props {
     result: IFileMatch
 
     /**
+     * Formatted repository name to be displayed in repository link. If not
+     * provided, the default format will be displayed.
+     */
+    repoDisplayName?: string
+
+    /**
      * The icon to show left to the title.
      */
     icon: React.ComponentType<{ className?: string }>
@@ -96,6 +102,7 @@ export class FileMatch extends React.PureComponent<Props> {
                 repoURL={result.repository.url}
                 filePath={result.file.path}
                 fileURL={result.file.url}
+                repoDisplayName={this.props.repoDisplayName}
             />
         )
 

--- a/shared/src/components/RepoFileLink.tsx
+++ b/shared/src/components/RepoFileLink.tsx
@@ -25,17 +25,24 @@ interface Props {
     repoURL: string
     filePath: string
     fileURL: string
+    repoDisplayName?: string
 }
 
 /**
  * A link to a repository or a file within a repository, formatted as "repo" or "repo > file". Unless you
  * absolutely need breadcrumb-like behavior, use this instead of FilePathBreadcrumb.
  */
-export const RepoFileLink: React.FunctionComponent<Props> = ({ repoName, repoURL, filePath, fileURL }) => {
+export const RepoFileLink: React.FunctionComponent<Props> = ({
+    repoDisplayName,
+    repoName,
+    repoURL,
+    filePath,
+    fileURL,
+}) => {
     const [fileBase, fileName] = splitPath(filePath)
     return (
         <>
-            <Link to={repoURL}>{displayRepoName(repoName)}</Link> ›{' '}
+            <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
             <Link to={fileURL}>
                 {fileBase ? `${fileBase}/` : null}
                 <strong>{fileName}</strong>

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -56,7 +56,8 @@ interface State {
     resultsShown: number
     visibleItems: Set<number>
     didScrollToItem: boolean
-    fileMatchRepoDisplayNames: Map<string, string>
+    /** Map from repo name to display name */
+    fileMatchRepoDisplayNames: ReadonlyMap<string, string>
 }
 
 export class SearchResultsList extends React.PureComponent<SearchResultsListProps, State> {

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -235,7 +235,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     )
                 )
                 .subscribe(fileMatches => {
-                    const fileMatchRepoDisplayNames = new Map<string, string>() // name => displayName
+                    const fileMatchRepoDisplayNames = new Map<string, string>()
                     for (const {
                         repository: { name },
                     } of fileMatches) {

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import { upperFirst } from 'lodash'
+import { isEqual, upperFirst } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import FileIcon from 'mdi-react/FileIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
@@ -13,6 +13,7 @@ import { parseSearchURLQuery } from '..'
 import { FetchFileCtx } from '../../../../shared/src/components/CodeExcerpt'
 import { FileMatch } from '../../../../shared/src/components/FileMatch'
 import { RepositoryIcon } from '../../../../shared/src/components/icons' // TODO: Switch to mdi icon
+import { displayRepoName } from '../../../../shared/src/components/RepoFileLink'
 import { VirtualList } from '../../../../shared/src/components/VirtualList'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
@@ -55,6 +56,7 @@ interface State {
     resultsShown: number
     visibleItems: Set<number>
     didScrollToItem: boolean
+    fileMatchRepoDisplayNames: Map<string, string>
 }
 
 export class SearchResultsList extends React.PureComponent<SearchResultsListProps, State> {
@@ -77,6 +79,8 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
     private jumpToTopClicks = new Subject<void>()
     private nextJumpToTopClick = () => this.jumpToTopClicks.next()
 
+    private componentUpdates = new Subject<SearchResultsListProps>()
+
     private subscriptions = new Subscription()
 
     constructor(props: SearchResultsListProps) {
@@ -86,6 +90,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
             resultsShown: this.getCheckpoint() + 15,
             visibleItems: new Set<number>(),
             didScrollToItem: false,
+            fileMatchRepoDisplayNames: new Map<string, string>(),
         }
 
         // Handle items that have become visible
@@ -215,12 +220,59 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                 this.setState({ didScrollToItem: false })
             })
         )
+
+        this.subscriptions.add(
+            this.componentUpdates
+                .pipe(
+                    distinctUntilChanged((a, b) => isEqual(a, b)),
+                    map(({ resultsOrError }) => resultsOrError),
+                    filter(isDefined),
+                    filter((resultsOrError): resultsOrError is GQL.ISearchResults => !isErrorLike(resultsOrError)),
+                    map(({ results }) => results),
+                    map(
+                        (results): GQL.IFileMatch[] =>
+                            results.filter((res): res is GQL.IFileMatch => res.__typename === 'FileMatch')
+                    )
+                )
+                .subscribe(fileMatches => {
+                    const fileMatchRepoDisplayNames = new Map<string, string>() // name => displayName
+                    for (const {
+                        repository: { name },
+                    } of fileMatches) {
+                        const displayName = displayRepoName(name)
+                        fileMatchRepoDisplayNames.set(name, displayName)
+                    }
+
+                    const displayNameCounts = new Map<string, number>()
+                    for (const displayName of fileMatchRepoDisplayNames.values()) {
+                        displayNameCounts.set(displayName, (displayNameCounts.get(displayName) || 0) + 1)
+                    }
+
+                    for (const [displayName, count] of displayNameCounts.entries()) {
+                        if (count > 1) {
+                            for (const [name, displayName1] of fileMatchRepoDisplayNames) {
+                                if (displayName === displayName1) {
+                                    fileMatchRepoDisplayNames.set(name, name)
+                                }
+                            }
+                        }
+                    }
+
+                    this.setState({ fileMatchRepoDisplayNames })
+                })
+        )
+    }
+
+    public componentDidMount(): void {
+        this.componentUpdates.next(this.props)
     }
 
     public componentDidUpdate(): void {
         const lowestIndex = Array.from(this.state.visibleItems).reduce((low, index) => Math.min(index, low), Infinity)
 
         this.firstVisibleItems.next(lowestIndex)
+
+        this.componentUpdates.next(this.props)
     }
 
     public componentWillUnmount(): void {
@@ -428,6 +480,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                         isLightTheme={this.props.isLightTheme}
                         allExpanded={this.props.allExpanded}
                         fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
+                        repoDisplayName={this.state.fileMatchRepoDisplayNames.get(result.repository.name)}
                     />
                 )
         }


### PR DESCRIPTION
If there are file match results from a repository and a mirror on a different code host, it's impossible to differentiate the repos in the list just by looking at the item. This PR shows the full name if there are duplicate display names. Closes https://github.com/sourcegraph/sourcegraph/issues/2181.