### PR TITLE
docs: add roadmap tracking issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -1,0 +1,32 @@
+---
+name: Roadmap tracking issue
+about: This is the template for the project tracking issue that the roadmap links to.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- A short description of the problems this plan addresses and what will ship in its associated release milestone. -->
+
+## Plan
+
+<!-- Either a Markdown checklist of tasks with issue links as needed: -->
+
+- [ ] Issue 1 title #123
+- [ ] Issue 2 title #456
+
+<!-- or a link to an issue query: -->
+
+[Issues](https://github.com/sourcegraph/sourcegraph/issues?q=is:issue+is:open+sort:updated-desc+label:mylabel+milestone:3.2)
+
+## Test/review plan
+
+<!-- This part of the template is experimental. We'll see how it goes -->
+
+- Code reviewer: <!-- fill in @user(s) -->
+- Tester: <!-- fill in @user(s) -->
+
+<!-- This is how the project will be tested for the release. Fill this out with at least high-level details right now, and finish it by one week before the release. -->
+
+<!-- Add other sections if needed to describe: future project work planned for the next release, technical or deadline risks, blockers/dependencies, backcompat/migration, or anything else important. -->


### PR DESCRIPTION
Add the [roadmap tracking issue template](/sourcegraph/sourcegraph/blob/master/doc/dev/product/tracking_issue_template.md) as an issue template