### PR TITLE
add code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![build](https://badge.buildkite.com/00bbe6fa9986c78b8e8591cffeb0b0f2e8c4bb610d7e339ff6.svg?branch=master)](https://buildkite.com/sourcegraph/sourcegraph)
 [![apache license](https://img.shields.io/badge/license-Apache-blue.svg)](LICENSE)
+[![Coverage](https://codecov.io/gh/sourcegraph/sourcegraph/branch/master/graph/badge.svg)](https://codecov.io/gh/sourcegraph/sourcegraph)
 
 [Sourcegraph](https://about.sourcegraph.com/) is a fast, open-source, fully-featured code search and navigation engine.
 


### PR DESCRIPTION
This will make it easier for anyone looking at the sourcegraph project to see the current level of test coverage and click through to see how it breaks down for the various subpackages.