### PR TITLE
CI: set concurrency limit to 1 on e2e tests

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -34,6 +34,8 @@ fi
 set -e
 echo "Waiting for $URL... done"
 
+yarn
+
 pushd web
 env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run test-e2e
 popd


### PR DESCRIPTION
This sets a concurrency limit of 1 to the e2e step.

To mitigate the reduction in build throughput, I'm split the e2e step into 2 pieces:

- Build the sourcegraph/server image for the current commit
- Run the e2e tests against that image

Fixes https://github.com/sourcegraph/sourcegraph/issues/2657