### PR TITLE
Send Content-Length for raw API archives

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -149,6 +150,12 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 		defer f.Close()
+		fi, err := f.Stat()
+		if err != nil {
+			return err
+		}
+		w.Header().Set("Content-Length", strconv.FormatInt(fi.Size(), 10))
+
 		_, err = io.Copy(w, f)
 		return err
 


### PR DESCRIPTION
Fixes #1554 

This allows browsers and language servers to show a progress bar while downloading.

According to the docs, `cachedFetch()`, which is called by `GitServerFetchArchive()`, always serves from the cache. If the cache item is missing, it will fill the cache first, then return a file handle to it. We can stat that file handle and return its size as `Content-Length`.

> cachedFetch will open a file from the local cache with key. If missing, fetcher will fill the cache first. cachedFetch also performs single-flighting.