### PR TITLE
ci: Remove running yarn for go tests

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -92,7 +92,6 @@ func main() {
 			bk.Cmd("./dev/ci/ci-db-backcompat.sh"))
 
 		pipeline.AddStep(":go:",
-			bk.Cmd("yarn"),
 			bk.Cmd("./cmd/symbols/build.sh buildLibsqlite3Pcre"), // for symbols tests
 			bk.Cmd("go test -coverprofile=coverage.txt -covermode=atomic -race ./..."),
 			bk.ArtifactPaths("coverage.txt"))


### PR DESCRIPTION
Not required to build sqlite anymore.