### PR TITLE
remove unnecessary CORS logic and corsOrigin docs + site config prop usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Symbols search is much faster now. After the initial indexing, you can expect code intelligence to be nearly instant no matter the size of your repository.
+- Massively reduced the number of code host API requests Sourcegraph performs, which caused rate limiting issues such as slow search result loading to appear.
+- The [`corsOrigin`](https://docs.sourcegraph.com/admin/config/site_config) site config property is no longer needed for integration with GitHub, GitLab, etc., via the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension). Only the [Phabricator extension](https://github.com/sourcegraph/phabricator-extension) requires it.
 
 ### Fixed
 

--- a/client/browser/src/libs/options/ServerURLForm.tsx
+++ b/client/browser/src/libs/options/ServerURLForm.tsx
@@ -149,20 +149,14 @@ export class ServerURLForm extends React.Component<ServerURLFormProps> {
                             </p>
                         )}
                         <p>
-                            <b>If you are an admin,</b> please ensure that{' '}
+                            <b>Site admins:</b> ensure that{' '}
                             <a
                                 href="https://docs.sourcegraph.com/admin/site_config/all#auth-accesstokens-object"
                                 target="_blank"
                             >
                                 all users can create access tokens
-                            </a>{' '}
-                            or you have added your code hosts to your{' '}
-                            <a
-                                href="https://docs.sourcegraph.com/admin/site_config/all#corsorigin-string"
-                                target="_blank"
-                            >
-                                corsOrigin setting.
                             </a>
+                            .
                         </p>
                     </div>
                 )}

--- a/client/browser/src/shared/backend/graphql.tsx
+++ b/client/browser/src/shared/backend/graphql.tsx
@@ -43,12 +43,10 @@ function privateRepoPublicSourcegraph({
  * @return Observable That emits the result or errors if the HTTP request failed
  */
 export const requestGraphQL: typeof performRequest = (args: GraphQLRequestArgs) => {
-    // https://github.com/sourcegraph/sourcegraph/issues/1945
-    // make sure all GraphQL API requests are sent
-    // from the background page, so as to bypass CORS restrictions
-    // when running on private code hosts with the public Sourcegraph instance.
-    // This allows us to run extensions on private code hosts without
-    // needing a private Sourcegraph instance.
+    // Make sure all GraphQL API requests are sent from the background page, so as to bypass CORS
+    // restrictions when running on private code hosts with the public Sourcegraph instance.  This
+    // allows us to run extensions on private code hosts without needing a private Sourcegraph
+    // instance. See https://github.com/sourcegraph/sourcegraph/issues/1945.
     if (isBackground || isInPage) {
         return performRequest(args)
     }

--- a/client/browser/src/shared/backend/headers.tsx
+++ b/client/browser/src/shared/backend/headers.tsx
@@ -1,4 +1,3 @@
-import { isInPage, isPhabricator } from '../../context'
 import { getExtensionVersionSync, getPlatformName } from '../util/context'
 
 /**
@@ -6,40 +5,10 @@ import { getExtensionVersionSync, getPlatformName } from '../util/context'
  * Requests can be blocked for various reasons and therefore the HTTP request MUST use the headers returned here.
  */
 export function getHeaders(): { [name: string]: string } | undefined {
-    if (isPhabricator && isInPage) {
-        return {
-            'X-Requested-With': `Sourcegraph - ${getPlatformName()} v${getExtensionVersionSync()}`,
-        }
+    // This is required (in most cases) for requests to be allowed by Sourcegraph's CORS rules. It
+    // is not required for browser extension background worker requests, but it's harmless to
+    // include it for those, too.
+    return {
+        'X-Requested-With': `Sourcegraph - ${getPlatformName()} v${getExtensionVersionSync()}`,
     }
-
-    const headers: { [name: string]: string } = {}
-
-    // The HTTP request MUST contain at least one of the following for the Sourcegraph server to accept it
-    // (according to its CORS rules).
-    //
-    // - An Origin header with a URI that Sourcegraph trusts. The prod and dev Chrome extension origins
-    //   (chrome-extension://...) are trusted, and site admins can specify other trusted origins in the site config
-    //   "corsOrigin" property.
-    // - An X-Requested-With header (with any nonempty value). This tells the server that the request is from a
-    //   trusted origin, because that header could not be added to a cross-domain request unless it already passed
-    //   the server's CORS rules. (See
-    //   https://stackoverflow.com/questions/17478731/whats-the-point-of-the-x-requested-with-header for more
-    //   info.)
-    // - Using application/json as the Content-Type or Accept result in CORS blocking the request.
-    //
-    // The browsers all handle this situation differently.
-    //
-    // - Chrome (usually) automatically includes "Origin: chrome-extension://..." but does NOT allow us to include
-    //   other headers (such as X-Requested-With), or else they are blocked by the CSP policy of GitHub (or other
-    //   target page). Chrome sometimes sends "Origin: <window.location.origin>" instead; it's not clear in what
-    //   cases or why this occurs.
-    // - Safari includes "Origin: <window.location.origin>" (where "<window.location.origin>" is the
-    //   `window.location.origin` of the current page).
-    // - Firefox does NOT include any Origin header, so we need to send an "X-Requested-With" header.
-    const needsCORSHeader = getPlatformName() === 'firefox-extension' || isPhabricator
-    if (needsCORSHeader) {
-        headers['X-Requested-With'] = `Sourcegraph - ${getPlatformName()} v${getExtensionVersionSync()}`
-    }
-
-    return headers
 }

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -133,21 +133,10 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 		// no cache by default
 		w.Header().Set("Cache-Control", "no-cache, max-age=0")
 
-		// CORS
-		// If the headerOrigin is the development or production Chrome Extension explicitly set the Allow-Control-Allow-Origin
-		// to the incoming header URL. Otherwise use the configured CORS origin.
-		headerOrigin := r.Header.Get("Origin")
-		isExtensionRequest := headerOrigin == devExtension || headerOrigin == prodExtension
-
-		if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" || isExtensionRequest {
+		if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Origin", corsOrigin)
 
-			allowOrigin := corsOrigin
-			if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
-				allowOrigin = headerOrigin
-			}
-
-			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 			if r.Method == "OPTIONS" {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization")
@@ -165,8 +154,6 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 func isTrustedOrigin(r *http.Request) bool {
 	requestOrigin := r.Header.Get("Origin")
 
-	isExtensionRequest := requestOrigin == devExtension || requestOrigin == prodExtension
-
 	var isCORSAllowedRequest bool
 	if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" {
 		isCORSAllowedRequest = isAllowedOrigin(requestOrigin, strings.Fields(corsOrigin))
@@ -176,5 +163,5 @@ func isTrustedOrigin(r *http.Request) bool {
 		isCORSAllowedRequest = true
 	}
 
-	return isExtensionRequest || isCORSAllowedRequest
+	return isCORSAllowedRequest
 }

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -44,11 +44,6 @@ var (
 	httpAddrInternal = env.Get("SRC_HTTP_ADDR_INTERNAL", ":3090", "HTTP listen address for internal HTTP API. This should never be exposed externally, as it lacks certain authz checks.")
 
 	nginxAddr = env.Get("SRC_NGINX_HTTP_ADDR", "", "HTTP listen address for nginx reverse proxy to SRC_HTTP_ADDR. Has preference over SRC_HTTP_ADDR for ExternalURL.")
-
-	// dev browser browser extension ID. You can find this by going to chrome://extensions
-	devExtension = "chrome-extension://bmfbcejdknlknpncfpeloejonjoledha"
-	// production browser extension ID. This is found by viewing our extension in the chrome store.
-	prodExtension = "chrome-extension://dgjhfomjieaadpoljlnidmbgkdffpack"
 )
 
 func init() {

--- a/dev/config.json
+++ b/dev/config.json
@@ -7,7 +7,6 @@
   "disablePublicRepoRedirects": true,
   "repoListUpdateInterval": 1,
   "update.channel": "release",
-  "corsOrigin": "https://github.com",
   "auth.providers": [
     {
       "type": "builtin",

--- a/dev/site-config.json
+++ b/dev/site-config.json
@@ -4,6 +4,5 @@
     "discussions": "enabled"
   },
   "disablePublicRepoRedirects": true,
-  "repoListUpdateInterval": 1,
-  "corsOrigin": "https://github.com"
+  "repoListUpdateInterval": 1
 }

--- a/doc/admin/external_service/phabricator.md
+++ b/doc/admin/external_service/phabricator.md
@@ -54,6 +54,17 @@ For production usage, we recommend installing the Sourcegraph Phabricator extens
 
 See the [phabricator-extension](https://github.com/sourcegraph/phabricator-extension) repository for installation instructions and configuration settings.
 
+The Sourcegraph instance's site admin must [update the `corsOrigin` site config property](../config/site_config.md) to allow the Phabricator extension to communicate with the Sourcegraph instance. For example:
+
+```json
+{
+  // ...
+  "corsOrigin":
+    "https://my-phabricator.example.com"
+  // ...
+}
+```
+
 ## Configuration
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/phabricator.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/phabricator) to see rendered content.</div>

--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -48,17 +48,6 @@ To use the browser extension with a different Sourcegraph instance:
 1.  Click **Update** and enter the URL of a Sourcegraph instance (such as `https://sourcegraph.example.com` or `https://sourcegraph.com`).
 1.  Click **Save**.
 
-> NOTE: The Sourcegraph instance's site admin must [update the `corsOrigin` site config property](../admin/config/site_config.md) to allow the extension to communicate with it from all of the code hosts and other sites it will be used on. For example:
-
-```json
-{
-  // ...
-  "corsOrigin":
-    "https://github.example.com https://gitlab.example.com"
-  // ...
-}
-```
-
 ### Troubleshooting
 
 The most common problem is:
@@ -70,7 +59,6 @@ Try the following:
 1.  Click the Sourcegraph extension icon in the browser toolbar to open the settings page.
     - Ensure that the Sourcegraph URL is correct. It must point to your own Sourcegraph instance to work on private code.
     - Check whether any permissions must be granted. If so, the settings page will display an alert with a **Grant permissions** button.
-    - Confirm with your Sourcegraph instance's site admin that the [site config](../admin/config/site_config.md) `corsOrigin` property contains the URL of the external site on which you are trying to use the browser extension.
 1. On some code hosts, you need to be signed in (to the code host) to use the browser extension. Try signing in.
 
 ## Privacy

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -38,10 +38,9 @@
       "hide": true
     },
     "corsOrigin": {
-      "description": "Value for the Access-Control-Allow-Origin header returned with all requests.",
+      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration.",
       "type": "string",
-      "default": "github.com",
-      "examples": ["github.com github-enterprise.example.com gitlab.com"],
+      "examples": ["https://my-phabricator.example.com"],
       "group": "Security"
     },
     "disableAutoGitUpdates": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -43,10 +43,9 @@ const SiteSchemaJSON = `{
       "hide": true
     },
     "corsOrigin": {
-      "description": "Value for the Access-Control-Allow-Origin header returned with all requests.",
+      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration.",
       "type": "string",
-      "default": "github.com",
-      "examples": ["github.com github-enterprise.example.com gitlab.com"],
+      "examples": ["https://my-phabricator.example.com"],
       "group": "Security"
     },
     "disableAutoGitUpdates": {


### PR DESCRIPTION
- Remove usage and documentation of `corsOrigin` for the browser extension.

  In https://github.com/sourcegraph/sourcegraph/issues/2182#issuecomment-471554710, @lguychard confirmed that the `corsOrigin` site config property is only required when using the [native Phabricator extension](https://github.com/sourcegraph/phabricator-extension), not when using the Sourcegraph browser extension. I (@sqs) confirmed that it is not required when using the Sourcegraph browser extension.
- Move `corsOrigin` documentation to the Phabricator native extension documentation (which is the only place it's needed).
- Remove special-case allowance for the prod and dev Chrome extension IDs (`chrome-extension://ID...`) to bypass CORS. This initially was useful when the Chrome extension needed to make "simple" (in CORS terminology) requests to abide by the GitHub CSP. Now that Chrome (and FF) make requests in the background page, the CSP no longer limits us, so this workaround is no longer necessary (and is not even in effect). Removing them reduces complexity and Chrome-specific impl code.

Test plan:

(Because this change affects browser extension and server communication, which isn't well covered by e2e tests, I wanted to manually test it.)

1. On my dev instance (http://localhost:3080), remove `corsOrigin` from site config.
1. Ensure the repository http://localhost:3080/github.com/sourcegraph/go-diff is enabled and the `sourcegraph/go` extension is enabled.
1. Run `cd client/browser && yarn run dev`.
1. For both Chrome and Firefox:
   1. Disable the prod version of the browser extension.
   1. Load the dev version of the browser extension.
   1. For both https://sourcegraph.com and http://localhost:3080:
      1. Set the URL in the browser extension options page. Ensure it turns green and says "Connected".
      1. For both https://github.com/sourcegraph/go-diff/blob/master/diff/parse.go (**GitHub**) and https://gitlab.com/sourcegraph/ctxvfs/blob/master/namespace.go (**GitLab**):
         1. Navigate to the URL.
         1. Ensure the "View file" buttons appear.
         1. Ensure hovers on `NewMultiFileDiffReader` work.

<!-- Remember to update the changelog for user-facing changes. -->
