### PR TITLE
docs: update docs homepage to include new quickstart content

### DIFF
--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -13,8 +13,7 @@ It takes less than 5 minutes to install Sourcegraph using Docker. If you've got 
 
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 2633:2633 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.0.0</code></pre>
 
-Access the server on port `7080`, then follow the steps in this screencast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
-
+Access the server on port `7080`, then the below screencast will show you how to configure Sourcegraph to search public and private repositories, and enable code intelligence on Sourcegraph and GitHub.com.
 <p class="container">
   <div style="padding:56.25% 0 0 0;position:relative;">
     <iframe src="https://player.vimeo.com/video/314926561?color=0CB6F4&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -13,7 +13,7 @@ It takes less than 5 minutes to install Sourcegraph using Docker. If you've got 
 
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 2633:2633 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.0.0</code></pre>
 
-Access the server on port `7080`, then follow the steps in this screen cast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
+Access the server on port `7080`, then follow the steps in this screencast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
 
 <p class="container">
   <div style="padding:56.25% 0 0 0;position:relative;">

--- a/doc/index.md
+++ b/doc/index.md
@@ -17,7 +17,7 @@ It takes less than 5 minutes to install Sourcegraph using Docker. If you've got 
 
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 2633:2633 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.0.0</code></pre>
 
-Access the server on port `7080`, then follow the steps in this screencast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
+Access the server on port `7080`, then the below screencast will show you how to configure Sourcegraph to search public and private repositories, and enable code intelligence on Sourcegraph and GitHub.com.
 
 <p class="container">
   <div style="padding:56.25% 0 0 0;position:relative;">

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
 # Sourcegraph documentation
 
-Sourcegraph is used by companies like Uber and Lyft to help developers search, navigate and review code at enterprise scale.
+Sourcegraph is used by developers at Uber, Lyft, Yelp, and more to help them search, navigate and review code at enterprise scale.
 
 # Quickstart guide
 
@@ -17,7 +17,7 @@ It takes less than 5 minutes to install Sourcegraph using Docker. If you've got 
 
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 2633:2633 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.0.0</code></pre>
 
-Access the server on port `7080`, then follow the steps in this screen cast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
+Access the server on port `7080`, then follow the steps in this screencast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
 
 <p class="container">
   <div style="padding:56.25% 0 0 0;position:relative;">

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,25 +1,37 @@
 # Sourcegraph documentation
 
-Sourcegraph is a code search and browsing tool with code intelligence that helps developers write and review code. Learn more about Sourcegraph at [about.sourcegraph.com](https://about.sourcegraph.com) and use it at [Sourcegraph.com](https://sourcegraph.com).
+Sourcegraph is used by companies like Uber and Lyft to help developers search, navigate and review code at enterprise scale.
 
-Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph). Need help? Use the [issue tracker](https://github.com/sourcegraph/sourcegraph/issues).
+# Quickstart guide
 
-## Quickstart
+> NOTE: If you get stuck or need help, [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new?&title=Improve+Sourcegraph+quickstart+guide), [tweet (@srcgraph)](https://twitter.com/srcgraph) or [email](mailto:support@sourcegraph.com?subject=Sourcegraph%20quickstart%20guide).
 
-> NOTE: We're working on a **[new quickstart guide for Sourcegraph 3.0](quickstart.md)** and want your opinion on how we can make it better.
 
-Run a self-hosted Sourcegraph instance in 1 command:
+It takes less than 5 minutes to install Sourcegraph using Docker. If you've got [Docker installed](https://docs.docker.com/engine/installation/), you're ready to start the server which listens on port `7080` by default.
 
 <!--
   DO NOT CHANGE THIS TO A CODEBLOCK.
   We want line breaks for readability, but backslashes to escape them do not work cross-platform.
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
+
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 2633:2633 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.0.0</code></pre>
 
-Continue at http://localhost:7080, and see [administrator documentation](admin/index.md) for next steps.
+Access the server on port `7080`, then follow the steps in this screen cast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
 
-## Overview
+<p class="container">
+  <div style="padding:56.25% 0 0 0;position:relative;">
+    <iframe src="https://player.vimeo.com/video/314926561?color=0CB6F4&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+  </div>
+</p>
+
+Once Sourcegraph has been configured, head to the [site administration documentation](admin/index.md) for next steps.
+
+## Learn about Sourcegraph
+
+Learn more about Sourcegraph at [Sourcegraph.com](https://sourcegraph.com/start) where you can also use it for [searching open source repositories](https://sourcegraph.com/search).
+
+Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph). Need help? Use the [issue tracker](https://github.com/sourcegraph/sourcegraph/issues).
 
 ### Core documentation
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -13,7 +13,7 @@ It takes less than 5 minutes to install Sourcegraph using Docker. If you've got 
 
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 2633:2633 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.0.0</code></pre>
 
-Access the server on port `7080`, then follow the steps in this screencast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
+Access the server on port `7080`, then the below screencast will show you how to configure Sourcegraph to search public and private repositories, and enable code intelligence on Sourcegraph and GitHub.com.
 
 <p class="container">
   <div style="padding:56.25% 0 0 0;position:relative;">

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -13,7 +13,7 @@ It takes less than 5 minutes to install Sourcegraph using Docker. If you've got 
 
 <pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 2633:2633 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.0.0</code></pre>
 
-Access the server on port `7080`, then follow the steps in this screen cast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
+Access the server on port `7080`, then follow the steps in this screencast to install and configure Sourcegraph with GitHub integration and code intelligence enabled.
 
 <p class="container">
   <div style="padding:56.25% 0 0 0;position:relative;">


### PR DESCRIPTION
This merges the new quickstart content into the docs home page.

You can preview the Docker related content at https://docs.sourcegraph.com/quickstart

![screenflow](https://user-images.githubusercontent.com/133014/52378667-2a15ca00-2a1d-11e9-838e-071f4dea07db.gif)
