### PR TITLE
Fix: check that table row exists before trying to highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue where search results loading slowly would display a `Cannot read property "lastChild" of undefined` error.
+
 ### Removed
 
 - The `"updateScheduler2"` experiment is now the default and it's no longer possible to configure.

--- a/shared/src/components/CodeExcerpt.tsx
+++ b/shared/src/components/CodeExcerpt.tsx
@@ -92,8 +92,16 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
         if (this.tableContainerElement) {
             const visibleRows = this.tableContainerElement.querySelectorAll('table tr')
             for (const highlight of this.props.highlightRanges) {
-                const code = visibleRows[highlight.line - this.getFirstLine()].lastChild as HTMLTableDataCellElement
-                highlightNode(code, highlight.character, highlight.highlightLength)
+                // Select the HTML row in the excerpt that corresponds to the line to be highlighted.
+                // `highlight.line` is the 1-indexed line number in the code file, and this.getFirstLine() returns the
+                // 1-indexed line number of the first visible line in the excerpt. So, subtract this.getFirstLine()
+                // from highlight.line to get the correct 0-based index in visibleRows that holds the HTML row.
+                const tableRow = visibleRows[highlight.line - this.getFirstLine()]
+                if (tableRow) {
+                    // Take the lastChild of the row to select the code portion of the table row (each table row consists of the line number and code).
+                    const code = tableRow.lastChild as HTMLTableDataCellElement
+                    highlightNode(code, highlight.character, highlight.highlightLength)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2655. 

When fetching highlighted code takes a long time, the HTML rows in search results do not immediately load. We assume that they would when we try to highlight the matches in a search result, so the search result page breaks. This fixes that, and adds some documentation because I always find this code a bit difficult to understand.
