### PR TITLE
style: explicitly show tags on licenses in site-admin on dotcom

### DIFF
--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
@@ -87,7 +87,7 @@ export class SiteAdminProductLicenseNode extends React.PureComponent<SiteAdminPr
                         </span>
                     </div>
                 </div>
-                {this.props.node.info && (
+                {this.props.node.info && this.props.node.info.tags.length > 0 && (
                     <div>
                         Tags:{' '}
                         {this.props.node.info.tags.map(tag => (

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
@@ -87,6 +87,14 @@ export class SiteAdminProductLicenseNode extends React.PureComponent<SiteAdminPr
                         </span>
                     </div>
                 </div>
+                {this.props.node.info && (
+                    <div>
+                        Tags:{' '}
+                        {this.props.node.info.tags.map(tag => (
+                            <div className="mr-1 badge badge-secondary">{tag}</div>
+                        ))}
+                    </div>
+                )}
                 <CopyableText text={this.props.node.licenseKey} className="mt-2 d-block" />
             </li>
         )


### PR DESCRIPTION
Adds a row with chips for each tag on a license in site-admin mode on sourcegraph.com.

I often find myself wondering whether a license is on a trial or not, set to true-up or not, etc. Some tags are shown in the product name, but not all. This displays all tags explicitly.

![image](https://user-images.githubusercontent.com/5589410/52601993-ae998b80-2e15-11e9-8682-067327a474f5.png)
