### PR TITLE
Simplify privateRepoPublicSourcegraph check

### DIFF
--- a/client/browser/src/shared/backend/graphql.test.tsx
+++ b/client/browser/src/shared/backend/graphql.test.tsx
@@ -1,4 +1,5 @@
 import { of, throwError } from 'rxjs'
+import * as GQL from '../../../../../shared/src/graphql/schema'
 import { DEFAULT_SOURCEGRAPH_URL } from '../util/context'
 import { RequestContext } from './context'
 import { ERAUTHREQUIRED, ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from './errors'
@@ -49,7 +50,7 @@ describe('requestGraphQL()', () => {
 
     it('makes a simple request to Sourcegraph.com', async () => {
         const ajaxRequest = existsOnSourcegraphDotCom()
-        const response = await requestGraphQL({
+        const response = await requestGraphQL<GQL.IGraphQLResponseRoot>({
             ctx: MOCK_CONTEXT,
             request: MOCK_RESOLVE_REV_REQUEST,
             ajaxRequest: ajaxRequest as any,
@@ -75,7 +76,7 @@ describe('requestGraphQL()', () => {
 
     it('falls back to the public Sourcegraph.com if a public repository is not found on the private instance', async () => {
         const ajaxRequest = existsOnSourcegraphDotCom()
-        const response = await requestGraphQL({
+        const response = await requestGraphQL<GQL.IGraphQLResponseRoot>({
             ctx: MOCK_CONTEXT,
             request: MOCK_RESOLVE_REV_REQUEST,
             url: 'https://sourcegraph.private.org',
@@ -87,7 +88,7 @@ describe('requestGraphQL()', () => {
 
     it('falls back to the public Sourcegraph.com if the user is logged out of his private instance and the repository is public', async () => {
         const ajaxRequest = existsOnSourcegraphDotCom()
-        const response = await requestGraphQL({
+        const response = await requestGraphQL<GQL.IGraphQLResponseRoot>({
             ctx: MOCK_CONTEXT,
             request: MOCK_RESOLVE_REV_REQUEST,
             url: 'https://sourcegraph.private.org',

--- a/client/browser/src/shared/backend/graphql.test.tsx
+++ b/client/browser/src/shared/backend/graphql.test.tsx
@@ -1,0 +1,147 @@
+import { of, throwError } from 'rxjs'
+import { DEFAULT_SOURCEGRAPH_URL } from '../util/context'
+import { RequestContext } from './context'
+import { ERAUTHREQUIRED, ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from './errors'
+import { requestGraphQL } from './graphql'
+
+const MOCK_SUCCESSFUL_RESPONSE = {
+    data: {
+        repository: {
+            mirrorInfo: {
+                cloneInProgress: false,
+            },
+            commit: {
+                oid: 'foo',
+            },
+        },
+    },
+}
+
+const MOCK_RESOLVE_REV_REQUEST = `query ResolveRev($repoName: String!, $rev: String!) {
+    repository(name: $repoName) {
+        mirrorInfo {
+            cloneInProgress
+        }
+        commit(rev: $rev) {
+            oid
+        }
+    }
+}`
+
+const MOCK_CONTEXT: RequestContext = {
+    repoKey: 'foo',
+    isRepoSpecific: true,
+    privateRepository: false,
+}
+
+describe('requestGraphQL()', () => {
+    /**
+     * Returns a mock for ajaxRequest that returns a successful response when the request
+     * is to DEFAULT_SOURCEGRAPH_URL, and `null` otherwise
+     */
+    const existsOnSourcegraphDotCom = () =>
+        jest.fn(({ url }: { url: string }) => {
+            if (url.startsWith(DEFAULT_SOURCEGRAPH_URL)) {
+                return of({ response: MOCK_SUCCESSFUL_RESPONSE })
+            }
+            return of({ response: {} })
+        })
+
+    it('makes a simple request to Sourcegraph.com', async () => {
+        const ajaxRequest = existsOnSourcegraphDotCom()
+        const response = await requestGraphQL({
+            ctx: MOCK_CONTEXT,
+            request: MOCK_RESOLVE_REV_REQUEST,
+            ajaxRequest: ajaxRequest as any,
+        }).toPromise()
+        expect(ajaxRequest.mock.calls.length).toBe(1)
+        expect(response).toMatchObject(MOCK_SUCCESSFUL_RESPONSE)
+    })
+
+    it('errors if the repository is private and the request is to Sourcegraph.com', async () => {
+        await expect(
+            requestGraphQL({
+                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                request: MOCK_RESOLVE_REV_REQUEST,
+                url: DEFAULT_SOURCEGRAPH_URL,
+                ajaxRequest: jest.fn() as any,
+            }).toPromise()
+        ).rejects.toMatchObject({
+            name: ERPRIVATEREPOPUBLICSOURCEGRAPHCOM,
+            message:
+                'A ResolveRev GraphQL request to the public Sourcegraph.com was blocked because the current repository is private.',
+        })
+    })
+
+    it('falls back to the public Sourcegraph.com if a public repository is not found on the private instance', async () => {
+        const ajaxRequest = existsOnSourcegraphDotCom()
+        const response = await requestGraphQL({
+            ctx: MOCK_CONTEXT,
+            request: MOCK_RESOLVE_REV_REQUEST,
+            url: 'https://sourcegraph.private.org',
+            ajaxRequest: ajaxRequest as any,
+        }).toPromise()
+        expect(ajaxRequest.mock.calls.length).toBe(2)
+        expect(response).toMatchObject(MOCK_SUCCESSFUL_RESPONSE)
+    })
+
+    it('falls back to the public Sourcegraph.com if the user is logged out of his private instance and the repository is public', async () => {
+        const ajaxRequest = existsOnSourcegraphDotCom()
+        const response = await requestGraphQL({
+            ctx: MOCK_CONTEXT,
+            request: MOCK_RESOLVE_REV_REQUEST,
+            url: 'https://sourcegraph.private.org',
+            ajaxRequest: ajaxRequest as any,
+        }).toPromise()
+        expect(ajaxRequest.mock.calls.length).toBe(2)
+        expect(response).toMatchObject(MOCK_SUCCESSFUL_RESPONSE)
+    })
+
+    it('errors if the repository is private and not found on the private instance', async () => {
+        const ajaxRequest = existsOnSourcegraphDotCom()
+        await expect(
+            requestGraphQL({
+                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                request: MOCK_RESOLVE_REV_REQUEST,
+                url: 'https://sourcegraph.private.org',
+                ajaxRequest: ajaxRequest as any,
+            }).toPromise()
+        ).rejects.toMatchObject({
+            name: ERPRIVATEREPOPUBLICSOURCEGRAPHCOM,
+            message:
+                'A ResolveRev GraphQL request to the public Sourcegraph.com was blocked because the current repository is private.',
+        })
+    })
+
+    it('errors if the repository is private and the user is logged out of his private instance', async () => {
+        const ajaxRequest = () => throwError({ status: 401 })
+        await expect(
+            requestGraphQL({
+                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                request: MOCK_RESOLVE_REV_REQUEST,
+                url: 'https://sourcegraph.private.org',
+                ajaxRequest: ajaxRequest as any,
+            }).toPromise()
+        ).rejects.toMatchObject({
+            name: ERPRIVATEREPOPUBLICSOURCEGRAPHCOM,
+            message:
+                'A ResolveRev GraphQL request to the public Sourcegraph.com was blocked because the current repository is private.',
+        })
+    })
+
+    it('errors without retrying the user is logged out of his private instance and retry is false', async () => {
+        const ajaxRequest = () => throwError({ status: 401 })
+        await expect(
+            requestGraphQL({
+                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                request: MOCK_RESOLVE_REV_REQUEST,
+                url: 'https://sourcegraph.private.org',
+                ajaxRequest: ajaxRequest as any,
+                retry: false,
+            }).toPromise()
+        ).rejects.toMatchObject({
+            code: ERAUTHREQUIRED,
+            message: 'private mode requires authentication: https://sourcegraph.private.org',
+        })
+    })
+})

--- a/client/browser/src/shared/backend/graphql.test.tsx
+++ b/client/browser/src/shared/backend/graphql.test.tsx
@@ -29,10 +29,16 @@ const MOCK_RESOLVE_REV_REQUEST = `query ResolveRev($repoName: String!, $rev: Str
     }
 }`
 
-const MOCK_CONTEXT: RequestContext = {
+const MOCK_CONTEXT_PUBLIC: RequestContext = {
     repoKey: 'foo',
     isRepoSpecific: true,
     privateRepository: false,
+}
+
+const MOCK_CONTEXT_PRIVATE: RequestContext = {
+    repoKey: 'foo',
+    isRepoSpecific: true,
+    privateRepository: true,
 }
 
 describe('requestGraphQL()', () => {
@@ -51,7 +57,7 @@ describe('requestGraphQL()', () => {
     it('makes a simple request to Sourcegraph.com', async () => {
         const ajaxRequest = existsOnSourcegraphDotCom()
         const response = await requestGraphQL<GQL.IGraphQLResponseRoot>({
-            ctx: MOCK_CONTEXT,
+            ctx: MOCK_CONTEXT_PUBLIC,
             request: MOCK_RESOLVE_REV_REQUEST,
             ajaxRequest: ajaxRequest as any,
         }).toPromise()
@@ -62,7 +68,7 @@ describe('requestGraphQL()', () => {
     it('errors if the repository is private and the request is to Sourcegraph.com', async () => {
         await expect(
             requestGraphQL({
-                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                ctx: MOCK_CONTEXT_PRIVATE,
                 request: MOCK_RESOLVE_REV_REQUEST,
                 url: DEFAULT_SOURCEGRAPH_URL,
                 ajaxRequest: jest.fn() as any,
@@ -77,7 +83,7 @@ describe('requestGraphQL()', () => {
     it('falls back to the public Sourcegraph.com if a public repository is not found on the private instance', async () => {
         const ajaxRequest = existsOnSourcegraphDotCom()
         const response = await requestGraphQL<GQL.IGraphQLResponseRoot>({
-            ctx: MOCK_CONTEXT,
+            ctx: MOCK_CONTEXT_PUBLIC,
             request: MOCK_RESOLVE_REV_REQUEST,
             url: 'https://sourcegraph.private.org',
             ajaxRequest: ajaxRequest as any,
@@ -89,7 +95,7 @@ describe('requestGraphQL()', () => {
     it('falls back to the public Sourcegraph.com if the user is logged out of his private instance and the repository is public', async () => {
         const ajaxRequest = existsOnSourcegraphDotCom()
         const response = await requestGraphQL<GQL.IGraphQLResponseRoot>({
-            ctx: MOCK_CONTEXT,
+            ctx: MOCK_CONTEXT_PUBLIC,
             request: MOCK_RESOLVE_REV_REQUEST,
             url: 'https://sourcegraph.private.org',
             ajaxRequest: ajaxRequest as any,
@@ -102,7 +108,7 @@ describe('requestGraphQL()', () => {
         const ajaxRequest = existsOnSourcegraphDotCom()
         await expect(
             requestGraphQL({
-                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                ctx: MOCK_CONTEXT_PRIVATE,
                 request: MOCK_RESOLVE_REV_REQUEST,
                 url: 'https://sourcegraph.private.org',
                 ajaxRequest: ajaxRequest as any,
@@ -118,7 +124,7 @@ describe('requestGraphQL()', () => {
         const ajaxRequest = () => throwError({ status: 401 })
         await expect(
             requestGraphQL({
-                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                ctx: MOCK_CONTEXT_PRIVATE,
                 request: MOCK_RESOLVE_REV_REQUEST,
                 url: 'https://sourcegraph.private.org',
                 ajaxRequest: ajaxRequest as any,
@@ -134,7 +140,7 @@ describe('requestGraphQL()', () => {
         const ajaxRequest = () => throwError({ status: 401 })
         await expect(
             requestGraphQL({
-                ctx: { ...MOCK_CONTEXT, privateRepository: true },
+                ctx: MOCK_CONTEXT_PRIVATE,
                 request: MOCK_RESOLVE_REV_REQUEST,
                 url: 'https://sourcegraph.private.org',
                 ajaxRequest: ajaxRequest as any,


### PR DESCRIPTION
`requestGraphQL()` may be called recursively from `performRequest()` when retrying with a different URL.

When this is done from the background script (`!isInPage`), the second call would not be checked for `privateRepoPublicSourcegraph()`, which is an issue because that second call usually _is_ to the public Sourcegraph.

The duplicate calls were in place because `isPrivateRepository()` relies on being executed in-page: see [`isPublicCodeHost`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/browser/src/context.ts#L48-54), which would fail to properly detect  a public code host if executed from the background page, and checks on the DOM in `isPrivateRepository()` itself.

This introduces the following changes:
- inject `privateRepository` as part of the request context in order to stop calling `isPrivateRepository()` from `privateRepoPublicSourcegraph()`
- remove duplicate `privateRepoPublicSourcegraph()` check: we no longer depend on this check being done in-page.

I added some tests for `requestGraphQL()`, made possible by optionally injecting `ajaxRequest()` to provide a stub for `rxjs.ajax()`. This is not the most elegant approach, but it at least allows to test the business logic in `requestGraphQL()`. See the new tests examplifying the fallback to public sourcegraph when the repo is not found on a public instance, for example.

The test `errors if the repository is private and the user is logged out of his private instance` would have failed prior to this fix.
