### PR TITLE
publish correct type of TextDocument#text (can be undefined)

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -501,7 +501,7 @@ export function handleCodeHost({
                         item: {
                             uri: toURIWithPath(info),
                             languageId: getModeFromPath(info.filePath) || 'could not determine mode',
-                            text: info.content!,
+                            text: info.content,
                         },
                         selections,
                         isActive: true,

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
   "dependencies": {
     "@sentry/browser": "^4.5.4",
     "@slimsag/react-shortcuts": "^1.2.1",
-    "@sourcegraph/codeintellify": "^6.0.3",
+    "@sourcegraph/codeintellify": "^6.0.4",
     "@sourcegraph/comlink": "^3.1.1-fork.3",
     "@sourcegraph/extension-api-types": "link:packages/@sourcegraph/extension-api-types",
     "@sourcegraph/react-loading-spinner": "0.0.7",

--- a/packages/@sourcegraph/extension-api-types/node_modules/sourcegraph
+++ b/packages/@sourcegraph/extension-api-types/node_modules/sourcegraph
@@ -1,0 +1,1 @@
+../../../sourcegraph-extension-api

--- a/packages/@sourcegraph/extension-api-types/package.json
+++ b/packages/@sourcegraph/extension-api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/extension-api-types",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Types for working with the Sourcegraph extension API. Extensions should use the 'sourcegraph' package, not this package. This package is only for client applications that embed Sourcegraph extensions and need to communicate with them.",
   "author": "Sourcegraph",
   "bugs": {
@@ -19,10 +19,10 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "tslint": "tslint -t stylish -c tslint.json -p tsconfig.json './src/**/*.{ts,js}'",
+    "tslint": "../../../node_modules/.bin/tslint -t stylish -c tslint.json -p tsconfig.json './src/**/*.{ts,js}'",
     "prepublishOnly": "yarn run tslint"
   },
-  "dependencies": {
+  "peerDependencies": {
     "sourcegraph": "*"
   }
 }

--- a/packages/sourcegraph-extension-api/package.json
+++ b/packages/sourcegraph-extension-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcegraph",
-  "version": "22.0.0",
+  "version": "23.0.0",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",
   "bugs": {

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -319,8 +319,13 @@ declare module 'sourcegraph' {
 
         /**
          * The text contents of the text document.
+         *
+         * When using the [Sourcegraph browser
+         * extension](https://docs.sourcegraph.com/integration/browser_extension), the value is
+         * `undefined` because determining the text contents (in general) is not possible without
+         * additional access to the code host API. In the future, this limitation may be removed.
          */
-        readonly text: string
+        readonly text: string | undefined
     }
 
     /**

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -2,7 +2,7 @@ import * as comlink from '@sourcegraph/comlink'
 import { isEqual } from 'lodash'
 import { from, Subject, Subscription } from 'rxjs'
 import { concatMap, distinctUntilChanged, map } from 'rxjs/operators'
-import { ContextValues, Progress, ProgressOptions, Unsubscribable } from 'sourcegraph'
+import { ContextValues, Progress, ProgressOptions, TextDocument, Unsubscribable } from 'sourcegraph'
 import { EndpointPair } from '../../platform/context'
 import { ExtensionHostAPIFactory } from '../extension/api/api'
 import { InitData } from '../extension/extensionHost'
@@ -25,7 +25,6 @@ import {
     ShowMessageParams,
     ShowMessageRequestParams,
 } from './services/notifications'
-import { TextDocumentItem } from './types/textDocument'
 
 export interface ExtensionHostClientConnection {
     /**
@@ -74,7 +73,7 @@ export async function createExtensionHostClientConnection(
     subscription.add(clientContext)
 
     // Sync visible views and text documents to the extension host
-    let visibleTextDocuments: TextDocumentItem[] = []
+    let visibleTextDocuments: TextDocument[] = []
     subscription.add(
         from(services.model.model)
             .pipe(

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, extname } from 'path'
+import { TextDocument } from 'sourcegraph'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/settings'
 import { Model, ViewComponentData } from '../model'
-import { TextDocumentItem } from '../types/textDocument'
 
 /**
  * Returns a new context created by applying the update context to the base context. It is equivalent to `{...base,
@@ -34,7 +34,7 @@ export interface Context<T = never>
 
 export type ContributionScope =
     | (Pick<ViewComponentData, 'type' | 'selections'> & {
-          item: Pick<TextDocumentItem, 'uri' | 'languageId'>
+          item: Pick<TextDocument, 'uri' | 'languageId'>
       })
     | { type: 'panelView'; id: string }
 

--- a/shared/src/api/client/model.ts
+++ b/shared/src/api/client/model.ts
@@ -1,6 +1,6 @@
 import { Selection, WorkspaceRoot } from '@sourcegraph/extension-api-types'
+import { TextDocument } from 'sourcegraph'
 import { TextDocumentPositionParams } from '../protocol'
-import { TextDocumentItem } from './types/textDocument'
 
 /**
  * Describes a view component.
@@ -11,7 +11,7 @@ import { TextDocumentItem } from './types/textDocument'
  */
 export interface ViewComponentData {
     type: 'textEditor'
-    item: TextDocumentItem
+    item: TextDocument
     selections: Selection[]
     isActive: boolean
 }
@@ -66,7 +66,7 @@ export const EMPTY_MODEL: Model = {
  */
 export function modelToTextDocumentPositionParams({
     visibleViewComponents,
-}: Pick<Model, 'visibleViewComponents'>): (TextDocumentPositionParams & { textDocument: TextDocumentItem }) | null {
+}: Pick<Model, 'visibleViewComponents'>): (TextDocumentPositionParams & { textDocument: TextDocument }) | null {
     if (!visibleViewComponents) {
         return null
     }

--- a/shared/src/api/client/types/textDocument.test.ts
+++ b/shared/src/api/client/types/textDocument.test.ts
@@ -1,7 +1,7 @@
-import { DocumentSelector } from 'sourcegraph'
-import { match, score, TextDocumentItem } from './textDocument'
+import { DocumentSelector, TextDocument } from 'sourcegraph'
+import { match, score } from './textDocument'
 
-const FIXTURE_TEXT_DOCUMENT: TextDocumentItem = { uri: 'file:///f', languageId: 'l', text: '' }
+const FIXTURE_TEXT_DOCUMENT: TextDocument = { uri: 'file:///f', languageId: 'l', text: '' }
 
 describe('match', () => {
     test('reports true if any selectors match', () => {

--- a/shared/src/api/client/types/textDocument.ts
+++ b/shared/src/api/client/types/textDocument.ts
@@ -1,5 +1,5 @@
 import minimatch from 'minimatch'
-import { DocumentFilter, DocumentSelector } from 'sourcegraph'
+import { DocumentFilter, DocumentSelector, TextDocument } from 'sourcegraph'
 
 /**
  * A literal to identify a text document in the client.
@@ -12,28 +12,11 @@ export interface TextDocumentIdentifier {
 }
 
 /**
- * An item to transfer a text document from the client to the server.
- */
-export interface TextDocumentItem extends TextDocumentIdentifier {
-    /**
-     * The ID of the document's language. This is a well-defined string identifier such as "python".
-     *
-     * @todo Document the known language IDs.
-     */
-    languageId: string
-
-    /**
-     * The document's text contents.
-     */
-    text: string
-}
-
-/**
  * Returns whether any of the document selectors match (or "select") the document.
  */
 export function match(
     selectors: DocumentSelector | IterableIterator<DocumentSelector>,
-    document: Pick<TextDocumentItem, 'uri' | 'languageId'>
+    document: Pick<TextDocument, 'uri' | 'languageId'>
 ): boolean {
     for (const selector of isSingleDocumentSelector(selectors) ? [selectors] : selectors) {
         if (match1(selector, document)) {
@@ -62,7 +45,7 @@ function isDocumentFilter(value: any): value is DocumentFilter {
     )
 }
 
-function match1(selector: DocumentSelector, document: Pick<TextDocumentItem, 'uri' | 'languageId'>): boolean {
+function match1(selector: DocumentSelector, document: Pick<TextDocument, 'uri' | 'languageId'>): boolean {
     return score(selector, document.uri, document.languageId) !== 0
 }
 

--- a/shared/src/api/extension/api/documents.ts
+++ b/shared/src/api/extension/api/documents.ts
@@ -1,18 +1,17 @@
 import { ProxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
 import { Subject } from 'rxjs'
 import { TextDocument } from 'sourcegraph'
-import { TextDocumentItem } from '../../client/types/textDocument'
 
 /** @internal */
 export interface ExtDocumentsAPI extends ProxyValue {
-    $acceptDocumentData(doc: TextDocumentItem[]): void
+    $acceptDocumentData(doc: TextDocument[]): void
 }
 
 /** @internal */
 export class ExtDocuments implements ExtDocumentsAPI, ProxyValue {
     public readonly [proxyValueSymbol] = true
 
-    private documents = new Map<string, TextDocumentItem>()
+    private documents = new Map<string, TextDocument>()
 
     constructor(private sync: () => Promise<void>) {}
 
@@ -56,7 +55,7 @@ export class ExtDocuments implements ExtDocumentsAPI, ProxyValue {
 
     public openedTextDocuments = new Subject<TextDocument>()
 
-    public $acceptDocumentData(docs: TextDocumentItem[] | null): void {
+    public $acceptDocumentData(docs: TextDocument[] | null): void {
         if (!docs) {
             // We don't ever (yet) communicate to the extension when docs are closed.
             return

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,13 +1486,13 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@sourcegraph/codeintellify@^6.0.3":
-  version "6.0.3"
-  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.0.3.tgz#c9bba298bd3bec9922441ef731b34c736902ceab"
-  integrity sha512-PYB7raZQd5ztzCBXcyjabf76Phn2zfr/AEyNlMu81llz6hW/WiyiAfvP9g4E8ml8wI1bDu873kyjSKObhxv5yw==
+"@sourcegraph/codeintellify@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.0.4.tgz#2f127bea3ca6c7f9d61f5f4d148894bee4e2386b"
+  integrity sha512-BSRNz5ydNaZga+ILfyQYE2VMcNDzs/UB9Hp95PFjpPA02iYVAxox0rSN/7EvHaO7Z3Cyb1wOOrdRljOm6b/2wQ==
   dependencies:
-    "@sourcegraph/event-positions" "^1.0.1"
-    "@sourcegraph/extension-api-types" "^1.0.1"
+    "@sourcegraph/event-positions" "^1.0.2"
+    "@sourcegraph/extension-api-types" "^2.0.0"
     lodash "^4.17.10"
     rxjs "^6.3.3"
     ts-key-enum "^2.0.0"
@@ -1502,26 +1502,23 @@
   resolved "https://registry.npmjs.org/@sourcegraph/comlink/-/comlink-3.1.1-fork.3.tgz#1bd76bc74ca8a9b55f1dbf508c703053ee66c961"
   integrity sha512-+vfSCJTS/GU391Hhdh2/s+wy5ok4hi6X+kizRQqQZwZI03Q1rR6SVLNFsbg4dhbX624mqr1UCRhwNnZdWHAR+A==
 
-"@sourcegraph/event-positions@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@sourcegraph/event-positions/-/event-positions-1.0.1.tgz#aa83c38170275db4e696a6d5fc0f4d1e733713be"
-  integrity sha512-CTmFVVcw0C+z6DWpW2EiyeAqhC1mrcAndyKh+ZSriRu3r4ZL1/6JG6JQFSqydLp4PelXOh/p8GqtdDdQae83Vw==
+"@sourcegraph/event-positions@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@sourcegraph/event-positions/-/event-positions-1.0.2.tgz#4c8150d14bdd25c4a2d6b2e14d589948a98ae4fc"
+  integrity sha512-EAfB5fz1AvUGw3MfHqH+i0fki8NqHLUSxNPeqTf5tnjvOyh/93tLug3HSEHfqGhCOFYTEUpXEYZ1NRNBci+XvA==
   dependencies:
-    "@sourcegraph/extension-api-types" "^1.1.0"
+    "@sourcegraph/extension-api-types" "^2.0.0"
     lodash "^4.17.10"
     rxjs "^6.3.2"
 
-"@sourcegraph/extension-api-types@^1.0.1", "@sourcegraph/extension-api-types@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/extension-api-types/-/extension-api-types-1.1.0.tgz#a947b1784c721e6e81988785e0a6fe6b9ebec7a3"
-  integrity sha512-XSImr1Xcjvtq0OrKTUhQLd8RhFMAvsIzCEqYLZ99fI/+252SJowuOGMGe7vMp0XLZ5cZxswJcdYdTiM6XOOsZA==
-  dependencies:
-    sourcegraph "*"
+"@sourcegraph/extension-api-types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/extension-api-types/-/extension-api-types-2.0.0.tgz#b38145521c0549b2be300df53bac48b648ccbc2d"
+  integrity sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "1.1.0"
-  dependencies:
-    sourcegraph "*"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -13823,13 +13820,9 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcegraph@*:
-  version "22.0.0"
-  resolved "https://registry.npmjs.org/sourcegraph/-/sourcegraph-22.0.0.tgz#b259929c31bf367f5160056698a881dc26eb36bd"
-  integrity sha512-cJHby0OPCM0y0BmRTKhY89D02f9koROluHMJGQGNE8q9CoIVbe1s6ctHCytz7bjY9mKtCpQMbtxYQhfIm5S4lg==
-
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "22.0.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/2051 introduced cases where `TextDocument#text` can be undefined. This should be incorporated into sourcegraph.d.ts and documented.

fix #2416