### PR TITLE
Add support for publishing debug releases

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -37,12 +37,16 @@ func main() {
 	if commit == "" {
 		commit = "1234567890123456789012345678901234567890" // for testing
 	}
-	taggedRelease := true // true if this is a semver tagged release
+	taggedRelease := true // true if this is a tagged release
 	now := time.Now()
 	if !strings.HasPrefix(version, "v") {
 		taggedRelease = false
 		buildNum, _ := strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))
 		version = fmt.Sprintf("%05d_%s_%.7s", buildNum, now.Format("2006-01-02"), commit)
+	} else if strings.HasPrefix(branch, "docker-images-debug/") {
+		// A branch like "docker-images-debug/foobar" will produce Docker images
+		// tagged as "debug-foobar-$COMMIT".
+		version = fmt.Sprintf("debug-%s-%s", strings.TrimPrefix(version, "debug-release/"), commit)
 	} else {
 		// The Git tag "v1.2.3" should map to the Docker image "1.2.3" (without v prefix).
 		version = strings.TrimPrefix(version, "v")


### PR DESCRIPTION
This PR adds CI functionality so that pushing a branch `debug-release/foobar`
will cause Docker images to be published with the tag `debug-foobar-$COMMIT`.
These published and tagged images can then be used to test e.g. a specific PR
on a real cluster instance.

Context:

As part of PR #2884 I wanted to test my change on a real, large cluster
instance of Sourcegraph.

The only way for me to get CI to publish the images needed for doing this
currently was to tag an actual release candidate like `v3.3.0-debug.0` but in
my mind this is wrong to do because that looks like it actually corresponds to
the version 3.3.0 when in reality my change is just arbitrary and not directly
a statement of releasing a version (as cutting a release candidate may be, for
example).

Test plan: Manual