### PR TITLE
Fix broken links on the /welcome page footer

### DIFF
--- a/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
+++ b/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
@@ -31,8 +31,8 @@ export const WelcomeAreaFooter: React.FunctionComponent<{ isLightTheme: boolean 
                         </a>
                     </li>
                     <li>
-                        <a href="https://docs.sourcegraph.com/extensions" target="_blank">
-                            Code intelligence &amp; extensions
+                        <a href="https://docs.sourcegraph.com/user/code_intelligence" target="_blank">
+                            Code intelligence
                         </a>
                     </li>
                     <li>

--- a/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
+++ b/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
 
 export const WelcomeAreaFooter: React.FunctionComponent<{ isLightTheme: boolean }> = ({ isLightTheme }) => (
     <>
@@ -27,13 +26,13 @@ export const WelcomeAreaFooter: React.FunctionComponent<{ isLightTheme: boolean 
                 <h3 className="mb-0">Features</h3>
                 <ul className="list-unstyled">
                     <li>
-                        <Link to="/welcome/search">Code search</Link>
+                        <a href="https://docs.sourcegraph.com/user/search">Code search</a>
                     </li>
                     <li>
-                        <Link to="/welcome/code-intelligence">Code intelligence</Link>
+                        <a href="https://docs.sourcegraph.com/extensions">Code intelligence &amp; extensions</a>
                     </li>
                     <li>
-                        <Link to="/welcome/integrations">Integrations</Link>
+                        <a href="https://docs.sourcegraph.com/integration">Integrations</a>
                     </li>
                     <li>
                         <a href="https://about.sourcegraph.com/pricing" target="_blank">

--- a/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
+++ b/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
@@ -26,13 +26,19 @@ export const WelcomeAreaFooter: React.FunctionComponent<{ isLightTheme: boolean 
                 <h3 className="mb-0">Features</h3>
                 <ul className="list-unstyled">
                     <li>
-                        <a href="https://docs.sourcegraph.com/user/search">Code search</a>
+                        <a href="https://docs.sourcegraph.com/user/search" target="_blank">
+                            Code search
+                        </a>
                     </li>
                     <li>
-                        <a href="https://docs.sourcegraph.com/extensions">Code intelligence &amp; extensions</a>
+                        <a href="https://docs.sourcegraph.com/extensions" target="_blank">
+                            Code intelligence &amp; extensions
+                        </a>
                     </li>
                     <li>
-                        <a href="https://docs.sourcegraph.com/integration">Integrations</a>
+                        <a href="https://docs.sourcegraph.com/integration" target="_blank">
+                            Integrations
+                        </a>
                     </li>
                     <li>
                         <a href="https://about.sourcegraph.com/pricing" target="_blank">


### PR DESCRIPTION
fixes https://github.com/sourcegraph/sourcegraph/issues/2252

These links now more closely mirror the about.sourcegraph.com footer. There are still some differences, though, in column ordering and specific links:  https://github.com/sourcegraph/sourcegraph/issues/2255