### PR TITLE
Activation UX improvements

### DIFF
--- a/shared/src/components/activation/ActivationChecklist.scss
+++ b/shared/src/components/activation/ActivationChecklist.scss
@@ -16,9 +16,6 @@
 }
 
 .activation-item {
-    cursor: pointer;
-    padding: 0.5rem 0.5rem;
-
     &__checkbox {
         &--done {
             color: $oc-green-6;

--- a/shared/src/components/activation/ActivationChecklist.tsx
+++ b/shared/src/components/activation/ActivationChecklist.tsx
@@ -4,6 +4,7 @@ import CheckboxBlankCircleOutlineIcon from 'mdi-react/CheckboxBlankCircleOutline
 import CheckboxMarkedCircleOutlineIcon from 'mdi-react/CheckboxMarkedCircleOutlineIcon'
 import * as React from 'react'
 import { Link } from '../Link'
+import { LinkOrButton } from '../LinkOrButton'
 import { ActivationCompletionStatus, ActivationStep } from './Activation'
 
 interface ActivationChecklistItemProps extends ActivationStep {
@@ -37,13 +38,15 @@ export class ActivationChecklistItem extends React.PureComponent<ActivationCheck
 
         return (
             <div onClick={this.onClick} data-tooltip={this.props.detail}>
-                {this.props.link ? (
-                    <Link className={'activation-item__link'} {...this.props.link}>
-                        {checkboxElem}
-                    </Link>
-                ) : (
-                    checkboxElem
-                )}
+                <LinkOrButton>
+                    {this.props.link ? (
+                        <Link className={'activation-item__link'} {...this.props.link}>
+                            {checkboxElem}
+                        </Link>
+                    ) : (
+                        checkboxElem
+                    )}
+                </LinkOrButton>
             </div>
         )
     }

--- a/shared/src/components/activation/ActivationDropdown.scss
+++ b/shared/src/components/activation/ActivationDropdown.scss
@@ -6,6 +6,7 @@
     &__progress-bar-container {
         display: inline-block;
         width: 1rem;
+        margin-top: -0.125rem;
         margin-left: 0.375rem;
     }
     &__circular-progress-bar {

--- a/shared/src/components/activation/ActivationDropdown.tsx
+++ b/shared/src/components/activation/ActivationDropdown.tsx
@@ -6,7 +6,7 @@ import CircularProgressbar from 'react-circular-progressbar'
 import Confetti from 'react-dom-confetti'
 import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 import { concat, of, Subject, Subscription } from 'rxjs'
-import { concatMap, delay, filter, map, pairwise, startWith } from 'rxjs/operators'
+import { concatMap, delay, filter, map, pairwise, startWith, tap } from 'rxjs/operators'
 import { Activation, percentageDone } from './Activation'
 import { ActivationChecklistItem } from './ActivationChecklist'
 
@@ -16,6 +16,7 @@ interface Props {
 }
 
 interface State {
+    shouldRemain: boolean
     isOpen: boolean
     animate: boolean
 }
@@ -27,7 +28,7 @@ const animationDurationMillis = 5700
  * status in the navbar.
  */
 export class ActivationDropdown extends React.PureComponent<Props, State> {
-    public state: State = { isOpen: false, animate: false }
+    public state: State = { isOpen: false, animate: false, shouldRemain: false }
     private toggleIsOpen = () => this.setState(prevState => ({ isOpen: !prevState.isOpen }))
     private componentUpdates = new Subject<Props>()
     private subscriptions = new Subscription()
@@ -45,6 +46,11 @@ export class ActivationDropdown extends React.PureComponent<Props, State> {
                         }
                         return percentageDone(cur) > percentageDone(prev)
                     }),
+                    tap(didIncrease => {
+                        if (didIncrease) {
+                            this.setState({ shouldRemain: true })
+                        }
+                    }),
                     concatMap(() => concat(of(true), of(false).pipe(delay(animationDurationMillis))))
                 )
                 .subscribe(animate => this.setState({ animate }))
@@ -60,7 +66,10 @@ export class ActivationDropdown extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element {
-        const show = this.state.animate || percentageDone(this.props.activation.completed) < 100
+        const show =
+            this.state.shouldRemain ||
+            this.state.animate ||
+            (this.props.activation.completed !== undefined && percentageDone(this.props.activation.completed) < 100)
         const confettiConfig = {
             spread: 68,
             startVelocity: 23,

--- a/shared/src/components/activation/ActivationDropdown.tsx
+++ b/shared/src/components/activation/ActivationDropdown.tsx
@@ -21,7 +21,7 @@ interface State {
     animate: boolean
 }
 
-const animationDurationMillis = 5700
+const animationDurationMillis = 3260
 
 /**
  * Renders the activation status navlink item, a dropdown button that shows activation
@@ -72,7 +72,7 @@ export class ActivationDropdown extends React.PureComponent<Props, State> {
             (this.props.activation.completed !== undefined && percentageDone(this.props.activation.completed) < 100)
         const confettiConfig = {
             spread: 68,
-            startVelocity: 23,
+            startVelocity: 12,
             elementCount: 81,
             dragFriction: 0.09,
             duration: animationDurationMillis,

--- a/shared/src/components/activation/__snapshots__/ActivationChecklist.test.tsx.snap
+++ b/shared/src/components/activation/__snapshots__/ActivationChecklist.test.tsx.snap
@@ -11,25 +11,33 @@ exports[`ActivationChecklist render 0/1 complete 1`] = `
       data-tooltip="detail1"
       onClick={[Function]}
     >
-      <div
-        className="activation-item"
+      <a
+        className="nav-link "
+        onAuxClick={[Function]}
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       >
-         
-        <svg
-          className="mdi-icon icon-inline activation-item__checkbox--todo"
-          fill="currentColor"
-          height={24}
-          viewBox="0 0 24 24"
-          width={24}
+        <div
+          className="activation-item"
         >
-          <path
-            d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
-          />
-        </svg>
-          
-        title1
-         
-      </div>
+           
+          <svg
+            className="mdi-icon icon-inline activation-item__checkbox--todo"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+            />
+          </svg>
+            
+          title1
+           
+        </div>
+      </a>
     </div>
   </div>
 </div>
@@ -46,25 +54,33 @@ exports[`ActivationChecklist render 0/1 complete 2`] = `
       data-tooltip="detail1"
       onClick={[Function]}
     >
-      <div
-        className="activation-item"
+      <a
+        className="nav-link "
+        onAuxClick={[Function]}
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       >
-         
-        <svg
-          className="mdi-icon icon-inline activation-item__checkbox--todo"
-          fill="currentColor"
-          height={24}
-          viewBox="0 0 24 24"
-          width={24}
+        <div
+          className="activation-item"
         >
-          <path
-            d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
-          />
-        </svg>
-          
-        title1
-         
-      </div>
+           
+          <svg
+            className="mdi-icon icon-inline activation-item__checkbox--todo"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+            />
+          </svg>
+            
+          title1
+           
+        </div>
+      </a>
     </div>
   </div>
 </div>
@@ -81,25 +97,33 @@ exports[`ActivationChecklist render 1/1 complete 1`] = `
       data-tooltip="detail1"
       onClick={[Function]}
     >
-      <div
-        className="activation-item"
+      <a
+        className="nav-link "
+        onAuxClick={[Function]}
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        tabIndex={0}
       >
-         
-        <svg
-          className="mdi-icon icon-inline activation-item__checkbox--done"
-          fill="currentColor"
-          height={24}
-          viewBox="0 0 24 24"
-          width={24}
+        <div
+          className="activation-item"
         >
-          <path
-            d="M20,12C20,16.42 16.42,20 12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C12.76,4 13.5,4.11 14.2,4.31L15.77,2.74C14.61,2.26 13.34,2 12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
-          />
-        </svg>
-          
-        title1
-         
-      </div>
+           
+          <svg
+            className="mdi-icon icon-inline activation-item__checkbox--done"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M20,12C20,16.42 16.42,20 12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C12.76,4 13.5,4.11 14.2,4.31L15.77,2.74C14.61,2.26 13.34,2 12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
+            />
+          </svg>
+            
+          title1
+           
+        </div>
+      </a>
     </div>
   </div>
 </div>

--- a/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
+++ b/shared/src/components/activation/__snapshots__/ActivationDropdown.test.tsx.snap
@@ -113,38 +113,12 @@ exports[`ActivationDropdown render 0/2 completed 1`] = `
         data-tooltip="detail1"
         onClick={[Function]}
       >
-        <div
-          className="activation-item"
-        >
-           
-          <svg
-            className="mdi-icon icon-inline activation-item__checkbox--todo"
-            fill="currentColor"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-          >
-            <path
-              d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
-            />
-          </svg>
-            
-          title1
-           
-        </div>
-      </div>
-    </div>
-    <div
-      className="activation-dropdown-item dropdown-item"
-      onClick={[Function]}
-    >
-      <div
-        data-tooltip="detail2"
-        onClick={[Function]}
-      >
         <a
-          className="activation-item__link"
-          to="/some/url"
+          className="nav-link "
+          onAuxClick={[Function]}
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          tabIndex={0}
         >
           <div
             className="activation-item"
@@ -162,9 +136,51 @@ exports[`ActivationDropdown render 0/2 completed 1`] = `
               />
             </svg>
               
-            title2
+            title1
              
           </div>
+        </a>
+      </div>
+    </div>
+    <div
+      className="activation-dropdown-item dropdown-item"
+      onClick={[Function]}
+    >
+      <div
+        data-tooltip="detail2"
+        onClick={[Function]}
+      >
+        <a
+          className="nav-link "
+          onAuxClick={[Function]}
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          tabIndex={0}
+        >
+          <a
+            className="activation-item__link"
+            to="/some/url"
+          >
+            <div
+              className="activation-item"
+            >
+               
+              <svg
+                className="mdi-icon icon-inline activation-item__checkbox--todo"
+                fill="currentColor"
+                height={24}
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+                />
+              </svg>
+                
+              title2
+               
+            </div>
+          </a>
         </a>
       </div>
     </div>
@@ -285,25 +301,33 @@ exports[`ActivationDropdown render 1/2 completed 1`] = `
         data-tooltip="detail1"
         onClick={[Function]}
       >
-        <div
-          className="activation-item"
+        <a
+          className="nav-link "
+          onAuxClick={[Function]}
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          tabIndex={0}
         >
-           
-          <svg
-            className="mdi-icon icon-inline activation-item__checkbox--done"
-            fill="currentColor"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
+          <div
+            className="activation-item"
           >
-            <path
-              d="M20,12C20,16.42 16.42,20 12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C12.76,4 13.5,4.11 14.2,4.31L15.77,2.74C14.61,2.26 13.34,2 12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
-            />
-          </svg>
-            
-          title1
-           
-        </div>
+             
+            <svg
+              className="mdi-icon icon-inline activation-item__checkbox--done"
+              fill="currentColor"
+              height={24}
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M20,12C20,16.42 16.42,20 12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C12.76,4 13.5,4.11 14.2,4.31L15.77,2.74C14.61,2.26 13.34,2 12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
+              />
+            </svg>
+              
+            title1
+             
+          </div>
+        </a>
       </div>
     </div>
     <div
@@ -315,28 +339,36 @@ exports[`ActivationDropdown render 1/2 completed 1`] = `
         onClick={[Function]}
       >
         <a
-          className="activation-item__link"
-          to="/some/url"
+          className="nav-link "
+          onAuxClick={[Function]}
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          tabIndex={0}
         >
-          <div
-            className="activation-item"
+          <a
+            className="activation-item__link"
+            to="/some/url"
           >
-             
-            <svg
-              className="mdi-icon icon-inline activation-item__checkbox--todo"
-              fill="currentColor"
-              height={24}
-              viewBox="0 0 24 24"
-              width={24}
+            <div
+              className="activation-item"
             >
-              <path
-                d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
-              />
-            </svg>
-              
-            title2
-             
-          </div>
+               
+              <svg
+                className="mdi-icon icon-inline activation-item__checkbox--todo"
+                fill="currentColor"
+                height={24}
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2Z"
+                />
+              </svg>
+                
+              title2
+               
+            </div>
+          </a>
         </a>
       </div>
     </div>
@@ -346,7 +378,7 @@ exports[`ActivationDropdown render 1/2 completed 1`] = `
 
 exports[`ActivationDropdown render loading 1`] = `
 <div
-  className=" nav-link p-0 btn-group"
+  className="activation-dropdown-button--hidden nav-link p-0 btn-group"
   onKeyDown={[Function]}
 >
   <a

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
 import { Subject } from 'rxjs'
+import { Activation, ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { RepoLink } from '../../../shared/src/components/RepoLink'
 import * as GQL from '../../../shared/src/graphql/schema'
 import {
@@ -25,7 +26,7 @@ import {
     updateMirrorRepository,
 } from './backend'
 
-interface RepositoryNodeProps {
+interface RepositoryNodeProps extends ActivationProps {
     node: GQL.IRepository
     onDidUpdate?: () => void
 }
@@ -136,15 +137,16 @@ class RepositoryNode extends React.PureComponent<RepositoryNodeProps, Repository
                     this.props.onDidUpdate()
                 }
                 this.setState({ loading: false })
+                activate(this.props.activation)
             },
             err => this.setState({ loading: false, errorDescription: err.message })
         )
     }
 }
 
-interface Props extends RouteComponentProps<any> {}
+interface Props extends RouteComponentProps<any>, ActivationProps {}
 
-class FilteredRepositoryConnection extends FilteredConnection<GQL.IRepository> {}
+class FilteredRepositoryConnection extends FilteredConnection<GQL.IRepository, ActivationProps> {}
 
 /**
  * A page displaying the repositories on this site.
@@ -214,8 +216,9 @@ export class SiteAdminRepositoriesPage extends React.PureComponent<Props, {}> {
     }
 
     public render(): JSX.Element | null {
-        const nodeProps: Pick<RepositoryNodeProps, 'onDidUpdate'> = {
+        const nodeProps: Pick<RepositoryNodeProps, 'onDidUpdate' | 'activation'> = {
             onDidUpdate: this.onDidUpdateRepository,
+            activation: this.props.activation,
         }
 
         return (
@@ -279,12 +282,21 @@ export class SiteAdminRepositoriesPage extends React.PureComponent<Props, {}> {
             promises.push(updateAllMirrorRepositories().toPromise())
         }
         Promise.all(promises).then(
-            this.onDidUpdateRepository,
+            () => {
+                activate(this.props.activation)
+                this.onDidUpdateRepository()
+            },
             // If one (or more) repositories fail, still update the UI before re-throwing
             err => {
                 this.onDidUpdateRepository()
                 throw err
             }
         )
+    }
+}
+
+function activate(activation?: Activation): void {
+    if (activation) {
+        activation.update({ EnabledRepository: true })
     }
 }

--- a/web/src/tracking/withActivation.tsx
+++ b/web/src/tracking/withActivation.tsx
@@ -36,6 +36,7 @@ const fetchActivationStatus = (isSiteAdmin: boolean): Observable<ActivationCompl
                           usageStatistics {
                               searchQueries
                               findReferencesActions
+                              codeIntelligenceActions
                           }
                       }
                   }
@@ -46,6 +47,7 @@ const fetchActivationStatus = (isSiteAdmin: boolean): Observable<ActivationCompl
                           usageStatistics {
                               searchQueries
                               findReferencesActions
+                              codeIntelligenceActions
                           }
                       }
                   }
@@ -54,9 +56,13 @@ const fetchActivationStatus = (isSiteAdmin: boolean): Observable<ActivationCompl
         map(dataOrThrowErrors),
         map(data => {
             const authProviders = window.context.authProviders
+            const usageStats = !!data.currentUser && data.currentUser.usageStatistics
             const completed: ActivationCompletionStatus = {
-                DidSearch: !!data.currentUser && data.currentUser.usageStatistics.searchQueries > 0,
-                FoundReferences: !!data.currentUser && data.currentUser.usageStatistics.findReferencesActions > 0,
+                DidSearch: usageStats && usageStats.searchQueries > 0,
+                FoundReferences:
+                    // TODO(beyang): revert this to usageStats.findReferencesActions > 0 in 3.3 or later.
+                    // Remove codeIntelligenceActions from the GraphQL query above, as well.
+                    usageStats && (usageStats.findReferencesActions > 0 || usageStats.codeIntelligenceActions > 10),
             }
             if (isSiteAdmin) {
                 completed.ConnectedCodeHost = data.externalServices && data.externalServices.totalCount > 0


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2638


- [x] For users who have already completed the actions before upgrading to a version that has the activation flow, don't show confetti the next time they visit
  - Fixes by disabling this action if more than 10 generic code intelligence actions have been completed (we have been tracking this previously). 
- [x] Progress does not advance until a full page reload (e.g. after adding an external service)
  - Fixed for all items except for SSO enablement, which goes through management console
- [x] The "Setup" button and the circle icon appear slightly misaligned with each other
- [x] The "Setup" button and icon disappear after clicking "Find references". It should stay around and show fully completed until the next page reload.
