### PR TITLE
Add search.defaultContextLines to set number of context lines in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph can now automatically use the system's theme.
   To enable, open the user menu in the top right and make sure the theme dropdown is set to "System".
   This is currently supported on macOS Mojave with Safari Technology Preview 68 and later.
-- The `search.defaultContextLines` setting was added to allow configuration of the number of lines of context to be displayed around search results.
+- The `search.contextLines` setting was added to allow configuration of the number of lines of context to be displayed around search results.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph can now automatically use the system's theme.
   To enable, open the user menu in the top right and make sure the theme dropdown is set to "System".
   This is currently supported on macOS Mojave with Safari Technology Preview 68 and later.
+- The `search.defaultContextLines` setting was added to allow configuration of the number of lines of context to be displayed around search results.
 
 ### Changed
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -360,12 +360,13 @@ type Sentry struct {
 
 // Settings description: Configuration settings for users and organizations on Sourcegraph.
 type Settings struct {
-	Extensions             map[string]bool           `json:"extensions,omitempty"`
-	Motd                   []string                  `json:"motd,omitempty"`
-	NotificationsSlack     *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
-	SearchRepositoryGroups map[string][]string       `json:"search.repositoryGroups,omitempty"`
-	SearchSavedQueries     []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
-	SearchScopes           []*SearchScope            `json:"search.scopes,omitempty"`
+	Extensions                map[string]bool           `json:"extensions,omitempty"`
+	Motd                      []string                  `json:"motd,omitempty"`
+	NotificationsSlack        *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
+	SearchDefaultContextLines int                       `json:"search.defaultContextLines,omitempty"`
+	SearchRepositoryGroups    map[string][]string       `json:"search.repositoryGroups,omitempty"`
+	SearchSavedQueries        []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
+	SearchScopes              []*SearchScope            `json:"search.scopes,omitempty"`
 }
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -360,13 +360,13 @@ type Sentry struct {
 
 // Settings description: Configuration settings for users and organizations on Sourcegraph.
 type Settings struct {
-	Extensions                map[string]bool           `json:"extensions,omitempty"`
-	Motd                      []string                  `json:"motd,omitempty"`
-	NotificationsSlack        *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
-	SearchDefaultContextLines int                       `json:"search.defaultContextLines,omitempty"`
-	SearchRepositoryGroups    map[string][]string       `json:"search.repositoryGroups,omitempty"`
-	SearchSavedQueries        []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
-	SearchScopes              []*SearchScope            `json:"search.scopes,omitempty"`
+	Extensions             map[string]bool           `json:"extensions,omitempty"`
+	Motd                   []string                  `json:"motd,omitempty"`
+	NotificationsSlack     *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
+	SearchContextLines     int                       `json:"search.ContextLines,omitempty"`
+	SearchRepositoryGroups map[string][]string       `json:"search.repositoryGroups,omitempty"`
+	SearchSavedQueries     []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
+	SearchScopes           []*SearchScope            `json:"search.scopes,omitempty"`
 }
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -363,7 +363,7 @@ type Settings struct {
 	Extensions             map[string]bool           `json:"extensions,omitempty"`
 	Motd                   []string                  `json:"motd,omitempty"`
 	NotificationsSlack     *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
-	SearchContextLines     int                       `json:"search.ContextLines,omitempty"`
+	SearchContextLines     int                       `json:"search.contextLines,omitempty"`
 	SearchRepositoryGroups map[string][]string       `json:"search.repositoryGroups,omitempty"`
 	SearchSavedQueries     []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
 	SearchScopes           []*SearchScope            `json:"search.scopes,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -55,6 +55,11 @@
         "items": { "type": "string" }
       }
     },
+    "search.defaultContextLines": {
+      "description": "The default number of lines to show as context around search results.",
+      "type": "integer",
+      "minimum": 0
+    },
     "notifications.slack": {
       "$ref": "#/definitions/SlackNotificationsConfig"
     },

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -55,7 +55,7 @@
         "items": { "type": "string" }
       }
     },
-    "search.defaultContextLines": {
+    "search.contextLines": {
       "description": "The default number of lines to show as context below and above search results. Default is 1.",
       "type": "integer",
       "minimum": 0,

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -56,9 +56,10 @@
       }
     },
     "search.defaultContextLines": {
-      "description": "The default number of lines to show as context below and above search results.",
+      "description": "The default number of lines to show as context below and above search results. Default is 1.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "default": 1
     },
     "notifications.slack": {
       "$ref": "#/definitions/SlackNotificationsConfig"

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -56,7 +56,7 @@
       }
     },
     "search.defaultContextLines": {
-      "description": "The default number of lines to show as context around search results.",
+      "description": "The default number of lines to show as context below and above search results.",
       "type": "integer",
       "minimum": 0
     },

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -60,7 +60,7 @@ const SettingsSchemaJSON = `{
         "items": { "type": "string" }
       }
     },
-    "search.defaultContextLines": {
+    "search.contextLines": {
       "description": "The default number of lines to show as context below and above search results. Default is 1.",
       "type": "integer",
       "minimum": 0,

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -61,9 +61,10 @@ const SettingsSchemaJSON = `{
       }
     },
     "search.defaultContextLines": {
-      "description": "The default number of lines to show as context below and above search results.",
+      "description": "The default number of lines to show as context below and above search results. Default is 1.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "default": 1
     },
     "notifications.slack": {
       "$ref": "#/definitions/SlackNotificationsConfig"

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -57,8 +57,15 @@ const SettingsSchemaJSON = `{
       "type": "object",
       "additionalProperties": {
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       }
+    },
+    "search.defaultContextLines": {
+      "description": "The default number of lines to show as context around search results.",
+      "type": "integer",
+      "minimum": 0
     },
     "notifications.slack": {
       "$ref": "#/definitions/SlackNotificationsConfig"
@@ -66,7 +73,9 @@ const SettingsSchemaJSON = `{
     "motd": {
       "description": "An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
       "type": "array",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
     "extensions": {
       "description": "The Sourcegraph extensions to use. Enable an extension by adding a property ` + "`" + `\"my/extension\": true` + "`" + ` (where ` + "`" + `my/extension` + "`" + ` is the extension ID). Override a previously enabled extension and disable it by setting its value to ` + "`" + `false` + "`" + `.",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -57,13 +57,11 @@ const SettingsSchemaJSON = `{
       "type": "object",
       "additionalProperties": {
         "type": "array",
-        "items": {
-          "type": "string"
-        }
+        "items": { "type": "string" }
       }
     },
     "search.defaultContextLines": {
-      "description": "The default number of lines to show as context around search results.",
+      "description": "The default number of lines to show as context below and above search results.",
       "type": "integer",
       "minimum": 0
     },
@@ -73,9 +71,7 @@ const SettingsSchemaJSON = `{
     "motd": {
       "description": "An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string" }
     },
     "extensions": {
       "description": "The Sourcegraph extensions to use. Enable an extension by adding a property ` + "`" + `\"my/extension\": true` + "`" + ` (where ` + "`" + `my/extension` + "`" + ` is the extension ID). Override a previously enabled extension and disable it by setting its value to ` + "`" + `false` + "`" + `.",

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -103,11 +103,18 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
     }
 
     private getFirstLine(): number {
-        return Math.max(0, Math.min(...this.props.highlightRanges.map(r => r.line)) - (this.props.context || 1))
+        const context = this.props.context || this.props.context === 0 ? this.props.context : 1
+        // Of the matches in this excerpt, pick the one with the lowest line number.
+        // Take the maximum between the (lowest line number - the lines of context) and 0,
+        // so we don't try and display a negative line index.
+        return Math.max(0, Math.min(...this.props.highlightRanges.map(r => r.line)) - context)
     }
 
     private getLastLine(): number {
+        // Of the matches in this excerpt, pick the one with the highest line number + lines of context.
         const lastLine = Math.max(...this.props.highlightRanges.map(r => r.line)) + (this.props.context || 1)
+        // If there lines, take the minimum of lastLine or the number of lines in the file,
+        // so we don't try to display a line index beyond the maximum line number in the file.
         return this.state.blobLines ? Math.min(lastLine, this.state.blobLines.length) : lastLine
     }
 
@@ -159,8 +166,12 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
     }
 
     private makeTableHTML(): string {
+        // If there is a context value, this.getLastLine() will output the correct 0-indexed last line value.
+        const additionalLine = this.props.context === 0 ? 0 : 1
         return (
-            '<table>' + this.state.blobLines!.slice(this.getFirstLine(), this.getLastLine() + 1).join('') + '</table>'
+            '<table>' +
+            this.state.blobLines!.slice(this.getFirstLine(), this.getLastLine() + additionalLine).join('') +
+            '</table>'
         )
     }
 }

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -133,9 +133,11 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
 
         // If the search.contextLines value is 0, we need to add 1 to the
         // last line value so that `range(firstLine, lastLine)` is a non-empty array
-        // since range is exclusive of the lastLine value.
+        // since range is exclusive of the lastLine value, and this.getFirstLine() and this.getLastLine()
+        // will return the same value.
         const additionalLine = this.props.context === 0 ? 1 : 0
 
+        console.log(this.getFirstLine(), this.getLastLine())
         return (
             <VisibilitySensor
                 onChange={this.onChangeVisibility}

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -103,16 +103,17 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
     }
 
     private getFirstLine(): number {
-        const context = this.props.context || this.props.context === 0 ? this.props.context : 1
+        const contextLines = this.props.context || this.props.context === 0 ? this.props.context : 1
         // Of the matches in this excerpt, pick the one with the lowest line number.
         // Take the maximum between the (lowest line number - the lines of context) and 0,
         // so we don't try and display a negative line index.
-        return Math.max(0, Math.min(...this.props.highlightRanges.map(r => r.line)) - context)
+        return Math.max(0, Math.min(...this.props.highlightRanges.map(r => r.line)) - contextLines)
     }
 
     private getLastLine(): number {
+        const contextLines = this.props.context || this.props.context === 0 ? this.props.context : 1
         // Of the matches in this excerpt, pick the one with the highest line number + lines of context.
-        const lastLine = Math.max(...this.props.highlightRanges.map(r => r.line)) + (this.props.context || 1)
+        const lastLine = Math.max(...this.props.highlightRanges.map(r => r.line)) + contextLines
         // If there are lines, take the minimum of lastLine and the number of lines in the file,
         // so we don't try to display a line index beyond the maximum line number in the file.
         return this.state.blobLines ? Math.min(lastLine, this.state.blobLines.length) : lastLine
@@ -146,7 +147,7 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
                     {!this.state.blobLines && (
                         <table>
                             <tbody>
-                                {range(this.getFirstLine(), this.getLastLine()).map(i => (
+                                {range(this.getFirstLine(), this.getLastLine() + 1).map(i => (
                                     <tr key={i}>
                                         <td className="line">{i + 1}</td>
                                         {/* create empty space to fill viewport (as if the blob content were already fetched, otherwise we'll overfetch) */}
@@ -166,12 +167,8 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
     }
 
     private makeTableHTML(): string {
-        // If there is a context value, this.getLastLine() will output the correct 0-indexed last line value.
-        const additionalLine = this.props.context === 0 ? 0 : 1
         return (
-            '<table>' +
-            this.state.blobLines!.slice(this.getFirstLine(), this.getLastLine() + additionalLine).join('') +
-            '</table>'
+            '<table>' + this.state.blobLines!.slice(this.getFirstLine(), this.getLastLine() + 1).join('') + '</table>'
         )
     }
 }

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -137,7 +137,6 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
         // will return the same value.
         const additionalLine = this.props.context === 0 ? 1 : 0
 
-        console.log(this.getFirstLine(), this.getLastLine())
         return (
             <VisibilitySensor
                 onChange={this.onChangeVisibility}

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -131,6 +131,11 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
             return null
         }
 
+        // If the search.contextLines value is 0, we need to add 1 to the
+        // last line value so that `range(firstLine, lastLine)` is a non-empty array
+        // since range is exclusive of the lastLine value.
+        const additionalLine = this.props.context === 0 ? 1 : 0
+
         return (
             <VisibilitySensor
                 onChange={this.onChangeVisibility}
@@ -147,7 +152,7 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
                     {!this.state.blobLines && (
                         <table>
                             <tbody>
-                                {range(this.getFirstLine(), this.getLastLine() + 1).map(i => (
+                                {range(this.getFirstLine(), this.getLastLine() + additionalLine).map(i => (
                                     <tr key={i}>
                                         <td className="line">{i + 1}</td>
                                         {/* create empty space to fill viewport (as if the blob content were already fetched, otherwise we'll overfetch) */}

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -113,7 +113,7 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
     private getLastLine(): number {
         // Of the matches in this excerpt, pick the one with the highest line number + lines of context.
         const lastLine = Math.max(...this.props.highlightRanges.map(r => r.line)) + (this.props.context || 1)
-        // If there lines, take the minimum of lastLine or the number of lines in the file,
+        // If there are lines, take the minimum of lastLine and the number of lines in the file,
         // so we don't try to display a line index beyond the maximum line number in the file.
         return this.state.blobLines ? Math.min(lastLine, this.state.blobLines.length) : lastLine
     }

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -164,17 +164,14 @@ export class FileMatch extends React.PureComponent<Props> {
             )
         }
 
-        // Check if search.defaultContextLines is configured in settings.
-        const defaultContextLinesSetting =
+        // Check if search.contextLines is configured in settings.
+        const contextLinesSetting =
             isSettingsValid<Settings>(this.props.settingsCascade) &&
             this.props.settingsCascade.final &&
-            this.props.settingsCascade.final['search.defaultContextLines']
+            this.props.settingsCascade.final['search.contextLines']
 
         // The number of lines of context to show before and after each match.
-        const context =
-            typeof defaultContextLinesSetting === 'number' && defaultContextLinesSetting >= 0
-                ? defaultContextLinesSetting
-                : 1
+        const context = typeof contextLinesSetting === 'number' && contextLinesSetting >= 0 ? contextLinesSetting : 1
 
         const groupsOfItems = mergeContext(
             context,

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -1,3 +1,4 @@
+import H from 'history'
 import { flatMap } from 'lodash'
 import React from 'react'
 import { Observable } from 'rxjs'
@@ -34,6 +35,7 @@ interface IMatchItem {
 }
 
 interface Props extends SettingsCascadeProps {
+    location: H.Location
     /**
      * The file match search result.
      */
@@ -164,14 +166,20 @@ export class FileMatch extends React.PureComponent<Props> {
             )
         }
 
-        // Check if search.contextLines is configured in settings.
-        const contextLinesSetting =
-            isSettingsValid<Settings>(this.props.settingsCascade) &&
-            this.props.settingsCascade.final &&
-            this.props.settingsCascade.final['search.contextLines']
-
         // The number of lines of context to show before and after each match.
-        const context = typeof contextLinesSetting === 'number' && contextLinesSetting >= 0 ? contextLinesSetting : 1
+        let context = 1
+
+        if (this.props.location.pathname === '/search') {
+            // Check if search.contextLines is configured in settings.
+            const contextLinesSetting =
+                isSettingsValid<Settings>(this.props.settingsCascade) &&
+                this.props.settingsCascade.final &&
+                this.props.settingsCascade.final['search.contextLines']
+
+            if (typeof contextLinesSetting === 'number' && contextLinesSetting >= 0) {
+                context = contextLinesSetting
+            }
+        }
 
         const groupsOfItems = mergeContext(
             context,

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -2,8 +2,9 @@ import { flatMap } from 'lodash'
 import React from 'react'
 import { Observable } from 'rxjs'
 import { pluralize } from '../../../shared/src/util/strings'
+import { Settings } from '../../../web/src/schema/settings.schema'
 import * as GQL from '../graphql/schema'
-import { SettingsCascadeProps, isSettingsValid } from '../settings/settings';
+import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
 import { SymbolIcon } from '../symbols/SymbolIcon'
 import { toPositionOrRangeHash } from '../util/url'
 import { CodeExcerpt, FetchFileCtx } from './CodeExcerpt'
@@ -12,7 +13,6 @@ import { mergeContext } from './FileMatchContext'
 import { Link } from './Link'
 import { RepoFileLink } from './RepoFileLink'
 import { Props as ResultContainerProps, ResultContainer } from './ResultContainer'
-import { Settings } from '../../../web/src/schema/settings.schema';
 
 const SUBSET_COUNT_KEY = 'fileMatchSubsetCount'
 
@@ -164,9 +164,17 @@ export class FileMatch extends React.PureComponent<Props> {
             )
         }
 
-        const defaultContextLinesSetting = isSettingsValid<Settings>(this.props.settingsCascade) && this.props.settingsCascade.final && this.props.settingsCascade.final['search.defaultContextLines'])
+        // Check if search.defaultContextLines is configured in settings.
+        const defaultContextLinesSetting =
+            isSettingsValid<Settings>(this.props.settingsCascade) &&
+            this.props.settingsCascade.final &&
+            this.props.settingsCascade.final['search.defaultContextLines']
+
         // The number of lines of context to show before and after each match.
-        const context = typeof defaultContextLinesSetting === 'number' && defaultContextLinesSetting > 0 ? defaultContextLinesSetting : 1
+        const context =
+            typeof defaultContextLinesSetting === 'number' && defaultContextLinesSetting >= 0
+                ? defaultContextLinesSetting
+                : 1
 
         const groupsOfItems = mergeContext(
             context,

--- a/shared/src/components/FileMatch.tsx
+++ b/shared/src/components/FileMatch.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Observable } from 'rxjs'
 import { pluralize } from '../../../shared/src/util/strings'
 import * as GQL from '../graphql/schema'
+import { SettingsCascadeProps, isSettingsValid } from '../settings/settings';
 import { SymbolIcon } from '../symbols/SymbolIcon'
 import { toPositionOrRangeHash } from '../util/url'
 import { CodeExcerpt, FetchFileCtx } from './CodeExcerpt'
@@ -11,6 +12,7 @@ import { mergeContext } from './FileMatchContext'
 import { Link } from './Link'
 import { RepoFileLink } from './RepoFileLink'
 import { Props as ResultContainerProps, ResultContainer } from './ResultContainer'
+import { Settings } from '../../../web/src/schema/settings.schema';
 
 const SUBSET_COUNT_KEY = 'fileMatchSubsetCount'
 
@@ -31,7 +33,7 @@ interface IMatchItem {
     line: number
 }
 
-interface Props {
+interface Props extends SettingsCascadeProps {
     /**
      * The file match search result.
      */
@@ -162,8 +164,9 @@ export class FileMatch extends React.PureComponent<Props> {
             )
         }
 
+        const defaultContextLinesSetting = isSettingsValid<Settings>(this.props.settingsCascade) && this.props.settingsCascade.final && this.props.settingsCascade.final['search.defaultContextLines'])
         // The number of lines of context to show before and after each match.
-        const context = 1
+        const context = typeof defaultContextLinesSetting === 'number' && defaultContextLinesSetting > 0 ? defaultContextLinesSetting : 1
 
         const groupsOfItems = mergeContext(
             context,

--- a/shared/src/panel/views/FileLocations.tsx
+++ b/shared/src/panel/views/FileLocations.tsx
@@ -9,6 +9,7 @@ import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxj
 import { FetchFileCtx } from '../../components/CodeExcerpt'
 import { FileMatch, IFileMatch, ILineMatch } from '../../components/FileMatch'
 import { VirtualList } from '../../components/VirtualList'
+import { SettingsCascadeProps } from '../../settings/settings'
 import { asError } from '../../util/errors'
 import { ErrorLike, isErrorLike } from '../../util/errors'
 import { propertyIsDefined } from '../../util/types'
@@ -26,7 +27,7 @@ export const FileLocationsNotFound: React.FunctionComponent = () => (
     </div>
 )
 
-interface Props {
+interface Props extends SettingsCascadeProps {
     /**
      * The observable that emits the locations.
      */
@@ -140,6 +141,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
                             showAllMatches={true}
                             isLightTheme={this.props.isLightTheme}
                             fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
+                            settingsCascade={this.props.settingsCascade}
                         />
                     ))}
                 />

--- a/shared/src/panel/views/FileLocations.tsx
+++ b/shared/src/panel/views/FileLocations.tsx
@@ -1,5 +1,6 @@
 import { Location } from '@sourcegraph/extension-api-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import H from 'history'
 import { upperFirst } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
@@ -28,6 +29,7 @@ export const FileLocationsNotFound: React.FunctionComponent = () => (
 )
 
 interface Props extends SettingsCascadeProps {
+    location: H.Location
     /**
      * The observable that emits the locations.
      */
@@ -134,6 +136,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
                     items={orderedURIs.map(({ uri, repo }, i) => (
                         <FileMatch
                             key={i}
+                            location={this.props.location}
                             expanded={true}
                             result={refsToFileMatch(uri, locationsByURI.get(uri)!)}
                             icon={this.props.icon}

--- a/shared/src/panel/views/HierarchicalLocationsView.test.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.test.tsx
@@ -4,6 +4,7 @@
 jest.mock('react-visibility-sensor', () => 'VisibilitySensor')
 
 import { Location } from '@sourcegraph/extension-api-types'
+import H from 'history'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { BehaviorSubject, concat, NEVER, Observable, of } from 'rxjs'
@@ -33,9 +34,17 @@ describe('<HierarchicalLocationsView />', () => {
             subjects: null,
             final: null,
         }
+        const location: H.Location = {
+            hash: '#L36:18&tab=references',
+            pathname: '/github.com/sourcegraph/sourcegraph/-/blob/client/browser/src/libs/phabricator/index.tsx',
+            search: '',
+            state: {},
+        }
+
         const props: HierarchicalLocationsViewProps = {
             extensionsController,
             settingsCascade,
+            location,
             locations: NEVER,
             defaultGroup: 'git://github.com/foo/bar',
             isLightTheme: true,

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -1,5 +1,6 @@
 import { Location } from '@sourcegraph/extension-api-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import H from 'history'
 import { merge } from 'lodash'
 import * as React from 'react'
 import { Observable, of, Subject, Subscription } from 'rxjs'
@@ -18,6 +19,7 @@ import { FileLocations, FileLocationsError, FileLocationsNotFound } from './File
 import { groupLocations } from './locations'
 
 export interface HierarchicalLocationsViewProps extends ExtensionsControllerProps<'services'>, SettingsCascadeProps {
+    location: H.Location
     /**
      * The higher-order observable that emits the locations.
      */
@@ -243,6 +245,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                     )}
                 <FileLocations
                     className="hierarchical-locations-view__content"
+                    location={this.props.location}
                     locations={of(visibleLocations)}
                     onSelect={this.props.onSelectLocation}
                     icon={RepositoryIcon}

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -248,6 +248,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                     icon={RepositoryIcon}
                     isLightTheme={this.props.isLightTheme}
                     fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
+                    settingsCascade={this.props.settingsCascade}
                 />
             </div>
         )

--- a/shared/src/panel/views/PanelView.tsx
+++ b/shared/src/panel/views/PanelView.tsx
@@ -76,6 +76,7 @@ export class PanelView extends React.PureComponent<Props, State> {
                 {this.props.panelView.reactElement}
                 {this.props.panelView.locationProvider && this.props.repoName && (
                     <HierarchicalLocationsView
+                        location={this.props.location}
                         locations={this.props.panelView.locationProvider}
                         defaultGroup={this.props.repoName}
                         isLightTheme={this.props.isLightTheme}

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -473,6 +473,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                 return (
                     <FileMatch
                         key={'file:' + result.file.url}
+                        location={this.props.location}
                         icon={result.lineMatches && result.lineMatches.length > 0 ? RepositoryIcon : FileIcon}
                         result={result}
                         onSelect={this.logEvent}

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -482,6 +482,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                         allExpanded={this.props.allExpanded}
                         fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
                         repoDisplayName={this.state.fileMatchRepoDisplayNames.get(result.repository.name)}
+                        settingsCascade={this.props.settingsCascade}
                     />
                 )
         }


### PR DESCRIPTION
Partially addresses https://github.com/sourcegraph/sourcegraph/issues/2432 by adding a setting field to set the number default number of context lines displayed in search results.

I named this "search.defaultContextLines" since this sets the default for the user or instance, whereas the issue specifically asks for a search token which configures this at query time, which I foresee us adding soon.
