### PR TITLE
Try updating settings once more if there was a version mismatch

### DIFF
--- a/web/src/platform/context.ts
+++ b/web/src/platform/context.ts
@@ -41,7 +41,16 @@ export function createPlatformContext(): PlatformContext {
                 )
             }
 
-            await updateSettings(context, subject, edit, mutateSettings)
+            try {
+                await updateSettings(context, subject, edit, mutateSettings)
+            } catch (error) {
+                if ('message' in error && /version mismatch/.test(error.message)) {
+                    // The user probably edited the settings in another tab, so
+                    // try once more.
+                    updatedSettings.next(await fetchViewerSettings().toPromise())
+                    await updateSettings(context, subject, edit, mutateSettings)
+                }
+            }
             updatedSettings.next(await fetchViewerSettings().toPromise())
         },
         queryGraphQL: (request, variables) =>


### PR DESCRIPTION
Previously, if there was a version mismatch when updating settings, an error would be thrown and the settings would not update. No further settings updates would work until a page refresh.

This adds 1 retry and fetches the new settings just before attempting to update the settings once more.

Fixes https://github.com/sourcegraph/sourcegraph/issues/1474
Fixes https://github.com/sourcegraph/sourcegraph/issues/1278