### PR TITLE
ci: Remove go generate in test step

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -92,7 +92,6 @@ func main() {
 			bk.Cmd("./dev/ci/ci-db-backcompat.sh"))
 
 		pipeline.AddStep(":go:",
-			bk.Cmd("go generate ./..."),
 			bk.Cmd("go test -coverprofile=coverage.txt -covermode=atomic -race ./..."),
 			bk.ArtifactPaths("coverage.txt"))
 


### PR DESCRIPTION
We run it in the next step for testing `go install`. Currently it is quite slow,
for example the one generate step takes 40s+ since it shells out to yarn.