### PR TITLE
Fix local repo path

### DIFF
--- a/doc/admin/repo/add_from_local_disk.md
+++ b/doc/admin/repo/add_from_local_disk.md
@@ -10,18 +10,18 @@ If you're using the default `--volume $HOME/.sourcegraph/data:/var/opt/sourcegra
 
 1.  If Sourcegraph is running, ensure the repository is disabled so it doesn't attempt to clone it.
 
-1.  On the host machine, ensure that a bare Git clone of the repository exists at `$HOME/.sourcegraph/repos/github.com/my/repo/.git`.
+1.  On the host machine, ensure that a bare Git clone of the repository exists at `$HOME/.sourcegraph/data/repos/github.com/my/repo/.git`.
 
     To create a new clone given its clone URL:
 
     ```
-    git clone --mirror YOUR-REPOSITORY-CLONE-URL $HOME/.sourcegraph/repos/github.com/my/repo/.git
+    git clone --mirror YOUR-REPOSITORY-CLONE-URL $HOME/.sourcegraph/data/repos/github.com/my/repo/.git
     ```
 
     Or, as an optimization, you can reuse an existing local clone to avoid needing to fetch all the repository data again:
 
     ```
-    git clone --mirror --reference PATH-TO-YOUR-EXISTING-LOCAL-CLONE --dissociate YOUR-REPOSITORY-CLONE-URL $HOME/.sourcegraph/repos/github.com/my/repo/.git
+    git clone --mirror --reference PATH-TO-YOUR-EXISTING-LOCAL-CLONE --dissociate YOUR-REPOSITORY-CLONE-URL $HOME/.sourcegraph/data/repos/github.com/my/repo/.git
     ```
 
 1.  Ensure that the code host of the added repository is configured as an [external service](../external_service/index.md).


### PR DESCRIPTION
It looks like local repos should be under `$HOME/.sourcegraph/data/repos` rather than `$HOME/.sourcegraph/repos`.