### PR TITLE
Add new "pressed" property for action item

### DIFF
--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -83,6 +83,10 @@ $theme-colors-light: (
 @import './shared/components/symbols';
 @import './shared/components/CodeViewToolbar.scss';
 @import './libs/options/styles.scss';
+@import './libs/bitbucket/style.scss';
+@import './libs/gitlab/style.scss';
+@import './libs/github/style.scss';
+@import './libs/phabricator/style.scss';
 @import './libs/code_intelligence/HoverOverlay.scss';
 @import './shared';
 

--- a/client/browser/src/libs/code_intelligence/HoverOverlay.scss
+++ b/client/browser/src/libs/code_intelligence/HoverOverlay.scss
@@ -1,26 +1,5 @@
-@import '../bitbucket/style.scss';
-@import '../gitlab/style.scss';
 @import '../../shared/global-styles/variables.scss';
 @import '../../../../../shared/src/hover/HoverOverlay.scss';
-
-.hover-overlay-mount__phabricator {
-    .hover-overlay {
-        .hover-overlay__action {
-            padding: 6px 12px;
-            color: #24292e;
-            background-color: #eff3f6;
-            background-image: linear-gradient(-180deg, #fafbfc 0%, #eff3f6 90%);
-
-            &:hover {
-                background-color: #e6ebf1;
-                background-image: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
-                background-position: -0.5em;
-                border-color: rgba(27, 31, 35, 0.35);
-                text-decoration: none;
-            }
-        }
-    }
-}
 
 .hover-overlay {
     z-index: $default-z-index;

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -28,6 +28,7 @@ import {
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 
 import { ActionItemProps } from '../../../../../shared/src/actions/ActionItem'
+import { ActionNavItemsClassProps } from '../../../../../shared/src/actions/ActionsNavItems'
 import { Model, ViewComponentData } from '../../../../../shared/src/api/client/model'
 import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
 import { Controller } from '../../../../../shared/src/extensions/controller'
@@ -192,6 +193,9 @@ export interface CodeHost {
 
     /** Returns a stream representing the selections in the current code view */
     selectionsChanges?: () => Observable<Selection[]>
+
+    /** Optional classes for ActionNavItems, useful to customize the style of buttons contributed to the code view toolbar */
+    actionNavItemClassProps?: ActionNavItemsClassProps
 }
 
 export interface FileInfo {
@@ -584,6 +588,7 @@ export function handleCodeHost({
                     <TelemetryContext.Provider value={eventLogger}>
                         <CodeViewToolbar
                             {...info}
+                            {...codeHost.actionNavItemClassProps}
                             platformContext={platformContext}
                             extensionsController={extensionsController}
                             buttonProps={

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -157,6 +157,11 @@ export const githubCodeHost: CodeHost = {
     getOverlayMount,
     getCommandPaletteMount,
     getGlobalDebugMount,
+    actionNavItemClassProps: {
+        listItemClass: 'BtnGroup',
+        actionItemClass: 'btn btn-sm tooltipped tooltipped-s BtnGroup-item action-item--github',
+        actionItemPressedClass: 'selected',
+    },
     urlToFile: (
         location: RepoSpec & RevSpec & FileSpec & Partial<PositionSpec> & Partial<ViewStateSpec> & { part?: DiffPart }
     ) => {

--- a/client/browser/src/libs/github/style.scss
+++ b/client/browser/src/libs/github/style.scss
@@ -1,0 +1,6 @@
+.action-item--github {
+    // Match GitHub's button height even if button only contains icon
+    // (no text that would push the height)
+    // stylelint-disable-next-line declaration-property-unit-whitelist
+    height: 28px;
+}

--- a/client/browser/src/libs/gitlab/code_intelligence.ts
+++ b/client/browser/src/libs/gitlab/code_intelligence.ts
@@ -92,4 +92,8 @@ export const gitlabCodeHost: CodeHost = {
     codeViewResolver,
     adjustOverlayPosition,
     getCommandPaletteMount,
+    actionNavItemClassProps: {
+        actionItemClass: 'btn btn-secondary action-item--gitlab',
+        actionItemPressedClass: 'active',
+    },
 }

--- a/client/browser/src/libs/gitlab/style.scss
+++ b/client/browser/src/libs/gitlab/style.scss
@@ -100,3 +100,11 @@
         font-weight: bold;
     }
 }
+
+.action-item--gitlab {
+    height: 30px;
+    .action-item__content {
+        height: 28px;
+        line-height: 28px;
+    }
+}

--- a/client/browser/src/libs/phabricator/code_intelligence.ts
+++ b/client/browser/src/libs/phabricator/code_intelligence.ts
@@ -198,6 +198,5 @@ export const phabricatorCodeHost: CodeHost = {
     selectionsChanges: () => of([]),
     actionNavItemClassProps: {
         actionItemClass: 'button grey action-item--phabricator',
-        actionItemPressedClass: 'action-item--phabricator__pressed',
     },
 }

--- a/client/browser/src/libs/phabricator/code_intelligence.ts
+++ b/client/browser/src/libs/phabricator/code_intelligence.ts
@@ -99,7 +99,7 @@ const adjustPosition: PositionAdjuster<RepoSpec & RevSpec & FileSpec & ResolvedR
     )
 
 const toolbarButtonProps = {
-    className: 'button button-grey has-icon has-text phui-button-default msl',
+    className: 'button grey button-grey has-icon has-text phui-button-default msl',
     iconStyle: { marginTop: '-1px', paddingRight: '4px', fontSize: '18px', height: '.8em', width: '.8em' },
     style: {},
 }
@@ -196,4 +196,8 @@ export const phabricatorCodeHost: CodeHost = {
     // TODO: handle parsing selected line number from Phabricator href,
     // and find a way to listen to changes (Phabricator does not emit popstate events).
     selectionsChanges: () => of([]),
+    actionNavItemClassProps: {
+        actionItemClass: 'button grey action-item--phabricator',
+        actionItemPressedClass: 'action-item--phabricator__pressed',
+    },
 }

--- a/client/browser/src/libs/phabricator/style.scss
+++ b/client/browser/src/libs/phabricator/style.scss
@@ -1,4 +1,4 @@
-.action-item--phabricator {
+.action-item--phabricator.action-item--pressed {
     &__pressed {
         box-shadow: inset 0 0.15em 0.3em #cad2e2;
     }

--- a/client/browser/src/libs/phabricator/style.scss
+++ b/client/browser/src/libs/phabricator/style.scss
@@ -1,0 +1,24 @@
+.action-item--phabricator {
+    &__pressed {
+        box-shadow: inset 0 0.15em 0.3em #cad2e2;
+    }
+}
+
+.hover-overlay-mount__phabricator {
+    .hover-overlay {
+        .hover-overlay__action {
+            padding: 6px 12px;
+            color: #24292e;
+            background-color: #eff3f6;
+            background-image: linear-gradient(-180deg, #fafbfc 0%, #eff3f6 90%);
+
+            &:hover {
+                background-color: #e6ebf1;
+                background-image: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
+                background-position: -0.5em;
+                border-color: rgba(27, 31, 35, 0.35);
+                text-decoration: none;
+            }
+        }
+    }
+}

--- a/client/browser/src/shared/components/CodeViewToolbar.scss
+++ b/client/browser/src/shared/components/CodeViewToolbar.scss
@@ -3,10 +3,3 @@
         vertical-align: middle;
     }
 }
-
-.action-item--github {
-    // Match GitHub's button height even if button only contains icon
-    // (no text that would push the height)
-    // stylelint-disable-next-line declaration-property-unit-whitelist
-    height: 28px;
-}

--- a/client/browser/src/shared/components/CodeViewToolbar.scss
+++ b/client/browser/src/shared/components/CodeViewToolbar.scss
@@ -1,5 +1,12 @@
 .code-view-toolbar {
-    & .icon-inline {
+    .icon-inline {
         vertical-align: middle;
     }
+}
+
+.action-item--github {
+    // Match GitHub's button height even if button only contains icon
+    // (no text that would push the height)
+    // stylelint-disable-next-line declaration-property-unit-whitelist
+    height: 28px;
 }

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -1,7 +1,7 @@
 import H from 'history'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
-import { ActionsNavItems } from '../../../../../shared/src/actions/ActionsNavItems'
+import { ActionsNavItems, ActionNavItemsClassProps } from '../../../../../shared/src/actions/ActionsNavItems'
 import { ContributableMenu } from '../../../../../shared/src/api/protocol'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { ISite, IUser } from '../../../../../shared/src/graphql/schema'
@@ -19,14 +19,14 @@ export interface ButtonProps {
     iconStyle?: React.CSSProperties
 }
 
-interface CodeViewToolbarProps extends PlatformContextProps<'forceUpdateTooltip'>, ExtensionsControllerProps, FileInfo {
+interface CodeViewToolbarProps
+    extends PlatformContextProps<'forceUpdateTooltip'>,
+        ExtensionsControllerProps,
+        FileInfo,
+        ActionNavItemsClassProps {
     onEnabledChange?: (enabled: boolean) => void
 
     buttonProps: ButtonProps
-    actionsNavItemClassProps?: {
-        listItemClass?: string
-        actionItemClass?: string
-    }
     location: H.Location
 }
 
@@ -57,12 +57,10 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
             >
                 <ul className={`nav ${this.props.platformContext ? 'pr-1' : ''}`}>
                     <ActionsNavItems
+                        {...this.props}
                         menu={ContributableMenu.EditorTitle}
                         extensionsController={this.props.extensionsController}
                         platformContext={this.props.platformContext}
-                        listItemClass="BtnGroup"
-                        actionItemClass="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
-                        actionItemPressedClass="selected btn-pressed"
                         location={this.props.location}
                         scope={{
                             type: 'textEditor',

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -62,6 +62,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                         platformContext={this.props.platformContext}
                         listItemClass="BtnGroup"
                         actionItemClass="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
+                        actionItemPressedClass="selected btn-pressed"
                         location={this.props.location}
                         scope={{
                             type: 'textEditor',

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -1,7 +1,7 @@
 import H from 'history'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
-import { ActionsNavItems, ActionNavItemsClassProps } from '../../../../../shared/src/actions/ActionsNavItems'
+import { ActionNavItemsClassProps, ActionsNavItems } from '../../../../../shared/src/actions/ActionsNavItems'
 import { ContributableMenu } from '../../../../../shared/src/api/protocol'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { ISite, IUser } from '../../../../../shared/src/graphql/schema'

--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -2,10 +2,6 @@
     &__content {
         display: flex;
         align-items: center;
-
-        .icon-inline {
-            margin-right: 0.2rem;
-        }
     }
     &--variant-action-item &__content {
         justify-content: center;

--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -1,4 +1,6 @@
 .action-item {
+    display: flex;
+
     &__content {
         display: flex;
         align-items: center;

--- a/shared/src/actions/ActionItem.test.tsx
+++ b/shared/src/actions/ActionItem.test.tsx
@@ -47,6 +47,19 @@ describe('ActionItem', () => {
         expect(component.toJSON()).toMatchSnapshot()
     })
 
+    test('pressed actionItem', () => {
+        const component = renderer.create(
+            <ActionItem
+                action={{ id: 'a', command: 'c', actionItem: { pressed: true, label: 'b' } }}
+                variant="actionItem"
+                location={history.location}
+                extensionsController={NOOP_EXTENSIONS_CONTROLLER}
+                platformContext={NOOP_PLATFORM_CONTEXT}
+            />
+        )
+        expect(component.toJSON()).toMatchSnapshot()
+    })
+
     test('title element', () => {
         const component = renderer.create(
             <ActionItem

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -143,7 +143,8 @@ export class ActionItem extends React.PureComponent<Props, State> {
                             alt={this.props.action.actionItem.iconDescription}
                             className="icon-inline"
                         />
-                    )}{' '}
+                    )}
+                    {this.props.action.actionItem.iconURL && this.props.action.actionItem.label && <>&nbsp;</>}
                     {this.props.action.actionItem.label}
                 </>
             )
@@ -151,7 +152,10 @@ export class ActionItem extends React.PureComponent<Props, State> {
         } else {
             content = (
                 <>
-                    {this.props.action.iconURL && <img src={this.props.action.iconURL} className="icon-inline" />}{' '}
+                    {this.props.action.iconURL && <img src={this.props.action.iconURL} className="icon-inline" />}
+                    {this.props.action.iconURL && (this.props.action.category || this.props.action.title) && (
+                        <>&nbsp;</>
+                    )}
                     {this.props.action.category ? `${this.props.action.category}: ` : ''}
                     {this.props.action.title}
                 </>

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { from, Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, mergeMap, startWith, tap } from 'rxjs/operators'
 import { ExecuteCommandParams } from '../api/client/services/command'
-import { ActionContribution } from '../api/protocol'
+import { EvaluatedActionContribution } from '../api/protocol'
 import { urlForOpenPanel } from '../commands/commands'
 import { LinkOrButton } from '../components/LinkOrButton'
 import { ExtensionsControllerProps } from '../extensions/controller'
@@ -17,16 +17,17 @@ export interface ActionItemProps {
      * The action specified in the menu item's {@link module:sourcegraph.module/protocol.MenuItemContribution#action}
      * property.
      */
-    action: ActionContribution
+    action: EvaluatedActionContribution
 
     /**
      * The alternative action specified in the menu item's
      * {@link module:sourcegraph.module/protocol.MenuItemContribution#alt} property.
      */
-    altAction?: ActionContribution
+    altAction?: EvaluatedActionContribution
 
     variant?: 'actionItem'
     className?: string
+    pressedClassName?: string
 
     /** Called after executing the action (for both success and failure). */
     onDidExecute?: (actionID: string) => void
@@ -173,6 +174,8 @@ export class ActionItem extends React.PureComponent<Props, State> {
         }
 
         const showLoadingSpinner = this.props.showLoadingSpinnerDuringExecution && this.state.actionOrError === LOADING
+        const pressed =
+            this.props.variant === 'actionItem' && this.props.action.actionItem && this.props.action.actionItem.pressed
 
         return (
             <LinkOrButton
@@ -187,7 +190,7 @@ export class ActionItem extends React.PureComponent<Props, State> {
                 }
                 className={`action-item ${this.props.className || ''} ${
                     showLoadingSpinner ? 'action-item--loading' : ''
-                } ${variantClassName}`}
+                } ${variantClassName} ${pressed ? `action-item--pressed ${this.props.pressedClassName || ''}` : ''}`}
                 // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
                 // it as a button that executes the command.
                 to={
@@ -251,7 +254,7 @@ export class ActionItem extends React.PureComponent<Props, State> {
     }
 }
 
-function urlForClientCommandOpen(action: ActionContribution, location: H.Location): string | undefined {
+function urlForClientCommandOpen(action: EvaluatedActionContribution, location: H.Location): string | undefined {
     if (action.command === 'open' && action.commandArguments && typeof action.commandArguments[0] === 'string') {
         return action.commandArguments[0]
     }

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -1,4 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import classNames from 'classnames'
 import H from 'history'
 import * as React from 'react'
 import { from, Subject, Subscription } from 'rxjs'
@@ -192,9 +193,13 @@ export class ActionItem extends React.PureComponent<Props, State> {
                     (this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
                     this.state.actionOrError === LOADING
                 }
-                className={`action-item ${this.props.className || ''} ${
-                    showLoadingSpinner ? 'action-item--loading' : ''
-                } ${variantClassName} ${pressed ? `action-item--pressed ${this.props.pressedClassName || ''}` : ''}`}
+                className={classNames(
+                    'action-item',
+                    this.props.className,
+                    showLoadingSpinner && 'action-item--loading',
+                    variantClassName,
+                    pressed && [`action-item--pressed`, this.props.pressedClassName]
+                )}
                 // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
                 // it as a button that executes the command.
                 to={

--- a/shared/src/actions/ActionsNavItems.tsx
+++ b/shared/src/actions/ActionsNavItems.tsx
@@ -7,7 +7,13 @@ import { ActionItem } from './ActionItem'
 import { ActionsState } from './actions'
 import { ActionsProps } from './ActionsContainer'
 
-interface Props extends ActionsProps {
+export interface ActionNavItemsClassProps {
+    actionItemClass?: string
+    actionItemPressedClass?: string
+    listItemClass?: string
+}
+
+interface Props extends ActionsProps, ActionNavItemsClassProps {
     /**
      * If true, it renders a <ul className="nav">...</ul> around the items. If there are no items, it renders null.
      *
@@ -16,9 +22,6 @@ interface Props extends ActionsProps {
     wrapInList?: boolean
 
     listClass?: string
-    actionItemClass?: string
-    actionItemPressedClass?: string
-    listItemClass?: string
 }
 
 /**

--- a/shared/src/actions/ActionsNavItems.tsx
+++ b/shared/src/actions/ActionsNavItems.tsx
@@ -17,6 +17,7 @@ interface Props extends ActionsProps {
 
     listClass?: string
     actionItemClass?: string
+    actionItemPressedClass?: string
     listItemClass?: string
 }
 
@@ -63,6 +64,7 @@ export class ActionsNavItems extends React.PureComponent<Props, ActionsState> {
                     extensionsController={this.props.extensionsController}
                     platformContext={this.props.platformContext}
                     className={this.props.actionItemClass}
+                    pressedClassName={this.props.actionItemPressedClass}
                     location={this.props.location}
                 />
             </li>

--- a/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ActionItem actionItem variant 1`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>
@@ -41,7 +41,7 @@ exports[`ActionItem non-actionItem variant 1`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>
@@ -57,7 +57,7 @@ exports[`ActionItem noop command 1`] = `
     className="icon-inline"
     src="u"
   />
-   
+   
   g: 
   t
 </span>
@@ -74,7 +74,6 @@ exports[`ActionItem pressed actionItem 1`] = `
   <div
     className="action-item__content"
   >
-     
     b
   </div>
 </a>
@@ -91,7 +90,6 @@ exports[`ActionItem render as link for "open" command 1`] = `
   <div
     className="action-item__content"
   >
-     
     
     t
   </div>
@@ -115,7 +113,7 @@ exports[`ActionItem run command 1`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>
@@ -139,7 +137,7 @@ exports[`ActionItem run command 2`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>
@@ -163,7 +161,7 @@ exports[`ActionItem run command with error 1`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>
@@ -187,7 +185,7 @@ exports[`ActionItem run command with error with showInlineError 1`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>
@@ -211,7 +209,7 @@ exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>
@@ -242,7 +240,7 @@ exports[`ActionItem run command with showLoadingSpinnerDuringExecution 2`] = `
       className="icon-inline"
       src="u"
     />
-     
+     
     g: 
     t
   </div>

--- a/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ActionItem actionItem variant 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item "
+  className="action-item   action-item--variant-action-item  "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -27,7 +27,7 @@ exports[`ActionItem actionItem variant 1`] = `
 exports[`ActionItem non-actionItem variant 1`] = `
 <a
   aria-label="d"
-  className="action-item    "
+  className="action-item     "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -63,9 +63,26 @@ exports[`ActionItem noop command 1`] = `
 </span>
 `;
 
+exports[`ActionItem pressed actionItem 1`] = `
+<a
+  className="action-item   action-item--variant-action-item action-item--pressed  "
+  onAuxClick={[Function]}
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+>
+  <div
+    className="action-item__content"
+  >
+     
+    b
+  </div>
+</a>
+`;
+
 exports[`ActionItem render as link for "open" command 1`] = `
 <a
-  className="action-item    "
+  className="action-item     "
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
@@ -84,7 +101,7 @@ exports[`ActionItem render as link for "open" command 1`] = `
 exports[`ActionItem run command 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item disabled"
+  className="action-item   action-item--variant-action-item  disabled"
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -108,7 +125,7 @@ exports[`ActionItem run command 1`] = `
 exports[`ActionItem run command 2`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item "
+  className="action-item   action-item--variant-action-item  "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -132,7 +149,7 @@ exports[`ActionItem run command 2`] = `
 exports[`ActionItem run command with error 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item "
+  className="action-item   action-item--variant-action-item  "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -156,7 +173,7 @@ exports[`ActionItem run command with error 1`] = `
 exports[`ActionItem run command with error with showInlineError 1`] = `
 <a
   aria-label="Error: x"
-  className="action-item   action-item--variant-action-item "
+  className="action-item   action-item--variant-action-item  "
   data-tooltip="Error: x"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -180,7 +197,7 @@ exports[`ActionItem run command with error with showInlineError 1`] = `
 exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
 <a
   aria-label="d"
-  className="action-item  action-item--loading action-item--variant-action-item disabled"
+  className="action-item  action-item--loading action-item--variant-action-item  disabled"
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -211,7 +228,7 @@ exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
 exports[`ActionItem run command with showLoadingSpinnerDuringExecution 2`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item "
+  className="action-item   action-item--variant-action-item  "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -235,7 +252,7 @@ exports[`ActionItem run command with showLoadingSpinnerDuringExecution 2`] = `
 exports[`ActionItem title element 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item "
+  className="action-item   action-item--variant-action-item  "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}

--- a/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ActionItem actionItem variant 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item  "
+  className="action-item action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -27,7 +27,7 @@ exports[`ActionItem actionItem variant 1`] = `
 exports[`ActionItem non-actionItem variant 1`] = `
 <a
   aria-label="d"
-  className="action-item     "
+  className="action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -65,7 +65,7 @@ exports[`ActionItem noop command 1`] = `
 
 exports[`ActionItem pressed actionItem 1`] = `
 <a
-  className="action-item   action-item--variant-action-item action-item--pressed  "
+  className="action-item action-item--variant-action-item action-item--pressed "
   onAuxClick={[Function]}
   onClick={[Function]}
   onKeyPress={[Function]}
@@ -81,7 +81,7 @@ exports[`ActionItem pressed actionItem 1`] = `
 
 exports[`ActionItem render as link for "open" command 1`] = `
 <a
-  className="action-item     "
+  className="action-item "
   onClick={[Function]}
   onKeyPress={[Function]}
   tabIndex={0}
@@ -99,7 +99,7 @@ exports[`ActionItem render as link for "open" command 1`] = `
 exports[`ActionItem run command 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item  disabled"
+  className="action-item action-item--variant-action-item disabled"
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -123,7 +123,7 @@ exports[`ActionItem run command 1`] = `
 exports[`ActionItem run command 2`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item  "
+  className="action-item action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -147,7 +147,7 @@ exports[`ActionItem run command 2`] = `
 exports[`ActionItem run command with error 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item  "
+  className="action-item action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -171,7 +171,7 @@ exports[`ActionItem run command with error 1`] = `
 exports[`ActionItem run command with error with showInlineError 1`] = `
 <a
   aria-label="Error: x"
-  className="action-item   action-item--variant-action-item  "
+  className="action-item action-item--variant-action-item "
   data-tooltip="Error: x"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -195,7 +195,7 @@ exports[`ActionItem run command with error with showInlineError 1`] = `
 exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
 <a
   aria-label="d"
-  className="action-item  action-item--loading action-item--variant-action-item  disabled"
+  className="action-item action-item--loading action-item--variant-action-item disabled"
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -226,7 +226,7 @@ exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
 exports[`ActionItem run command with showLoadingSpinnerDuringExecution 2`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item  "
+  className="action-item action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}
@@ -250,7 +250,7 @@ exports[`ActionItem run command with showLoadingSpinnerDuringExecution 2`] = `
 exports[`ActionItem title element 1`] = `
 <a
   aria-label="d"
-  className="action-item   action-item--variant-action-item  "
+  className="action-item action-item--variant-action-item "
   data-tooltip="d"
   onAuxClick={[Function]}
   onClick={[Function]}

--- a/shared/src/actions/actions.ts
+++ b/shared/src/actions/actions.ts
@@ -1,6 +1,6 @@
-import { Contributions } from '../api/protocol'
+import { EvaluatedContributions } from '../api/protocol'
 
 export interface ActionsState {
     /** The contributions, merged from all extensions, or undefined before the initial emission. */
-    contributions?: Contributions
+    contributions?: EvaluatedContributions
 }

--- a/shared/src/api/client/context/expr/evaluator.ts
+++ b/shared/src/api/client/context/expr/evaluator.ts
@@ -24,7 +24,7 @@ export function evaluate(expr: string, context: ComputedContext): any {
  * A template is a string that interpolates expressions in ${...}. It uses the same syntax as
  * JavaScript templates.
  */
-export function evaluateTemplate(template: string, context: ComputedContext): any {
+export function evaluateTemplate(template: string, context: ComputedContext): string {
     return exec(new TemplateParser().parse(template), context)
 }
 

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -2,7 +2,7 @@ import { Observable, of } from 'rxjs'
 import { Subscription } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { ContributableMenu, Contributions } from '../../protocol'
+import { ContributableMenu, Contributions, EvaluatedContributions } from '../../protocol'
 import { Context, ContributionScope } from '../context/context'
 import { EMPTY_COMPUTED_CONTEXT } from '../context/expr/evaluator'
 import { EMPTY_MODEL, Model } from '../model'
@@ -96,7 +96,7 @@ describe('ContributionRegistry', () => {
             const registry = new class extends ContributionRegistry {
                 public getContributionsFromEntries(
                     entries: Observable<ContributionsEntry[]>
-                ): Observable<Contributions> {
+                ): Observable<EvaluatedContributions> {
                     return super.getContributionsFromEntries(entries, undefined)
                 }
             }(of(EMPTY_MODEL), { data: of(EMPTY_SETTINGS_CASCADE) }, of({}))
@@ -120,7 +120,7 @@ describe('ContributionRegistry', () => {
             const registry = new class extends ContributionRegistry {
                 public getContributionsFromEntries(
                     entries: Observable<ContributionsEntry[]>
-                ): Observable<Contributions> {
+                ): Observable<EvaluatedContributions> {
                     return super.getContributionsFromEntries(entries, undefined)
                 }
             }(of(EMPTY_MODEL), { data: of(EMPTY_SETTINGS_CASCADE) }, of({}))
@@ -166,7 +166,7 @@ describe('ContributionRegistry', () => {
 
                     public getContributionsFromEntries(
                         entries: Observable<ContributionsEntry[]>
-                    ): Observable<Contributions> {
+                    ): Observable<EvaluatedContributions> {
                         return super.getContributionsFromEntries(entries, undefined)
                     }
                 }()
@@ -199,7 +199,7 @@ describe('ContributionRegistry', () => {
                     public getContributionsFromEntries(
                         entries: Observable<ContributionsEntry[]>,
                         scope?: ContributionScope
-                    ): Observable<Contributions> {
+                    ): Observable<EvaluatedContributions> {
                         return super.getContributionsFromEntries(entries, scope, undefined, () => void 0 /* noop log */)
                     }
                 }()
@@ -225,11 +225,19 @@ describe('ContributionRegistry', () => {
 
 describe('mergeContributions', () => {
     test('handles an empty array', () => expect(mergeContributions([])).toEqual({}))
-    test('handles an single item', () =>
-        expect(mergeContributions([FIXTURE_CONTRIBUTIONS_1])).toEqual(FIXTURE_CONTRIBUTIONS_1))
+    test('handles a single item', () =>
+        expect(mergeContributions([FIXTURE_CONTRIBUTIONS_1 as EvaluatedContributions])).toEqual(
+            FIXTURE_CONTRIBUTIONS_1
+        ))
     test('handles multiple items', () =>
         expect(
-            mergeContributions([FIXTURE_CONTRIBUTIONS_1, FIXTURE_CONTRIBUTIONS_2, {}, { actions: [] }, { menus: {} }])
+            mergeContributions([
+                FIXTURE_CONTRIBUTIONS_1 as EvaluatedContributions,
+                FIXTURE_CONTRIBUTIONS_2 as EvaluatedContributions,
+                {},
+                { actions: [] },
+                { menus: {} },
+            ])
         ).toEqual(FIXTURE_CONTRIBUTIONS_MERGED))
 })
 
@@ -407,6 +415,13 @@ describe('evaluateContributions', () => {
     test('throws an error if an error occurs during evaluation', () => {
         const input: Contributions = { actions: [{ id: 'a', command: 'c', title: 'a' }] }
         expect(() => evaluateContributions(FIXTURE_CONTEXT, input, TEST_THROW_EVALUATOR)).toThrow()
+    })
+
+    test('evaluates `actionItem.pressed` if present', () => {
+        const input: Contributions = { actions: [{ id: 'a', command: 'c', title: 'a', actionItem: { pressed: 'a' } }] }
+        expect(evaluateContributions(FIXTURE_CONTEXT, input)).toEqual({
+            actions: [{ id: 'a', command: 'c', title: 'a', actionItem: { pressed: true } }],
+        })
     })
 })
 // tslint:enable:no-invalid-template-strings

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -33,7 +33,7 @@ const FIXTURE_CONTRIBUTIONS_2: Contributions = {
     },
 }
 
-const FIXTURE_CONTRIBUTIONS_MERGED: Contributions = {
+const FIXTURE_CONTRIBUTIONS_MERGED: EvaluatedContributions = {
     actions: [
         { id: '1.a', command: 'c', title: '1.A' },
         { id: '1.b', command: 'c', title: '1.B' },
@@ -224,20 +224,41 @@ describe('ContributionRegistry', () => {
 })
 
 describe('mergeContributions', () => {
+    const FIXTURE_CONTRIBUTIONS_1: EvaluatedContributions = {
+        actions: [{ id: '1.a', command: 'c', title: '1.A' }, { id: '1.b', command: 'c', title: '1.B' }],
+        menus: {
+            [ContributableMenu.CommandPalette]: [{ action: '1.a' }],
+            [ContributableMenu.GlobalNav]: [{ action: '1.a' }, { action: '1.b' }],
+        },
+    }
+
+    const FIXTURE_CONTRIBUTIONS_2: EvaluatedContributions = {
+        actions: [{ id: '2.a', command: 'c', title: '2.A' }, { id: '2.b', command: 'c', title: '2.B' }],
+        menus: {
+            [ContributableMenu.CommandPalette]: [{ action: '2.a' }],
+            [ContributableMenu.EditorTitle]: [{ action: '2.a' }, { action: '2.b' }],
+        },
+    }
+    const FIXTURE_CONTRIBUTIONS_MERGED: EvaluatedContributions = {
+        actions: [
+            { id: '1.a', command: 'c', title: '1.A' },
+            { id: '1.b', command: 'c', title: '1.B' },
+            { id: '2.a', command: 'c', title: '2.A' },
+            { id: '2.b', command: 'c', title: '2.B' },
+        ],
+        menus: {
+            [ContributableMenu.CommandPalette]: [{ action: '1.a' }, { action: '2.a' }],
+            [ContributableMenu.GlobalNav]: [{ action: '1.a' }, { action: '1.b' }],
+            [ContributableMenu.EditorTitle]: [{ action: '2.a' }, { action: '2.b' }],
+        },
+    }
+
     test('handles an empty array', () => expect(mergeContributions([])).toEqual({}))
     test('handles a single item', () =>
-        expect(mergeContributions([FIXTURE_CONTRIBUTIONS_1 as EvaluatedContributions])).toEqual(
-            FIXTURE_CONTRIBUTIONS_1
-        ))
+        expect(mergeContributions([FIXTURE_CONTRIBUTIONS_1])).toEqual(FIXTURE_CONTRIBUTIONS_1))
     test('handles multiple items', () =>
         expect(
-            mergeContributions([
-                FIXTURE_CONTRIBUTIONS_1 as EvaluatedContributions,
-                FIXTURE_CONTRIBUTIONS_2 as EvaluatedContributions,
-                {},
-                { actions: [] },
-                { menus: {} },
-            ])
+            mergeContributions([FIXTURE_CONTRIBUTIONS_1, FIXTURE_CONTRIBUTIONS_2, {}, { actions: [] }, { menus: {} }])
         ).toEqual(FIXTURE_CONTRIBUTIONS_MERGED))
 })
 

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -3,11 +3,8 @@ import { BehaviorSubject, combineLatest, isObservable, Observable, of, Subscriba
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
 import {
-    ActionContribution,
-    ActionItem,
     ContributableMenu,
     Contributions,
-    EvaluatedActionContribution,
     EvaluatedContributions,
     MenuContributions,
     MenuItemContribution,
@@ -262,61 +259,31 @@ export function evaluateContributions(
     contributions: Contributions,
     { evaluateTemplate, needsEvaluation } = DEFAULT_TEMPLATE_EVALUATOR
 ): EvaluatedContributions {
-    if (!contributions.actions || contributions.actions.length === 0) {
-        return { ...contributions } as EvaluatedContributions
+    const evaluateTemplateIfNeeded = (template: string | undefined, context: ComputedContext): string | undefined =>
+        template && needsEvaluation(template) ? evaluateTemplate(template, context) : template
+    return {
+        ...contributions,
+        actions:
+            contributions.actions &&
+            contributions.actions.map(action => ({
+                ...action,
+                title: evaluateTemplateIfNeeded(action.title, context),
+                category: evaluateTemplateIfNeeded(action.category, context),
+                description: evaluateTemplateIfNeeded(action.description, context),
+                iconURL: evaluateTemplateIfNeeded(action.iconURL, context),
+                actionItem: action.actionItem && {
+                    ...action.actionItem,
+                    label: evaluateTemplateIfNeeded(action.actionItem.label, context),
+                    description: evaluateTemplateIfNeeded(action.actionItem.description, context),
+                    iconURL: evaluateTemplateIfNeeded(action.actionItem.iconURL, context),
+                    iconDescription: evaluateTemplateIfNeeded(action.actionItem.iconDescription, context),
+                    pressed: action.actionItem.pressed && evaluate(action.actionItem.pressed, context),
+                },
+                commandArguments:
+                    action.commandArguments &&
+                    action.commandArguments.map(arg =>
+                        typeof arg === 'string' && needsEvaluation(arg) ? evaluateTemplate(arg, context) : arg
+                    ),
+            })),
     }
-    const evaluatedActions: EvaluatedActionContribution[] = []
-    for (const action of contributions.actions as Readonly<ActionContribution>[]) {
-        const changed: Partial<EvaluatedActionContribution> = {}
-        if (action.commandArguments) {
-            for (const [i, arg] of action.commandArguments.entries()) {
-                if (typeof arg === 'string' && needsEvaluation(arg)) {
-                    const evaluatedArg = evaluateTemplate(arg, context)
-                    if (changed.commandArguments) {
-                        changed.commandArguments.push(evaluatedArg)
-                    } else {
-                        changed.commandArguments = action.commandArguments.slice(0, i).concat(evaluatedArg)
-                    }
-                } else if (changed.commandArguments) {
-                    changed.commandArguments.push(arg)
-                }
-            }
-        }
-        if (action.title && needsEvaluation(action.title)) {
-            changed.title = evaluateTemplate(action.title, context)
-        }
-        if (action.category && needsEvaluation(action.category)) {
-            changed.category = evaluateTemplate(action.category, context)
-        }
-        if (action.description && needsEvaluation(action.description)) {
-            changed.description = evaluateTemplate(action.description, context)
-        }
-        if (action.iconURL && needsEvaluation(action.iconURL)) {
-            changed.iconURL = evaluateTemplate(action.iconURL, context)
-        }
-        if (action.actionItem) {
-            const changedActionItem: Partial<ActionItem> = {}
-            if (action.actionItem.label && needsEvaluation(action.actionItem.label)) {
-                changedActionItem.label = evaluateTemplate(action.actionItem.label, context)
-            }
-            if (action.actionItem.description && needsEvaluation(action.actionItem.description)) {
-                changedActionItem.description = evaluateTemplate(action.actionItem.description, context)
-            }
-            if (action.actionItem.iconURL && needsEvaluation(action.actionItem.iconURL)) {
-                changedActionItem.iconURL = evaluateTemplate(action.actionItem.iconURL, context)
-            }
-            if (action.actionItem.iconDescription && needsEvaluation(action.actionItem.iconDescription)) {
-                changedActionItem.iconDescription = evaluateTemplate(action.actionItem.iconDescription, context)
-            }
-            if (action.actionItem.pressed) {
-                changedActionItem.pressed = evaluate(action.actionItem.pressed, context)
-            }
-            if (Object.keys(changedActionItem).length !== 0) {
-                changed.actionItem = { ...action.actionItem, ...changedActionItem } as any
-            }
-        }
-        const modified = Object.keys(changed).length !== 0
-        evaluatedActions.push(modified ? { ...action, ...changed } : (action as any))
-    }
-    return { ...contributions, actions: evaluatedActions }
 }

--- a/shared/src/api/protocol/contribution.ts
+++ b/shared/src/api/protocol/contribution.ts
@@ -20,6 +20,15 @@ export interface Contributions {
     searchFilters?: SearchFilters[]
 }
 
+export interface EvaluatedContributions extends Pick<Contributions, Exclude<keyof Contributions, 'actions'>> {
+    actions?: EvaluatedActionContribution[]
+}
+
+export interface EvaluatedActionContribution
+    extends Pick<ActionContribution, Exclude<keyof ActionContribution, 'actionItem'>> {
+    actionItem?: EvaluatedActionItem
+}
+
 /**
  * An action contribution describes a command that can be invoked, along with a title, description, icon, etc.
  */
@@ -186,6 +195,22 @@ export interface ActionItem {
      * to users needing the textual description.
      */
     iconDescription?: string
+
+    /**
+     * An expression that, if given, should evaluate to a boolean value specifying whether
+     * the action item should be rendered as a pressed button.
+     */
+    pressed?: string
+}
+
+/**
+ * An {@link ActionItem} with all expressions replaced by their evaluated value.
+ */
+export interface EvaluatedActionItem extends Pick<ActionItem, Exclude<keyof ActionItem, 'pressed'>> {
+    /**
+     * Whether the action item should be rendered as a pressed button.
+     */
+    pressed?: boolean
 }
 
 export enum ContributableMenu {

--- a/shared/src/api/protocol/contribution.ts
+++ b/shared/src/api/protocol/contribution.ts
@@ -20,12 +20,22 @@ export interface Contributions {
     searchFilters?: SearchFilters[]
 }
 
+/**
+ * An extension's contributions, with all template strings interpolated,
+ * and all expressions replaced by their evaluated value.
+ */
 export interface EvaluatedContributions extends Pick<Contributions, Exclude<keyof Contributions, 'actions'>> {
+    /** Actions contributed by the extension */
     actions?: EvaluatedActionContribution[]
 }
 
+/**
+ * An action contribution, with all template strings interpolated,
+ * and all expressions replaced by their evaluated value.
+ */
 export interface EvaluatedActionContribution
     extends Pick<ActionContribution, Exclude<keyof ActionContribution, 'actionItem'>> {
+    /** A specification of how to display this action as a button on a toolbar. */
     actionItem?: EvaluatedActionItem
 }
 
@@ -145,9 +155,12 @@ export interface ActionContributionClientCommandUpdateConfiguration extends Acti
 }
 
 /**
- * A description of how to display an {@link ActionContribution} on a toolbar. This value is set on the
- * {@link ActionContribution#actionItem} interface field (it always is directly associated with an
- * {@link ActionContribution}).
+ * A description of how to display an {@link ActionContribution} on a toolbar,
+ * with all template properties interpolated, and all expression properties replaced
+ * by their evaluated value.
+ *
+ * This value is set on the {@link ActionContribution#actionItem} interface field
+ * (it always is directly associated with an {@link ActionContribution}).
  *
  * It is necessary because an action's ({@link ActionContribution}'s) fields are intended for display in a command
  * palette or list, not in a button. The {@link ActionContribution} fields usually have long, descriptive text
@@ -166,7 +179,7 @@ export interface ActionContributionClientCommandUpdateConfiguration extends Acti
  * duplicate code to combine them. Also, some clients may not be able to display buttons and need to display the
  * more verbose command form of an action, which is possible when they are combined.
  */
-export interface ActionItem {
+export interface EvaluatedActionItem {
     /** The text label for this item. */
     label?: string
 
@@ -197,21 +210,12 @@ export interface ActionItem {
     iconDescription?: string
 
     /**
-     * An expression that, if given, should evaluate to a boolean value specifying whether
-     * the action item should be rendered as a pressed button.
-     */
-    pressed?: string
-}
-
-/**
- * An {@link ActionItem} with all expressions replaced by their evaluated value.
- */
-export interface EvaluatedActionItem extends Pick<ActionItem, Exclude<keyof ActionItem, 'pressed'>> {
-    /**
      * Whether the action item should be rendered as a pressed button.
      */
     pressed?: boolean
 }
+
+export type ActionItem = { [K in keyof EvaluatedActionItem]: string }
 
 export enum ContributableMenu {
     /** The global command palette. */

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -7,7 +7,7 @@ import { Subscription } from 'rxjs'
 import stringScore from 'string-score'
 import { Key } from 'ts-key-enum'
 import { ActionItem, ActionItemProps } from '../actions/ActionItem'
-import { ContributableMenu, Contributions } from '../api/protocol'
+import { ContributableMenu, EvaluatedContributions } from '../api/protocol'
 import { HighlightedMatches } from '../components/HighlightedMatches'
 import { PopoverButton } from '../components/PopoverButton'
 import { getContributedActionItems } from '../contributions/contributions'
@@ -28,7 +28,7 @@ interface Props
 
 interface State {
     /** The contributions, merged from all extensions, or undefined before the initial emission. */
-    contributions?: Contributions
+    contributions?: EvaluatedContributions
 
     input: string
     selectedIndex: number

--- a/shared/src/contributions/contributions.ts
+++ b/shared/src/contributions/contributions.ts
@@ -1,6 +1,6 @@
 import { sortBy } from 'lodash'
 import { ActionItemProps } from '../actions/ActionItem'
-import { ContributableMenu, Contributions } from '../api/protocol'
+import { ContributableMenu, EvaluatedContributions } from '../api/protocol'
 
 const MENU_ITEMS_PROP_SORT_ORDER = ['group', 'id']
 
@@ -9,7 +9,10 @@ const MENU_ITEMS_PROP_SORT_ORDER = ['group', 'id']
  *
  * @param prioritizeActions sort these actions first
  */
-export function getContributedActionItems(contributions: Contributions, menu: ContributableMenu): ActionItemProps[] {
+export function getContributedActionItems(
+    contributions: EvaluatedContributions,
+    menu: ContributableMenu
+): ActionItemProps[] {
     if (!contributions.actions) {
         return []
     }

--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -98,6 +98,10 @@
                   "label": {
                     "description": "The text label for this item.",
                     "type": "string"
+                  },
+                  "pressed": {
+                    "description": "An expression that, if given, should evaluate to a boolean value specifying whether the action item should be rendered as a pressed button.",
+                    "type": "string"
                   }
                 },
                 "type": "object"

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -61,10 +61,16 @@
     .repo-header {
         border-color: #233043;
     }
+    .action-item--pressed {
+        background-color: $color-bg-3;
+    }
 }
 
 .theme-light {
     .repo-header {
         border-color: $color-light-border;
+    }
+    .action-item--pressed {
+        background-color: $color-light-bg-3;
     }
 }

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -5,8 +5,8 @@
 
 .repo-header {
     flex: none;
-    padding-top: 0.125rem;
-    padding-bottom: 0.05rem;
+    padding-top: 0;
+    padding-bottom: 0;
     border-style: solid;
     border-width: 0 0 1px;
 

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { concat, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators'
 import { parseSearchURLQuery } from '..'
-import { Contributions } from '../../../../shared/src/api/protocol'
+import { EvaluatedContributions } from '../../../../shared/src/api/protocol'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
@@ -46,7 +46,7 @@ interface SearchResultsState {
     showSavedQueryModal: boolean
     didSaveQuery: boolean
     /** The contributions, merged from all extensions, or undefined before the initial emission. */
-    contributions?: Contributions
+    contributions?: EvaluatedContributions
 }
 
 const newRepoFilters = localStorage.getItem('newRepoFilters') !== 'false'


### PR DESCRIPTION
Fixes #2055 

This PR adds a new "pressed" property for contributed action items:

> An expression that, if given, should evaluate to a boolean value specifying whether the action item should be rendered as a pressed button.

The original use case for this is for language extensions to contribute "toggle code intelligence" buttons to the code view toolbar:

![image](https://user-images.githubusercontent.com/1741180/53415627-fd2c5580-39d1-11e9-93af-20ebaefe94c9.png)
![image](https://user-images.githubusercontent.com/1741180/53415641-04ebfa00-39d2-11e9-81e1-3962e07b8254.png)
![image](https://user-images.githubusercontent.com/1741180/53415479-a4f55380-39d1-11e9-9fa1-8f10c84df050.png)

For integrations, the aim is to match the styling of pressed buttons on the code host. This is done for Github, but:
- [ ] TODO Gitlab
- [ ] TODO BitBucket Server
- [ ] TODO Phabricator

@francisschmaltz @sqs How should this be rendered in the Sourcegraph web app? Up until now action items contributed to the repo header were just rendered as links, not buttons. I simply added a different background color as a wip, but we might want to do something different. (and yes, icon alignment is off in the below screenshots)

![image](https://user-images.githubusercontent.com/1741180/53415989-cf93dc00-39d2-11e9-978a-592a5ed4c8b2.png)
![image](https://user-images.githubusercontent.com/1741180/53416000-d4589000-39d2-11e9-91be-c71c103b82f7.png)
