### PR TITLE
ci: build all docker images on every commit to master

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -298,12 +298,6 @@ func main() {
 		"symbols",
 	}
 
-	masterDockerImages := []string{
-		"frontend",
-		"management-console",
-		"server",
-	}
-
 	switch {
 	case taggedRelease:
 		for _, dockerImage := range allDockerImages {
@@ -316,14 +310,14 @@ func main() {
 		pipeline.AddWait()
 
 	case branch == "master":
-		for _, dockerImage := range masterDockerImages {
+		for _, dockerImage := range allDockerImages {
 			addDockerImageStep(dockerImage, true)
 		}
 		pipeline.AddWait()
 		addDeploySteps()
 
 	case strings.HasPrefix(branch, "master-dry-run/"): // replicates `master` build but does not deploy
-		for _, dockerImage := range masterDockerImages {
+		for _, dockerImage := range allDockerImages {
 			addDockerImageStep(dockerImage, true)
 		}
 		pipeline.AddWait()
@@ -333,21 +327,8 @@ func main() {
 		addDockerImageStep(branch[20:], false)
 
 	case strings.HasPrefix(branch, "docker-images/"):
-		shouldBuildImage := true
-
-		// Only deploy images that aren't auto-deployed from master.
-		for _, dockerImage := range masterDockerImages {
-			ignoredBranch := fmt.Sprintf("docker-images/%s", dockerImage)
-			if branch == ignoredBranch {
-				shouldBuildImage = false
-				break
-			}
-		}
-
-		if shouldBuildImage {
-			addDockerImageStep(branch[14:], true)
-			pipeline.AddWait()
-			addDeploySteps()
-		}
+		// Don't deploy since they are auto-deployed from master.
+		addDockerImageStep(branch[14:], true)
+		pipeline.AddWait()
 	}
 }


### PR DESCRIPTION
This PR makes Buildkite build all of our docker images on every commit to the master branch. sourcegraph.com is the only place that we run our k8s deployment, and making sure that sourcegraph.com is running the latest version of the images will reveal issues more quickly. 

- I have bumped the upper limit on our buildkite agents to 60 so that CI's throughput isn't destroyed by this change
- I told Renovate to not auto-merge updates to `gitserver` in https://github.com/sourcegraph/deploy-sourcegraph-dot-com since it's a single point of failure and will cause blips in our alerting. Renovate will still raise a PR for bumping the gitserver digest, so one of us can still manually merge it in if they want to. 