### PR TITLE
Add page to docs on open company and open product

### DIFF
--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -34,6 +34,7 @@ Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](h
 
 </blockquote>
 
+- [Open product, open company, open source](open_source_open_company.md)
 - [Roadmap](roadmap/index.md)
 - [Product planning](product/index.md)
 - [Issue triage](issues.md)

--- a/doc/dev/open_source_open_company.md
+++ b/doc/dev/open_source_open_company.md
@@ -1,0 +1,33 @@
+---
+ignoreDisconnectedPageCheck: true
+---
+
+# Sourcegraph: open product, open company, open source
+
+As part of making Sourcegraph open source, we now build Sourcegraph ([roadmap](roadmap/index.md) and [issues](http://github.com/sourcegraph/sourcegraph/issues/)) as an **open product**, and **open company**. Our [website](https://github.com/sourcegraph/about) and [documentation](https://github.com/sourcegraph/sourcegraph/tree/master/doc) is now open source  which holds product- and company-related docs.
+
+Here's how we define these terms:
+
+## Open product
+
+This means the [product roadmap](roadmap/index.md) is public and open for input.
+
+You might not realize it, but the products you use every day are not just open source; they are also open products. Products like [Kubernetes](https://github.com/kubernetes/kubernetes/milestones?direction=asc&sort=due_date) and [Visual Studio Code](https://github.com/Microsoft/vscode/wiki/Iteration-Plans) do all their product planning in the open. They get useful input from the community and make it easy to integrate and rely on their products.
+
+## Open company
+
+This means that principles, strategies, and processes for internal company functions are publicly documented, including for recruiting, marketing, pricing, and sales—not just engineering and product.
+
+Being an open company is important because being an open product isn't enough to gain the trust of developers. You need to do the same for other important parts of the company that affect the product, the open-source project, and the users. See [GitLab's pricing strategy](https://about.gitlab.com/handbook/product/pricing/) in their public handbook for a great example of this.
+
+Open company doesn't mean that everything is public; only principles, strategies, and processes related to our internal functions. We're proud to be sharing more about how we run Sourcegraph Inc!
+
+## Open source
+
+<!-- TODO (ryan): Talk to @sqs about what content should go here -->
+
+Sourcegraph OSS is available freely under the [Apache 2 license](LICENSE.apache). Sourcegraph OSS comprises all files in this repository except those in the `enterprise/` and `web/src/enterprise` directories.
+
+All files in the `enterprise/` and `web/src/enterprise/` directories are subject to the [Sourcegraph Enterprise license](LICENSE.enterprise).
+
+More info is in the [open source FAQs](faq.md)

--- a/doc/dev/open_source_open_company.md
+++ b/doc/dev/open_source_open_company.md
@@ -1,7 +1,3 @@
----
-ignoreDisconnectedPageCheck: true
----
-
 # Sourcegraph: open product, open company, open source
 
 As part of making Sourcegraph open source, we now build Sourcegraph ([roadmap](roadmap/index.md) and [issues](http://github.com/sourcegraph/sourcegraph/issues/)) as an **open product**, and **open company**. Our [website](https://github.com/sourcegraph/about) and [documentation](https://github.com/sourcegraph/sourcegraph/tree/master/doc) is now open source  which holds product- and company-related docs.
@@ -26,8 +22,4 @@ Open company doesn't mean that everything is public; only principles, strategies
 
 <!-- TODO (ryan): Talk to @sqs about what content should go here -->
 
-Sourcegraph OSS is available freely under the [Apache 2 license](LICENSE.apache). Sourcegraph OSS comprises all files in this repository except those in the `enterprise/` and `web/src/enterprise` directories.
-
-All files in the `enterprise/` and `web/src/enterprise/` directories are subject to the [Sourcegraph Enterprise license](LICENSE.enterprise).
-
-More info is in the [open source FAQs](faq.md)
+To learn more about what **open source** means at Sourcegraph, see the [open source FAQs](faq.md) and [license documentation](../README.md#license).

--- a/doc/dev/open_source_open_company.md
+++ b/doc/dev/open_source_open_company.md
@@ -20,4 +20,4 @@ Open company doesn't mean that everything is public; only principles, strategies
 
 ## Open source
 
-To learn more about what **open source** means at Sourcegraph, see the [open source FAQs](faq.md) and [license documentation](../README.md#license).
+To learn more about what **open source** means at Sourcegraph, see the [open source FAQs](faq.md) and [license documentation](https://github.com/sourcegraph/sourcegraph#license).

--- a/doc/dev/open_source_open_company.md
+++ b/doc/dev/open_source_open_company.md
@@ -20,6 +20,4 @@ Open company doesn't mean that everything is public; only principles, strategies
 
 ## Open source
 
-<!-- TODO (ryan): Talk to @sqs about what content should go here -->
-
 To learn more about what **open source** means at Sourcegraph, see the [open source FAQs](faq.md) and [license documentation](../README.md#license).


### PR DESCRIPTION
This info was previously available as a blog post on `sourcegraph/about` but there needs to be a point of reference about Sourcegraph's philosophy of developing in the open.

Catalyst for this was wanting to link to such a page from the latest 3.2 blog post as it discusses how we develop in the open and the benefits that has for getting input on the product roadmap.