### PR TITLE
doc/admin: Add initial troubleshooting instructions for tracing/logging

### DIFF
--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -17,6 +17,7 @@ Site administrators are the admins responsible for deploying, managing, and conf
   - [nginx HTTP server configuration](nginx.md)
   - [Setting the URL for your instance](url.md)
   - [Monitoring and tracing](monitoring_and_tracing.md)
+     - [Troubleshooting](monitoring_and_tracing.md#troubleshooting)
   - [Repository permissions](repo/permissions.md)
   - [Upgrading PostgreSQL](postgres.md)
   - [Using external databases (PostgreSQL and Redis)](external_database.md)

--- a/doc/admin/monitoring_and_tracing.md
+++ b/doc/admin/monitoring_and_tracing.md
@@ -2,15 +2,16 @@
 
 Sourcegraph supports forwarding internal performance and debugging information to many monitoring and tracing systems.
 
-- [LightStep](https://lightstep.com) (full [OpenTracing](http://opentracing.io/) support coming soon)
-- [Jaeger](https://github.com/jaegertracing/jaeger#readme)
-- [Go net/trace](https://godoc.org/golang.org/x/net/trace)
+- [Jaeger](https://github.com/jaegertracing/jaeger#readme) tracing, configured via the `useJaeger` properties in [critical configuration](config/critical_config.md)
+- [LightStep](https://lightstep.com) tracing, configured via the `lightstep*` properties in [critical configuration](config/critical_config.md) (full [OpenTracing](http://opentracing.io/) support coming soon)
+- [Sentry](https://sentry.io) logging, configured via the `sentry` property in [critical configuration](config/critical_config.md)
+- [Go net/trace](#viewing-go-net-trace-information)
 - [Honeycomb](https://honeycomb.io/)
 - [Prometheus](https://prometheus.io/) and alerting systems that integrate with it
 
 If you're using the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), see "[Kubernetes cluster administrator guide](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/admin-guide.md)" and "[Prometheus metrics](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/prom-metrics.md)" for more information.
 
-We are in the process of documenting more common monitoring and tracing deployment scenarios. For help configuring monitoring and tracing on your Sourcegraph instance, contact us at [@srcgraph](https://twitter.com/srcgraph) or <mailto:support@sourcegraph.com>, or file issues on our [public issue tracker](https://github.com/sourcegraph/issues/issues).
+We are in the process of documenting more common monitoring and tracing deployment scenarios. For help configuring monitoring and tracing on your Sourcegraph instance, use our [public issue tracker](https://github.com/sourcegraph/issues/issues).
 
 ## Health check
 
@@ -20,15 +21,15 @@ The [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy
 
 ## Troubleshooting
 
-Sourcegraph provides tracing, metrics and logs to facilitate troubleshooting. When investigating an issue, first [inspect traces](#tracing) (if you have tracing set up). Next, [increase the log verbosity](#logs) by setting the environment variable `SRC_LOG_LEVEL=dbug`. If that is too noisy, inspecting the Go net/trace page for individual services is valuable.
+Sourcegraph provides tracing, metrics and logs to help you troubleshoot problems. When investigating an issue, we recommend using the following resources:
 
-### Tracing
+1. [View verbose logs](#viewing-logs) (most common)
+1. [Inspect traces](#inspecting-traces-jaeger-or-lightstep)
+1. [Inspect the Go net/trace information](#viewing-go-net-trace-information) for individual services (rarely needed)
 
-If Jaeger or LightStep is configured, every HTTP response will include an `X-Trace` header which links to the trace for that request. Inspecting the spans and logs attached to the trace will help quickly identify the problematic service or dependency.
+### Viewing logs
 
-### Logs
-
-A Sourcegraph service log level is configured via the environment variable `SRC_LOG_LEVEL`. The valid values (from most to least verbose) are:
+A Sourcegraph service's log level is configured via the environment variable `SRC_LOG_LEVEL`. The valid values (from most to least verbose) are:
 
 * `dbug`: Debug. Output all logs. Default in cluster deployments.
 * `info`: Informational.
@@ -38,6 +39,10 @@ A Sourcegraph service log level is configured via the environment variable `SRC_
 
 If you are having issues with repository syncing, view the output of `repo-updater`'s logs.
 
-### Go net/trace
+### Inspecting traces (Jaeger or LightStep)
 
-If you are using Sourcegraph's Docker deployment, site admins can access `net/trace` information at https://sourcegraph.example.com/-/debug/. If you are using Sourcegraph cluster, you need to `kubectl port-forward ${POD_NAME} 6060` to access the debug page. Once on the debug page of a service, click **Requests** to view the traces for that service.
+If LightStep or Jaeger is configured (using the [`useJaeger` or `lightstep*` critical configuration properties](config/critical_config.md), every HTTP response will include an `X-Trace` header with a link to the trace for that request. Inspecting the spans and logs attached to the trace will help identify the problematic service or dependency.
+
+### Viewing Go net/trace information
+
+If you are using Sourcegraph's Docker deployment, site admins can access [Go `net/trace`](https://godoc.org/golang.org/x/net/trace) information at https://sourcegraph.example.com/-/debug/. If you are using Sourcegraph cluster, you need to `kubectl port-forward ${POD_NAME} 6060` to access the debug page. From there, when you are viewing the debug page of a service, click **Requests** to view the traces for that service.

--- a/doc/admin/monitoring_and_tracing.md
+++ b/doc/admin/monitoring_and_tracing.md
@@ -20,19 +20,19 @@ The [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy
 
 ## Troubleshooting
 
-Sourcegraph provides tracing, metrics and logs to facilitate troubleshooting. When investigating an issue the best place to start is tracing if you have it setup. Followed by increasing the logging verbosity by setting the environment variable `SRC_LOG_LEVEL=dbug`. If that is too noisy, inspecting the Go net/trace page for individual services is valuable.
+Sourcegraph provides tracing, metrics and logs to facilitate troubleshooting. When investigating an issue, first [inspect traces](#tracing) (if you have tracing set up). Next, [increase the log verbosity](#logs) by setting the environment variable `SRC_LOG_LEVEL=dbug`. If that is too noisy, inspecting the Go net/trace page for individual services is valuable.
 
 ### Tracing
 
-If Jaeger or Lightstep is configured, every HTTP response will include an `X-Trace` header which links to the trace for that request. Inspecting the spans and logs attached to the trace will help quickly identify the problematic service or dependency.
+If Jaeger or LightStep is configured, every HTTP response will include an `X-Trace` header which links to the trace for that request. Inspecting the spans and logs attached to the trace will help quickly identify the problematic service or dependency.
 
 ### Logs
 
-A sourcegraph service log level is configured via the environment variable `SRC_LOG_LEVEL`. The valid values in decreasing order of verbosity:
+A Sourcegraph service log level is configured via the environment variable `SRC_LOG_LEVEL`. The valid values (from most to least verbose) are:
 
 * `dbug`: Debug. Output all logs. Default in cluster deployments.
 * `info`: Informational.
-* `warn`: Warning. Default in docker deployments.
+* `warn`: Warning. Default in Docker deployments.
 * `eror`: Error.
 * `crit`: Critical.
 
@@ -40,4 +40,4 @@ If you are having issues with repository syncing, view the output of `repo-updat
 
 ### Go net/trace
 
-If you are using Sourcegraph's Docker deployment we provide a convenient access to site admins via https://sourcegraph.example.com/-/debug/. If you are using Sourcegraph cluster you will need to `kubectl port-forward ${POD_NAME} 6060` to access the debug page. Once on the debug page of a service click `Requests` to view the traces for that service.
+If you are using Sourcegraph's Docker deployment, site admins can access `net/trace` information at https://sourcegraph.example.com/-/debug/. If you are using Sourcegraph cluster, you need to `kubectl port-forward ${POD_NAME} 6060` to access the debug page. Once on the debug page of a service, click **Requests** to view the traces for that service.

--- a/doc/admin/monitoring_and_tracing.md
+++ b/doc/admin/monitoring_and_tracing.md
@@ -17,3 +17,27 @@ We are in the process of documenting more common monitoring and tracing deployme
 An application health check status endpoint is available at the URL path `/healthz`. It returns HTTP 200 if and only if the main frontend server and databases (PostgreSQL and Redis) are available.
 
 The [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph) ships with comprehensive health checks for each Kubernetes deployment.
+
+## Troubleshooting
+
+Sourcegraph provides tracing, metrics and logs to facilitate troubleshooting. When investigating an issue the best place to start is tracing if you have it setup. Followed by increasing the logging verbosity by setting the environment variable `SRC_LOG_LEVEL=dbug`. If that is too noisy, inspecting the Go net/trace page for individual services is valuable.
+
+### Tracing
+
+If Jaeger or Lightstep is configured, every HTTP response will include an `X-Trace` header which links to the trace for that request. Inspecting the spans and logs attached to the trace will help quickly identify the problematic service or dependency.
+
+### Logs
+
+A sourcegraph service log level is configured via the environment variable `SRC_LOG_LEVEL`. The valid values in decreasing order of verbosity:
+
+* `dbug`: Debug. Output all logs. Default in cluster deployments.
+* `info`: Informational.
+* `warn`: Warning. Default in docker deployments.
+* `eror`: Error.
+* `crit`: Critical.
+
+If you are having issues with repository syncing, view the output of `repo-updater`'s logs.
+
+### Go net/trace
+
+If you are using Sourcegraph's Docker deployment we provide a convenient access to site admins via https://sourcegraph.example.com/-/debug/. If you are using Sourcegraph cluster you will need to `kubectl port-forward ${POD_NAME} 6060` to access the debug page. Once on the debug page of a service click `Requests` to view the traces for that service.


### PR DESCRIPTION
Inspired by the need to communicate logging information to a customer for https://github.com/sourcegraph/sourcegraph/issues/2677