### PR TITLE
repo-updater: Use repository URL to generate github links

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -244,12 +244,12 @@ func newRepoInfo(r *repos.Repo) (*protocol.RepoInfo, error) {
 
 	switch strings.ToLower(r.ExternalRepo.ServiceType) {
 	case "github":
-		baseURL := r.ExternalRepo.ServiceID
+		ghrepo := r.Metadata.(*github.Repository)
 		info.Links = &protocol.RepoLinks{
-			Root:   baseURL,
-			Tree:   baseURL + "/tree/{rev}/{path}",
-			Blob:   baseURL + "/blob/{rev}/{path}",
-			Commit: baseURL + "/commit/{commit}",
+			Root:   ghrepo.URL,
+			Tree:   ghrepo.URL + "/tree/{rev}/{path}",
+			Blob:   ghrepo.URL + "/blob/{rev}/{path}",
+			Commit: ghrepo.URL + "/commit/{commit}",
 		}
 	}
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -247,9 +247,9 @@ func newRepoInfo(r *repos.Repo) (*protocol.RepoInfo, error) {
 		ghrepo := r.Metadata.(*github.Repository)
 		info.Links = &protocol.RepoLinks{
 			Root:   ghrepo.URL,
-			Tree:   ghrepo.URL + "/tree/{rev}/{path}",
-			Blob:   ghrepo.URL + "/blob/{rev}/{path}",
-			Commit: ghrepo.URL + "/commit/{commit}",
+			Tree:   pathAppend(ghrepo.URL, "/tree/{rev}/{path}"),
+			Blob:   pathAppend(ghrepo.URL, "/blob/{rev}/{path}"),
+			Commit: pathAppend(ghrepo.URL, "/commit/{commit}"),
 		}
 	}
 
@@ -275,4 +275,11 @@ func isUnauthorized(err error) bool {
 
 func isTemporarilyUnavailable(err error) bool {
 	return err == repos.ErrGitHubAPITemporarilyUnavailable || github.IsRateLimitExceeded(err)
+}
+
+func pathAppend(base, p string) string {
+	if strings.HasPrefix(p, "/") {
+		return strings.TrimRight(base, "/") + p
+	}
+	return strings.TrimRight(base, "/") + "/" + p
 }

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -279,7 +279,7 @@ func TestRepoLookup_syncer(t *testing.T) {
 	now := time.Now().UTC()
 	ctx := context.Background()
 	s := Server{
-		OtherReposSyncer: repos.NewOtherReposSyncer(api.InternalClient, nil),
+		OtherReposSyncer: repos.NewOtherReposSyncer(repos.NewFakeInternalAPI(nil, nil), nil),
 		Syncer:           &repos.Syncer{},
 		Store: repos.NewFakeStore(nil, nil, nil,
 			&repos.Repo{


### PR DESCRIPTION
We accidently used the service URL rather than the repository URL. This
problem currently only affects dogfood since it is the only place with the new
syncer enabled.

Fixes https://github.com/sourcegraph/sourcegraph/issues/2636