### PR TITLE
authz: prevent access to repos with no external repo spec

### DIFF
--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
@@ -85,8 +86,12 @@ func TestRepos_List(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 
+	ctx := dbtesting.TestContext(t)
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	want := mustCreate(ctx, t, &types.Repo{Name: "r"})
@@ -105,8 +110,11 @@ func TestRepos_List_fork(t *testing.T) {
 		t.Skip()
 	}
 
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 	ctx := dbtesting.TestContext(t)
-
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	mine := mustCreate(ctx, t, &types.Repo{Name: "a/r", Fork: false})
@@ -147,8 +155,11 @@ func TestRepos_List_pagination(t *testing.T) {
 		t.Skip()
 	}
 
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 	ctx := dbtesting.TestContext(t)
-
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -195,8 +206,11 @@ func TestRepos_List_query1(t *testing.T) {
 		t.Skip()
 	}
 
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 	ctx := dbtesting.TestContext(t)
-
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -234,8 +248,11 @@ func TestRepos_List_query2(t *testing.T) {
 		t.Skip()
 	}
 
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 	ctx := dbtesting.TestContext(t)
-
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -276,8 +293,11 @@ func TestRepos_List_sort(t *testing.T) {
 		t.Skip()
 	}
 
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 	ctx := dbtesting.TestContext(t)
-
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -346,8 +366,11 @@ func TestRepos_List_patterns(t *testing.T) {
 		t.Skip()
 	}
 
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 	ctx := dbtesting.TestContext(t)
-
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -400,8 +423,11 @@ func TestRepos_List_patterns(t *testing.T) {
 // TestRepos_List_patterns tests the behavior of Repos.List when called with
 // a QueryPattern.
 func TestRepos_List_queryPattern(t *testing.T) {
+	mockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { mockAuthzFilter = nil }()
 	ctx := dbtesting.TestContext(t)
-
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -76,6 +76,11 @@ func getFilteredRepoNames(ctx context.Context, currentUser *types.User, repos ma
 	accepted = make(map[api.RepoName]struct{})  // repositories that have been claimed and have read permissions
 	unverified := make(map[authz.Repo]struct{}) // repositories that have not been claimed by any authz provider
 	for repo := range repos {
+		// 🚨 SECURITY: Defensively bar access to repos with no external repo spec (we don't know
+		// where they came from, so can't reliably enforce permissions)
+		if s := repo.ExternalRepoSpec; s.ID == "" || s.ServiceID == "" || s.ServiceType == "" {
+			continue
+		}
 		unverified[repo] = struct{}{}
 	}
 


### PR DESCRIPTION
In case the external repo spec is not set in the DB, the repo will not be accessible to any user, because we have no way of assigning that repo to an external service and verifying its permissions.