### PR TITLE
remove extra bottom spacing on diff search results

### DIFF
--- a/web/src/components/SearchResultMatch.scss
+++ b/web/src/components/SearchResultMatch.scss
@@ -77,10 +77,13 @@
 
     &__code-excerpt {
         padding-top: 0;
-        padding-bottom: 1rem;
+        padding-bottom: 0;
         padding-left: 0;
         padding-right: 0;
 
+        table {
+            margin-bottom: 0 !important; // Override docsite Markdown table CSS. A currently open PR removes that CSS and lets us remove this override.
+        }
         td.line {
             display: none;
         }

--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -67,7 +67,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                             const lang = this.getLanguage() || 'txt'
                             const parser = new DOMParser()
                             // Extract the text content of the result.
-                            const codeContent = parser.parseFromString(markdownHTML, 'text/html').body.innerText.trim()
+                            const codeContent = parser.parseFromString(markdownHTML, 'text/html').body.innerText
                             if (codeContent) {
                                 return highlightCode({
                                     code: codeContent,

--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -77,7 +77,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                                 }).pipe(
                                     switchMap(highlightedStr => {
                                         const highlightedMarkdown = decode(markdownHTML).replace(
-                                            '<pre>' + codeContent + '\n</pre>',
+                                            codeContent,
                                             highlightedStr
                                         )
                                         return of(highlightedMarkdown)

--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -67,7 +67,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                             const lang = this.getLanguage() || 'txt'
                             const parser = new DOMParser()
                             // Extract the text content of the result.
-                            const codeContent = parser.parseFromString(markdownHTML, 'text/html').body.innerText
+                            const codeContent = parser.parseFromString(markdownHTML, 'text/html').body.innerText.trim()
                             if (codeContent) {
                                 return highlightCode({
                                     code: codeContent,
@@ -77,7 +77,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                                 }).pipe(
                                     switchMap(highlightedStr => {
                                         const highlightedMarkdown = decode(markdownHTML).replace(
-                                            codeContent,
+                                            '<pre>' + codeContent + '\n</pre>',
                                             highlightedStr
                                         )
                                         return of(highlightedMarkdown)


### PR DESCRIPTION
Related to #2405. I will merge this PR before #2405.

---

Too much spacing at the bottom of search results:

![withtoomuchspacing](https://user-images.githubusercontent.com/1976/53347575-fa046d00-38de-11e9-83ee-e36f1312f47d.png)

After this PR (there's still a bit of extra spacing, but that spacing at least makes sense on other search result types that don't have a background color, and it's more complex to remove it just for diff search results):

![withlessspacing](https://user-images.githubusercontent.com/1976/53347573-fa046d00-38de-11e9-9ad3-6de4ab872aca.png)

Other results are unaffected:

![otherresultsok](https://user-images.githubusercontent.com/1976/53347572-fa046d00-38de-11e9-84b0-e96da405cae4.png)
