### PR TITLE
React to OS dark theme setting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
     "shinnn.stylelint",
     "exiasr.hadolint",
     "bierner.markdown-mermaid",
+    "zignd.html-css-class-completion",
     "orta.vscode-jest"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Sourcegraph can now automatically use the system's theme.
+  To enable, open the user menu in the top right and make sure the theme dropdown is set to "System".
+  This is currently supported on macOS Mojave with Safari Technology Preview 68 and later.
+
 ### Changed
 
 ### Fixed

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -26,6 +26,7 @@ import { LayoutRouteProps } from './routes'
 import { parseSearchURLQuery } from './search'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
+import { ThemePreferenceProps, ThemeProps } from './theme'
 import { UserAccountAreaRoute } from './user/account/UserAccountArea'
 import { UserAccountSidebarItems } from './user/account/UserAccountSidebar'
 import { UserAreaRoute } from './user/area/UserArea'
@@ -37,7 +38,9 @@ export interface LayoutProps
         SettingsCascadeProps,
         PlatformContextProps,
         ExtensionsControllerProps,
-        KeybindingsProps {
+        KeybindingsProps,
+        ThemeProps,
+        ThemePreferenceProps {
     exploreSections: ReadonlyArray<ExploreSectionDescriptor>
     extensionAreaRoutes: ReadonlyArray<ExtensionAreaRoute>
     extensionAreaHeaderNavItems: ReadonlyArray<ExtensionAreaHeaderNavItem>
@@ -62,8 +65,6 @@ export interface LayoutProps
      */
     viewerSubject: Pick<GQL.ISettingsSubject, 'id' | 'viewerCanAdminister'>
 
-    isLightTheme: boolean
-    onThemeChange: () => void
     navbarSearchQuery: string
     onNavbarQueryChange: (query: string) => void
 
@@ -75,11 +76,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
 
     const needsSiteInit = window.context.showOnboarding
     const isSiteInit = props.location.pathname === '/site-admin/init'
-
-    // Force light theme on site init page.
-    if (isSiteInit && !props.isLightTheme) {
-        props.onThemeChange()
-    }
 
     // Remove trailing slash (which is never valid in any of our URLs).
     if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -184,22 +184,27 @@ describe('e2e test suite', function(this: any): void {
     }
 
     describe('Theme switcher', () => {
-        test('changes the theme when toggle is clicked', async () => {
+        test('changes the theme', async () => {
             await page.goto(baseURL + '/github.com/gorilla/mux/-/blob/mux.go')
             await enableOrAddRepositoryIfNeeded()
             await page.waitForSelector('.theme')
-            const currentThemes: string[] = await page.evaluate(() =>
+            const currentThemes = await page.evaluate(() =>
                 Array.from(document.querySelector('.theme')!.classList).filter(c => c.startsWith('theme-'))
             )
-            expect(currentThemes.length).toEqual(1)
-            const expectedTheme = currentThemes[0] === 'theme-dark' ? 'theme-light' : 'theme-dark'
+            expect(currentThemes).toHaveLength(1)
             await page.click('.e2e-user-nav-item-toggle')
-            await page.click('.e2e-user-nav-item__theme')
+            await page.select('.e2e-theme-toggle', 'dark')
             expect(
                 await page.evaluate(() =>
                     Array.from(document.querySelector('.theme')!.classList).filter(c => c.startsWith('theme-'))
                 )
-            ).toEqual([expectedTheme])
+            ).toEqual(['theme-dark'])
+            await page.select('.e2e-theme-toggle', 'light')
+            expect(
+                await page.evaluate(() =>
+                    Array.from(document.querySelector('.theme')!.classList).filter(c => c.startsWith('theme-'))
+                )
+            ).toEqual(['theme-light'])
         })
     })
 

--- a/web/src/global-styles/forms.scss
+++ b/web/src/global-styles/forms.scss
@@ -1,4 +1,5 @@
 @import 'bootstrap/scss/forms';
+@import 'bootstrap/scss/custom-forms';
 @import 'bootstrap/scss/input-group';
 
 .theme-dark {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -10,15 +10,20 @@ import { authRequired } from '../auth'
 import { KeybindingsProps } from '../keybindings'
 import { parseSearchURLQuery } from '../search'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
+import { ThemePreferenceProps, ThemeProps } from '../theme'
 import { showDotComMarketing } from '../util/features'
 import { NavLinks } from './NavLinks'
 
-interface Props extends SettingsCascadeProps, PlatformContextProps, ExtensionsControllerProps, KeybindingsProps {
+interface Props
+    extends SettingsCascadeProps,
+        PlatformContextProps,
+        ExtensionsControllerProps,
+        KeybindingsProps,
+        ThemeProps,
+        ThemePreferenceProps {
     history: H.History
     location: H.Location
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
-    onThemeChange: () => void
     navbarSearchQuery: string
     onNavbarQueryChange: (query: string) => void
 

--- a/web/src/nav/NavLinks.test.tsx
+++ b/web/src/nav/NavLinks.test.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import { flatten } from 'lodash'
+import { flatten, noop } from 'lodash'
 import React from 'react'
 import { createRenderer } from 'react-test-renderer/shallow'
 import { setLinkComponent } from '../../../shared/src/components/Link'
@@ -7,6 +7,7 @@ import { ExtensionsControllerProps } from '../../../shared/src/extensions/contro
 import * as GQL from '../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { KeybindingsProps } from '../keybindings'
+import { ThemePreference } from '../theme'
 import { NavLinks } from './NavLinks'
 
 // Renders a human-readable list of the NavLinks' contents so that humans can more easily diff
@@ -51,7 +52,8 @@ describe('NavLinks', () => {
         extensionsController: NOOP_EXTENSIONS_CONTROLLER,
         platformContext: NOOP_PLATFORM_CONTEXT,
         isLightTheme: true,
-        onThemeChange: () => void 0,
+        themePreference: ThemePreference.Light,
+        onThemePreferenceChange: noop,
         keybindings: KEYBINDINGS,
         settingsCascade: SETTINGS_CASCADE,
     }

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -11,17 +11,18 @@ import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { isDiscussionsEnabled } from '../discussions'
 import { KeybindingsProps } from '../keybindings'
+import { ThemePreferenceProps, ThemeProps } from '../theme'
 import { UserNavItem } from './UserNavItem'
 
 interface Props
     extends SettingsCascadeProps,
         KeybindingsProps,
         ExtensionsControllerProps<'executeCommand' | 'services'>,
-        PlatformContextProps<'forceUpdateTooltip'> {
+        PlatformContextProps<'forceUpdateTooltip'>,
+        ThemeProps,
+        ThemePreferenceProps {
     location: H.Location
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
-    onThemeChange: () => void
     showDotComMarketing: boolean
 }
 

--- a/web/src/nav/UserNavItem.tsx
+++ b/web/src/nav/UserNavItem.tsx
@@ -3,14 +3,12 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 import * as GQL from '../../../shared/src/graphql/schema'
-import { eventLogger } from '../tracking/eventLogger'
+import { ThemePreference, ThemePreferenceProps, ThemeProps } from '../theme'
 import { UserAvatar } from '../user/UserAvatar'
 
-interface Props {
+interface Props extends ThemeProps, ThemePreferenceProps {
     location: H.Location
     authenticatedUser: GQL.IUser
-    isLightTheme: boolean
-    onThemeChange: () => void
     showAbout: boolean
     showDiscussions: boolean
 }
@@ -69,13 +67,6 @@ export class UserNavItem extends React.PureComponent<Props, State> {
                     <Link to="/search/searches" className="dropdown-item">
                         Saved searches
                     </Link>
-                    <button
-                        type="button"
-                        className="dropdown-item e2e-user-nav-item__theme"
-                        onClick={this.onThemeChange}
-                    >
-                        Use {this.props.isLightTheme ? 'dark' : 'light'} theme
-                    </button>
                     {window.context.sourcegraphDotComMode ? (
                         <a href="https://docs.sourcegraph.com" target="_blank" className="dropdown-item">
                             Help
@@ -93,6 +84,20 @@ export class UserNavItem extends React.PureComponent<Props, State> {
                             </Link>
                         </>
                     )}
+                    <DropdownItem divider={true} />
+                    <div className="dropdown-item d-flex align-items-center">
+                        <div className="mr-2">Theme</div>
+                        {/* tslint:disable-next-line: jsx-ban-elements <Select> doesn't support small version */}
+                        <select
+                            className="custom-select custom-select-sm e2e-theme-toggle"
+                            onChange={this.onThemeChange}
+                            value={this.props.themePreference}
+                        >
+                            <option value={ThemePreference.Light}>Light</option>
+                            <option value={ThemePreference.Dark}>Dark</option>
+                            <option value={ThemePreference.System}>System</option>
+                        </select>
+                    </div>
                     {this.props.authenticatedUser.session && this.props.authenticatedUser.session.canSignOut && (
                         <>
                             <DropdownItem divider={true} />
@@ -116,8 +121,7 @@ export class UserNavItem extends React.PureComponent<Props, State> {
 
     private toggleIsOpen = () => this.setState(prevState => ({ isOpen: !prevState.isOpen }))
 
-    private onThemeChange = () => {
-        eventLogger.log(this.props.isLightTheme ? 'DarkThemeClicked' : 'LightThemeClicked')
-        this.setState(prevState => ({ isOpen: !prevState.isOpen }), this.props.onThemeChange)
+    private onThemeChange: React.ChangeEventHandler<HTMLSelectElement> = event => {
+        this.props.onThemePreferenceChange(event.target.value as ThemePreference)
     }
 }

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -6,6 +6,7 @@ import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/se
 import { Form } from '../../components/Form'
 import { PageTitle } from '../../components/PageTitle'
 import { Settings } from '../../schema/settings.schema'
+import { ThemePreferenceProps, ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { limitString } from '../../util'
 import { queryIndexOfScope, submitSearch } from '../helpers'
@@ -14,12 +15,10 @@ import { QueryInput } from './QueryInput'
 import { SearchButton } from './SearchButton'
 import { ISearchScope, SearchFilterChips } from './SearchFilterChips'
 
-interface Props extends SettingsCascadeProps {
+interface Props extends SettingsCascadeProps, ThemeProps, ThemePreferenceProps {
     authenticatedUser: GQL.IUser | null
     location: H.Location
     history: H.History
-    isLightTheme: boolean
-    onThemeChange: () => void
 }
 
 interface State {

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,0 +1,24 @@
+/**
+ * Props that can be extended by any component's Props which needs to react to theme change.
+ */
+export interface ThemeProps {
+    isLightTheme: boolean
+}
+
+/**
+ * The user preference for the theme.
+ * These values are stored in local storage.
+ */
+export enum ThemePreference {
+    Light = 'light',
+    Dark = 'dark',
+    System = 'system',
+}
+
+/**
+ * Props that can be extended by any component's Props which needs to manipulate the theme preferences.
+ */
+export interface ThemePreferenceProps {
+    themePreference: ThemePreference
+    onThemePreferenceChange: (theme: ThemePreference) => void
+}


### PR DESCRIPTION
https://caniuse.com/#feat=prefers-color-scheme

Closes #507

Also cleans up some of the `isLightTheme` props passing.

<!-- Remember to update the changelog for user-facing changes. -->

![2019-02-21 00 19 53](https://user-images.githubusercontent.com/10532611/53131942-7f4df180-356e-11e9-8b63-071f5b22fe8c.gif)

![2019-02-21 00 22 38](https://user-images.githubusercontent.com/10532611/53132077-d5bb3000-356e-11e9-95a3-36dd9f33012f.gif)

If no preference is saved yet, system is the default (which will be light for browsers/OS not supporting it).