### PR TITLE
Update Sourcegraph Theme

### DIFF
--- a/shared/src/components/FileMatch.scss
+++ b/shared/src/components/FileMatch.scss
@@ -6,7 +6,7 @@
         padding: 0.25rem 0.5rem;
         overflow-x: auto;
         overflow-y: hidden;
-        background-color: #070a0d;
+        background-color: #0e121b;
 
         &-clickable {
             cursor: pointer;

--- a/shared/src/components/ResultContainer.scss
+++ b/shared/src/components/ResultContainer.scss
@@ -2,6 +2,7 @@
     position: relative;
     margin-bottom: 0.5rem;
     border-radius: 2px;
+	border: 1px solid #2b3750;
 
     &__header {
         padding: 0.25rem 0.5rem;

--- a/shared/src/components/ResultContainer.scss
+++ b/shared/src/components/ResultContainer.scss
@@ -2,7 +2,7 @@
     position: relative;
     margin-bottom: 0.5rem;
     border-radius: 2px;
-	border: 1px solid #2b3750;
+    border: 1px solid #2b3750;
 
     &__header {
         padding: 0.25rem 0.5rem;

--- a/web/src/global-styles/type.scss
+++ b/web/src/global-styles/type.scss
@@ -7,7 +7,7 @@ $body-color-dark: $white;
 
 .theme-light {
     --body-color: #{$body-color-light};
-    --body-bg: #ffffff;
+    --body-bg: #FBFDFF;
     --text-muted: #{$color-light-text-2};
     --link-color: #566e9f;
     --link-hover-color: #1d2535;
@@ -15,7 +15,7 @@ $body-color-dark: $white;
 
 .theme-dark {
     --body-color: #{$body-color-dark};
-    --body-bg: #151c28;
+    --body-bg: #04070E;
     --text-muted: #{$color-text-1};
     --link-color: #a2b0cd;
     --link-hover-color: #ffffff;

--- a/web/src/global-styles/type.scss
+++ b/web/src/global-styles/type.scss
@@ -7,7 +7,7 @@ $body-color-dark: $white;
 
 .theme-light {
     --body-color: #{$body-color-light};
-    --body-bg: #FBFDFF;
+    --body-bg: #fbfdff;
     --text-muted: #{$color-light-text-2};
     --link-color: #566e9f;
     --link-hover-color: #1d2535;
@@ -15,7 +15,7 @@ $body-color-dark: $white;
 
 .theme-dark {
     --body-color: #{$body-color-dark};
-    --body-bg: #04070E;
+    --body-bg: #04070e;
     --text-muted: #{$color-text-1};
     --link-color: #a2b0cd;
     --link-hover-color: #ffffff;


### PR DESCRIPTION
This PR updates the colors of the Sourcegraph theme colors for the background. 

- Dark is a touch darker
- Light is a touch lighter
- Dark search results now have a border and color is a tad lighter.
# Before and After:

## Light Theme

### Search Page
![screen shot 2019-02-14 at 8 59 51 pm](https://user-images.githubusercontent.com/11583013/52835581-ddc12e80-309b-11e9-863b-117da030f7a7.png)
![screen shot 2019-02-14 at 8 58 42 pm](https://user-images.githubusercontent.com/11583013/52835585-e154b580-309b-11e9-9148-e4c18064e354.png)

### Search Results
![screen shot 2019-02-14 at 8 59 53 pm](https://user-images.githubusercontent.com/11583013/52835594-eb76b400-309b-11e9-9bea-1f86a152d3ce.png)
![screen shot 2019-02-14 at 8 58 44 pm](https://user-images.githubusercontent.com/11583013/52835599-edd90e00-309b-11e9-9ce4-a4a901b0ae6b.png)


### Site Admin
![screen shot 2019-02-14 at 8 59 55 pm](https://user-images.githubusercontent.com/11583013/52835604-f5001c00-309b-11e9-874a-d2716358244a.png)
![screen shot 2019-02-14 at 8 58 46 pm](https://user-images.githubusercontent.com/11583013/52835608-f9c4d000-309b-11e9-93a2-5d0c1321fc2f.png)

## Dark Theme

### Search Page
![screen shot 2019-02-14 at 8 59 46 pm](https://user-images.githubusercontent.com/11583013/52835627-0b0ddc80-309c-11e9-80db-119b5c7e0f7e.png)
![screen shot 2019-02-14 at 8 58 36 pm](https://user-images.githubusercontent.com/11583013/52835632-16610800-309c-11e9-9d2d-d995cffa8795.png)

### Search Results
![screen shot 2019-02-14 at 8 59 48 pm](https://user-images.githubusercontent.com/11583013/52835638-1f51d980-309c-11e9-8551-bacdc3fc2057.png)
![screen shot 2019-02-14 at 8 58 38 pm](https://user-images.githubusercontent.com/11583013/52835641-211b9d00-309c-11e9-901f-5924ef749199.png)

### Site Admin
![screen shot 2019-02-14 at 8 59 50 pm](https://user-images.githubusercontent.com/11583013/52835651-27aa1480-309c-11e9-8353-71470e8f42d7.png)
![screen shot 2019-02-14 at 8 58 40 pm](https://user-images.githubusercontent.com/11583013/52835657-28db4180-309c-11e9-869d-408fe46728e1.png)
