### PR TITLE
fix: rename instances of derekparker/delve to go-delve/delve

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -70,7 +70,7 @@ github.com/google/zoekt/cmd/zoekt-webserver \
 "
 
 if [ ! -n "${OFFLINE-}" ]; then
-    INSTALL_GO_PKGS="$INSTALL_GO_PKGS github.com/derekparker/delve/cmd/dlv"
+    INSTALL_GO_PKGS="$INSTALL_GO_PKGS github.com/go-delve/delve/cmd/dlv"
 fi
 
 if ! go install $INSTALL_GO_PKGS; then

--- a/dev/tools.go
+++ b/dev/tools.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	_ "github.com/derekparker/delve"
+	_ "github.com/go-delve/delve"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/zoekt/cmd/zoekt-archive-index"
 	_ "github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver"


### PR DESCRIPTION
delve was moved from `derekparker` to the [go-delve](https://github.com/go-delve/delve) org.
