### PR TITLE
Catch errPrivateRepoPublicSourcegraph when resolving code views

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -8,7 +8,6 @@ import {
     HoverState,
     PositionAdjuster,
 } from '@sourcegraph/codeintellify'
-import { propertyIsDefined } from '@sourcegraph/codeintellify/lib/helpers'
 import { Selection } from '@sourcegraph/extension-api-types'
 import * as H from 'history'
 import { isEqual } from 'lodash'
@@ -37,6 +36,7 @@ import { HoverContext, HoverOverlay } from '../../../../../shared/src/hover/Hove
 import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryContext } from '../../../../../shared/src/telemetry/telemetryContext'
+import { isDefined, propertyIsDefined } from '../../../../../shared/src/util/types'
 import {
     FileSpec,
     lprToSelectionsZeroIndexed,
@@ -474,6 +474,13 @@ export function handleCodeHost({
         switchMap(({ info, ...rest }) =>
             fetchFileContents(info).pipe(map(infoWithContents => ({ info: infoWithContents, ...rest })))
         ),
+        catchError(err => {
+            if ((err as Error).name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+                return of(null)
+            }
+            throw err
+        }),
+        filter(isDefined),
         observeOn(animationFrameScheduler)
     )
 

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -13,7 +13,7 @@ import * as H from 'history'
 import { isEqual } from 'lodash'
 import * as React from 'react'
 import { createPortal, render } from 'react-dom'
-import { animationFrameScheduler, combineLatest, fromEvent, Observable, of, Subject, Subscription } from 'rxjs'
+import { animationFrameScheduler, combineLatest, EMPTY, fromEvent, Observable, of, Subject, Subscription } from 'rxjs'
 import {
     catchError,
     distinctUntilChanged,
@@ -36,7 +36,7 @@ import { HoverContext, HoverOverlay } from '../../../../../shared/src/hover/Hove
 import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryContext } from '../../../../../shared/src/telemetry/telemetryContext'
-import { isDefined, propertyIsDefined } from '../../../../../shared/src/util/types'
+import { propertyIsDefined } from '../../../../../shared/src/util/types'
 import {
     FileSpec,
     lprToSelectionsZeroIndexed,
@@ -424,8 +424,8 @@ export function handleCodeHost({
         resolveRev(context).pipe(
             retryWhenCloneInProgressError(),
             map(rev => !!rev),
-            catchError(error => {
-                if ((error as Error).name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+            catchError((err: Error) => {
+                if (err.name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
                     return [false]
                 }
 
@@ -474,13 +474,12 @@ export function handleCodeHost({
         switchMap(({ info, ...rest }) =>
             fetchFileContents(info).pipe(map(infoWithContents => ({ info: infoWithContents, ...rest })))
         ),
-        catchError(err => {
-            if ((err as Error).name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
-                return of(null)
+        catchError((err: Error) => {
+            if (err.name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+                return EMPTY
             }
             throw err
         }),
-        filter(isDefined),
         observeOn(animationFrameScheduler)
     )
 

--- a/client/browser/src/shared/repo/backend.tsx
+++ b/client/browser/src/shared/repo/backend.tsx
@@ -150,7 +150,7 @@ export const fetchBlobContentLines = memoizeObservable(
                     }
                 }
 
-                // Don't swollow unexpected errors
+                // Don't swallow unexpected errors.
                 throw { errors, ...rest }
             })
         ),


### PR DESCRIPTION
`ERPRIVATEREPOPUBLICSOURCEGRAPHCOM` is the top reported exception in Sentry/browser-extension, while it typically is an internal error that should be handled.

All stacks I looked at had were related to the same scenario: trying to resolve diff code views on Github PRs, where [`resolveDiffFileInfo()`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/browser/src/libs/github/file_info.ts#L11:14) calls [`resolveRev()`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/browser/src/shared/repo/backend.tsx#L39:14) to try and resolve the head and base revisions.

To avoid undesired reporting of this exception on sentry, this PR adds a `catchError()` block to the `codeViews` observable, so that in such cases we simply ignore the code view without uncaught exceptions.
