### PR TITLE
Allow requesting sourcegraphURL permissions in options menu

### DIFF
--- a/client/browser/src/browser/permissions.ts
+++ b/client/browser/src/browser/permissions.ts
@@ -9,7 +9,7 @@ export function contains(url: string): Promise<boolean> {
 export function request(urls: string[]): Promise<boolean> {
     return new Promise((resolve, reject) => {
         if (chrome && chrome.permissions) {
-            urls = urls.map(url => url + '/')
+            urls = urls.map(url => url + '/*')
             chrome.permissions.request(
                 {
                     origins: [...urls],

--- a/client/browser/src/libs/options/OptionsContainer.tsx
+++ b/client/browser/src/libs/options/OptionsContainer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, share, switchMap } from 'rxjs/operators'
 import * as GQL from '../../../../../shared/src/graphql/schema'
-import { contains as containsPermissions, request as requestPermissions } from '../../browser/permissions'
+import * as permissions from '../../browser/permissions'
 import { getExtensionVersionSync } from '../../browser/runtime'
 import { ERAUTHREQUIRED, ErrorLike, isErrorLike } from '../../shared/backend/errors'
 import { OptionsMenu, OptionsMenuProps } from './Menu'
@@ -84,7 +84,7 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
                     url = res
                 }
 
-                const urlHasPermissions = await containsPermissions(url)
+                const urlHasPermissions = await permissions.contains(url)
                 this.setState({ urlHasPermissions })
 
                 props.setSourcegraphURL(url)
@@ -119,7 +119,7 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
     }
 
     private requestPermissions = async () => {
-        await requestPermissions([this.state.sourcegraphURL])
+        await permissions.request([this.state.sourcegraphURL])
     }
 
     private handleURLChange = (value: string) => {

--- a/client/browser/src/libs/options/OptionsContainer.tsx
+++ b/client/browser/src/libs/options/OptionsContainer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, share, switchMap } from 'rxjs/operators'
 import * as GQL from '../../../../../shared/src/graphql/schema'
+import { contains as containsPermissions, request as requestPermissions } from '../../browser/permissions'
 import { getExtensionVersionSync } from '../../browser/runtime'
 import { ERAUTHREQUIRED, ErrorLike, isErrorLike } from '../../shared/backend/errors'
 import { OptionsMenu, OptionsMenuProps } from './Menu'
@@ -20,7 +21,10 @@ export interface OptionsContainerProps {
 }
 
 interface OptionsContainerState
-    extends Pick<OptionsMenuProps, 'status' | 'sourcegraphURL' | 'connectionError' | 'isSettingsOpen'> {}
+    extends Pick<
+        OptionsMenuProps,
+        'status' | 'sourcegraphURL' | 'connectionError' | 'isSettingsOpen' | 'urlHasPermissions'
+    > {}
 
 export class OptionsContainer extends React.Component<OptionsContainerProps, OptionsContainerState> {
     private version = getExtensionVersionSync()
@@ -35,6 +39,7 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
         this.state = {
             status: 'connecting',
             sourcegraphURL: props.sourcegraphURL,
+            urlHasPermissions: false,
             connectionError: undefined,
             isSettingsOpen: false,
         }
@@ -64,7 +69,7 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
         )
 
         this.subscriptions.add(
-            fetchingSite.subscribe(res => {
+            fetchingSite.subscribe(async res => {
                 let url = ''
 
                 if (isErrorLike(res)) {
@@ -78,6 +83,9 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
                     this.setState({ status: 'connected' })
                     url = res
                 }
+
+                const urlHasPermissions = await containsPermissions(url)
+                this.setState({ urlHasPermissions })
 
                 props.setSourcegraphURL(url)
             })
@@ -105,8 +113,13 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
                 toggleFeatureFlag={this.props.toggleFeatureFlag}
                 featureFlags={this.props.featureFlags}
                 onSettingsClick={this.handleSettingsClick}
+                requestPermissions={this.requestPermissions}
             />
         )
+    }
+
+    private requestPermissions = async () => {
+        await requestPermissions([this.state.sourcegraphURL])
     }
 
     private handleURLChange = (value: string) => {

--- a/client/browser/src/libs/options/ServerURLForm.test.tsx
+++ b/client/browser/src/libs/options/ServerURLForm.test.tsx
@@ -20,6 +20,8 @@ describe('ServerURLForm', () => {
                 status={'connected'}
                 onChange={onChange}
                 onSubmit={onSubmit}
+                urlHasPermissions={false}
+                requestPermissions={noop}
             />
         )
 
@@ -39,6 +41,8 @@ describe('ServerURLForm', () => {
             status: 'connected',
             onChange: noop,
             onSubmit: noop,
+            urlHasPermissions: false,
+            requestPermissions: noop,
         }
 
         const { container, rerender } = render(<ServerURLForm {...props} />)
@@ -56,7 +60,14 @@ describe('ServerURLForm', () => {
         const onSubmit = sinon.spy()
 
         const { container } = render(
-            <ServerURLForm value={'https://sourcegraph.com'} status={'connected'} onChange={noop} onSubmit={onSubmit} />
+            <ServerURLForm
+                value={'https://sourcegraph.com'}
+                status={'connected'}
+                onChange={noop}
+                onSubmit={onSubmit}
+                urlHasPermissions={false}
+                requestPermissions={noop}
+            />
         )
 
         const form = container.querySelector('form')!
@@ -79,6 +90,8 @@ describe('ServerURLForm', () => {
                     status={'connected'}
                     onChange={noop}
                     onSubmit={nextSubmit}
+                    urlHasPermissions={false}
+                    requestPermissions={noop}
                 />
             )
 
@@ -120,6 +133,8 @@ describe('ServerURLForm', () => {
                 status: 'connected',
                 onChange: nextChange,
                 onSubmit: nextSubmit,
+                urlHasPermissions: false,
+                requestPermissions: noop,
             }
 
             const { container } = render(<ServerURLForm {...props} />)

--- a/client/browser/src/libs/options/ServerURLForm.tsx
+++ b/client/browser/src/libs/options/ServerURLForm.tsx
@@ -35,6 +35,8 @@ export interface ServerURLFormProps {
     value: string
     onChange: (value: string) => void
     onSubmit: () => void
+    urlHasPermissions: boolean
+    requestPermissions: () => void
 
     /**
      * Overrides `this.props.status` and `this.state.isUpdating` in order to
@@ -137,6 +139,15 @@ export class ServerURLForm extends React.Component<ServerURLFormProps> {
                             </a>
                             .
                         </p>
+                        {!this.props.urlHasPermissions && (
+                            <p>
+                                You may need to{' '}
+                                <a href="#" onClick={this.props.requestPermissions}>
+                                    grant the Sourcegraph browser extension additional permissions
+                                </a>{' '}
+                                for this URL.
+                            </p>
+                        )}
                         <p>
                             <b>If you are an admin,</b> please ensure that{' '}
                             <a


### PR DESCRIPTION
Fixes #2228

In certain cases, the browser extension might need to be granted permissions to the Sourcegraph URL, for example, if the Sourcegraph instance is setup behind an oauth2_proxy (#2228).

Permission requests [must stem for a user gesture](https://developer.chrome.com/apps/permissions#request). What we do here is:
- If a connection attempt to the Sourcegraph URL has failed, and the browser extensions does not have permissions for the Sourcegraph URL, tell the user he might need additional permissions.
![image](https://user-images.githubusercontent.com/1741180/53739371-dff3fd00-3e91-11e9-8999-45e646560c28.png)
- When clicking "grant [...] additional permissions", the user wil be presented with a Chrome prompt.
![image](https://user-images.githubusercontent.com/1741180/53739381-e5514780-3e91-11e9-9070-c56206e71f77.png)
