### PR TITLE
Undeprecate `showNotification()` and add `NotificationType`

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -429,7 +429,7 @@ declare module 'sourcegraph' {
          * @param message The message to show. Markdown is supported.
          * @param type a {@link NotificationType} affecting the display of the notification.
          */
-        showNotification<T extends string>(message: string, type: NotificationType): void
+        showNotification(message: string, type: NotificationType): void
 
         /**
          * Show progress in the window. Progress is shown while running the given callback

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -426,11 +426,10 @@ declare module 'sourcegraph' {
         /**
          * Show a notification message to the user that does not require interaction or steal focus.
          *
-         * @deprecated This API will change.
          * @param message The message to show. Markdown is supported.
-         * @return A promise that resolves when the user dismisses the message.
+         * @param type a {@link NotificationType} affecting the display of the notification.
          */
-        showNotification(message: string): void
+        showNotification<T extends string>(message: string, type: NotificationType): void
 
         /**
          * Show progress in the window. Progress is shown while running the given callback
@@ -844,6 +843,16 @@ declare module 'sourcegraph' {
          * @default MarkupKind.Markdown
          */
         kind?: MarkupKind
+    }
+
+    /**
+     * The type of a notification shown through {@link Window.showNotification}.
+     */
+    export const enum NotificationType {
+        Info = 'Info',
+        Success = 'Success',
+        Warning = 'Warning',
+        Error = 'Error',
     }
 
     /**

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -849,10 +849,26 @@ declare module 'sourcegraph' {
      * The type of a notification shown through {@link Window.showNotification}.
      */
     export const enum NotificationType {
-        Info = 'Info',
-        Success = 'Success',
-        Warning = 'Warning',
-        Error = 'Error',
+        /**
+         * An error message.
+         */
+        Error = 1,
+        /**
+         * A warning message.
+         */
+        Warning = 2,
+        /**
+         * An info message.
+         */
+        Info = 3,
+        /**
+         * A log message.
+         */
+        Log = 4,
+        /**
+         * A success message.
+         */
+        Success = 5,
     }
 
     /**

--- a/shared/src/api/client/api/windows.ts
+++ b/shared/src/api/client/api/windows.ts
@@ -3,15 +3,15 @@ import { Subject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import {
     MessageActionItem,
-    MessageType,
+    NotificationType,
     ShowInputParams,
-    ShowMessageParams,
     ShowMessageRequestParams,
+    ShowNotificationParams,
 } from '../services/notifications'
 
 /** @internal */
 export interface ClientWindowsAPI extends ProxyValue {
-    $showNotification(message: string): void
+    $showNotification(message: string, type: sourcegraph.NotificationType): void
     $showMessage(message: string): Promise<void>
     $showInputBox(options?: sourcegraph.InputBoxOptions): Promise<string | undefined>
     $showProgress(options: sourcegraph.ProgressOptions): sourcegraph.ProgressReporter & ProxyValue
@@ -23,7 +23,7 @@ export class ClientWindows implements ClientWindowsAPI {
 
     constructor(
         /** Called when the client receives a window/showMessage notification. */
-        private showMessage: (params: ShowMessageParams) => void,
+        private showMessage: (params: ShowNotificationParams) => void,
         /**
          * Called when the client receives a window/showMessageRequest request and expected to return a promise
          * that resolves to the selected action.
@@ -37,12 +37,12 @@ export class ClientWindows implements ClientWindowsAPI {
         private createProgressReporter: (options: sourcegraph.ProgressOptions) => Subject<sourcegraph.Progress>
     ) {}
 
-    public $showNotification(message: string): void {
-        this.showMessage({ type: MessageType.Info, message })
+    public $showNotification(message: string, type: sourcegraph.NotificationType): void {
+        this.showMessage({ type, message })
     }
 
     public $showMessage(message: string): Promise<void> {
-        return this.showMessageRequest({ type: MessageType.Info, message }).then(
+        return this.showMessageRequest({ type: NotificationType.Info, message }).then(
             () =>
                 // TODO(sqs): update the showInput API to unify null/undefined etc between the old internal API and the new
                 // external API.

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -22,8 +22,8 @@ import { Services } from './services'
 import {
     MessageActionItem,
     ShowInputParams,
-    ShowMessageParams,
     ShowMessageRequestParams,
+    ShowNotificationParams,
 } from './services/notifications'
 
 export interface ExtensionHostClientConnection {
@@ -107,7 +107,7 @@ export async function createExtensionHostClientConnection(
     )
 
     const clientWindows = new ClientWindows(
-        (params: ShowMessageParams) => services.notifications.showMessages.next({ ...params }),
+        (params: ShowNotificationParams) => services.notifications.showMessages.next({ ...params }),
         (params: ShowMessageRequestParams) =>
             new Promise<MessageActionItem | null>(resolve => {
                 services.notifications.showMessageRequests.next({ ...params, resolve })

--- a/shared/src/api/client/services/notifications.ts
+++ b/shared/src/api/client/services/notifications.ts
@@ -8,10 +8,11 @@ import * as sourcegraph from 'sourcegraph'
  *
  */
 export const NotificationType = {
-    Error: 'Error' as sourcegraph.NotificationType.Error,
-    Warning: 'Warning' as sourcegraph.NotificationType.Warning,
-    Info: 'Info' as sourcegraph.NotificationType.Info,
-    Success: 'Success' as sourcegraph.NotificationType.Success,
+    Error: 1,
+    Warning: 2,
+    Info: 3,
+    Log: 4,
+    Success: 5,
 }
 
 interface PromiseCallback<T> {

--- a/shared/src/api/client/services/notifications.ts
+++ b/shared/src/api/client/services/notifications.ts
@@ -1,40 +1,31 @@
 import { Observable, Subject } from 'rxjs'
-import { Progress } from 'sourcegraph'
+import * as sourcegraph from 'sourcegraph'
+
+/**
+ * The type of a notification.
+ * This is needed because if sourcegraph.NotificationType enum values are referenced,
+ * the `sourcegraph` module import at the top of the file is emitted in the generated code.
+ *
+ */
+export const NotificationType = {
+    Error: 'Error' as sourcegraph.NotificationType.Error,
+    Warning: 'Warning' as sourcegraph.NotificationType.Warning,
+    Info: 'Info' as sourcegraph.NotificationType.Info,
+    Success: 'Success' as sourcegraph.NotificationType.Success,
+}
 
 interface PromiseCallback<T> {
     resolve: (p: T | Promise<T>) => void
 }
 
 /**
- * The type of a message.
- */
-export enum MessageType {
-    /**
-     * An error message.
-     */
-    Error,
-    /**
-     * A warning message.
-     */
-    Warning,
-    /**
-     * An information message.
-     */
-    Info,
-    /**
-     * A log message.
-     */
-    Log,
-}
-
-/**
  * The parameters of a notification message.
  */
-export interface ShowMessageParams {
+export interface ShowNotificationParams {
     /**
-     * The message type. See {@link MessageType}
+     * The notification type. See {@link NotificationType}
      */
-    type: MessageType
+    type: sourcegraph.NotificationType
 
     /**
      * The actual message
@@ -51,9 +42,9 @@ export interface MessageActionItem {
 
 export interface ShowMessageRequestParams {
     /**
-     * The message type. See {@link MessageType}
+     * The message type. See {@link NotificationType}
      */
-    type: MessageType
+    type: sourcegraph.NotificationType
 
     /**
      * The actual message
@@ -75,36 +66,18 @@ export interface ShowInputParams {
     defaultValue?: string
 }
 
-/**
- * The log message parameters.
- */
-interface LogMessageParams {
-    /**
-     * The message type. See {@link MessageType}
-     */
-    type: MessageType
-
-    /**
-     * The actual message
-     */
-    message: string
-}
-
 type ShowMessageRequest = ShowMessageRequestParams & PromiseCallback<MessageActionItem | null>
 
 type ShowInputRequest = ShowInputParams & PromiseCallback<string | null>
 
 export class NotificationsService {
-    /** Log messages from extensions. */
-    public readonly logMessages = new Subject<LogMessageParams>()
-
     /** Messages from extensions intended for display to the user. */
-    public readonly showMessages = new Subject<ShowMessageParams>()
+    public readonly showMessages = new Subject<ShowNotificationParams>()
 
     /** Messages from extensions requesting the user to select an action. */
     public readonly showMessageRequests = new Subject<ShowMessageRequest>()
     /** Messages from extensions requesting the user to select an action. */
-    public readonly progresses = new Subject<{ title?: string; progress: Observable<Progress> }>()
+    public readonly progresses = new Subject<{ title?: string; progress: Observable<sourcegraph.Progress> }>()
 
     /** Messages from extensions requesting text input from the user. */
     public readonly showInputs = new Subject<ShowInputRequest>()

--- a/shared/src/api/extension/api/windows.ts
+++ b/shared/src/api/extension/api/windows.ts
@@ -30,9 +30,9 @@ class ExtWindow implements sourcegraph.Window {
         return this.textEditors.find(({ isActive }) => isActive)
     }
 
-    public showNotification(message: string): void {
+    public showNotification(message: string, type: sourcegraph.NotificationType): void {
         // tslint:disable-next-line: no-floating-promises
-        this.windowsProxy.$showNotification(message)
+        this.windowsProxy.$showNotification(message, type)
     }
 
     public showMessage(message: string): Promise<void> {

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -3,6 +3,7 @@ import { Subscription, Unsubscribable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { EndpointPair } from '../../platform/context'
 import { ClientAPI } from '../client/api/api'
+import { NotificationType } from '../client/services/notifications'
 import { ExtensionHostAPI, ExtensionHostAPIFactory } from './api/api'
 import { ExtCommands } from './api/commands'
 import { ExtConfiguration } from './api/configuration'
@@ -167,7 +168,7 @@ function createExtensionAPI(
             PlainText: 'plaintext' as sourcegraph.MarkupKind.PlainText,
             Markdown: 'markdown' as sourcegraph.MarkupKind.Markdown,
         },
-
+        NotificationType,
         app: {
             activeWindowChanges: windows.activeWindowChanges,
             get activeWindow(): sourcegraph.Window | undefined {

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -1,7 +1,6 @@
 import { from } from 'rxjs'
 import { map, take, toArray } from 'rxjs/operators'
-import { ViewComponent, Window } from 'sourcegraph'
-import { MessageType } from '../client/services/notifications'
+import { NotificationType, ViewComponent, Window } from 'sourcegraph'
 import { assertToJSON } from '../extension/types/testHelpers'
 import { collectSubscribableValues, integrationTestContext } from './testHelpers'
 
@@ -179,9 +178,9 @@ describe('Windows (integration)', () => {
         test('Window#showNotification', async () => {
             const { extensionAPI, services } = await integrationTestContext()
             const values = collectSubscribableValues(services.notifications.showMessages)
-            extensionAPI.app.activeWindow!.showNotification('a') // tslint:disable-line deprecation
+            extensionAPI.app.activeWindow!.showNotification('a', NotificationType.Info) // tslint:disable-line deprecation
             await extensionAPI.internal.sync()
-            expect(values).toEqual([{ message: 'a', type: MessageType.Info }] as typeof values)
+            expect(values).toEqual([{ message: 'a', type: NotificationType.Info }] as typeof values)
         })
 
         test('Window#showMessage', async () => {
@@ -191,7 +190,7 @@ describe('Windows (integration)', () => {
                 services.notifications.showMessageRequests.pipe(map(({ message, type }) => ({ message, type })))
             )
             expect(await extensionAPI.app.activeWindow!.showMessage('a')).toBe(undefined)
-            expect(values).toEqual([{ message: 'a', type: MessageType.Info }] as typeof values)
+            expect(values).toEqual([{ message: 'a', type: NotificationType.Info }] as typeof values)
         })
 
         test('Window#showInputBox', async () => {

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -84,7 +84,7 @@ export function createController(context: PlatformContext): Controller {
     )
     subscriptions.add(
         services.notifications.progresses.subscribe(({ title, progress }) => {
-            notifications.next({ message: title, progress })
+            notifications.next({ message: title, progress, type: NotificationType.Log })
         })
     )
 

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -5,7 +5,7 @@ import { Services } from '../api/client/services'
 import { ExecuteCommandParams } from '../api/client/services/command'
 import { ContributionRegistry } from '../api/client/services/contribution'
 import { ExtensionsService } from '../api/client/services/extensionsService'
-import { MessageType } from '../api/client/services/notifications'
+import { NotificationType } from '../api/client/services/notifications'
 import { InitData } from '../api/extension/extensionHost'
 import { Contributions } from '../api/protocol'
 import { registerBuiltinClientCommands } from '../commands/commands'
@@ -84,7 +84,7 @@ export function createController(context: PlatformContext): Controller {
     )
     subscriptions.add(
         services.notifications.progresses.subscribe(({ title, progress }) => {
-            notifications.next({ message: title, progress, type: MessageType.Log })
+            notifications.next({ message: title, progress })
         })
     )
 
@@ -113,13 +113,6 @@ export function createController(context: PlatformContext): Controller {
         )
     )
 
-    // Print window/logMessage log messages to the browser devtools console.
-    subscriptions.add(
-        services.notifications.logMessages.subscribe(({ message }) => {
-            log('info', 'EXT', message)
-        })
-    )
-
     // Debug helpers.
     const DEBUG = true
     if (DEBUG) {
@@ -143,7 +136,7 @@ export function createController(context: PlatformContext): Controller {
                 if (!suppressNotificationOnError) {
                     notifications.next({
                         message: asError(err).message,
-                        type: MessageType.Error,
+                        type: NotificationType.Error,
                         source: params.command,
                     })
                 }

--- a/shared/src/notifications/NotificationItem.tsx
+++ b/shared/src/notifications/NotificationItem.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import { from, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, scan, switchMap } from 'rxjs/operators'
-import { Progress } from 'sourcegraph'
-import { MessageType } from '../api/client/services/notifications'
+import * as sourcegraph from 'sourcegraph'
+import { NotificationType } from '../api/client/services/notifications'
 import { renderMarkdown } from '../util/markdown'
 import { Notification } from './notification'
 
@@ -13,7 +13,7 @@ interface Props {
 }
 
 interface State {
-    progress?: Required<Progress>
+    progress?: Required<sourcegraph.Progress>
 }
 
 /**
@@ -41,7 +41,7 @@ export class NotificationItem extends React.PureComponent<Props, State> {
                         from(progress || []).pipe(
                             // Hide progress bar and update message if error occured
                             // Merge new progress updates with previous
-                            scan<Progress, Required<Progress>>(
+                            scan<sourcegraph.Progress, Required<sourcegraph.Progress>>(
                                 (current, { message = current.message, percentage = current.percentage }) => ({
                                     message,
                                     percentage,
@@ -119,15 +119,16 @@ export class NotificationItem extends React.PureComponent<Props, State> {
 /**
  * @return The Bootstrap class that corresponds to {@link type}.
  */
-function getBootstrapClass(type: MessageType | undefined): string {
+function getBootstrapClass(type: sourcegraph.NotificationType | undefined): string {
     switch (type) {
-        case MessageType.Error:
+        case NotificationType.Error:
             return 'danger'
-        case MessageType.Warning:
+        case NotificationType.Warning:
             return 'warning'
-        case MessageType.Info:
+        case NotificationType.Success:
+            return 'success'
+        case NotificationType.Info:
             return 'info'
-        case MessageType.Log:
         default:
             return 'secondary'
     }

--- a/shared/src/notifications/Notifications.tsx
+++ b/shared/src/notifications/Notifications.tsx
@@ -2,7 +2,7 @@ import { uniqueId } from 'lodash'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
 import { delay, map, takeWhile } from 'rxjs/operators'
-import { MessageType } from '../api/client/services/notifications'
+import { NotificationType } from '../api/client/services/notifications'
 import { ExtensionsControllerProps } from '../extensions/controller'
 import { asError } from '../util/errors'
 import { Notification } from './notification'
@@ -53,7 +53,7 @@ export class Notifications extends React.PureComponent<Props, State> {
                                                 n === notification
                                                     ? {
                                                           ...n,
-                                                          type: MessageType.Error,
+                                                          type: NotificationType.Error,
                                                           message: asError(err).message,
                                                       }
                                                     : n

--- a/shared/src/notifications/notification.ts
+++ b/shared/src/notifications/notification.ts
@@ -11,7 +11,7 @@ export interface Notification {
     /**
      * The type of the message.
      */
-    type?: NotificationType
+    type: NotificationType
 
     /** The source of the notification.  */
     source?: string

--- a/shared/src/notifications/notification.ts
+++ b/shared/src/notifications/notification.ts
@@ -1,6 +1,5 @@
 import { Observable } from 'rxjs'
-import { Progress } from 'sourcegraph'
-import { MessageType } from '../api/client/services/notifications'
+import { NotificationType, Progress } from 'sourcegraph'
 
 /**
  * A notification message to display to the user.
@@ -11,10 +10,8 @@ export interface Notification {
 
     /**
      * The type of the message.
-     *
-     * @default MessageType.Info
      */
-    type?: MessageType
+    type?: NotificationType
 
     /** The source of the notification.  */
     source?: string


### PR DESCRIPTION
Fixes #1471

This PR removes the (unintended) deprecation of  `window.showNotification()` (see [this comment](https://github.com/sourcegraph/sourcegraph/issues/1471#issuecomment-458976742)) and extends it to accept a `NotificationType`.

Notable changes:
- The internal `MessageType` enum has been removed in favour of `NotificationType`.
- Removed unused `NotificationsService.logMessages` & `LogMessageParams` interface (it was never exposed to extensions): again, while we should introduce a logging interface for extensions, it should be distinct from the notifications service.
-  Here's how notifications look in the browser extension and the web app:

![image](https://user-images.githubusercontent.com/1741180/53826880-f37a9300-3f79-11e9-8c24-5b778548e2e4.png)
![image](https://user-images.githubusercontent.com/1741180/53826889-f6758380-3f79-11e9-8e13-d36b2bc1bf49.png)
