### PR TITLE
ci: Move Docker labels declaration inside Dockerfile

### DIFF
--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 ENV CONFIGURATION_MODE=server PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg PUBLIC_REPO_REDIRECTS=true CACHE_DIR=/mnt/cache/frontend
 USER sourcegraph
 CMD ["serve"]

--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -22,4 +22,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/frontend; do
 done
 
 echo "--- docker build $IMAGE"
-docker build -f cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/frontend/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/github-proxy/Dockerfile
+++ b/cmd/github-proxy/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/github-proxy/Dockerfile
+++ b/cmd/github-proxy/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 ENV LOG_REQUEST=true
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/github-proxy"]

--- a/cmd/github-proxy/build.sh
+++ b/cmd/github-proxy/build.sh
@@ -20,4 +20,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/github-proxy; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/github-proxy/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 # hadolint ignore=DL3018

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -20,4 +20,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/gitserver; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/gitserver/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/loadtest/Dockerfile
+++ b/cmd/loadtest/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/loadtest/Dockerfile
+++ b/cmd/loadtest/Dockerfile
@@ -4,5 +4,15 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/loadtest"]
 COPY loadtest /usr/local/bin/

--- a/cmd/loadtest/build.sh
+++ b/cmd/loadtest/build.sh
@@ -20,4 +20,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/loadtest; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/loadtest/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/management-console/Dockerfile
+++ b/cmd/management-console/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 ENV PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/management-console"]

--- a/cmd/management-console/Dockerfile
+++ b/cmd/management-console/Dockerfile
@@ -12,8 +12,8 @@ ARG VERSION="unknown"
 LABEL org.opencontainers.image.revision=${COMMIT_SHA}
 LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
-
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 ENV PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/management-console"]

--- a/cmd/management-console/Dockerfile
+++ b/cmd/management-console/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/management-console/build.sh
+++ b/cmd/management-console/build.sh
@@ -21,4 +21,7 @@ for pkg in $path_to_package; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/management-console/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/query-runner/Dockerfile
+++ b/cmd/query-runner/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/query-runner"]
 COPY query-runner /usr/local/bin/

--- a/cmd/query-runner/Dockerfile
+++ b/cmd/query-runner/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/query-runner/build.sh
+++ b/cmd/query-runner/build.sh
@@ -20,4 +20,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/query-runner; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/query-runner/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/repo-updater/Dockerfile
+++ b/cmd/repo-updater/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/repo-updater/Dockerfile
+++ b/cmd/repo-updater/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/repo-updater"]
 COPY repo-updater /usr/local/bin/

--- a/cmd/repo-updater/build.sh
+++ b/cmd/repo-updater/build.sh
@@ -20,4 +20,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/repo-updater; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/repo-updater/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 ENV CACHE_DIR=/mnt/cache/searcher
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/searcher"]

--- a/cmd/searcher/build.sh
+++ b/cmd/searcher/build.sh
@@ -20,4 +20,7 @@ for pkg in github.com/sourcegraph/sourcegraph/cmd/searcher; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/searcher/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,19 +1,28 @@
 FROM alpine:3.9 AS ctags
 
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 # hadolint ignore=DL3003,DL3018,DL4006
 RUN apk --no-cache add --virtual build-deps curl jansson-dev \
-  libseccomp-dev linux-headers autoconf pkgconfig make automake \
-  gcc g++ binutils
+    libseccomp-dev linux-headers autoconf pkgconfig make automake \
+    gcc g++ binutils
 
 ENV CTAGS_VERSION=08a69b5a030cf56c079e3006238b992b34c9cc51
 
 # hadolint ignore=DL3003
 RUN curl -fsSL -o ctags.tar.gz "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" && \
-  tar -C /tmp -xzf ctags.tar.gz && cd /tmp/ctags-$CTAGS_VERSION && \
-  ./autogen.sh && LDFLAGS=-static ./configure --program-prefix=universal- --enable-json --enable-seccomp && \
-  make -j8 && make install && cd && \
-  rm -rf /tmp/ctags-$CTAGS_VERSION && \
-  apk --no-cache --purge del build-deps
+    tar -C /tmp -xzf ctags.tar.gz && cd /tmp/ctags-$CTAGS_VERSION && \
+    ./autogen.sh && LDFLAGS=-static ./configure --program-prefix=universal- --enable-json --enable-seccomp && \
+    make -j8 && make install && cd && \
+    rm -rf /tmp/ctags-$CTAGS_VERSION && \
+    apk --no-cache --purge del build-deps
 
 # TODO: Make this image use our sourcegraph/alpine:3.9 base image.
 FROM alpine:3.9
@@ -28,13 +37,13 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repo
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
-  # NOTE that the Postgres version we run is different
-  # from our *Minimum Supported Version* which alone dictates
-  # the features we can depend on. See this link for more information:
-  # https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/postgresql.md#version-requirements
-  'bash=4.4.19-r1' 'postgresql-contrib=11.1-r0' 'postgresql=11.1-r0' \
-  'redis=3.2.12-r0' bind-tools ca-certificates git@edge \
-  mailcap nginx openssh-client su-exec tini
+    # NOTE that the Postgres version we run is different
+    # from our *Minimum Supported Version* which alone dictates
+    # the features we can depend on. See this link for more information:
+    # https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/postgresql.md#version-requirements
+    'bash=4.4.19-r1' 'postgresql-contrib=11.1-r0' 'postgresql=11.1-r0' \
+    'redis=3.2.12-r0' bind-tools ca-certificates git@edge \
+    mailcap nginx openssh-client su-exec tini
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:056c730 /syntect_server /usr/local/bin/

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -46,4 +46,7 @@ echo "--- build sqlite for symbols"
 env CTAGS_D_OUTPUT_PATH="$OUTPUT/.ctags.d" SYMBOLS_EXECUTABLE_OUTPUT_PATH="$bindir/symbols" BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImageDependencies
 
 echo "--- docker build"
-docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -173,9 +173,9 @@ function buildSymbolsDockerImage() {
 
     echo "Building the $IMAGE Docker image..."
     docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" \
-    --build-arg COMMIT_SHA \
-    --build-arg DATE \
-    --build-arg VERSION
+        --build-arg COMMIT_SHA \
+        --build-arg DATE \
+        --build-arg VERSION
     echo "Building the $IMAGE Docker image... done"
 }
 

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -172,7 +172,10 @@ function buildSymbolsDockerImage() {
     buildSymbolsDockerImageDependencies
 
     echo "Building the $IMAGE Docker image..."
-    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+    docker build --quiet -f cmd/symbols/Dockerfile -t "$IMAGE" "$symbolsDockerBuildContext" \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION
     echo "Building the $IMAGE Docker image... done"
 }
 

--- a/docker-images/alpine/Dockerfile
+++ b/docker-images/alpine/Dockerfile
@@ -3,6 +3,10 @@
 
 FROM alpine:3.9
 
+LABEL org.opencontainers.image.url=https://sourcegraph.com/
+LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
+LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
+
 # Add the sourcegraph group, user, and create the home directory.
 #
 # We use a static GID/UID assignment to ensure files can be chown'd to this

--- a/enterprise/cmd/frontend/Dockerfile
+++ b/enterprise/cmd/frontend/Dockerfile
@@ -4,6 +4,16 @@
 # ignores.
 
 FROM sourcegraph/alpine:3.9
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
 ENV CONFIGURATION_MODE=server PGDATABASE=sg PGHOST=pgsql PGPORT=5432 PGSSLMODE=disable PGUSER=sg PUBLIC_REPO_REDIRECTS=true
 USER sourcegraph
 CMD ["serve"]

--- a/enterprise/cmd/frontend/Dockerfile
+++ b/enterprise/cmd/frontend/Dockerfile
@@ -3,7 +3,7 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
-FROM sourcegraph/alpine:3.9@sha256:987f878657f0dd9734a597c9b5fe6ecd0bda633f6ea556103b9449838b1ed834
+FROM sourcegraph/alpine:3.9@sha256:e9264d4748e16de961a2b973cc12259dee1d33473633beccb1dfb8a0e62c6459
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/enterprise/cmd/frontend/build.sh
+++ b/enterprise/cmd/frontend/build.sh
@@ -20,4 +20,7 @@ for pkg in github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend; do
     go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o $OUTPUT/$(basename $pkg) $pkg
 done
 
-docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT --label "org.opencontainers.image.revision=$COMMIT_SHA" --label="org.opencontainers.image.created=$DATE" --label "org.opencontainers.image.version=$VERSION"
+docker build -f enterprise/cmd/frontend/Dockerfile -t $IMAGE $OUTPUT \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/sourcegraph/pull/2806

This PR:
1. Moves the `COMMIT_SHA`, etc. labels to be declared inside the Dockerfile via build args instead of in the `docker build ...` command. This is slightly cleaner, and makes it so that people don't need to remember the full metadata key (`org.opencontainer...`) when modifying the build scripts.
1. Adds basic URL, docs metadata labels to the `sourcegraph/alpine` image. All images that use `sourcegraph/alpine` as a base will inherit the value of these labels. cc @slimsag (The sourcegraph/alpine image will need to be re-deployed after this change)


