### PR TITLE
Fix head commit ID detection for commented snippets on github PRs

### DIFF
--- a/client/browser/src/libs/github/file_info.ts
+++ b/client/browser/src/libs/github/file_info.ts
@@ -24,7 +24,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
             return { ...rest, codeView, headFilePath, baseFilePath }
         }),
         map(data => {
-            const diffResolvedRev = getDiffResolvedRev()
+            const diffResolvedRev = getDiffResolvedRev(codeView)
             if (!diffResolvedRev) {
                 throw new Error('cannot determine delta info')
             }


### PR DESCRIPTION
Fixes #1801 (hover loads indefinitely on outdated github commented snippet)
