### PR TITLE
remove unused stylelint-compact yarn command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -94,8 +94,8 @@
     },
     {
       "label": "stylelint",
-      "command": "yarn",
-      "args": ["--prefix", "web", "run", "stylelint"],
+      "command": "npm",
+      "args": ["--silent", "--prefix", "web", "run", "stylelint", "--", "--formatter", "compact"],
       "problemMatcher": {
         "owner": "stylelint",
         "applyTo": "closedDocuments",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -95,7 +95,7 @@
     {
       "label": "stylelint",
       "command": "yarn",
-      "args": ["--prefix", "web", "run", "stylelint-compact"],
+      "args": ["--prefix", "web", "run", "stylelint"],
       "problemMatcher": {
         "owner": "stylelint",
         "applyTo": "closedDocuments",

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "webpack": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" gulp webpack",
     "lint": "yarn run tslint && gulp unusedExports && yarn run stylelint",
     "tslint": "tslint -t stylish -c tslint.json -p tsconfig.json -e 'src/schema/**' 'src/**/*.ts?(x)' 'types/**/*.ts?(x)' './*.ts?(x)'",
-    "stylelint": "stylelint --quiet 'src/**/*.scss'",
+    "stylelint": "stylelint 'src/**/*.scss'",
     "bundlesize": "cross-env GITHUB_TOKEN= bundlesize",
     "browserslist": "browserslist"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,6 @@
     "lint": "yarn run tslint && gulp unusedExports && yarn run stylelint",
     "tslint": "tslint -t stylish -c tslint.json -p tsconfig.json -e 'src/schema/**' 'src/**/*.ts?(x)' 'types/**/*.ts?(x)' './*.ts?(x)'",
     "stylelint": "stylelint --quiet 'src/**/*.scss'",
-    "stylelint-compact": "yarn run stylelint --custom-formatter ./node_modules/stylelint-formatter-compact/index.js",
     "bundlesize": "cross-env GITHUB_TOKEN= bundlesize",
     "browserslist": "browserslist"
   },


### PR DESCRIPTION
e97c94fb15f7298c2e24e58c1ab9839220c20e5d removed the stylelint-formatter-compact npm dep because it was deprecated, which meant that the `yarn run stylelint-compact` command would fail. Nobody complained, so I'm assuming nobody was using it.