### PR TITLE
search: show a "Did you mean" link for invalid regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Sourcegraph are documented in this file.
   To enable, open the user menu in the top right and make sure the theme dropdown is set to "System".
   This is currently supported on macOS Mojave with Safari Technology Preview 68 and later.
 - The `github.exclude` setting was added to the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) to allow excluding repositories yielded by `github.repos` or `github.repositoryQuery` from being synced.
+- We now suggest fixes for common invalid regexes in search queries.
 
 ### Changed
 
@@ -813,8 +814,8 @@ You may now optionally provide the SAML Identity Provider metadata XML file cont
 
 When using `auth.provider == "builtin"`, two new important changes mean that a Sourcegraph server will be locked down and only accessible to users who are invited by an admin user (previously, we advised users to place their own auth proxy in front of Sourcegraph servers).
 
-1.  When `auth.provider == "builtin"` Sourcegraph will now by default require an admin to invite users instead of allowing anyone who can visit the site to sign up. Set `auth.allowSignup == true` to retain the old behavior of allowing anyone who can access the site to signup.
-2.  When `auth.provider == "builtin"`, Sourcegraph will now respects a new `auth.public` site configuration option (default value: `false`). When `auth.public == false`, Sourcegraph will not allow anyone to access the site unless they have an account and are signed in.
+1. When `auth.provider == "builtin"` Sourcegraph will now by default require an admin to invite users instead of allowing anyone who can visit the site to sign up. Set `auth.allowSignup == true` to retain the old behavior of allowing anyone who can access the site to signup.
+2. When `auth.provider == "builtin"`, Sourcegraph will now respects a new `auth.public` site configuration option (default value: `false`). When `auth.public == false`, Sourcegraph will not allow anyone to access the site unless they have an account and are signed in.
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to Sourcegraph are documented in this file.
   To enable, open the user menu in the top right and make sure the theme dropdown is set to "System".
   This is currently supported on macOS Mojave with Safari Technology Preview 68 and later.
 - The `github.exclude` setting was added to the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) to allow excluding repositories yielded by `github.repos` or `github.repositoryQuery` from being synced.
-- We now suggest fixes for common invalid regexes in search queries.
+- We now provide "Did you mean...?" links when search queries fail to parse as regular expressions.
 
 ### Changed
 
@@ -814,8 +814,8 @@ You may now optionally provide the SAML Identity Provider metadata XML file cont
 
 When using `auth.provider == "builtin"`, two new important changes mean that a Sourcegraph server will be locked down and only accessible to users who are invited by an admin user (previously, we advised users to place their own auth proxy in front of Sourcegraph servers).
 
-1. When `auth.provider == "builtin"` Sourcegraph will now by default require an admin to invite users instead of allowing anyone who can visit the site to sign up. Set `auth.allowSignup == true` to retain the old behavior of allowing anyone who can access the site to signup.
-2. When `auth.provider == "builtin"`, Sourcegraph will now respects a new `auth.public` site configuration option (default value: `false`). When `auth.public == false`, Sourcegraph will not allow anyone to access the site unless they have an account and are signed in.
+1.  When `auth.provider == "builtin"` Sourcegraph will now by default require an admin to invite users instead of allowing anyone who can visit the site to sign up. Set `auth.allowSignup == true` to retain the old behavior of allowing anyone who can access the site to signup.
+2.  When `auth.provider == "builtin"`, Sourcegraph will now respects a new `auth.public` site configuration option (default value: `false`). When `auth.public == false`, Sourcegraph will not allow anyone to access the site unless they have an account and are signed in.
 
 ## 2.4.3
 

--- a/cmd/frontend/internal/pkg/search/query/types/check.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check.go
@@ -53,7 +53,13 @@ func (c *Config) Check(query *syntax.Query) (*Query, error) {
 		field, fieldType, value, err := c.checkExpr(expr)
 		if err != nil {
 			errCount++
-			fx = `"` + fx + `"`
+if err != nil {
+	if expr.ValueType != syntax.TokenPattern {
+		return err
+	}
+	errCount++
+	fx = `"` + fx + `"`
+}
 		}
 		fixedExprs = append(fixedExprs, fx)
 		if fieldType.Singular && len(checkedQuery.Fields[field]) >= 1 {

--- a/cmd/frontend/internal/pkg/search/query/types/check_test.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/syntax"
@@ -112,8 +113,8 @@ func TestCheck(t *testing.T) {
 				t.Fatal(err)
 			} else if err == nil && test.wantErr != nil {
 				t.Fatalf("got err == nil, want %q", test.wantErr)
-			} else if test.wantErr != nil && err.Error() != test.wantErr.Error() {
-				t.Fatalf("got err == %q, want %q", err, test.wantErr)
+			} else if test.wantErr != nil && !strings.Contains(err.Error(), test.wantErr.Error()) {
+				t.Fatalf("got err == %q, want it to contain %q", err, test.wantErr)
 			}
 			if err != nil {
 				return

--- a/web/src/search/results/ResultsError.tsx
+++ b/web/src/search/results/ResultsError.tsx
@@ -20,7 +20,7 @@ export class ResultsError extends React.Component<Props> {
     }
 
     private renderMessage(): React.ReactNode {
-        let {
+        const {
             error: { message },
         } = this.props
 

--- a/web/src/search/results/ResultsError.tsx
+++ b/web/src/search/results/ResultsError.tsx
@@ -1,0 +1,41 @@
+import { upperFirst } from 'lodash'
+import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+import { ErrorLike } from '../../../../shared/src/util/errors'
+import { buildSearchURLQuery } from '../../../../shared/src/util/url'
+
+interface Props {
+    error: ErrorLike
+}
+
+export class ResultsError extends React.Component<Props> {
+    public render(): React.ReactNode {
+        return (
+            <div className="alert alert-warning">
+                <AlertCircleIcon className="icon-inline" />
+                {this.renderMessage()}
+            </div>
+        )
+    }
+
+    private renderMessage(): React.ReactNode {
+        let { error: { message } } = this.props
+
+        const match = message.match(/Did you mean `.*`?/)
+        if (!match) {
+            return upperFirst(message)
+        }
+
+        const error = message.slice(0, match.index)
+        const suggestion = message.slice(match.index)
+        const query = buildSearchURLQuery(suggestion)
+
+        return (
+            <>
+                {error}
+                <Link to={`/search?${query}`}>{suggestion}</Link>
+            </>
+        )
+    }
+}

--- a/web/src/search/results/ResultsError.tsx
+++ b/web/src/search/results/ResultsError.tsx
@@ -20,21 +20,24 @@ export class ResultsError extends React.Component<Props> {
     }
 
     private renderMessage(): React.ReactNode {
-        let { error: { message } } = this.props
+        let {
+            error: { message },
+        } = this.props
 
-        const match = message.match(/Did you mean `.*`?/)
+        const match = message.match(/Did you mean `(.*?)`/)
         if (!match) {
             return upperFirst(message)
         }
 
-        const error = message.slice(0, match.index)
-        const suggestion = message.slice(match.index)
+        const suggestion = match[1]
+        const [before, after] = message.split(suggestion)
         const query = buildSearchURLQuery(suggestion)
 
         return (
             <>
-                {error}
+                {before}
                 <Link to={`/search?${query}`}>{suggestion}</Link>
+                {after}
             </>
         )
     }

--- a/web/src/search/results/ResultsError.tsx
+++ b/web/src/search/results/ResultsError.tsx
@@ -24,20 +24,28 @@ export class ResultsError extends React.Component<Props> {
             error: { message },
         } = this.props
 
+        // TODO: Send more robust error response from backend to prevent the need to string match.
         const match = message.match(/Did you mean `(.*?)`/)
         if (!match) {
             return upperFirst(message)
         }
 
         const suggestion = match[1]
-        const [before, after] = message.split(suggestion)
+
+        const [before] = message.split(suggestion)
+
         const query = buildSearchURLQuery(suggestion)
+
+        const [firstLine] = before.split('Did you mean')
 
         return (
             <>
-                {before}
+                {firstLine}
+                <br />
+                <br />
+                {'Did you mean `'}
                 <Link to={`/search?${query}`}>{suggestion}</Link>
-                {after}
+                {'`?'}
             </>
         )
     }

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -231,13 +231,16 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     filter(isDefined),
                     filter((resultsOrError): resultsOrError is GQL.ISearchResults => !isErrorLike(resultsOrError)),
                     map(({ results }) => results),
-                    map((results): GQL.IFileMatch[] =>
-                        results.filter((res): res is GQL.IFileMatch => res.__typename === 'FileMatch')
+                    map(
+                        (results): GQL.IFileMatch[] =>
+                            results.filter((res): res is GQL.IFileMatch => res.__typename === 'FileMatch')
                     )
                 )
                 .subscribe(fileMatches => {
                     const fileMatchRepoDisplayNames = new Map<string, string>()
-                    for (const { repository: { name } } of fileMatches) {
+                    for (const {
+                        repository: { name },
+                    } of fileMatches) {
                         const displayName = displayRepoName(name)
                         fileMatchRepoDisplayNames.set(name, displayName)
                     }
@@ -346,15 +349,14 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                     />
 
                                     {/* Show more button */}
-                                    {results.limitHit &&
-                                        results.results.length === this.state.resultsShown && (
-                                            <button
-                                                className="btn btn-secondary btn-block"
-                                                onClick={this.props.onShowMoreResultsClick}
-                                            >
-                                                Show more
-                                            </button>
-                                        )}
+                                    {results.limitHit && results.results.length === this.state.resultsShown && (
+                                        <button
+                                            className="btn btn-secondary btn-block"
+                                            onClick={this.props.onShowMoreResultsClick}
+                                        >
+                                            Show more
+                                        </button>
+                                    )}
 
                                     {/* Server-provided help message */}
                                     {results.alert ? (
@@ -451,7 +453,11 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
         return (
             <>
                 <h4>Recommendations:</h4>
-                <ul>{recommendations.map((recommendation, i) => <li key={i}>{recommendation}</li>)}</ul>
+                <ul>
+                    {recommendations.map((recommendation, i) => (
+                        <li key={i}>{recommendation}</li>
+                    ))}
+                </ul>
             </>
         )
     }


### PR DESCRIPTION
Add a "Did you mean" link for invalid regexes in search queries.

Closes https://github.com/sourcegraph/sourcegraph/issues/2772.