### PR TITLE
disable e2e tests

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -116,6 +116,10 @@ func main() {
 
 	pipeline.AddWait()
 
+/**
+ * TODO: Renable once we solve what is causing random test failures (ex:
+ * https://buildkite.com/sourcegraph/sourcegraph/builds/29205#afeaafc5-4056-4a7b-b287-282b24f11181)
+ *
 	if !isBextReleaseBranch {
 		pipeline.AddStep(":chromium:",
 			// Avoid crashing the sourcegraph/server containers. See
@@ -129,6 +133,7 @@ func main() {
 			bk.Cmd("./dev/ci/e2e.sh"),
 			bk.ArtifactPaths("./puppeteer/*.png"))
 	}
+ */
 
 	pipeline.AddWait()
 


### PR DESCRIPTION
Temporarily disable e2e tests due to random test failures.

Examples: https://buildkite.com/sourcegraph/sourcegraph/builds/29204#70d14ecd-14ad-42c3-adda-e53b7c72922c
