### PR TITLE
CI: always dump container logs

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -27,7 +27,7 @@ echo "Copying $IMAGE to the dedicated e2e testing node... done"
 
 echo "Running a daemonized $IMAGE as the test subject..."
 CONTAINER="$(docker container run -d $IMAGE)"
-trap 'kill $(jobs -p)'" ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
+trap 'kill $(jobs -p)'" ; docker logs --timestamps $CONTAINER ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
 
 docker exec "$CONTAINER" apk add --no-cache socat
 # Connect the server container's port 7080 to localhost:7080 so that e2e tests
@@ -58,6 +58,3 @@ pushd web
 ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp4 > ffmpeg.log 2>&1 &
 env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run test-e2e
 popd
-
-echo "Logs from the sourcegraph/server Docker container that was subject to e2e tests:"
-docker logs --timestamps "$CONTAINER"


### PR DESCRIPTION
This will help debug build failures such as https://buildkite.com/sourcegraph/sourcegraph/builds/29860#1b68fa96-0a3a-4629-91be-1b16682f7d8e

cc @tsenart 
