### PR TITLE
CI: wait for repositories to clone in e2e tests

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -144,9 +144,15 @@ describe('e2e test suite', function(this: any): void {
             await page.waitForSelector(`.repository-node[data-e2e-repository='github.com/${slug}']`)
             if (await page.$(`.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='false']`)) {
                 await page.click(`.repository-node[data-e2e-repository='github.com/${slug}'] .e2e-enable-repository`)
-                await page.waitForSelector(
-                    `.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='true']`
-                )
+                if (slug === 'sourcegraphtest/AlwaysCloningTest') {
+                    await page.waitForSelector(
+                        `.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='true']`
+                    )
+                } else {
+                    await page.waitForSelector(
+                        `.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='true'][data-e2e-cloned='true']`
+                    )
+                }
             }
         }
     }

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -47,6 +47,7 @@ class RepositoryNode extends React.PureComponent<RepositoryNodeProps, Repository
                 className="repository-node list-group-item py-2"
                 data-e2e-repository={this.props.node.name}
                 data-e2e-enabled={this.props.node.enabled}
+                data-e2e-cloned={this.props.node.mirrorInfo.cloned}
             >
                 <div className="d-flex align-items-center justify-content-between">
                     <div>


### PR DESCRIPTION
Fixes flaky Percy test (reported by @sqs in https://github.com/sourcegraph/sourcegraph/pull/2755#issuecomment-473182808)