### PR TITLE
CI: fix async warning

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -287,7 +287,7 @@ describe('e2e test suite', function(this: any): void {
         await page.waitForSelector('.panel__tabs-content .hierarchical-locations-view__item')
     }
 
-    describe('External services', async () => {
+    describe('External services', () => {
         test('External service add, edit, delete', async () => {
             const displayName = 'e2e-github-test-2'
             await ensureHasExternalService(


### PR DESCRIPTION
Fixes the warning from https://buildkite.com/sourcegraph/sourcegraph/builds/29749#81e6aee4-9814-43b1-a96d-7fd05c281b18

> Returning a Promise from "describe" is not supported. Tests must be defined synchronously.

cc @beyang no action necessary