### PR TITLE
management console: always use relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue which prevented Sourcegraph's management console from being hosted under a subdirectory (e.g. `/console`) when behind a reverse proxy.
+
 ### Removed
 
 ## 3.2.0

--- a/cmd/management-console/web/package.json
+++ b/cmd/management-console/web/package.json
@@ -7,8 +7,8 @@
     "rxjs": "^6.3.3"
   },
   "scripts": {
-    "serve": "cp ../../../ui/assets/img/favicon.png ./src && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/parcel serve --out-dir=../assets --no-source-maps -p 2680 src/index.html",
-    "build": "cp ../../../ui/assets/img/favicon.png ./src && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/parcel build --out-dir=../assets --no-source-maps --no-minify src/index.html"
+    "serve": "cp ../../../ui/assets/img/favicon.png ./src && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/parcel serve --public-url ./ --out-dir=../assets --no-source-maps -p 2680 src/index.html",
+    "build": "cp ../../../ui/assets/img/favicon.png ./src && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/parcel build --public-url ./ --out-dir=../assets --no-source-maps --no-minify src/index.html"
   },
   "devDependencies": {
     "monaco-editor": "^0.15.0",

--- a/cmd/management-console/web/src/CriticalConfigEditor.tsx
+++ b/cmd/management-console/web/src/CriticalConfigEditor.tsx
@@ -103,7 +103,7 @@ export class CriticalConfigEditor extends React.Component<Props, State> {
 
         // Load the initial critical config.
         this.subscriptions.add(
-            ajax('/api/get')
+            ajax('api/get')
                 .pipe(
                     delay(DEBUG_LOADING_STATE_DELAY),
                     catchError(err => of(err.xhr))
@@ -175,7 +175,7 @@ export class CriticalConfigEditor extends React.Component<Props, State> {
             () =>
                 this.subscriptions.add(
                     from(
-                        fetch('/api/update', {
+                        fetch('api/update', {
                             method: 'POST',
                             body: JSON.stringify({
                                 LastID: this.state.criticalConfig.ID,


### PR DESCRIPTION
This allows us to use a reverse proxy in front of the management console and
mount it at a subdirectory like e.g. `/console`.

Test plan: Build a sourcegraph/server image with this and verify the management console works regularly (i.e. without a reverse proxy). Merge. Then verify it works with a reverse proxy.