### PR TITLE
backend: Use conf.Get for DisablePublicRepoRedirects

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -70,7 +70,7 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 		}
 		return db.Repos.GetByName(ctx, name)
 	} else if err != nil {
-		if !conf.GetTODO().DisablePublicRepoRedirects && strings.HasPrefix(strings.ToLower(string(name)), "github.com/") {
+		if !conf.Get().DisablePublicRepoRedirects && strings.HasPrefix(strings.ToLower(string(name)), "github.com/") {
 			return nil, ErrRepoSeeOther{RedirectURL: (&url.URL{
 				Scheme:   "https",
 				Host:     "sourcegraph.com",

--- a/pkg/conf/client.go
+++ b/pkg/conf/client.go
@@ -69,24 +69,6 @@ func (c *client) Get() *Unified {
 	return c.store.LastValid()
 }
 
-// GetTODO denotes code that may or may not be using configuration correctly.
-// The code may need to be updated to use conf.Watch, or it may already be e.g.
-// invoked only in response to a user action (in which case it does not need to
-// use conf.Watch). See Get documentation for more details.
-//
-// GetTODO is a wrapper around client.GetTODO.
-func GetTODO() *Unified {
-	return defaultClient.GetTODO()
-}
-
-// GetTODO denotes code that may or may not be using configuration correctly.
-// The code may need to be updated to use conf.Watch, or it may already be e.g.
-// invoked only in response to a user action (in which case it does not need to
-// use conf.Watch). See Get documentation for more details.
-func (c *client) GetTODO() *Unified {
-	return c.Get()
-}
-
 // Mock sets up mock data for the site configuration.
 //
 // Mock is a wrapper around client.Mock.


### PR DESCRIPTION
This is called for satisfying a user request, so we can just use
conf.Get. This was also the last use of GetTODO, so we can remove the
function.
