### PR TITLE
style: don't assume HTML structure of rendered markdown in searchResultMatch

### DIFF
--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -70,7 +70,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                             const codeContent = parser.parseFromString(markdownHTML, 'text/html').body.innerText
                             if (codeContent) {
                                 return highlightCode({
-                                    code: decode(codeContent),
+                                    code: codeContent,
                                     fuzzyLanguage: lang,
                                     disableTimeout: false,
                                     isLightTheme: this.props.isLightTheme,

--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -63,14 +63,11 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                             : renderMarkdown({ markdown: props.item.body.text })
                     ),
                     switchMap(markdownHTML => {
-                        if (this.bodyIsCode() && markdownHTML.includes('<pre') && markdownHTML.includes('</pre>')) {
+                        if (this.bodyIsCode()) {
                             const lang = this.getLanguage() || 'txt'
                             const parser = new DOMParser()
-                            // Get content between the outermost code tags.
-                            const codeContent = parser
-                                .parseFromString(markdownHTML, 'text/html')
-                                .querySelector('pre')!
-                                .innerHTML.toString()
+                            // Extract the text content of the result.
+                            const codeContent = parser.parseFromString(markdownHTML, 'text/html').body.innerText
                             if (codeContent) {
                                 return highlightCode({
                                     code: decode(codeContent),
@@ -79,7 +76,10 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                                     isLightTheme: this.props.isLightTheme,
                                 }).pipe(
                                     switchMap(highlightedStr => {
-                                        const highlightedMarkdown = markdownHTML.replace(codeContent, highlightedStr)
+                                        const highlightedMarkdown = decode(markdownHTML).replace(
+                                            codeContent,
+                                            highlightedStr
+                                        )
                                         return of(highlightedMarkdown)
                                     }),
                                     // Return the rendered markdown if highlighting fails.


### PR DESCRIPTION
Avoid relying on the structure of the response of our markdown renderer when rendering code blocks. Instead, we just want the text of any result wrapped in a code block, so we can pass it to the syntax highlighter.

Should mean that we avoid issues where syntax highlighting does not occur because we fail to detect a code block, such as https://github.com/sourcegraph/sourcegraph/issues/2325.
