### PR TITLE
Debug e2e ci errors

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -20,10 +20,18 @@ socat tcp-listen:7080,reuseaddr,fork system:"docker exec -i $CONTAINER socat std
 
 URL="http://localhost:7080"
 
+set +e
 timeout 30s bash -c "until curl --output /dev/null --silent --head --fail $URL; do
     echo Waiting 5s for $URL...
     sleep 5
 done"
+if [ $? -ne 0 ]; then
+    echo "$URL was not accessible within 30s. Here's the output of docker inspect and docker logs:"
+    docker inspect "$CONTAINER"
+    docker logs "$CONTAINER"
+    exit 1
+fi
+set -e
 echo "Waiting for $URL... done"
 
 pushd web

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -9,8 +9,8 @@ if [ -z "$IMAGE" ]; then
 fi
 
 echo "Running a daemonized $IMAGE as the test subject..."
-CONTAINER="$(docker container run --rm -d $IMAGE)"
-trap 'kill $(jobs -p)'" ; docker container stop $CONTAINER" EXIT
+CONTAINER="$(docker container run -d $IMAGE)"
+trap 'kill $(jobs -p)'" ; docker container rm -f $CONTAINER" EXIT
 
 docker exec "$CONTAINER" apk add --no-cache socat
 # Connect the server container's port 7080 to localhost:7080 so that e2e tests


### PR DESCRIPTION
CI errored out before running e2e tests earlier today:

https://buildkite.com/sourcegraph/sourcegraph/builds/28952#dea33fa5-e581-4cd9-a2d4-1084aee65ec8

```
+ timeout 30s bash -c 'until curl --output /dev/null --silent --head --fail http://localhost:7080; do
--
  | echo Waiting 5s for http://localhost:7080...
  | sleep 5
  | done'
  | + socat tcp-listen:7080,reuseaddr,fork 'system:docker exec -i 7debb79dd4b5edd39e133551fb9c0c42c8d0e68ff77884d8be9164e6b90c8e5c socat stdio '\''tcp:localhost:7080'\'''
  | 2019/03/06 01:46:56 socat[43] E connect(5, AF=2 127.0.0.1:7080, 16): Connection refused
  | 2019/03/06 01:46:56 socat[10745] E waitpid(): child 10751 exited with status 1
  | Waiting 5s for http://localhost:7080...
  | Waiting 5s for http://localhost:7080...
  | Waiting 5s for http://localhost:7080...
  | Waiting 5s for http://localhost:7080...
  | Waiting 5s for http://localhost:7080...
  | Waiting 5s for http://localhost:7080...
  | ++ jobs -p
  | + kill 10745
  | ./dev/ci/e2e.sh: line 1: kill: (10745) - No such process
```

This PR adds output of `docker inspect` and `docker logs` to aid debugging.