### PR TITLE
Fix: wrap single-word exact matches entered in query builder in quotes

### DIFF
--- a/web/src/search/input/QueryBuilder.test.tsx
+++ b/web/src/search/input/QueryBuilder.test.tsx
@@ -50,7 +50,7 @@ describe('QueryBuilder', () => {
         expect(onChange.calledWith('(open|close) file')).toBe(true)
     })
 
-    it('field fires the onFieldsQueryChange prop handler with the term wrapped in double quotes when updating the "Exact match"', () => {
+    it('field fires the onFieldsQueryChange prop handler with a multi-word term wrapped in double quotes when updating the "Exact match"', () => {
         const onChange = sinon.spy()
         const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
 
@@ -58,6 +58,16 @@ describe('QueryBuilder', () => {
         fireEvent.change(exactMatchField, { target: { value: 'foo bar baz' } })
         expect(onChange.calledOnce).toBe(true)
         expect(onChange.calledWith('"foo bar baz"')).toBe(true)
+    })
+
+    it('field fires the onFieldsQueryChange prop handler with a single-word term wrapped in double quotes when updating the "Exact match"', () => {
+        const onChange = sinon.spy()
+        const { container } = render(<QueryBuilder onFieldsQueryChange={onChange} isSourcegraphDotCom={false} />)
+
+        const exactMatchField = container.querySelector('#query-builder-exactMatch')!
+        fireEvent.change(exactMatchField, { target: { value: 'open(' } })
+        expect(onChange.calledOnce).toBe(true)
+        expect(onChange.calledWith('"open("')).toBe(true)
     })
 
     it('checks that the "Author", "Before", "After", and "Message" fields do not exist if the search type is set to code search', () => {

--- a/web/src/search/input/QueryBuilder.tsx
+++ b/web/src/search/input/QueryBuilder.tsx
@@ -407,7 +407,7 @@ function formatFieldForQuery(field: string, value: string, alwaysQuote?: boolean
 
     // See if we need to double-quote value.
     const jsonValue = JSON.stringify(value)
-    if (value.includes(' ') || jsonValue.slice(1, jsonValue.length - 1) !== value || !!alwaysQuote) {
+    if (value.includes(' ') || jsonValue.slice(1, jsonValue.length - 1) !== value || alwaysQuote) {
         value = jsonValue
     }
 

--- a/web/src/search/input/QueryBuilder.tsx
+++ b/web/src/search/input/QueryBuilder.tsx
@@ -83,7 +83,7 @@ export class QueryBuilder extends React.Component<Props, QueryBuilderState> {
                         fieldsQueryParts.push(inputValue)
                     } else if (inputField === 'exactMatch') {
                         // Exact matches don't have a literal field operator (e.g. exactMatch:) in the query.
-                        fieldsQueryParts.push(formatFieldForQuery('', inputValue))
+                        fieldsQueryParts.push(formatFieldForQuery('', inputValue, true))
                     } else if (inputField === 'type' && inputValue === 'code') {
                         // code searches don't need to be specified.
                         continue
@@ -393,7 +393,11 @@ export class QueryBuilder extends React.Component<Props, QueryBuilderState> {
     }
 }
 
-function formatFieldForQuery(field: string, value: string): string {
+/**
+ *
+ * @param alwaysQuote if true, the value will always be wrapped in quotes. Used for fields like exactMatch.
+ */
+function formatFieldForQuery(field: string, value: string, alwaysQuote?: boolean): string {
     // The user shouldn't include the 'repo:' (or other field name) in the value, but
     // if they do, then be helpful and remove it for them to avoid double fields like
     // 'repo:repo:foo'.
@@ -403,7 +407,7 @@ function formatFieldForQuery(field: string, value: string): string {
 
     // See if we need to double-quote value.
     const jsonValue = JSON.stringify(value)
-    if (value.includes(' ') || jsonValue.slice(1, jsonValue.length - 1) !== value) {
+    if (value.includes(' ') || jsonValue.slice(1, jsonValue.length - 1) !== value || !!alwaysQuote) {
         value = jsonValue
     }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2383.

<!-- Remember to update the changelog for user-facing changes. -->
