### PR TITLE
Remove non-standard deprecated methods from URI API

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -21,26 +21,9 @@ declare module 'sourcegraph' {
      * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL)
      */
     export class URI {
-        /**
-         * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL), which does not contain this method.
-         */
-        static parse(value: string): URI
-
-        /**
-         * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL), which does not contain this method.
-         */
-        static file(path: string): URI
-
         constructor(value: string)
 
         toString(): string
-
-        /**
-         * Returns a JSON representation of this Uri.
-         *
-         * @deprecated In the future the API will use the [native `URL` API](https://developer.mozilla.org/en-US/docs/Web/API/URL), which returns a string instead of an object.
-         */
-        toJSON(): any
     }
 
     export class Position {

--- a/shared/src/api/extension/types/uri.ts
+++ b/shared/src/api/extension/types/uri.ts
@@ -1,16 +1,16 @@
 import * as sourcegraph from 'sourcegraph'
 
 export class URI implements sourcegraph.URI {
-    public static parse(uri: string): sourcegraph.URI {
+    public static parse(uri: string): URI {
         return new URI(uri)
     }
 
-    public static file(path: string): sourcegraph.URI {
+    public static file(path: string): URI {
         return new URI(`file://${path}`)
     }
 
-    public static isURI(value: any): value is sourcegraph.URI {
-        return value instanceof URI || typeof value === 'string'
+    public static isURI(value: any): value is URI {
+        return value instanceof URI || typeof value === 'string' // TODO this is blatandly wrong, strings are not URI objects!
     }
 
     constructor(private value: string) {}


### PR DESCRIPTION
The implementations will remain for now, but after this we can swap out URI with WHATWG URL.