### PR TITLE
Massively reduced the number of code host API requests Sourcegraph performs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Symbols search is much faster now. After the initial indexing, you can expect code intelligence to be nearly instant no matter the size of your repository.
+- Massively reduced the number of code host API requests Sourcegraph performs, which caused rate limiting issues such as slow search result loading to appear.
 
 ### Fixed
 

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -158,10 +158,8 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 	ctx, done := trace(ctx, "Repos", "ResolveRev", map[string]interface{}{"repo": repo.Name, "rev": rev}, &err)
 	defer done()
 
-	// We use fastGitRepoForRevResolution to intelligently choose between
-	// GitRepo / CachedGitRepo here based on whether or not Gitserver is aware
-	// of the revision or not. See that function for more details.
-	grepo, err := fastGitRepoForRevResolution(ctx, repo, rev)
+	// Try to get latest remote URL, but continue even if that fails.
+	grepo, err := GitRepo(ctx, repo)
 	maybeLogRepoUpdaterError(repo, err)
 	if err != nil && !isIgnorableRepoUpdaterError(err) {
 		return "", err
@@ -183,43 +181,13 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 		return nil, errors.Errorf("non-absolute CommitID for Repos.GetCommit: %v", commitID)
 	}
 
-	// We use fastGitRepoForRevResolution to intelligently choose between
-	// GitRepo / CachedGitRepo here based on whether or not Gitserver is aware
-	// of the revision or not. See that function for more details.
-	gitserverRepo, err := fastGitRepoForRevResolution(ctx, repo, string(commitID))
+	// Try to get latest remote URL, but continue even if that fails.
+	gitserverRepo, err := GitRepo(ctx, repo)
 	maybeLogRepoUpdaterError(repo, err)
 	if err != nil && !isIgnorableRepoUpdaterError(err) {
 		return nil, err
 	}
 	return git.GetCommit(ctx, gitserverRepo, commitID)
-}
-
-// fastGitRepoForRevResolution returns a CachedGitRepo if it contains the
-// specified rev, or else returns a GitRepo (which will update the gitserver
-// repo if the rev does not exist).
-//
-// This is primarily useful for resolving commit and revision information from
-// the returned gitserver repository, because this is done VERY often (e.g.
-// twice per search result viewed!), and using GitRepo incurs the cost of a
-// repo-updater /repo-lookup request -- which itself involves two code host API
-// requests (which are strictly rate-limited).
-//
-// It should be noted that while this will always ensure valid revs exist in
-// the repository -- it makes no guarantees about them being up to date. For
-// example, requesting "mybranch" will cause gitserver to pull down that branch
-// if it is not already aware of it, but it will not go out of its way to
-// update it. This is usually fine because this is the same behavior a plain
-// GitRepo has under the hood: gitserver won't update it unless the revision
-// does not exist (see cmd/gitserver/server/server.go Server.ensureRevision).
-func fastGitRepoForRevResolution(ctx context.Context, repo *types.Repo, rev string) (gitserver.Repo, error) {
-	gitserverRepo, err := CachedGitRepo(ctx, repo)
-	if err == nil {
-		_, err := git.ResolveRevision(ctx, *gitserverRepo, nil, rev, nil)
-		if err == nil {
-			return *gitserverRepo, nil // Gitserver has the revision so we can spare ourselves a bunch of work.
-		}
-	}
-	return GitRepo(ctx, repo) // Gitserver doesn't have the revision, so we must use a GitRepo.
 }
 
 func isIgnorableRepoUpdaterError(err error) bool {

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -187,7 +187,7 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 	if err != nil && !isIgnorableRepoUpdaterError(err) {
 		return nil, err
 	}
-	return git.GetCommit(ctx, gitserverRepo, commitID)
+	return git.GetCommit(ctx, gitserverRepo, nil, commitID)
 }
 
 func isIgnorableRepoUpdaterError(err error) bool {

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -42,8 +42,8 @@ func TestRepos_ResolveRev_noRevSpecified_getsDefaultBranch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !calledRepoLookup {
-		t.Error("!calledRepoLookup")
+	if calledRepoLookup {
+		t.Error("calledRepoLookup")
 	}
 	if !calledVCSRepoResolveRevision {
 		t.Error("!calledVCSRepoResolveRevision")
@@ -81,8 +81,8 @@ func TestRepos_ResolveRev_noCommitIDSpecified_resolvesRev(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !calledRepoLookup {
-		t.Error("!calledRepoLookup")
+	if calledRepoLookup {
+		t.Error("calledRepoLookup")
 	}
 	if !calledVCSRepoResolveRevision {
 		t.Error("!calledVCSRepoResolveRevision")
@@ -120,8 +120,8 @@ func TestRepos_ResolveRev_commitIDSpecified_resolvesCommitID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !calledRepoLookup {
-		t.Error("!calledRepoLookup")
+	if calledRepoLookup {
+		t.Error("calledRepoLookup")
 	}
 	if !calledVCSRepoResolveRevision {
 		t.Error("!calledVCSRepoResolveRevision")
@@ -159,8 +159,8 @@ func TestRepos_ResolveRev_commitIDSpecified_failsToResolve(t *testing.T) {
 	if !reflect.DeepEqual(err, want) {
 		t.Fatalf("got err %v, want %v", err, want)
 	}
-	if !calledRepoLookup {
-		t.Error("!calledRepoLookup")
+	if calledRepoLookup {
+		t.Error("calledRepoLookup")
 	}
 	if !calledVCSRepoResolveRevision {
 		t.Error("!calledVCSRepoResolveRevision")
@@ -193,8 +193,8 @@ func TestRepos_GetCommit_repoupdaterError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !calledRepoLookup {
-		t.Error("!calledRepoLookup")
+	if calledRepoLookup {
+		t.Error("calledRepoLookup")
 	}
 	if !calledVCSRepoGetCommit {
 		t.Error("!calledVCSRepoGetCommit")

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -51,7 +51,7 @@ func (r *hunkResolver) Commit(ctx context.Context) (*gitCommitResolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	commit, err := git.GetCommit(ctx, *cachedRepo, r.hunk.CommitID)
+	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -50,7 +50,7 @@ func (r *repositoryResolver) Comparison(ctx context.Context, args *repositoryCom
 			return nil, err
 		}
 
-		commit, err := git.GetCommit(ctx, repo, commitID)
+		commit, err := git.GetCommit(ctx, repo, nil, commitID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/vcs/git/commits.go
+++ b/pkg/vcs/git/commits.go
@@ -44,8 +44,6 @@ type CommitsOptions struct {
 
 	Path string // only commits modifying the given path are selected (optional)
 
-	NoEnsureRevision bool // do not try to fetch from remote if revision doesn't exist locally
-
 	// RemoteURLFunc is called to get the Git remote URL if it's not set in
 	// repo and if it is needed. The Git remote URL is only required if the
 	// gitserver doesn't already contain a clone of the repository or if the

--- a/pkg/vcs/git/commits_test.go
+++ b/pkg/vcs/git/commits_test.go
@@ -36,7 +36,7 @@ func TestRepository_GetCommit(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commit, err := git.GetCommit(ctx, test.repo, test.id)
+		commit, err := git.GetCommit(ctx, test.repo, nil, test.id)
 		if err != nil {
 			t.Errorf("%s: GetCommit: %s", label, err)
 			continue
@@ -47,7 +47,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := git.GetCommit(ctx, test.repo, nonexistentCommitID); !git.IsRevisionNotFound(err) {
+		if _, err := git.GetCommit(ctx, test.repo, nil, nonexistentCommitID); !git.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 		}
 	}

--- a/pkg/vcs/git/exec.go
+++ b/pkg/vcs/git/exec.go
@@ -266,10 +266,9 @@ func (c *commandRetryer) run() error {
 			return true // The repository doesn't exist yet, so retry after pulling.
 		}
 		if IsRevisionNotFound(err) {
-			if c.cmd.EnsureRevision == "HEAD" {
-				return false // We didn't find HEAD, so the repo is empty: nothing to do.
-			}
-			return true // The revision wasn't found, so we try again.
+			// If we didn't find HEAD, the repo is empty and there is no reason to retry.
+			// Otherwise, the revision wasn't found, so we try again.
+			return c.cmd.EnsureRevision != "HEAD"
 		}
 		return false // All other error types (e.g. network failure).
 	}

--- a/pkg/vcs/git/exec.go
+++ b/pkg/vcs/git/exec.go
@@ -12,6 +12,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
+	"github.com/sourcegraph/sourcegraph/pkg/vcs"
 )
 
 // checkSpecArgSafety returns a non-nil err if spec begins with a "-", which could
@@ -189,4 +190,103 @@ type cmdFunc func(args []string) cmd
 type cmd interface {
 	Output(context.Context) ([]byte, error)
 	String() string
+}
+
+// commandRetryer executes a gitserver command first without a remote URL and
+// ensured revision, then secondarily retries with a remote URL and ensured
+// revision.
+//
+// This is such that gitserver commands invoked very often do not need to
+// lookup the remote URL through repo-updater (an expensive process which
+// consumes 2 code host API requests), unless the revision is actually missing
+// and gitserver would want to try fetching it.
+type commandRetryer struct {
+	// cmd is the gitserver command to execute. It is never modified, except
+	// when setting cmd.Repo.URL in the case that remoteURLFunc is called.
+	cmd *gitserver.Cmd
+
+	// remoteURLFunc is called to get the Git remote URL if it's not set in
+	// repo and if it is needed. The Git remote URL is only required if the
+	// gitserver doesn't already contain a clone of the repository or if the
+	// commit must be fetched from the remote.
+	//
+	// If cmd.EnsureRevision == "", this field is ignored.
+	remoteURLFunc func() (string, error)
+
+	// exec is called when the cmd should be executed. It is expected to run
+	// the gitserver command and return errors (e.g. RevisionNotFoundError),
+	// which will be handled by the retryer by invoking exec again.
+	//
+	// For basic usage, see the implementation of DividedOutput.
+	//
+	// Any case involving the need to parse out missing revision errors from
+	// the Git command output yourself will need to use this instead of the
+	// DividedOutput helper.
+	exec func() error
+}
+
+// DividedOutput is a helper which sets c.exec to a function which invokes
+// c.cmd.DividedOutput and returns the result after calling c.run.
+//
+// It is the most basic usage of c.exec and c.run, and more complex usage
+// patterns can be based on this implementation.
+func (c *commandRetryer) DividedOutput(ctx context.Context) (data []byte, stderr []byte, err error) {
+	c.exec = func() error {
+		data, stderr, err = c.cmd.DividedOutput(ctx)
+		return err
+	}
+	err = c.run()
+	return
+}
+
+func (c *commandRetryer) run() error {
+	// First, we try executing the command but without any EnsureRevision or
+	// URL. The command most likely did not have either of these, but we zero
+	// them just to make the code flow here more straightforward.
+	cpy := *c.cmd
+	cpy.EnsureRevision = ""
+	cpy.Repo.URL = ""
+	err := c.exec()
+	if err == nil {
+		// We didn't encounter any error, so gitserver did not need to fetch
+		// the repository in order to fulfill the request.
+		return nil
+	}
+
+	// Second, we retry the request if we can determine a URL and have a
+	// revision we want to ensure exists, etc.
+	tryAgain := func(err error) bool {
+		haveURL := c.cmd.Repo.URL != "" || c.remoteURLFunc != nil
+		if !haveURL || c.cmd.EnsureRevision == "" {
+			// We don't have a repository URL or know the revision in question,
+			// so we cannot retry the request.
+			return false
+		}
+		if vcs.IsRepoNotExist(err) {
+			return true // The repository doesn't exist yet, so retry after pulling.
+		}
+		if IsRevisionNotFound(err) {
+			if c.cmd.EnsureRevision == "HEAD" {
+				return false // We didn't find HEAD, so the repo is empty: nothing to do.
+			}
+			return true // The revision wasn't found, so we try again.
+		}
+		return false // All other error types (e.g. network failure).
+	}
+	if !tryAgain(err) {
+		return err
+	}
+
+	// Determine the remote URL, if needed, then retry the command.
+	if c.cmd.Repo.URL == "" {
+		// We do modify c.cmd here because the caller may want to reuse this
+		// information.
+		c.cmd.Repo.URL, err = c.remoteURLFunc()
+		if err != nil {
+			return err
+		}
+	}
+	cpy.EnsureRevision = c.cmd.EnsureRevision
+	cpy.Repo.URL = c.cmd.Repo.URL
+	return c.exec()
 }

--- a/pkg/vcs/git/refs.go
+++ b/pkg/vcs/git/refs.go
@@ -140,7 +140,7 @@ func ListBranches(ctx context.Context, repo gitserver.Repo, opt BranchesOptions)
 
 		branch := &Branch{Name: name, Head: id}
 		if opt.IncludeCommit {
-			branch.Commit, err = getCommit(ctx, repo, id)
+			branch.Commit, err = getCommit(ctx, repo, nil, id)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/vcs/git/revisions.go
+++ b/pkg/vcs/git/revisions.go
@@ -80,56 +80,29 @@ func ResolveRevision(ctx context.Context, repo gitserver.Repo, remoteURLFunc fun
 		spec = spec + "^0"
 	}
 
+	var (
+		commit api.CommitID
+		err    error
+	)
 	cmd := gitserver.DefaultClient.Command("git", "rev-parse", spec)
 	cmd.Repo = repo
-	commit, err := runRevParse(ctx, cmd, spec)
-	if err == nil {
-		return commit, nil
+	cmd.EnsureRevision = spec
+	retryer := &commandRetryer{
+		cmd:           cmd,
+		remoteURLFunc: remoteURLFunc,
+		exec: func() error {
+			commit, err = runRevParse(ctx, cmd, spec)
+			return err
+		},
 	}
-
-	tryAgain := func(err error) bool {
-		// We need to try again with remote URL set so we can clone.
-		if vcs.IsRepoNotExist(err) {
-			return true
-		}
-
-		// We need to try again with the remote URL set so we can fetch.
-		if IsRevisionNotFound(err) {
-			// If we didn't find HEAD, then the repo is empty.
-			if spec == "HEAD" {
-				return false
-			}
-
-			// We can also disable enqueuing an update.
-			if opt != nil && opt.NoEnsureRevision {
-				return false
-			}
-
-			return true
-		}
-
-		return false
+	if opt != nil && opt.NoEnsureRevision {
+		// Make the commandRetryer no-op so that gitserver does not try to
+		// update the repository.
+		cmd.EnsureRevision = ""
+		retryer.remoteURLFunc = nil
 	}
-
-	if !tryAgain(err) {
-		return "", err
-	}
-	doEnsureRevision := IsRevisionNotFound(err)
-
-	var remoteURL string
-	if remoteURLFunc != nil {
-		remoteURL, err = remoteURLFunc()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	cmd = gitserver.DefaultClient.Command("git", "rev-parse", spec)
-	cmd.Repo = gitserver.Repo{Name: repo.Name, URL: remoteURL}
-	if doEnsureRevision {
-		cmd.EnsureRevision = spec
-	}
-	return runRevParse(ctx, cmd, spec)
+	err = retryer.run()
+	return commit, err
 }
 
 // runRevParse sends the git rev-parse command to gitserver. It interprets


### PR DESCRIPTION
# TL;DR

Prior to this change, for every search result you viewed we would perform 4 code host API requests and this led to us running out of our rate limit rapidly. It causes:

- [Search results to take a very long time to load when using Bitbucket Server.](https://github.com/sourcegraph/sourcegraph/issues/2618)
- Links to the GitHub repository, etc. to not appear on repo pages.
- And likely many, many, more issues.

After this change, we massively reduce the number of code host API requests we perform because it turned out in 99% of cases (not just when searching) we were doing them for literally no reason due to unfiled technical debt.

**IMPORTANT:** This change **does NOT** change any user-facing behavior. It only prevents us from doing needless work. The behavior observed _in all cases_ before and after this change is _identical_.

# Detailed explanation

Repository revision resolutions (`ResolveRev` and `GetCommit`) occur very often in our codebase. For example, every search result you view makes two of these calls.

Prior to this change, each revision resolution would consume two code host API requests (which are heavily rate limited) due to the fact that they must perform a repo-updater `/repo-lookup` request in order to determine what the remote URL for the repository is when updating the gitserver repo mirror.

We already knew this was costly, and in fact that is why there is a `CachedGitRepo` variant of `GitRepo` in this same file. Basically, if you don't need the remote URL we can spare ourselves tons of work and, most importantly, code host API reservations.

But revision resolution wasn't able to use `CachedGitRepo` because we operated under the assumption that when resolving a revision you _do_ want the repository to update. For example, when resolving `master` or `mybranch` you want the repository updated to reflect the latest state of those branches.

Times changed, repo-updater changed how we did things, and we started operating with more explicit requests to update repositories via `repoupdater.DefaultClient.EnqueueRepoUpdate`.

At some point, gitserver became not responsible for updating repositories _unless_ the rev in question was not known to it (i.e. `mybranch` may be stale if already known to gitserver until repo-updater updates it, but gitserver will explicitly update the repository if `mybranch` is unknown to gitserver). You can see this logic clearly in gitserver's [`ensureRevision` function](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e1f88f6dfc5cbdc6cac0754cf4eeff1492609253/-/blob/cmd/gitserver/server/server.go#L1275-1276).

What this means is that despite the fact that we always use a `GitRepo` for `ResolveRev` and `GetCommit` requests, in 99% of cases gitserver already has the rev and will not update it, _but we'll still ask repo-updater to do all of that work and make those code-host requests just cuz'._

After this change, the user observed behavior remains the exact same: gitserver doesn't update revs it is already aware of (but note our UI does ask it to in specific locations via `EnqueueRepoUpdate`). We just don't ask repo-updater to do all that work for nothing anymore.

Helps #2618 