### PR TITLE
Make selections specific to a code view

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_views.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.ts
@@ -1,4 +1,5 @@
 import { DOMFunctions, PositionAdjuster } from '@sourcegraph/codeintellify'
+import { Selection } from '@sourcegraph/extension-api-types'
 import { Observable, of, zip } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
@@ -36,6 +37,14 @@ export interface CodeViewSpec extends Pick<CodeView, Exclude<keyof CodeView, 'el
     adjustPosition?: PositionAdjuster<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec>
     /** Props for styling the buttons in the `CodeViewToolbar`. */
     toolbarButtonProps?: ButtonProps
+    /**
+     * Gets the current selections for a code view.
+     */
+    getSelections?: (codeViewElement: HTMLElement) => Selection[]
+    /**
+     * Returns a stream of selections changes for a code view.
+     */
+    observeSelections?: (codeViewElement: HTMLElement) => Observable<Selection[]>
 }
 
 /**

--- a/client/browser/src/libs/code_intelligence/util/selections.ts
+++ b/client/browser/src/libs/code_intelligence/util/selections.ts
@@ -1,0 +1,16 @@
+import { Selection } from '@sourcegraph/extension-api-types'
+import { isEqual } from 'lodash'
+import { fromEvent, Observable } from 'rxjs'
+import { distinctUntilChanged, map } from 'rxjs/operators'
+import { lprToSelectionsZeroIndexed, parseHash } from '../../../../../../shared/src/util/url'
+
+export function getSelectionsFromHash(): Selection[] {
+    return lprToSelectionsZeroIndexed(parseHash(window.location.hash))
+}
+
+export function observeSelectionsFromHash(): Observable<Selection[]> {
+    return fromEvent(window, 'hashchange').pipe(
+        map(getSelectionsFromHash),
+        distinctUntilChanged(isEqual)
+    )
+}

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -14,6 +14,7 @@ import { querySelectorOrSelf } from '../../shared/util/dom'
 import { toAbsoluteBlobURL } from '../../shared/util/url'
 import { CodeHost, MountGetter } from '../code_intelligence'
 import { CodeView, CodeViewSpec, toCodeViewResolver } from '../code_intelligence/code_views'
+import { getSelectionsFromHash, observeSelectionsFromHash } from '../code_intelligence/util/selections'
 import { ViewResolver } from '../code_intelligence/views'
 import { markdownBodyViewResolver } from './content_views'
 import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions } from './dom_functions'
@@ -85,6 +86,8 @@ const singleFileCodeView: CodeViewSpec = {
     getToolbarMount: createFileActionsToolbarMount,
     resolveFileInfo,
     toolbarButtonProps,
+    getSelections: getSelectionsFromHash,
+    observeSelections: observeSelectionsFromHash,
 }
 
 /**
@@ -177,10 +180,8 @@ export const fileLineContainerResolver: ViewResolver<CodeView> = {
         }
         return {
             element: repositoryContent as HTMLElement,
-            dom: singleFileDOMFunctions,
+            ...singleFileCodeView,
             getToolbarMount: createFileLineContainerToolbarMount,
-            resolveFileInfo,
-            toolbarButtonProps,
         }
     },
 }

--- a/client/browser/src/libs/gitlab/code_intelligence.ts
+++ b/client/browser/src/libs/gitlab/code_intelligence.ts
@@ -1,5 +1,6 @@
 import { CodeHost } from '../code_intelligence'
 import { CodeView, CodeViewSpec } from '../code_intelligence/code_views'
+import { getSelectionsFromHash, observeSelectionsFromHash } from '../code_intelligence/util/selections'
 import { ViewResolver } from '../code_intelligence/views'
 import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { getCommandPaletteMount } from './extensions'
@@ -49,6 +50,8 @@ const singleFileCodeView: CodeViewSpec = {
     getToolbarMount,
     resolveFileInfo,
     toolbarButtonProps,
+    getSelections: getSelectionsFromHash,
+    observeSelections: observeSelectionsFromHash,
 }
 
 const mergeRequestCodeView: CodeViewSpec = {

--- a/client/browser/src/libs/phabricator/code_intelligence.ts
+++ b/client/browser/src/libs/phabricator/code_intelligence.ts
@@ -1,6 +1,5 @@
 import { AdjustmentDirection, PositionAdjuster } from '@sourcegraph/codeintellify'
 import { Position } from '@sourcegraph/extension-api-types'
-import { of } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { convertSpacesToTabs, spacesToTabsAdjustment } from '.'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
@@ -167,7 +166,6 @@ export const phabricatorCodeHost: CodeHost = {
 
     // TODO: handle parsing selected line number from Phabricator href,
     // and find a way to listen to changes (Phabricator does not emit popstate events).
-    selectionsChanges: () => of([]),
     codeViewToolbarClassProps: {
         actionItemClass: 'button grey action-item--phabricator',
         actionItemIconClass: 'action-item__icon--phabricator',


### PR DESCRIPTION
Having selections as a property of `CodeHost` is a problem, because [it is incorrect to assume that all code views on the page have the same selections](https://github.com/sourcegraph/sourcegraph/pull/2909#discussion_r268261523).

This adds `getSelections` and `observeSelections` as optional properties of `CodeViewSpec`, and changes the code to make sure that when selections change, we only set them on the relevant editor. Selections are parsed from the URL hash on single file code views, only for code hosts where this is relevant (GitHub, Gitlab).