### PR TITLE
Fix permissions request instructions in integration docs

### DIFF
--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -17,5 +17,9 @@ The [Sourcegraph browser extension](browser_extension.md) supports Bitbucket Ser
 
 1.  Install the [Sourcegraph browser extension](browser_extension.md).
 1.  [Configure the browser extension](browser_extension.md#configuring-the-sourcegraph-instance-to-use) to use your Sourcegraph instance.
-1.  Click the Sourcegraph icon in the browser toolbar to open the settings page. If a permissions notice is displayed, click **Grant permissions** to allow the browser extension to work on your Bitbucket Server instance.
+1.  To allow the browser extension to work on your Bitbucket Server instance:
+    - Navigate to any page on Bitbucket Server.
+    - Right-click the Sourcegraph icon in the browser extension toolbar.
+    - Click "Enable Sourcegraph on this domain".
+    - Click "Allow" in the permissions request popup.
 1.  Visit any file or pull request on Bitbucket Server. Hover over code or click the "View file" and "View repository" buttons.

--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -38,7 +38,9 @@ The Sourcegraph extension adds a search engine shortcut to your web browser that
 
 To install this search engine shortcut manually, and for more information, see "[Browser search engine shortcuts](browser_search_engine.md)".
 
-## Configuring the Sourcegraph instance to use
+## Configuration
+
+### Configuring the Sourcegraph instance to use
 
 By default, the browser extension communicates with [Sourcegraph.com](https://sourcegraph.com), which has only public code.
 
@@ -47,6 +49,17 @@ To use the browser extension with a different Sourcegraph instance:
 1.  Click the Sourcegraph extension icon in the browser toolbar to open the settings page.
 1.  Click **Update** and enter the URL of a Sourcegraph instance (such as `https://sourcegraph.example.com` or `https://sourcegraph.com`).
 1.  Click **Save**.
+
+### Enabling the browser extension on your code host
+
+By default, the Sourcegraph browser extension will only provide code intelligence on [github.com](https://github.com/). It needs additional permissions in order to run on other code hosts.
+
+To grant these permissions:
+
+1.  Navigate to any page on your code host.
+1.  Right-click the Sourcegraph icon in the browser extension toolbar.
+1.  Click "Enable Sourcegraph on this domain".
+1.  Click "Allow" in the permissions request popup.
 
 ### Troubleshooting
 
@@ -58,7 +71,7 @@ Try the following:
 
 1.  Click the Sourcegraph extension icon in the browser toolbar to open the settings page.
     - Ensure that the Sourcegraph URL is correct. It must point to your own Sourcegraph instance to work on private code.
-    - Check whether any permissions must be granted. If so, the settings page will display an alert with a **Grant permissions** button.
+    - Check whether any permissions must be granted. If so, the settings page will offer you to "grant the Sourcegraph browser extension additional permissions".
 1. On some code hosts, you need to be signed in (to the code host) to use the browser extension. Try signing in.
 
 ## Privacy

--- a/doc/integration/gitlab.md
+++ b/doc/integration/gitlab.md
@@ -30,7 +30,11 @@ The [Sourcegraph browser extension](browser_extension.md) supports GitLab. When 
 
 - You can also use [`https://sourcegraph.com`](https://sourcegraph.com) for public code from GitLab.com only.
 
-1.  Click the Sourcegraph icon in the browser toolbar to open the settings page. If a permissions notice is displayed, click **Grant permissions** to allow the browser extension to work on your GitLab instance.
+1.  To allow the browser extension to work on your Gitlab:
+    - Navigate to any page on Gitlab.
+    - Right-click the Sourcegraph icon in the browser extension toolbar.
+    - Click "Enable Sourcegraph on this domain".
+    - Click "Allow" in the permissions request popup.
 1.  Visit any file or merge request on GitLab. Hover over code or click the "View file" and "View repository" buttons.
 
 ![Sourcegraph for GitLab](https://cl.ly/7916fe1453a4/download/sourcegraph-for-gitLab.gif)

--- a/doc/integration/phabricator.md
+++ b/doc/integration/phabricator.md
@@ -20,7 +20,11 @@ The [Sourcegraph browser extension](browser_extension.md) supports Phabricator. 
 
 1.  Install the [Sourcegraph browser extension](browser_extension.md).
 1.  [Configure the browser extension](browser_extension.md#configuring-the-sourcegraph-instance-to-use) to use your Sourcegraph instance.
-1.  Click the Sourcegraph icon in the browser toolbar to open the settings page. If a permissions notice is displayed, click **Grant permissions** to allow the browser extension to work on your Phabricator instance.
+1.  To allow the browser extension to work on your Phabricator instance:
+    - Navigate to any page on Phabricator.
+    - Right-click the Sourcegraph icon in the browser extension toolbar.
+    - Click "Enable Sourcegraph on this domain".
+    - Click "Allow" in the permissions request popup.
 1.  Visit any file or diff on Phabricator. Hover over code or click the "View file" and "View repository" buttons.
 
 > NOTE: Site admins can also install the [native Phabricator extension](../admin/external_service/phabricator.md#native-extension) to avoid needing each user to install the browser extension.


### PR DESCRIPTION
We used to display permissions notices in the options page, but we don't do it anymore. The integrations docs had not been updated to reflect this, and the current permissions request flow (right-click browser action + "Enable Sourcegraph on this domain") was not discoverable in the docs (see #2770, cc @slimsag).