### PR TITLE
repo-updater: Extend Store with methods for external services

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -123,9 +123,8 @@ func main() {
 			httpcli.NewCachedTransportOpt(httputil.Cache, true),
 		)
 
-		src := repos.NewExternalServicesSourcer(frontendAPI, cliFactory)
-
 		store = repos.NewDBStore(ctx, db, sql.TxOptions{Isolation: sql.LevelSerializable})
+		src := repos.NewExternalServicesSourcer(store, cliFactory)
 		syncer = repos.NewSyncer(store, src, diffs, func() time.Time {
 			return time.Now().UTC()
 		})

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -30,6 +30,8 @@ func TestIntegration(t *testing.T) {
 		test func(*testing.T)
 	}{
 		{"DBStore/Transact", testDBStoreTransact(db)},
+		{"DBStore/ListExternalServices", testDBStoreListExternalServices(db)},
+		{"DBStore/UpsertExternalServices", testDBStoreUpsertExternalServices(db)},
 		{"DBStore/GetRepoByName", testDBStoreGetRepoByName(db)},
 		{"DBStore/UpsertRepos", testDBStoreUpsertRepos(db)},
 		{"DBStore/ListRepos", testDBStoreListRepos(db)},

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -25,19 +25,21 @@ func TestIntegration(t *testing.T) {
 	db, cleanup := testDatabase(t)
 	defer cleanup()
 
+	store := repos.NewDBStore(ctx, db, sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+	})
+
 	for _, tc := range []struct {
 		name string
 		test func(*testing.T)
 	}{
-		{"DBStore/Transact", testDBStoreTransact(db)},
-		{"DBStore/ListExternalServices", testDBStoreListExternalServices(db)},
-		{"DBStore/UpsertExternalServices", testDBStoreUpsertExternalServices(db)},
-		{"DBStore/GetRepoByName", testDBStoreGetRepoByName(db)},
-		{"DBStore/UpsertRepos", testDBStoreUpsertRepos(db)},
-		{"DBStore/ListRepos", testDBStoreListRepos(db)},
-		{"Syncer/Sync", testSyncerSync(
-			repos.NewDBStore(ctx, db, sql.TxOptions{Isolation: sql.LevelSerializable}),
-		)},
+		{"DBStore/Transact", testDBStoreTransact(store)},
+		{"DBStore/ListExternalServices", testStoreListExternalServices(store)},
+		{"DBStore/UpsertExternalServices", testStoreUpsertExternalServices(store)},
+		{"DBStore/GetRepoByName", testStoreGetRepoByName(store)},
+		{"DBStore/UpsertRepos", testStoreUpsertRepos(store)},
+		{"DBStore/ListRepos", testStoreListRepos(store)},
+		{"Syncer/Sync", testSyncerSync(store)},
 	} {
 		t.Run(tc.name, tc.test)
 	}

--- a/cmd/repo-updater/repos/source.go
+++ b/cmd/repo-updater/repos/source.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
@@ -21,22 +20,22 @@ type Sourcer interface {
 }
 
 // ExternalServicesSourcer converts each code host connection configured via external services
-// in the frontend API to a Source that yields Repos. Each invocation of ListSources
-// may yield different Sources depending on what the user configured at a given point in time.
+// to a Source that yields Repos. Each invocation of ListSources may yield different Sources
+// depending on what the user configured at a given point in time.
 type ExternalServicesSourcer struct {
-	api InternalAPI
-	cf  httpcli.Factory
+	st Store
+	cf httpcli.Factory
 }
 
-// NewExternalServicesSourcer returns a new ExternalServicesSourcer with the given Frontend API.
-func NewExternalServicesSourcer(api InternalAPI, cf httpcli.Factory) *ExternalServicesSourcer {
-	return &ExternalServicesSourcer{api: api, cf: cf}
+// NewExternalServicesSourcer returns a new ExternalServicesSourcer with the given Store.
+func NewExternalServicesSourcer(st Store, cf httpcli.Factory) *ExternalServicesSourcer {
+	return &ExternalServicesSourcer{st: st, cf: cf}
 }
 
 // ListSources lists all configured repository yielding Sources of the given kinds,
 // based on the code host connections configured via external services in the frontend API.
 func (s ExternalServicesSourcer) ListSources(ctx context.Context, kinds ...string) ([]Source, error) {
-	svcs, err := s.api.ExternalServicesList(ctx, api.ExternalServicesListRequest{Kinds: kinds})
+	svcs, err := s.st.ListExternalServices(ctx, kinds...)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +62,8 @@ func (s ExternalServicesSourcer) ListSources(ctx context.Context, kinds ...strin
 	return srcs, errs.ErrorOrNil()
 }
 
-// NewSource returns a repository yielding Source from the given api.ExternalService configuration.
-func NewSource(svc *api.ExternalService, cf httpcli.Factory) (Source, error) {
+// NewSource returns a repository yielding Source from the given ExternalService configuration.
+func NewSource(svc *ExternalService, cf httpcli.Factory) (Source, error) {
 	switch svc.Kind {
 	case "GITHUB":
 		return NewGithubSource(svc, cf)
@@ -96,12 +95,12 @@ type Source interface {
 // A GithubSource yields repositories from a single Github connection configured
 // in Sourcegraph via the external services configuration.
 type GithubSource struct {
-	svc  *api.ExternalService
+	svc  *ExternalService
 	conn *githubConnection
 }
 
 // NewGithubSource returns a new GithubSource from the given external service.
-func NewGithubSource(svc *api.ExternalService, cf httpcli.Factory) (*GithubSource, error) {
+func NewGithubSource(svc *ExternalService, cf httpcli.Factory) (*GithubSource, error) {
 	var c schema.GitHubConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -113,7 +112,7 @@ func NewGithubSource(svc *api.ExternalService, cf httpcli.Factory) (*GithubSourc
 // to the list of sources in Sourcer when one isn't already configured in order to
 // support navigating to URL paths like /github.com/foo/bar to auto-add that repository.
 func NewGithubDotComSource(cf httpcli.Factory) (*GithubSource, error) {
-	svc := api.ExternalService{Kind: "GITHUB"}
+	svc := ExternalService{Kind: "GITHUB"}
 	return newGithubSource(&svc, &schema.GitHubConnection{
 		RepositoryQuery:             []string{"none"}, // don't try to list all repositories during syncs
 		Url:                         "https://github.com",
@@ -121,7 +120,7 @@ func NewGithubDotComSource(cf httpcli.Factory) (*GithubSource, error) {
 	}, cf)
 }
 
-func newGithubSource(svc *api.ExternalService, c *schema.GitHubConnection, cf httpcli.Factory) (*GithubSource, error) {
+func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf httpcli.Factory) (*GithubSource, error) {
 	conn, err := newGitHubConnection(c, cf)
 	if err != nil {
 		return nil, err
@@ -140,7 +139,7 @@ func (s GithubSource) ListRepos(ctx context.Context) (repos []*Repo, err error) 
 }
 
 func githubRepoToRepo(
-	svc *api.ExternalService,
+	svc *ExternalService,
 	ghrepo *github.Repository,
 	conn *githubConnection,
 ) *Repo {
@@ -161,6 +160,6 @@ func githubRepoToRepo(
 	}
 }
 
-func externalServiceURN(svc *api.ExternalService) string {
+func externalServiceURN(svc *ExternalService) string {
 	return "extsvc:" + strconv.FormatInt(svc.ID, 10)
 }

--- a/cmd/repo-updater/repos/source_test.go
+++ b/cmd/repo-updater/repos/source_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
-	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -31,13 +30,13 @@ func TestGithubSource_ListRepos(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		ctx    context.Context
-		svc    api.ExternalService
+		svc    ExternalService
 		assert func(testing.TB, Repos)
 		err    string
 	}{
 		{
 			name: "excluded repos are never yielded",
-			svc: api.ExternalService{
+			svc: ExternalService{
 				Kind: "GITHUB",
 				Config: config(&schema.GitHubConnection{
 					Url: "https://github.com",

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -178,9 +178,9 @@ func upsertExternalServicesQuery(svcs []*ExternalService) *sqlf.Query {
 			s.Kind,
 			s.DisplayName,
 			s.Config,
-			s.CreatedAt,
-			s.UpdatedAt,
-			nullTime{&s.DeletedAt},
+			s.CreatedAt.UTC(),
+			s.UpdatedAt.UTC(),
+			nullTimeColumn(s.DeletedAt.UTC()),
 		))
 	}
 

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -115,7 +115,7 @@ const listExternalServicesQueryFmtstr = `
 -- source: cmd/repo-updater/repos/store.go:DBStore.ListExternalServices
 SELECT
   id,
-  LOWER(kind),
+  kind,
   display_name,
   config,
   created_at,
@@ -191,7 +191,7 @@ func upsertExternalServicesQuery(svcs []*ExternalService) *sqlf.Query {
 }
 
 const upsertExternalServicesQueryValueFmtstr = `
-  (COALESCE(NULLIF(%s, 0), (SELECT nextval('external_services_id_seq'))), %s, %s, %s, %s, %s, %s)
+  (COALESCE(NULLIF(%s, 0), (SELECT nextval('external_services_id_seq'))), UPPER(%s), %s, %s, %s, %s, %s)
 `
 
 const upsertExternalServicesQueryFmtstr = `
@@ -208,7 +208,7 @@ INSERT INTO external_services (
 VALUES %s
 ON CONFLICT(id) DO UPDATE
 SET
-  kind         = excluded.kind,
+  kind         = UPPER(excluded.kind),
   display_name = excluded.display_name,
   config       = excluded.config,
   created_at   = excluded.created_at,

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -100,7 +100,7 @@ func testDBStoreUpsertRepos(db *sql.DB) func(*testing.T) {
 				t.Errorf("ListRepos:\n%s", diff)
 			}
 
-			want.Apply(repos.Opt.DeletedAt(now))
+			want.Apply(repos.Opt.RepoDeletedAt(now))
 
 			if err = tx.UpsertRepos(ctx, want.Clone()...); err != nil {
 				t.Errorf("UpsertRepos error: %s", err)
@@ -147,7 +147,7 @@ func testDBStoreListRepos(db *sql.DB) func(*testing.T) {
 	equal := func(rs ...*repos.Repo) func(testing.TB, repos.Repos) {
 		want := repos.Repos(rs)
 		return func(t testing.TB, have repos.Repos) {
-			have.Apply(repos.Opt.ID(0)) // Exclude auto-generated IDs from equality tests
+			have.Apply(repos.Opt.RepoID(0)) // Exclude auto-generated IDs from equality tests
 			if !reflect.DeepEqual(have, want) {
 				t.Errorf("repos: %s", cmp.Diff(have, want))
 			}
@@ -195,8 +195,8 @@ func testDBStoreListRepos(db *sql.DB) func(*testing.T) {
 			{
 				name:   "returns soft deleted repos",
 				kinds:  []string{"github"},
-				stored: repos.Repos{foo.With(repos.Opt.DeletedAt(now))},
-				repos:  equal(foo.With(repos.Opt.DeletedAt(now))),
+				stored: repos.Repos{foo.With(repos.Opt.RepoDeletedAt(now))},
+				repos:  equal(foo.With(repos.Opt.RepoDeletedAt(now))),
 			},
 			{
 				name:   "returns repos in ascending order by id",

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -81,7 +81,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				stored:  repos.Repos{},
 				now:     clock.Now,
 				diff: repos.Diff{Added: repos.Repos{
-					foo.With(repos.Opt.CreatedAt(clock.Time(1)), repos.Opt.Sources("a")),
+					foo.With(repos.Opt.RepoCreatedAt(clock.Time(1)), repos.Opt.RepoSources("a")),
 				}},
 				err: "<nil>",
 			})
@@ -93,12 +93,12 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				name:    "had name and got external_id",
 				sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource("a", "github", nil, foo.Clone())),
 				store:   s,
-				stored: repos.Repos{foo.With(repos.Opt.Sources("a"), func(r *repos.Repo) {
+				stored: repos.Repos{foo.With(repos.Opt.RepoSources("a"), func(r *repos.Repo) {
 					r.ExternalRepo.ID = ""
 				})},
 				now: clock.Now,
 				diff: repos.Diff{Modified: repos.Repos{
-					foo.With(repos.Opt.ModifiedAt(clock.Time(1)), repos.Opt.Sources("a")),
+					foo.With(repos.Opt.RepoModifiedAt(clock.Time(1)), repos.Opt.RepoSources("a")),
 				}},
 				err: "<nil>",
 			})
@@ -113,10 +113,10 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					repos.NewFakeSource("b", "github", nil, foo.Clone()),
 				),
 				store:  s,
-				stored: repos.Repos{foo.With(repos.Opt.Sources("a"))},
+				stored: repos.Repos{foo.With(repos.Opt.RepoSources("a"))},
 				now:    clock.Now,
 				diff: repos.Diff{Modified: repos.Repos{
-					foo.With(repos.Opt.ModifiedAt(clock.Time(1)), repos.Opt.Sources("a", "b")),
+					foo.With(repos.Opt.RepoModifiedAt(clock.Time(1)), repos.Opt.RepoSources("a", "b")),
 				}},
 				err: "<nil>",
 			})
@@ -130,9 +130,9 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					r.Enabled = !r.Enabled
 				}))),
 				store:  s,
-				stored: repos.Repos{foo.With(repos.Opt.Sources("a"))},
+				stored: repos.Repos{foo.With(repos.Opt.RepoSources("a"))},
 				now:    clock.Now,
-				diff:   repos.Diff{Unmodified: repos.Repos{foo.With(repos.Opt.Sources("a"))}},
+				diff:   repos.Diff{Unmodified: repos.Repos{foo.With(repos.Opt.RepoSources("a"))}},
 				err:    "<nil>",
 			})
 		}
@@ -145,10 +145,10 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					r.Enabled = !r.Enabled
 				}))),
 				store:  s,
-				stored: repos.Repos{foo.With(repos.Opt.Sources("a"), repos.Opt.DeletedAt(clock.Time(0)))},
+				stored: repos.Repos{foo.With(repos.Opt.RepoSources("a"), repos.Opt.RepoDeletedAt(clock.Time(0)))},
 				now:    clock.Now,
 				diff: repos.Diff{Added: repos.Repos{
-					foo.With(repos.Opt.Sources("a"), repos.Opt.CreatedAt(clock.Time(1))),
+					foo.With(repos.Opt.RepoSources("a"), repos.Opt.RepoCreatedAt(clock.Time(1))),
 				}},
 				err: "<nil>",
 			})
@@ -162,10 +162,10 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					repos.NewFakeSource("a", "github", nil, foo.Clone()),
 				),
 				store:  s,
-				stored: repos.Repos{foo.With(repos.Opt.Sources("a", "b"))},
+				stored: repos.Repos{foo.With(repos.Opt.RepoSources("a", "b"))},
 				now:    clock.Now,
 				diff: repos.Diff{Modified: repos.Repos{
-					foo.With(repos.Opt.ModifiedAt(clock.Time(1)), repos.Opt.Sources("a")),
+					foo.With(repos.Opt.RepoModifiedAt(clock.Time(1)), repos.Opt.RepoSources("a")),
 				}},
 				err: "<nil>",
 			})
@@ -177,10 +177,10 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				name:    "deleted ALL repo sources",
 				sourcer: repos.NewFakeSourcer(nil),
 				store:   s,
-				stored:  repos.Repos{foo.With(repos.Opt.Sources("a", "b"))},
+				stored:  repos.Repos{foo.With(repos.Opt.RepoSources("a", "b"))},
 				now:     clock.Now,
 				diff: repos.Diff{Deleted: repos.Repos{
-					foo.With(repos.Opt.DeletedAt(clock.Time(1))),
+					foo.With(repos.Opt.RepoDeletedAt(clock.Time(1))),
 				}},
 				err: "<nil>",
 			})
@@ -192,12 +192,12 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				name:    "renamed repo is detected via external_id",
 				sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource("a", "github", nil, foo.Clone())),
 				store:   s,
-				stored: repos.Repos{foo.With(repos.Opt.Sources("a"), func(r *repos.Repo) {
+				stored: repos.Repos{foo.With(repos.Opt.RepoSources("a"), func(r *repos.Repo) {
 					r.Name = "old-name"
 				})},
 				now: clock.Now,
 				diff: repos.Diff{Modified: repos.Repos{
-					foo.With(repos.Opt.Sources("a"), repos.Opt.ModifiedAt(clock.Time(1))),
+					foo.With(repos.Opt.RepoSources("a"), repos.Opt.RepoModifiedAt(clock.Time(1))),
 				}},
 				err: "<nil>",
 			})
@@ -216,7 +216,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				})},
 				now: clock.Now,
 				diff: repos.Diff{Added: repos.Repos{
-					foo.With(repos.Opt.Sources("a"), repos.Opt.CreatedAt(clock.Time(1))),
+					foo.With(repos.Opt.RepoSources("a"), repos.Opt.RepoCreatedAt(clock.Time(1))),
 				}},
 				err: "<nil>",
 			})
@@ -227,17 +227,17 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 			testCases = append(testCases, testCase{
 				name: "metadata update",
 				sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource("a", "github", nil,
-					foo.With(repos.Opt.ModifiedAt(clock.Time(1)),
-						repos.Opt.Sources("a"),
-						repos.Opt.Metadata(&github.Repository{IsArchived: true})),
+					foo.With(repos.Opt.RepoModifiedAt(clock.Time(1)),
+						repos.Opt.RepoSources("a"),
+						repos.Opt.RepoMetadata(&github.Repository{IsArchived: true})),
 				)),
 				store:  s,
-				stored: repos.Repos{foo.With(repos.Opt.Sources("a"))},
+				stored: repos.Repos{foo.With(repos.Opt.RepoSources("a"))},
 				now:    clock.Now,
 				diff: repos.Diff{Modified: repos.Repos{
-					foo.With(repos.Opt.ModifiedAt(clock.Time(1)),
-						repos.Opt.Sources("a"),
-						repos.Opt.Metadata(&github.Repository{IsArchived: true})),
+					foo.With(repos.Opt.RepoModifiedAt(clock.Time(1)),
+						repos.Opt.RepoSources("a"),
+						repos.Opt.RepoMetadata(&github.Repository{IsArchived: true})),
 				}},
 				err: "<nil>",
 			})
@@ -278,7 +278,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 
 				var want repos.Repos
 				want.Concat(diff.Added, diff.Modified, diff.Unmodified, diff.Deleted)
-				want.Apply(repos.Opt.ID(0)) // Exclude auto-generated ID from comparisons
+				want.Apply(repos.Opt.RepoID(0)) // Exclude auto-generated ID from comparisons
 
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("have error %q, want %q", have, want)

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSyncer_Sync(t *testing.T) {
 	t.Parallel()
-	testSyncerSync(repos.NewFakeStore(nil, nil, nil))
+	testSyncerSync(new(repos.FakeStore))
 }
 
 func testSyncerSync(s repos.Store) func(*testing.T) {
@@ -58,13 +58,13 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		{
 			name:    "store list error aborts sync",
 			sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource("a", "github", nil, foo.Clone())),
-			store:   repos.NewFakeStore(nil, errors.New("boom"), nil),
+			store:   &repos.FakeStore{ListReposError: errors.New("boom")},
 			err:     "syncer.sync.store.list-repos: boom",
 		},
 		{
 			name:    "store upsert error aborts sync",
 			sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource("a", "github", nil, foo.Clone())),
-			store:   repos.NewFakeStore(nil, nil, errors.New("booya")),
+			store:   &repos.FakeStore{UpsertReposError: errors.New("booya")},
 			err:     "syncer.sync.store.upsert-repos: booya",
 		},
 	}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -220,14 +220,27 @@ func (s *FakeStore) UpsertRepos(ctx context.Context, upserts ...*Repo) error {
 
 // Opt contains functional options to be used in tests.
 var Opt = struct {
-	RepoID         func(uint32) func(*Repo)
-	RepoCreatedAt  func(time.Time) func(*Repo)
-	RepoModifiedAt func(time.Time) func(*Repo)
-	RepoDeletedAt  func(time.Time) func(*Repo)
-	RepoSources    func(...string) func(*Repo)
-	RepoMetadata   func(interface{}) func(*Repo)
-	RepoExternalID func(string) func(*Repo)
+	ExternalServiceID        func(int64) func(*ExternalService)
+	ExternalServiceDeletedAt func(time.Time) func(*ExternalService)
+	RepoID                   func(uint32) func(*Repo)
+	RepoCreatedAt            func(time.Time) func(*Repo)
+	RepoModifiedAt           func(time.Time) func(*Repo)
+	RepoDeletedAt            func(time.Time) func(*Repo)
+	RepoSources              func(...string) func(*Repo)
+	RepoMetadata             func(interface{}) func(*Repo)
+	RepoExternalID           func(string) func(*Repo)
 }{
+	ExternalServiceID: func(n int64) func(*ExternalService) {
+		return func(e *ExternalService) {
+			e.ID = n
+		}
+	},
+	ExternalServiceDeletedAt: func(ts time.Time) func(*ExternalService) {
+		return func(e *ExternalService) {
+			e.UpdatedAt = ts
+			e.DeletedAt = ts
+		}
+	},
 	RepoID: func(n uint32) func(*Repo) {
 		return func(r *Repo) {
 			r.ID = n

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -68,7 +68,7 @@ func NewFakeSource(urn, kind string, err error, rs ...*Repo) *FakeSource {
 func (s FakeSource) ListRepos(context.Context) ([]*Repo, error) {
 	repos := make([]*Repo, len(s.repos))
 	for i, r := range s.repos {
-		repos[i] = r.With(Opt.Sources(s.urn))
+		repos[i] = r.With(Opt.RepoSources(s.urn))
 	}
 	return repos, s.err
 }
@@ -215,25 +215,25 @@ func (s *FakeStore) UpsertRepos(ctx context.Context, upserts ...*Repo) error {
 }
 
 //
-// Repo functional options
+// Functional options
 //
 
-// Opt contains functional options for Repos to be used in tests.
+// Opt contains functional options to be used in tests.
 var Opt = struct {
-	ID         func(uint32) func(*Repo)
-	CreatedAt  func(time.Time) func(*Repo)
-	ModifiedAt func(time.Time) func(*Repo)
-	DeletedAt  func(time.Time) func(*Repo)
-	Sources    func(...string) func(*Repo)
-	Metadata   func(interface{}) func(*Repo)
-	ExternalID func(string) func(*Repo)
+	RepoID         func(uint32) func(*Repo)
+	RepoCreatedAt  func(time.Time) func(*Repo)
+	RepoModifiedAt func(time.Time) func(*Repo)
+	RepoDeletedAt  func(time.Time) func(*Repo)
+	RepoSources    func(...string) func(*Repo)
+	RepoMetadata   func(interface{}) func(*Repo)
+	RepoExternalID func(string) func(*Repo)
 }{
-	ID: func(n uint32) func(*Repo) {
+	RepoID: func(n uint32) func(*Repo) {
 		return func(r *Repo) {
 			r.ID = n
 		}
 	},
-	CreatedAt: func(ts time.Time) func(*Repo) {
+	RepoCreatedAt: func(ts time.Time) func(*Repo) {
 		return func(r *Repo) {
 			r.CreatedAt = ts
 			r.UpdatedAt = ts
@@ -241,14 +241,14 @@ var Opt = struct {
 			r.Enabled = true
 		}
 	},
-	ModifiedAt: func(ts time.Time) func(*Repo) {
+	RepoModifiedAt: func(ts time.Time) func(*Repo) {
 		return func(r *Repo) {
 			r.UpdatedAt = ts
 			r.DeletedAt = time.Time{}
 			r.Enabled = true
 		}
 	},
-	DeletedAt: func(ts time.Time) func(*Repo) {
+	RepoDeletedAt: func(ts time.Time) func(*Repo) {
 		return func(r *Repo) {
 			r.UpdatedAt = ts
 			r.DeletedAt = ts
@@ -256,7 +256,7 @@ var Opt = struct {
 			r.Enabled = false
 		}
 	},
-	Sources: func(srcs ...string) func(*Repo) {
+	RepoSources: func(srcs ...string) func(*Repo) {
 		return func(r *Repo) {
 			r.Sources = map[string]*SourceInfo{}
 			for _, src := range srcs {
@@ -264,12 +264,12 @@ var Opt = struct {
 			}
 		}
 	},
-	Metadata: func(md interface{}) func(*Repo) {
+	RepoMetadata: func(md interface{}) func(*Repo) {
 		return func(r *Repo) {
 			r.Metadata = md
 		}
 	},
-	ExternalID: func(id string) func(*Repo) {
+	RepoExternalID: func(id string) func(*Repo) {
 		return func(r *Repo) {
 			r.ExternalRepo.ID = id
 		}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -121,9 +121,7 @@ func (s *FakeStore) Transact(ctx context.Context) (TxStore, error) {
 
 // Done fakes the implementation of a TxStore's Done method by always discarding all state
 // changes made during the transaction.
-func (s *FakeStore) Done(...*error) {
-	return
-}
+func (s *FakeStore) Done(...*error) {}
 
 // ListExternalServices lists all stored external services that are not deleted and have one of the
 // specified kinds.

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -167,6 +167,7 @@ func (s *FakeStore) UpsertExternalServices(ctx context.Context, svcs ...*Externa
 		} else {
 			s.svcIDSeq++
 			svc.ID = s.svcIDSeq
+			svc.Kind = strings.ToUpper(svc.Kind)
 			s.svcByID[svc.ID] = svc
 		}
 	}

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -18,6 +18,9 @@ type ExternalService struct {
 	DeletedAt   time.Time
 }
 
+// IsDeleted returns true if the external service is deleted.
+func (e *ExternalService) IsDeleted() bool { return !e.DeletedAt.IsZero() }
+
 // Update updates ExternalService r with the fields from the given newer ExternalService n,
 // returning true if modified.
 func (e *ExternalService) Update(n *ExternalService) (modified bool) {
@@ -285,4 +288,11 @@ func (es ExternalServices) Apply(opts ...func(*ExternalService)) {
 	for _, r := range es {
 		r.Apply(opts...)
 	}
+}
+
+// With returns a clone of the given external services with the given functional options applied.
+func (es ExternalServices) With(opts ...func(*ExternalService)) ExternalServices {
+	clone := es.Clone()
+	clone.Apply(opts...)
+	return clone
 }

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -214,10 +214,13 @@ func (rs Repos) Swap(i, j int) {
 }
 
 func (rs Repos) Less(i, j int) bool {
-	if rs[i].Name == rs[j].Name {
-		return rs[i].ExternalRepo.Compare(rs[j].ExternalRepo) == -1
+	if rs[i].ID != rs[j].ID {
+		return rs[i].ID < rs[j].ID
 	}
-	return rs[i].Name < rs[j].Name
+	if rs[i].Name != rs[j].Name {
+		return rs[i].Name < rs[j].Name
+	}
+	return rs[i].ExternalRepo.Compare(rs[j].ExternalRepo) == -1
 }
 
 // Concat adds the given Repos to the end of rs.

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -2,6 +2,7 @@ package repos
 
 import (
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -28,8 +29,8 @@ func (e *ExternalService) Update(n *ExternalService) (modified bool) {
 		return false
 	}
 
-	if e.Kind != n.Kind {
-		e.Kind, modified = n.Kind, true
+	if kind := strings.ToUpper(n.Kind); strings.ToUpper(e.Kind) != kind {
+		e.Kind, modified = kind, true
 	}
 
 	if e.DisplayName != n.DisplayName {


### PR DESCRIPTION
In preparation for the migrations of external services needed in #2025, this change set extends the `Store` interface with two methods:

1. `ListExternalServices(ctx context.Context, kinds ...string) ([]*ExternalService, error)`
2. `UpsertExternalServices(ctx context.Context, svcs ... *ExternalService) error`

All the following changes cascaded from this one and replicate the design of the code that deals with Repos:

1. Introduction of `ExternalService` and `ExternalServices` types.
2. Implementation of the `ListExternalServices` and `UpsertExternalServices` methods in `DBStore` and `FakeStore`.
3. Refactoring of `ExternalServicesSourcer` to use a `Store` instead of an `InternalAPI`.
