### PR TITLE
migrations: New migrations use transactions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,6 @@
 /web/src/ @felixfbecker
 /cmd/frontend/internal/app/pkg/updatecheck/ @dadlerj
 /web/src/tracking/ @dadlerj
-/cmd/gitserver/ @sourcegraph/core-services
-/cmd/repo-updater/ @sourcegraph/core-services
 /cmd/frontend/authz/ @beyang
 /cmd/frontend/auth/ @beyang
 /cmd/frontend/internal/auth/ @beyang
@@ -18,6 +16,11 @@
 /cmd/frontend/external/session/session.go @beyang
 /enterprise/cmd/frontend/internal/authz @beyang
 /enterprise/cmd/frontend/auth @beyang
+
+# Core Services
+/cmd/gitserver/ @sourcegraph/core-services
+/cmd/repo-updater/ @sourcegraph/core-services
+/migrations/ @sourcegraph/core-services
 
 # Search
 /cmd/frontend/graphqlbackend/*search* @sourcegraph/code-search

--- a/dev/add_migration.sh
+++ b/dev/add_migration.sh
@@ -13,7 +13,7 @@ files=$(ls -1 | grep '^[0-9]'.*\.sql | sort -n | tail -n2)
 
 for f in $files; do
     cat > $f <<EOF
-BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+BEGIN;
 
 -- Insert migration here. See README.md. Highlights:
 --  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;

--- a/dev/add_migration.sh
+++ b/dev/add_migration.sh
@@ -1,8 +1,29 @@
 #!/bin/bash
 
+cd $(dirname "${BASH_SOURCE[0]}")/../migrations
+set -e
+
 # The name is intentionally empty ('') so that it forces a merge conflict if two branches attempt to
 # create a migration at the same sequence number (because they will both add a file with the same
 # name, like `migrations/1528277032_.up.sql`).
-unset CDPATH
-cd migrations && migrate create -ext sql -dir . -digits 10 -seq ''
-echo Empty migration files added in migrations/
+
+migrate create -ext sql -dir . -digits 10 -seq ''
+
+files=$(ls -1 | grep '^[0-9]'.*\.sql | sort -n | tail -n2)
+
+for f in $files; do
+    cat > $f <<EOF
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+COMMIT;
+EOF
+   
+    echo "Created migrations/$f"
+done

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -21,10 +21,10 @@ Run the following:
 ./dev/add_migration.sh
 ```
 
-There will be up/down `.sql` migration files created in this directory. Add SQL statements to these
-files that will perform the desired migration. **NOTE**: the migration runner wraps each migration
-script in a transaction block; do not add explicit transaction blocks to the migration script as
-this has caused issues in the past.
+There will be up/down `.sql` migration files created in this directory. Add
+SQL statements to these files that will perform the desired
+migration. **NOTE**: the migration runner does not use transactions. Use the
+explicit transaction blocks added to the migration script template.
 
 ```sql
 # Enter statements here


### PR DESCRIPTION
We discovered that the migration library does not use transactions, nor has it
ever used transactions. The only place it uses transactions is for SetVersion,
not the actual migrations. The [README][1] for the postgres driver encourages
the use of transactions for multi-statement migrations. We believe it is better
to just always use transactions.

We added a template for the created migrations. It uses a transaction and it includes comments with advice from the README.

Reference: The PR which added the deprecated advice https://github.com/sourcegraph/enterprise/pull/11564#pullrequestreview-123318799

Note: This PR originally used the `ISOLATION LEVEL SERIALIZABLE` for the transaction. However, this level requires retries by the application (which migrate does not do) and it is not appropriate for all migrations.

[1]: https://sourcegraph.com/github.com/golang-migrate/migrate@v4.2.5/-/blob/database/postgres/README.md?view=code#L26