### PR TITLE
simplify settings JSON Schema code, fix validation errors

### DIFF
--- a/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
@@ -97,8 +97,7 @@ export class RegistryExtensionManifestPage extends React.PureComponent<Props, St
                             id="registry-extension-edit-page__data"
                             value={this.props.extension.rawManifest}
                             height={500}
-                            jsonSchemaId="extension.schema.json#"
-                            extraSchema={extensionSchemaJSON}
+                            jsonSchema={extensionSchemaJSON}
                             readOnly={true}
                             isLightTheme={this.props.isLightTheme}
                             history={this.props.history}

--- a/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -13,10 +13,7 @@ import { EditorAction } from '../site-admin/configHelpers'
 const disposableToFn = (disposable: _monaco.IDisposable) => () => disposable.dispose()
 
 interface Props
-    extends Pick<
-        _monacoSettingsEditorModule.Props,
-        'id' | 'readOnly' | 'height' | 'jsonSchemaId' | 'extraSchema' | 'isLightTheme'
-    > {
+    extends Pick<_monacoSettingsEditorModule.Props, 'id' | 'readOnly' | 'height' | 'jsonSchema' | 'isLightTheme'> {
     value: string
 
     actions?: EditorAction[]

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -26,14 +26,9 @@ export interface Props {
     height?: number
 
     /**
-     * The id of the JSON schema for the document.
+     * JSON Schema of the document.
      */
-    jsonSchemaId: string
-
-    /**
-     * Extra schema that is transitively referenced by jsonSchemaId.
-     */
-    extraSchema?: JSONSchema
+    jsonSchema?: JSONSchema
 
     monacoRef?: (monacoValue: typeof monaco | null) => void
     isLightTheme: boolean
@@ -90,9 +85,9 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
         )
 
         this.subscriptions.add(
-            componentUpdates.pipe(distinctUntilKeyChanged('jsonSchemaId')).subscribe(props => {
+            componentUpdates.pipe(distinctUntilKeyChanged('jsonSchema')).subscribe(props => {
                 if (this.monaco) {
-                    setDiagnosticsOptions(this.monaco, props)
+                    setDiagnosticsOptions(this.monaco, props.jsonSchema)
                 }
             })
         )
@@ -265,16 +260,14 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
     }
 }
 
-function setDiagnosticsOptions(m: typeof monaco, props: Props): void {
+function setDiagnosticsOptions(m: typeof monaco, jsonSchema: any): void {
     m.languages.json.jsonDefaults.setDiagnosticsOptions({
         validate: true,
         allowComments: true,
         schemas: [
             {
                 uri: 'root#', // doesn't matter as long as it doesn't collide
-                schema: {
-                    $ref: props.jsonSchemaId,
-                },
+                schema: jsonSchema,
                 fileMatch: ['*'],
             },
 
@@ -287,7 +280,7 @@ function setDiagnosticsOptions(m: typeof monaco, props: Props): void {
                 uri: 'settings.schema.json#',
                 schema: settingsSchema,
             },
-        ].concat(props.extraSchema ? [{ uri: props.extraSchema.$id, schema: props.extraSchema }] : []),
+        ],
     })
 }
 

--- a/web/src/settings/SettingsFile.tsx
+++ b/web/src/settings/SettingsFile.tsx
@@ -16,14 +16,9 @@ interface Props {
     settings: GQL.ISettings | null
 
     /**
-     * The id of the JSON schema for the document.
+     * JSON Schema of the document.
      */
-    jsonSchemaId: string
-
-    /**
-     * Extra schema that is transitively referenced by jsonSchemaId.
-     */
-    extraSchema?: { $id: string }
+    jsonSchema?: { $id: string }
 
     /**
      * Called when the user saves changes to the settings file's contents.
@@ -193,8 +188,7 @@ export class SettingsFile extends React.PureComponent<Props, State> {
                 <React.Suspense fallback={<LoadingSpinner className="icon-inline mt-2" />}>
                     <MonacoSettingsEditor
                         value={contents}
-                        jsonSchemaId={this.props.jsonSchemaId}
-                        extraSchema={this.props.extraSchema}
+                        jsonSchema={this.props.jsonSchema}
                         onChange={this.onEditorChange}
                         readOnly={this.state.saving}
                         monacoRef={this.monacoRef}

--- a/web/src/settings/SettingsPage.tsx
+++ b/web/src/settings/SettingsPage.tsx
@@ -25,8 +25,7 @@ export class SettingsPage extends React.PureComponent<Props, State> {
         return (
             <SettingsFile
                 settings={this.props.data.subjects[this.props.data.subjects.length - 1].latestSettings}
-                jsonSchemaId="settings.schema.json#"
-                extraSchema={this.props.data.settingsJSONSchema}
+                jsonSchema={this.props.data.settingsJSONSchema}
                 commitError={this.state.commitError}
                 onDidCommit={this.onDidCommit}
                 onDidDiscard={this.onDidDiscard}

--- a/web/src/settings/configuration.test.ts
+++ b/web/src/settings/configuration.test.ts
@@ -1,0 +1,71 @@
+import settingsSchemaJSON from '../../../schema/settings.schema.json'
+import { mergeSettingsSchemas } from './configuration'
+
+describe('mergeSettingsSchemas', () => {
+    it('handles empty', () =>
+        expect(mergeSettingsSchemas([])).toEqual({
+            allOf: [{ $ref: settingsSchemaJSON.$id }],
+        }))
+
+    it('overwrites additionalProperties and required', () =>
+        expect(
+            mergeSettingsSchemas([
+                {
+                    manifest: {
+                        url: '',
+                        activationEvents: [],
+                        contributes: {
+                            configuration: { additionalProperties: false, properties: { a: { type: 'string' } } },
+                        },
+                    },
+                },
+                {
+                    manifest: {
+                        url: '',
+                        activationEvents: [],
+                        contributes: {
+                            configuration: { required: ['b'], properties: { b: { type: 'string' } } },
+                        },
+                    },
+                },
+            ])
+        ).toEqual({
+            allOf: [
+                { $ref: settingsSchemaJSON.$id },
+                { additionalProperties: true, required: [], properties: { a: { type: 'string' } } },
+                { additionalProperties: true, required: [], properties: { b: { type: 'string' } } },
+            ],
+        }))
+
+    it('handles error and null configuration', () =>
+        expect(
+            mergeSettingsSchemas([
+                {
+                    manifest: {
+                        url: '',
+                        activationEvents: [],
+                        contributes: {
+                            configuration: { additionalProperties: false, properties: { a: { type: 'string' } } },
+                        },
+                    },
+                },
+                {
+                    manifest: new Error('x'),
+                },
+                {
+                    manifest: null,
+                },
+                {
+                    manifest: { url: '', activationEvents: [] },
+                },
+                {
+                    manifest: { url: '', activationEvents: [], contributes: {} },
+                },
+            ])
+        ).toEqual({
+            allOf: [
+                { $ref: settingsSchemaJSON.$id },
+                { additionalProperties: true, required: [], properties: { a: { type: 'string' } } },
+            ],
+        }))
+})

--- a/web/src/settings/configuration.ts
+++ b/web/src/settings/configuration.ts
@@ -1,7 +1,9 @@
 import { parse, ParseError, ParseErrorCode } from '@sqs/jsonc-parser'
+import settingsSchemaJSON from '../../../schema/settings.schema.json'
+import { ConfiguredRegistryExtension } from '../../../shared/src/extensions/extension'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../shared/src/settings/settings'
-import { createAggregateError } from '../../../shared/src/util/errors'
+import { createAggregateError, isErrorLike } from '../../../shared/src/util/errors'
 
 /**
  * Parses the JSON input using the error-tolerant parser used for site config and settings.
@@ -36,4 +38,53 @@ export function getLastIDForSubject(settingsCascade: SettingsCascadeOrError, sub
         throw new Error('unable to find owner (settings subject) of saved search')
     }
     return subjectInfo.lastID
+}
+
+/**
+ * Merges settings schemas from base settings and all configured extensions.
+ *
+ * @param configuredExtensions
+ * @returns A JSON Schema that describes an instance of settings for a particular subject.
+ */
+export function mergeSettingsSchemas(configuredExtensions: Pick<ConfiguredRegistryExtension, 'manifest'>[]): any {
+    return {
+        allOf: [
+            { $ref: settingsSchemaJSON.$id },
+            ...(configuredExtensions || [])
+                .map(ce => {
+                    if (
+                        ce.manifest &&
+                        !isErrorLike(ce.manifest) &&
+                        ce.manifest.contributes &&
+                        ce.manifest.contributes.configuration
+                    ) {
+                        // Adjust the schema to describe a valid instance of settings for a subject (instead of the
+                        // final, merged settings).
+                        //
+                        // This is necessary to avoid erroneous validation errors. For example, suppose an extension's
+                        // configuration schema declares that the property "x" is required. For the configuration to be
+                        // valid, "x" may be set in global, organization, or user settings. It is valid for user
+                        // settings to NOT contain "x" (if global or organization settings contains "x").
+                        //
+                        // The JSON Schema returned by mergeSettingsSchema is used for a single subject's settings
+                        // (e.g., for user settings in the above example). Therefore, we must allow additionalProperties
+                        // and set required to [] to avoid erroneous validation errors.
+                        return {
+                            ...ce.manifest.contributes.configuration,
+
+                            // Force allow additionalProperties to prevent any single extension's configuration schema
+                            // from invalidating all other extensions' configuration properties.
+                            additionalProperties: true,
+
+                            // Force no required properties because this instance is only the settings for a single
+                            // subject. It is possible that a required property is specified at a different subject in
+                            // the cascade, in which case we don't want to report this instance as invalid.
+                            required: [],
+                        }
+                    }
+                    return true // JSON Schema that matches everything
+                })
+                .filter(schema => schema !== true), // omit trivial JSON Schemas
+        ],
+    }
 }

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -252,8 +252,7 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                     <div>
                         <DynamicallyImportedMonacoSettingsEditor
                             value={contents || ''}
-                            jsonSchemaId="site.schema.json#"
-                            extraSchema={siteSchemaJSON}
+                            jsonSchema={siteSchemaJSON}
                             onDirtyChange={this.onDirtyChange}
                             canEdit={true}
                             saving={this.state.saving}

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -64,7 +64,7 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
                         // so the editor is keyed on the kind.
                         key={this.props.input.kind}
                         value={this.props.input.config}
-                        {...getJSONSchemaId(this.props.input.kind)}
+                        jsonSchema={ALL_EXTERNAL_SERVICES[this.props.input.kind].jsonSchema}
                         canEdit={false}
                         loading={this.props.loading}
                         height={300}
@@ -95,9 +95,4 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
     private onConfigChange = (config: string) => {
         this.props.onChange({ ...this.props.input, config })
     }
-}
-
-function getJSONSchemaId(kind: GQL.ExternalServiceKind): { jsonSchemaId: string; extraSchema: any } {
-    const service = ALL_EXTERNAL_SERVICES[kind]
-    return { jsonSchemaId: service.jsonSchema.$id, extraSchema: service.jsonSchema }
 }


### PR DESCRIPTION
- fix #1778
- simplify settings JSON Schema code
- remove most useless/temporary JSON Schema IDs
- add tests and comments for JSON Schema merging

Test plan:

- With at least 1 extension enabled (that contributes configuration, such as sourcegraph/go or sourcegraph/typescript), visit all settings pages: global, org, user. Completion should work for extension-defined settings properties AND base settings properties. There should be no validation errors for an empty (`{}`) settings document.


Justification for not adding full test coverage: This involves the Monaco editor, which is a particularly hard-to-test component because it requires a full headless browser and a complex interaction-based test suite. Overall, this diff removes (non-test, non-comment) code, simplifies code, and fixes a bug, so IMO it is a big net win even though it doesn't add this new kind of e2e test to test it.