### PR TITLE
repo-updater: Introduce InternalAPI interface for repoupdater server

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -154,6 +154,7 @@ func main() {
 		Store:            store,
 		Syncer:           syncer,
 		OtherReposSyncer: otherSyncer,
+		InternalAPI:      frontendAPI,
 	}
 
 	handler := nethttp.Middleware(opentracing.GlobalTracer(), repoupdater.Handler())

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -21,11 +21,17 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
+// InternalAPI captures the internal API methods needed for repo-updater handler.
+type InternalAPI interface {
+	ReposUpdateMetadata(ctx context.Context, repo api.RepoName, description string, fork, archived bool) error
+}
+
 // Server is a repoupdater server.
 type Server struct {
 	repos.Store
 	*repos.Syncer
 	*repos.OtherReposSyncer
+	InternalAPI
 }
 
 // Handler returns the http.Handler that should be used to serve requests.
@@ -220,7 +226,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		}
 		if repo != nil {
 			go func() {
-				err := api.InternalClient.ReposUpdateMetadata(context.Background(), repo.Name, repo.Description, repo.Fork, repo.Archived)
+				err := s.InternalAPI.ReposUpdateMetadata(context.Background(), repo.Name, repo.Description, repo.Fork, repo.Archived)
 				if err != nil {
 					log15.Warn("Error updating repo metadata", "repo", repo.Name, "err", err)
 				}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -21,17 +21,14 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-// InternalAPI captures the internal API methods needed for repo-updater handler.
-type InternalAPI interface {
-	ReposUpdateMetadata(ctx context.Context, repo api.RepoName, description string, fork, archived bool) error
-}
-
 // Server is a repoupdater server.
 type Server struct {
 	repos.Store
 	*repos.Syncer
 	*repos.OtherReposSyncer
-	InternalAPI
+	InternalAPI interface {
+		ReposUpdateMetadata(ctx context.Context, repo api.RepoName, description string, fork, archived bool) error
+	}
 }
 
 // Handler returns the http.Handler that should be used to serve requests.


### PR DESCRIPTION
I noticed non-determinism in the test case coverage. It was due to us using
the default client for InternalAPI, and that failing. So we apply the same
pattern we use the in repos package and declare the interface we use of
InternalAPI.

<!-- Remember to update the changelog for user-facing changes. -->
