### PR TITLE
CI: make the repositories list e2e test more deterministic

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -221,7 +221,7 @@ describe('e2e test suite', function(this: any): void {
 
     describe('Visual tests', () => {
         test('Repositories list', async () => {
-            await page.goto(baseURL + '/site-admin/repositories')
+            await page.goto(baseURL + '/site-admin/repositories?query=gorilla%2Fmux')
             await page.waitForSelector('a[href="/github.com/gorilla/mux"]')
             await percySnapshot(page, 'Repositories list')
         })


### PR DESCRIPTION
Previously, in a dev environment, the repositories list would usually contain a bunch of repositories and gorilla/mux would not show up on the front page.

This adds a filter for `gorilla/mux` to increase the probability it's on the front page.