### PR TITLE
CI: fix e2e tests

### DIFF
--- a/web/src/marketing/Toast.tsx
+++ b/web/src/marketing/Toast.tsx
@@ -19,7 +19,7 @@ export class Toast extends React.Component<Props, {}> {
                     {this.props.subtitle}
                     {this.props.cta && <div className="toast__contents-cta">{this.props.cta}</div>}
                 </div>
-                <button onClick={this.props.onDismiss} className="toast__close-button btn btn-icon">
+                <button onClick={this.props.onDismiss} className="toast__close-button btn btn-icon e2e-close-toast">
                     <CloseIcon className="icon-inline" />
                 </button>
             </div>


### PR DESCRIPTION
- Closes the integrations toast, which was preventing focusing of the external service configuration editor
- Replaces the external service name, which used to be blank but now defaults to the name of the service
- Sets `localStorage` to disable toasts