### PR TITLE
feat: Add config option to customize logo and search icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Enterprise admins can now customize the appearance of the homepage and search icon.
+
 ### Changed
 
 ### Fixed
@@ -23,7 +25,6 @@ All notable changes to Sourcegraph are documented in this file.
   To enable, open the user menu in the top right and make sure the theme dropdown is set to "System".
   This is currently supported on macOS Mojave with Safari Technology Preview 68 and later.
 - The `github.exclude` setting was added to the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) to allow excluding repositories yielded by `github.repos` or `github.repositoryQuery` from being synced.
-- Enterprise admins can now customize the appearance of the homepage and search icon.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
   To enable, open the user menu in the top right and make sure the theme dropdown is set to "System".
   This is currently supported on macOS Mojave with Safari Technology Preview 68 and later.
 - The `github.exclude` setting was added to the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) to allow excluding repositories yielded by `github.repos` or `github.repositoryQuery` from being synced.
+- Enterprise admins can now customize the appearance of the homepage and search icon.
 
 ### Changed
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -76,6 +76,8 @@ type JSContext struct {
 	ResetPasswordEnabled bool `json:"resetPasswordEnabled"`
 
 	AuthProviders []authProviderInfo `json:"authProviders"`
+
+	Branding schema.Branding `json:"branding"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -168,6 +170,8 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		AllowSignup: conf.AuthAllowSignup(),
 
 		AuthProviders: authProviders,
+
+		Branding: conf.Branding(),
 	}
 }
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -77,7 +77,7 @@ type JSContext struct {
 
 	AuthProviders []authProviderInfo `json:"authProviders"`
 
-	Branding schema.Branding `json:"branding"`
+	Branding *schema.Branding `json:"branding"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP

--- a/cmd/frontend/internal/app/misc_handlers.go
+++ b/cmd/frontend/internal/app/misc_handlers.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/assetsutil"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
 )
 
@@ -34,5 +35,9 @@ func robotsTxtHelper(w io.Writer, allowRobots bool) {
 }
 
 func favicon(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, assetsutil.URL("/img/favicon.png").String(), http.StatusMovedPermanently)
+	path := assetsutil.URL("/img/favicon.png").String()
+	if branding := conf.Branding(); branding != nil && branding.Favicon != "" {
+		path = branding.Favicon
+	}
+	http.Redirect(w, r, path, http.StatusMovedPermanently)
 }

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -292,13 +292,6 @@ func IsBuiltinSignupAllowed() bool {
 	return false
 }
 
-func Branding() schema.Branding {
-	brandSettings := Get().Branding
-	if brandSettings == nil {
-		return schema.Branding{
-			Logo:    "",
-			Favicon: "",
-		}
-	}
-	return *brandSettings
+func Branding() *schema.Branding {
+	return Get().Branding
 }

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -291,3 +291,14 @@ func IsBuiltinSignupAllowed() bool {
 	}
 	return false
 }
+
+func Branding() schema.Branding {
+	brandSettings := Get().Branding
+	if brandSettings == nil {
+		return schema.Branding{
+			Logo:    "",
+			Favicon: "",
+		}
+	}
+	return *brandSettings
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -95,8 +95,9 @@ type BitbucketServerConnection struct {
 
 // Branding description: Customize Sourcegraph homepage logo and search icon.
 type Branding struct {
+	Dark    *Dark  `json:"dark,omitempty"`
 	Favicon string `json:"favicon,omitempty"`
-	Logo    string `json:"logo,omitempty"`
+	Light   *Light `json:"light,omitempty"`
 }
 
 // BuiltinAuthProvider description: Configures the builtin username-password authentication provider.
@@ -129,6 +130,12 @@ type CriticalConfiguration struct {
 	Log                        *Log                `json:"log,omitempty"`
 	UpdateChannel              string              `json:"update.channel,omitempty"`
 	UseJaeger                  bool                `json:"useJaeger,omitempty"`
+}
+
+// Dark description: Override style for dark themes
+type Dark struct {
+	Logo   string `json:"logo,omitempty"`
+	Symbol string `json:"symbol,omitempty"`
 }
 
 // Discussions description: Configures Sourcegraph code discussions.
@@ -274,6 +281,12 @@ func (v *IdentityProvider) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, &v.Username)
 	}
 	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"oauth", "username", "external"})
+}
+
+// Light description: Override style for light themes
+type Light struct {
+	Logo   string `json:"logo,omitempty"`
+	Symbol string `json:"symbol,omitempty"`
 }
 
 // Log description: Configuration for logging and alerting, including to external services.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -93,6 +93,12 @@ type BitbucketServerConnection struct {
 	Username                    string `json:"username,omitempty"`
 }
 
+// Branding description: Customize Sourcegraph homepage logo and search icon.
+type Branding struct {
+	Favicon string `json:"favicon,omitempty"`
+	Logo    string `json:"logo,omitempty"`
+}
+
 // BuiltinAuthProvider description: Configures the builtin username-password authentication provider.
 type BuiltinAuthProvider struct {
 	AllowSignup bool   `json:"allowSignup,omitempty"`
@@ -377,6 +383,7 @@ type Settings struct {
 // SiteConfiguration description: Configuration for a Sourcegraph site.
 type SiteConfiguration struct {
 	AuthAccessTokens                  *AuthAccessTokens           `json:"auth.accessTokens,omitempty"`
+	Branding                          *Branding                   `json:"branding,omitempty"`
 	CorsOrigin                        string                      `json:"corsOrigin,omitempty"`
 	DisableAutoGitUpdates             bool                        `json:"disableAutoGitUpdates,omitempty"`
 	DisableBuiltInSearches            bool                        `json:"disableBuiltInSearches,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -92,12 +92,16 @@ type BitbucketServerConnection struct {
 	Url                         string `json:"url"`
 	Username                    string `json:"username,omitempty"`
 }
+type BrandAssets struct {
+	Logo   string `json:"logo,omitempty"`
+	Symbol string `json:"symbol,omitempty"`
+}
 
 // Branding description: Customize Sourcegraph homepage logo and search icon.
 type Branding struct {
-	Dark    *Dark  `json:"dark,omitempty"`
-	Favicon string `json:"favicon,omitempty"`
-	Light   *Light `json:"light,omitempty"`
+	Dark    *BrandAssets `json:"dark,omitempty"`
+	Favicon string       `json:"favicon,omitempty"`
+	Light   *BrandAssets `json:"light,omitempty"`
 }
 
 // BuiltinAuthProvider description: Configures the builtin username-password authentication provider.
@@ -130,12 +134,6 @@ type CriticalConfiguration struct {
 	Log                        *Log                `json:"log,omitempty"`
 	UpdateChannel              string              `json:"update.channel,omitempty"`
 	UseJaeger                  bool                `json:"useJaeger,omitempty"`
-}
-
-// Dark description: Override style for dark themes
-type Dark struct {
-	Logo   string `json:"logo,omitempty"`
-	Symbol string `json:"symbol,omitempty"`
 }
 
 // Discussions description: Configures Sourcegraph code discussions.
@@ -281,12 +279,6 @@ func (v *IdentityProvider) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, &v.Username)
 	}
 	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"oauth", "username", "external"})
-}
-
-// Light description: Override style for light themes
-type Light struct {
-	Logo   string `json:"logo,omitempty"`
-	Symbol string `json:"symbol,omitempty"`
 }
 
 // Log description: Configuration for logging and alerting, including to external services.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -146,33 +146,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "dark": {
-          "description": "Override style for dark themes",
-          "type": "object",
-          "properties": {
-            "logo": {
-              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
-              "type": "string"
-            },
-            "symbol": {
-              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
-              "type": "string"
-            }
-          }
-        },
         "light": {
-          "description": "Override style for light themes",
-          "type": "object",
-          "properties": {
-            "logo": {
-              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
-              "type": "string"
-            },
-            "symbol": {
-              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
-              "type": "string"
-            }
-          }
+          "$ref": "#/definitions/BrandAssets"
+        },
+        "dark": {
+            "$ref": "#/definitions/BrandAssets"
         },
         "favicon": {
           "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
@@ -319,6 +297,21 @@
       },
       "group": "Experimental",
       "hide": true
+    }
+  },
+  "definitions": {
+    "BrandAssets": {
+      "type": "object",
+      "properties": {
+        "logo": {
+          "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
+          "type": "string"
+        },
+        "symbol": {
+          "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -141,6 +141,23 @@
       ],
       "group": "Security"
     },
+    "branding": {
+      "description": "Customize Sourcegraph homepage logo and search icon.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "logo": {
+          "description": "The image URL to be used on the search homepage.",
+          "type": "string",
+          "default": ""
+        },
+        "favicon": {
+          "description": "The image URL to be used as the search icon.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
     "email.smtp": {
       "title": "SMTPServerConfig",
       "description": "The SMTP server used to send transactional emails (such as email verifications, reset-password emails, and notifications).",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -150,11 +150,12 @@
           "$ref": "#/definitions/BrandAssets"
         },
         "dark": {
-            "$ref": "#/definitions/BrandAssets"
+          "$ref": "#/definitions/BrandAssets"
         },
         "favicon": {
           "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -305,11 +306,13 @@
       "properties": {
         "logo": {
           "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         },
         "symbol": {
           "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       }
     }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -151,11 +151,11 @@
           "type": "object",
           "properties": {
             "logo": {
-              "description": "The URL to the logo used on the homepage.",
+              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
               "type": "string"
             },
             "symbol": {
-              "description": "The URL to the symbol used as the search icon.",
+              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
               "type": "string"
             }
           }
@@ -165,17 +165,17 @@
           "type": "object",
           "properties": {
             "logo": {
-              "description": "The URL to the logo used on the homepage.",
+              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
               "type": "string"
             },
             "symbol": {
-              "description": "The URL to the symbol used as the search icon.",
+              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
               "type": "string"
             }
           }
         },
         "favicon": {
-          "description": "The URL of the favicon to be used for your instance",
+          "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
           "type": "string"
         }
       }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -146,15 +146,37 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "logo": {
-          "description": "The image URL to be used on the search homepage.",
-          "type": "string",
-          "default": ""
+        "dark": {
+          "description": "Override style for dark themes",
+          "type": "object",
+          "properties": {
+            "logo": {
+              "description": "The URL to the logo used on the homepage.",
+              "type": "string"
+            },
+            "symbol": {
+              "description": "The URL to the symbol used as the search icon.",
+              "type": "string"
+            }
+          }
+        },
+        "light": {
+          "description": "Override style for light themes",
+          "type": "object",
+          "properties": {
+            "logo": {
+              "description": "The URL to the logo used on the homepage.",
+              "type": "string"
+            },
+            "symbol": {
+              "description": "The URL to the symbol used as the search icon.",
+              "type": "string"
+            }
+          }
         },
         "favicon": {
-          "description": "The image URL to be used as the search icon.",
-          "type": "string",
-          "default": ""
+          "description": "The URL of the favicon to be used for your instance",
+          "type": "string"
         }
       }
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -156,11 +156,11 @@ const SiteSchemaJSON = `{
           "type": "object",
           "properties": {
             "logo": {
-              "description": "The URL to the logo used on the homepage.",
+              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
               "type": "string"
             },
             "symbol": {
-              "description": "The URL to the symbol used as the search icon.",
+              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
               "type": "string"
             }
           }
@@ -170,17 +170,17 @@ const SiteSchemaJSON = `{
           "type": "object",
           "properties": {
             "logo": {
-              "description": "The URL to the logo used on the homepage.",
+              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
               "type": "string"
             },
             "symbol": {
-              "description": "The URL to the symbol used as the search icon.",
+              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
               "type": "string"
             }
           }
         },
         "favicon": {
-          "description": "The URL of the favicon to be used for your instance",
+          "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
           "type": "string"
         }
       }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -146,6 +146,23 @@ const SiteSchemaJSON = `{
       ],
       "group": "Security"
     },
+    "branding": {
+      "description": "Customize Sourcegraph homepage logo and search icon.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "logo": {
+          "description": "The image URL to be used on the search homepage.",
+          "type": "string",
+          "default": ""
+        },
+        "favicon": {
+          "description": "The image URL to be used in the navigation bar.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
     "email.smtp": {
       "title": "SMTPServerConfig",
       "description": "The SMTP server used to send transactional emails (such as email verifications, reset-password emails, and notifications).",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -151,15 +151,37 @@ const SiteSchemaJSON = `{
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "logo": {
-          "description": "The image URL to be used on the search homepage.",
-          "type": "string",
-          "default": ""
+        "dark": {
+          "description": "Override style for dark themes",
+          "type": "object",
+          "properties": {
+            "logo": {
+              "description": "The URL to the logo used on the homepage.",
+              "type": "string"
+            },
+            "symbol": {
+              "description": "The URL to the symbol used as the search icon.",
+              "type": "string"
+            }
+          }
+        },
+        "light": {
+          "description": "Override style for light themes",
+          "type": "object",
+          "properties": {
+            "logo": {
+              "description": "The URL to the logo used on the homepage.",
+              "type": "string"
+            },
+            "symbol": {
+              "description": "The URL to the symbol used as the search icon.",
+              "type": "string"
+            }
+          }
         },
         "favicon": {
-          "description": "The image URL to be used in the navigation bar.",
-          "type": "string",
-          "default": ""
+          "description": "The URL of the favicon to be used for your instance",
+          "type": "string"
         }
       }
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -155,11 +155,12 @@ const SiteSchemaJSON = `{
           "$ref": "#/definitions/BrandAssets"
         },
         "dark": {
-            "$ref": "#/definitions/BrandAssets"
+          "$ref": "#/definitions/BrandAssets"
         },
         "favicon": {
           "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -310,11 +311,13 @@ const SiteSchemaJSON = `{
       "properties": {
         "logo": {
           "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         },
         "symbol": {
           "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       }
     }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -151,33 +151,11 @@ const SiteSchemaJSON = `{
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "dark": {
-          "description": "Override style for dark themes",
-          "type": "object",
-          "properties": {
-            "logo": {
-              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
-              "type": "string"
-            },
-            "symbol": {
-              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
-              "type": "string"
-            }
-          }
-        },
         "light": {
-          "description": "Override style for light themes",
-          "type": "object",
-          "properties": {
-            "logo": {
-              "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
-              "type": "string"
-            },
-            "symbol": {
-              "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
-              "type": "string"
-            }
-          }
+          "$ref": "#/definitions/BrandAssets"
+        },
+        "dark": {
+            "$ref": "#/definitions/BrandAssets"
         },
         "favicon": {
           "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
@@ -324,6 +302,21 @@ const SiteSchemaJSON = `{
       },
       "group": "Experimental",
       "hide": true
+    }
+  },
+  "definitions": {
+    "BrandAssets": {
+      "type": "object",
+      "properties": {
+        "logo": {
+          "description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
+          "type": "string"
+        },
+        "symbol": {
+          "description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -116,20 +116,17 @@ interface SourcegraphContext {
         favicon?: string
 
         /** Override style for light themes */
-        light?: {
-            /** The URL to the logo used on the homepage */
-            logo?: string
-            /** The URL to the symbol used as the search icon */
-            symbol?: string
-        }
+        light?: BrandAssets
         /** Override style for dark themes */
-        dark?: {
-            /** The URL to the logo used on the homepage */
-            logo?: string
-            /** The URL to the symbol used as the search icon */
-            symbol?: string
-        }
+        dark?: BrandAssets
     }
+}
+
+interface BrandAssets {
+    /** The URL to the logo used on the homepage */
+    logo?: string
+    /** The URL to the symbol used as the search icon */
+    symbol?: string
 }
 
 /**

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -112,10 +112,23 @@ interface SourcegraphContext {
 
     /** Custom branding for the homepage and search icon. */
     branding?: {
-        /** The URL to the logo used on the search homepage. */
-        logo: string
-        /** The URL to the icon used as the search logo */
-        favicon: string
+        /** The URL of the favicon to be used for your instance */
+        favicon?: string
+
+        /** Override style for light themes */
+        light?: {
+            /** The URL to the logo used on the homepage */
+            logo?: string
+            /** The URL to the symbol used as the search icon */
+            symbol?: string
+        }
+        /** Override style for dark themes */
+        dark?: {
+            /** The URL to the logo used on the homepage */
+            logo?: string
+            /** The URL to the symbol used as the search icon */
+            symbol?: string
+        }
     }
 }
 

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -109,6 +109,14 @@ interface SourcegraphContext {
         isBuiltin: boolean
         authenticationURL?: string
     }[]
+
+    /** Custom branding for the homepage and search icon. */
+    branding?: {
+        /** The URL to the logo used on the search homepage. */
+        logo: string
+        /** The URL to the icon used as the search logo */
+        favicon: string
+    }
 }
 
 /**

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -85,10 +85,17 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                 ? '/.assets/img/sourcegraph-light-head-logo.svg'
                 : '/.assets/img/sourcegraph-head-logo.svg'
         } else {
-            logoSrc =
-                window.context.branding && window.context.branding.favicon
-                    ? window.context.branding.favicon
-                    : '/.assets/img/sourcegraph-mark.svg'
+            logoSrc = '/.assets/img/sourcegraph-mark.svg'
+            const { branding } = window.context
+            if (branding) {
+                if (this.props.isLightTheme) {
+                    if (branding.light && branding.light.symbol) {
+                        logoSrc = branding.light.symbol
+                    }
+                } else if (branding.dark && branding.dark.symbol) {
+                    logoSrc = branding.dark.symbol
+                }
+            }
         }
 
         const logo = (

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -85,7 +85,10 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                 ? '/.assets/img/sourcegraph-light-head-logo.svg'
                 : '/.assets/img/sourcegraph-head-logo.svg'
         } else {
-            logoSrc = '/.assets/img/sourcegraph-mark.svg'
+            logoSrc =
+                window.context.branding && window.context.branding.favicon
+                    ? window.context.branding.favicon
+                    : '/.assets/img/sourcegraph-mark.svg'
         }
 
         const logo = (

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -58,18 +58,18 @@ export class SearchPage extends React.Component<Props, State> {
     }
 
     public render(): JSX.Element | null {
+        let logoUrl =
+            `${window.context.assetsRoot}/img/sourcegraph` +
+            (this.props.isLightTheme ? '-light' : '') +
+            '-head-logo.svg'
+        if (window.context.branding && window.context.branding.logo) {
+            logoUrl = window.context.branding.logo
+        }
         const hasScopes = this.getScopes().length > 0
         return (
             <div className="search-page">
                 <PageTitle title={this.getPageTitle()} />
-                <img
-                    className="search-page__logo"
-                    src={
-                        `${window.context.assetsRoot}/img/sourcegraph` +
-                        (this.props.isLightTheme ? '-light' : '') +
-                        '-head-logo.svg'
-                    }
-                />
+                <img className="search-page__logo" src={logoUrl} />
                 <Form className="search search-page__container" onSubmit={this.onSubmit}>
                     <div className="search-page__input-container">
                         <QueryInput

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -62,8 +62,15 @@ export class SearchPage extends React.Component<Props, State> {
             `${window.context.assetsRoot}/img/sourcegraph` +
             (this.props.isLightTheme ? '-light' : '') +
             '-head-logo.svg'
-        if (window.context.branding && window.context.branding.logo) {
-            logoUrl = window.context.branding.logo
+        const { branding } = window.context
+        if (branding) {
+            if (this.props.isLightTheme) {
+                if (branding.light && branding.light.logo) {
+                    logoUrl = branding.light.logo
+                }
+            } else if (branding.dark && branding.dark.logo) {
+                logoUrl = branding.dark.logo
+            }
         }
         const hasScopes = this.getScopes().length > 0
         return (


### PR DESCRIPTION
Adds a lightweight way to customize the homepage logo, search icon, and favicon. Supports light and dark theme icons.

Future additions:
~Support light and dark theme for both icons (if this is something we want now I can update PR)~
- Allow custom CSS to override theme
