### PR TITLE
Revert "Clean up external service updating UI code (#2033)"

### DIFF
--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -2,8 +2,8 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
-import { concat, Observable, of, Subject, Subscription } from 'rxjs'
-import { catchError, delay, distinctUntilChanged, map, mapTo, mergeMap, startWith, switchMap } from 'rxjs/operators'
+import { Observable, Subject, Subscription } from 'rxjs'
+import { catchError, distinctUntilChanged, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
 import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
@@ -25,13 +25,15 @@ interface State {
      * The result of updating the external service: null when complete or not started yet,
      * loading, or an error.
      */
-    updatedOrError: null | true | typeof LOADING | ErrorLike
+    updateOrError: null | typeof LOADING | ErrorLike
+    updated: boolean
 }
 
 export class SiteAdminExternalServicePage extends React.Component<Props, State> {
     public state: State = {
         externalServiceOrError: LOADING,
-        updatedOrError: null,
+        updateOrError: null,
+        updated: false,
     }
 
     private componentUpdates = new Subject<Props>()
@@ -64,19 +66,15 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                         updateExternalService(input).pipe(
                             mapTo(null),
                             startWith(LOADING),
-                            mergeMap(u =>
-                                concat(
-                                    // Flash "updated" text
-                                    of<Partial<State>>({ updatedOrError: true }),
-                                    // Hide "updated" text again after 1s
-                                    of<Partial<State>>({ updatedOrError: u }).pipe(delay(1000))
-                                )
-                            ),
-                            catchError((error: Error) => [{ updateOrError: asError(error) }])
+                            catchError(err => [asError(err)]),
+                            // Flash updated text if not an error
+                            map(u => ({ updateOrError: u, updated: !isErrorLike(u) })),
+                            // Remove updated text after 500ms
+                            tap(() => setTimeout(() => this.setState({ updated: false }), 500))
                         )
                     )
                 )
-                .subscribe(stateUpdate => this.setState(stateUpdate as State))
+                .subscribe(stateUpdate => this.setState(stateUpdate))
         )
 
         this.componentUpdates.next(this.props)
@@ -92,8 +90,8 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
 
     public render(): JSX.Element | null {
         let error: ErrorLike | undefined
-        if (isErrorLike(this.state.updatedOrError)) {
-            error = this.state.updatedOrError
+        if (isErrorLike(this.state.updateOrError)) {
+            error = this.state.updateOrError
         }
 
         const externalService =
@@ -119,14 +117,14 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                         input={externalService}
                         error={error}
                         mode="edit"
-                        loading={this.state.updatedOrError === LOADING}
+                        loading={this.state.updateOrError === LOADING}
                         onSubmit={this.onSubmit}
                         onChange={this.onChange}
                         history={this.props.history}
                         isLightTheme={this.props.isLightTheme}
                     />
                 )}
-                {this.state.updatedOrError === true && (
+                {this.state.updated && (
                     <p className="alert alert-success user-settings-profile-page__alert">Updated!</p>
                 )}
             </div>


### PR DESCRIPTION
This reverts commit 62a0bb3e94a75fc6126c8e5dfaabbe92bbc2a9c5.

Reverting this commit fixes the weird behaviour I reported in https://github.com/sourcegraph/sourcegraph/issues/2227.

I don't know exactly why, because my TypeScript skills are lacking and I'd go down a rabbit hole to debug this.

Fixes #2227