### PR TITLE
Improve integrations docs

### DIFF
--- a/doc/integration/google_gsuite.md
+++ b/doc/integration/google_gsuite.md
@@ -1,4 +1,4 @@
-# G Suite integration
+# G Suite and Chrome Enterprise integration
 
 > NOTE: Company-wide deployment via G Suite is a [paid upgrade](https://about.sourcegraph.com/pricing)
 

--- a/doc/integration/index.md
+++ b/doc/integration/index.md
@@ -3,7 +3,8 @@
 Sourcegraph integrates with your other tools to help you search, navigate, and review your code.
 
 - [Browser extension](browser_extension.md): go-to-definitions and hovers in your code host and code reviews
-- 3rd-party services (for syncing repositories, user authentication, etc.):
+  - [Google G Suite and Chrome Enterprise](google_gsuite.md)
+- Code hosts
   - [GitHub](github.md)
   - [GitLab](gitlab.md)
   - [Bitbucket Server](bitbucket_server.md)
@@ -11,6 +12,11 @@ Sourcegraph integrates with your other tools to help you search, navigate, and r
   - [AWS CodeCommit](aws_codecommit.md)
   - [Gitolite](gitolite.md)
   - [Other Git repository hosts](../admin/external_service/other.md)
+- Other services
+  - [Codecov](https://sourcegraph.com/extensions/sourcegraph/codecov)
+  - [Datadog](https://sourcegraph.com/extensions/sourcegraph/datadog-metrics)
+  - [LightStep](lightstep.md)
+  - [View all "External services" extensions](https://sourcegraph.com/extensions?query=category%3A%22External+services%22)
 - [Editor plugins](editor.md): jump to Sourcegraph from your editor
 - [Search shortcuts](browser_search_engine.md): quickly search from your browser
 - [GraphQL API](../api/graphql/index.md): create custom tools using Sourcegraph data

--- a/doc/integration/lightstep.md
+++ b/doc/integration/lightstep.md
@@ -1,0 +1,20 @@
+# LightStep integration with Sourcegraph
+
+[LightStep](https://lightstep.com) is an application performance management (APM) tool that supports distributed tracing and the [OpenTracing](https://opentracing.io/) standard.
+
+Sourcegraph integrates with LightStep both for users (to easily view live traces when navigating code) and site admins (to monitor a self-hosted Sourcegraph instance).
+
+Feature | Supported?
+------- | ----------
+For users: [View live traces for your code](#view-live-traces-for-your-code) | ✅
+For site admins: [Monitoring a self-hosted Sourcegraph instance](#instrumenting-a-self-hosted-sourcegraph-instance) | ✅
+
+# View live traces for your code
+
+Any user can [enable the LightStep extension for Sourcegraph](https://sourcegraph.com/extensions/sourcegraph/lightstep) to view live traces for OpenTracing spans in their own code.
+
+![Screenshot](https://storage.googleapis.com/sourcegraph-assets/LightStep_Sourcegraph.png)
+
+# Monitoring a self-hosted Sourcegraph instance
+
+In the management console for a self-hosted Sourcegraph instance, site admins can [configure LightStep tracing](../admin/config/critical_config.md) using the `lightstepAccessToken` and `lightstepProject` critical configuration properties.


### PR DESCRIPTION
- Adds a LightStep docs page (because it has both a user- and site-admin-facing component)
- Adds all 3rd-party service extensions to integrations page
- Mention Chrome Enterprise because some customers consider the G Suite force-install feature to be a part of that


<!-- Remember to update the changelog for user-facing changes. -->