### PR TITLE
simplify "Is Sourcegraph.com?" check

### DIFF
--- a/cmd/frontend/envvar/envvar.go
+++ b/cmd/frontend/envvar/envvar.go
@@ -4,16 +4,19 @@ package envvar
 import (
 	"strconv"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
-
 	"github.com/sourcegraph/sourcegraph/pkg/env"
 )
 
 var sourcegraphDotComMode, _ = strconv.ParseBool(env.Get("SOURCEGRAPHDOTCOM_MODE", "false", "run as Sourcegraph.com, with add'l marketing and redirects"))
 
-// SourcegraphDotComMode is true if this server is running Sourcegraph.com. It shows
-// add'l marketing and sets up some add'l redirects.
+// SourcegraphDotComMode is true if this server is running Sourcegraph.com (solely by checking the
+// SOURCEGRAPHDOTCOM_MODE env var). Sourcegraph.com shows add'l marketing and sets up some add'l
+// redirects.
 func SourcegraphDotComMode() bool {
-	u := globals.ExternalURL.String()
-	return sourcegraphDotComMode || u == "https://sourcegraph.com" || u == "https://sourcegraph.com/"
+	return sourcegraphDotComMode
+}
+
+// MockSourcegraphDotComMode is used by tests to mock the result of SourcegraphDotComMode.
+func MockSourcegraphDotComMode(value bool) {
+	sourcegraphDotComMode = value
 }

--- a/cmd/frontend/internal/app/ui/router_test.go
+++ b/cmd/frontend/internal/app/ui/router_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	uirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui/router"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -19,8 +19,8 @@ import (
 )
 
 func init() {
-	// Enable SourcegraphDotComMode
-	globals.ExternalURL = &url.URL{Scheme: "https", Host: "sourcegraph.com"}
+	// Enable SourcegraphDotComMode for all tests in this package.
+	envvar.MockSourcegraphDotComMode(true)
 
 	// Reinit router
 	initRouter()

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
@@ -1,11 +1,10 @@
 package registry
 
 import (
-	"net/url"
 	"reflect"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -23,9 +22,10 @@ func TestFilteringExtensionIDs(t *testing.T) {
 		}
 	})
 	t.Run("filterStripLocalExtensionIDs on Sourcegraph.com", func(t *testing.T) {
-		oldExternalURL := globals.ExternalURL
-		globals.ExternalURL = &url.URL{Scheme: "https", Host: "sourcegraph.com"}
-		defer func() { globals.ExternalURL = oldExternalURL }()
+		orig := envvar.SourcegraphDotComMode()
+		envvar.MockSourcegraphDotComMode(true)
+		defer envvar.MockSourcegraphDotComMode(orig) // reset
+
 		input := []string{"localhost:3080/owner1/name1", "owner2/name2"}
 		want := []string{"owner2/name2"}
 		got := filterStripLocalExtensionIDs(input)


### PR DESCRIPTION
I wanted to write a test for Sourcegraph.com and non-Sourcegraph.com behavior for something, so I wanted to mock the result of SourcegraphDotComMode. It is simpler to mock it if we remove the special-case checking of the URL. That special-case is not necessary anyway because Sourcegraph.com is deployed with SOURCEGRAPHDOTCOM_MODE=true (I confirmed this with `kubectl -n prod describe deployment/sourcegraph-frontend` on the Sourcegraph.com k8s cluster).