### PR TITLE
move (English) style guide here from the about repository

### DIFF
--- a/doc/dev/code_style_guide.md
+++ b/doc/dev/code_style_guide.md
@@ -1,16 +1,10 @@
-# Sourcegraph style guide
+# Code style guide
 
-This file documents the style used in Sourcegraph's code and product.
+This file documents the style used in Sourcegraph's code. For non-code text, see the overall [style guide](style_guide.md).
 
 For all things not covered in this document, defer to
 [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)
 and [Effective Go](http://golang.org/doc/effective_go.html).
-
-# English
-
-See https://sourcegraph.com/github.com/sourcegraph/about/-/blob/STYLEGUIDE.md.
-
-# Code
 
 ## Panics
 

--- a/doc/dev/documentation/style_guide.md
+++ b/doc/dev/documentation/style_guide.md
@@ -4,7 +4,7 @@
 
 The documentation style guide defines the markup structure used in Sourcegraph documentation. Check the [documentation guidelines](index.md) for general development instructions.
 
-See the [Sourcegraph style guide](https://github.com/sourcegraph/about/blob/master/STYLEGUIDE.md) for general information.
+See the [Sourcegraph style guide](../style_guide.md) for general information.
 
 For help adhering to the guidelines, see [Linting](index.md#linting).
 

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -19,7 +19,7 @@ Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](h
 - [Developing the GraphQL API](graphql_api.md)
 - [Using PostgreSQL](postgresql.md)
 - [Testing](testing.md)
-- [Code style guide](style.md)
+- [Code style guide](code_style_guide.md)
 - [Telemetry](telemetry.md)
 - [Phabricator/Gitolite documentation](phabricator_gitolite.md)
 
@@ -46,6 +46,7 @@ Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](h
 
 ### Other
 
+- [Style guide](style_guide.md)
 - [about.sourcegraph.com](https://github.com/sourcegraph/about/tree/master/website)
 - [FAQ](faq.md)
 - [Code of conduct](conduct.md)

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -410,9 +410,9 @@ If you think a diff is erroneous, don't commit it. Add a tech debt
 item to the issue tracker and assign the person who you think is
 responsible (or ask).
 
-## Code style guide
+## [Code style guide](code_style_guide.md)
 
-See [docs/style.md](style.md).
+See "[Code style guide](code_style_guide.md)".
 
 ## Windows support
 

--- a/doc/dev/style_guide.md
+++ b/doc/dev/style_guide.md
@@ -1,0 +1,163 @@
+# Sourcegraph style guide
+
+Text in our product, documentation, and marketing materials should be:
+
+- Correct
+- Clear
+- Consistent
+
+The goal of this style guide is to help us all achieve these goals when writing.
+
+## General
+
+- Use "Sentence case" not "Title Case" everywhere (in UI text, button labels, headings, titles, etc.).
+- Render proper nouns as their creators prefer ("GitHub" not "Github").
+- Remove unnecessary words.
+- Punctuation goes outside of quotation marks, except in marketing when displaying a quote.
+- Use the most popular US English spelling and phrasing.
+- Prefer the serial comma in lists, except where ambiguity would be introduced by including it.
+
+### Clarity
+
+Assume the reader is a busy non-native English speaker.
+
+- Assume copy will be read through a screen-reader, poor translation, and on a device/screen that is different than your own.
+- Remove unnecessary words.
+- Use simple sentence syntax.
+  - Prefer commands ("Publish xyz to...") to 2nd-person phrasing ("Let's publish xyz to..." or "We can now publish xyz to...").
+- Avoid ambiguous verbs. For example, avoid using verbs like "cluster", "document", "label", "group", "admin", etc., because we commonly use those as nouns.
+- Write robust sentences that can be understood even if the reader doesn't recognize all of the words.
+
+### Referring to the product and features
+
+- Sourcegraph: main product, prefer using this name unless you need to be more precise
+  - Sourcegraph Core: This build is the free tier of Sourcegraph built separately from Sourcegraph OSS.
+  - Sourcegraph Enterprise: the tier of Sourcegraph that includes all enterprise features to deploy Sourcegraph at a large scale. Enterprise includes the cluster deployment option formerly called Data Center.
+  - Sourcegraph.com: the public instance of Sourcegraph for open-source code at https://sourcegraph.com
+  - Sourcegraph integrations: the general term for our integrations
+    - Sourcegraph['s] Phabricator integration
+    - Sourcegraph['s] GitHub integration
+    - Sourcegraph['s] browser extensions
+      - Sourcegraph['s] Chrome extension
+      - Sourcegraph['s] Firefox add-on
+      - Sourcegraph['s] Safari extension
+
+When referring to the build result of the open-source repository, use the name Sourcegraph OSS.
+
+When specifically distinguishing between Core and Sourcegraph OSS it is important to note that Core is not built from the open-source code base and Sourcegraph OSS does not include the ability to upgrade, or access the extension registry on sourcegraph.com. These are included in the Core version of Sourcegraph, that is built from the same code as Sourcegraph Enterprise and has the ability to upgrade later.
+
+You don't need to use the full name of the product each time you refer to it, but don't use a shortened name that could be confused with an official name. For example:
+
+- Good: "Use the Phabricator integration to get Sourcegraph features in code review"
+- Bad: "Use the Sourcegraph Phabricator integration to get Sourcegraph features in code review" (sounds repetitive and stilted)
+- Bad: "Use the Phabricator Integration to..." (the capital "I" makes it into a proper noun, which implies it's a separate product from "Sourcegraph Phabricator integration")
+- Bad: "Want to use this in your code review tool? Use [Sourcegraph for Phabricator](#_) or [Sourcegraph for GitHub](#_)." (This implies that "Sourcegraph for Phabricator" and "Sourcegraph for GitHub" are official product names.
+
+Only use "our" (as in "our GitHub integration") in discussion threads; in documentation or marketing material, depending on the context, use "the" or "Sourcegraph".
+
+## Conventions
+
+### UX
+
+- Prefer labels over placeholders to describe input fields.
+- Use placeholders sparingly. Don't use them for examples or descriptions.
+
+### Links
+
+The text of a link should be a short and specific description of what you'll see/do when you click.
+
+For example:
+
+- Good: See [how to add repositories](#_).
+- Bad: See [documentation](#_) for adding repositories.
+- Bad: See [this page](#_) for how to add repositories.
+- Bad: [Click here](#_) for documentation on adding repositories.
+
+Another example:
+
+- Good: [Edit site configuration](#_) to add a repository.
+- Bad: Edit [site configuration](#_) to add a repository.
+- Bad: [Go to the site configuration editor](#_) to add a repository.
+- Bad: [Click here](#_) to add a repository.
+
+Never use any of the following as link text:
+
+- here
+- click here
+- this
+- this page
+- page
+- instructions
+- these instructions
+
+### Instructions, references, and citations
+
+Render references to UI text in bold. Match the actual case of the UI text in other products even if it violates our style guide.
+
+> Click **Add user**.
+
+> In the \*_Single Sign On Url_ field, ...
+
+Refer to and cite other documents by quoting and linking their title. The quotation marks are not linked, and the period goes outside the quotes.
+
+> For more information, see "[Monitoring and tracing](#_)".
+
+### Examples
+
+- Don't use examples to compensate for poor documentation.
+- Don't use "cutesy" examples.
+
+For consistency, all examples should use the following names (as appropriate).
+
+- People: Alice, Bob, Carol, David, Elizabeth, etc. (alphabetical first names)
+- Usernames: `alice`, `bob`, etc.
+- Hostnames: example.com and subdomains of example.com (avoid using real names such as `mycompany.com`)
+- Email addresses: alice@example.com, bob@example.com, etc.
+- URLs: https://sourcegraph.example.com (assume HTTPS)
+- Organizations: ABC Organization (`abc-org`)
+
+### Technical
+
+- Treat all supported platforms equally. For example, don't give instructions for Chrome or GitHub in a way that implies they are the "default".
+- Prefer linking to a 3rd-party tool's existing documentation over explaining it in our own documentation.
+
+### Specific terms in prose
+
+- Repository (not "repo")
+- Organization (not "org")
+- When referring to a user's assumed corporate entity or employer, prefer calling it an "organization" (not "company" or "team")
+- Email address (not "email")
+- Admin or Site admin (not "administrator" or "site administrator")
+- Documentation not docs ("docs" is OK in paths and navigation links)
+- Configuration not config ("config" is OK in paths and navigation links)
+- Setup is a noun, "set up" is a verb ([see notaverb.com/setup](http://notaverb.com/setup), although see [note on descriptivism](#note))
+- Prefer "sign in" to "log in" (also: "login" is a noun, "log in" is a verb)
+- Sourcegraph (not "sourcegraph" or "SourceGraph")
+- URL (not "url")
+- OpenID Connect (not "OIDC")
+- PostgreSQL (not any of: Postgres, postgres, PgSQL, Postgresql, PostGres, etc.)
+- Go (not "Golang")
+- macOS (not any of: OS X, OSX, MacOS, MacOSX, etc.)
+- Capitalize as shown (in prose): Docker, Bitbucket, GitHub, React, Git, JavaScript, TypeScript (all according to the intent of the creator)
+
+### "Contact us" Language
+
+When letting users know they can contact us with questions, feedback, or issues, always use the phrasing below:
+
+> Questions/feedback? Contact us at [@srcgraph](https://twitter.com/srcgraph) or <mailto:support@sourcegraph.com>, or file issues on our [public issue tracker](https://github.com/sourcegraph/sourcegraph/issues).
+
+The `FeedbackText` component in the [Sourcegraph repository](https://github.com/sourcegraph/sourcegraph) should be used when possible.
+
+If this is too general, or not suited to the specific context, you can use more exact language. For example, from our security policy:
+
+> If you have specific questions or concerns, contact us at <a href="mailto:security@sourcegraph.com">security@sourcegraph.com</a>.
+
+## Note
+
+This style guide isn't about "correct" and "incorrect" writing. It is about effective writing (for our target users). Of course, effectiveness involves correctness to some degree, but only correctness as judged by the audience, not as judged by an appeal to authority.
+
+Consider the common case of using "setup" as a verb, as in "To setup the cluster, ...". Many of our target users consider that usage incorrect and would think (slightly) less of us for using it. It doesn't matter if we think that usage is acceptable; the effect it has on our audience is negative, so we should not use it.
+
+To dispute a guideline in this style guide, argue based on effectiveness, not correctness.
+
+For further reading, see [linguistic prescription on Wikipedia](https://en.wikipedia.org/wiki/Linguistic_prescription).

--- a/doc/docsite.json
+++ b/doc/docsite.json
@@ -6,6 +6,6 @@
   "assets": "_resources/assets",
   "assetsBaseURLPath": "/assets/",
   "check": {
-    "ignoreURLPattern": "(^https?://)|(^#)|(^mailto:support@sourcegraph\\.com(\\?|$))|(^chrome://)|(^/@)"
+    "ignoreURLPattern": "(^https?://)|(^#)|(^mailto:(support|security)@sourcegraph\\.com(\\?|$))|(^chrome://)|(^/@)"
   }
 }


### PR DESCRIPTION
The style guide will live at https://docs.sourcegraph.com/dev/style_guide. Previously it was hosted in a Markdown file in our about repository, which meant it was separate from all of our other docs (which wasn't good).