### PR TITLE
CI: skip non-doc checks for docs-only changes

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -55,6 +56,34 @@ func main() {
 		bk.Env("FORCE_COLOR", "1"),
 		bk.Env("ENTERPRISE", "1"),
 	)
+
+	isPR := !isBextReleaseBranch &&
+		!releaseBranch &&
+		!taggedRelease &&
+		branch != "master" &&
+		!strings.HasPrefix(branch, "master-dry-run/") &&
+		!strings.HasPrefix(branch, "docker-images-patch/")
+	if isPR {
+		output, err := exec.Command("git", "diff", "--name-only", "origin/master...").Output()
+		if err != nil {
+			panic(err)
+		}
+
+		onlyDocsChange := true
+		for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+			if !strings.HasPrefix(line, "doc") {
+				onlyDocsChange = false
+				break
+			}
+		}
+
+		if onlyDocsChange {
+			pipeline.AddStep(":memo:",
+				bk.Cmd("./dev/ci/yarn-run.sh prettier-check"),
+				bk.Cmd("./dev/check/docsite.sh"))
+			return
+		}
+	}
 
 	if !isBextReleaseBranch {
 		pipeline.AddStep(":docker:",


### PR DESCRIPTION
This runs only `prettier-check` and `docsite check` on docs-only PRs. All steps still run on master.

See:

- https://github.com/sourcegraph/sourcegraph/issues/2706
- https://sourcegraph.slack.com/archives/C07KZF47K/p1552422899189900
- https://sourcegraph.slack.com/archives/C08JA8Q1H/p1552448146079500
