### PR TITLE
Fix Global Alert on Sourcegraph.com/start

### DIFF
--- a/web/src/search/input/MainPage.tsx
+++ b/web/src/search/input/MainPage.tsx
@@ -253,6 +253,11 @@ export class MainPage extends React.Component<Props, State> {
                 transform: translateY(-0px);
                 opacity: .5;
             }
+			.global-alerts {
+				position: sticky;
+				position: -webkit-sticky;
+				z-index: 99;
+			}
         `,
         }
     }


### PR DESCRIPTION
This push fixes the global alert on Sourcegraph.com/start

Fixes: #2215 

before:
<img width="1444" alt="screen shot 2019-02-08 at 11 10 26 am" src="https://user-images.githubusercontent.com/11583013/52500173-3707fa00-2b92-11e9-8ea7-749f1559f1b3.png">

after:
<img width="1444" alt="screen shot 2019-02-08 at 11 10 31 am" src="https://user-images.githubusercontent.com/11583013/52500188-3e2f0800-2b92-11e9-893f-ae9aa1e53373.png">
