### PR TITLE
use sentence case

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,4 @@
 
 <!-- Reminder: Have you updated the changelog? -->
 
-Test Plan: <!-- Required: What is the test plan for this change? -->
+Test plan: <!-- Required: What is the test plan for this change? -->


### PR DESCRIPTION
Our style guide calls for "Sentence case", not "Title Case". https://github.com/sourcegraph/about/blob/master/STYLEGUIDE.md#general (note this style guide will live at https://docs.sourcegraph.com/dev/style_guide soon when #2784 is merged)



