### PR TITLE
Symbols: include Go packages

### DIFF
--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -68,7 +68,6 @@ func NewParser(ctagsCommand string) (Parser, error) {
 	cmd := exec.Command(ctagsCommand, "--_interactive="+opt, "--fields=*",
 		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,Tcl,typescript,Verilog,Vim",
 		"--map-CSS=+.scss", "--map-CSS=+.less", "--map-CSS=+.sass",
-		"--kinds-Go=-p", // omit because 1 symbol per `package` keyword (1 for each file in a package) is not useful
 	)
 	in, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
Motivation: basic-code-intel will be more precise when it filters definitions by which package it's defined in. Before this change, parent information was being suppressed for some Go symbols.

Before to this change, many Go symbols had a `null` parent because packages were suppressed with `--kinds-Go=-p`.

```
sqlite> select * from symbols where path = 'mux.go';
name               namelowercase      path        pathlowercase  line        kind        language    parent      parentkind  signature   pattern                                                       filelimited
-----------------  -----------------  ----------  -------------  ----------  ----------  ----------  ----------  ----------  ----------  ------------------------------------------------------------  -----------
ErrMethodMismatch  errmethodmismatch  mux.go      mux.go         18          var         Go                                              /^	ErrMethodMismatch = errors.New("method is not allowed")$/  0
ErrNotFound        errnotfound        mux.go      mux.go         20          var         Go                                              /^	ErrNotFound = errors.New("no matching route was found")$/  0
NewRouter          newrouter          mux.go      mux.go         24          func        Go                                  ()          /^func NewRouter() *Router {$/                                0
Router             router             mux.go      mux.go         46          struct      Go                                              /^type Router struct {$/                                      0
NotFoundHandler    notfoundhandler    mux.go      mux.go         48          member      Go          Router      struct                  /^	NotFoundHandler http.Handler$/                             0
```

After this change, more Go symbols will have a valid parent, which is often times the package they're defined in. Contrast the `parent` column before and after:

```
sqlite> select * from symbols where path = 'mux.go';
name        namelowercase  path        pathlowercase  line        kind        language    parent      parentkind  signature   pattern          filelimited
----------  -------------  ----------  -------------  ----------  ----------  ----------  ----------  ----------  ----------  ---------------  -----------
mux         mux            mux.go      mux.go         5           package     Go                                              /^package mux$/  0
ErrMethodM  errmethodmism  mux.go      mux.go         18          var         Go          mux         package                 /^	ErrMethodMis  0
ErrNotFoun  errnotfound    mux.go      mux.go         20          var         Go          mux         package                 /^	ErrNotFound   0
NewRouter   newrouter      mux.go      mux.go         24          func        Go          mux         package     ()          /^func NewRoute  0
Router      router         mux.go      mux.go         46          struct      Go          mux         package                 /^type Router s  0
NotFoundHa  notfoundhandl  mux.go      mux.go         48          member      Go          mux.Router  struct                  /^	NotFoundHand  0
```

As a side effect, for any package `foo`, there will be N symbols named `foo` of kind `package`, one for each file in the package's directory. This isn't exactly desirable, but will be mitigated by scoping the symbols sidebar to the current file.

![image](https://user-images.githubusercontent.com/1387653/54548411-17b87580-4965-11e9-8901-4086917b5922.png)
