### PR TITLE
remove upgrade notice from docs homepage

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,5 @@
 # Sourcegraph documentation
 
-> NOTE: Upgrading to `3.0.1+`? Read our [migration guide](admin/migration/3_0.md) for `2.x` and `3.0.0`.
-
 [Sourcegraph](https://sourcegraph.com) is used by developers at Uber, Lyft, Yelp, and more to help them search, navigate and review code at enterprise scale.
 
 ## Quickstart guide


### PR DESCRIPTION
Now that 3.x has been out for longer and most instances are on 3.x, we can remove the migration notice. It is probably more confusing/irrelevant now than helpful. The migration doc is still linked from the changelog, which site admins upgrading should consult.

