### PR TITLE
simplify locations panel code, show partial results

### DIFF
--- a/client/browser/src/shared/backend/lsp.tsx
+++ b/client/browser/src/shared/backend/lsp.tsx
@@ -1,6 +1,6 @@
 import { Location } from '@sourcegraph/extension-api-types'
 import { from, Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { map, switchMap } from 'rxjs/operators'
 import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
 import { TextDocumentIdentifier } from '../../../../../shared/src/api/client/types/textDocument'
 import { TextDocumentPositionParams } from '../../../../../shared/src/api/protocol'
@@ -44,7 +44,7 @@ export const createLSPFromExtensions = (extensionsController: Controller): Simpl
             map(hover => (hover === null ? HoverMerged.from([]) : hover))
         ),
     fetchDefinition: pos =>
-        from(
-            extensionsController.services.textDocumentDefinition.getLocations(toTextDocumentPositionParams(pos))
+        from(extensionsController.services.textDocumentDefinition.getLocations(toTextDocumentPositionParams(pos))).pipe(
+            switchMap(locations => locations)
         ) as Observable<Location | Location[] | null>,
 })

--- a/shared/src/api/client/services/view.ts
+++ b/shared/src/api/client/services/view.ts
@@ -16,7 +16,7 @@ export interface PanelViewWithComponent extends Pick<sourcegraph.PanelView, 'tit
     /**
      * The location provider whose results to render in the panel view.
      */
-    locationProvider?: Observable<Location[] | null>
+    locationProvider?: Observable<Observable<Location[] | null>>
 
     /**
      * The React element to render in the panel view.

--- a/shared/src/api/integration-test/languageFeatures.test.ts
+++ b/shared/src/api/integration-test/languageFeatures.test.ts
@@ -1,6 +1,6 @@
 import { Location } from '@sourcegraph/extension-api-types'
 import { asyncScheduler, Observable, of } from 'rxjs'
-import { observeOn, take, toArray } from 'rxjs/operators'
+import { observeOn, switchMap, take, toArray } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { languages as sourcegraphLanguages } from 'sourcegraph'
 import { Services } from '../client/services'
@@ -37,10 +37,12 @@ describe('LanguageFeatures (integration)', () => {
         labeledProviderResults: labeledDefinitionResults,
         providerWithImplementation: run => ({ provideDefinition: run } as sourcegraph.DefinitionProvider),
         getResult: services =>
-            services.textDocumentDefinition.getLocations({
-                textDocument: { uri: 'file:///f' },
-                position: { line: 1, character: 2 },
-            }),
+            services.textDocumentDefinition
+                .getLocations({
+                    textDocument: { uri: 'file:///f' },
+                    position: { line: 1, character: 2 },
+                })
+                .pipe(switchMap(locations => locations)),
     })
     // tslint:disable deprecation The tests must remain until they are removed.
     testLocationProvider({
@@ -53,10 +55,12 @@ describe('LanguageFeatures (integration)', () => {
         labeledProviderResults: labeledDefinitionResults,
         providerWithImplementation: run => ({ provideTypeDefinition: run } as sourcegraph.TypeDefinitionProvider),
         getResult: services =>
-            services.textDocumentTypeDefinition.getLocations({
-                textDocument: { uri: 'file:///f' },
-                position: { line: 1, character: 2 },
-            }),
+            services.textDocumentTypeDefinition
+                .getLocations({
+                    textDocument: { uri: 'file:///f' },
+                    position: { line: 1, character: 2 },
+                })
+                .pipe(switchMap(locations => locations)),
     })
     testLocationProvider<sourcegraph.ImplementationProvider>({
         name: 'registerImplementationProvider',
@@ -68,10 +72,12 @@ describe('LanguageFeatures (integration)', () => {
         labeledProviderResults: labeledDefinitionResults,
         providerWithImplementation: run => ({ provideImplementation: run } as sourcegraph.ImplementationProvider),
         getResult: services =>
-            services.textDocumentImplementation.getLocations({
-                textDocument: { uri: 'file:///f' },
-                position: { line: 1, character: 2 },
-            }),
+            services.textDocumentImplementation
+                .getLocations({
+                    textDocument: { uri: 'file:///f' },
+                    position: { line: 1, character: 2 },
+                })
+                .pipe(switchMap(locations => locations)),
     })
     // tslint:enable deprecation
     testLocationProvider<sourcegraph.ReferenceProvider>({
@@ -94,11 +100,13 @@ describe('LanguageFeatures (integration)', () => {
                 ) => run(doc, pos),
             } as sourcegraph.ReferenceProvider),
         getResult: services =>
-            services.textDocumentReferences.getLocations({
-                textDocument: { uri: 'file:///f' },
-                position: { line: 1, character: 2 },
-                context: { includeDeclaration: true },
-            }),
+            services.textDocumentReferences
+                .getLocations({
+                    textDocument: { uri: 'file:///f' },
+                    position: { line: 1, character: 2 },
+                    context: { includeDeclaration: true },
+                })
+                .pipe(switchMap(locations => locations)),
     })
     testLocationProvider<sourcegraph.LocationProvider>({
         name: 'registerLocationProvider',

--- a/shared/src/hover/actions.ts
+++ b/shared/src/hover/actions.ts
@@ -175,6 +175,7 @@ export function getDefinitionURL(
     params: TextDocumentPositionParams
 ): Observable<{ url: string; multiple: boolean } | null> {
     return textDocumentDefinition.getLocations(params).pipe(
+        switchMap(locations => locations),
         map(definitions => {
             if (definitions === null || definitions.length === 0) {
                 return null

--- a/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/shared/src/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<HierarchicalLocationsView /> displays a single location 1`] = `
+exports[`<HierarchicalLocationsView /> displays a single location when complete 1`] = `
 <div
   className="hierarchical-locations-view "
 >
@@ -376,7 +376,155 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
 </div>
 `;
 
-exports[`<HierarchicalLocationsView /> shows a spinner in loading state 1`] = `
+exports[`<HierarchicalLocationsView /> displays partial locations before complete 1`] = `
+<div
+  className="hierarchical-locations-view "
+>
+  <div
+    className="file-locations hierarchical-locations-view__content"
+  >
+    <div>
+      <VisibilitySensor
+        onChange={[Function]}
+        partialVisibility={true}
+      >
+        <div
+          className="result-container"
+        >
+          <div
+            className="result-container__header result-container__header--collapsible"
+            onClick={[Function]}
+          >
+            <svg
+              className="mdi-icon icon-inline"
+              height="24"
+              viewBox="0 0 64 64"
+              width="24"
+            >
+              <g>
+                <path
+                  d="M23,22.4c1.3,0,2.4-1.1,2.4-2.4s-1.1-2.4-2.4-2.4c-1.3,0-2.4,1.1-2.4,2.4S21.7,22.4,23,22.4z"
+                />
+                <path
+                  d="M35,26.4c1.3,0,2.4-1.1,2.4-2.4s-1.1-2.4-2.4-2.4s-2.4,1.1-2.4,2.4S33.7,26.4,35,26.4z"
+                />
+                <path
+                  d="M23,42.4c1.3,0,2.4-1.1,2.4-2.4s-1.1-2.4-2.4-2.4s-2.4,1.1-2.4,2.4S21.7,42.4,23,42.4z"
+                />
+                <path
+                  d="M50,16h-1.5c-0.3,0-0.5,0.2-0.5,0.5v35c0,0.3-0.2,0.5-0.5,0.5h-27c-0.5,0-1-0.2-1.4-0.6l-0.6-0.6c-0.1-0.1-0.1-0.2-0.1-0.4
+		c0-0.3,0.2-0.5,0.5-0.5H44c1.1,0,2-0.9,2-2V12c0-1.1-0.9-2-2-2H14c-1.1,0-2,0.9-2,2v36.3c0,1.1,0.4,2.1,1.2,2.8l3.1,3.1
+		c1.1,1.1,2.7,1.8,4.2,1.8H50c1.1,0,2-0.9,2-2V18C52,16.9,51.1,16,50,16z M19,20c0-2.2,1.8-4,4-4c1.4,0,2.8,0.8,3.5,2
+		c1.1,1.9,0.4,4.3-1.5,5.4V33c1-0.6,2.3-0.9,4-0.9c1,0,2-0.5,2.8-1.3C32.5,30,33,29.1,33,28v-0.6c-1.2-0.7-2-2-2-3.5
+		c0-2.2,1.8-4,4-4c2.2,0,4,1.8,4,4c0,1.5-0.8,2.7-2,3.5h0c-0.1,2.1-0.9,4.4-2.5,6c-1.6,1.6-3.4,2.4-5.5,2.5c-0.8,0-1.4,0.1-1.9,0.3
+		c-0.2,0.1-1,0.8-1.2,0.9C26.6,38,27,38.9,27,40c0,2.2-1.8,4-4,4s-4-1.8-4-4c0-1.5,0.8-2.7,2-3.4V23.4C19.8,22.7,19,21.4,19,20z"
+                />
+              </g>
+            </svg>
+            <div
+              className="result-container__header-title "
+            >
+              <span
+                onClick={[Function]}
+              >
+                <a
+                  to="/github.com/foo/bar"
+                >
+                  foo/bar
+                </a>
+                 ›
+                 
+                <a
+                  to="/github.com/foo/bar/-/blob/undefined"
+                >
+                  <strong>
+                    
+                  </strong>
+                </a>
+              </span>
+            </div>
+            <small
+              className="result-container__toggle-matches-container"
+            >
+              <svg
+                className="mdi-icon icon-inline"
+                fill="currentColor"
+                height={24}
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                />
+              </svg>
+            </small>
+          </div>
+          <div
+            className="file-match__list"
+          >
+            <a
+              className="file-match__item file-match__item-clickable"
+              onClick={[Function]}
+              to="/github.com/foo/bar/-/blob/undefined#L2:1"
+            >
+              <VisibilitySensor
+                offset={
+                  Object {
+                    "bottom": -500,
+                  }
+                }
+                onChange={[Function]}
+                partialVisibility={true}
+              >
+                <code
+                  className="code-excerpt file-match__item-code-excerpt"
+                >
+                  <table>
+                    <tbody>
+                      <tr>
+                        <td
+                          className="line"
+                        >
+                          1
+                        </td>
+                        <td
+                          className="code"
+                        >
+                           
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          className="line"
+                        >
+                          2
+                        </td>
+                        <td
+                          className="code"
+                        >
+                           
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </code>
+              </VisibilitySensor>
+            </a>
+          </div>
+        </div>
+      </VisibilitySensor>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<HierarchicalLocationsView /> shows a spinner before any locations emissions 1`] = `
+<div
+  className="loading-spinner icon-inline m-1"
+/>
+`;
+
+exports[`<HierarchicalLocationsView /> shows a spinner if locations emits empty and is not complete 1`] = `
 <div
   className="loading-spinner icon-inline m-1"
 />


### PR DESCRIPTION
- Add tests for HierarchicalLocationsView, especially for loading, partial, and empty states. **Most of the added line count comes from the tests.**
- Simplify the API (TextDocumentLocationProviderRegistry#hasProvidersForActiveTextDocument).
- Partial results (i.e., when a non-empty array of locations has been emitted by a location provider but the observable is not yet complete) are now shown in the locations view. Previously, no locations were shown until the observable was complete. Showing partial results is important when cross-repo references are shown because those typically take longer to load than same-repo results, and we don't want the user to need to wait.
