### PR TITLE
Symbols: scope sidebar to current file or directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- The symbols sidebar now only shows symbols defined in the current file or directory.
+
 ### Fixed
 
 ### Removed

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1726,6 +1726,9 @@ type GitCommit implements Node {
         first: Int
         # Return symbols matching the query.
         query: String
+        # A list of regular expressions, all of which must match all
+        # file paths returned in the list.
+        includePatterns: [String!]
     ): SymbolConnection!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1733,6 +1733,9 @@ type GitCommit implements Node {
         first: Int
         # Return symbols matching the query.
         query: String
+        # A list of regular expressions, all of which must match all
+        # file paths returned in the list.
+        includePatterns: [String!]
     ): SymbolConnection!
 }
 

--- a/web/src/repo/RepoRevSidebar.tsx
+++ b/web/src/repo/RepoRevSidebar.tsx
@@ -125,6 +125,7 @@ export class RepoRevSidebar extends React.PureComponent<Props, State> {
                             key="symbols"
                             repoID={this.props.repoID}
                             rev={this.props.rev}
+                            activePath={this.props.filePath}
                             history={this.props.history}
                             location={this.props.location}
                         />

--- a/web/src/repo/RepoRevSidebarSymbols.tsx
+++ b/web/src/repo/RepoRevSidebarSymbols.tsx
@@ -61,6 +61,7 @@ interface Props {
     rev: string | undefined
     history: H.History
     location: H.Location
+    /** The path of the file or directory currently shown in the content area */
     activePath: string
 }
 

--- a/web/src/symbols/backend.tsx
+++ b/web/src/symbols/backend.tsx
@@ -11,15 +11,15 @@ import { queryGraphQL } from '../backend/graphql'
 export function fetchSymbols(
     repo: GQL.ID,
     rev: string,
-    args: { first?: number; query?: string }
+    args: { first?: number; query?: string; includePatterns?: string[] }
 ): Observable<GQL.ISymbolConnection> {
     return queryGraphQL(
         gql`
-            query Symbols($repo: ID!, $rev: String!, $first: Int, $query: String) {
+            query Symbols($repo: ID!, $rev: String!, $first: Int, $query: String, $includePatterns: [String!]) {
                 node(id: $repo) {
                     ... on Repository {
                         commit(rev: $rev) {
-                            symbols(first: $first, query: $query) {
+                            symbols(first: $first, query: $query, includePatterns: $includePatterns) {
                                 pageInfo {
                                     hasNextPage
                                 }


### PR DESCRIPTION
Previously, the symbols sidebar would show ALL symbols in the entire repository.

Now, the sidebar will only show symbols defined in the current file (or directory, or the entire repository if you're at the repository's home page).

![image](https://user-images.githubusercontent.com/1387653/54726047-8bf24500-4b2e-11e9-92f5-ef0c11aca159.png)
