### PR TITLE
fix bug in docsite check template with zero headings

### DIFF
--- a/dev/check/docsite/doc.html
+++ b/dev/check/docsite/doc.html
@@ -19,7 +19,7 @@ broken link checker checks the links that are produced by the actual templates.
 {{end}}
 
 {{define "index"}}
-	{{with (or (and (eq (len .Doc.Tree) 1) (index .Doc.Tree 0).Children) .Doc.Tree)}}
+	{{with .Doc.Tree}}
 		<h4 class="visible-sm">{{$.Doc.Title}}</h4>
 		<ul>{{template "doc_nav" .}}</ul>
 	{{end}}


### PR DESCRIPTION
<!-- Remember to update the changelog for user-facing changes. -->

If a doc/ Markdown document has zero headings (i.e., no `# Foo` or `#### Foo` headings), `docsite check` would fail with an inscrutable error like:

```
dev/release_issue_template.md: template: root:22:41: executing "index" at <index .Doc.Tree 0>: error calling index: index out of range: 0
dev/releases.md: broken link to /dev/release_issue_template
dev/releases.md: broken link to /dev/release_issue_template
```

This occurs because the Go template expression tries to index into the 0th element. Go's template expressions don't short-circuit, so this index attempt occurs even if the length check fails.

We don't need this precise behavior because this template is only used for checking, not for actual rendering.

https://sourcegraph.slack.com/archives/C07KZF47K/p1549645446768200?thread_ts=1549569483.746300&cid=C07KZF47K