### PR TITLE
Do not render empty hovers

### DIFF
--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -76,6 +76,9 @@ class BaseHoverOverlay extends React.PureComponent<HoverOverlayProps & { telemet
             location,
         } = this.props
 
+        if (!hoverOrError && (!actionsOrError || isErrorLike(actionsOrError))) {
+            return null
+        }
         return (
             <div
                 className={`hover-overlay card ${className}`}

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -138,23 +138,7 @@ exports[`HoverOverlay actions and hover present 1`] = `
 </div>
 `;
 
-exports[`HoverOverlay actions and hover undefined 1`] = `
-<div
-  className="hover-overlay card "
-  style={
-    Object {
-      "left": "0px",
-      "opacity": 1,
-      "top": "0px",
-      "visibility": "visible",
-    }
-  }
->
-  <div
-    className="hover-overlay__contents"
-  />
-</div>
-`;
+exports[`HoverOverlay actions and hover undefined 1`] = `null`;
 
 exports[`HoverOverlay actions empty 1`] = `
 <div
@@ -174,23 +158,7 @@ exports[`HoverOverlay actions empty 1`] = `
 </div>
 `;
 
-exports[`HoverOverlay actions error 1`] = `
-<div
-  className="hover-overlay card "
-  style={
-    Object {
-      "left": "0px",
-      "opacity": 1,
-      "top": "0px",
-      "visibility": "visible",
-    }
-  }
->
-  <div
-    className="hover-overlay__contents"
-  />
-</div>
-`;
+exports[`HoverOverlay actions error 1`] = `null`;
 
 exports[`HoverOverlay actions error, hover present 1`] = `
 <div
@@ -353,23 +321,7 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
 </div>
 `;
 
-exports[`HoverOverlay hover empty 1`] = `
-<div
-  className="hover-overlay card "
-  style={
-    Object {
-      "left": "0px",
-      "opacity": 1,
-      "top": "0px",
-      "visibility": "visible",
-    }
-  }
->
-  <div
-    className="hover-overlay__contents"
-  />
-</div>
-`;
+exports[`HoverOverlay hover empty 1`] = `null`;
 
 exports[`HoverOverlay hover error 1`] = `
 <div


### PR DESCRIPTION
Fixes #1741

Empty hovers were rendered as an empty `div.hover-overlay.card`, with the border from `card` class causing them to be rendered as a 'line' above hovered tokens.

![image](https://user-images.githubusercontent.com/1741180/54224268-757a3700-44f9-11e9-826a-63cb86294faa.png)
