### PR TITLE
skip repo-updater DB tests when `go test -short` is used

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -15,6 +15,10 @@ import (
 var errRollback = errors.New("tx: rollback")
 
 func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	t.Parallel()
 
 	ctx := context.Background()


### PR DESCRIPTION
This is the convention for our other integration tests that use DBs or other external, slightly slower resources.


I use `go test -short ./...` frequently while developing to quickly check that all tests compile and that most tests pass. With Go's test caching, it is quite fast to run.