### PR TITLE
CI: use 4 jest workers to prevent OOM

### DIFF
--- a/dev/ci/yarn-test.sh
+++ b/dev/ci/yarn-test.sh
@@ -7,5 +7,9 @@ yarn --frozen-lockfile --network-timeout 60000
 
 cd $1
 echo "--- test"
-yarn -s run test
 
+# Limit the number of workers to prevent the default of 1 worker per core from
+# causing OOM on the buildkite nodes that have 96 CPUs. 4 matches the CPU limits
+# in
+# infrastructure/kubernetes/ci/buildkite/buildkite-agent/buildkite-agent.Deployment.yaml
+yarn -s run test --maxWorkers 4

--- a/dev/ci/yarn-test.sh
+++ b/dev/ci/yarn-test.sh
@@ -10,6 +10,5 @@ echo "--- test"
 
 # Limit the number of workers to prevent the default of 1 worker per core from
 # causing OOM on the buildkite nodes that have 96 CPUs. 4 matches the CPU limits
-# in
-# infrastructure/kubernetes/ci/buildkite/buildkite-agent/buildkite-agent.Deployment.yaml
+# in infrastructure/kubernetes/ci/buildkite/buildkite-agent/buildkite-agent.Deployment.yaml
 yarn -s run test --maxWorkers 4


### PR DESCRIPTION
This prevents the Buildkite agents from getting killed due to OOM when run on CI nodes with 96 cores, which by default causes 96 jest workers to be spawned.