### PR TITLE
github: Remove overriding token for ListViewerRepositories

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -440,13 +440,13 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 					var repos []*github.Repository
 					var rateLimitCost int
 					var err error
-					repos, hasNextPage, rateLimitCost, err = c.client.ListViewerRepositories(ctx, page)
+					repos, hasNextPage, rateLimitCost, err = c.client.ListUserRepositories(ctx, page)
 					if err != nil {
-						ch <- batch{err: errors.Wrapf(err, "Error listing viewer's affiliated GitHub repositories page %d", page)}
+						ch <- batch{err: errors.Wrapf(err, "Error listing affiliated GitHub repositories page %d", page)}
 						break
 					}
 					rateLimitRemaining, rateLimitReset, _ := c.client.RateLimit.Get()
-					log15.Debug("github sync: ListViewerRepositories", "repos", len(repos), "rateLimitCost", rateLimitCost, "rateLimitRemaining", rateLimitRemaining, "rateLimitReset", rateLimitReset)
+					log15.Debug("github sync: ListUserRepositories", "repos", len(repos), "rateLimitCost", rateLimitCost, "rateLimitRemaining", rateLimitRemaining, "rateLimitReset", rateLimitReset)
 
 					var b batch
 					for _, r := range repos {

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -440,7 +440,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 					var repos []*github.Repository
 					var rateLimitCost int
 					var err error
-					repos, hasNextPage, rateLimitCost, err = c.client.ListViewerRepositories(ctx, "", page)
+					repos, hasNextPage, rateLimitCost, err = c.client.ListViewerRepositories(ctx, page)
 					if err != nil {
 						ch <- batch{err: errors.Wrapf(err, "Error listing viewer's affiliated GitHub repositories page %d", page)}
 						break

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -334,10 +334,10 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 	return repos, nil
 }
 
-// ListViewerRepositories lists GitHub repositories affiliated with the viewer
-// (the currently authenticated user). page is the page of results to
-// return. Pages are 1-indexed (so the first call should be for page 1).
-func (c *Client) ListViewerRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+// ListUserRepositories lists GitHub repositories affiliated with the client
+// token. page is the page of results to return. Pages are 1-indexed (so the
+// first call should be for page 1).
+func (c *Client) ListUserRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	var restRepos []restRepository
 	path := fmt.Sprintf("user/repos?sort=pushed&page=%d&per_page=100", page)
 	if err := c.requestGet(ctx, "", path, &restRepos); err != nil {

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -337,10 +337,10 @@ func (c *Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) 
 // ListViewerRepositories lists GitHub repositories affiliated with the viewer
 // (the currently authenticated user). page is the page of results to
 // return. Pages are 1-indexed (so the first call should be for page 1).
-func (c *Client) ListViewerRepositories(ctx context.Context, token string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+func (c *Client) ListViewerRepositories(ctx context.Context, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	var restRepos []restRepository
 	path := fmt.Sprintf("user/repos?sort=pushed&page=%d&per_page=100", page)
-	if err := c.requestGet(ctx, token, path, &restRepos); err != nil {
+	if err := c.requestGet(ctx, "", path, &restRepos); err != nil {
 		return nil, false, 1, err
 	}
 	repos = make([]*Repository, 0, len(restRepos))
@@ -348,7 +348,7 @@ func (c *Client) ListViewerRepositories(ctx context.Context, token string, page 
 		repos = append(repos, convertRestRepo(restRepo))
 	}
 	// 🚨 SECURITY: must forward token here to ensure caching by token
-	c.addRepositoriesToCache(token, repos)
+	c.addRepositoriesToCache("", repos)
 	return repos, len(repos) > 0, 1, nil
 }
 


### PR DESCRIPTION
It was only ever set to the empty string, which lead to using the default token
for the connection. This was added by https://github.com/sourcegraph/sourcegraph/pull/920 but is unused.