### PR TITLE
Add quick configure buttons to more external services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A new settings property `notices` allows showing custom informational messages on the homepage and at the top of each page.
 - The new `gitlab.exclude` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to exclude specific repositories matched by `gitlab.projectQuery` and `gitlab.projects` (so that they won't be synced).
 - The new `gitlab.projects` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to select specific repositories to be synced.
+- "Quick configure" buttons for common actions have been added to the config editor for all external services.
 
 ### Changed
 

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -1,0 +1,50 @@
+package repos
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_projectQueryToURL(t *testing.T) {
+	tests := []struct {
+		projectQuery string
+		perPage      int
+		expURL       string
+		expErr       error
+	}{{
+		projectQuery: "?membership=true",
+		perPage:      100,
+		expURL:       "projects?membership=true&order_by=last_activity_at&per_page=100",
+	}, {
+		projectQuery: "projects?membership=true",
+		perPage:      100,
+		expURL:       "projects?membership=true&order_by=last_activity_at&per_page=100",
+	}, {
+		projectQuery: "groups/groupID/projects",
+		perPage:      100,
+		expURL:       "groups/groupID/projects?order_by=last_activity_at&per_page=100",
+	}, {
+		projectQuery: "groups/groupID/projects?foo=bar",
+		perPage:      100,
+		expURL:       "groups/groupID/projects?foo=bar&order_by=last_activity_at&per_page=100",
+	}, {
+		projectQuery: "",
+		perPage:      100,
+		expURL:       "projects?order_by=last_activity_at&per_page=100",
+	}, {
+		projectQuery: "https://somethingelse.com/foo/bar",
+		perPage:      100,
+		expErr:       schemeOrHostNotEmptyErr,
+	}}
+
+	for _, test := range tests {
+		t.Logf("Test case %+v", test)
+		url, err := projectQueryToURL(test.projectQuery, test.perPage)
+		if url != test.expURL {
+			t.Errorf("expected %v, got %v", test.expURL, url)
+		}
+		if !reflect.DeepEqual(test.expErr, err) {
+			t.Errorf("expected err %v, got %v", test.expErr, err)
+		}
+	}
+}

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -54,7 +54,7 @@
       "examples": ["ssh"]
     },
     "certificate": {
-      "description": "TLS certificate of a Bitbucket Server instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
+      "description": "TLS certificate of the Bitbucket Server instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
       "type": "string",
       "pattern": "^-----BEGIN CERTIFICATE-----\n",
       "examples": ["-----BEGIN CERTIFICATE-----\n..."]

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -59,7 +59,7 @@ const BitbucketServerSchemaJSON = `{
       "examples": ["ssh"]
     },
     "certificate": {
-      "description": "TLS certificate of a Bitbucket Server instance. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
+      "description": "TLS certificate of the Bitbucket Server instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
       "type": "string",
       "pattern": "^-----BEGIN CERTIFICATE-----\n",
       "examples": ["-----BEGIN CERTIFICATE-----\n..."]

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -30,9 +30,10 @@
       "minLength": 1
     },
     "certificate": {
-      "description": "TLS certificate of a GitHub Enterprise instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
+      "description": "TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
       "type": "string",
-      "pattern": "^-----BEGIN CERTIFICATE-----\n"
+      "pattern": "^-----BEGIN CERTIFICATE-----\n",
+      "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
     "repos": {
       "description": "An array of repository \"owner/name\" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.",

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -35,9 +35,10 @@ const GitHubSchemaJSON = `{
       "minLength": 1
     },
     "certificate": {
-      "description": "TLS certificate of a GitHub Enterprise instance. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
+      "description": "TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
       "type": "string",
-      "pattern": "^-----BEGIN CERTIFICATE-----\n"
+      "pattern": "^-----BEGIN CERTIFICATE-----\n",
+      "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
     "repos": {
       "description": "An array of repository \"owner/name\" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.",

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -30,9 +30,10 @@
       "default": "http"
     },
     "certificate": {
-      "description": "TLS certificate of a GitLab instance. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
+      "description": "TLS certificate of the GitLab instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`",
       "type": "string",
-      "pattern": "^-----BEGIN CERTIFICATE-----\n"
+      "pattern": "^-----BEGIN CERTIFICATE-----\n",
+      "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
     "projects": {
       "description": "A list of projects to mirror from this GitLab instance.",
@@ -79,7 +80,7 @@
       }
     },
     "projectQuery": {
-      "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL query string for the GitLab projects API, such as \"?membership=true&search=foo\".\n\nThe query string is passed directly to GitLab to retrieve the list of projects. The special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. See https://docs.gitlab.com/ee/api/projects.html#list-all-projects for available query string options.",
+      "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL path and query that targets a GitLab API endpoint returning a list of projects. If the string only contains a query, then \"projects\" is used as the path. Examples: \"?membership=true&search=foo\", \"groups/mygroup/projects\".\n\nThe special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. Here are a few endpoints that return a list of projects: https://docs.gitlab.com/ee/api/projects.html#list-all-projects, https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects, https://docs.gitlab.com/ee/api/search.html#scope-projects.",
       "type": "array",
       "default": ["none"],
       "items": {

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -35,9 +35,10 @@ const GitLabSchemaJSON = `{
       "default": "http"
     },
     "certificate": {
-      "description": "TLS certificate of a GitLab instance. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
+      "description": "TLS certificate of the GitLab instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run ` + "`" + `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM` + "`" + `",
       "type": "string",
-      "pattern": "^-----BEGIN CERTIFICATE-----\n"
+      "pattern": "^-----BEGIN CERTIFICATE-----\n",
+      "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
     "projects": {
       "description": "A list of projects to mirror from this GitLab instance.",
@@ -84,7 +85,7 @@ const GitLabSchemaJSON = `{
       }
     },
     "projectQuery": {
-      "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL query string for the GitLab projects API, such as \"?membership=true&search=foo\".\n\nThe query string is passed directly to GitLab to retrieve the list of projects. The special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. See https://docs.gitlab.com/ee/api/projects.html#list-all-projects for available query string options.",
+      "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL path and query that targets a GitLab API endpoint returning a list of projects. If the string only contains a query, then \"projects\" is used as the path. Examples: \"?membership=true&search=foo\", \"groups/mygroup/projects\".\n\nThe special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. Here are a few endpoints that return a list of projects: https://docs.gitlab.com/ee/api/projects.html#list-all-projects, https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects, https://docs.gitlab.com/ee/api/search.html#scope-projects.",
       "type": "array",
       "default": ["none"],
       "items": {

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -55,7 +55,7 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
                         jsonSchema={this.props.jsonSchema}
                         canEdit={false}
                         loading={this.props.loading}
-                        height={300}
+                        height={350}
                         isLightTheme={this.props.isLightTheme}
                         onChange={this.onConfigChange}
                         history={this.props.history}

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -1,4 +1,4 @@
-import { FormattingOptions } from '@sqs/jsonc-parser'
+import { Edit, FormattingOptions, JSONPath } from '@sqs/jsonc-parser'
 import { setProperty } from '@sqs/jsonc-parser/lib/edit'
 import { flatMap, map } from 'lodash'
 import AmazonIcon from 'mdi-react/AmazonIcon'
@@ -77,50 +77,89 @@ const defaultFormattingOptions: FormattingOptions = {
     tabSize: 2,
 }
 
-const githubEditorActions: EditorAction[] = [
-    {
-        id: 'setAccessToken',
-        label: 'Set access token',
-        run: config => {
-            const value = '<GitHub personal access token>'
-            const edits = setProperty(config, ['token'], value, defaultFormattingOptions)
-            return { edits, selectText: '<GitHub personal access token>' }
-        },
-    },
-    {
-        id: 'addOrgRepo',
-        label: 'Add organization repositories',
-        run: config => {
-            const value = 'org:<organization name>'
-            const edits = setProperty(config, ['repositoryQuery', -1], value, defaultFormattingOptions)
-            return { edits, selectText: '<organization name>' }
-        },
-    },
-    {
-        id: 'addSingleRepo',
-        label: 'Add single repository',
-        run: config => {
-            const value = '<GitHub owner>/<GitHub repository name>'
-            const edits = setProperty(config, ['repos', -1], value, defaultFormattingOptions)
-            return { edits, selectText: '<GitHub owner>/<GitHub repository name>' }
-        },
-    },
-    {
-        id: 'addSearchQueryRepos',
-        label: 'Add repositories matching search query',
-        run: config => {
-            const value = '<GitHub search query>'
-            const edits = setProperty(config, ['repositoryQuery', -1], value, defaultFormattingOptions)
-            return { edits, selectText: '<GitHub search query>' }
-        },
-    },
-]
+/**
+ * editWithComment returns a Monaco edit action that sets the value of a JSON field with a
+ * "//" comment annotating the field. The comment is inserted wherever
+ * `"COMMENT_SENTINEL": true` appears in the JSON.
+ */
+function editWithComment(config: string, path: JSONPath, value: any, comment: string): Edit {
+    const edit = setProperty(config, path, value, defaultFormattingOptions)[0]
+    edit.content = edit.content.replace('"COMMENT_SENTINEL": true', comment)
+    return edit
+}
+
+const editorActionComments = {
+    enablePermissions:
+        '// Prerequisite: you must configure GitHub as an OAuth auth provider in the critical site config (https://docs.sourcegraph.com/admin/auth#github). Otherwise, access to all repositories will be disallowed.',
+    enforcePermissionsOAuth: `// Prerequisite: you must first update the critical site configuration to
+    // include GitLab OAuth as an auth provider.
+    // See https://docs.sourcegraph.com/admin/auth#gitlab for instructions.`,
+    enforcePermissionsSSO: `// Prerequisite: You will need a sudo-level access token. If you can configure
+    // GitLab as an OAuth identity provider for Sourcegraph, we recommend that
+    // option instead.
+    //
+    // 1. Ensure the personal access token in this config has admin privileges
+    //    (https://docs.gitlab.com/ee/api/#sudo).
+    // 2. Update the critical site configuration in the management console to
+    //    include the SSO auth provider for GitLab (https://docs.sourcegraph.com/admin/auth).
+    // 3. Update the fields below to match the properties of this auth provider
+    //    (https://docs.sourcegraph.com/admin/repo/permissions#sudo-access-token).`,
+}
 
 export const GITHUB_EXTERNAL_SERVICE: ExternalServiceKindMetadata = {
     title: 'GitHub repositories',
     icon: <GithubCircleIcon size={ICON_SIZE} />,
     jsonSchema: githubSchemaJSON,
-    editorActions: githubEditorActions,
+    editorActions: [
+        {
+            id: 'setAccessToken',
+            label: 'Set access token',
+            run: config => {
+                const value = '<GitHub personal access token>'
+                const edits = setProperty(config, ['token'], value, defaultFormattingOptions)
+                return { edits, selectText: '<GitHub personal access token>' }
+            },
+        },
+        {
+            id: 'addOrgRepo',
+            label: 'Add organization repositories',
+            run: config => {
+                const value = 'org:<organization name>'
+                const edits = setProperty(config, ['repositoryQuery', -1], value, defaultFormattingOptions)
+                return { edits, selectText: '<organization name>' }
+            },
+        },
+        {
+            id: 'addSingleRepo',
+            label: 'Add single repository',
+            run: config => {
+                const value = '<GitHub owner>/<GitHub repository name>'
+                const edits = setProperty(config, ['repos', -1], value, defaultFormattingOptions)
+                return { edits, selectText: '<GitHub owner>/<GitHub repository name>' }
+            },
+        },
+        {
+            id: 'addSearchQueryRepos',
+            label: 'Add repositories matching search query',
+            run: config => {
+                const value = '<GitHub search query>'
+                const edits = setProperty(config, ['repositoryQuery', -1], value, defaultFormattingOptions)
+                return { edits, selectText: '<GitHub search query>' }
+            },
+        },
+        {
+            id: 'enablePermissions',
+            label: 'Enforce permissions',
+            run: config => {
+                const value = {
+                    COMMENT_SENTINEL: true,
+                }
+                const comment = editorActionComments.enablePermissions
+                const edit = editWithComment(config, ['authorization'], value, comment)
+                return { edits: [edit], selectText: comment }
+            },
+        },
+    ],
     iconBrandColor: 'github',
     shortDescription: 'Add GitHub repositories.',
     longDescription: (
@@ -178,6 +217,35 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
   "accessKeyID": "",
   "secretAccessKey": ""
 }`,
+        editorActions: [
+            {
+                id: 'setRegion',
+                label: 'Set AWS region',
+                run: config => {
+                    const value = '<AWS region>'
+                    const edits = setProperty(config, ['region'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setAccessKeyID',
+                label: 'Set access key ID',
+                run: config => {
+                    const value = '<AWS access key ID>'
+                    const edits = setProperty(config, ['accessKeyID'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setSecretAccessKey',
+                label: 'Set AWS secret access key',
+                run: config => {
+                    const value = '<AWS secret access key>'
+                    const edits = setProperty(config, ['secretAccessKey'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+        ],
     },
     [GQL.ExternalServiceKind.BITBUCKETSERVER]: {
         title: 'Bitbucket Server repositories',
@@ -197,6 +265,35 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
   // https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add
   "token": ""
 }`,
+        editorActions: [
+            {
+                id: 'setURL',
+                label: 'Set Bitbucket Server URL',
+                run: config => {
+                    const value = 'https://bitbucket.example.com'
+                    const edits = setProperty(config, ['url'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setPersonalAccessToken',
+                label: 'Set personal access token',
+                run: config => {
+                    const value = '<Bitbucket Server personal access token>'
+                    const edits = setProperty(config, ['token'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setSelfSignedCert',
+                label: 'Set internal or self-signed certificate',
+                run: config => {
+                    const value = '<internal-CA- or self-signed certificate>'
+                    const edits = setProperty(config, ['certificate'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+        ],
     },
     [GQL.ExternalServiceKind.GITLAB]: {
         title: 'GitLab projects',
@@ -222,6 +319,127 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
       "none"
   ]
 }`,
+        editorActions: [
+            {
+                id: 'setURL',
+                label: 'Set GitLab URL',
+                run: config => {
+                    const value = 'https://gitlab.example.com'
+                    const edits = setProperty(config, ['url'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setPersonalAccessToken',
+                label: 'Set personal access token',
+                run: config => {
+                    const value = '<GitLab personal access token>'
+                    const edits = setProperty(config, ['token'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setSelfSignedCert',
+                label: 'Set internal or self-signed certificate',
+                run: config => {
+                    const value = '<internal-CA- or self-signed certificate>'
+                    const edits = setProperty(config, ['certificate'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'syncInternalProjects',
+                label: 'Sync internal projects',
+                run: config => {
+                    const value = '?visibility=internal'
+                    const edits = setProperty(config, ['projectQuery', -1], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'syncPrivateProjects',
+                label: 'Sync private projects',
+                run: config => {
+                    const value = '?visibility=private'
+                    const edits = setProperty(config, ['projectQuery', -1], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'syncPublicProjects',
+                label: 'Sync public projects',
+                run: config => {
+                    const value = '?visibility=public'
+                    const edits = setProperty(config, ['projectQuery', -1], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'syncGroupProjects',
+                label: 'Sync group projects',
+                run: config => {
+                    const value = 'groups/<group ID>/projects'
+                    const edits = setProperty(config, ['projectQuery', -1], value, defaultFormattingOptions)
+                    return { edits, selectText: '<group ID>' }
+                },
+            },
+            {
+                id: 'syncMembershipProjects',
+                label: 'Sync all projects the access token user is a member of',
+                run: config => {
+                    const value = '?membership=true'
+                    const edits = setProperty(config, ['projectQuery', -1], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'syncProjectsMatchingSearch',
+                label: 'Sync projects matching search',
+                run: config => ({
+                    edits: setProperty(
+                        config,
+                        ['projectQuery', -1],
+                        '?search=<search query>',
+                        defaultFormattingOptions
+                    ),
+                    selectText: '<search query>',
+                }),
+            },
+            {
+                id: 'enforcePermissionsOAuth',
+                label: 'Enforce permissions (OAuth)',
+                run: config => {
+                    const value = {
+                        identityProvider: {
+                            COMMENT_SENTINEL: true,
+                            type: 'oauth',
+                        },
+                    }
+                    const comment = editorActionComments.enforcePermissionsOAuth
+                    const edit = editWithComment(config, ['authorization'], value, comment)
+                    return { edits: [edit], selectText: comment }
+                },
+            },
+            {
+                id: 'enforcePermissionsSSO',
+                label: 'Enforce permissions (SSO)',
+                run: config => {
+                    const value = {
+                        COMMENT_SENTINEL: true,
+                        identityProvider: {
+                            type: 'external',
+                            authProviderID: '<configID field of the auth provider>',
+                            authProviderType: '<type field of the auth provider>',
+                            gitlabProvider:
+                                '<name that identifies the auth provider to GitLab (hover over "gitlabProvider" for docs)>',
+                        },
+                    }
+                    const comment = editorActionComments.enforcePermissionsSSO
+                    const edit = editWithComment(config, ['authorization'], value, comment)
+                    return { edits: [edit], selectText: comment }
+                },
+            },
+        ],
     },
     [GQL.ExternalServiceKind.GITOLITE]: {
         title: 'Gitolite repositories',
@@ -238,6 +456,26 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
   "prefix": "gitolite.example.com/",
   "host": "git@gitolite.example.com"
 }`,
+        editorActions: [
+            {
+                id: 'setPrefix',
+                label: 'Set prefix',
+                run: config => {
+                    const value = 'gitolite.example.com/'
+                    const edits = setProperty(config, ['prefix'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setHost',
+                label: 'Set host',
+                run: config => {
+                    const value = 'git@gitolite.example.com'
+                    const edits = setProperty(config, ['host'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+        ],
     },
     [GQL.ExternalServiceKind.PHABRICATOR]: {
         title: 'Phabricator connection',
@@ -255,6 +493,38 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
   "token": "",
   "repos": []
 }`,
+        editorActions: [
+            {
+                id: 'setPhabricatorURL',
+                label: 'Set Phabricator URL',
+                run: config => {
+                    const value = 'https://phabricator.example.com'
+                    const edits = setProperty(config, ['url'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'setAccessToken',
+                label: 'Set Phabricator access token',
+                run: config => {
+                    const value = '<Phabricator access token>'
+                    const edits = setProperty(config, ['token'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'addRepository',
+                label: 'Add repository',
+                run: config => {
+                    const value = {
+                        callsign: '<Phabricator repository callsign>',
+                        path: '<Sourcegraph repository full name>',
+                    }
+                    const edits = setProperty(config, ['repos', -1], value, defaultFormattingOptions)
+                    return { edits, selectText: '<Phabricator repository callsign>' }
+                },
+            },
+        ],
     },
     [GQL.ExternalServiceKind.OTHER]: {
         title: 'Single Git repositories',
@@ -274,6 +544,26 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
   // Repository clone paths may be relative to the url (preferred) or absolute.
   "repos": []
 }`,
+        editorActions: [
+            {
+                id: 'setURL',
+                label: 'Set Git host URL',
+                run: config => {
+                    const value = 'https://my-other-githost.example.com'
+                    const edits = setProperty(config, ['url'], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+            {
+                id: 'addRepo',
+                label: 'Add repository',
+                run: config => {
+                    const value = 'path/to/repository'
+                    const edits = setProperty(config, ['repos', -1], value, defaultFormattingOptions)
+                    return { edits, selectText: value }
+                },
+            },
+        ],
     },
 }
 
@@ -304,8 +594,7 @@ const externalServiceAddVariants: Partial<
         dotcom: {
             title: 'GitHub.com repositories',
             shortDescription: 'Add GitHub.com repositories.',
-            editorActions: [
-                ...githubEditorActions,
+            editorActions: (GITHUB_EXTERNAL_SERVICE.editorActions || []).concat([
                 {
                     id: 'addPublicRepo',
                     label: 'Add public repository',
@@ -315,7 +604,7 @@ const externalServiceAddVariants: Partial<
                         return { edits, selectText: '<GitHub owner>/<GitHub repository name>' }
                     },
                 },
-            ],
+            ]),
         },
         enterprise: {
             title: 'GitHub Enterprise repositories',


### PR DESCRIPTION
This covers all the actions in this doc (except syncing GitLab group projects, which requires a larger backend change): https://docs.google.com/document/d/1bX5GkOdkKb19-Mg96G93WfyIghZILAvuMxcIbM-VOls/edit

Test plan:
- [ ] Go through every external service (http://localhost:3080/site-admin/external-services/new) and click every button under "Quick configure"

Before merge:
- [x] Update changelog

Post-merge:
- [ ] Follow up on remaining items in https://docs.google.com/document/d/1bX5GkOdkKb19-Mg96G93WfyIghZILAvuMxcIbM-VOls/edit