### PR TITLE
Symbols sqlite: fix sourcegraph/server build

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,6 +39,9 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:393a538 /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
+# hadolint ignore=DL3022
+COPY --from=libsqlite3-pcre /sqlite3-pcre/pcre.so /libsqlite3-pcre.so
+ENV LIBSQLITE3_PCRE /libsqlite3-pcre.so
 COPY . /
 
 ENV GO111MODULES=on LANG=en_US.utf8

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -41,8 +41,6 @@ for pkg in $server_pkg \
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o "$bindir/$(basename "$pkg")" "$pkg"
 done
 
-mkdir -p "$OUTPUT/.ctags.d"
-cp cmd/symbols/.ctags.d/additional-languages.ctags "$OUTPUT/.ctags.d/additional-languages.ctags"
-env SYMBOLS_EXECUTABLE_OUTPUT_PATH="$bindir/symbols" BUILD_TYPE=dist ./cmd/symbols/build.sh buildExecutable
+env CTAGS_D_OUTPUT_PATH="$OUTPUT/.ctags.d" SYMBOLS_EXECUTABLE_OUTPUT_PATH="$bindir/symbols" BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImageDependencies
 
 docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT"

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -1,13 +1,3 @@
-FROM alpine:3.9 AS libsqlite3-pcre
-
-# hadolint ignore=DL3003,DL3018,DL4006
-RUN apk --no-cache add --virtual build-deps curl git gcc make libc-dev pcre-dev sqlite-dev && \
-  mkdir /sqlite3-pcre && \
-  curl -fsSL https://codeload.github.com/ralight/sqlite3-pcre/tar.gz/c98da412b431edb4db22d3245c99e6c198d49f7a | tar -C /sqlite3-pcre -xzvf - --strip 1 && \
-  cd /sqlite3-pcre && \
-  make && \
-  apk --no-cache --purge del build-deps
-
 FROM alpine:3.9
 
 # hadolint ignore=DL3018
@@ -16,6 +6,7 @@ RUN apk add --no-cache bind-tools ca-certificates mailcap tini
 # hadolint ignore=DL3022
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 
+# hadolint ignore=DL3022
 COPY --from=libsqlite3-pcre /sqlite3-pcre/pcre.so /libsqlite3-pcre.so
 ENV LIBSQLITE3_PCRE /libsqlite3-pcre.so
 # hadolint ignore=DL3018

--- a/cmd/symbols/libsqlite3-pcre/Dockerfile
+++ b/cmd/symbols/libsqlite3-pcre/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.9
+
+# hadolint ignore=DL3003,DL3018,DL4006
+RUN apk --no-cache add --virtual build-deps curl git gcc make libc-dev pcre-dev sqlite-dev && \
+  mkdir /sqlite3-pcre && \
+  curl -fsSL https://codeload.github.com/ralight/sqlite3-pcre/tar.gz/c98da412b431edb4db22d3245c99e6c198d49f7a | tar -C /sqlite3-pcre -xzvf - --strip 1 && \
+  cd /sqlite3-pcre && \
+  make && \
+  apk --no-cache --purge del build-deps


### PR DESCRIPTION
I broke the sourcegraph/server:insiders Docker image in https://github.com/sourcegraph/sourcegraph/pull/2334 by forgetting to build libsqlite3-pcre and set `LIBSQLITE3_PCRE` when building sourcegraph/server.

This factors out the libsqlite3-pcre part of `cmd/symbols/Dockerfile` as `cmd/symbols/libsqlite3-pcre/Dockerfile` so that it can be used in `cmd/server/Dockerfile`.

This is a continuation of:

- https://github.com/sourcegraph/sourcegraph/pull/2334
- https://github.com/sourcegraph/sourcegraph/pull/2418
- https://github.com/sourcegraph/sourcegraph/pull/2420