### PR TITLE
cmd/server: use sourcegraph/alpine base image and sourcegraph user

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -fsSL -o ctags.tar.gz "https://codeload.github.com/universal-ctags/ctag
   apk --no-cache --purge del build-deps
 
 # TODO: Make this image use our sourcegraph/alpine:3.9 base image.
-FROM alpine:3.9
+FROM sourcegraph/alpine:3.9
 RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
@@ -44,5 +44,6 @@ COPY --from=libsqlite3-pcre /sqlite3-pcre/pcre.so /libsqlite3-pcre.so
 ENV LIBSQLITE3_PCRE /libsqlite3-pcre.so
 COPY . /
 
+USER sourcegraph
 ENV GO111MODULES=on LANG=en_US.utf8
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/server"]

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -15,7 +15,6 @@ RUN curl -fsSL -o ctags.tar.gz "https://codeload.github.com/universal-ctags/ctag
   rm -rf /tmp/ctags-$CTAGS_VERSION && \
   apk --no-cache --purge del build-deps
 
-# TODO: Make this image use our sourcegraph/alpine:3.9 base image.
 FROM sourcegraph/alpine:3.9
 RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
@@ -44,6 +43,5 @@ COPY --from=libsqlite3-pcre /sqlite3-pcre/pcre.so /libsqlite3-pcre.so
 ENV LIBSQLITE3_PCRE /libsqlite3-pcre.so
 COPY . /
 
-USER sourcegraph
 ENV GO111MODULES=on LANG=en_US.utf8
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/server"]
+ENTRYPOINT ["/sbin/tini", "--", "/chown-sourcegraph-user.sh", "/usr/local/bin/server"]

--- a/cmd/server/rootfs/chown-sourcegraph-user.sh
+++ b/cmd/server/rootfs/chown-sourcegraph-user.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# This migration script gives the "sourcegraph" user ownership over all the folders
+# in Sourcegraph's external volumes so that the container itself can be run
+# as a non-"root" user ("sourcegraph").
+#
+# This script expects to run as root, and it can be deleted in the future once all of our users
+# have ran through this migration process.
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root."
+    exit 1
+fi
+
+chown -R sourcegraph:sourcegraph /etc/sourcegraph
+chown -R sourcegraph:sourcegraph /var/opt/sourcegraph
+
+exec runuser -u sourcegraph "$@"


### PR DESCRIPTION
See: #2044 

When migrating from the latest insiders to this version, we get the following error: 

```
2019/02/26 19:46:34 enterprise edition
/etc/sourcegraph/ssh does not exist, so only repos that do not require SSH will be accessible.
$ mkdir -p /run/postgresql
✱ Setting up postgres failed:

$ mkdir -p /run/postgresql
mkdir: can't create directory '/run/postgresql': Permission denied

exit status 1
```