### PR TITLE
feat: add GA on the /welcome page on sourcegraph.com

### DIFF
--- a/cmd/frontend/internal/app/templates/ui/app.html
+++ b/cmd/frontend/internal/app/templates/ui/app.html
@@ -25,7 +25,18 @@
 	<script ignore-csp>
 		; (function (t, r, a, c, k, e, d) { if (!t[k]) { t.GlobalTelligentNamespace = t.GlobalTelligentNamespace || []; t.GlobalTelligentNamespace.push(k); t[k] = function () { (t[k].q = t[k].q || []).push(arguments) }; t[k].q = t[k].q || []; e = r.createElement(a); d = r.getElementsByTagName(a)[0]; e.async = 1; e.src = c; d.parentNode.insertBefore(e, d) } }(window, document, "script", "https://storage.googleapis.com/telligent-artifacts/tracker/tel.js", "telligent"));
 	</script>
-	{{end}}
+    {{end}}
+    {{if .InjectGoogleAnalyticsTracker}}
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-17"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-40540747-17');
+        gtag('config', 'AW-868484203');
+        </script>
+    {{end}}
 	<script ignore-csp>
 		window.context = {{.Context }}
 		window.pageError = {{.Error }}

--- a/cmd/frontend/internal/app/templates/ui/app.html
+++ b/cmd/frontend/internal/app/templates/ui/app.html
@@ -28,7 +28,7 @@
     {{end}}
     {{if .InjectGoogleAnalyticsTracker}}
         <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-17"></script>
+        <script ignore-csp async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-17"></script>
         <script ignore-csp>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}

--- a/cmd/frontend/internal/app/templates/ui/app.html
+++ b/cmd/frontend/internal/app/templates/ui/app.html
@@ -29,7 +29,7 @@
     {{if .InjectGoogleAnalyticsTracker}}
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-17"></script>
-        <script>
+        <script ignore-csp>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -58,7 +58,8 @@ type Common struct {
 	Title    string
 	Error    *pageError
 
-	InjectSourcegraphTracker bool
+	InjectSourcegraphTracker     bool
+	InjectGoogleAnalyticsTracker bool
 
 	// The fields below have zero values when not on a repo page.
 	Repo         *types.Repo
@@ -93,8 +94,12 @@ func repoShortName(name api.RepoName) string {
 // returned but it has an incomplete RevSpec.
 func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError func(w http.ResponseWriter, r *http.Request, err error, statusCode int)) (*Common, error) {
 	injectTelligentTracker := false
+	injectGoogleAnalyticsTracker := false
 	if envvar.SourcegraphDotComMode() {
 		injectTelligentTracker = true
+		if strings.TrimPrefix(r.URL.Path, "/") == routeWelcome {
+			injectGoogleAnalyticsTracker = true
+		}
 	}
 
 	common := &Common{
@@ -108,7 +113,8 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 		AssetURL: assetsutil.URL("").String(),
 		Title:    title,
 
-		InjectSourcegraphTracker: injectTelligentTracker,
+		InjectSourcegraphTracker:     injectTelligentTracker,
+		InjectGoogleAnalyticsTracker: injectGoogleAnalyticsTracker,
 	}
 
 	if _, ok := mux.Vars(r)["Repo"]; ok {


### PR DESCRIPTION
NOTE: this change only affects sourcegraph.com, and only the /welcome page.

This is necessary because most of our inbound links go to "sourcegraph.com", which doesn't redirect to our about.sourcegraph.com or docs.sourcegraph.com subdomains when a user is unauthenticated. This means we're missing visibility of a huge chunk of non-app-usage traffic, and we can't track ad effectiveness.