### PR TITLE
CI: fix stack traces for e2e tests

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -6,7 +6,11 @@ import { Key } from 'ts-key-enum'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/util/screenshotReporter'
 import { readEnvBoolean, readEnvString, retry } from '../util/e2e-test-utils'
 
-jest.setTimeout(30000)
+// 1 minute test timeout. This must be greater than the default Puppeteer
+// command timeout of 30s in order to get the stack trace to point to the
+// Puppeteer command that failed instead of a cryptic Jest test timeout
+// location.
+jest.setTimeout(1 * 60 * 1000)
 
 // tslint:disable-next-line: no-empty
 const noopPercySnapshot: typeof realPercySnapshot = async () => {}


### PR DESCRIPTION
Previously, the Jest test would time out before any individual Puppeteer command would time out, causing cryptic errors such as:

![image](https://user-images.githubusercontent.com/1387653/54405579-5bc12700-4694-11e9-999b-4710374e886c.png)

Now you'll get the stack trace to point to the Puppeteer command that timed out:

![image](https://user-images.githubusercontent.com/1387653/54405561-45b36680-4694-11e9-9cbd-c9f2e6ffc196.png)
