### PR TITLE
Run bext e2e tests on all branches, against a local instance

### DIFF
--- a/client/browser/src/e2e/chrome.e2e.test.ts
+++ b/client/browser/src/e2e/chrome.e2e.test.ts
@@ -101,31 +101,32 @@ describe('Sourcegraph Chrome extension', () => {
 
     test('connects to sourcegraph.com by default', async () => {
         await page.goto(OPTIONS_PAGE_URL)
-        await page.waitForSelector('.server-url-form__input-container__status__indicator--success')
+        await page.waitForSelector('.e2e-server-url-status-success')
     })
 
     if (SOURCEGRAPH_BASE_URL !== 'https://sourcegraph.com') {
         test("sets the Sourcegraph URL and warns the user he's not logged in", async () => {
+            await ensureLoggedIn({ page, baseURL: SOURCEGRAPH_BASE_URL })
+            // Make sure we're actually logged out of the instance
+            await page.goto(SOURCEGRAPH_BASE_URL + '/-/sign-out')
+            await page.waitForSelector('.signin-form')
             await page.goto(OPTIONS_PAGE_URL)
-            await page.waitForSelector('.server-url-form__input-container__input')
-            await page.focus('.server-url-form__input-container__input')
+            await page.waitForSelector('.e2e-server-url-input')
+            await page.focus('.e2e-server-url-input')
             // Erase input value
             await page.evaluate(
-                () =>
-                    ((document.querySelector('.server-url-form__input-container__input')! as HTMLInputElement).value =
-                        '')
+                () => ((document.querySelector('.e2e-server-url-input')! as HTMLInputElement).value = '')
             )
             await page.keyboard.type(SOURCEGRAPH_BASE_URL)
             // Clear the focus on the input field.
             await page.evaluate(() => (document.activeElement! as HTMLElement).blur())
-            await page.waitForSelector('.server-url-form__input-container__status__indicator--error')
-            await getTokenWithSelector(page, 'Sign in to your instance', '.server-url-form__error a')
+            await page.waitForSelector('.e2e-server-url-status-error')
         })
 
         test('connects to the instance once the user is logged in', async () => {
             await ensureLoggedIn({ page, baseURL: SOURCEGRAPH_BASE_URL })
             await page.goto(OPTIONS_PAGE_URL)
-            await page.waitForSelector('.server-url-form__input-container__status__indicator--success')
+            await page.waitForSelector('.e2e-server-url-status-success')
         })
     }
 

--- a/client/browser/src/e2e/chrome.e2e.test.ts
+++ b/client/browser/src/e2e/chrome.e2e.test.ts
@@ -10,6 +10,15 @@ const SOURCEGRAPH_BASE_URL = readEnvString({
     defaultValue: 'https://sourcegraph.com',
 })
 
+// The default value here is the dev extension ID.
+// In CI, tests are be run against the prod extension ID.
+const EXTENSION_ID = readEnvString({
+    variable: 'SOURCEGRAPH_EXTENSION_ID',
+    defaultValue: 'bmfbcejdknlknpncfpeloejonjoledha',
+})
+
+const OPTIONS_PAGE_URL = `chrome-extension://${EXTENSION_ID}/options.html`
+
 async function getTokenWithSelector(
     page: puppeteer.Page,
     token: string,
@@ -91,13 +100,13 @@ describe('Sourcegraph Chrome extension', () => {
     const repoBaseURL = 'https://github.com/gorilla/mux'
 
     test('connects to sourcegraph.com by default', async () => {
-        await page.goto('chrome-extension://bmfbcejdknlknpncfpeloejonjoledha/options.html')
+        await page.goto(OPTIONS_PAGE_URL)
         await page.waitForSelector('.server-url-form__input-container__status__indicator--success')
     })
 
     if (SOURCEGRAPH_BASE_URL !== 'https://sourcegraph.com') {
         test("sets the Sourcegraph URL and warns the user he's not logged in", async () => {
-            await page.goto('chrome-extension://bmfbcejdknlknpncfpeloejonjoledha/options.html')
+            await page.goto(OPTIONS_PAGE_URL)
             await page.waitForSelector('.server-url-form__input-container__input')
             await page.focus('.server-url-form__input-container__input')
             // Erase input value
@@ -115,7 +124,7 @@ describe('Sourcegraph Chrome extension', () => {
 
         test('connects to the instance once the user is logged in', async () => {
             await ensureLoggedIn({ page, baseURL: SOURCEGRAPH_BASE_URL })
-            await page.goto('chrome-extension://bmfbcejdknlknpncfpeloejonjoledha/options.html')
+            await page.goto(OPTIONS_PAGE_URL)
             await page.waitForSelector('.server-url-form__input-container__status__indicator--success')
         })
     }

--- a/client/browser/src/extension/manifest.spec.json
+++ b/client/browser/src/extension/manifest.spec.json
@@ -68,6 +68,7 @@
       "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvyGmcOkw4cTnhO0bgl3fQLAdv1jZp8T1ZHYI+4d8FgwwVKLYWE+pAuJ/0LrI69ibed4Nnnw5YleB1xCpI+mzB56xfXWboKp6lljevKqWJ5TpJk/Vam3kSSoZwpmJRXnzmcM3qKpL6viUhTfwGmQO6WVTsN4YCx+KWXv97IyF6yDTgd6hwFsvCZY2n1ADgurrQkE6AcJ3kK4xZ14jaHllXEdFcqwh0+Am5qLcIJ1cNo5iFD35exXsjwdQbmpt8sEk5f95pK5FEEbJFmOTguu2fOZycqIoTgoDrbbhT5k9TUogZaN5Lup0Iwh0Cv60i4C1f7IdPrxHuaYmYCfoUezXnQIDAQAB"
   },
   "prod": {
+    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCl2X/axNHMbP0K/NCpMzGo/pgBSsHB2xKx6tfohORKtEv2wUMBPmkK3++kirrwYO2f8Ficyq6pjlXV8LjwPSjSw9KZj6bkDn8QNoSdCp6x9i8ZOWPw6UTQ6s54b3rGQNyvrvfD7S6LphxGEx8rNlkjpWKcrvY3+DyoFKHP/hax7wIDAQAB",
     "content_scripts": [
       {
         "matches": ["https://github.com/*", "https://sourcegraph.com/*"],

--- a/client/browser/src/libs/options/ServerURLForm.tsx
+++ b/client/browser/src/libs/options/ServerURLForm.tsx
@@ -92,6 +92,7 @@ export class ServerURLForm extends React.Component<ServerURLFormProps> {
     }
 
     public render(): React.ReactNode {
+        const statusClassName = this.isUpdating ? 'default' : statusClassNames[this.props.status]
         return (
             // tslint:disable-next-line:jsx-ban-elements
             <form className={`server-url-form ${this.props.className || ''}`} onSubmit={this.handleSubmit}>
@@ -101,8 +102,8 @@ export class ServerURLForm extends React.Component<ServerURLFormProps> {
                         <span
                             className={
                                 'server-url-form__input-container__status__indicator ' +
-                                'server-url-form__input-container__status__indicator--' +
-                                (this.isUpdating ? 'default' : statusClassNames[this.props.status])
+                                `server-url-form__input-container__status__indicator--${statusClassName} ` +
+                                `e2e-server-url-status-${statusClassName}`
                             }
                         />
                         <span className="server-url-form__input-container__status__text">
@@ -113,7 +114,7 @@ export class ServerURLForm extends React.Component<ServerURLFormProps> {
                         type="text"
                         ref={this.inputElement}
                         value={this.props.value}
-                        className="server-url-form__input-container__input"
+                        className="server-url-form__input-container__input e2e-server-url-input"
                         onChange={this.handleChange}
                         spellCheck={false}
                         autoCapitalize="off"

--- a/dev/ci/e2e-bext.sh
+++ b/dev/ci/e2e-bext.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+cd $(dirname "${BASH_SOURCE[0]}")/../..
+set -ex
+
+if [ -z "$IMAGE" ]; then
+    echo "Must specify \$IMAGE."
+    exit 1
+fi
+
+# Switch the default Docker host to the dedicated e2e testing host
+BUILD_DOCKER_HOST="$DOCKER_HOST"
+BUILD_DOCKER_PASSWORD="$DOCKER_PASSWORD"
+BUILD_DOCKER_USERNAME="$DOCKER_USERNAME"
+export DOCKER_HOST="$E2E_DOCKER_HOST"
+export DOCKER_PASSWORD="$E2E_DOCKER_PASSWORD"
+export DOCKER_USERNAME="$E2E_DOCKER_USERNAME"
+
+echo "Copying $IMAGE to the dedicated e2e testing node..."
+env \
+    DOCKER_HOST="$BUILD_DOCKER_HOST" \
+    DOCKER_PASSWORD="$BUILD_DOCKER_PASSWORD" \
+    DOCKER_USERNAME="$BUILD_DOCKER_USERNAME" \
+    docker save "$IMAGE" \
+    | docker load
+echo "Copying $IMAGE to the dedicated e2e testing node... done"
+
+echo "Running a daemonized $IMAGE as the test subject..."
+CONTAINER="$(docker container run -d $IMAGE)"
+trap 'kill $(jobs -p)'" ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
+
+docker exec "$CONTAINER" apk add --no-cache socat
+# Connect the server container's port 7080 to localhost:7080 so that e2e tests
+# can hit it. This is similar to port-forwarding via SSH tunneling, but uses
+# docker exec as the transport.
+socat tcp-listen:7080,reuseaddr,fork system:"docker exec -i $CONTAINER socat stdio 'tcp:localhost:7080'" &
+
+URL="http://localhost:7080"
+
+set +e
+timeout 30s bash -c "until curl --output /dev/null --silent --head --fail $URL; do
+    echo Waiting 5s for $URL...
+    sleep 5
+done"
+if [ $? -ne 0 ]; then
+    echo "$URL was not accessible within 30s. Here's the output of docker inspect and docker logs:"
+    docker inspect "$CONTAINER"
+    docker logs --timestamps "$CONTAINER"
+    exit 1
+fi
+set -e
+echo "Waiting for $URL... done"
+
+yarn
+
+pushd client/browser
+yarn run build
+env SOURCEGRAPH_BASE_URL="$URL" SOURCEGRAPH_EXTENSION_ID="dgjhfomjieaadpoljlnidmbgkdffpack" yarn run test-e2e
+popd
+
+echo "Logs from the sourcegraph/server Docker container that was subject to e2e tests:"
+docker logs --timestamps "$CONTAINER"

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -59,10 +59,5 @@ ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp
 env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run test-e2e
 popd
 
-pushd client/browser
-yarn run build
-env SOURCEGRAPH_BASE_URL="$URL" yarn run test-e2e
-popd
-
 echo "Logs from the sourcegraph/server Docker container that was subject to e2e tests:"
 docker logs --timestamps "$CONTAINER"

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -60,6 +60,7 @@ env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- 
 popd
 
 pushd client/browser
+yarn run build
 env SOURCEGRAPH_BASE_URL="$URL" yarn run test-e2e
 popd
 

--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -59,5 +59,9 @@ ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp
 env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run test-e2e
 popd
 
+pushd client/browser
+env SOURCEGRAPH_BASE_URL="$URL" yarn run test-e2e
+popd
+
 echo "Logs from the sourcegraph/server Docker container that was subject to e2e tests:"
 docker logs --timestamps "$CONTAINER"

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -168,7 +168,8 @@ func main() {
 		bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
 		bk.Env("VERSION", version),
 		bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
-		bk.Cmd("./dev/ci/e2e-bext.sh"))
+		bk.Cmd("./dev/ci/e2e-bext.sh"),
+		bk.ArtifactPaths("./puppeteer/*.png"))
 
 	pipeline.AddWait()
 

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -162,6 +162,14 @@ func main() {
 			bk.ArtifactPaths("./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log"))
 	}
 
+	pipeline.AddStep(":chromium:",
+		bk.ConcurrencyGroup("e2e"),
+		bk.Concurrency(1),
+		bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
+		bk.Env("VERSION", version),
+		bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
+		bk.Cmd("./dev/ci/e2e-bext.sh"))
+
 	pipeline.AddWait()
 
 	pipeline.AddStep(":codecov:",

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -160,16 +160,16 @@ func main() {
 			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
 			bk.Cmd("./dev/ci/e2e.sh"),
 			bk.ArtifactPaths("./puppeteer/*.png;./web/e2e.mp4;./web/ffmpeg.log"))
-	}
 
-	pipeline.AddStep(":chromium:",
-		bk.ConcurrencyGroup("e2e"),
-		bk.Concurrency(1),
-		bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
-		bk.Env("VERSION", version),
-		bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
-		bk.Cmd("./dev/ci/e2e-bext.sh"),
-		bk.ArtifactPaths("./puppeteer/*.png"))
+		pipeline.AddStep(":chromium:",
+			bk.ConcurrencyGroup("e2e"),
+			bk.Concurrency(1),
+			bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
+			bk.Env("VERSION", version),
+			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
+			bk.Cmd("./dev/ci/e2e-bext.sh"),
+			bk.ArtifactPaths("./puppeteer/*.png"))
+	}
 
 	pipeline.AddWait()
 
@@ -249,6 +249,7 @@ func main() {
 		// Run e2e tests
 		pipeline.AddStep(":chromium:",
 			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
+			bk.Env("SOURCEGRAPH_EXTENSION_ID", "dgjhfomjieaadpoljlnidmbgkdffpack"),
 			bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("pushd client/browser"),
 			bk.Cmd("yarn -s run build"),

--- a/shared/src/util/e2e-test-utils.ts
+++ b/shared/src/util/e2e-test-utils.ts
@@ -1,4 +1,5 @@
 import pRetry from 'p-retry'
+import puppeteer from 'puppeteer'
 import { OperationOptions } from 'retry'
 
 /**
@@ -51,4 +52,33 @@ export function readEnvString({ variable, defaultValue }: { variable: string; de
         return defaultValue
     }
     return value
+}
+
+export async function ensureLoggedIn({
+    page,
+    baseURL,
+    email = 'test@test.com',
+    username = 'test',
+    password = 'test',
+}: {
+    page: puppeteer.Page
+    baseURL: string
+    email?: string
+    username?: string
+    password?: string
+}): Promise<void> {
+    await page.goto(baseURL)
+    const url = new URL(await page.url())
+    if (url.pathname === '/site-admin/init') {
+        await page.type('input[name=email]', email)
+        await page.type('input[name=username]', username)
+        await page.type('input[name=password]', password)
+        await page.click('button[type=submit]')
+        await page.waitForNavigation()
+    } else if (url.pathname === '/sign-in') {
+        await page.type('input', username)
+        await page.type('input[name=password]', password)
+        await page.click('button[type=submit]')
+        await page.waitForNavigation()
+    }
 }

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -3,8 +3,8 @@ import * as os from 'os'
 import * as path from 'path'
 import puppeteer, { LaunchOptions } from 'puppeteer'
 import { Key } from 'ts-key-enum'
+import { ensureLoggedIn, readEnvBoolean, readEnvString, retry } from '../../../shared/src/util/e2e-test-utils'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/util/screenshotReporter'
-import { readEnvBoolean, readEnvString, retry } from '../util/e2e-test-utils'
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
 // command timeout of 30s in order to get the stack trace to point to the
@@ -38,8 +38,7 @@ describe('e2e test suite', function(this: any): void {
     let page: puppeteer.Page
 
     async function init(): Promise<void> {
-        await ensureLoggedIn()
-
+        await ensureLoggedIn({ page, baseURL })
         const repoSlugs = [
             'gorilla/mux',
             'gorilla/securecookie',
@@ -86,28 +85,6 @@ describe('e2e test suite', function(this: any): void {
             await browser.close()
         }
     })
-
-    async function ensureLoggedIn(): Promise<void> {
-        await page.goto(baseURL)
-        await page.evaluate(() => {
-            localStorage.setItem('has-dismissed-browser-ext-toast', 'true')
-            localStorage.setItem('has-dismissed-integrations-toast', 'true')
-            localStorage.setItem('has-dismissed-survey-toast', 'true')
-        })
-        const url = new URL(await page.url())
-        if (url.pathname === '/site-admin/init') {
-            await page.type('input[name=email]', 'test@test.com')
-            await page.type('input[name=username]', 'test')
-            await page.type('input[name=password]', 'test')
-            await page.click('button[type=submit]')
-            await page.waitForNavigation()
-        } else if (url.pathname === '/sign-in') {
-            await page.type('input', 'test')
-            await page.type('input[name=password]', 'test')
-            await page.click('button[type=submit]')
-            await page.waitForNavigation()
-        }
-    }
 
     /**
      * Specifies how `replaceText` will select the content of the element. No

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -3,7 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import puppeteer, { LaunchOptions } from 'puppeteer'
 import { Key } from 'ts-key-enum'
-import { ensureLoggedIn, readEnvBoolean, readEnvString, retry } from '../../../shared/src/util/e2e-test-utils'
+import { readEnvBoolean, readEnvString, retry } from '../../../shared/src/util/e2e-test-utils'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/util/screenshotReporter'
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
@@ -38,7 +38,8 @@ describe('e2e test suite', function(this: any): void {
     let page: puppeteer.Page
 
     async function init(): Promise<void> {
-        await ensureLoggedIn({ page, baseURL })
+        await ensureLoggedIn()
+
         const repoSlugs = [
             'gorilla/mux',
             'gorilla/securecookie',
@@ -85,6 +86,28 @@ describe('e2e test suite', function(this: any): void {
             await browser.close()
         }
     })
+
+    async function ensureLoggedIn(): Promise<void> {
+        await page.goto(baseURL)
+        await page.evaluate(() => {
+            localStorage.setItem('has-dismissed-browser-ext-toast', 'true')
+            localStorage.setItem('has-dismissed-integrations-toast', 'true')
+            localStorage.setItem('has-dismissed-survey-toast', 'true')
+        })
+        const url = new URL(await page.url())
+        if (url.pathname === '/site-admin/init') {
+            await page.type('input[name=email]', 'test@test.com')
+            await page.type('input[name=username]', 'test')
+            await page.type('input[name=password]', 'test')
+            await page.click('button[type=submit]')
+            await page.waitForNavigation()
+        } else if (url.pathname === '/sign-in') {
+            await page.type('input', 'test')
+            await page.type('input[name=password]', 'test')
+            await page.click('button[type=submit]')
+            await page.waitForNavigation()
+        }
+    }
 
     /**
      * Specifies how `replaceText` will select the content of the element. No


### PR DESCRIPTION
Adds e2e tests for setting the Sourcegraph URL through the options page, which in turns makes it possible to run the browser extension e2e tests against a local instance in CI. This would allow to run the e2e tests on all branches.

Still have to figure out how to fix the [build fail](https://buildkite.com/sourcegraph/sourcegraph/builds/29589#68be8180-ab22-43ba-bf13-08fe572ca160/38-222) on this -- fails with `TimeoutError: Timed out after 30000 ms while trying to connect to Chrome`, maybe linked to running puppeteer twice in a row (webapp, then bext)?