### PR TITLE
add smart case and enable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - File match search results now show full repo name if there are results from mirrors on different code hosts (e.g. github.com/sourcegraph/sourcegraph and gitlab.com/sourcegraph/sourcegraph)
-- Search queries now use "smart case" by default. Searches are case insensitive unless you use uppercase letters. To explicitely set the case, you can still use the `case` field (e.g. `case:yes`, `case:no`, `case:smartcase`).
+- Search queries now use "smart case" by default. Searches are case insensitive unless you use uppercase letters. To explicitely set the case, you can still use the `case` field (e.g. `case:yes`, `case:no`). To explicitely set smart case, use `case:auto`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - File match search results now show full repo name if there are results from mirrors on different code hosts (e.g. github.com/sourcegraph/sourcegraph and gitlab.com/sourcegraph/sourcegraph)
+- Search queries now use "smart case" by default. Searches are case insensitive unless you use uppercase letters. To explicitely set the case, you can still use the `case` field (e.g. `case:yes`, `case:no`, `case:smartcase`).
 
 ### Fixed
 

--- a/cmd/frontend/internal/pkg/search/query/searchquery.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery.go
@@ -118,7 +118,7 @@ func (q *Query) BoolValue(field string) bool {
 // case sensitively.
 func (q *Query) IsCaseSensitive() bool {
 	value, _ := q.StringValue(FieldCase)
-	if value == "smartcase" || value == "" { // default to smartcase if no case was provided
+	if value == "auto" || value == "" { // default to smartcase if no case was provided
 		for _, value := range q.Values(FieldDefault) {
 			if value.String != nil {
 				return *value.String != strings.ToLower(*value.String)

--- a/cmd/frontend/internal/pkg/search/query/searchquery_test.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery_test.go
@@ -22,10 +22,10 @@ func TestQuery_IsCaseSensitive(t *testing.T) {
 	}{
 		{"yes", "case:yes", true},
 		{"no (explicit)", "case:no", false},
-		{"no (smartcase/regexp)", "case:smartcase test", false},
-		{"yes (smartcase/regexp)", "case:smartcase Test", true},
-		{"no (smartcase/string)", "case:smartcase \"test\"", false},
-		{"yes (smartcase/string)", "case:smartcase \"Test\"", true},
+		{"no (smartcase/regexp)", "case:auto test", false},
+		{"yes (smartcase/regexp)", "case:auto Test", true},
+		{"no (smartcase/string)", "case:auto \"test\"", false},
+		{"yes (smartcase/string)", "case:auto \"Test\"", true},
 		{"yes (default)", "Test", true},
 		{"no (default)", "test", false},
 	}

--- a/cmd/frontend/internal/pkg/search/query/searchquery_test.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery_test.go
@@ -10,39 +10,37 @@ import (
 func TestQuery_IsCaseSensitive(t *testing.T) {
 	conf := types.Config{
 		FieldTypes: map[string]types.FieldType{
-			FieldCase: {Literal: types.BoolType, Quoted: types.BoolType, Singular: true},
+			FieldCase:    {Literal: types.StringType, Quoted: types.StringType, Singular: true},
+			FieldDefault: {Literal: types.RegexpType, Quoted: types.StringType},
 		},
 	}
 
-	t.Run("yes", func(t *testing.T) {
-		query, err := parseAndCheck(&conf, "case:yes")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !query.IsCaseSensitive() {
-			t.Error("IsCaseSensitive() == false, want true")
-		}
-	})
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"yes", "case:yes", true},
+		{"no (explicit)", "case:no", false},
+		{"no (smartcase/regexp)", "case:smartcase test", false},
+		{"yes (smartcase/regexp)", "case:smartcase Test", true},
+		{"no (smartcase/string)", "case:smartcase \"test\"", false},
+		{"yes (smartcase/string)", "case:smartcase \"Test\"", true},
+		{"yes (default)", "Test", true},
+		{"no (default)", "test", false},
+	}
 
-	t.Run("no (explicit)", func(t *testing.T) {
-		query, err := parseAndCheck(&conf, "case:no")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if query.IsCaseSensitive() {
-			t.Error("IsCaseSensitive() == true, want false")
-		}
-	})
-
-	t.Run("no (default)", func(t *testing.T) {
-		query, err := parseAndCheck(&conf, "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if query.IsCaseSensitive() {
-			t.Error("IsCaseSensitive() == true, want false")
-		}
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query, err := parseAndCheck(&conf, test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := query.IsCaseSensitive(); got != test.want {
+				t.Errorf("%s: got %v, want %v", test.name, got, test.want)
+			}
+		})
+	}
 }
 
 func TestQuery_RegexpPatterns(t *testing.T) {

--- a/cmd/frontend/internal/pkg/search/query/types/check.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check.go
@@ -129,7 +129,7 @@ func setValue(dst *Value, valueString string, valueType ValueType) error {
 		}
 		dst.Regexp = p
 	case BoolType:
-		b, err := parseBool(valueString)
+		b, err := ParseBool(valueString)
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func unquoteString(s string) (string, error) {
 
 // parseBool is like strconv.ParseBool except that it also accepts y, Y, yes,
 // YES, Yes, n, N, no, NO, No.
-func parseBool(s string) (bool, error) {
+func ParseBool(s string) (bool, error) {
 	switch s {
 	case "y", "Y", "yes", "YES", "Yes":
 		return true, nil


### PR DESCRIPTION
This PR adds "smart case" detection to our query parser. Smart case is now enabled by default.

Closes https://github.com/sourcegraph/sourcegraph/issues/2084.