### PR TITLE
cmd/management-console: only generate TLS cert/key if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue where the management console would improperly regenerate the TLS cert/key unless `CUSTOM_TLS=true` was set. See the documentation for [how to use your own TLS certificate with the management console](doc/admin/management_console.md#how-can-i-use-my-own-tls-certificates-with-the-management-console).
+
 ### Removed
 
 ## 3.0.1

--- a/cmd/management-console/shared/main.go
+++ b/cmd/management-console/shared/main.go
@@ -41,11 +41,13 @@ var (
 func configureTLS() error {
 	customTLS, _ := strconv.ParseBool(customTLS)
 
+	generate := false
 	_, err := os.Stat(tlsCert)
 	if os.IsNotExist(err) {
 		if customTLS {
 			return err
 		}
+		generate = true
 	} else if err != nil {
 		return err
 	}
@@ -55,13 +57,15 @@ func configureTLS() error {
 		if customTLS {
 			return err
 		}
+		generate = true
 	} else if err != nil {
 		return err
 	}
 
-	if customTLS {
+	if customTLS || !generate {
 		return nil // cert files exist
 	}
+	log.Println("Generating and using self-signed TLS cert/key")
 
 	if err := os.MkdirAll(filepath.Dir(tlsCert), 0700); err != nil {
 		return err

--- a/doc/admin/management_console.md
+++ b/doc/admin/management_console.md
@@ -92,4 +92,17 @@ You may now sign into the management console using your plaintext password `abc1
 
 ### How can I use my own TLS certificates with the management console?
 
-This section coming soon. Please contact support@sourcegraph.com for further information.
+The management console looks for TLS certificates in the following location inside the Docker container:
+
+- `/etc/sourcegraph/management/cert.pem`
+- `/etc/sourcegraph/management/key.pem`
+
+If you are using `sourcegraph/server` and the regular Docker flag:
+
+```
+--volume ~/.sourcegraph/config:/etc/sourcegraph
+```
+
+This means you can simply place them in `~/.sourcegraph/config/management/`  on the host.
+
+Restart the container once you have copied the files there for the changes to take effect.


### PR DESCRIPTION
Prior to this change this code had a bug in which we would always generate a
new TLS cert/key on startup, which prevented using your own unless you set
`CUSTOM_TLS=true` (which is not desirable, setting that is only useful as a
"keep me sane that this thing won't overwrite my TLS cert/key" feature, not as
a requirement for using your own TLS cert/key pair).

Fixes #1683
Fixes #1507