### PR TITLE
Symbols: continue parsing on error

### DIFF
--- a/cmd/symbols/internal/symbols/parse.go
+++ b/cmd/symbols/internal/symbols/parse.go
@@ -98,12 +98,6 @@ func (s *Service) parseUncached(ctx context.Context, repo api.RepoName, commitID
 			}()
 			entries, parseErr := s.parse(ctx, req)
 			if parseErr != nil && parseErr != context.Canceled && parseErr != context.DeadlineExceeded {
-				if err == nil {
-					mu.Lock()
-					err = errors.Wrap(parseErr, fmt.Sprintf("parse repo %s commit %s path %s", repo, commitID, req.path))
-					mu.Unlock()
-				}
-				cancel()
 				log15.Error("Error parsing symbols.", "repo", repo, "commitID", commitID, "path", req.path, "dataSize", len(req.data), "error", parseErr)
 			}
 			if len(entries) > 0 {


### PR DESCRIPTION
Previously, when ctags crashed while parsing, the symbols service would bail on that repository and return the error. The same error would occur the next time a query was made on that repository again. I was only able to repro on my macOS, not on Sourcegraph.com. To repro, go to http://localhost:3080/github.com/mas-cli/mas (and click on the symbols sidebar)

> 23:35:07                symbols | ERROR Closing failed parser and creating a new one., path: Carthage/Checkouts/Commandant/Carthage/Checkouts/Nimble/Sources/NimbleObjectiveC/DSL.h, error: unexpected EOF from ctags
> 23:35:07                symbols | ERROR Error parsing symbols., repo: github.com/mas-cli/mas, commitID: 262dacade307bb592f50371c0fab185a0dd6ff7b, path: Carthage/Checkouts/Commandant/Carthage/Checkouts/Nimble/Sources/NimbleObjectiveC/DSL.h, dataSize: 15233, error: unexpected EOF from ctags

Now, when ctags crashes, the symbols service will continue on to the next file.

Upstream bug https://github.com/universal-ctags/ctags/issues/2053