### PR TITLE
Fix hover tooltip buttons to be centered

### DIFF
--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -4,6 +4,7 @@
     &__content {
         display: flex;
         align-items: center;
+        width: 100%;
     }
     &--variant-action-item &__content {
         justify-content: center;


### PR DESCRIPTION
Fixes: https://sourcegraph.slack.com/archives/C0C324C91/p1551984503020000

Hover tool tip buttons were aligned to the left. This fixes that.

Before/After:

![screen shot 2019-03-07 at 2 10 15 pm](https://user-images.githubusercontent.com/11583013/53993084-3dcb5380-40e3-11e9-9859-48d9761ca6f1.png)
![screen shot 2019-03-07 at 2 11 12 pm](https://user-images.githubusercontent.com/11583013/53993087-3dcb5380-40e3-11e9-8903-583754429fec.png)
