### PR TITLE
Fix selector in getResolvedDiffForCompare()

### DIFF
--- a/client/browser/src/libs/github/util.tsx
+++ b/client/browser/src/libs/github/util.tsx
@@ -193,7 +193,7 @@ export function getDiffResolvedRev(): DiffResolvedRevSpec | null {
 }
 
 function getResolvedDiffForCompare(): DiffResolvedRevSpec | undefined {
-    const branchElements = document.querySelectorAll('.commitish-suggester span.js-select-button') as NodeListOf<
+    const branchElements = document.querySelectorAll('.commitish-suggester .select-menu-button span') as NodeListOf<
         HTMLSpanElement
     >
     if (branchElements && branchElements.length === 2) {


### PR DESCRIPTION
I've been seeing a lot of `'cannot determine delta info'` Sentry exceptions on github compare pages (eg. https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...felixfbecker:sinon-spy?expand=1). Turns out the `branchElements` selector was outdated.