### PR TITLE
replace auth.disableUsernameChanges with auth.enableUsernameChanges

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -305,10 +305,10 @@ func viewerCanChangeUsername(ctx context.Context, userID int32) bool {
 	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
 		return false
 	}
-	if !conf.Get().Critical.AuthDisableUsernameChanges {
+	if conf.Get().Critical.AuthEnableUsernameChanges {
 		return true
 	}
-	// 🚨 SECURITY: Only site admins are allowed to change a user's username when auth.disableUsernameChanges == true.
+	// 🚨 SECURITY: Only site admins are allowed to change a user's username when auth.enableUsernameChanges == false.
 	isSiteAdminErr := backend.CheckCurrentUserIsSiteAdmin(ctx)
 	return isSiteAdminErr == nil
 }

--- a/cmd/frontend/internal/auth/config.go
+++ b/cmd/frontend/internal/auth/config.go
@@ -12,5 +12,11 @@ func validateConfig(c conf.Unified) (problems []string) {
 	if len(c.Critical.AuthProviders) == 0 {
 		problems = append(problems, "no auth providers set (all access will be forbidden)")
 	}
+
+	// Validate that `auth.enableUsernameChanges` is not set if SSO is configured
+	if conf.HasExternalAuthProvider(c) && c.Critical.AuthEnableUsernameChanges {
+		problems = append(problems, "`auth.enableUsernameChanges` must not be true if external auth providers are set in `auth.providers`")
+	}
+
 	return problems
 }

--- a/pkg/conf/helpers.go
+++ b/pkg/conf/helpers.go
@@ -1,0 +1,10 @@
+package conf
+
+func HasExternalAuthProvider(c Unified) bool {
+	for _, p := range c.Critical.AuthProviders {
+		if p.Builtin == nil { // not builtin implies SSO
+			return true
+		}
+	}
+	return false
+}

--- a/schema/critical.schema.json
+++ b/schema/critical.schema.json
@@ -125,7 +125,12 @@
       "group": "Authentication"
     },
     "auth.disableUsernameChanges": {
-      "description": "Prevent users from changing their username after account creation.",
+      "description": "WARNING: This option has been removed in favor of `auth.enableUsernameChanges`. As of 3.3, it has no effect, and as of 3.4, it will be removed entirely.",
+      "type": "boolean",
+      "default": false
+    },
+    "auth.enableUsernameChanges": {
+      "description": "Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.",
       "type": "boolean",
       "default": false
     },

--- a/schema/critical_stringdata.go
+++ b/schema/critical_stringdata.go
@@ -130,7 +130,12 @@ const CriticalSchemaJSON = `{
       "group": "Authentication"
     },
     "auth.disableUsernameChanges": {
-      "description": "Prevent users from changing their username after account creation.",
+      "description": "WARNING: This option has been removed in favor of ` + "`" + `auth.enableUsernameChanges` + "`" + `. As of 3.3, it has no effect, and as of 3.4, it will be removed entirely.",
+      "type": "boolean",
+      "default": false
+    },
+    "auth.enableUsernameChanges": {
+      "description": "Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or SSO provider. For this reason, setting this to true is disallowed if any SSO provider is currently configured in the ` + "`" + `auth.providers` + "`" + ` field of the critical site configuration or if any permissions are enabled that rely on username equivalency.",
       "type": "boolean",
       "default": false
     },

--- a/schema/critical_stringdata.go
+++ b/schema/critical_stringdata.go
@@ -135,7 +135,7 @@ const CriticalSchemaJSON = `{
       "default": false
     },
     "auth.enableUsernameChanges": {
-      "description": "Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or SSO provider. For this reason, setting this to true is disallowed if any SSO provider is currently configured in the ` + "`" + `auth.providers` + "`" + ` field of the critical site configuration or if any permissions are enabled that rely on username equivalency.",
+      "description": "Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.",
       "type": "boolean",
       "default": false
     },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -108,6 +108,7 @@ type CloneURLToRepositoryName struct {
 // CriticalConfiguration description: Critical configuration for a Sourcegraph site.
 type CriticalConfiguration struct {
 	AuthDisableUsernameChanges bool                `json:"auth.disableUsernameChanges,omitempty"`
+	AuthEnableUsernameChanges  bool                `json:"auth.enableUsernameChanges,omitempty"`
 	AuthProviders              []AuthProviders     `json:"auth.providers,omitempty"`
 	AuthPublic                 bool                `json:"auth.public,omitempty"`
 	AuthSessionExpiry          string              `json:"auth.sessionExpiry,omitempty"`


### PR DESCRIPTION
Replace `auth.disableUsernameChanges` with `auth.enableUsernameChanges`, which defaults to false. Addresses https://github.com/sourcegraph/sourcegraph/issues/2438.