### PR TITLE
use divs instead of ul li to avoid GitHub styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search queries now use "smart case" by default. Searches are case insensitive unless you use uppercase letters. To explicitly set the case, you can still use the `case` field (e.g. `case:yes`, `case:no`). To explicitly set smart case, use `case:auto`.
 
 ### Fixed
+- The extension debug menu no longer shows a bullet point.
 
 - Fixed an issue where the management console would improperly regenerate the TLS cert/key unless `CUSTOM_TLS=true` was set. See the documentation for [how to use your own TLS certificate with the management console](doc/admin/management_console.md#how-can-i-use-my-own-tls-certificates-with-the-management-console).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Search queries now use "smart case" by default. Searches are case insensitive unless you use uppercase letters. To explicitly set the case, you can still use the `case` field (e.g. `case:yes`, `case:no`). To explicitly set smart case, use `case:auto`.
 
 ### Fixed
-- The extension debug menu no longer shows a bullet point.
 
 - Fixed an issue where the management console would improperly regenerate the TLS cert/key unless `CUSTOM_TLS=true` was set. See the documentation for [how to use your own TLS certificate with the management console](doc/admin/management_console.md#how-can-i-use-my-own-tls-certificates-with-the-management-console).
 

--- a/client/browser/src/shared/components/GlobalDebug.tsx
+++ b/client/browser/src/shared/components/GlobalDebug.tsx
@@ -25,8 +25,8 @@ const ExtensionLink: React.FunctionComponent<{ id: string }> = props => {
 export const GlobalDebug: React.FunctionComponent<Props> = props =>
     SHOW_DEBUG ? (
         <div className="global-debug navbar navbar-expand">
-            <ul className="navbar-nav align-items-center">
-                <li className="nav-item">
+            <div className="navbar-nav align-items-center">
+                <div className="nav-item">
                     <ShortcutProvider>
                         <ExtensionStatusPopover
                             location={props.location}
@@ -35,7 +35,7 @@ export const GlobalDebug: React.FunctionComponent<Props> = props =>
                             platformContext={props.platformContext}
                         />
                     </ShortcutProvider>
-                </li>
-            </ul>
+                </div>
+            </div>
         </div>
     ) : null


### PR DESCRIPTION
Problem (issue #1765): Our Ext debug menu is showing a bullet point due to GitHub's css styling the `li`. 

Solution: Use `div`s instead of `ul > li` to avoid external styling and also improve the appearance of the menu from this:
![image](https://user-images.githubusercontent.com/9110008/52533650-329e3580-2d7a-11e9-9891-3d56c4046360.png)

to this:
![image](https://user-images.githubusercontent.com/9110008/52533658-4a75b980-2d7a-11e9-8963-f271d8c873f0.png)


