### PR TITLE
optimize graphqlbackend gitserver API usage to improve performance of admin repositories page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue where the site-admin repositories page `Cloning`, `Not Cloned`, `Needs Index` tabs were very slow on instances with thousands of repositories.
+
 ## 3.2.2
 
 ### Changed

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -135,7 +135,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 					lookup[repo.Name] = repo
 				}
 				keepRepos := repos[:0]
-				info, err := gitserver.DefaultClient.MultiRepoInfo(ctx, repoNames)
+				info, err := gitserver.DefaultClient.RepoInfo(ctx, repoNames)
 				if err != nil {
 					r.err = err
 					return

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -135,7 +135,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 					lookup[repo.Name] = repo
 				}
 				keepRepos := repos[:0]
-				info, err := gitserver.DefaultClient.RepoInfo(ctx, repoNames)
+				info, err := gitserver.DefaultClient.RepoInfo(ctx, repoNames...)
 				if err != nil {
 					r.err = err
 					return

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -32,11 +32,11 @@ type repositoryMirrorInfoResolver struct {
 
 	// memoize the gitserver RepoInfo call
 	repoInfoOnce     sync.Once
-	repoInfoResponse *protocol.RepoInfoResponse
+	repoInfoResponse *protocol.RepoInfo
 	repoInfoErr      error
 }
 
-func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfoResponse, error) {
+func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfo, error) {
 	r.repoInfoOnce.Do(func() {
 		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.repo.Name)
 		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.repo.Name], err

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -38,7 +38,8 @@ type repositoryMirrorInfoResolver struct {
 
 func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfoResponse, error) {
 	r.repoInfoOnce.Do(func() {
-		r.repoInfoResponse, r.repoInfoErr = gitserver.DefaultClient.RepoInfo(ctx, r.repository.repo.Name)
+		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.repo.Name)
+		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.repo.Name], err
 	})
 	return r.repoInfoResponse, r.repoInfoErr
 }

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -82,7 +82,7 @@ func (s *Server) handleMultiRepoInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRepoDelete(w http.ResponseWriter, r *http.Request) {
-	var req protocol.RepoInfoRequest
+	var req protocol.RepoDeleteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -14,10 +14,10 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-func (s *Server) doRepoInfo(ctx context.Context, repo api.RepoName) (*protocol.RepoInfoResponse, error) {
+func (s *Server) repoInfo(ctx context.Context, repo api.RepoName) (*protocol.RepoInfo, error) {
 	repo = protocol.NormalizeRepo(repo)
 	dir := path.Join(s.ReposDir, string(repo))
-	resp := protocol.RepoInfoResponse{
+	resp := protocol.RepoInfo{
 		Cloned: repoCloned(dir),
 	}
 	if resp.Cloned {
@@ -64,10 +64,10 @@ func (s *Server) handleRepoInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := protocol.RepoInfoResponse{
-		Results: make(map[api.RepoName]*protocol.RepoInfoResponse, len(req.Repos)),
+		Results: make(map[api.RepoName]*protocol.RepoInfo, len(req.Repos)),
 	}
 	for _, repoName := range req.Repos {
-		result, err := s.doRepoInfo(r.Context(), repoName)
+		result, err := s.repoInfo(r.Context(), repoName)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -56,14 +56,14 @@ func (s *Server) doRepoInfo(ctx context.Context, repo api.RepoName) (*protocol.R
 	return &resp, nil
 }
 
-func (s *Server) handleMultiRepoInfo(w http.ResponseWriter, r *http.Request) {
-	var req protocol.MultiRepoInfoRequest
+func (s *Server) handleRepoInfo(w http.ResponseWriter, r *http.Request) {
+	var req protocol.RepoInfoRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	resp := protocol.MultiRepoInfoResponse{
+	resp := protocol.RepoInfoResponse{
 		Results: make(map[api.RepoName]*protocol.RepoInfoResponse),
 	}
 	for _, repoName := range req.Repos {

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -64,7 +64,7 @@ func (s *Server) handleRepoInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := protocol.RepoInfoResponse{
-		Results: make(map[api.RepoName]*protocol.RepoInfoResponse),
+		Results: make(map[api.RepoName]*protocol.RepoInfoResponse, len(req.Repos)),
 	}
 	for _, repoName := range req.Repos {
 		result, err := s.doRepoInfo(r.Context(), repoName)

--- a/cmd/gitserver/server/repo_info_test.go
+++ b/cmd/gitserver/server/repo_info_test.go
@@ -45,7 +45,7 @@ func TestServer_handleRepoInfo(t *testing.T) {
 		defer func() { repoCloned = origRepoCloned }()
 
 		want := protocol.RepoInfoResponse{
-			Results: map[api.RepoName]*protocol.RepoInfoResponse{
+			Results: map[api.RepoName]*protocol.RepoInfo{
 				"x": {},
 			},
 		}
@@ -60,7 +60,7 @@ func TestServer_handleRepoInfo(t *testing.T) {
 		defer func() { repoCloned = origRepoCloned }()
 
 		want := protocol.RepoInfoResponse{
-			Results: map[api.RepoName]*protocol.RepoInfoResponse{
+			Results: map[api.RepoName]*protocol.RepoInfo{
 				"a": {
 					CloneInProgress: true,
 					CloneProgress:   "test status",
@@ -92,7 +92,7 @@ func TestServer_handleRepoInfo(t *testing.T) {
 		defer func() { repoRemoteURL = origRepoRemoteURL }()
 
 		want := protocol.RepoInfoResponse{
-			Results: map[api.RepoName]*protocol.RepoInfoResponse{
+			Results: map[api.RepoName]*protocol.RepoInfo{
 				"x": {
 					Cloned:      true,
 					LastFetched: &lastFetched,
@@ -112,7 +112,7 @@ func TestServer_handleRepoInfo(t *testing.T) {
 		defer func() { repoCloned = origRepoCloned }()
 
 		want := protocol.RepoInfoResponse{
-			Results: map[api.RepoName]*protocol.RepoInfoResponse{
+			Results: map[api.RepoName]*protocol.RepoInfo{
 				"a": {
 					CloneInProgress: true,
 					CloneProgress:   "test status",

--- a/cmd/gitserver/server/repo_info_test.go
+++ b/cmd/gitserver/server/repo_info_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver/protocol"
 )
 
-func TestServer_handleMultiRepoInfo(t *testing.T) {
+func TestServer_handleRepoInfo(t *testing.T) {
 	s := &Server{ReposDir: "/testroot"}
 	h := s.Handler()
 	_, ok := s.locker.TryAcquire("/testroot/a", "test status")
@@ -22,9 +22,9 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 		t.Fatal("could not acquire lock")
 	}
 
-	getMultiRepoInfo := func(t *testing.T, repos ...api.RepoName) (resp protocol.MultiRepoInfoResponse) {
+	getRepoInfo := func(t *testing.T, repos ...api.RepoName) (resp protocol.RepoInfoResponse) {
 		rr := httptest.NewRecorder()
-		body, err := json.Marshal(protocol.MultiRepoInfoRequest{Repos: repos})
+		body, err := json.Marshal(protocol.RepoInfoRequest{Repos: repos})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -44,12 +44,12 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 		repoCloned = func(dir string) bool { return false }
 		defer func() { repoCloned = origRepoCloned }()
 
-		want := protocol.MultiRepoInfoResponse{
+		want := protocol.RepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
 				"x": {},
 			},
 		}
-		if got := getMultiRepoInfo(t, "x"); !reflect.DeepEqual(got, want) {
+		if got := getRepoInfo(t, "x"); !reflect.DeepEqual(got, want) {
 			t.Errorf("got %+v, want %+v", got, want)
 		}
 	})
@@ -59,7 +59,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 		repoCloned = func(dir string) bool { return false }
 		defer func() { repoCloned = origRepoCloned }()
 
-		want := protocol.MultiRepoInfoResponse{
+		want := protocol.RepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
 				"a": {
 					CloneInProgress: true,
@@ -67,7 +67,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 				},
 			},
 		}
-		if got := getMultiRepoInfo(t, "a"); !reflect.DeepEqual(got, want) {
+		if got := getRepoInfo(t, "a"); !reflect.DeepEqual(got, want) {
 			t.Errorf("got %+v, want %+v", got, want)
 		}
 	})
@@ -91,7 +91,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 		repoRemoteURL = func(context.Context, string) (string, error) { return "u", nil }
 		defer func() { repoRemoteURL = origRepoRemoteURL }()
 
-		want := protocol.MultiRepoInfoResponse{
+		want := protocol.RepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
 				"x": {
 					Cloned:      true,
@@ -101,7 +101,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 				},
 			},
 		}
-		if got := getMultiRepoInfo(t, "x"); !reflect.DeepEqual(got, want) {
+		if got := getRepoInfo(t, "x"); !reflect.DeepEqual(got, want) {
 			t.Errorf("got %+v, want %+v", got, want)
 		}
 	})
@@ -111,7 +111,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 		repoCloned = func(dir string) bool { return false }
 		defer func() { repoCloned = origRepoCloned }()
 
-		want := protocol.MultiRepoInfoResponse{
+		want := protocol.RepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
 				"a": {
 					CloneInProgress: true,
@@ -120,7 +120,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 				"b": {}, // not cloned
 			},
 		}
-		if got := getMultiRepoInfo(t, "a", "b"); !reflect.DeepEqual(got, want) {
+		if got := getRepoInfo(t, "a", "b"); !reflect.DeepEqual(got, want) {
 			t.Errorf("got %+v want %+v", got, want)
 		}
 	})

--- a/cmd/gitserver/server/repo_info_test.go
+++ b/cmd/gitserver/server/repo_info_test.go
@@ -46,7 +46,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 
 		want := protocol.MultiRepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
-				"x": &protocol.RepoInfoResponse{},
+				"x": {},
 			},
 		}
 		if got := getMultiRepoInfo(t, "x"); !reflect.DeepEqual(got, want) {
@@ -61,7 +61,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 
 		want := protocol.MultiRepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
-				"a": &protocol.RepoInfoResponse{
+				"a": {
 					CloneInProgress: true,
 					CloneProgress:   "test status",
 				},
@@ -93,7 +93,7 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 
 		want := protocol.MultiRepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
-				"x": &protocol.RepoInfoResponse{
+				"x": {
 					Cloned:      true,
 					LastFetched: &lastFetched,
 					LastChanged: &lastChanged,
@@ -113,11 +113,11 @@ func TestServer_handleMultiRepoInfo(t *testing.T) {
 
 		want := protocol.MultiRepoInfoResponse{
 			Results: map[api.RepoName]*protocol.RepoInfoResponse{
-				"a": &protocol.RepoInfoResponse{
+				"a": {
 					CloneInProgress: true,
 					CloneProgress:   "test status",
 				},
-				"b": &protocol.RepoInfoResponse{}, // not cloned
+				"b": {}, // not cloned
 			},
 		}
 		if got := getMultiRepoInfo(t, "a", "b"); !reflect.DeepEqual(got, want) {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -224,6 +224,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/is-repo-cloneable", s.handleIsRepoCloneable)
 	mux.HandleFunc("/is-repo-cloned", s.handleIsRepoCloned)
 	mux.HandleFunc("/repo", s.handleRepoInfo)
+	mux.HandleFunc("/repos", s.handleMultiRepoInfo)
 	mux.HandleFunc("/delete", s.handleRepoDelete)
 	mux.HandleFunc("/repo-update", s.handleRepoUpdate)
 	mux.HandleFunc("/getGitolitePhabricatorMetadata", s.handleGetGitolitePhabricatorMetadata)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -223,7 +223,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/list-gitolite", s.handleListGitolite)
 	mux.HandleFunc("/is-repo-cloneable", s.handleIsRepoCloneable)
 	mux.HandleFunc("/is-repo-cloned", s.handleIsRepoCloned)
-	mux.HandleFunc("/repos", s.handleMultiRepoInfo)
+	mux.HandleFunc("/repos", s.handleRepoInfo)
 	mux.HandleFunc("/delete", s.handleRepoDelete)
 	mux.HandleFunc("/repo-update", s.handleRepoUpdate)
 	mux.HandleFunc("/getGitolitePhabricatorMetadata", s.handleGetGitolitePhabricatorMetadata)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -223,7 +223,6 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/list-gitolite", s.handleListGitolite)
 	mux.HandleFunc("/is-repo-cloneable", s.handleIsRepoCloneable)
 	mux.HandleFunc("/is-repo-cloned", s.handleIsRepoCloned)
-	mux.HandleFunc("/repo", s.handleRepoInfo)
 	mux.HandleFunc("/repos", s.handleMultiRepoInfo)
 	mux.HandleFunc("/delete", s.handleRepoDelete)
 	mux.HandleFunc("/repo-update", s.handleRepoUpdate)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -223,6 +223,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/list-gitolite", s.handleListGitolite)
 	mux.HandleFunc("/is-repo-cloneable", s.handleIsRepoCloneable)
 	mux.HandleFunc("/is-repo-cloned", s.handleIsRepoCloned)
+	mux.HandleFunc("/repo", s.handleDeprecatedRepoInfo) // TODO(slimsag): Remove this after 3.3 is released.
 	mux.HandleFunc("/repos", s.handleRepoInfo)
 	mux.HandleFunc("/delete", s.handleRepoDelete)
 	mux.HandleFunc("/repo-update", s.handleRepoUpdate)

--- a/cmd/repo-updater/repos/purge.go
+++ b/cmd/repo-updater/repos/purge.go
@@ -79,7 +79,7 @@ func purge(ctx context.Context, log log15.Logger) error {
 			purgeFailed.Inc()
 			failed++
 			continue
-		} else if info.CloneTime != nil && time.Since(*info.CloneTime) < 12*time.Hour {
+		} else if info.Results[repo].CloneTime != nil && time.Since(*info.Results[repo].CloneTime) < 12*time.Hour {
 			log.Info("skipping repository since it was cloned less than 12 hours ago", "repo", repo, "age", time.Since(*info.CloneTime))
 			purgeSkipped.Inc()
 			skipped++

--- a/cmd/repo-updater/repos/purge.go
+++ b/cmd/repo-updater/repos/purge.go
@@ -72,15 +72,20 @@ func purge(ctx context.Context, log log15.Logger) error {
 		// We skip repositories that have been cloned in the last 12
 		// hours. This is to give time for a user to enable a repository they
 		// manually placed directly into gitserver's repository directory.
-		if info, err := gitserver.DefaultClient.RepoInfo(ctx, repo); err != nil {
+		infos, err := gitserver.DefaultClient.RepoInfo(ctx, repo)
+		if err != nil {
 			// Do not fail at this point, just log so we can remove other
 			// repos.
 			log.Error("failed to get RepoInfo of cloned repository", "repo", repo, "error", err)
 			purgeFailed.Inc()
 			failed++
 			continue
-		} else if info.Results[repo].CloneTime != nil && time.Since(*info.Results[repo].CloneTime) < 12*time.Hour {
-			log.Info("skipping repository since it was cloned less than 12 hours ago", "repo", repo, "age", time.Since(*info.CloneTime))
+		}
+
+		info := infos.Results[repo]
+		age := time.Since(*info.CloneTime)
+		if info.CloneTime != nil && age < 12*time.Hour {
+			log.Info("skipping repository since it was cloned less than 12 hours ago", "repo", repo, "age", age)
 			purgeSkipped.Inc()
 			skipped++
 			continue
@@ -89,8 +94,7 @@ func purge(ctx context.Context, log log15.Logger) error {
 		// Race condition: A repo can be re-enabled between our listing and
 		// now. This should be very rare, so we ignore it since it will get
 		// cloned again.
-		err := gitserver.DefaultClient.Remove(ctx, repo)
-		if err != nil {
+		if err = gitserver.DefaultClient.Remove(ctx, repo); err != nil {
 			// Do not fail at this point, just log so we can remove other
 			// repos.
 			log.Error("failed to remove disabled repository", "repo", repo, "error", err)

--- a/pkg/gitserver/client.go
+++ b/pkg/gitserver/client.go
@@ -560,7 +560,7 @@ func (c *Client) IsRepoCloned(ctx context.Context, repo api.RepoName) (bool, err
 // *multierror.Error.
 func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol.RepoInfoResponse, error) {
 	numPossibleShards := len(c.Addrs(ctx))
-	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos) / numPossibleShards) * 1.5) // 1.5x because it may not be a perfect division
+	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos) / numPossibleShards) * 2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
 		addr := c.addrForRepo(ctx, r)

--- a/pkg/gitserver/client.go
+++ b/pkg/gitserver/client.go
@@ -552,13 +552,13 @@ func (c *Client) IsRepoCloned(ctx context.Context, repo api.RepoName) (bool, err
 
 // RepoInfo retrieves information about one or more repositories on gitserver.
 //
-// The repository not existing is not an error; in that case, MultiRepoInfoResponse.Results[i].Cloned
+// The repository not existing is not an error; in that case, RepoInfoResponse.Results[i].Cloned
 // will be false and the error will be nil.
 //
 // If multiple errors occurred, an incomplete result is returned along with a
 // *multierror.Error.
-func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol.MultiRepoInfoResponse, error) {
-	req := &protocol.MultiRepoInfoRequest{
+func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol.RepoInfoResponse, error) {
+	req := &protocol.RepoInfoRequest{
 		Repos: repos,
 	}
 	resp, err := c.httpPost(ctx, repos[0], "repos", req)
@@ -570,7 +570,7 @@ func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol
 		return nil, &url.Error{URL: resp.Request.URL.String(), Op: "RepoInfo", Err: fmt.Errorf("RepoInfo: http status %d", resp.StatusCode)}
 	}
 
-	var info *protocol.MultiRepoInfoResponse
+	var info *protocol.RepoInfoResponse
 	err = json.NewDecoder(resp.Body).Decode(&info)
 	return info, err
 }

--- a/pkg/gitserver/client.go
+++ b/pkg/gitserver/client.go
@@ -560,7 +560,7 @@ func (c *Client) IsRepoCloned(ctx context.Context, repo api.RepoName) (bool, err
 // *multierror.Error.
 func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol.RepoInfoResponse, error) {
 	numPossibleShards := len(c.Addrs(ctx))
-	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos) / numPossibleShards) * 2) // 2x because it may not be a perfect division
+	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
 		addr := c.addrForRepo(ctx, r)

--- a/pkg/gitserver/client.go
+++ b/pkg/gitserver/client.go
@@ -550,25 +550,14 @@ func (c *Client) IsRepoCloned(ctx context.Context, repo api.RepoName) (bool, err
 	return cloned, nil
 }
 
-// RepoInfo is a helper for calling MultiRepoInfo with one repository. See that
-// method for details.
-func (c *Client) RepoInfo(ctx context.Context, repo api.RepoName) (*protocol.RepoInfoResponse, error) {
-	info, err := c.MultiRepoInfo(ctx, []api.RepoName{repo})
-	if err != nil {
-		return nil, err
-	}
-	return info.Results[repo], nil
-}
-
-// MultiRepoInfo retrieves information about multiple repositories on gitserver.
+// RepoInfo retrieves information about one or more repositories on gitserver.
 //
 // The repository not existing is not an error; in that case, MultiRepoInfoResponse.Results[i].Cloned
 // will be false and the error will be nil.
 //
-//
 // If multiple errors occurred, an incomplete result is returned along with a
 // *multierror.Error.
-func (c *Client) MultiRepoInfo(ctx context.Context, repos []api.RepoName) (*protocol.MultiRepoInfoResponse, error) {
+func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol.MultiRepoInfoResponse, error) {
 	req := &protocol.MultiRepoInfoRequest{
 		Repos: repos,
 	}

--- a/pkg/gitserver/client.go
+++ b/pkg/gitserver/client.go
@@ -550,26 +550,14 @@ func (c *Client) IsRepoCloned(ctx context.Context, repo api.RepoName) (bool, err
 	return cloned, nil
 }
 
-// RepoInfo retrieves information about the repository on gitserver.
-//
-// The repository not existing is not an error; in that case, RepoInfoResponse.Cloned will be false
-// and the error will be nil.
+// RepoInfo is a helper for calling MultiRepoInfo with one repository. See that
+// method for details.
 func (c *Client) RepoInfo(ctx context.Context, repo api.RepoName) (*protocol.RepoInfoResponse, error) {
-	req := &protocol.RepoInfoRequest{
-		Repo: repo,
-	}
-	resp, err := c.httpPost(ctx, repo, "repo", req)
+	info, err := c.MultiRepoInfo(ctx, []api.RepoName{repo})
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, &url.Error{URL: resp.Request.URL.String(), Op: "RepoInfo", Err: fmt.Errorf("RepoInfo: http status %d", resp.StatusCode)}
-	}
-
-	var info *protocol.RepoInfoResponse
-	err = json.NewDecoder(resp.Body).Decode(&info)
-	return info, err
+	return info.Results[repo], nil
 }
 
 // MultiRepoInfo retrieves information about multiple repositories on gitserver.

--- a/pkg/gitserver/protocol/gitserver.go
+++ b/pkg/gitserver/protocol/gitserver.go
@@ -98,6 +98,12 @@ type RepoInfoRequest struct {
 	Repo api.RepoName
 }
 
+// MultiRepoInfoRequest is a request for information about multiple repositories on gitserver.
+type MultiRepoInfoRequest struct {
+	// Repos are the repositories to get information about.
+	Repos []api.RepoName
+}
+
 // RepoDeleteRequest is a request to delete a repository clone on gitserver
 type RepoDeleteRequest struct {
 	// Repo is the repository to delete.
@@ -117,6 +123,13 @@ type RepoInfoResponse struct {
 	// recloned automatically, so this time is likely to move forward
 	// periodically.
 	CloneTime *time.Time
+}
+
+// MultiRepoInfoResponse is the response to a repository information request
+// for multiple repositories at the same time.
+type MultiRepoInfoResponse struct {
+	// Results mapping from the repository name to the repository information.
+	Results map[api.RepoName]*RepoInfoResponse
 }
 
 // CreateCommitFromPatchRequest is the request information needed for creating

--- a/pkg/gitserver/protocol/gitserver.go
+++ b/pkg/gitserver/protocol/gitserver.go
@@ -92,8 +92,8 @@ type IsRepoClonedRequest struct {
 	Repo api.RepoName
 }
 
-// MultiRepoInfoRequest is a request for information about multiple repositories on gitserver.
-type MultiRepoInfoRequest struct {
+// RepoInfoRequest is a request for information about multiple repositories on gitserver.
+type RepoInfoRequest struct {
 	// Repos are the repositories to get information about.
 	Repos []api.RepoName
 }
@@ -104,7 +104,7 @@ type RepoDeleteRequest struct {
 	Repo api.RepoName
 }
 
-// RepoInfoResponse is the response to a repository information request (MultiRepoInfoRequest).
+// RepoInfoResponse is the response to a repository information request (RepoInfoRequest).
 type RepoInfoResponse struct {
 	URL             string     // this repository's Git remote URL
 	CloneInProgress bool       // whether the repository is currently being cloned
@@ -119,9 +119,9 @@ type RepoInfoResponse struct {
 	CloneTime *time.Time
 }
 
-// MultiRepoInfoResponse is the response to a repository information request
+// RepoInfoResponse is the response to a repository information request
 // for multiple repositories at the same time.
-type MultiRepoInfoResponse struct {
+type RepoInfoResponse struct {
 	// Results mapping from the repository name to the repository information.
 	Results map[api.RepoName]*RepoInfoResponse
 }

--- a/pkg/gitserver/protocol/gitserver.go
+++ b/pkg/gitserver/protocol/gitserver.go
@@ -92,6 +92,31 @@ type IsRepoClonedRequest struct {
 	Repo api.RepoName
 }
 
+// DeprecatedRepoInfoRequest is a request for information about a repository on gitserver.
+//
+// TODO(slimsag): Remove this after 3.3 is released.
+type DeprecatedRepoInfoRequest struct {
+	// Repo is the repository to get information about.
+	Repo api.RepoName
+}
+
+// DeprecatedRepoInfoResponse is the response to a repository information request (RepoInfoRequest).
+//
+// TODO(slimsag): Remove this after 3.3 is released.
+type DeprecatedRepoInfoResponse struct {
+	URL             string     // this repository's Git remote URL
+	CloneInProgress bool       // whether the repository is currently being cloned
+	CloneProgress   string     // a progress message from the running clone command.
+	Cloned          bool       // whether the repository has been cloned successfully
+	LastFetched     *time.Time // when the last `git remote update` or `git fetch` occurred
+	LastChanged     *time.Time // timestamp of the most recent ref in the git repository
+
+	// CloneTime is the time the clone occurred. Note: Repositories may be
+	// recloned automatically, so this time is likely to move forward
+	// periodically.
+	CloneTime *time.Time
+}
+
 // RepoInfoRequest is a request for information about multiple repositories on gitserver.
 type RepoInfoRequest struct {
 	// Repos are the repositories to get information about.

--- a/pkg/gitserver/protocol/gitserver.go
+++ b/pkg/gitserver/protocol/gitserver.go
@@ -92,12 +92,6 @@ type IsRepoClonedRequest struct {
 	Repo api.RepoName
 }
 
-// RepoInfoRequest is a request for information about a repository on gitserver.
-type RepoInfoRequest struct {
-	// Repo is the repository to get information about.
-	Repo api.RepoName
-}
-
 // MultiRepoInfoRequest is a request for information about multiple repositories on gitserver.
 type MultiRepoInfoRequest struct {
 	// Repos are the repositories to get information about.
@@ -110,7 +104,7 @@ type RepoDeleteRequest struct {
 	Repo api.RepoName
 }
 
-// RepoInfoResponse is the response to a repository information request (RepoInfoRequest).
+// RepoInfoResponse is the response to a repository information request (MultiRepoInfoRequest).
 type RepoInfoResponse struct {
 	URL             string     // this repository's Git remote URL
 	CloneInProgress bool       // whether the repository is currently being cloned

--- a/pkg/gitserver/protocol/gitserver.go
+++ b/pkg/gitserver/protocol/gitserver.go
@@ -104,8 +104,9 @@ type RepoDeleteRequest struct {
 	Repo api.RepoName
 }
 
-// RepoInfoResponse is the response to a repository information request (RepoInfoRequest).
-type RepoInfoResponse struct {
+// RepoInfo is the information requests about a single repository
+// via a RepoInfoRequest.
+type RepoInfo struct {
 	URL             string     // this repository's Git remote URL
 	CloneInProgress bool       // whether the repository is currently being cloned
 	CloneProgress   string     // a progress message from the running clone command.
@@ -123,7 +124,7 @@ type RepoInfoResponse struct {
 // for multiple repositories at the same time.
 type RepoInfoResponse struct {
 	// Results mapping from the repository name to the repository information.
-	Results map[api.RepoName]*RepoInfoResponse
+	Results map[api.RepoName]*RepoInfo
 }
 
 // CreateCommitFromPatchRequest is the request information needed for creating


### PR DESCRIPTION
Prior to this change, for every repository in the connection resolver (which on e.g. the /site-admin/repositories page is often _a lot_), we would independently ask gitserver for information about the repository via its API. This was costly because it meant performing literally thousands of tiny sub-millisecond HTTP requests, individually JSON encoding them (which may create lots of GC pressure, too).

The solution here is simple: When we ask gitserver for info about thousands of repositories, do so using a single request instead of thousands.

On a dev instance with ~12k repositories, before:

```
01:37:35               frontend | took 3.96825239s
01:37:50               frontend | took 4.236735448s
01:38:01               frontend | took 5.147227239s
01:38:11               frontend | took 6.093235795s
01:38:33               frontend | took 10.372046862s
01:38:57               frontend | took 13.729139161s
01:39:51               frontend | took 14.654338045s
01:42:08               frontend | took 3.814422443s
01:42:19               frontend | took 4.560987174s
01:42:31               frontend | took 4.626022391s
01:42:40               frontend | took 4.8749788s
01:42:48               frontend | took 3.687233796s
01:42:55               frontend | took 3.738414004s
01:43:04               frontend | took 3.672425721s
01:43:14               frontend | took 3.682802146s
```

And after:

```
02:07:51               frontend | took 1.25605805s
02:07:58               frontend | took 1.441502375s
02:08:03               frontend | took 1.43875787s
02:08:12               frontend | took 1.410966593s
02:08:18               frontend | took 1.416104619s
02:08:26               frontend | took 1.382661535s
02:08:30               frontend | took 1.282073601s
02:08:34               frontend | took 1.635967947s
02:08:38               frontend | took 1.231089455s
02:08:42               frontend | took 1.230096699s
02:08:47               frontend | took 1.272247102s
02:08:51               frontend | took 1.267581576s
02:08:55               frontend | took 1.307818437s
02:08:59               frontend | took 1.272283421s
02:09:05               frontend | took 1.165448496s
```

I suspect the result may be even more pronounced on a larger instance, but haven't yet verified that.

Test plan: Covered by existing tests + new tests added (see diff).

Fixes #2779