### PR TITLE
E2e tests: reenable some code intel tests

### DIFF
--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -66,7 +66,12 @@ describe('HoverOverlay', () => {
 
     test('actions present', () => {
         expect(
-            renderShallow(<HoverOverlay {...commonProps} actionsOrError={[{ action: { id: 'a', command: 'c' } }]} />)
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError={[{ action: { id: 'a', command: 'c', title: 'Some title' } }]}
+                />
+            )
         ).toMatchSnapshot()
     })
 

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -11,6 +11,7 @@ import { TelemetryContext } from '../telemetry/telemetryContext'
 import { TelemetryService } from '../telemetry/telemetryService'
 import { isErrorLike } from '../util/errors'
 import { highlightCodeSafe, renderMarkdown } from '../util/markdown'
+import { sanitizeClass } from '../util/strings'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../util/url'
 import { toNativeEvent } from './helpers'
 
@@ -168,7 +169,9 @@ class BaseHoverOverlay extends React.PureComponent<HoverOverlayProps & { telemet
                             {actionsOrError.map((action, i) => (
                                 <ActionItem
                                     key={i}
-                                    className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+                                    className={`btn btn-secondary hover-overlay__action e2e-tooltip-${sanitizeClass(
+                                        action.action.title || 'untitled'
+                                    )}`}
                                     {...action}
                                     variant="actionItem"
                                     disabledDuringExecution={true}

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`HoverOverlay actions and hover present 1`] = `
           "id": "a",
         }
       }
-      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-untitled"
       disabledDuringExecution={true}
       extensionsController={
         Object {
@@ -261,9 +261,10 @@ exports[`HoverOverlay actions present 1`] = `
         Object {
           "command": "c",
           "id": "a",
+          "title": "Some title",
         }
       }
-      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-some-title"
       disabledDuringExecution={true}
       extensionsController={
         Object {
@@ -324,7 +325,7 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
           "id": "a",
         }
       }
-      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-untitled"
       disabledDuringExecution={true}
       extensionsController={
         Object {
@@ -439,7 +440,7 @@ exports[`HoverOverlay hover error, actions present 1`] = `
           "id": "a",
         }
       }
-      className="btn btn-secondary hover-overlay__action e2e-tooltip-j2d"
+      className="btn btn-secondary hover-overlay__action e2e-tooltip-untitled"
       disabledDuringExecution={true}
       extensionsController={
         Object {

--- a/shared/src/util/strings.ts
+++ b/shared/src/util/strings.ts
@@ -23,3 +23,10 @@ export function numberWithCommas(x: any): string {
 export function pluralize(str: string, n: number, plural = str + 's'): string {
     return n === 1 ? str : plural
 }
+
+/**
+ * Replaces all non alphabetic characters with `-` and lowercases the result.
+ */
+export function sanitizeClass(value: string): string {
+    return value.replace(/[^A-Za-z]/g, '-').toLowerCase()
+}


### PR DESCRIPTION
These code intel tests were disabled because they had no language servers to test against.

Now that basic code intel is on by default, we can use that to test some code intel features.