### PR TITLE
bitbucket: log when bitbucket requests take >200ms waiting for rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Symbols search is much faster now. After the initial indexing, you can expect code intelligence to be nearly instant no matter the size of your repository.
 - Massively reduced the number of code host API requests Sourcegraph performs, which caused rate limiting issues such as slow search result loading to appear.
+- Improved logging in various situations where Sourcegraph would potentially hit code host API rate limits.
 
 ### Fixed
 


### PR DESCRIPTION
I've also updated the changelog here to include mention of @keegancsmith's [recent changes](https://github.com/sourcegraph/sourcegraph/issues/2677#issuecomment-471740439) around the same thing (better logging when hitting rate limits).