### PR TITLE
ci: add commit and date labels to our docker images

### DIFF
--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -22,4 +22,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/frontend; do
 done
 
 echo "--- docker build $IMAGE"
-docker build -f cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -22,4 +22,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/frontend; do
 done
 
 echo "--- docker build $IMAGE"
-docker build -f cmd/frontend/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/github-proxy/build.sh
+++ b/cmd/github-proxy/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/github-proxy; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/github-proxy/build.sh
+++ b/cmd/github-proxy/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/github-proxy; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/gitserver; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/gitserver; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/loadtest/build.sh
+++ b/cmd/loadtest/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/loadtest; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/loadtest/build.sh
+++ b/cmd/loadtest/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/loadtest; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/management-console/build.sh
+++ b/cmd/management-console/build.sh
@@ -21,4 +21,4 @@ for pkg in $path_to_package; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/management-console/build.sh
+++ b/cmd/management-console/build.sh
@@ -21,4 +21,4 @@ for pkg in $path_to_package; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/query-runner/build.sh
+++ b/cmd/query-runner/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/query-runner; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/query-runner/build.sh
+++ b/cmd/query-runner/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/query-runner; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/repo-updater/build.sh
+++ b/cmd/repo-updater/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/repo-updater; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/repo-updater/build.sh
+++ b/cmd/repo-updater/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/repo-updater; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/searcher/build.sh
+++ b/cmd/searcher/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/searcher; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT
+docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/searcher/build.sh
+++ b/cmd/searcher/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/searcher; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -46,4 +46,4 @@ echo "--- build sqlite for symbols"
 env CTAGS_D_OUTPUT_PATH="$OUTPUT/.ctags.d" SYMBOLS_EXECUTABLE_OUTPUT_PATH="$bindir/symbols" BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImageDependencies
 
 echo "--- docker build"
-docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT"
+docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -46,4 +46,4 @@ echo "--- build sqlite for symbols"
 env CTAGS_D_OUTPUT_PATH="$OUTPUT/.ctags.d" SYMBOLS_EXECUTABLE_OUTPUT_PATH="$bindir/symbols" BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImageDependencies
 
 echo "--- docker build"
-docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -172,7 +172,7 @@ function buildSymbolsDockerImage() {
     buildSymbolsDockerImageDependencies
 
     echo "Building the $IMAGE Docker image..."
-    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
     echo "Building the $IMAGE Docker image... done"
 }
 

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -172,7 +172,7 @@ function buildSymbolsDockerImage() {
     buildSymbolsDockerImageDependencies
 
     echo "Building the $IMAGE Docker image..."
-    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext"
+    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
     echo "Building the $IMAGE Docker image... done"
 }
 

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -172,7 +172,7 @@ function buildSymbolsDockerImage() {
     buildSymbolsDockerImageDependencies
 
     echo "Building the $IMAGE Docker image..."
-    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
     echo "Building the $IMAGE Docker image... done"
 }
 

--- a/enterprise/cmd/frontend/build.sh
+++ b/enterprise/cmd/frontend/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"
+docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"

--- a/enterprise/cmd/frontend/build.sh
+++ b/enterprise/cmd/frontend/build.sh
@@ -20,4 +20,4 @@ for pkg in github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT
+docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "commitSHA=$COMMIT_SHA" --label "version=$VERSION"

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -38,16 +38,16 @@ func main() {
 		commit = "1234567890123456789012345678901234567890" // for testing
 	}
 	taggedRelease := true // true if this is a semver tagged release
+	now := time.Now()
 	if !strings.HasPrefix(version, "v") {
 		taggedRelease = false
 		buildNum, _ := strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))
-		version = fmt.Sprintf("%05d_%s_%.7s", buildNum, time.Now().Format("2006-01-02"), commit)
+		version = fmt.Sprintf("%05d_%s_%.7s", buildNum, now.Format("2006-01-02"), commit)
 	} else {
 		// The Git tag "v1.2.3" should map to the Docker image "1.2.3" (without v prefix).
 		version = strings.TrimPrefix(version, "v")
 	}
 	releaseBranch := regexp.MustCompile(`^[0-9]+\.[0-9]+$`).MatchString(branch)
-	date := time.Now().Format(time.RFC3339)
 
 	isBextReleaseBranch := branch == "bext/release"
 
@@ -57,7 +57,7 @@ func main() {
 		bk.Env("FORCE_COLOR", "1"),
 		bk.Env("ENTERPRISE", "1"),
 		bk.Env("COMMIT_SHA", commit),
-		bk.Env("DATE", date),
+		bk.Env("DATE", now.Format(time.RFC3339)),
 	)
 
 	isPR := !isBextReleaseBranch &&

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -34,7 +34,6 @@ func main() {
 	branch := os.Getenv("BUILDKITE_BRANCH")
 	version := os.Getenv("BUILDKITE_TAG")
 	commit := os.Getenv("BUILDKITE_COMMIT")
-	date := time.Now().Format(time.RFC3339)
 	if commit == "" {
 		commit = "1234567890123456789012345678901234567890" // for testing
 	}
@@ -48,6 +47,7 @@ func main() {
 		version = strings.TrimPrefix(version, "v")
 	}
 	releaseBranch := regexp.MustCompile(`^[0-9]+\.[0-9]+$`).MatchString(branch)
+	date := time.Now().Format(time.RFC3339)
 
 	isBextReleaseBranch := branch == "bext/release"
 

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -55,6 +55,7 @@ func main() {
 		bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", "true"),
 		bk.Env("FORCE_COLOR", "1"),
 		bk.Env("ENTERPRISE", "1"),
+		bk.Env("COMMIT_SHA", commit),
 	)
 
 	isPR := !isBextReleaseBranch &&
@@ -91,7 +92,6 @@ func main() {
 			bk.Cmd("./cmd/server/pre-build.sh"),
 			bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
 			bk.Env("VERSION", version),
-			bk.Env("COMMIT_SHA", commit),
 			bk.Cmd("./cmd/server/build.sh"),
 			bk.Cmd("popd"))
 
@@ -202,7 +202,6 @@ func main() {
 
 		cmds = append(cmds,
 			bk.Env("IMAGE", image+":"+version),
-			bk.Env("COMMIT_SHA", commit),
 			bk.Env("VERSION", version),
 			bk.Cmd(getBuildScript()),
 		)

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -91,6 +91,7 @@ func main() {
 			bk.Cmd("./cmd/server/pre-build.sh"),
 			bk.Env("IMAGE", "sourcegraph/server:"+version+"_candidate"),
 			bk.Env("VERSION", version),
+			bk.Env("COMMIT_SHA", commit),
 			bk.Cmd("./cmd/server/build.sh"),
 			bk.Cmd("popd"))
 

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -34,6 +34,7 @@ func main() {
 	branch := os.Getenv("BUILDKITE_BRANCH")
 	version := os.Getenv("BUILDKITE_TAG")
 	commit := os.Getenv("BUILDKITE_COMMIT")
+	date := time.Now().Format(time.RFC3339)
 	if commit == "" {
 		commit = "1234567890123456789012345678901234567890" // for testing
 	}
@@ -56,6 +57,7 @@ func main() {
 		bk.Env("FORCE_COLOR", "1"),
 		bk.Env("ENTERPRISE", "1"),
 		bk.Env("COMMIT_SHA", commit),
+		bk.Env("DATE", date),
 	)
 
 	isPR := !isBextReleaseBranch &&

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -33,13 +33,13 @@ func main() {
 
 	branch := os.Getenv("BUILDKITE_BRANCH")
 	version := os.Getenv("BUILDKITE_TAG")
+	commit := os.Getenv("BUILDKITE_COMMIT")
+	if commit == "" {
+		commit = "1234567890123456789012345678901234567890" // for testing
+	}
 	taggedRelease := true // true if this is a semver tagged release
 	if !strings.HasPrefix(version, "v") {
 		taggedRelease = false
-		commit := os.Getenv("BUILDKITE_COMMIT")
-		if commit == "" {
-			commit = "1234567890123456789012345678901234567890" // for testing
-		}
 		buildNum, _ := strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))
 		version = fmt.Sprintf("%05d_%s_%.7s", buildNum, time.Now().Format("2006-01-02"), commit)
 	} else {
@@ -201,6 +201,7 @@ func main() {
 
 		cmds = append(cmds,
 			bk.Env("IMAGE", image+":"+version),
+			bk.Env("COMMIT_SHA", commit),
 			bk.Env("VERSION", version),
 			bk.Cmd(getBuildScript()),
 		)


### PR DESCRIPTION
This PR tells CI to add [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) for the commit sha and timestamp to all of our images. We should now be able to get this information via `docker inspect` from now on. 

The label names / definitions come from https://github.com/opencontainers/image-spec/blob/master/annotations.md