### PR TITLE
do not spellcheck/etc. browser ext URL input field

### DIFF
--- a/client/browser/src/libs/options/ServerURLForm.tsx
+++ b/client/browser/src/libs/options/ServerURLForm.tsx
@@ -115,6 +115,9 @@ export class ServerURLForm extends React.Component<ServerURLFormProps> {
                         value={this.props.value}
                         className="server-url-form__input-container__input"
                         onChange={this.handleChange}
+                        spellCheck={false}
+                        autoCapitalize="off"
+                        autoCorrect="off"
                     />
                 </div>
                 {!this.state.isUpdating && this.props.connectionError === ConnectionErrors.AuthError && (


### PR DESCRIPTION
Spellcheck, autocapitalization, and autocorrect is not useful in the Sourcegraph browser extension URL input field.


<!-- Remember to update the changelog for user-facing changes. -->