### PR TITLE
docs: Removed hard-coded `master` value in shell example and removed multi-version support locally content until docsite is fixed

### DIFF
--- a/doc/dev/documentation/site.md
+++ b/doc/dev/documentation/site.md
@@ -16,26 +16,41 @@ The [local documentation server](index.md#previewing-changes-locally) on http://
 
 In very rare cases, you may want to run a local documentation server with a different configuration (described in the following sections).
 
+<!-- TODO(ryan): Uncomment once https://github.com/sourcegraph/docsite/issues/13 is fixed.
+
 ### Running multi-version support locally
+
+> NOTE: The below does not currently work due to an issue with docsite being unable to load a combination of content and templates/assets locally and over http.
 
 If you're working on a docs template change involving multiple content versions (i.e., doc site URL paths like `/@v1.2.3/my/doc/page`), then you must run a [docsite](https://github.com/sourcegraph/docsite) server that can read multiple content versions:
 
 ``` shell
-DOCSITE_CONFIG='{"templates":"doc/_resources/templates","assets":"doc/_resources/assets","content":"https://codeload.github.com/sourcegraph/sourcegraph/zip/$VERSION#*/doc/","baseURLPath":"/","assetsBaseURLPath":"/assets/"}' .bin/docsite serve -http=localhost:5081
+DOCSITE_CONFIG=$(cat <<-'DOCSITE'
+{
+  "templates": "_resources/templates",
+  "content": "https://codeload.github.com/sourcegraph/sourcegraph/zip/$VERSION#*/doc/",
+  "baseURLPath": "/",
+  "assets": "_resources/assets",
+  "assetsBaseURLPath": "/assets/"
+}
+DOCSITE
+) docsite serve -http=localhost:5081
+
 ```
 
 This runs a docsite server on http://localhost:5081 that reads templates and assets from disk (so yo can see your changes reflected immediately upon page reload) but reads content from the remote Git repository at any version (by default `master` if no version is given in the URL path, as in `/@v1.2.3/my/doc/page`).
+-->
 
 ### Running a local server that mimics prod configuration
 
 If you want to run the doc site *exactly* as it's deployed (reading templates and assets from the remote Git repository, too), consult the current Kubernetes deployment spec and invoke `docsite serve` with the deployment's `DOCSITE_CONFIG` env var, the end result looking something like:
 
 ```shell
-DOCSITE_CONFIG=$(cat <<-DOCSITE
+DOCSITE_CONFIG=$(cat <<-'DOCSITE'
 {
   "templates": "https://codeload.github.com/sourcegraph/sourcegraph/zip/master#*/doc/_resources/templates/",
   "assets": "https://codeload.github.com/sourcegraph/sourcegraph/zip/master#*/doc/_resources/assets/",
-  "content": "https://codeload.github.com/sourcegraph/sourcegraph/zip/master#*/doc/",
+  "content": "https://codeload.github.com/sourcegraph/sourcegraph/zip/$VERSION#*/doc/",
   "baseURLPath": "/",
   "assetsBaseURLPath": "/assets/"
 }


### PR DESCRIPTION
Docsite issue - sourcegraph/docsite#13