### PR TITLE
E2e tests: default to visible:true

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -27,6 +27,14 @@ process.on('rejectionHandled', error => {
 })
 
 /**
+ * Changes the default options passed to `waitForSelector` to `{ visible: true }`
+ */
+function patchWaitForSelector(page: puppeteer.Page): void {
+    const original = page.waitForSelector.bind(page)
+    page.waitForSelector = (selector: string, options: any): any => original(selector, { visible: true, ...options })
+}
+
+/**
  * Used in the external service configuration.
  */
 export const gitHubToken = readEnvString({ variable: 'GITHUB_TOKEN' })
@@ -78,6 +86,7 @@ describe('e2e test suite', function(this: any): void {
             }
             browser = await puppeteer.launch(launchOpt)
             page = await browser.newPage()
+            patchWaitForSelector(page)
             await init()
         },
         // Cloning the repositories takes ~1 minute, so give initialization 2


### PR DESCRIPTION
I expect this to cut down on errors like https://buildkite.com/sourcegraph/sourcegraph/builds/29894#f7b46967-f982-4a35-a995-aa9938440cf9/42-204

> Node is either not visible or not an HTMLElement

The default of not waiting for presence regardless of visibility doesn't match my (or the author of this test's) intuition about the behavior of `waitForSelector`.