### PR TITLE
[WIP] Issue 408 - search by file with line number

### DIFF
--- a/cmd/frontend/internal/pkg/search/query/types/query.go
+++ b/cmd/frontend/internal/pkg/search/query/types/query.go
@@ -31,6 +31,11 @@ type Value struct {
 	Bool   *bool          // if a bool value, the bool value
 }
 
+func (v *Value) SyntaxValue() string {
+	return v.syntax.Value
+}
+
+
 // Not returns whether the value is negated in the query (e.g., -value or -field:value).
 func (v *Value) Not() bool {
 	return v.syntax.Not

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -93,7 +93,9 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
             const visibleRows = this.tableContainerElement.querySelectorAll('table tr')
             for (const highlight of this.props.highlightRanges) {
                 const code = visibleRows[highlight.line - this.getFirstLine()].lastChild as HTMLTableDataCellElement
-                highlightNode(code, highlight.character, highlight.highlightLength)
+                // a highlight length of -1 means highlight the entire line
+                const highlightLength = highlight.highlightLength === -1 ? code.textContent.length : highlight.highlightLength
+                highlightNode(code, highlight.character, highlightLength)
             }
         }
     }

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -96,12 +96,22 @@ export class FileMatch extends React.PureComponent<Props> {
             line: m.lineNumber,
         }))
 
+        let filePath = result.file.path
+        let fileUrl = result.file.url
+
+        // when there is only one line match, link directly to that line
+        if (result.lineMatches.length === 1) {
+            const lineNumber = result.lineMatches[0].lineNumber + 1
+            filePath = `${filePath}:${lineNumber}`
+            fileUrl = `${fileUrl}#L${lineNumber}`
+        }
+
         const title = (
             <RepoFileLink
                 repoName={result.repository.name}
                 repoURL={result.repository.url}
-                filePath={result.file.path}
-                fileURL={result.file.url}
+                filePath={filePath}
+                fileURL={fileUrl}
                 repoDisplayName={this.props.repoDisplayName}
             />
         )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3819855/52916193-ab524400-32dc-11e9-9adc-0b5dc658b522.png)

This adds support for a file line number to the Search query. The approach is based on @nicksnyder 's suggestion [here](https://github.com/sourcegraph/sourcegraph/issues/408#issuecomment-463721457).

The synthetic line match is given an empty preview and a offset/length pair of `[0,-1]`. This is a hack. I thought it was worth considering for this reason: The client doesn't use the preview field to show the highlighted code in the search results list. Instead, the client fetches the entire file from the HighlightedFile query and builds the preview itself. I could get the real line length on the server but this would mean fetching and iterating over the file a second time. Since the client already does this, and since it doesn't seem to use the preview field, it seems cheaper to set `-1` and modify the client to understand this means highlight the entire line. 