### PR TITLE
add settings action for search.contextLines

### DIFF
--- a/web/src/site-admin/configHelpers.ts
+++ b/web/src/site-admin/configHelpers.ts
@@ -9,6 +9,11 @@ const defaultFormattingOptions: FormattingOptions = {
     tabSize: 2,
 }
 
+const setSearchContextLines: ConfigInsertionFunction = config => {
+    const DEFAULT = 3 // a reasonable value that will be clearly different from the default 1
+    return { edits: setProperty(config, ['search.contextLines'], DEFAULT, defaultFormattingOptions) }
+}
+
 const addSearchScopeToSettings: ConfigInsertionFunction = config => {
     const value: { name: string; value: string } = {
         name: '<name>',
@@ -33,6 +38,11 @@ export interface EditorAction {
 }
 
 export const settingsActions: EditorAction[] = [
+    {
+        id: 'sourcegraph.settings.search.contextLines',
+        label: 'Search: show # before/after lines',
+        run: setSearchContextLines,
+    },
     { id: 'sourcegraph.settings.searchScopes', label: 'Add search scope', run: addSearchScopeToSettings },
     { id: 'sourcegraph.settings.addSlackWebhook', label: 'Add Slack webhook', run: addSlackWebhook },
 ]


### PR DESCRIPTION
Adds a button to change the `search.contextLines` value on the page where you edit the global/org/user settings JSON. Improves the situation in #2754.

There is a bug in our quick action buttons where the Monaco editor's selection after running the quick action is incorrect in some cases (e.g., if the edit it applied also added a comma to the preceding line). This is annoying but is not critical (filed as https://github.com/sourcegraph/sourcegraph/issues/2756).


---

![searchclsettings](https://user-images.githubusercontent.com/1976/54413084-e401f500-46b1-11e9-9855-1fd99a9a6908.png)
![search-cl5](https://user-images.githubusercontent.com/1976/54413085-e401f500-46b1-11e9-825d-d9e207ba827d.png)
