### PR TITLE
Fix: remove loading spinner from query input

### DIFF
--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -1,4 +1,3 @@
-import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
 import * as React from 'react'
 import { fromEvent, merge, Observable, of, Subject, Subscription } from 'rxjs'
@@ -294,7 +293,6 @@ export class QueryInput extends React.Component<Props, State> {
                     placeholder={this.props.placeholder === undefined ? 'Search code...' : this.props.placeholder}
                     ref={ref => (this.inputElement = ref!)}
                 />
-                {this.state.loading && <LoadingSpinner className="icon-inline query-input2__loading-notifier" />}
                 {showSuggestions && (
                     <ul className="query-input2__suggestions" ref={this.setSuggestionListElement}>
                         {this.state.suggestions.map((suggestion, i) => {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2127.
