### PR TITLE
show Go package "used by" counts including repository subpackages

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -146,7 +146,7 @@ func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) (
 
 	importPaths := make([]string, 0, len(subpaths))
 	for subpath := range subpaths {
-		importPaths = append(importPaths, string(repo.Name)+"/"+subpath)
+		importPaths = append(importPaths, path.Join(string(repo.Name), subpath))
 	}
 	sort.Strings(importPaths)
 	return importPaths, nil

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -3,44 +3,153 @@ package backend
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
 
-	"github.com/die-net/lrucache"
-	"github.com/gregjones/httpcache"
+	"github.com/golang/groupcache/lru"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
+	"golang.org/x/net/context/ctxhttp"
 )
 
 var MockCountGoImporters func(ctx context.Context, repo api.RepoName) (int, error)
 
-// 100 MiB cache, no age-based eviction
-var httpClient = &http.Client{Transport: httpcache.NewTransport(lrucache.New(100*1024*1024, 0))}
+var (
+	goImportersCountCacheMu sync.Mutex
+	goImportersCountCache   = lru.New(1000) // 1000 is arbitrarily chosen
 
-// CountGoImporters returns the number of Go importers for the repository. This is a special case
-// used only on Sourcegraph.com for repository badges.
+	countGoImportersHTTPClient *http.Client // mockable in tests
+)
+
+// CountGoImporters returns the number of Go importers for the repository's Go subpackages. This is
+// a special case used only on Sourcegraph.com for repository badges.
 //
 // TODO: The import path is not always the same as the repository name.
-func CountGoImporters(ctx context.Context, repo api.RepoName) (int, error) {
+func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err error) {
 	if MockCountGoImporters != nil {
 		return MockCountGoImporters(ctx, repo)
 	}
-	// Assumes the import path is the same as the repo name - not always true!
-	response, err := httpClient.Get("https://api.godoc.org/importers/" + string(repo))
+
+	if !envvar.SourcegraphDotComMode() {
+		// Avoid confusing users by exposing this on self-hosted instances, because it relies on the
+		// public godoc.org API.
+		return 0, errors.New("counting Go importers is not supported on self-hosted instances")
+	}
+
+	goImportersCountCacheMu.Lock()
+	v, ok := goImportersCountCache.Get(repo)
+	goImportersCountCacheMu.Unlock()
+	if ok {
+		return v.(int), nil // cache hit
+	}
+
+	defer func() {
+		if err == nil {
+			// Store in cache.
+			goImportersCountCacheMu.Lock()
+			defer goImportersCountCacheMu.Unlock()
+			goImportersCountCache.Add(repo, count)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second) // avoid tying up resources unduly
+	defer cancel()
+
+	// Find all (possible) Go packages in the repository.
+	goPackages, err := listGoPackagesInRepoImprecise(ctx, repo)
 	if err != nil {
 		return 0, err
 	}
-	var result struct {
-		Results []struct {
-			Path string
+	const maxSubpackages = 50 // arbitrary limit to avoid overloading api.godoc.org
+	if len(goPackages) > maxSubpackages {
+		goPackages = goPackages[:maxSubpackages]
+	}
+
+	// Count importers for each of the repository's Go packages.
+	for _, pkg := range goPackages {
+		// Assumes the import path is the same as the repo name - not always true!
+		response, err := ctxhttp.Get(ctx, countGoImportersHTTPClient, "https://api.godoc.org/importers/"+string(pkg))
+		if err != nil {
+			return 0, err
+		}
+		var result struct {
+			Results []struct {
+				Path string
+			}
+		}
+		bytes, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return 0, err
+		}
+		err = json.Unmarshal(bytes, &result)
+		if err != nil {
+			return 0, err
+		}
+		count += len(result.Results)
+	}
+
+	return count, nil
+}
+
+// listGoPackagesInRepo returns a list of import paths for all (probable) Go packages in the
+// repository. It computes the list based solely on the repository name (as a prefix) and filenames
+// in the repository; it does not parse or build the Go files to determine the list precisely.
+func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) ([]string, error) {
+	if !envvar.SourcegraphDotComMode() {
+		// 🚨 SECURITY: Avoid leaking information about private repositories that the viewer is not
+		// allowed to access.
+		return nil, errors.New("listGoPackagesInRepo is only supported on Sourcegraph.com for public repositories")
+	}
+
+	repo, err := Repos.GetByName(ctx, repoName)
+	if err != nil {
+		return nil, err
+	}
+	gitRepo, err := CachedGitRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	commitID, err := git.ResolveRevision(ctx, *gitRepo, nil, "HEAD", nil)
+	if err != nil {
+		return nil, err
+	}
+	fis, err := git.ReadDir(ctx, *gitRepo, commitID, "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	subpaths := map[string]struct{}{} // all non-vendor/internal/hidden dirs containing *.go files
+	for _, fi := range fis {
+		if name := fi.Name(); filepath.Ext(name) == ".go" {
+			dir := path.Dir(name)
+			if isPossibleExternallyImportableGoPackageDir(dir) {
+				subpaths[dir] = struct{}{}
+			}
 		}
 	}
-	bytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return 0, err
+
+	importPaths := make([]string, 0, len(subpaths))
+	for subpath := range subpaths {
+		importPaths = append(importPaths, string(repo.Name)+"/"+subpath)
 	}
-	err = json.Unmarshal(bytes, &result)
-	if err != nil {
-		return 0, err
+	sort.Strings(importPaths)
+	return importPaths, nil
+}
+
+func isPossibleExternallyImportableGoPackageDir(dirPath string) bool {
+	components := strings.Split(dirPath, "/")
+	for _, c := range components {
+		if (strings.HasPrefix(c, ".") && len(c) > 1) || strings.HasPrefix(c, "_") || c == "vendor" || c == "internal" || c == "testdata" {
+			return false
+		}
 	}
-	return len(result.Results), nil
+	return true
 }

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -118,6 +118,9 @@ func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) (
 	if err != nil {
 		return nil, err
 	}
+	if !repo.Enabled {
+		return nil, errors.New("repository is not enabled")
+	}
 	gitRepo, err := CachedGitRepo(ctx, repo)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -74,6 +74,11 @@ func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err er
 	}
 
 	// Count importers for each of the repository's Go packages.
+	//
+	// TODO: The count sums together the user counts of all of the repository's subpackages. This
+	// overcounts the number of users, because if another project uses multiple subpackages in this
+	// repository, it is counted multiple times. This limitation is now documented and will be
+	// addressed in the future. See https://github.com/sourcegraph/sourcegraph/issues/2663.
 	for _, pkg := range goPackages {
 		// Assumes the import path is the same as the repo name - not always true!
 		response, err := ctxhttp.Get(ctx, countGoImportersHTTPClient, "https://api.godoc.org/importers/"+string(pkg))

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -104,14 +104,15 @@ func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err er
 	return count, nil
 }
 
-// listGoPackagesInRepo returns a list of import paths for all (probable) Go packages in the
-// repository. It computes the list based solely on the repository name (as a prefix) and filenames
-// in the repository; it does not parse or build the Go files to determine the list precisely.
+// listGoPackagesInRepoImprecise returns a list of import paths for all (probable) Go packages in
+// the repository. It computes the list based solely on the repository name (as a prefix) and
+// filenames in the repository; it does not parse or build the Go files to determine the list
+// precisely.
 func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) ([]string, error) {
 	if !envvar.SourcegraphDotComMode() {
 		// 🚨 SECURITY: Avoid leaking information about private repositories that the viewer is not
 		// allowed to access.
-		return nil, errors.New("listGoPackagesInRepo is only supported on Sourcegraph.com for public repositories")
+		return nil, errors.New("listGoPackagesInRepoImprecise is only supported on Sourcegraph.com for public repositories")
 	}
 
 	repo, err := Repos.GetByName(ctx, repoName)

--- a/cmd/frontend/backend/go_importers_test.go
+++ b/cmd/frontend/backend/go_importers_test.go
@@ -35,7 +35,11 @@ func TestCountGoImporters(t *testing.T) {
 		if repoName != wantRepoName {
 			t.Errorf("got repo name %q, want %q", repoName, wantRepoName)
 		}
-		return &types.Repo{Name: repoName, ExternalRepo: &api.ExternalRepoSpec{ServiceType: github.ServiceType}}, nil
+		return &types.Repo{
+			Name:         repoName,
+			ExternalRepo: &api.ExternalRepoSpec{ServiceType: github.ServiceType},
+			Enabled:      true,
+		}, nil
 	}
 	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
 		return "c", nil

--- a/cmd/frontend/backend/go_importers_test.go
+++ b/cmd/frontend/backend/go_importers_test.go
@@ -1,0 +1,97 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
+	"github.com/sourcegraph/sourcegraph/pkg/vcs/util"
+)
+
+func TestCountGoImporters(t *testing.T) {
+	ctx := testContext()
+	const wantRepoName = "github.com/alice/myrepo"
+
+	orig := envvar.SourcegraphDotComMode()
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(orig) // reset
+
+	mockTransport := mockRoundTripper{
+		response: `{"results":[{"path":"w/x"},{"path":"y/z"}]}`,
+	}
+	countGoImportersHTTPClient = &http.Client{Transport: mockTransport}
+	defer func() { countGoImportersHTTPClient = nil }()
+
+	Mocks.Repos.GetByName = func(_ context.Context, repoName api.RepoName) (*types.Repo, error) {
+		if repoName != wantRepoName {
+			t.Errorf("got repo name %q, want %q", repoName, wantRepoName)
+		}
+		return &types.Repo{Name: repoName, ExternalRepo: &api.ExternalRepoSpec{ServiceType: github.ServiceType}}, nil
+	}
+	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+		return "c", nil
+	}
+	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error) {
+		return []os.FileInfo{
+			&util.FileInfo{Name_: "d/a.go", Mode_: os.ModeDir},
+			&util.FileInfo{Name_: "d/b.go", Mode_: os.ModeDir},
+			&util.FileInfo{Name_: "c.go", Mode_: 0},
+		}, nil
+	}
+
+	count, err := CountGoImporters(ctx, wantRepoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 4; /* 2 results (w/x, y/z) * 2 Go packages (d and root) */ count != want {
+		t.Errorf("got count %d, want %d", count, want)
+	}
+}
+
+func TestListGoPackagesInRepoImprecise(t *testing.T) {
+	t.Run("disabled on non-Sourcegraph.com", func(t *testing.T) {
+		if _, err := listGoPackagesInRepoImprecise(context.Background(), "a"); err == nil || !strings.Contains(err.Error(), "only supported on Sourcegraph.com") {
+			t.Error("want listGoPackagesInRepoImprecise to only be supported on Sourcegraph.com")
+		}
+	})
+}
+
+type mockRoundTripper struct {
+	response string
+}
+
+func (t mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(t.response)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestIsPossibleExternallyImportableGoPackageDir(t *testing.T) {
+	tests := map[string]bool{
+		"a":            true,
+		"a/b":          true,
+		".":            true,
+		"a/internal/b": false,
+		"a/_b":         false,
+		"a/_b/c":       false,
+		"vendor/a":     false,
+		"a/vendor/b":   false,
+		"a/testdata/b": false,
+	}
+	for dirPath, want := range tests {
+		if got := isPossibleExternallyImportableGoPackageDir(dirPath); got != want {
+			t.Errorf("%q: got %v, want %v", dirPath, got, want)
+		}
+	}
+}

--- a/cmd/frontend/backend/mocks.go
+++ b/cmd/frontend/backend/mocks.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
+	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
 )
 
 var Mocks MockServices
@@ -19,6 +20,7 @@ type MockServices struct {
 func testContext() context.Context {
 	db.Mocks = db.MockStores{}
 	Mocks = MockServices{}
+	git.ResetMocks()
 
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})

--- a/doc/user/index.md
+++ b/doc/user/index.md
@@ -24,6 +24,7 @@ Welcome to Sourcegraph! As a developer, you can use Sourcegraph to get help whil
   - Cross-repository jump-to-definition and find-references
   - Supports [Go](https://sourcegraph.com/extensions/sourcegraph/go), [TypeScript](https://sourcegraph.com/extensions/sourcegraph/typescript), [Python](https://sourcegraph.com/extensions/sourcegraph/python) - check the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22) for more
 - [GraphQL API](../api/graphql/index.md)
+- [Repository badges](repository/badges.md)
 
 All features:
 

--- a/doc/user/repository/badges.md
+++ b/doc/user/repository/badges.md
@@ -1,0 +1,25 @@
+# Repository badges (Go open-source projects only)
+
+> NOTE: Right now, this feature is only supported for open-source Go repositories on Sourcegraph.com.
+
+Sourcegraph.com generates badges with usage statistics for open-source Go repositories. The badges shows the total number of Go packages (among all known public repositories) that import the repository's Go packages.
+
+To add a badge to your project's README.md, add this Markdown:
+
+``` markdown
+[![Sourcegraph](https://sourcegraph.com/github.com/gorilla/mux/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/mux?badge)
+```
+
+(Be sure to replace `github.com/gorilla/mux` with your own repository's name.)
+
+This renders the following badge:
+
+[![Sourcegraph](https://sourcegraph.com/github.com/gorilla/mux/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/mux?badge)
+
+## Known issues
+
+Please report any other issues and feature requests on the [Sourcegraph issue tracker](https://github.com/sourcegraph/sourcegraph/issues).
+
+- The number may be overcounted because it is the sum of counts for all of the repository's subpackages. If another project uses multiple subpackages in this repository, the project is counted multiple times.
+- Importers using custom Go import paths (i.e., anything other than import paths prefixed by the repository name, such as `github.com/foo/bar`) will not be counted.
+

--- a/doc/user/repository/index.md
+++ b/doc/user/repository/index.md
@@ -1,0 +1,7 @@
+# Repositories
+
+Users can search and navigate repositories on Sourcegraph.
+
+> NOTE: This documentation page is incomplete. More user-facing information about repositories will be added here.
+
+- [Badges](badges.md)


### PR DESCRIPTION
Previously, our "used by" badge (for Go packages) would only show the number of other packages using a repository's *top-level* package, not its subpackages. Now the "used by" badge counts users of its subpackages.

It works as follows:

- Determine the custom import path (if any) in use by looking for Go import path comments in the repository. We implement this heuristic in our Go language server already, and we can reuse that code.
- Perform iterated calls to the importers API for each of the (non-vendor, non-internal) Go subpackages in the repository. Sum the result.

The count sums together the user counts of all of the repository's subpackages. This overcounts the number of users, because if another project uses multiple subpackages in this repository, it is counted multiple times. This limitation is now documented and will be addressed in the future.

Fixes some of https://github.com/sourcegraph/sourcegraph/issues/849 (does not implement actually showing the packages that use it).


<!-- Remember to update the changelog for user-facing changes. -->