### PR TITLE
Minimize Prop drilling

### DIFF
--- a/shared/src/panel/Panel.tsx
+++ b/shared/src/panel/Panel.tsx
@@ -70,24 +70,12 @@ export class Panel extends React.PureComponent<Props, State> {
         const items = this.state.panelViews
             ? this.state.panelViews
                   .map(
-                      panelView =>
-                          ({
-                              label: panelView.title,
-                              id: panelView.id,
-                              priority: panelView.priority,
-                              element: (
-                                  <PanelView
-                                      panelView={panelView}
-                                      repoName={this.props.repoName}
-                                      history={this.props.history}
-                                      location={this.props.location}
-                                      isLightTheme={this.props.isLightTheme}
-                                      extensionsController={this.props.extensionsController}
-                                      settingsCascade={this.props.settingsCascade}
-                                      fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
-                                  />
-                              ),
-                          } as PanelItem)
+                      (panelView): PanelItem => ({
+                          label: panelView.title,
+                          id: panelView.id,
+                          priority: panelView.priority,
+                          element: <PanelView {...this.props} panelView={panelView} />,
+                      })
                   )
                   .sort(byPriority)
             : []
@@ -114,12 +102,10 @@ export class Panel extends React.PureComponent<Props, State> {
                         }
                         toolbarFragment={
                             <ActionsNavItems
+                                {...this.props}
                                 listClass="w-100 justify-content-end"
                                 actionItemClass="nav-link"
                                 menu={ContributableMenu.PanelToolbar}
-                                extensionsController={this.props.extensionsController}
-                                platformContext={this.props.platformContext}
-                                location={this.props.location}
                                 scope={
                                     activePanelViewID !== undefined
                                         ? {

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -124,13 +124,8 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
             </ErrorBoundary>
             {parseHash(props.location.hash).viewState && props.location.pathname !== '/sign-in' && (
                 <ResizablePanel
+                    {...props}
                     repoName={`git://${parseBrowserRepoURL(props.location.pathname).repoName}`}
-                    history={props.history}
-                    location={props.location}
-                    extensionsController={props.extensionsController}
-                    platformContext={props.platformContext}
-                    settingsCascade={props.settingsCascade}
-                    isLightTheme={props.isLightTheme}
                     fetchHighlightedFileLines={fetchHighlightedFileLines}
                 />
             )}

--- a/web/src/components/SearchResult.tsx
+++ b/web/src/components/SearchResult.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { ResultContainer } from '../../../shared/src/components/ResultContainer'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
+import { ThemeProps } from '../theme'
 import { SearchResultMatch } from './SearchResultMatch'
 
 export interface HighlightRange {
@@ -21,9 +22,8 @@ export interface HighlightRange {
     length: number
 }
 
-interface Props {
+interface Props extends ThemeProps {
     result: GQL.GenericSearchResultInterface
-    isLightTheme: boolean
 }
 
 export class SearchResult extends React.Component<Props> {

--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -13,12 +13,12 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { highlightNode } from '../../../shared/src/util/dom'
 import { renderMarkdown } from '../discussions/backend'
 import { highlightCode } from '../search/backend'
+import { ThemeProps } from '../theme'
 import { HighlightRange } from './SearchResult'
 
-interface SearchResultMatchProps {
+interface SearchResultMatchProps extends ThemeProps {
     item: GQL.ISearchResultMatch
     highlightRanges: HighlightRange[]
-    isLightTheme: boolean
 }
 
 interface SearchResultMatchState {

--- a/web/src/components/d3/BarChart.tsx
+++ b/web/src/components/d3/BarChart.tsx
@@ -4,6 +4,7 @@ import { select, Selection } from 'd3-selection'
 import { stack } from 'd3-shape'
 import { isEqual } from 'lodash'
 import * as React from 'react'
+import { ThemeProps } from '../../theme'
 
 interface BarChartSeries {
     [key: string]: null
@@ -14,7 +15,7 @@ interface BarChartDatum<T extends BarChartSeries> {
     yValues: { [key in keyof T]: number }
 }
 
-interface Props<T extends BarChartSeries> {
+interface Props<T extends BarChartSeries> extends ThemeProps {
     /**
      * Bar chart data.
      * One datum for each column, with each datum containing values for each series in the given column.
@@ -37,7 +38,6 @@ interface Props<T extends BarChartSeries> {
      */
     showLegend?: boolean
     className?: string
-    isLightTheme: boolean
 }
 
 export class BarChart<T extends BarChartSeries> extends React.Component<Props<T>> {

--- a/web/src/enterprise/dotcom/welcome/WelcomeArea.tsx
+++ b/web/src/enterprise/dotcom/welcome/WelcomeArea.tsx
@@ -10,6 +10,7 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { ErrorBoundary } from '../../../components/ErrorBoundary'
 import { HeroPage } from '../../../components/HeroPage'
+import { ThemeProps } from '../../../theme'
 import { RouteDescriptor } from '../../../util/contributions'
 import { WelcomeAreaFooter } from './WelcomeAreaFooter'
 
@@ -17,9 +18,12 @@ const NotFoundPage = () => <HeroPage icon={MapSearchIcon} title="404: Not Found"
 
 export interface WelcomeAreaRoute extends RouteDescriptor<WelcomeAreaRouteContext> {}
 
-export interface WelcomeAreaProps extends ExtensionsControllerProps, PlatformContextProps, RouteComponentProps<{}> {
+export interface WelcomeAreaProps
+    extends ExtensionsControllerProps,
+        PlatformContextProps,
+        ThemeProps,
+        RouteComponentProps<{}> {
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
     routes: ReadonlyArray<WelcomeAreaRoute>
     location: H.Location
     history: H.History

--- a/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
+++ b/web/src/enterprise/dotcom/welcome/WelcomeAreaFooter.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import { ThemeProps } from '../../../theme'
 
-export const WelcomeAreaFooter: React.FunctionComponent<{ isLightTheme: boolean }> = ({ isLightTheme }) => (
+export const WelcomeAreaFooter: React.FunctionComponent<ThemeProps> = ({ isLightTheme }) => (
     <>
         <div className="row mt-5 pt-4 border-top">
             <div className="col-sm-4 col-m-4 col-lg-4">

--- a/web/src/enterprise/dotcom/welcome/WelcomeMainPage.tsx
+++ b/web/src/enterprise/dotcom/welcome/WelcomeMainPage.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
+import { ThemeProps } from '../../../theme'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { WelcomeMainPageDemos } from './WelcomeMainPageDemos'
 import { WelcomeMainPageLogos } from './WelcomeMainPageLogos'
@@ -14,9 +15,8 @@ import { WelcomeMainPageLogos } from './WelcomeMainPageLogos'
 //
 // tslint:disable:jsx-no-lambda
 
-interface Props extends ExtensionsControllerProps, PlatformContextProps {
+interface Props extends ExtensionsControllerProps, PlatformContextProps, ThemeProps {
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
     location: H.Location
     history: H.History
 }

--- a/web/src/enterprise/dotcom/welcome/WelcomeMainPageLogos.tsx
+++ b/web/src/enterprise/dotcom/welcome/WelcomeMainPageLogos.tsx
@@ -1,10 +1,11 @@
 import { shuffle } from 'lodash'
 import React from 'react'
+import { ThemeProps } from '../../../theme'
 import { Logo1, Logo2, Logo3 } from './logos'
 
 // Shuffle logos because we love all of them infinitely. :)
 const LOGOS: {
-    component: React.ComponentType<{ className: string; isLightTheme: boolean }>
+    component: React.ComponentType<{ className: string } & ThemeProps>
     className: string
 }[] = shuffle([
     {
@@ -24,7 +25,7 @@ const LOGOS: {
 /**
  * The logos for the welcome main page.
  */
-export const WelcomeMainPageLogos: React.FunctionComponent<{ isLightTheme: boolean }> = ({ isLightTheme }) => (
+export const WelcomeMainPageLogos: React.FunctionComponent<ThemeProps> = ({ isLightTheme }) => (
     <>
         {LOGOS.map(({ component: C, className }, i) => (
             <C key={i} className={`welcome-main-page-logos__logo ${className}`} isLightTheme={isLightTheme} />

--- a/web/src/enterprise/dotcom/welcome/logos.tsx
+++ b/web/src/enterprise/dotcom/welcome/logos.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
+import { ThemeProps } from '../../../theme'
 
-interface Props {
-    isLightTheme: boolean
+interface Props extends ThemeProps {
     className: string
 }
 

--- a/web/src/enterprise/user/productSubscriptions/NewProductSubscriptionPageOrRedirectUser.tsx
+++ b/web/src/enterprise/user/productSubscriptions/NewProductSubscriptionPageOrRedirectUser.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { RouteComponentProps } from 'react-router'
 import * as GQL from '../../../../../shared/src/graphql/schema'
+import { ThemeProps } from '../../../theme'
 import { RedirectToUserPage } from '../../../user/account/RedirectToUserPage'
 import { UserSubscriptionsNewProductSubscriptionPage } from './UserSubscriptionsNewProductSubscriptionPage'
 
-interface Props extends RouteComponentProps<{}> {
+interface Props extends RouteComponentProps<{}>, ThemeProps {
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
 }
 
 /**

--- a/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.tsx
+++ b/web/src/enterprise/user/productSubscriptions/PaymentTokenFormControl.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { CardElement, ReactStripeElements } from 'react-stripe-elements'
+import { ThemeProps } from '../../../theme'
 
-interface Props {
+interface Props extends ThemeProps {
     disabled?: boolean
-    isLightTheme: boolean
 }
 
 interface State {}

--- a/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { isEqual } from 'lodash'
 import { upperFirst } from 'lodash'
+import { isEqual } from 'lodash'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { ReactStripeElements } from 'react-stripe-elements'
@@ -9,6 +9,7 @@ import { catchError, map, startWith, switchMap } from 'rxjs/operators'
 import * as GQL from '../../../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
 import { Form } from '../../../components/Form'
+import { ThemeProps } from '../../../theme'
 import { StripeWrapper } from '../../dotcom/billing/StripeWrapper'
 import { ProductPlanFormControl } from '../../dotcom/productPlans/ProductPlanFormControl'
 import { ProductSubscriptionUserCountFormControl } from '../../dotcom/productPlans/ProductSubscriptionUserCountFormControl'
@@ -29,7 +30,7 @@ export interface ProductSubscriptionFormData {
 
 const LOADING: 'loading' = 'loading'
 
-interface Props {
+interface Props extends ThemeProps {
     /**
      * The ID of the account associated with the subscription, or null if there is none (in which case this form
      * can only be used to price out a subscription, not to buy).
@@ -41,8 +42,6 @@ interface Props {
      * or null if this is a new subscription.
      */
     subscriptionID: GQL.ID | null
-
-    isLightTheme: boolean
 
     /** Called when the user submits the form (to buy or update the subscription). */
     onSubmit: (args: ProductSubscriptionFormData) => void

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -20,12 +20,12 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
 import { mutateGraphQL, queryGraphQL } from '../../../backend/graphql'
 import { PageTitle } from '../../../components/PageTitle'
+import { ThemeProps } from '../../../theme'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { ProductSubscriptionForm, ProductSubscriptionFormData } from './ProductSubscriptionForm'
 
-interface Props extends RouteComponentProps<{ subscriptionUUID: string }> {
+interface Props extends RouteComponentProps<{ subscriptionUUID: string }>, ThemeProps {
     user: GQL.IUser
-    isLightTheme: boolean
 }
 
 const LOADING: 'loading' = 'loading'

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsNewProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsNewProductSubscriptionPage.tsx
@@ -11,18 +11,17 @@ import { asError, createAggregateError, ErrorLike } from '../../../../../shared/
 import { mutateGraphQL } from '../../../backend/graphql'
 import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
+import { ThemeProps } from '../../../theme'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { BackToAllSubscriptionsLink } from './BackToAllSubscriptionsLink'
 import { ProductSubscriptionForm, ProductSubscriptionFormData } from './ProductSubscriptionForm'
 
-interface Props extends RouteComponentProps<{}> {
+interface Props extends RouteComponentProps<{}>, ThemeProps {
     /**
      * The user who will own the new subscrption when created, or null when there is no authenticated user and this
      * page is accessed at /user/subscriptions/new.
      */
     user: GQL.IUser | null
-
-    isLightTheme: boolean
 }
 
 const LOADING: 'loading' = 'loading'

--- a/web/src/explore/ExploreArea.tsx
+++ b/web/src/explore/ExploreArea.tsx
@@ -4,13 +4,14 @@ import { Subject, Subscription } from 'rxjs'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { SettingsCascadeOrError } from '../../../shared/src/settings/settings'
+import { ThemeProps } from '../theme'
 import { eventLogger } from '../tracking/eventLogger'
 import { ComponentDescriptor } from '../util/contributions'
 
 /**
  * Properties passed to all section components in the explore area.
  */
-export interface ExploreAreaSectionContext extends ExtensionsControllerProps {
+export interface ExploreAreaSectionContext extends ExtensionsControllerProps, ThemeProps {
     /** The currently authenticated user. */
     authenticatedUser: GQL.IUser | null
 
@@ -20,7 +21,6 @@ export interface ExploreAreaSectionContext extends ExtensionsControllerProps {
     /** The viewer's settings. */
     settingsCascade: SettingsCascadeOrError
 
-    isLightTheme: boolean
     location: H.Location
     history: H.History
 }

--- a/web/src/extensions/ExtensionsArea.tsx
+++ b/web/src/extensions/ExtensionsArea.tsx
@@ -6,6 +6,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { HeroPage } from '../components/HeroPage'
+import { ThemeProps } from '../theme'
 import { RouteDescriptor } from '../util/contributions'
 import { ExtensionAreaRoute } from './extension/ExtensionArea'
 import { ExtensionAreaHeaderNavItem } from './extension/ExtensionAreaHeader'
@@ -18,13 +19,12 @@ export interface ExtensionsAreaRoute extends RouteDescriptor<ExtensionsAreaRoute
 /**
  * Properties passed to all page components in the extensions area.
  */
-export interface ExtensionsAreaRouteContext extends SettingsCascadeProps, PlatformContextProps {
+export interface ExtensionsAreaRouteContext extends SettingsCascadeProps, PlatformContextProps, ThemeProps {
     /** The currently authenticated user. */
     authenticatedUser: GQL.IUser | null
 
     /** The subject whose extensions and configuration to display. */
     subject: Pick<GQL.ISettingsSubject, 'id' | 'viewerCanAdminister'>
-    isLightTheme: boolean
     extensionAreaRoutes: ReadonlyArray<ExtensionAreaRoute>
     extensionAreaHeaderNavItems: ReadonlyArray<ExtensionAreaHeaderNavItem>
 }
@@ -32,7 +32,8 @@ export interface ExtensionsAreaRouteContext extends SettingsCascadeProps, Platfo
 interface ExtensionsAreaProps
     extends RouteComponentProps<{ extensionID: string }>,
         SettingsCascadeProps,
-        PlatformContextProps {
+        PlatformContextProps,
+        ThemeProps {
     routes: ReadonlyArray<ExtensionsAreaRoute>
 
     /**
@@ -41,7 +42,6 @@ interface ExtensionsAreaProps
     authenticatedUser: GQL.IUser | null
 
     viewerSubject: Pick<GQL.ISettingsSubject, 'id' | 'viewerCanAdminister'>
-    isLightTheme: boolean
     extensionAreaRoutes: ReadonlyArray<ExtensionAreaRoute>
     extensionsAreaHeaderActionButtons: ReadonlyArray<ExtensionsAreaHeaderActionButton>
     extensionAreaHeaderNavItems: ReadonlyArray<ExtensionAreaHeaderNavItem>

--- a/web/src/extensions/extension/ExtensionArea.tsx
+++ b/web/src/extensions/extension/ExtensionArea.tsx
@@ -16,6 +16,7 @@ import { createAggregateError } from '../../../../shared/src/util/errors'
 import { queryGraphQL } from '../../backend/graphql'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
+import { ThemeProps } from '../../theme'
 import { RouteDescriptor } from '../../util/contributions'
 import { ExtensionsAreaRouteContext } from '../ExtensionsArea'
 import { ExtensionAreaHeader, ExtensionAreaHeaderNavItem } from './ExtensionAreaHeader'
@@ -61,9 +62,11 @@ const NotFoundPage = () => <HeroPage icon={MapSearchIcon} title="404: Not Found"
 
 export interface ExtensionAreaRoute extends RouteDescriptor<ExtensionAreaRouteContext> {}
 
-export interface ExtensionAreaProps extends ExtensionsAreaRouteContext, RouteComponentProps<{ extensionID: string }> {
+export interface ExtensionAreaProps
+    extends ExtensionsAreaRouteContext,
+        RouteComponentProps<{ extensionID: string }>,
+        ThemeProps {
     routes: ReadonlyArray<ExtensionAreaRoute>
-    isLightTheme: boolean
     extensionAreaHeaderNavItems: ReadonlyArray<ExtensionAreaHeaderNavItem>
 }
 
@@ -75,7 +78,7 @@ interface ExtensionAreaState {
 /**
  * Properties passed to all page components in the registry extension area.
  */
-export interface ExtensionAreaRouteContext extends SettingsCascadeProps, PlatformContextProps {
+export interface ExtensionAreaRouteContext extends SettingsCascadeProps, PlatformContextProps, ThemeProps {
     /** The extension registry area main URL. */
     url: string
 
@@ -86,7 +89,6 @@ export interface ExtensionAreaRouteContext extends SettingsCascadeProps, Platfor
 
     /** The currently authenticated user. */
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
 }
 
 /**

--- a/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
@@ -4,13 +4,12 @@ import { ContributableMenu } from '../../../../shared/src/api/protocol'
 import { ExtensionManifest } from '../../../../shared/src/schema/extension.schema'
 import { asError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { PageTitle } from '../../components/PageTitle'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionNoManifestAlert } from './RegistryExtensionManifestPage'
 
-interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}> {
-    isLightTheme: boolean
-}
+interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}>, ThemeProps {}
 
 interface ContributionGroup {
     title: string

--- a/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
@@ -7,9 +7,9 @@ import { ConfiguredRegistryExtension } from '../../../../shared/src/extensions/e
 import extensionSchemaJSON from '../../../../shared/src/schema/extension.schema.json'
 import { PageTitle } from '../../components/PageTitle'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../settings/DynamicallyImportedMonacoSettingsEditor'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
-
 export const ExtensionNoManifestAlert: React.FunctionComponent<{
     extension: ConfiguredRegistryExtension
 }> = ({ extension }) => (
@@ -26,9 +26,7 @@ export const ExtensionNoManifestAlert: React.FunctionComponent<{
     </div>
 )
 
-interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}> {
-    isLightTheme: boolean
-}
+interface Props extends ExtensionAreaRouteContext, RouteComponentProps<{}>, ThemeProps {}
 
 interface State {
     viewMode: ViewMode

--- a/web/src/marketing/SurveyPage.tsx
+++ b/web/src/marketing/SurveyPage.tsx
@@ -8,10 +8,10 @@ import { FeedbackText } from '../components/FeedbackText'
 import { Form } from '../components/Form'
 import { HeroPage } from '../components/HeroPage'
 import { PageTitle } from '../components/PageTitle'
+import { ThemeProps } from '../theme'
 import { eventLogger } from '../tracking/eventLogger'
 import { submitSurvey } from './backend'
 import { SurveyCTA } from './SurveyToast'
-
 interface SurveyFormProps {
     location: H.Location
     history: H.History
@@ -160,8 +160,7 @@ class SurveyForm extends React.Component<SurveyFormProps, SurveyFormState> {
     }
 }
 
-interface SurveyPageProps extends RouteComponentProps<{ score?: string }> {
-    isLightTheme: boolean
+interface SurveyPageProps extends RouteComponentProps<{ score?: string }>, ThemeProps {
     authenticatedUser: GQL.IUser | null
 }
 

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -58,13 +58,7 @@ export class NavLinks extends React.PureComponent<Props> {
                         </a>
                     </li>
                 )}
-                <ActionsNavItems
-                    menu={ContributableMenu.GlobalNav}
-                    actionItemClass="nav-link"
-                    extensionsController={this.props.extensionsController}
-                    platformContext={this.props.platformContext}
-                    location={this.props.location}
-                />
+                <ActionsNavItems {...this.props} menu={ContributableMenu.GlobalNav} actionItemClass="nav-link" />
                 {(!this.props.showDotComMarketing ||
                     !!this.props.authenticatedUser ||
                     this.props.location.pathname !== '/welcome') && (
@@ -108,11 +102,9 @@ export class NavLinks extends React.PureComponent<Props> {
                 )}
                 {this.props.location.pathname !== '/welcome' && (
                     <CommandListPopoverButton
+                        {...this.props}
                         menu={ContributableMenu.CommandPalette}
-                        extensionsController={this.props.extensionsController}
-                        platformContext={this.props.platformContext}
                         toggleVisibilityKeybinding={this.props.keybindings.commandPalette}
-                        location={this.props.location}
                     />
                 )}
                 {this.props.authenticatedUser && (

--- a/web/src/org/OrgsArea.tsx
+++ b/web/src/org/OrgsArea.tsx
@@ -5,6 +5,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { HeroPage } from '../components/HeroPage'
+import { ThemeProps } from '../theme'
 import { OrgArea } from './area/OrgArea'
 import { NewOrganizationPage } from './new/NewOrganizationPage'
 
@@ -16,9 +17,8 @@ const NotFoundPage = () => (
     />
 )
 
-interface Props extends RouteComponentProps<any>, PlatformContextProps, SettingsCascadeProps {
+interface Props extends RouteComponentProps<any>, PlatformContextProps, SettingsCascadeProps, ThemeProps {
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
 }
 
 /**

--- a/web/src/org/account/OrgAccountArea.tsx
+++ b/web/src/org/account/OrgAccountArea.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
+import { ThemeProps } from '../../theme'
 import { OrgAreaPageProps } from '../area/OrgArea'
 import { OrgAccountProfilePage } from './OrgAccountProfilePage'
 import { OrgAccountSidebar } from './OrgAccountSidebar'
@@ -17,9 +18,8 @@ const NotFoundPage = () => (
     />
 )
 
-interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {
+interface Props extends OrgAreaPageProps, RouteComponentProps<{}>, ThemeProps {
     location: H.Location
-    isLightTheme: boolean
 }
 
 /**

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -16,6 +16,7 @@ import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { SettingsArea } from '../../settings/SettingsArea'
 import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
+import { ThemeProps } from '../../theme'
 import { OrgAccountArea } from '../account/OrgAccountArea'
 import { OrgHeader } from './OrgHeader'
 import { OrgInvitationPage } from './OrgInvitationPage'
@@ -64,13 +65,11 @@ const NotFoundPage = () => (
     <HeroPage icon={MapSearchIcon} title="404: Not Found" subtitle="Sorry, the requested organization was not found." />
 )
 
-interface Props extends RouteComponentProps<{ name: string }>, PlatformContextProps, SettingsCascadeProps {
+interface Props extends RouteComponentProps<{ name: string }>, PlatformContextProps, SettingsCascadeProps, ThemeProps {
     /**
      * The currently authenticated user.
      */
     authenticatedUser: GQL.IUser | null
-
-    isLightTheme: boolean
 }
 
 interface State {

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -16,6 +16,7 @@ import { ErrorBoundary } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { searchQueryForRepoRev } from '../search'
 import { queryUpdates } from '../search/input/QueryInput'
+import { ThemeProps } from '../theme'
 import { parseBrowserRepoURL, ParsedRepoRev, parseRepoRev } from '../util/url'
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
 import { EREPONOTFOUND, EREPOSEEOTHER, fetchRepository, RepoSeeOtherError, ResolvedRev } from './backend'
@@ -39,11 +40,11 @@ export interface RepoContainerProps
     extends RouteComponentProps<{ repoRevAndRest: string }>,
         SettingsCascadeProps,
         PlatformContextProps,
-        ExtensionsControllerProps {
+        ExtensionsControllerProps,
+        ThemeProps {
     repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute>
     repoHeaderActionButtons: ReadonlyArray<RepoHeaderActionButton>
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
 }
 
 interface RepoRevContainerState extends ParsedRepoRev {

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -15,6 +15,7 @@ import { PopoverButton } from '../components/PopoverButton'
 import { ChromeExtensionToast } from '../marketing/BrowserExtensionToast'
 import { SurveyToast } from '../marketing/SurveyToast'
 import { IS_CHROME } from '../marketing/util'
+import { ThemeProps } from '../theme'
 import { RouteDescriptor } from '../util/contributions'
 import { CopyLinkAction } from './actions/CopyLinkAction'
 import { GoToPermalinkAction } from './actions/GoToPermalinkAction'
@@ -28,12 +29,12 @@ export interface RepoRevContainerContext
     extends RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
         ExtensionsControllerProps,
-        PlatformContextProps {
+        PlatformContextProps,
+        ThemeProps {
     repo: GQL.IRepository
     rev: string
     authenticatedUser: GQL.IUser | null
     resolvedRev: ResolvedRev
-    isLightTheme: boolean
     routePrefix: string
 }
 
@@ -44,12 +45,12 @@ interface RepoRevContainerProps
         RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
         PlatformContextProps,
-        ExtensionsControllerProps {
+        ExtensionsControllerProps,
+        ThemeProps {
     routes: ReadonlyArray<RepoRevContainerRoute>
     repo: GQL.IRepository
     rev: string
     authenticatedUser: GQL.IUser | null
-    isLightTheme: boolean
     routePrefix: string
 
     /**

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -33,6 +33,7 @@ import { searchQueryForRepoRev } from '../search'
 import { submitSearch } from '../search/helpers'
 import { QueryInput } from '../search/input/QueryInput'
 import { SearchButton } from '../search/input/SearchButton'
+import { ThemeProps } from '../theme'
 import { eventLogger } from '../tracking/eventLogger'
 import { basename } from '../util/path'
 import { fetchTree } from './backend'
@@ -119,16 +120,14 @@ const fetchTreeCommits = memoizeObservable(
     args => `${args.repo}:${args.revspec}:${args.first}:${args.filePath}`
 )
 
-interface Props extends SettingsCascadeProps, ExtensionsControllerProps, PlatformContextProps {
+interface Props extends SettingsCascadeProps, ExtensionsControllerProps, PlatformContextProps, ThemeProps {
     repoName: string
     repoID: GQL.ID
     repoDescription: string
-    // filePath is the tree's path in TreePage. We call it filePath for consistency elsewhere.
+    /** The tree's path in TreePage. We call it filePath for consistency elsewhere. */
     filePath: string
     commitID: string
     rev: string
-    isLightTheme: boolean
-
     location: H.Location
     history: H.History
 }
@@ -273,12 +272,11 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 </h3>
                                 <Form className="tree-page__section-search" onSubmit={this.onSubmit}>
                                     <QueryInput
+                                        {...this.props}
                                         value={this.state.query}
                                         onChange={this.onQueryChange}
                                         prependQueryForSuggestions={this.getQueryPrefix()}
                                         autoFocus={true}
-                                        location={this.props.location}
-                                        history={this.props.history}
                                         placeholder=""
                                     />
                                     <SearchButton />
@@ -293,11 +291,8 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 <div className="tree-page__section mt-2 tree-page__section--discussions">
                                     <h3 className="tree-page__section-header">Discussions</h3>
                                     <DiscussionsList
-                                        repoID={this.props.repoID}
-                                        rev={this.props.rev}
+                                        {...this.props}
                                         filePath={this.props.filePath + '/**' || undefined}
-                                        history={this.props.history}
-                                        location={this.props.location}
                                         noun="discussion in this tree"
                                         pluralNoun="discussions in this tree"
                                         defaultFirst={2}
@@ -306,6 +301,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 </div>
                             )}
                             <ActionsContainer
+                                {...this.props}
                                 menu={ContributableMenu.DirectoryPage}
                                 // tslint:disable-next-line:jsx-no-lambda
                                 render={items => (
@@ -313,20 +309,15 @@ export class TreePage extends React.PureComponent<Props, State> {
                                         <h3 className="tree-page__section-header">Actions</h3>
                                         {items.map((item, i) => (
                                             <ActionItem
+                                                {...this.props}
                                                 key={i}
                                                 {...item}
                                                 className="btn btn-secondary mr-1 mb-1"
-                                                extensionsController={this.props.extensionsController}
-                                                platformContext={this.props.platformContext}
-                                                location={this.props.location}
                                             />
                                         ))}
                                     </section>
                                 )}
                                 empty={null}
-                                extensionsController={this.props.extensionsController}
-                                platformContext={this.props.platformContext}
-                                location={this.props.location}
                             />
                             <div className="tree-page__section">
                                 <h3 className="tree-page__section-header">Changes</h3>
@@ -334,6 +325,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                                     GQL.IGitCommit,
                                     Pick<GitCommitNodeProps, 'repoName' | 'className' | 'compact'>
                                 >
+                                    {...this.props}
                                     className="mt-2 tree-page__section--commits"
                                     listClassName="list-group list-group-flush"
                                     noun="commit in this tree"
@@ -347,10 +339,8 @@ export class TreePage extends React.PureComponent<Props, State> {
                                     }}
                                     updateOnChange={`${this.props.repoName}:${this.props.rev}:${this.props.filePath}`}
                                     defaultFirst={7}
-                                    history={this.props.history}
                                     shouldUpdateURLQuery={false}
                                     hideSearch={true}
-                                    location={this.props.location}
                                 />
                             </div>
                         </>

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../../../shared/src/util/url'
 import { getHover } from '../../backend/features'
 import { isDiscussionsEnabled } from '../../discussions'
+import { ThemeProps } from '../../theme'
 import { DiscussionsGutterOverlay } from './discussions/DiscussionsGutterOverlay'
 import { LineDecorationAttachment } from './LineDecorationAttachment'
 
@@ -45,7 +46,8 @@ interface BlobProps
         ModeSpec,
         SettingsCascadeProps,
         PlatformContextProps,
-        ExtensionsControllerProps {
+        ExtensionsControllerProps,
+        ThemeProps {
     /** The raw content of the blob. */
     content: string
 
@@ -57,7 +59,6 @@ interface BlobProps
     className: string
     wrapCode: boolean
     renderMode: RenderMode
-    isLightTheme: boolean
 }
 
 interface BlobState extends HoverState<HoverContext, HoverMerged, ActionItemProps> {

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -23,6 +23,7 @@ import { queryGraphQL } from '../../backend/graphql'
 import { HeroPage } from '../../components/HeroPage'
 import { PageTitle } from '../../components/PageTitle'
 import { isDiscussionsEnabled } from '../../discussions'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
 import { RepoHeaderContributionPortal } from '../RepoHeaderContributionPortal'
@@ -93,10 +94,10 @@ interface Props
         RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
         PlatformContextProps,
-        ExtensionsControllerProps {
+        ExtensionsControllerProps,
+        ThemeProps {
     location: H.Location
     history: H.History
-    isLightTheme: boolean
     repoID: GQL.ID
     authenticatedUser: GQL.IUser | null
 }
@@ -277,22 +278,12 @@ export class BlobPage extends React.PureComponent<Props, State> {
                 )}
                 {renderMode === 'code' && !this.state.blobOrError.highlight.aborted && (
                     <Blob
+                        {...this.props}
                         className="blob-page__blob"
-                        repoName={this.props.repoName}
-                        commitID={this.props.commitID}
-                        filePath={this.props.filePath}
                         content={this.state.blobOrError.content}
                         html={this.state.blobOrError.highlight.html}
-                        rev={this.props.rev}
-                        mode={this.props.mode}
-                        settingsCascade={this.props.settingsCascade}
-                        platformContext={this.props.platformContext}
-                        extensionsController={this.props.extensionsController}
                         wrapCode={this.state.wrapCode}
                         renderMode={renderMode}
-                        location={this.props.location}
-                        history={this.props.history}
-                        isLightTheme={this.props.isLightTheme}
                     />
                 )}
                 {!this.state.blobOrError.richHTML && this.state.blobOrError.highlight.aborted && (
@@ -307,17 +298,11 @@ export class BlobPage extends React.PureComponent<Props, State> {
                 )}
                 <BlobPanel
                     {...this.props}
-                    repoID={this.props.repoID}
-                    repoName={this.props.repoName}
-                    commitID={this.props.commitID}
-                    platformContext={this.props.platformContext}
-                    extensionsController={this.props.extensionsController}
                     position={
                         lprToRange(parseHash(this.props.location.hash))
                             ? lprToRange(parseHash(this.props.location.hash))!.start
                             : undefined
                     }
-                    repoHeaderContributionsLifecycleProps={this.props.repoHeaderContributionsLifecycleProps}
                 />
             </>
         )

--- a/web/src/repo/blob/LineDecorationAttachment.tsx
+++ b/web/src/repo/blob/LineDecorationAttachment.tsx
@@ -4,12 +4,12 @@ import { DecorationAttachmentRenderOptions } from 'sourcegraph'
 import { decorationAttachmentStyleForTheme } from '../../../../shared/src/api/client/services/decoration'
 import { LinkOrSpan } from '../../../../shared/src/components/LinkOrSpan'
 import { AbsoluteRepoFile } from '../../../../shared/src/util/url'
+import { ThemeProps } from '../../theme'
 
-interface LineDecorationAttachmentProps extends AbsoluteRepoFile {
+interface LineDecorationAttachmentProps extends AbsoluteRepoFile, ThemeProps {
     line: number
     portalID: string
     attachment: DecorationAttachmentRenderOptions
-    isLightTheme: boolean
 }
 
 /** Displays text after a line in Blob. */

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -17,10 +17,10 @@ import { PlatformContextProps } from '../../../../../shared/src/platform/context
 import { SettingsCascadeProps } from '../../../../../shared/src/settings/settings'
 import { AbsoluteRepoFile, ModeSpec, parseHash, PositionSpec } from '../../../../../shared/src/util/url'
 import { isDiscussionsEnabled } from '../../../discussions'
+import { ThemeProps } from '../../../theme'
 import { RepoHeaderContributionsLifecycleProps } from '../../RepoHeader'
 import { RepoRevSidebarCommits } from '../../RepoRevSidebarCommits'
 import { DiscussionsTree } from '../discussions/DiscussionsTree'
-
 interface Props
     extends AbsoluteRepoFile,
         Partial<PositionSpec>,
@@ -28,13 +28,13 @@ interface Props
         RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
         PlatformContextProps,
-        ExtensionsControllerProps {
+        ExtensionsControllerProps,
+        ThemeProps {
     location: H.Location
     history: H.History
     repoID: GQL.ID
     repoName: string
     commitID: string
-    isLightTheme: boolean
     authenticatedUser: GQL.IUser | null
 }
 

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -13,6 +13,7 @@ import { isErrorLike } from '../../../../shared/src/util/errors'
 import { PageTitle } from '../../components/PageTitle'
 import { fetchHighlightedFileLines } from '../../repo/backend'
 import { Settings } from '../../schema/settings.schema'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { search } from '../backend'
 import { FilterChip } from '../FilterChip'
@@ -22,11 +23,10 @@ import { SearchResultsList } from './SearchResultsList'
 
 const UI_PAGE_SIZE = 75
 
-interface SearchResultsProps extends ExtensionsControllerProps, SettingsCascadeProps, PlatformContextProps {
+interface SearchResultsProps extends ExtensionsControllerProps, SettingsCascadeProps, PlatformContextProps, ThemeProps {
     authenticatedUser: GQL.IUser | null
     location: H.Location
     history: H.History
-    isLightTheme: boolean
     navbarSearchQuery: string
 }
 

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -22,14 +22,14 @@ import { isDefined } from '../../../../shared/src/util/types'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { ModalContainer } from '../../components/ModalContainer'
 import { SearchResult } from '../../components/SearchResult'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { SavedQueryCreateForm } from '../saved-queries/SavedQueryCreateForm'
 import { SearchResultsInfoBar } from './SearchResultsInfoBar'
 
 const isSearchResults = (val: any): val is GQL.ISearchResults => val && val.__typename === 'SearchResults'
 
-interface SearchResultsListProps extends SettingsCascadeProps {
-    isLightTheme: boolean
+interface SearchResultsListProps extends SettingsCascadeProps, ThemeProps {
     location: H.Location
     history: H.History
     authenticatedUser: GQL.IUser | null

--- a/web/src/search/saved-queries/SavedQueries.tsx
+++ b/web/src/search/saved-queries/SavedQueries.tsx
@@ -11,6 +11,7 @@ import { map, startWith, switchMap } from 'rxjs/operators'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { siteFlags } from '../../site/backend'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { fetchSavedQueries } from '../backend'
 import { ExampleSearches } from './ExampleSearches'
@@ -18,10 +19,9 @@ import { SavedQuery } from './SavedQuery'
 import { SavedQueryCreateForm } from './SavedQueryCreateForm'
 import { SavedQueryFields } from './SavedQueryForm'
 
-interface Props extends SettingsCascadeProps {
+interface Props extends SettingsCascadeProps, ThemeProps {
     authenticatedUser: GQL.IUser | null
     location: H.Location
-    isLightTheme: boolean
     hideExampleSearches?: boolean
     hideTitle?: boolean
 }

--- a/web/src/search/saved-queries/SavedQuery.tsx
+++ b/web/src/search/saved-queries/SavedQuery.tsx
@@ -7,18 +7,17 @@ import { mapTo, startWith, switchMap, withLatestFrom } from 'rxjs/operators'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { getLastIDForSubject } from '../../settings/configuration'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { createSavedQuery, deleteSavedQuery } from '../backend'
 import { SavedQueryRow } from './SavedQueryRow'
 import { SavedQueryUpdateForm } from './SavedQueryUpdateForm'
-
-interface Props extends SettingsCascadeProps {
+interface Props extends SettingsCascadeProps, ThemeProps {
     authenticatedUser: GQL.IUser | null
     savedQuery: GQL.ISavedQuery
     onDidUpdate?: () => void
     onDidDuplicate?: () => void
     onDidDelete?: () => void
-    isLightTheme: boolean
 }
 
 interface State {

--- a/web/src/search/saved-queries/SavedQueryRow.tsx
+++ b/web/src/search/saved-queries/SavedQueryRow.tsx
@@ -5,11 +5,12 @@ import { Link } from 'react-router-dom'
 import { Subject, Subscription } from 'rxjs'
 import { debounceTime, map, startWith, switchMap, withLatestFrom } from 'rxjs/operators'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
+import { ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { fetchSearchResultStats } from '../backend'
 import { Sparkline } from './Sparkline'
 
-interface Props {
+interface Props extends ThemeProps {
     query: string
     description: string
 
@@ -17,7 +18,6 @@ interface Props {
     form?: React.ReactNode
 
     className?: string
-    isLightTheme: boolean
 
     /**
      * The event logged when a user clicks on the link (e.g. 'SavedQueryClick' or 'ExampleSearchClick')

--- a/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs'
 import { SaveToolbar } from '../components/SaveToolbar'
 import * as _monacoSettingsEditorModule from '../settings/MonacoSettingsEditor' // type only
 import { EditorAction } from '../site-admin/configHelpers'
+import { ThemeProps } from '../theme'
 
 /**
  * Converts a Monaco/vscode style Disposable object to a simple function that can be added to a rxjs Subscription
@@ -13,7 +14,8 @@ import { EditorAction } from '../site-admin/configHelpers'
 const disposableToFn = (disposable: _monaco.IDisposable) => () => disposable.dispose()
 
 interface Props
-    extends Pick<_monacoSettingsEditorModule.Props, 'id' | 'readOnly' | 'height' | 'jsonSchema' | 'isLightTheme'> {
+    extends Pick<_monacoSettingsEditorModule.Props, 'id' | 'readOnly' | 'height' | 'jsonSchema'>,
+        ThemeProps {
     value: string
 
     actions?: EditorAction[]
@@ -26,9 +28,6 @@ interface Props
     onSave?: (value: string) => void
     onChange?: (value: string) => void
     onDirtyChange?: (dirty: boolean) => void
-
-    isLightTheme: boolean
-
     history: H.History
 }
 

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -6,6 +6,7 @@ import { distinctUntilChanged, distinctUntilKeyChanged, map, startWith } from 'r
 import jsonSchemaMetaSchema from '../../../schema/json-schema-draft-07.schema.json'
 import settingsSchema from '../../../schema/settings.schema.json'
 import { BuiltinTheme, MonacoEditor } from '../components/MonacoEditor'
+import { ThemeProps } from '../theme'
 import { eventLogger } from '../tracking/eventLogger'
 
 const isLightThemeToMonacoTheme = (isLightTheme: boolean): BuiltinTheme => (isLightTheme ? 'vs' : 'sourcegraph-dark')
@@ -18,7 +19,7 @@ interface JSONSchema {
     $id: string
 }
 
-export interface Props {
+export interface Props extends ThemeProps {
     id?: string
     value: string | undefined
     onChange?: (newValue: string) => void
@@ -31,8 +32,6 @@ export interface Props {
     jsonSchema?: JSONSchema
 
     monacoRef?: (monacoValue: typeof monaco | null) => void
-    isLightTheme: boolean
-
     /**
      * Called when the user presses the key binding for "save" (Ctrl+S/Cmd+S).
      */

--- a/web/src/settings/SettingsArea.tsx
+++ b/web/src/settings/SettingsArea.tsx
@@ -15,14 +15,14 @@ import { gqlToCascade, SettingsCascadeProps } from '../../../shared/src/settings
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { queryGraphQL } from '../backend/graphql'
 import { HeroPage } from '../components/HeroPage'
+import { ThemeProps } from '../theme'
 import { eventLogger } from '../tracking/eventLogger'
 import { mergeSettingsSchemas } from './configuration'
 import { SettingsPage } from './SettingsPage'
-
 const NotFoundPage = () => <HeroPage icon={MapSearchIcon} title="404: Not Found" />
 
 /** Props shared by SettingsArea and its sub-pages. */
-interface SettingsAreaPageCommonProps extends PlatformContextProps, SettingsCascadeProps {
+interface SettingsAreaPageCommonProps extends PlatformContextProps, SettingsCascadeProps, ThemeProps {
     /** The subject whose settings to edit. */
     subject: Pick<GQL.SettingsSubject, '__typename' | 'id'>
 
@@ -30,8 +30,6 @@ interface SettingsAreaPageCommonProps extends PlatformContextProps, SettingsCasc
      * The currently authenticated user, NOT (necessarily) the user who is the subject of the page.
      */
     authenticatedUser: GQL.IUser | null
-
-    isLightTheme: boolean
 }
 
 interface SettingsData {

--- a/web/src/settings/SettingsFile.tsx
+++ b/web/src/settings/SettingsFile.tsx
@@ -7,10 +7,11 @@ import { distinctUntilChanged, filter, map, startWith } from 'rxjs/operators'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { SaveToolbar } from '../components/SaveToolbar'
 import { settingsActions } from '../site-admin/configHelpers'
+import { ThemeProps } from '../theme'
 import { eventLogger } from '../tracking/eventLogger'
 import * as _monacoSettingsEditorModule from './MonacoSettingsEditor' // type only
 
-interface Props {
+interface Props extends ThemeProps {
     history: H.History
 
     settings: GQL.ISettings | null
@@ -35,8 +36,6 @@ interface Props {
      * if any.
      */
     commitError?: Error
-
-    isLightTheme: boolean
 }
 
 interface State {

--- a/web/src/settings/SettingsPage.tsx
+++ b/web/src/settings/SettingsPage.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { overwriteSettings } from '../../../shared/src/settings/edit'
+import { ThemeProps } from '../theme'
 import { SettingsAreaPageProps } from './SettingsArea'
 import { SettingsFile } from './SettingsFile'
 
-interface Props extends SettingsAreaPageProps, Pick<RouteComponentProps<{}>, 'history' | 'location'> {
-    isLightTheme: boolean
-
+interface Props extends SettingsAreaPageProps, Pick<RouteComponentProps<{}>, 'history' | 'location'>, ThemeProps {
     /** Optional description to render above the editor. */
     description?: JSX.Element
 }

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -2,6 +2,10 @@
  * Props that can be extended by any component's Props which needs to react to theme change.
  */
 export interface ThemeProps {
+    /**
+     * `true` if the current theme to be shown is the light theme,
+     * `false` if it is the dark theme.
+     */
     isLightTheme: boolean
 }
 

--- a/web/src/user/account/UserAccountArea.tsx
+++ b/web/src/user/account/UserAccountArea.tsx
@@ -10,6 +10,7 @@ import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { siteFlags } from '../../site/backend'
+import { ThemeProps } from '../../theme'
 import { RouteDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
 import { UserAccountSidebar, UserAccountSidebarItems } from './UserAccountSidebar'
@@ -18,9 +19,8 @@ const NotFoundPage = () => <HeroPage icon={MapSearchIcon} title="404: Not Found"
 
 export interface UserAccountAreaRoute extends RouteDescriptor<UserAccountAreaRouteContext> {}
 
-export interface UserAccountAreaProps extends UserAreaRouteContext, RouteComponentProps<{}> {
+export interface UserAccountAreaProps extends UserAreaRouteContext, RouteComponentProps<{}>, ThemeProps {
     authenticatedUser: GQL.IUser
-    isLightTheme: boolean
     sideBarItems: UserAccountSidebarItems
     routes: ReadonlyArray<UserAccountAreaRoute>
 }

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -14,6 +14,7 @@ import { createAggregateError, ErrorLike, isErrorLike } from '../../../../shared
 import { queryGraphQL } from '../../backend/graphql'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
+import { ThemeProps } from '../../theme'
 import { RouteDescriptor } from '../../util/contributions'
 import { UserAccountAreaRoute } from '../account/UserAccountArea'
 import { UserAccountSidebarItems } from '../account/UserAccountSidebar'
@@ -64,7 +65,11 @@ const NotFoundPage = () => (
 
 export interface UserAreaRoute extends RouteDescriptor<UserAreaRouteContext> {}
 
-interface UserAreaProps extends RouteComponentProps<{ username: string }>, PlatformContextProps, SettingsCascadeProps {
+interface UserAreaProps
+    extends RouteComponentProps<{ username: string }>,
+        PlatformContextProps,
+        SettingsCascadeProps,
+        ThemeProps {
     userAreaRoutes: ReadonlyArray<UserAreaRoute>
     userAreaHeaderNavItems: ReadonlyArray<UserAreaHeaderNavItem>
     userAccountSideBarItems: UserAccountSidebarItems
@@ -75,8 +80,6 @@ interface UserAreaProps extends RouteComponentProps<{ username: string }>, Platf
      * parameter.
      */
     authenticatedUser: GQL.IUser | null
-
-    isLightTheme: boolean
 }
 
 interface UserAreaState {
@@ -90,7 +93,7 @@ interface UserAreaState {
 /**
  * Properties passed to all page components in the user area.
  */
-export interface UserAreaRouteContext extends PlatformContextProps, SettingsCascadeProps {
+export interface UserAreaRouteContext extends PlatformContextProps, SettingsCascadeProps, ThemeProps {
     /** The extension registry area main URL. */
     url: string
 
@@ -109,8 +112,6 @@ export interface UserAreaRouteContext extends PlatformContextProps, SettingsCasc
      * user is Bob.
      */
     authenticatedUser: GQL.IUser | null
-
-    isLightTheme: boolean
     userAccountSideBarItems: UserAccountSidebarItems
     userAccountAreaRoutes: ReadonlyArray<UserAccountAreaRoute>
 }


### PR DESCRIPTION
Prop drilling refers to having to pass-through the same props through a lot of components. This removes duplicated Prop declarations by sharing common Prop interfaces and uses the `{...props}` spread syntax to pass through bags of props. This eliminates the need to add each new prop that needs to be passed through to a lot of components on every change.

As an example, @beyang would not have to manually pass-through the `activation` prop in a lot of places in https://github.com/sourcegraph/sourcegraph/pull/2258/files.

<!-- Remember to update the changelog for user-facing changes. -->
