### PR TITLE
GitLab: add sudo auth provider

### DIFF
--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -248,7 +248,7 @@ func newGitLabConnection(config *schema.GitLabConnection) (*gitlabConnection, er
 	return &gitlabConnection{
 		config:  config,
 		baseURL: baseURL,
-		client:  gitlab.NewClientProvider(baseURL, transport).GetPATClient(config.Token),
+		client:  gitlab.NewClientProvider(baseURL, transport).GetPATClient(config.Token, ""),
 	}, nil
 }
 

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo.go
@@ -1,0 +1,368 @@
+// Package gitlab contains an authorization provider for GitLab.
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/pkg/rcache"
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+type pcache interface {
+	Get(key string) ([]byte, bool)
+	Set(key string, b []byte)
+	Delete(key string)
+}
+
+// SudoProvider is an implementation of AuthzProvider that provides repository permissions as
+// determined from a GitLab instance API. For documentation of specific fields, see the docstrings
+// of SudoProviderOp.
+type SudoProvider struct {
+	// sudoToken is the sudo-scoped access token. This is different from the Sudo parameter, which
+	// is set per client and defines which user to impersonate.
+	sudoToken string
+
+	clientProvider    *gitlab.ClientProvider
+	clientURL         *url.URL
+	codeHost          *gitlab.CodeHost
+	gitlabProvider    string
+	authnConfigID     auth.ProviderConfigID
+	useNativeUsername bool
+	cache             pcache
+	cacheTTL          time.Duration
+}
+
+var _ authz.Provider = ((*SudoProvider)(nil))
+
+type SudoProviderOp struct {
+	// BaseURL is the URL of the GitLab instance.
+	BaseURL *url.URL
+
+	// AuthnConfigID identifies the authn provider to use to lookup users on the GitLab instance.
+	// This should be the authn provider that's used to sign into the GitLab instance.
+	AuthnConfigID auth.ProviderConfigID
+
+	// GitLabProvider is the id of the authn provider to GitLab. It will be used in the
+	// `users?extern_uid=$uid&provider=$provider` API query.
+	GitLabProvider string
+
+	// SudoToken is an access token with sudo *and* api scope.
+	//
+	// 🚨 SECURITY: This value contains secret information that must not be shown to non-site-admins.
+	SudoToken string
+
+	// CacheTTL is the TTL of cached permissions lists from the GitLab API.
+	CacheTTL time.Duration
+
+	// UseNativeUsername, if true, maps Sourcegraph users to GitLab users using username equivalency
+	// instead of the authn provider user ID. This is *very* insecure (Sourcegraph usernames can be
+	// changed at the user's will) and should only be used in development environments.
+	UseNativeUsername bool
+
+	// MockCache, if non-nil, replaces the default Redis-based cache with the supplied cache mock.
+	// Should only be used in tests.
+	MockCache pcache
+}
+
+func NewSudoProvider(op SudoProviderOp) *SudoProvider {
+	p := &SudoProvider{
+		sudoToken: op.SudoToken,
+
+		clientProvider:    gitlab.NewClientProvider(op.BaseURL, nil),
+		clientURL:         op.BaseURL,
+		codeHost:          gitlab.NewCodeHost(op.BaseURL),
+		cache:             op.MockCache,
+		authnConfigID:     op.AuthnConfigID,
+		gitlabProvider:    op.GitLabProvider,
+		cacheTTL:          op.CacheTTL,
+		useNativeUsername: op.UseNativeUsername,
+	}
+	if p.cache == nil {
+		p.cache = rcache.NewWithTTL(fmt.Sprintf("gitlabAuthz:%s", op.BaseURL.String()), int(math.Ceil(op.CacheTTL.Seconds())))
+	}
+	return p
+}
+
+func (p *SudoProvider) Validate() (problems []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, _, err := p.clientProvider.GetPATClient(p.sudoToken, "1").ListProjects(ctx, "projects"); err != nil {
+		if err == ctx.Err() {
+			problems = append(problems, fmt.Sprintf("GitLab API did not respond within 5s (%s)", err.Error()))
+		} else if !gitlab.IsNotFound(err) {
+			problems = append(problems, "access token did not have sufficient privileges, requires scopes \"sudo\" and \"api\"")
+		}
+	}
+	return problems
+}
+
+func (p *SudoProvider) ServiceID() string {
+	return p.codeHost.ServiceID()
+}
+
+func (p *SudoProvider) ServiceType() string {
+	return p.codeHost.ServiceType()
+}
+
+func (p *SudoProvider) Repos(ctx context.Context, repos map[authz.Repo]struct{}) (mine map[authz.Repo]struct{}, others map[authz.Repo]struct{}) {
+	// Note(beyang): this is identical to GitLabOAuthAuthzProvider.Repos, so is not explicitly
+	// unit-tested. If this impl ever changes, unit tests should be added.
+	return authz.GetCodeHostRepos(p.codeHost, repos)
+}
+
+func (p *SudoProvider) RepoPerms(ctx context.Context, account *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (map[api.RepoName]map[authz.Perm]bool, error) {
+	accountID := "" // empty means public / unauthenticated to the code host
+	if account != nil && account.ServiceID == p.codeHost.ServiceID() && account.ServiceType == p.codeHost.ServiceType() {
+		accountID = account.AccountID
+	}
+
+	perms := map[api.RepoName]map[authz.Perm]bool{}
+
+	remaining, _ := p.Repos(ctx, repos)
+	nextRemaining := map[authz.Repo]struct{}{}
+
+	// Populate perms using cached repository visibility information. After this block,
+	// nextRemaining records the repositories that we still have to check.
+	for repo := range remaining {
+		projID, err := strconv.Atoi(repo.ExternalRepoSpec.ID)
+		if err != nil {
+			return nil, errors.Wrap(err, "GitLab repo external ID did not parse to int")
+		}
+		vis, exists := cacheGetRepoVisibility(p.cache, projID, p.cacheTTL)
+		if !exists {
+			nextRemaining[repo] = struct{}{}
+			continue
+		}
+		if v := vis.Visibility; v == gitlab.Public || (v == gitlab.Internal && accountID != "") {
+			perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: true}
+			continue
+		}
+		nextRemaining[repo] = struct{}{}
+	}
+
+	if len(nextRemaining) == 0 { // shortcut
+		return perms, nil
+	}
+
+	// Populate perms using cached user-can-access-repository information. After this block,
+	// nextRemaining records the repositories that we still have to check.
+	if accountID != "" {
+		remaining, nextRemaining = nextRemaining, map[authz.Repo]struct{}{}
+		for repo := range remaining {
+			projID, err := strconv.Atoi(repo.ExternalRepoSpec.ID)
+			if err != nil {
+				return nil, errors.Wrap(err, "GitLab repo external ID did not parse to int")
+			}
+			userRepo, exists := cacheGetUserRepo(p.cache, accountID, projID, p.cacheTTL)
+			if !exists {
+				nextRemaining[repo] = struct{}{}
+				continue
+			}
+			perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: userRepo.Read}
+		}
+
+		if len(nextRemaining) == 0 { // shortcut
+			return perms, nil
+		}
+	}
+
+	// Populate perms for the remaining repos (nextRemaining) by fetching directly from the GitLab
+	// API (and update the user repo-visibility and user-can-access-repo permissions, as well)
+	var sudo string
+	if account != nil {
+		usr, _, err := gitlab.GetExternalAccountData(&account.ExternalAccountData)
+		if err != nil {
+			return nil, err
+		}
+		sudo = strconv.Itoa(int(usr.ID))
+	}
+	for repo := range remaining {
+		projID, err := strconv.Atoi(repo.ExternalRepoSpec.ID)
+		if err != nil {
+			return nil, errors.Wrap(err, "GitLab repo external ID did not parse to int")
+		}
+		isAccessible, vis, isContentAccessible, err := p.fetchProjVis(ctx, sudo, projID)
+		if err != nil {
+			log15.Error("Failed to fetch visibility for GitLab project", "projectID", projID, "gitlabHost", p.codeHost.BaseURL().String(), "error", err)
+			continue
+		}
+		if isAccessible {
+			// Set perms
+			perms[repo.RepoName] = map[authz.Perm]bool{authz.Read: true}
+
+			// Update visibility cache
+			err := cacheSetRepoVisibility(p.cache, projID, repoVisibilityCacheVal{Visibility: vis, TTL: p.cacheTTL})
+			if err != nil {
+				return nil, errors.Wrap(err, "could not set cached repo visibility")
+			}
+
+			// Update userRepo cache if the visibility is private
+			if vis == gitlab.Private {
+				err := cacheSetUserRepo(p.cache, accountID, projID, userRepoCacheVal{Read: isContentAccessible, TTL: p.cacheTTL})
+				if err != nil {
+					return nil, errors.Wrap(err, "could not set cached user repo")
+				}
+			}
+		} else if accountID != "" {
+			// A repo is private if it is not accessible to an authenticated user
+			err := cacheSetRepoVisibility(p.cache, projID, repoVisibilityCacheVal{Visibility: gitlab.Private, TTL: p.cacheTTL})
+			if err != nil {
+				return nil, errors.Wrap(err, "could not set cached repo visibility")
+			}
+			err = cacheSetUserRepo(p.cache, accountID, projID, userRepoCacheVal{Read: false, TTL: p.cacheTTL})
+			if err != nil {
+				return nil, errors.Wrap(err, "could not set cached user repo")
+			}
+		}
+	}
+	return perms, nil
+}
+
+// fetchProjVis fetches a repository's visibility with usr's credentials. It returns:
+// - whether the project is accessible to the user,
+// - the visibility if the repo is accessible (otherwise this is empty),
+// - whether the repository contents are accessible to usr, and
+// - any error encountered in fetching (not including an error due to the repository not being visible);
+//   if the error is non-nil, all other return values should be disregraded
+func (p *SudoProvider) fetchProjVis(ctx context.Context, sudo string, projID int) (
+	isAccessible bool, vis gitlab.Visibility, isContentAccessible bool, err error,
+) {
+	proj, err := p.clientProvider.GetPATClient(p.sudoToken, sudo).GetProject(ctx, gitlab.GetProjectOp{
+		ID:       projID,
+		CommonOp: gitlab.CommonOp{NoCache: true},
+	})
+	if err != nil {
+		return false, "", false, err
+	}
+
+	if proj.Visibility == gitlab.Public {
+		return true, proj.Visibility, true, nil
+	}
+
+	if sudo == "" {
+		return false, proj.Visibility, false, nil
+	}
+
+	// At this point, sudo is non-nil *and* project visibility is internal or private
+
+	if proj.Visibility == gitlab.Internal {
+		// All authenticated users can read the contents of all internal/public projects
+		// (https://docs.gitlab.com/ee/user/permissions.html).
+		return true, proj.Visibility, true, nil
+	}
+
+	// If project visibility is private and it's accessible to user, we still need to check if the user
+	// can read the repository contents (i.e., does not merely have "Guest" permissions).
+
+	if _, err := p.clientProvider.GetPATClient(p.sudoToken, sudo).ListTree(ctx, gitlab.ListTreeOp{
+		ProjID:   projID,
+		CommonOp: gitlab.CommonOp{NoCache: true},
+	}); err != nil {
+		if errCode := gitlab.HTTPErrorCode(err); errCode == http.StatusNotFound {
+			return true, proj.Visibility, false, nil
+		}
+		return false, "", false, err
+	}
+	return true, proj.Visibility, true, nil
+}
+
+// FetchAccount satisfies the authz.Provider interface. It iterates through the current list of
+// linked external accounts, find the one (if it exists) that matches the authn provider specified
+// in the SudoProvider struct, and fetches the user account from the GitLab API using that identity.
+func (p *SudoProvider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.ExternalAccount) (mine *extsvc.ExternalAccount, err error) {
+	if user == nil {
+		return nil, nil
+	}
+
+	var glUser *gitlab.User
+	if p.useNativeUsername {
+		glUser, err = p.fetchAccountByUsername(ctx, user.Username)
+	} else {
+		// resolve the GitLab account using the authn provider (specified by p.AuthnConfigID)
+		authnProvider := getProviderByConfigID(p.authnConfigID)
+		if authnProvider == nil {
+			return nil, nil
+		}
+		var authnAcct *extsvc.ExternalAccount
+		for _, acct := range current {
+			if acct.ServiceID == authnProvider.CachedInfo().ServiceID && acct.ServiceType == authnProvider.ConfigID().Type {
+				authnAcct = acct
+				break
+			}
+		}
+		if authnAcct == nil {
+			return nil, nil
+		}
+		glUser, err = p.fetchAccountByExternalUID(ctx, authnAcct.AccountID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if glUser == nil {
+		return nil, nil
+	}
+
+	var accountData extsvc.ExternalAccountData
+	gitlab.SetExternalAccountData(&accountData, glUser, nil)
+
+	glExternalAccount := extsvc.ExternalAccount{
+		UserID: user.ID,
+		ExternalAccountSpec: extsvc.ExternalAccountSpec{
+			ServiceType: p.codeHost.ServiceType(),
+			ServiceID:   p.codeHost.ServiceID(),
+			AccountID:   strconv.Itoa(int(glUser.ID)),
+		},
+		ExternalAccountData: accountData,
+	}
+	return &glExternalAccount, nil
+}
+
+func (p *SudoProvider) fetchAccountByExternalUID(ctx context.Context, uid string) (*gitlab.User, error) {
+	q := make(url.Values)
+	q.Add("extern_uid", uid)
+	q.Add("provider", p.gitlabProvider)
+	q.Add("per_page", "2")
+	glUsers, _, err := p.clientProvider.GetPATClient(p.sudoToken, "").ListUsers(ctx, "users?"+q.Encode())
+	if err != nil {
+		return nil, err
+	}
+	if len(glUsers) >= 2 {
+		return nil, fmt.Errorf("failed to determine unique GitLab user for query %q", q.Encode())
+	}
+	if len(glUsers) == 0 {
+		return nil, nil
+	}
+	return glUsers[0], nil
+}
+
+func (p *SudoProvider) fetchAccountByUsername(ctx context.Context, username string) (*gitlab.User, error) {
+	q := make(url.Values)
+	q.Add("username", username)
+	q.Add("per_page", "2")
+	glUsers, _, err := p.clientProvider.GetPATClient(p.sudoToken, "").ListUsers(ctx, "users?"+q.Encode())
+	if err != nil {
+		return nil, err
+	}
+	if len(glUsers) >= 2 {
+		return nil, fmt.Errorf("failed to determine unique GitLab user for query %q", q.Encode())
+	}
+	if len(glUsers) == 0 {
+		return nil, nil
+	}
+	return glUsers[0], nil
+}
+
+var getProviderByConfigID = auth.GetProviderByConfigID

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
@@ -1,0 +1,386 @@
+package gitlab
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
+)
+
+func Test_GitLab_FetchAccount(t *testing.T) {
+	// Test structures
+	type call struct {
+		description string
+
+		user    *types.User
+		current []*extsvc.ExternalAccount
+
+		expMine *extsvc.ExternalAccount
+	}
+	type test struct {
+		description string
+
+		// authnProviders is the list of auth providers that are mocked
+		authnProviders []auth.Provider
+
+		// op configures the SudoProvider instance
+		op SudoProviderOp
+
+		calls []call
+	}
+
+	// Mocks
+	gitlabMock := newMockGitLab(mockGitLabOp{
+		t: t,
+		users: []*gitlab.User{
+			{
+				ID:       101,
+				Username: "b.l",
+				Identities: []gitlab.Identity{
+					{Provider: "okta.mine", ExternUID: "bl"},
+					{Provider: "onelogin.mine", ExternUID: "bl"},
+				},
+			},
+			{
+				ID:         102,
+				Username:   "k.l",
+				Identities: []gitlab.Identity{{Provider: "okta.mine", ExternUID: "kl"}},
+			},
+			{
+				ID:         199,
+				Username:   "user-without-extern-id",
+				Identities: nil,
+			},
+		},
+	})
+	gitlab.MockListUsers = gitlabMock.ListUsers
+
+	// Test cases
+	tests := []test{
+		{
+			description: "1 authn provider, basic authz provider",
+			authnProviders: []auth.Provider{
+				mockAuthnProvider{
+					configID:  auth.ProviderConfigID{ID: "okta.mine", Type: "saml"},
+					serviceID: "https://okta.mine/",
+				},
+			},
+			op: SudoProviderOp{
+				BaseURL:           mustURL(t, "https://gitlab.mine"),
+				AuthnConfigID:     auth.ProviderConfigID{ID: "okta.mine", Type: "saml"},
+				GitLabProvider:    "okta.mine",
+				UseNativeUsername: false,
+			},
+			calls: []call{
+				{
+					description: "1 account, matches",
+					user:        &types.User{ID: 123},
+					current:     []*extsvc.ExternalAccount{acct(t, 1, "saml", "https://okta.mine/", "bl", "")},
+					expMine:     acct(t, 123, gitlab.ServiceType, "https://gitlab.mine/", "101", ""),
+				},
+				{
+					description: "many accounts, none match",
+					user:        &types.User{ID: 123},
+					current: []*extsvc.ExternalAccount{
+						acct(t, 1, "saml", "https://okta.mine/", "nomatch", ""),
+						acct(t, 1, "saml", "nomatch", "bl", ""),
+						acct(t, 1, "nomatch", "https://okta.mine/", "bl", ""),
+					},
+					expMine: nil,
+				},
+				{
+					description: "many accounts, 1 match",
+					user:        &types.User{ID: 123},
+					current: []*extsvc.ExternalAccount{
+						acct(t, 1, "saml", "nomatch", "bl", ""),
+						acct(t, 1, "nomatch", "https://okta.mine/", "bl", ""),
+						acct(t, 1, "saml", "https://okta.mine/", "bl", ""),
+					},
+					expMine: acct(t, 123, gitlab.ServiceType, "https://gitlab.mine/", "101", ""),
+				},
+				{
+					description: "no user",
+					user:        nil,
+					current:     nil,
+					expMine:     nil,
+				},
+			},
+		},
+		{
+			description:    "0 authn providers, native username",
+			authnProviders: nil,
+			op: SudoProviderOp{
+				BaseURL:           mustURL(t, "https://gitlab.mine"),
+				UseNativeUsername: true,
+			},
+			calls: []call{
+				{
+					description: "username match",
+					user:        &types.User{ID: 123, Username: "b.l"},
+					expMine:     acct(t, 123, gitlab.ServiceType, "https://gitlab.mine/", "101", ""),
+				},
+				{
+					description: "no username match",
+					user:        &types.User{ID: 123, Username: "nomatch"},
+					expMine:     nil,
+				},
+			},
+		},
+		{
+			description:    "0 authn providers, basic authz provider",
+			authnProviders: nil,
+			op: SudoProviderOp{
+				BaseURL:           mustURL(t, "https://gitlab.mine"),
+				AuthnConfigID:     auth.ProviderConfigID{ID: "okta.mine", Type: "saml"},
+				GitLabProvider:    "okta.mine",
+				UseNativeUsername: false,
+			},
+			calls: []call{
+				{
+					description: "no matches",
+					user:        &types.User{ID: 123, Username: "b.l"},
+					expMine:     nil,
+				},
+			},
+		},
+		{
+			description: "2 authn providers, basic authz provider",
+			authnProviders: []auth.Provider{
+				mockAuthnProvider{
+					configID:  auth.ProviderConfigID{ID: "okta.mine", Type: "saml"},
+					serviceID: "https://okta.mine/",
+				},
+				mockAuthnProvider{
+					configID:  auth.ProviderConfigID{ID: "onelogin.mine", Type: "openidconnect"},
+					serviceID: "https://onelogin.mine/",
+				},
+			},
+			op: SudoProviderOp{
+				BaseURL:           mustURL(t, "https://gitlab.mine"),
+				AuthnConfigID:     auth.ProviderConfigID{ID: "onelogin.mine", Type: "openidconnect"},
+				GitLabProvider:    "onelogin.mine",
+				UseNativeUsername: false,
+			},
+			calls: []call{
+				{
+					description: "1 authn provider matches",
+					user:        &types.User{ID: 123},
+					current:     []*extsvc.ExternalAccount{acct(t, 1, "openidconnect", "https://onelogin.mine/", "bl", "")},
+					expMine:     acct(t, 123, gitlab.ServiceType, "https://gitlab.mine/", "101", ""),
+				},
+				{
+					description: "0 authn providers match",
+					user:        &types.User{ID: 123},
+					current:     []*extsvc.ExternalAccount{acct(t, 1, "openidconnect", "https://onelogin.mine/", "nomatch", "")},
+					expMine:     nil,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			auth.MockProviders = test.authnProviders
+			defer func() { auth.MockProviders = nil }()
+
+			ctx := context.Background()
+			authzProvider := NewSudoProvider(test.op)
+			for _, c := range test.calls {
+				t.Run(c.description, func(t *testing.T) {
+					acct, err := authzProvider.FetchAccount(ctx, c.user, c.current)
+					if err != nil {
+						t.Errorf("unexpected error: %v", err)
+						return
+					}
+					// ignore AccountData field in comparison
+					if acct != nil {
+						acct.AccountData, c.expMine.AccountData = nil, nil
+					}
+
+					if !reflect.DeepEqual(acct, c.expMine) {
+						dmp := diffmatchpatch.New()
+						t.Errorf("wantUser != user\n%s",
+							dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(c.expMine), spew.Sdump(acct), false)))
+					}
+				})
+			}
+		})
+	}
+}
+
+func Test_SudoProvider_RepoPerms(t *testing.T) {
+	type call struct {
+		description string
+		account     *extsvc.ExternalAccount
+		repos       map[authz.Repo]struct{}
+		expPerms    map[api.RepoName]map[authz.Perm]bool
+	}
+	type test struct {
+		description string
+		op          SudoProviderOp
+		calls       []call
+	}
+
+	// Mock the following scenario:
+	// - public projects begin with 99
+	// - internal projects begin with 98
+	// - private projects begin with the digit of the user that owns them (other users may have access)
+	// - user 1 owns its own repositories and nothing else
+	// - user 2 owns its own repos and has guest access to user 1's
+	// - user 3 owns its own repos and has full access to user 1's and guest access to user 2's
+	gitlabMock := newMockGitLab(mockGitLabOp{
+		t: t,
+		publicProjs: []int{ // public projects
+			991,
+		},
+		internalProjs: []int{ // internal projects
+			981,
+		},
+		privateProjs: map[int][2][]int32{ // private projects
+			10: {
+				{ // guests
+					2,
+				},
+				{ // content ("full access")
+					1,
+					3,
+				},
+			},
+			20: {
+				{
+					3,
+				},
+				{
+					2,
+				},
+			},
+			30: {
+				{},
+				{3},
+			},
+		},
+		sudoTok: "sudo-token",
+	})
+	gitlab.MockGetProject = gitlabMock.GetProject
+	gitlab.MockListTree = gitlabMock.ListTree
+
+	tests := []test{
+		{
+			description: "standard config",
+			op: SudoProviderOp{
+				BaseURL:   mustURL(t, "https://gitlab.mine"),
+				SudoToken: "sudo-token",
+			},
+			calls: []call{
+				{
+					description: "u1 user has expected perms",
+					account:     acct(t, 1, "gitlab", "https://gitlab.mine/", "1", "oauth-u1"),
+					repos: map[authz.Repo]struct{}{
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
+					},
+					expPerms: map[api.RepoName]map[authz.Perm]bool{
+						"u1/repo1":       {authz.Read: true},
+						"internal/repo1": {authz.Read: true},
+						"public/repo1":   {authz.Read: true},
+					},
+				},
+				{
+					description: "u2 user has expected perms",
+					account:     acct(t, 2, "gitlab", "https://gitlab.mine/", "2", "oauth-u2"),
+					repos: map[authz.Repo]struct{}{
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
+					},
+					expPerms: map[api.RepoName]map[authz.Perm]bool{
+						"u2/repo1":       {authz.Read: true},
+						"internal/repo1": {authz.Read: true},
+						"public/repo1":   {authz.Read: true},
+					},
+				},
+				{
+					description: "other user has expected perms (internal and public)",
+					account:     acct(t, 4, "gitlab", "https://gitlab.mine/", "555", "oauth-other"),
+					repos: map[authz.Repo]struct{}{
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
+					},
+					expPerms: map[api.RepoName]map[authz.Perm]bool{
+						"internal/repo1": {authz.Read: true},
+						"public/repo1":   {authz.Read: true},
+					},
+				},
+				{
+					description: "no token means only public and internal repos",
+					account:     acct(t, 4, "gitlab", "https://gitlab.mine/", "555", ""),
+					repos: map[authz.Repo]struct{}{
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
+					},
+					expPerms: map[api.RepoName]map[authz.Perm]bool{
+						"internal/repo1": {authz.Read: true},
+						"public/repo1":   {authz.Read: true},
+					},
+				},
+				{
+					description: "unauthenticated means only public repos",
+					account:     nil,
+					repos: map[authz.Repo]struct{}{
+						repo("u1/repo1", gitlab.ServiceType, "https://gitlab.mine/", "10"):        {},
+						repo("u2/repo1", gitlab.ServiceType, "https://gitlab.mine/", "20"):        {},
+						repo("u3/repo1", gitlab.ServiceType, "https://gitlab.mine/", "30"):        {},
+						repo("internal/repo1", gitlab.ServiceType, "https://gitlab.mine/", "981"): {},
+						repo("public/repo1", gitlab.ServiceType, "https://gitlab.mine/", "991"):   {},
+					},
+					expPerms: map[api.RepoName]map[authz.Perm]bool{
+						"public/repo1": {authz.Read: true},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			for _, c := range test.calls {
+				// Recreate the authz provider cache every time, before running twice (once uncached, once cached)
+				ctx := context.Background()
+				op := test.op
+				op.MockCache = make(mockCache)
+				authzProvider := NewSudoProvider(op)
+
+				for i := 0; i < 2; i++ {
+					t.Logf("iter %d", i)
+					perms, err := authzProvider.RepoPerms(ctx, c.account, c.repos)
+					if err != nil {
+						t.Errorf("unexpected error: %v", err)
+						continue
+					}
+					if !reflect.DeepEqual(perms, c.expPerms) {
+						t.Errorf("expected %s, but got %s", asJSON(t, c.expPerms), asJSON(t, perms))
+					}
+				}
+			}
+		})
+	}
+}

--- a/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
+++ b/enterprise/cmd/frontend/internal/authz/gitlab/gitlab_sudo_test.go
@@ -363,6 +363,8 @@ func Test_SudoProvider_RepoPerms(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			for _, c := range test.calls {
+				t.Logf("Call %q", c.description)
+
 				// Recreate the authz provider cache every time, before running twice (once uncached, once cached)
 				ctx := context.Background()
 				op := test.op

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -56,11 +56,78 @@
       "description": "If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type \"gitlab\" with the same `url` field as specified in this `GitLabConnection`.",
       "type": "object",
       "additionalProperties": false,
+      "required": ["identityProvider"],
       "properties": {
+        "identityProvider": {
+          "description": "The source of identity to use when computing permissions. This defines how to compute the GitLab identity to use for a given Sourcegraph user.",
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["oauth", "username", "external"]
+            }
+          },
+          "oneOf": [
+            { "$ref": "#/definitions/OAuthIdentity" },
+            { "$ref": "#/definitions/UsernameIdentity" },
+            { "$ref": "#/definitions/ExternalIdentity" }
+          ],
+          "!go": {
+            "taggedUnionType": true
+          }
+        },
         "ttl": {
           "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
           "default": "3h"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OAuthIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "oauth"
+        }
+      }
+    },
+    "UsernameIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "username"
+        }
+      }
+    },
+    "ExternalIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "authProviderID", "authProviderType", "gitlabProvider"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "external"
+        },
+        "authProviderID": {
+          "type": "string",
+          "description": "The value of the `configID` field of the targeted authentication provider."
+        },
+        "authProviderType": {
+          "type": "string",
+          "description": "The `type` field of the targeted authentication provider."
+        },
+        "gitlabProvider": {
+          "type": "string",
+          "description": "The name that identifies the authentication provider to GitLab. This is passed to the `?provider=` query parameter in calls to the GitLab Users API. If you're not sure what this value is, you can look at the `identities` field of the GitLab Users API result (`curl  -H 'PRIVATE-TOKEN: $YOUR_TOKEN' $GITLAB_URL/api/v4/users`)."
         }
       }
     }

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -61,11 +61,78 @@ const GitLabSchemaJSON = `{
       "description": "If non-null, enforces GitLab repository permissions. This requires that there be an item in the ` + "`" + `auth.providers` + "`" + ` field of type \"gitlab\" with the same ` + "`" + `url` + "`" + ` field as specified in this ` + "`" + `GitLabConnection` + "`" + `.",
       "type": "object",
       "additionalProperties": false,
+      "required": ["identityProvider"],
       "properties": {
+        "identityProvider": {
+          "description": "The source of identity to use when computing permissions. This defines how to compute the GitLab identity to use for a given Sourcegraph user.",
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["oauth", "username", "external"]
+            }
+          },
+          "oneOf": [
+            { "$ref": "#/definitions/OAuthIdentity" },
+            { "$ref": "#/definitions/UsernameIdentity" },
+            { "$ref": "#/definitions/ExternalIdentity" }
+          ],
+          "!go": {
+            "taggedUnionType": true
+          }
+        },
         "ttl": {
           "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/100 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
           "default": "3h"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OAuthIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "oauth"
+        }
+      }
+    },
+    "UsernameIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "username"
+        }
+      }
+    },
+    "ExternalIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "authProviderID", "authProviderType", "gitlabProvider"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "external"
+        },
+        "authProviderID": {
+          "type": "string",
+          "description": "The value of the ` + "`" + `configID` + "`" + ` field of the targeted authentication provider."
+        },
+        "authProviderType": {
+          "type": "string",
+          "description": "The ` + "`" + `type` + "`" + ` field of the targeted authentication provider."
+        },
+        "gitlabProvider": {
+          "type": "string",
+          "description": "The name that identifies the authentication provider to GitLab. This is passed to the ` + "`" + `?provider=` + "`" + ` query parameter in calls to the GitLab Users API. If you're not sure what this value is, you can look at the ` + "`" + `identities` + "`" + ` field of the GitLab Users API result (` + "`" + `curl  -H 'PRIVATE-TOKEN: $YOUR_TOKEN' $GITLAB_URL/api/v4/users` + "`" + `)."
         }
       }
     }


### PR DESCRIPTION
This adds back the GitLab sudo-token-based permissions checking that was taken out in e9cd0086517d6fd2d069cf6239fdbebd37e21531. Now we have two mechanisms for computing GitLab permissions:
* OAuth-based, which requires GitLab to be configured as an authentication provider.
* Sudo-token-based, which requires the admin to provide a sudo-level token in the Sourcegraph GitLab connection config.

Each of these uses the same mechanism to compute permissions (authenticating as a user and using the GitLab API `GetProject` and `ListTree` endpoints). The OAuth-based mechanism uses the user's OAuth login token to authenticate to GitLab; the sudo-token-based mechanism uses the sudo-level token and the `Sudo` HTTP header to impersonate the user.

The Sourcegraph config has been updated so that the external service config for GitLab now include a `authorization.identityProvider` field, which in turn has a `type` subfield that is one of the following:
* `oauth`: Use OAuth-based authentication to identify the user to GitLab
* `external`: Use another SSO provider (the fields of this config object will then identify that provider among the `auth.providers` list)
* `username`: User exact username matching, which is generally insecure, but can be secure when HTTP header auth is the only element of `auth.providers`.