### PR TITLE
allow contributing RepoContainer routes

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -24,6 +24,7 @@ import { KeybindingsProps } from './keybindings'
 import { IntegrationsToast } from './marketing/IntegrationsToast'
 import { GlobalNavbar } from './nav/GlobalNavbar'
 import { fetchHighlightedFileLines } from './repo/backend'
+import { RepoContainerRoute } from './repo/RepoContainer'
 import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevContainerRoute } from './repo/RepoRevContainer'
 import { LayoutRouteProps } from './routes'
@@ -60,6 +61,7 @@ export interface LayoutProps
     userAreaRoutes: ReadonlyArray<UserAreaRoute>
     userSettingsSideBarItems: UserSettingsSidebarItems
     userSettingsAreaRoutes: ReadonlyArray<UserSettingsAreaRoute>
+    repoContainerRoutes: ReadonlyArray<RepoContainerRoute>
     repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute>
     repoHeaderActionButtons: ReadonlyArray<RepoHeaderActionButton>
     routes: ReadonlyArray<LayoutRouteProps>

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -31,6 +31,7 @@ import { Layout, LayoutProps } from './Layout'
 import { updateUserSessionStores } from './marketing/util'
 import { createPlatformContext } from './platform/context'
 import { fetchHighlightedFileLines } from './repo/backend'
+import { RepoContainerRoute } from './repo/RepoContainer'
 import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevContainerRoute } from './repo/RepoRevContainer'
 import { LayoutRouteProps } from './routes'
@@ -58,6 +59,7 @@ export interface SourcegraphWebAppProps extends KeybindingsProps {
     userAreaRoutes: ReadonlyArray<UserAreaRoute>
     userSettingsSideBarItems: UserSettingsSidebarItems
     userSettingsAreaRoutes: ReadonlyArray<UserSettingsAreaRoute>
+    repoContainerRoutes: ReadonlyArray<RepoContainerRoute>
     repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute>
     repoHeaderActionButtons: ReadonlyArray<RepoHeaderActionButton>
     routes: ReadonlyArray<LayoutRouteProps>

--- a/web/src/enterprise/main.tsx
+++ b/web/src/enterprise/main.tsx
@@ -17,7 +17,7 @@ import { enterpriseExtensionAreaRoutes } from './extensions/extension/routes'
 import { enterpriseExtensionsAreaHeaderActionButtons } from './extensions/extensionsAreaHeaderActionButtons'
 import { enterpriseExtensionsAreaRoutes } from './extensions/routes'
 import { enterpriseRepoHeaderActionButtons } from './repo/repoHeaderActionButtons'
-import { enterpriseRepoRevContainerRoutes } from './repo/routes'
+import { enterpriseRepoContainerRoutes, enterpriseRepoRevContainerRoutes } from './repo/routes'
 import { enterpriseRoutes } from './routes'
 import { enterpriseSiteAdminOverviewComponents } from './site-admin/overviewComponents'
 import { enterpriseSiteAdminAreaRoutes } from './site-admin/routes'
@@ -42,6 +42,7 @@ window.addEventListener('DOMContentLoaded', () => {
             userAreaRoutes={enterpriseUserAreaRoutes}
             userSettingsSideBarItems={enterpriseUserSettingsSideBarItems}
             userSettingsAreaRoutes={enterpriseUserSettingsAreaRoutes}
+            repoContainerRoutes={enterpriseRepoContainerRoutes}
             repoRevContainerRoutes={enterpriseRepoRevContainerRoutes}
             repoHeaderActionButtons={enterpriseRepoHeaderActionButtons}
             routes={enterpriseRoutes}

--- a/web/src/enterprise/repo/routes.tsx
+++ b/web/src/enterprise/repo/routes.tsx
@@ -1,4 +1,7 @@
+import { RepoContainerRoute } from '../../repo/RepoContainer'
 import { RepoRevContainerRoute } from '../../repo/RepoRevContainer'
-import { repoRevContainerRoutes } from '../../repo/routes'
+import { repoContainerRoutes, repoRevContainerRoutes } from '../../repo/routes'
+
+export const enterpriseRepoContainerRoutes: ReadonlyArray<RepoContainerRoute> = repoContainerRoutes
 
 export const enterpriseRepoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute> = repoRevContainerRoutes

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -16,7 +16,7 @@ import { extensionsAreaHeaderActionButtons } from './extensions/extensionsAreaHe
 import { extensionsAreaRoutes } from './extensions/routes'
 import { keybindings } from './keybindings'
 import { repoHeaderActionButtons } from './repo/repoHeaderActionButtons'
-import { repoRevContainerRoutes } from './repo/routes'
+import { repoContainerRoutes, repoRevContainerRoutes } from './repo/routes'
 import { routes } from './routes'
 import { siteAdminOverviewComponents } from './site-admin/overviewComponents'
 import { siteAdminAreaRoutes } from './site-admin/routes'
@@ -42,6 +42,7 @@ window.addEventListener('DOMContentLoaded', () => {
             userAreaHeaderNavItems={userAreaHeaderNavItems}
             userSettingsSideBarItems={userSettingsSideBarItems}
             userSettingsAreaRoutes={userSettingsAreaRoutes}
+            repoContainerRoutes={repoContainerRoutes}
             repoRevContainerRoutes={repoRevContainerRoutes}
             repoHeaderActionButtons={repoHeaderActionButtons}
             routes={routes}

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -18,26 +18,44 @@ import { searchQueryForRepoRev } from '../search'
 import { queryUpdates } from '../search/input/QueryInput'
 import { ThemeProps } from '../theme'
 import { EventLoggerProps } from '../tracking/eventLogger'
+import { RouteDescriptor } from '../util/contributions'
 import { parseBrowserRepoURL, ParsedRepoRev, parseRepoRev } from '../util/url'
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
 import { EREPONOTFOUND, EREPOSEEOTHER, fetchRepository, RepoSeeOtherError, ResolvedRev } from './backend'
-import { RepositoryBranchesArea } from './branches/RepositoryBranchesArea'
-import { RepositoryCommitPage } from './commit/RepositoryCommitPage'
-import { RepositoryCompareArea } from './compare/RepositoryCompareArea'
-import { RepositoryReleasesArea } from './releases/RepositoryReleasesArea'
 import { RepoHeader, RepoHeaderActionButton, RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
 import { RepoRevContainer, RepoRevContainerRoute } from './RepoRevContainer'
-import { RepositoryGitDataContainer } from './RepositoryGitDataContainer'
 import { RepositoryNotFoundPage } from './RepositoryNotFoundPage'
-import { RepoSettingsArea } from './settings/RepoSettingsArea'
-import { RepositoryStatsArea } from './stats/RepositoryStatsArea'
+
+/**
+ * Props passed to sub-routes of {@link RepoContainer}.
+ */
+export interface RepoContainerContext
+    extends RepoHeaderContributionsLifecycleProps,
+        SettingsCascadeProps,
+        ExtensionsControllerProps,
+        PlatformContextProps,
+        ThemeProps,
+        EventLoggerProps,
+        ActivationProps {
+    repo: GQL.IRepository
+    authenticatedUser: GQL.IUser | null
+
+    /** The URL route match for {@link RepoContainer}. */
+    routePrefix: string
+
+    onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    onDidUpdateExternalLinks: (externalLinks: GQL.IExternalLink[] | undefined) => void
+}
+
+/** A sub-route of {@link RepoContainer}. */
+export interface RepoContainerRoute extends RouteDescriptor<RepoContainerContext> {}
 
 const RepoPageNotFound: React.FunctionComponent = () => (
     <HeroPage icon={MapSearchIcon} title="404: Not Found" subtitle="The repository page was not found." />
 )
 
-export interface RepoContainerProps
+interface RepoContainerProps
     extends RouteComponentProps<{ repoRevAndRest: string }>,
         SettingsCascadeProps,
         PlatformContextProps,
@@ -45,6 +63,7 @@ export interface RepoContainerProps
         ExtensionsControllerProps,
         ActivationProps,
         ThemeProps {
+    repoContainerRoutes: ReadonlyArray<RepoContainerRoute>
     repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute>
     repoHeaderActionButtons: ReadonlyArray<RepoHeaderActionButton>
     authenticatedUser: GQL.IUser | null
@@ -208,17 +227,19 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
 
         const repoMatchURL = `/${this.state.repoOrError.name}`
 
-        const transferProps = {
+        const context: RepoContainerContext = {
             repo: this.state.repoOrError,
             authenticatedUser: this.props.authenticatedUser,
             isLightTheme: this.props.isLightTheme,
             activation: this.props.activation,
             telemetryService: this.props.telemetryService,
-            repoMatchURL,
+            routePrefix: repoMatchURL,
             settingsCascade: this.props.settingsCascade,
             platformContext: this.props.platformContext,
             extensionsController: this.props.extensionsController,
             ...this.state.repoHeaderContributionsLifecycleProps,
+            onDidUpdateExternalLinks: this.onDidUpdateExternalLinks,
+            onDidUpdateRepository: this.onDidUpdateRepository,
         }
 
         return (
@@ -273,7 +294,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                                 render={routeComponentProps => (
                                     <RepoRevContainer
                                         {...routeComponentProps}
-                                        {...transferProps}
+                                        {...context}
                                         routes={this.props.repoRevContainerRoutes}
                                         rev={this.state.rev || ''}
                                         resolvedRevOrError={this.state.resolvedRevOrError}
@@ -286,72 +307,18 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                                 )}
                             />
                         ))}
-                        <Route
-                            path={`${repoMatchURL}/-/commit/:revspec+`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryCommitPage
-                                        {...routeComponentProps}
-                                        {...transferProps}
-                                        onDidUpdateExternalLinks={this.onDidUpdateExternalLinks}
+                        {this.props.repoContainerRoutes.map(
+                            ({ path, render, exact, condition = () => true }) =>
+                                condition(context) && (
+                                    <Route
+                                        path={context.routePrefix + path}
+                                        key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                        exact={exact}
+                                        // tslint:disable-next-line:jsx-no-lambda RouteProps.render is an exception
+                                        render={routeComponentProps => render({ ...context, ...routeComponentProps })}
                                     />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/branches`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryBranchesArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/tags`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryReleasesArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/compare/:spec*`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryCompareArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/stats`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepositoryGitDataContainer repoName={this.state.repoName}>
-                                    <RepositoryStatsArea {...routeComponentProps} {...transferProps} />
-                                </RepositoryGitDataContainer>
-                            )}
-                        />
-                        <Route
-                            path={`${repoMatchURL}/-/settings`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            // tslint:disable-next-line:jsx-no-lambda
-                            render={routeComponentProps => (
-                                <RepoSettingsArea
-                                    {...routeComponentProps}
-                                    {...transferProps}
-                                    onDidUpdateRepository={this.onDidUpdateRepository}
-                                />
-                            )}
-                        />
+                                )
+                        )}
                         <Route key="hardcoded-key" component={RepoPageNotFound} />
                     </Switch>
                 </ErrorBoundary>

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -22,11 +22,13 @@ import { RouteDescriptor } from '../util/contributions'
 import { CopyLinkAction } from './actions/CopyLinkAction'
 import { GoToPermalinkAction } from './actions/GoToPermalinkAction'
 import { CloneInProgressError, ECLONEINPROGESS, EREPONOTFOUND, EREVNOTFOUND, ResolvedRev, resolveRev } from './backend'
+import { RepoContainerContext } from './RepoContainer'
 import { RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
 import { EmptyRepositoryPage, RepositoryCloningInProgressPage } from './RepositoryGitDataContainer'
 import { RevisionsPopover } from './RevisionsPopover'
 
+/** Props passed to sub-routes of {@link RepoRevContainer}. */
 export interface RepoRevContainerContext
     extends RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
@@ -34,14 +36,20 @@ export interface RepoRevContainerContext
         PlatformContextProps,
         ThemeProps,
         EventLoggerProps,
-        ActivationProps {
+        ActivationProps,
+        Pick<
+            RepoContainerContext,
+            Exclude<keyof RepoContainerContext, 'onDidUpdateRepository' | 'onDidUpdateExternalLinks'>
+        > {
     repo: GQL.IRepository
     rev: string
-    authenticatedUser: GQL.IUser | null
     resolvedRev: ResolvedRev
+
+    /** The URL route match for {@link RepoRevContainer}. */
     routePrefix: string
 }
 
+/** A sub-route of {@link RepoRevContainer}. */
 export interface RepoRevContainerRoute extends RouteDescriptor<RepoRevContainerContext> {}
 
 interface RepoRevContainerProps

--- a/web/src/repo/releases/RepositoryReleasesArea.tsx
+++ b/web/src/repo/releases/RepositoryReleasesArea.tsx
@@ -6,7 +6,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import { Subscription } from 'rxjs'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { HeroPage } from '../../components/HeroPage'
-import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
+import { RepoContainerContext } from '../RepoContainer'
 import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
 import { RepoHeaderContributionPortal } from '../RepoHeaderContributionPortal'
 import { RepositoryReleasesTagsPage } from './RepositoryReleasesTagsPage'
@@ -19,11 +19,10 @@ const NotFoundPage = () => (
     />
 )
 
-interface Props extends RouteComponentProps<{}>, RepoHeaderContributionsLifecycleProps {
+interface Props
+    extends RouteComponentProps<{}>,
+        Pick<RepoContainerContext, 'repo' | 'routePrefix' | 'repoHeaderContributionsLifecycleProps'> {
     repo: GQL.IRepository
-
-    /** The URL match from RepoContainer. */
-    repoMatchURL: string
 }
 
 interface State {
@@ -72,7 +71,7 @@ export class RepositoryReleasesArea extends React.Component<Props> {
                     <div className="area--vertical__content-inner">
                         <Switch>
                             <Route
-                                path={`${this.props.repoMatchURL}/-/tags`}
+                                path={`${this.props.routePrefix}/-/tags`}
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                 exact={true}
                                 // tslint:disable-next-line:jsx-no-lambda

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -4,6 +4,7 @@ import { getModeFromPath } from '../../../shared/src/languages'
 import { isLegacyFragment, parseHash } from '../../../shared/src/util/url'
 import { lazyComponent } from '../util/lazyComponent'
 import { formatHash } from '../util/url'
+import { RepoContainerRoute } from './RepoContainer'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
 import { RepoRevContainerContext, RepoRevContainerRoute } from './RepoRevContainer'
 
@@ -12,6 +13,74 @@ const RepositoryCommitsPage = lazyComponent(() => import('./commits/RepositoryCo
 const FilePathBreadcrumb = lazyComponent(() => import('./FilePathBreadcrumb'), 'FilePathBreadcrumb')
 const RepoRevSidebar = lazyComponent(() => import('./RepoRevSidebar'), 'RepoRevSidebar')
 const TreePage = lazyComponent(() => import('./TreePage'), 'TreePage')
+
+const RepositoryGitDataContainer = lazyComponent(
+    () => import('./RepositoryGitDataContainer'),
+    'RepositoryGitDataContainer'
+)
+const RepositoryCommitPage = lazyComponent(() => import('./commit/RepositoryCommitPage'), 'RepositoryCommitPage')
+const RepositoryBranchesArea = lazyComponent(
+    () => import('./branches/RepositoryBranchesArea'),
+    'RepositoryBranchesArea'
+)
+const RepositoryReleasesArea = lazyComponent(
+    () => import('./releases/RepositoryReleasesArea'),
+    'RepositoryReleasesArea'
+)
+const RepoSettingsArea = lazyComponent(() => import('./settings/RepoSettingsArea'), 'RepoSettingsArea')
+const RepositoryCompareArea = lazyComponent(() => import('./compare/RepositoryCompareArea'), 'RepositoryCompareArea')
+const RepositoryStatsArea = lazyComponent(() => import('./stats/RepositoryStatsArea'), 'RepositoryStatsArea')
+
+export const repoContainerRoutes: ReadonlyArray<RepoContainerRoute> = [
+    {
+        path: '/-/commit/:revspec+',
+        render: context => (
+            <RepositoryGitDataContainer repoName={context.repo.name}>
+                <RepositoryCommitPage {...context} />
+            </RepositoryGitDataContainer>
+        ),
+    },
+    {
+        path: '/-/branches',
+        render: context => (
+            <RepositoryGitDataContainer repoName={context.repo.name}>
+                <RepositoryBranchesArea {...context} />
+            </RepositoryGitDataContainer>
+        ),
+    },
+    {
+        path: '/-/tags',
+        render: context => (
+            <RepositoryGitDataContainer repoName={context.repo.name}>
+                <RepositoryReleasesArea {...context} />
+            </RepositoryGitDataContainer>
+        ),
+    },
+    {
+        path: '/-/compare/:spec*',
+        render: context => (
+            <RepositoryGitDataContainer repoName={context.repo.name}>
+                <RepositoryCompareArea {...context} />
+            </RepositoryGitDataContainer>
+        ),
+    },
+    {
+        path: '/-/stats',
+        render: context => (
+            <RepositoryGitDataContainer repoName={context.repo.name}>
+                <RepositoryStatsArea {...context} />
+            </RepositoryGitDataContainer>
+        ),
+    },
+    {
+        path: '/-/settings',
+        render: context => (
+            <RepositoryGitDataContainer repoName={context.repo.name}>
+                <RepoSettingsArea {...context} />
+            </RepositoryGitDataContainer>
+        ),
+    },
+]
 
 /** Dev feature flag to make benchmarking the file tree in isolation easier. */
 const hideRepoRevContent = localStorage.getItem('hideRepoRevContent')


### PR DESCRIPTION
It was already possible to contribute RepoRevContainer routes (i.e., from the enterprise tree). Now it is possible to also contribute RepoContainer routes; i.e., repository routes that do not include the `@rev` in the URL for pages that don't have a concept of "current revision".

This is useful for a feature I was prototyping (the new codemod UI). It is OK to wait to merge this until it is needed if you want.