### PR TITLE
Add new fileLineContainer code view for github

### DIFF
--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -98,6 +98,37 @@ const commentSnippetCodeView: CodeView = {
     isDiff: false,
 }
 
+const fileLineContainerCodeView: CodeView = {
+    selector: '.js-file-line-container',
+    dom: singleFileDOMFunctions,
+    getToolbarMount: fileLineContainer => {
+        const codeViewParent = fileLineContainer.closest('.repository-content')
+        if (!codeViewParent) {
+            throw new Error('Repository content element not found')
+        }
+        const className = 'sourcegraph-app-annotator'
+        const existingMount = codeViewParent.querySelector(`.${className}`) as HTMLElement
+        if (existingMount) {
+            return existingMount
+        }
+        const mountEl = document.createElement('div')
+        mountEl.style.display = 'inline-flex'
+        mountEl.style.verticalAlign = 'middle'
+        mountEl.style.alignItems = 'center'
+        mountEl.className = className
+        const rawURLLink = codeViewParent.querySelector('#raw-url')
+        const buttonGroup = rawURLLink && rawURLLink.closest('.BtnGroup')
+        if (!buttonGroup || !buttonGroup.parentNode) {
+            throw new Error('File actions not found')
+        }
+        buttonGroup.parentNode.insertBefore(mountEl, buttonGroup)
+        return mountEl
+    },
+    resolveFileInfo,
+    toolbarButtonProps,
+    isDiff: false,
+}
+
 const resolveCodeView = (elem: HTMLElement): CodeViewWithOutSelector | null => {
     if (elem.querySelector('article.markdown-body')) {
         // This code view is rendered markdown, we shouldn't add code intelligence
@@ -148,7 +179,7 @@ const getOverlayMount = () => {
 
 export const githubCodeHost: CodeHost = {
     name: 'github',
-    codeViews: [searchResultCodeView, commentSnippetCodeView],
+    codeViews: [searchResultCodeView, commentSnippetCodeView, fileLineContainerCodeView],
     codeViewResolver,
     getContext: parseURL,
     getViewContextOnSourcegraphMount: createOpenOnSourcegraphIfNotExists,


### PR DESCRIPTION
Fixes #2857

Github.com's DOM changed, and the `'.file'` selector we used to rely on is obsolete.

This adds a new `CodeView` to handle the new Github DOM (but preserves the old selector because it is still useful on some PRs, and probably on GHE).

This new code view does not reuse the existing `createCodeViewToolbarMount()`, because it also relies on obsolete selectors (`'.file-actions'`).
