### PR TITLE
Reenable browser extension e2e tests

### DIFF
--- a/client/browser/package.json
+++ b/client/browser/package.json
@@ -18,7 +18,7 @@
     "stylelint": "stylelint 'app/**/*.scss'",
     "clean": "rm -rf build/ dist/ *.zip *.xpi .checksum",
     "test": "jest --testPathIgnorePatterns e2e",
-    "test-e2e": "cross-env OVERRIDE_AUTH_SECRET=sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ jest --coverage=false e2e",
+    "test-e2e": "jest --coverage=false e2e",
     "storybook": "start-storybook -s ./src/extension/assets -c ./config/storybook -p 6006",
     "build-storybook": "build-storybook -c ./config/storybook"
   },

--- a/client/browser/src/e2e/chrome.e2e.test.ts
+++ b/client/browser/src/e2e/chrome.e2e.test.ts
@@ -34,17 +34,8 @@ async function clickElement(page: puppeteer.Page, element: puppeteer.ElementHand
 }
 
 describe('Sourcegraph Chrome extension', () => {
-    let authenticate: (page: puppeteer.Page) => Promise<void>
-
     let browser: puppeteer.Browser
     let page: puppeteer.Page
-
-    const overrideAuthSecret = process.env.OVERRIDE_AUTH_SECRET
-    if (!overrideAuthSecret) {
-        throw new Error('Auth secret not set - unable to execute tests')
-    }
-
-    authenticate = page => page.setExtraHTTPHeaders({ 'X-Override-Auth-Secret': overrideAuthSecret })
 
     // Open browser.
     beforeAll(
@@ -72,13 +63,12 @@ describe('Sourcegraph Chrome extension', () => {
     // Open page.
     beforeEach(async () => {
         page = await browser.newPage()
-        await authenticate(page)
     })
 
     // Take a screenshot when a test fails.
     saveScreenshotsUponFailuresAndClosePage(
         path.resolve(__dirname, '..', '..', '..', '..'),
-        path.resolve(__dirname, '..', '..', '..', 'puppeteer'),
+        path.resolve(__dirname, '..', '..', '..', '..', 'puppeteer'),
         () => page
     )
 
@@ -129,9 +119,7 @@ describe('Sourcegraph Chrome extension', () => {
 
                 // Scrolls the element into view so that code view is in view.
                 await element.hover()
-                await page.waitForSelector(
-                    '[data-path="regexp.go"] .code-view-toolbar .open-on-sourcegraph:nth-of-type(2)'
-                )
+                await page.waitForSelector('[data-path="regexp.go"] .code-view-toolbar .open-on-sourcegraph')
                 await clickElement(page, element)
                 await page.waitForSelector('.e2e-tooltip-j2d')
             })

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -193,41 +193,15 @@ func main() {
 	}
 
 	addBrowserExtensionReleaseSteps := func() {
-		// // Run e2e tests
-		// pipeline.AddStep(":chromium:",
-		// 	bk.Env("FORCE_COLOR", "1"),
-		// 	bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
-		// 	bk.Env("DISPLAY", ":99"),
-		// 	bk.Cmd("Xvfb :99 &"),
-		// 	bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
-		// 	bk.Cmd("pushd client/browser"),
-		// 	bk.Cmd("yarn -s run build"),
-		// 	bk.Cmd("yarn -s run test:ci"),
-		// 	bk.Cmd("yarn -s run test:e2e-ci --retries 5"),
-		// 	bk.Cmd("popd"),
-		// 	bk.ArtifactPaths("./puppeteer/*.png"),
-		// )
-
-		// pipeline.AddWait()
-
-		// // Run e2e tests with extensions enabled
-		// //
-		// // TODO: Remove this step when extensions are enabled by default
-		// pipeline.AddStep(":chromium:",
-		// 	bk.Env("FORCE_COLOR", "1"),
-		// 	bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
-		// 	bk.Env("DISPLAY", ":99"),
-		// 	bk.Cmd("Xvfb :99 &"),
-		// 	bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
-		// 	bk.Cmd("pushd client/browser"),
-		// 	bk.Cmd("USE_EXTENSIONS=true yarn -s run build"),
-		// 	bk.Cmd("yarn -s run test:ci"),
-		// 	bk.Cmd("yarn -s run test:e2e-ci --retries 5"),
-		// 	bk.Cmd("popd"),
-		// 	bk.ArtifactPaths("./puppeteer/*.png"),
-		// )
-
-		// pipeline.AddWait()
+		// Run e2e tests
+		pipeline.AddStep(":chromium:",
+			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
+			bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
+			bk.Cmd("pushd client/browser"),
+			bk.Cmd("yarn -s run build"),
+			bk.Cmd("yarn -s run test-e2e"),
+			bk.Cmd("popd"),
+			bk.ArtifactPaths("./puppeteer/*.png"))
 
 		// Release to the Chrome Webstore
 		pipeline.AddStep(":chrome:",


### PR DESCRIPTION
This reenables the browser extension e2e tests.

It only tests on pushes to the `bext/release` branch.

It tests against Sourcegraph.com because I couldn't figure out how to set the `chrome.storage.sync` `sourcegraphURL` value through Puppeteer by getting a handle to the background script (see docs at https://github.com/GoogleChrome/puppeteer/blob/bc28f3b3dc42105e4214402fd16aaeea06e77f8b/docs/api.md#working-with-chrome-extensions). When I would do `backgroundPage.evaluate(() => chrome.storage.sync)`, I would get `could not read property 'sync' of undefined`. It seems that accessing storage is not supported. Testing against Sourcegraph.com is better than nothing, though.

Similar to https://github.com/sourcegraph/sourcegraph/pull/2533