### PR TITLE
Preserve query builder toggle state

### DIFF
--- a/web/src/search/input/QueryBuilder.test.tsx
+++ b/web/src/search/input/QueryBuilder.test.tsx
@@ -9,6 +9,8 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the `repo:` filter when updating the "Repository" field', () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
+        // Only the first test needs to click the toggle, since after this,
+        // the toggle state is stored in localStorage and the query builder open by default.
         const toggle = getByTestId(container, 'test-query-builder-toggle')
         fireEvent.click(toggle)
 
@@ -21,8 +23,6 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the `file:` filter when updating the "File" field', () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const fileField = container.querySelector('#query-builder-file')!
         fireEvent.change(fileField, { target: { value: 'web' } })
@@ -33,8 +33,6 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the `case:` filter when updating the "Case" field', () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const caseField = container.querySelector('#query-builder-case')!
         fireEvent.change(caseField, { target: { value: 'yes' } })
@@ -45,8 +43,6 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the patterns left untransformed when updating the "Patterns" field', () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const patternsField = container.querySelector('#query-builder-patterns')!
         fireEvent.change(patternsField, { target: { value: '(open|close) file' } })
@@ -57,8 +53,6 @@ describe('QueryBuilder', () => {
     it('field fires the onFieldsQueryChange prop handler with the term wrapped in double quotes when updating the "Exact match"', () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const exactMatchField = container.querySelector('#query-builder-exactMatch')!
         fireEvent.change(exactMatchField, { target: { value: 'foo bar baz' } })
@@ -69,8 +63,6 @@ describe('QueryBuilder', () => {
     it('checks that the "Author", "Before", "After", and "Message" fields do not exist if the search type is set to code search', () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         expect(queryByTestId(container, 'test-author')).toBeNull()
         expect(queryByTestId(container, 'test-after')).toBeNull()
@@ -81,8 +73,6 @@ describe('QueryBuilder', () => {
     it('checks that the "Author", "Before", "After", and "Message" fields exist if the search type is set to diff search', async () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const typeField = getBySelectText(container, 'Code (default)')!
         fireEvent.change(typeField, { target: { value: 'diff' } })
@@ -100,8 +90,6 @@ describe('QueryBuilder', () => {
     it('checks that the "Author", "Before", and "After" fields exist if type is commit', async () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const typeField = getBySelectText(container, 'Code (default)')!
         fireEvent.change(typeField, { target: { value: 'commit' } })
@@ -119,8 +107,6 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the "author:" filter when updating the "Author" field', async () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const typeField = getBySelectText(container, 'Code (default)')!
         fireEvent.change(typeField, { target: { value: 'diff' } })
@@ -135,8 +121,6 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the "after:" filter when updating the "After" field ', async () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const typeField = getBySelectText(container, 'Code (default)')!
         fireEvent.change(typeField, { target: { value: 'diff' } })
@@ -152,8 +136,6 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the "before:" filter when updating the "Before" field', async () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const typeField = getBySelectText(container, 'Code (default)')!
         fireEvent.change(typeField, { target: { value: 'diff' } })
@@ -169,8 +151,6 @@ describe('QueryBuilder', () => {
     it('fires the onFieldsQueryChange prop handler with the "message:" filter when updating the "Message" field', async () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
-        const toggle = getByTestId(container, 'test-query-builder-toggle')
-        fireEvent.click(toggle)
 
         const typeField = getBySelectText(container, 'Code (default)')!
         fireEvent.change(typeField, { target: { value: 'diff' } })

--- a/web/src/search/input/QueryBuilder.tsx
+++ b/web/src/search/input/QueryBuilder.tsx
@@ -39,6 +39,7 @@ export interface QueryBuilderState {
     fields: QueryFields
 }
 
+const QUERY_BUILDER_KEY = 'query-builder-open'
 /**
  * The individual input fields for the various elements of the search query syntax.
  */
@@ -46,7 +47,7 @@ export class QueryBuilder extends React.Component<Props, QueryBuilderState> {
     constructor(props: Props) {
         super(props)
         this.state = {
-            showQueryBuilder: false,
+            showQueryBuilder: localStorage.getItem(QUERY_BUILDER_KEY) === 'true',
             builderQuery: '',
             typeOfSearch: 'code',
             fields: {
@@ -383,6 +384,7 @@ export class QueryBuilder extends React.Component<Props, QueryBuilderState> {
 
     private toggleShowQueryBuilder = (e: React.MouseEvent<HTMLAnchorElement>) => {
         e.preventDefault()
+        localStorage.setItem(QUERY_BUILDER_KEY, (!this.state.showQueryBuilder).toString())
         this.setState(prevState => ({ showQueryBuilder: !prevState.showQueryBuilder }))
     }
 


### PR DESCRIPTION
Retain the open/closed state of the query builder when going between the main search page and others.