### PR TITLE
remove empty "Experimental configuration" section

### DIFF
--- a/client/browser/src/libs/options/Menu.tsx
+++ b/client/browser/src/libs/options/Menu.tsx
@@ -24,9 +24,6 @@ export interface OptionsMenuProps
 const buildFeatureFlagToggleHandler = (key: string, handler: OptionsMenuProps['toggleFeatureFlag']) => () =>
     handler(key)
 
-const withSentry = (flags: ConfigurableFeatureFlag[]) => flags.filter(({ key }) => key === 'allowErrorReporting')
-const withOutSentry = (flags: ConfigurableFeatureFlag[]) => flags.filter(({ key }) => key !== 'allowErrorReporting')
-
 const isFullPage = (): boolean => !new URLSearchParams(window.location.search).get('popup')
 
 export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
@@ -51,28 +48,7 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
             <div className="options-menu__section">
                 <label>Configuration</label>
                 <div>
-                    {withSentry(featureFlags).map(({ key, value }) => (
-                        <div className="form-check" key={key}>
-                            <label className="form-check-label">
-                                <input
-                                    id={key}
-                                    onClick={buildFeatureFlagToggleHandler(key, toggleFeatureFlag)}
-                                    className="form-check-input"
-                                    type="checkbox"
-                                    checked={value}
-                                />{' '}
-                                {upperFirst(lowerCase(key))}
-                            </label>
-                        </div>
-                    ))}
-                </div>
-            </div>
-        )}
-        {isSettingsOpen && featureFlags && (
-            <div className="options-menu__section">
-                <label>Experimental configuration</label>
-                <div>
-                    {withOutSentry(featureFlags).map(({ key, value }) => (
+                    {featureFlags.map(({ key, value }) => (
                         <div className="form-check" key={key}>
                             <label className="form-check-label">
                                 <input


### PR DESCRIPTION
The browser ext options menu "Experimental configuration" section was empty. The configuration section only had "Allow error reporting". Instead of refactoring this code to selectively show the experimental section when it would be non-empty, this commit just removes it altogether. If a new experimental configuration option is added, it is OK for it to be in the "Configuration" section (and it can be annotated with "EXPERIMENTAL" if needed).


Here is what it looked like before (with the empty section):

![image](https://user-images.githubusercontent.com/1976/52764633-c6b80900-2fd5-11e9-8284-49e868ccb38b.png)
