### PR TITLE
fix usage of custom location providers in extension API panel views

### DIFF
--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -123,7 +123,7 @@ export async function createExtensionHostClientConnection(
         }
     )
 
-    const clientViews = new ClientViews(services.views, services.textDocumentLocations)
+    const clientViews = new ClientViews(services.views, services.textDocumentLocations, services.model)
 
     const clientCodeEditor = new ClientCodeEditor(services.textDocumentDecoration)
     subscription.add(clientCodeEditor)

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -209,8 +209,18 @@ describe('getComputedContextProperty', () => {
                 getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, {}, 'panel.activeView.id', {
                     type: 'panelView',
                     id: 'x',
+                    hasLocations: true,
                 })
             ).toBe('x'))
+
+        test('provides panel.activeView.hasLocations', () =>
+            expect(
+                getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, {}, 'panel.activeView.hasLocations', {
+                    type: 'panelView',
+                    id: 'x',
+                    hasLocations: true,
+                })
+            ).toBe(true))
 
         test('returns null for panel.activeView.id when there is no panel', () =>
             expect(getComputedContextProperty(EMPTY_MODEL, EMPTY_SETTINGS_CASCADE, {}, 'panel.activeView.id')).toBe(

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -36,7 +36,11 @@ export type ContributionScope =
     | (Pick<ViewComponentData, 'type' | 'selections'> & {
           item: Pick<TextDocument, 'uri' | 'languageId'>
       })
-    | { type: 'panelView'; id: string }
+    | {
+          type: 'panelView'
+          id: string
+          hasLocations: boolean
+      }
 
 /**
  * Looks up a key in the computed context, which consists of computed context properties (with higher precedence)
@@ -122,6 +126,8 @@ export function getComputedContextProperty(
         switch (prop) {
             case 'id':
                 return component.id
+            case 'hasLocations':
+                return component.hasLocations
         }
     }
     if (key === 'context') {

--- a/shared/src/api/integration-test/languageFeatures.test.ts
+++ b/shared/src/api/integration-test/languageFeatures.test.ts
@@ -86,10 +86,12 @@ describe('LanguageFeatures (integration)', () => {
                 provideLocations: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => run(doc, pos),
             } as sourcegraph.LocationProvider),
         getResult: services =>
-            services.textDocumentLocations.getLocations('x', {
-                textDocument: { uri: 'file:///f' },
-                position: { line: 1, character: 2 },
-            }),
+            services.textDocumentLocations
+                .getLocations('x', {
+                    textDocument: { uri: 'file:///f' },
+                    position: { line: 1, character: 2 },
+                })
+                .pipe(switchMap(x => x)),
     })
 })
 

--- a/shared/src/panel/Panel.tsx
+++ b/shared/src/panel/Panel.tsx
@@ -41,6 +41,13 @@ interface PanelItem extends Tab<string> {
 
     /** The content element to display when the tab is active. */
     element: React.ReactElement<any>
+
+    /**
+     * Whether this panel contains a list of locations (from a location provider). This value is
+     * exposed to contributions as `panel.activeView.hasLocations`. It is true if there is a
+     * location provider (even if the result set is empty).
+     */
+    hasLocations?: boolean
 }
 
 /**
@@ -76,6 +83,7 @@ export class Panel extends React.PureComponent<Props, State> {
                           id: panelView.id,
                           priority: panelView.priority,
                           element: <PanelView {...this.props} panelView={panelView} />,
+                          hasLocations: !!panelView.locationProvider,
                       })
                   )
                   .sort(byPriority)
@@ -83,6 +91,7 @@ export class Panel extends React.PureComponent<Props, State> {
 
         const hasTabs = items.length > 0
         const activePanelViewID = TabsWithURLViewStatePersistence.readFromURL(this.props.location, items)
+        const activePanelView = items.find(item => item.id === activePanelViewID)
 
         return (
             <div className="panel">
@@ -112,6 +121,7 @@ export class Panel extends React.PureComponent<Props, State> {
                                         ? {
                                               type: 'panelView',
                                               id: activePanelViewID,
+                                              hasLocations: Boolean(activePanelView && activePanelView.hasLocations),
                                           }
                                         : undefined
                                 }

--- a/shared/src/panel/views/contributions.ts
+++ b/shared/src/panel/views/contributions.ts
@@ -4,10 +4,6 @@ import { ExtensionsControllerProps } from '../../extensions/controller'
 export function registerPanelToolbarContributions({
     extensionsController,
 }: ExtensionsControllerProps<'services'>): Unsubscribable {
-    const isLocationsPanelView = ['def', 'references', 'impl', 'typedef']
-        .map(id => `(panel.activeView.id == "${id}")`) // must be explicit about operator precedence
-        .join(' || ')
-
     return extensionsController.services.contribution.registerContributions({
         contributions: {
             actions: [
@@ -31,7 +27,7 @@ export function registerPanelToolbarContributions({
                 'panel/toolbar': [
                     {
                         action: 'panel.locations.groupByFile',
-                        when: `panel.locations.hasResults && (${isLocationsPanelView})`,
+                        when: `panel.locations.hasResults && panel.activeView.hasLocations`,
                     },
                 ],
             },


### PR DESCRIPTION
Previously, a TypeScript cast `as PanelViewWithComponent` resulted in panel views (that used a custom location provider registered with `registerLocationProvider`) having an incorrectly typed `locationProvider` value. This meant that using a panel view with a custom location provider would throw a JavaScript error.


Depends on https://github.com/sourcegraph/sourcegraph/pull/1697

Related:
- https://github.com/sourcegraph/sourcegraph-go/pull/47
- https://github.com/sourcegraph/sourcegraph-typescript/pull/132