### PR TITLE
fix: differentiate telemetry between refs/defs, log codeintel actions…

### DIFF
--- a/client/browser/src/shared/tracking/EventLogger.tsx
+++ b/client/browser/src/shared/tracking/EventLogger.tsx
@@ -1,4 +1,5 @@
 import uuid from 'uuid'
+import * as GQL from '../../../../../shared/src/graphql/schema'
 import { TelemetryService } from '../../../../../shared/src/telemetry/telemetryService'
 import storage from '../../browser/storage'
 import { isInPage } from '../../context'
@@ -65,9 +66,9 @@ export class EventLogger implements TelemetryService {
      *
      * This is never sent to Sourcegraph.com (i.e., when using the integration with open source code).
      */
-    public logCodeIntelligenceEvent(): void {
+    public logCodeIntelligenceEvent(event: GQL.UserEvent): void {
         this.getAnonUserID().then(
-            anonUserId => logUserEvent('CODEINTELINTEGRATION', anonUserId),
+            anonUserId => logUserEvent(event, anonUserId),
             () => {
                 /* noop */
             }
@@ -77,11 +78,15 @@ export class EventLogger implements TelemetryService {
     /**
      * Implements {@link TelemetryService}.
      *
-     * @todo Use the eventName. It is currently ignored.
+     * @todo Handle arbitrary action IDs.
      *
-     * @param _eventName This parameter is ignored; see the @todo.
+     * @param _eventName The ID of the action executed.
      */
     public log(_eventName: string): void {
-        this.logCodeIntelligenceEvent()
+        if (_eventName === 'goToDefinition' || _eventName === 'goToDefinition.preloaded' || _eventName === 'hover') {
+            this.logCodeIntelligenceEvent(GQL.UserEvent.CODEINTELINTEGRATION)
+        } else if (_eventName === 'findReferences') {
+            this.logCodeIntelligenceEvent(GQL.UserEvent.CODEINTELINTEGRATIONREFS)
+        }
     }
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2857,7 +2857,9 @@ enum UserEvent {
     PAGEVIEW
     SEARCHQUERY
     CODEINTEL
+    CODEINTELREFS
     CODEINTELINTEGRATION
+    CODEINTELINTEGRATIONREFS
 }
 
 # A period of time in which a set of users have been active.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2864,7 +2864,9 @@ enum UserEvent {
     PAGEVIEW
     SEARCHQUERY
     CODEINTEL
+    CODEINTELREFS
     CODEINTELINTEGRATION
+    CODEINTELINTEGRATIONREFS
 }
 
 # A period of time in which a set of users have been active.

--- a/cmd/frontend/internal/pkg/usagestats/usage_stats.go
+++ b/cmd/frontend/internal/pkg/usagestats/usage_stats.go
@@ -452,13 +452,7 @@ func LogActivity(isAuthenticated bool, userID int32, userCookieID string, event 
 		if err := logSearchOccurred(); err != nil {
 			return err
 		}
-	case "CODEINTEL":
-		// TODO(Dan): differentiate between go to def and find refs
-		if err := logFindRefsOccurred(); err != nil {
-			return err
-		}
-	case "CODEINTELINTEGRATION":
-		// TODO(Dan): differentiate between go to def and find refs
+	case "CODEINTELREFS", "CODEINTELINTEGRATIONREFS":
 		if err := logFindRefsOccurred(); err != nil {
 			return err
 		}
@@ -474,9 +468,9 @@ func LogActivity(isAuthenticated bool, userID int32, userCookieID string, event 
 		return logSearchQuery(userID)
 	case "PAGEVIEW":
 		return logPageView(userID)
-	case "CODEINTEL":
+	case "CODEINTEL", "CODEINTELREFS":
 		return logCodeIntelAction(userID)
-	case "CODEINTELINTEGRATION":
+	case "CODEINTELINTEGRATION", "CODEINTELINTEGRATIONREFS":
 		if err := logCodeHostIntegrationUsage(userID); err != nil {
 			return err
 		}

--- a/web/src/tracking/eventLogger.tsx
+++ b/web/src/tracking/eventLogger.tsx
@@ -113,7 +113,7 @@ class EventLogger implements TelemetryService {
             eventLabel,
         }
         telligent.track(eventLabel, decoratedProps)
-        serverAdmin.trackAction(eventLabel, decoratedProps)
+        serverAdmin.trackAction(eventLabel)
         this.logToConsole(eventLabel, decoratedProps)
     }
 

--- a/web/src/tracking/services/serverAdminWrapper.tsx
+++ b/web/src/tracking/services/serverAdminWrapper.tsx
@@ -23,16 +23,18 @@ class ServerAdminWrapper {
         logUserEvent(GQL.UserEvent.PAGEVIEW)
     }
 
-    public trackAction(eventAction: string, eventProps: any): void {
+    public trackAction(eventAction: string): void {
         if (this.isAuthenicated) {
             if (eventAction === 'SearchSubmitted') {
                 logUserEvent(GQL.UserEvent.SEARCHQUERY)
             } else if (
                 eventAction === 'goToDefinition' ||
                 eventAction === 'goToDefinition.preloaded' ||
-                eventAction === 'findReferences'
+                eventAction === 'hover'
             ) {
                 logUserEvent(GQL.UserEvent.CODEINTEL)
+            } else if (eventAction === 'findReferences') {
+                logUserEvent(GQL.UserEvent.CODEINTELREFS)
             }
         }
     }


### PR DESCRIPTION
… on hovers, only log telemetry on codeintel from integrations

Fixes three issues:
* Sourcegraph can now differentiate between refs and other types of codeintel (so the activation step is only "completed" when a user actually does a find-refs)
* Contributed actions executed in integrations (e.g. browser extensions) now ONLY log a user action if they are a code intel action (i.e., have an `_eventName` of `'hover'`, `'findReferences'`, `'goToDefinition'`, or `'goToDefinition.preloaded'`). There's a TODO here of logging other event types (need to rethink this API, and whether servers should even log other types of actions).
* Hovers now log user codeintel actions. This means they are included in the code intelligence metrics on the **site-admin > Usage statistics** page.

Addresses part of https://github.com/sourcegraph/sourcegraph/issues/2024