### PR TITLE
CSS: Fix repository page padding

### DIFF
--- a/web/src/components/ConnectionPopover.scss
+++ b/web/src/components/ConnectionPopover.scss
@@ -56,7 +56,7 @@ $popover-item-padding-v: 0.325rem;
             border-color: $color-light-border;
         }
 
-        .e2e-filtered-connection {
+        .filtered-connection {
             &__summary {
                 border-top-color: $color-light-border;
             }

--- a/web/src/components/FilteredConnection.scss
+++ b/web/src/components/FilteredConnection.scss
@@ -1,4 +1,4 @@
-.e2e-filtered-connection {
+.filtered-connection {
     &__nodes {
         list-style-type: none;
         padding: 0;
@@ -60,7 +60,7 @@
 }
 
 .theme-light {
-    .e2e-filtered-connection {
+    .filtered-connection {
         &--compact .filtered-connection__summary {
             border-color: $color-light-border;
         }

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -627,7 +627,10 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
 
         const compactnessClass = `filtered-connection--${this.props.compact ? 'compact' : 'noncompact'}`
         return (
-            <div className={`e2e-filtered-connection ${compactnessClass} ${this.props.className || ''}`}>
+            <div
+                className={`filtered-connection e2e-filtered-connection ${compactnessClass} ${this.props.className ||
+                    ''}`}
+            >
                 {(!this.props.hideSearch || this.props.filters) && (
                     <Form className="filtered-connection__form" onSubmit={this.onSubmit}>
                         {!this.props.hideSearch && (
@@ -689,7 +692,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                     />
                 )}
                 {this.state.loading && (
-                    <span className="e2e-filtered-connection__loader">
+                    <span className="filtered-connection__loader e2e-filtered-connection__loader">
                         <LoadingSpinner className="icon-inline" />
                     </span>
                 )}


### PR DESCRIPTION
This adds `e2e-` classes instead of modifying existing classes. @felixfbecker Have you encountered this problem before? One downside of this solution is redundancy in the class names. On the upside, this doesn't require any CSS changes.

Fixes https://github.com/sourcegraph/sourcegraph/issues/2591