### PR TITLE
Add link to issue tracker from search error page

### DIFF
--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -436,9 +436,21 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
 
                     <div className="pb-4" />
                     {this.props.resultsOrError !== undefined && (
-                        <Link className="mb-2" to="/help/user/search">
-                            Not seeing expected results?
-                        </Link>
+                        <div>
+                            Not seeing expected results?{' '}
+                            <Link className="mb-2" to="/help/user/search">
+                                View search documentation
+                            </Link>
+                            {' or '}
+                            <a
+                                className="mb-2"
+                                href="https://github.com/sourcegraph/sourcegraph/issues/new/choose"
+                                target="_blank"
+                            >
+                                file an issue
+                            </a>
+                            .
+                        </div>
                     )}
                 </div>
             </React.Fragment>


### PR DESCRIPTION
Adds a link to **file an issue** at the bottom of the search result error page.

![Screenshot 2019-03-12 13 39 01](https://user-images.githubusercontent.com/4897310/54236861-e574c700-44d1-11e9-9b64-a9e606a9ace3.png)
