### PR TITLE
CI: set concurrency limit of 1 on Docker steps

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -58,6 +58,11 @@ func main() {
 
 	if !isBextReleaseBranch {
 		pipeline.AddStep(":docker:",
+			// Avoid crashing the sourcegraph/server containers running on the
+			// same dind pod. See
+			// https://github.com/sourcegraph/sourcegraph/issues/2657
+			bk.ConcurrencyGroup("docker"),
+			bk.Concurrency(1),
 			bk.Cmd("pushd enterprise"),
 			bk.Cmd("./cmd/server/pre-build.sh"),
 			bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
@@ -118,9 +123,10 @@ func main() {
 
 	if !isBextReleaseBranch {
 		pipeline.AddStep(":chromium:",
-			// Avoid crashing the sourcegraph/server containers. See
+			// Avoid crashing the sourcegraph/server containers running on the
+			// same dind pod. See
 			// https://github.com/sourcegraph/sourcegraph/issues/2657
-			bk.ConcurrencyGroup("e2e"),
+			bk.ConcurrencyGroup("docker"),
 			bk.Concurrency(1),
 
 			bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
@@ -142,6 +148,11 @@ func main() {
 	addDockerImageStep := func(app string, insiders bool) {
 		cmds := []bk.StepOpt{
 			bk.Cmd(fmt.Sprintf(`echo "Building %s..."`, app)),
+			// Avoid crashing the sourcegraph/server containers running on the
+			// same dind pod. See
+			// https://github.com/sourcegraph/sourcegraph/issues/2657
+			bk.ConcurrencyGroup("docker"),
+			bk.Concurrency(1),
 		}
 
 		cmdDir := "cmd/" + app


### PR DESCRIPTION
Previously, Docker builds could starve the sourcegraph/server container that was the subject of e2e tests, causing initialization to take >30s and timeout, causing build errors.

This PR applies the concurrency limit of 1 to all Docker steps, not just the e2e runs.

This will slow down CI, but there are some other ways to mitigate that: https://github.com/sourcegraph/sourcegraph/issues/2657#issuecomment-472219579