### PR TITLE
Revert "CI: set concurrency limit of 1 on Docker steps"

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -58,11 +58,6 @@ func main() {
 
 	if !isBextReleaseBranch {
 		pipeline.AddStep(":docker:",
-			// Avoid crashing the sourcegraph/server containers running on the
-			// same dind pod. See
-			// https://github.com/sourcegraph/sourcegraph/issues/2657
-			bk.ConcurrencyGroup("docker"),
-			bk.Concurrency(1),
 			bk.Cmd("pushd enterprise"),
 			bk.Cmd("./cmd/server/pre-build.sh"),
 			bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
@@ -123,10 +118,9 @@ func main() {
 
 	if !isBextReleaseBranch {
 		pipeline.AddStep(":chromium:",
-			// Avoid crashing the sourcegraph/server containers running on the
-			// same dind pod. See
+			// Avoid crashing the sourcegraph/server containers. See
 			// https://github.com/sourcegraph/sourcegraph/issues/2657
-			bk.ConcurrencyGroup("docker"),
+			bk.ConcurrencyGroup("e2e"),
 			bk.Concurrency(1),
 
 			bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
@@ -148,11 +142,6 @@ func main() {
 	addDockerImageStep := func(app string, insiders bool) {
 		cmds := []bk.StepOpt{
 			bk.Cmd(fmt.Sprintf(`echo "Building %s..."`, app)),
-			// Avoid crashing the sourcegraph/server containers running on the
-			// same dind pod. See
-			// https://github.com/sourcegraph/sourcegraph/issues/2657
-			bk.ConcurrencyGroup("docker"),
-			bk.Concurrency(1),
 		}
 
 		cmdDir := "cmd/" + app


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#2710

One Docker step at a time is killing our throughput:

![image](https://user-images.githubusercontent.com/1387653/54256091-052ede00-4518-11e9-94c1-513726d342e1.png)
