### PR TITLE
E2e tests: replace patch with passing visible:true explicitly

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -145,7 +145,12 @@ describe('e2e test suite', function(this: any): void {
             },
         }
 
-        await (await page.waitForSelector(selector, { visible: true })).click()
+        // The Monaco editor sometimes detaches nodes from the DOM, causing
+        // `click()` to fail unpredictably.
+        await retry(async () => {
+            await page.waitForSelector(selector)
+            await page.click(selector)
+        })
         await selectAllByMethod[method]()
         await page.keyboard.press(Key.Backspace)
         await page.keyboard.type(newText)

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -27,14 +27,6 @@ process.on('rejectionHandled', error => {
 })
 
 /**
- * Changes the default options passed to `waitForSelector` to `{ visible: true }`
- */
-function patchWaitForSelector(page: puppeteer.Page): void {
-    const original = page.waitForSelector.bind(page)
-    page.waitForSelector = (selector: string, options: any): any => original(selector, { visible: true, ...options })
-}
-
-/**
  * Used in the external service configuration.
  */
 export const gitHubToken = readEnvString({ variable: 'GITHUB_TOKEN' })
@@ -86,7 +78,6 @@ describe('e2e test suite', function(this: any): void {
             }
             browser = await puppeteer.launch(launchOpt)
             page = await browser.newPage()
-            patchWaitForSelector(page)
             await init()
         },
         // Cloning the repositories takes ~1 minute, so give initialization 2
@@ -187,7 +178,7 @@ describe('e2e test suite', function(this: any): void {
             })
         }
 
-        await (await page.waitForSelector('.e2e-goto-add-external-service-page')).click()
+        await (await page.waitForSelector('.e2e-goto-add-external-service-page', { visible: true })).click()
 
         const githubButton = await await page.waitForSelector(`.linked-external-service-card--${kind}`)
         await githubButton.click()
@@ -224,11 +215,13 @@ describe('e2e test suite', function(this: any): void {
                     )
                     if (slug === 'sourcegraphtest/AlwaysCloningTest') {
                         await page.waitForSelector(
-                            `.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='true']`
+                            `.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='true']`,
+                            { visible: true }
                         )
                     } else {
                         await page.waitForSelector(
-                            `.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='true'][data-e2e-cloned='true']`
+                            `.repository-node[data-e2e-repository='github.com/${slug}'][data-e2e-enabled='true'][data-e2e-cloned='true']`,
+                            { visible: true }
                         )
                     }
                 }
@@ -259,7 +252,7 @@ describe('e2e test suite', function(this: any): void {
     }
 
     const assertStickyHighlightedToken = async (label: string): Promise<void> => {
-        await page.waitForSelector('.selection-highlight-sticky') // make sure matched token is highlighted
+        await page.waitForSelector('.selection-highlight-sticky', { visible: true }) // make sure matched token is highlighted
         await retry(async () =>
             expect(
                 await page.evaluate(() => document.querySelector('.selection-highlight-sticky')!.textContent)
@@ -280,7 +273,7 @@ describe('e2e test suite', function(this: any): void {
             "//*[contains(@class, 'panel__tabs')]//*[contains(@class, 'tab-bar__tab--active') and contains(text(), 'References')]"
         )
         // verify there are some references
-        await page.waitForSelector('.panel__tabs-content .file-match__item')
+        await page.waitForSelector('.panel__tabs-content .file-match__item', { visible: true })
     }
 
     const assertNonemptyExternalRefs = async (): Promise<void> => {
@@ -289,7 +282,7 @@ describe('e2e test suite', function(this: any): void {
             "//*[contains(@class, 'panel__tabs')]//*[contains(@class, 'tab-bar__tab--active') and contains(text(), 'References')]"
         )
         // verify there are some references
-        await page.waitForSelector('.panel__tabs-content .hierarchical-locations-view__item')
+        await page.waitForSelector('.panel__tabs-content .hierarchical-locations-view__item', { visible: true })
     }
 
     describe('External services', () => {
@@ -316,9 +309,9 @@ describe('e2e test suite', function(this: any): void {
                 method: 'keyboard',
             })
             await page.click('.e2e-update-external-service-button')
-            await page.waitForSelector('.e2e-update-external-service-button:not([disabled])')
+            await page.waitForSelector('.e2e-update-external-service-button:not([disabled])', { visible: true })
 
-            await page.waitForSelector('.list-group-item[href="/site-admin/external-services"]')
+            await page.waitForSelector('.list-group-item[href="/site-admin/external-services"]', { visible: true })
             await page.click('.list-group-item[href="/site-admin/external-services"]')
             await page.waitFor('.e2e-filtered-connection')
             await page.waitForSelector('.e2e-filtered-connection__loader', { hidden: true })
@@ -342,28 +335,28 @@ describe('e2e test suite', function(this: any): void {
     describe('Visual tests', () => {
         test('Repositories list', async () => {
             await page.goto(baseURL + '/site-admin/repositories?query=gorilla%2Fmux')
-            await page.waitForSelector('a[href="/github.com/gorilla/mux"]')
+            await page.waitForSelector('a[href="/github.com/gorilla/mux"]', { visible: true })
             await percySnapshot(page, 'Repositories list')
         })
 
         test('Search results repo', async () => {
             await page.goto(baseURL + '/github.com/gorilla/mux')
             await page.goto(baseURL + '/search?q=repo:%5Egithub.com/gorilla/mux%24')
-            await page.waitForSelector('a[href="/github.com/gorilla/mux"]')
+            await page.waitForSelector('a[href="/github.com/gorilla/mux"]', { visible: true })
             // Flaky https://github.com/sourcegraph/sourcegraph/issues/2704
             // await percySnapshot(page, 'Search results repo')
         })
 
         test('Search results file', async () => {
             await page.goto(baseURL + '/search?q=repo:%5Egithub.com/gorilla/mux%24+file:%5Emux.go%24')
-            await page.waitForSelector('a[href="/github.com/gorilla/mux"]')
+            await page.waitForSelector('a[href="/github.com/gorilla/mux"]', { visible: true })
             // Flaky https://github.com/sourcegraph/sourcegraph/issues/2704
             // await percySnapshot(page, 'Search results file')
         })
 
         test('Search results code', async () => {
             await page.goto(baseURL + '/search?q=repo:^github.com/gorilla/mux$ file:mux.go "func NewRouter"')
-            await page.waitForSelector('a[href="/github.com/gorilla/mux"]')
+            await page.waitForSelector('a[href="/github.com/gorilla/mux"]', { visible: true })
             // Flaky https://github.com/sourcegraph/sourcegraph/issues/2704
             // await percySnapshot(page, 'Search results code')
         })
@@ -372,7 +365,7 @@ describe('e2e test suite', function(this: any): void {
     describe('Theme switcher', () => {
         test('changes the theme', async () => {
             await page.goto(baseURL + '/github.com/gorilla/mux/-/blob/mux.go')
-            await page.waitForSelector('.theme')
+            await page.waitForSelector('.theme', { visible: true })
             const currentThemes = await page.evaluate(() =>
                 Array.from(document.querySelector('.theme')!.classList).filter(c => c.startsWith('theme-'))
             )
@@ -444,19 +437,19 @@ describe('e2e test suite', function(this: any): void {
 
             test('expands directory on row click (no navigation)', async () => {
                 await page.goto(baseURL + '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d')
-                await page.waitForSelector('.tree__row-icon')
+                await page.waitForSelector('.tree__row-icon', { visible: true })
                 await page.click('.tree__row-icon')
-                await page.waitForSelector('.tree__row--selected [data-tree-path="websocket"]')
-                await page.waitForSelector('.tree__row--expanded [data-tree-path="websocket"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="websocket"]', { visible: true })
+                await page.waitForSelector('.tree__row--expanded [data-tree-path="websocket"]', { visible: true })
                 await assertWindowLocation('/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d')
             })
 
             test('does navigation on directory row click', async () => {
                 await page.goto(baseURL + '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d')
-                await page.waitForSelector('.tree__row-label')
+                await page.waitForSelector('.tree__row-label', { visible: true })
                 await page.click('.tree__row-label')
-                await page.waitForSelector('.tree__row--selected [data-tree-path="websocket"]')
-                await page.waitForSelector('.tree__row--expanded [data-tree-path="websocket"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="websocket"]', { visible: true })
+                await page.waitForSelector('.tree__row--expanded [data-tree-path="websocket"]', { visible: true })
                 await assertWindowLocation(
                     '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/tree/websocket'
                 )
@@ -467,7 +460,7 @@ describe('e2e test suite', function(this: any): void {
                     baseURL +
                         '/github.com/sourcegraph/godockerize@05bac79edd17c0f55127871fa9c6f4d91bebf07c/-/blob/godockerize.go'
                 )
-                await page.waitForSelector('.tree__row--active [data-tree-path="godockerize.go"]')
+                await page.waitForSelector('.tree__row--active [data-tree-path="godockerize.go"]', { visible: true })
             })
 
             test('shows partial tree when opening directory', async () => {
@@ -475,7 +468,7 @@ describe('e2e test suite', function(this: any): void {
                     baseURL +
                         '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/tree/websocket'
                 )
-                await page.waitForSelector('.tree__row')
+                await page.waitForSelector('.tree__row', { visible: true })
                 expect(await page.evaluate(() => document.querySelectorAll('.tree__row').length)).toEqual(1)
             })
 
@@ -490,38 +483,40 @@ describe('e2e test suite', function(this: any): void {
                     baseURL +
                         '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/.travis.yml'
                 )
-                await page.waitForSelector('.tree__row') // waitForSelector for tree to render
+                await page.waitForSelector('.tree__row', { visible: true }) // waitForSelector for tree to render
 
                 await page.click('.tree')
                 await page.keyboard.press('ArrowUp') // arrow up to 'diff' directory
-                await page.waitForSelector('.tree__row--selected [data-tree-path="diff"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="diff"]', { visible: true })
                 await page.keyboard.press('ArrowRight') // arrow right (expand 'diff' directory)
-                await page.waitForSelector('.tree__row--selected [data-tree-path="diff"]')
-                await page.waitForSelector('.tree__row--expanded [data-tree-path="diff"]')
-                await page.waitForSelector('.tree__row [data-tree-path="diff/testdata"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="diff"]', { visible: true })
+                await page.waitForSelector('.tree__row--expanded [data-tree-path="diff"]', { visible: true })
+                await page.waitForSelector('.tree__row [data-tree-path="diff/testdata"]', { visible: true })
                 await page.keyboard.press('ArrowRight') // arrow right (move to nested 'diff/testdata' directory)
-                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]', { visible: true })
                 await assertNumRowsExpanded(1) // only `diff` directory is expanded, though `diff/testdata` is expanded
 
                 await page.keyboard.press('ArrowRight') // arrow right (expand 'diff/testdata' directory)
-                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]')
-                await page.waitForSelector('.tree__row--expanded [data-tree-path="diff/testdata"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]', { visible: true })
+                await page.waitForSelector('.tree__row--expanded [data-tree-path="diff/testdata"]', { visible: true })
                 await assertNumRowsExpanded(2) // `diff` and `diff/testdata` directories expanded
 
-                await page.waitForSelector('.tree__row [data-tree-path="diff/testdata/empty.diff"]')
+                await page.waitForSelector('.tree__row [data-tree-path="diff/testdata/empty.diff"]', { visible: true })
                 // select some file nested under `diff/testdata`
                 await page.keyboard.press('ArrowDown') // arrow down
                 await page.keyboard.press('ArrowDown') // arrow down
                 await page.keyboard.press('ArrowDown') // arrow down
                 await page.keyboard.press('ArrowDown') // arrow down
-                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata/empty_orig.diff"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata/empty_orig.diff"]', {
+                    visible: true,
+                })
 
                 await page.keyboard.press('ArrowLeft') // arrow left (navigate immediately up to parent directory `diff/testdata`)
-                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]')
+                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]', { visible: true })
                 await assertNumRowsExpanded(2) // `diff` and `diff/testdata` directories expanded
 
                 await page.keyboard.press('ArrowLeft') // arrow left
-                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]') // `diff/testdata` still selected
+                await page.waitForSelector('.tree__row--selected [data-tree-path="diff/testdata"]', { visible: true }) // `diff/testdata` still selected
                 await assertNumRowsExpanded(1) // only `diff` directory expanded
             })
         })
@@ -532,7 +527,7 @@ describe('e2e test suite', function(this: any): void {
             it('shows a row for each file in the directory', async () => {
                 await page.goto(baseURL + '/github.com/gorilla/securecookie@e59506cc896acb7f7bf732d4fdf5e25f7ccd8983')
                 await enableOrAddRepositoryIfNeeded()
-                await page.waitForSelector('.tree-page__entries-directories')
+                await page.waitForSelector('.tree-page__entries-directories', { visible: true })
                 await retry(async () =>
                     assert.equal(
                         await page.evaluate(
@@ -556,7 +551,7 @@ describe('e2e test suite', function(this: any): void {
                 await page.goto(baseURL + '/github.com/gorilla/securecookie@e59506cc896acb7f7bf732d4fdf5e25f7ccd8983', {
                     waitUntil: 'domcontentloaded',
                 })
-                await page.waitForSelector('.git-commit-node__message')
+                await page.waitForSelector('.git-commit-node__message', { visible: true })
                 await retry(async () =>
                     expect(
                         await page.evaluate(() => document.querySelectorAll('.git-commit-node__message')[2].textContent)
@@ -582,7 +577,7 @@ describe('e2e test suite', function(this: any): void {
                 await page.goto(baseURL + '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d')
                 await enableOrAddRepositoryIfNeeded()
                 // click on directory
-                await page.waitForSelector('.tree-entry')
+                await page.waitForSelector('.tree-entry', { visible: true })
                 await page.click('.tree-entry')
                 await assertWindowLocation(
                     '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/tree/websocket'
@@ -594,7 +589,7 @@ describe('e2e test suite', function(this: any): void {
         describe('rev resolution', () => {
             test('shows clone in progress interstitial page', async () => {
                 await page.goto(baseURL + '/github.com/sourcegraphtest/AlwaysCloningTest')
-                await page.waitForSelector('.hero-page__subtitle')
+                await page.waitForSelector('.hero-page__subtitle', { visible: true })
                 await retry(async () =>
                     expect(
                         await page.evaluate(() => document.querySelector('.hero-page__subtitle')!.textContent)
@@ -604,7 +599,7 @@ describe('e2e test suite', function(this: any): void {
 
             test('resolves default branch when unspecified', async () => {
                 await page.goto(baseURL + '/github.com/sourcegraph/go-diff/-/blob/diff/diff.go')
-                await page.waitForSelector('.repo-header__rev')
+                await page.waitForSelector('.repo-header__rev', { visible: true })
                 await retry(async () => {
                     expect(
                         await page.evaluate(() => document.querySelector('.repo-header__rev')!.textContent!.trim())
@@ -617,11 +612,11 @@ describe('e2e test suite', function(this: any): void {
             test('updates rev with switcher', async () => {
                 await page.goto(baseURL + '/github.com/sourcegraph/checkup/-/blob/s3.go')
                 // Open rev switcher
-                await page.waitForSelector('.repo-header__rev')
+                await page.waitForSelector('.repo-header__rev', { visible: true })
                 await page.click('.repo-header__rev')
                 // Click "Tags" tab
                 await page.click('.revisions-popover .tab-bar__tab:nth-child(2)')
-                await page.waitForSelector('a.git-ref-node[href*="0.1.0"]')
+                await page.waitForSelector('a.git-ref-node[href*="0.1.0"]', { visible: true })
                 await page.click('a.git-ref-node[href*="0.1.0"]')
                 await assertWindowLocation('/github.com/sourcegraph/checkup@v0.1.0/-/blob/s3.go')
             })
@@ -685,7 +680,9 @@ describe('e2e test suite', function(this: any): void {
                             '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/diff.pb.go#L38:6'
                         )
                         // Verify file tree is highlighting the new path.
-                        return await page.waitForSelector('.tree__row--active [data-tree-path="diff/diff.pb.go"]')
+                        return await page.waitForSelector('.tree__row--active [data-tree-path="diff/diff.pb.go"]', {
+                            visible: true,
+                        })
                     })
 
                     // basic code intel doesn't support cross-repo jump-to-definition yet.
@@ -717,7 +714,7 @@ describe('e2e test suite', function(this: any): void {
                         await assertNonemptyLocalRefs()
 
                         // verify the appropriate # of references are fetched
-                        await page.waitForSelector('.panel__tabs-content .file-match__list')
+                        await page.waitForSelector('.panel__tabs-content .file-match__list', { visible: true })
                         await retry(async () =>
                             expect(
                                 await page.evaluate(
@@ -793,7 +790,7 @@ describe('e2e test suite', function(this: any): void {
                         '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go#L19',
                     { waitUntil: 'domcontentloaded' }
                 )
-                await page.waitForSelector('.nav-link[href*="https://github"]')
+                await page.waitForSelector('.nav-link[href*="https://github"]', { visible: true })
                 await retry(async () =>
                     expect(
                         await page.evaluate(
@@ -825,14 +822,14 @@ describe('e2e test suite', function(this: any): void {
                 .join('+')
 
             await page.goto(`${baseURL}/search?q=diff+${operatorsQuery}`)
-            await page.waitForSelector('.e2e-search-results-stats')
+            await page.waitForSelector('.e2e-search-results-stats', { visible: true })
             await retry(async () => {
                 const label = await page.evaluate(
                     () => document.querySelector('.e2e-search-results-stats')!.textContent || ''
                 )
                 expect(label.includes('results')).toEqual(true)
             })
-            await page.waitForSelector('.e2e-file-match-item')
+            await page.waitForSelector('.e2e-file-match-item', { visible: true })
         })
 
         test('renders results for sourcegraph/go-diff (no search group)', async () => {
@@ -840,7 +837,7 @@ describe('e2e test suite', function(this: any): void {
             await page.goto(
                 baseURL + '/search?q=diff+repo:sourcegraph/go-diff%403f415a150aec0685cb81b73cc201e762e075006d+type:file'
             )
-            await page.waitForSelector('.e2e-search-results-stats')
+            await page.waitForSelector('.e2e-search-results-stats', { visible: true })
             await retry(async () => {
                 const label = await page.evaluate(
                     () => document.querySelector('.e2e-search-results-stats')!.textContent || ''
@@ -862,7 +859,7 @@ describe('e2e test suite', function(this: any): void {
             await page.goto(baseURL + '/search')
 
             // Update the input value
-            await page.waitForSelector('.e2e-query-input')
+            await page.waitForSelector('.e2e-query-input', { visible: true })
             await page.keyboard.type('test repo:sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d')
 
             // TODO: test search scopes
@@ -870,7 +867,7 @@ describe('e2e test suite', function(this: any): void {
             // Submit the search
             await page.click('.search-button')
 
-            await page.waitForSelector('.e2e-search-results-stats')
+            await page.waitForSelector('.e2e-search-results-stats', { visible: true })
             await retry(async () => {
                 const label = await page.evaluate(
                     () => document.querySelector('.e2e-search-results-stats')!.textContent || ''

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -416,8 +416,7 @@ describe('e2e test suite', function(this: any): void {
                 await page.goto(
                     baseURL + '/github.com/sourcegraph/godockerize@05bac79edd17c0f55127871fa9c6f4d91bebf07c'
                 )
-                await page.waitForSelector(`[data-tree-path="godockerize.go"]`)
-                await page.click(`[data-tree-path="godockerize.go"]`)
+                await (await page.waitForSelector(`[data-tree-path="godockerize.go"]`, { visible: true })).click()
                 await assertWindowLocation(
                     '/github.com/sourcegraph/godockerize@05bac79edd17c0f55127871fa9c6f4d91bebf07c/-/blob/godockerize.go'
                 )


### PR DESCRIPTION
Subsumes https://github.com/sourcegraph/sourcegraph/pull/2935 which patched `waitForSelector`, but rendered Jest call site previews useless.

@felixfbecker What do you think about this? It's redundant, but avoids the patch and associated problems.

Fixes https://buildkite.com/sourcegraph/sourcegraph/builds/29931#be09df0f-20a2-4c61-9de2-52fa00f80c17/42-209