### PR TITLE
capitalization Github -> GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@ See the changelog entries for 3.0.0 beta releases and our [3.0](doc/admin/migrat
 - The **Info** panel was removed. The information it presented can be viewed in the hover.
 - The top-level `repos.list` site configuration was removed in favour of each code-host's equivalent options,
   now configured via the new _External Services UI_ available at `/site-admin/external-services`. Equivalent options in code hosts configuration:
-  - Github via [`github.repos`](https://docs.sourcegraph.com/admin/site_config/all#repos-array)
+  - GitHub via [`github.repos`](https://docs.sourcegraph.com/admin/site_config/all#repos-array)
   - Gitlab via [`gitlab.projectQuery`](https://docs.sourcegraph.com/admin/site_config/all#projectquery-array)
   - Phabricator via [`phabricator.repos`](https://docs.sourcegraph.com/admin/site_config/all#phabricator-array)
   - [Other external services](https://docs.sourcegraph.com/admin/repo/add_from_other_external_services)
@@ -820,7 +820,7 @@ See the changelog entries for 3.0.0 beta releases and our [3.0](doc/admin/migrat
 
 ### Phabricator Integration Changes
 
-We now display a "View on Phabricator" link rather than a "View on other code host" link if you are using Phabricator and hosting on Github or another code host with a UI. Commit links also will point to Phabricator.
+We now display a "View on Phabricator" link rather than a "View on other code host" link if you are using Phabricator and hosting on GitHub or another code host with a UI. Commit links also will point to Phabricator.
 
 ### Improvements to SAML authentication
 

--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -105,7 +105,7 @@ Save a file and wait for webpack to finish rebuilding.
 
 The window that is spun up is completely separate from any existing sessions you have on Firefox.
 You'll have to sign into everything at the begining of each development session(each time you run `yarn run dev:firefox`).
-You should ensure you're signed into any Sourcegraph instance you point the extension at as well as Github.
+You should ensure you're signed into any Sourcegraph instance you point the extension at as well as GitHub.
 
 ### Firefox (manual)
 

--- a/doc/admin/migration/3_0.md
+++ b/doc/admin/migration/3_0.md
@@ -34,8 +34,8 @@ The data from your existing site configuration will be automatically migrated wh
 ## `repos.list` was removed from site configuration
 
 The top-level `repos.list` site configuration was removed in favour of each code-host's equivalent options, now configured via [external services](#Repositories-are-managed-by-configuring-external-services). Equivalent options in code hosts configuration:
-  - Github via [`github.repos`](https://docs.sourcegraph.com/admin/site_config/all#repos-array)
-  - Gitlab via [`gitlab.projectQuery`](https://docs.sourcegraph.com/admin/site_config/all#projectquery-array)
+  - GitHub via [`github.repos`](https://docs.sourcegraph.com/admin/site_config/all#repos-array)
+  - GitLab via [`gitlab.projectQuery`](https://docs.sourcegraph.com/admin/site_config/all#projectquery-array)
   - Phabricator via [`phabricator.repos`](https://docs.sourcegraph.com/admin/site_config/all#phabricator-array)
   - [Other external services](https://docs.sourcegraph.com/admin/repo/add_from_other_external_services)
 

--- a/doc/dev/retrospectives/3_0.md
+++ b/doc/dev/retrospectives/3_0.md
@@ -10,7 +10,7 @@
    * https://github.com/sourcegraph/sourcegraph/issues/2312
    * https://github.com/sourcegraph/sourcegraph/issues/2313
    * https://github.com/sourcegraph/sourcegraph/issues/2314 
-* Tomás to make master a protected branch on Github and require the buildkite check to pass before merging it.
+* Tomás to make master a protected branch on GitHub and require the Buildkite check to pass before merging it.
 * Nick document reviewing previous retrospective and include link in survey answers
 * Nick to change retro question to be a single question
 * Chris asks: What did we decide regarding manual testing, and how will we communicate that? Can be a Slack message

--- a/doc/dev/retrospectives/postgresql_upgrade.md
+++ b/doc/dev/retrospectives/postgresql_upgrade.md
@@ -4,7 +4,7 @@
 
 1. Master must always be in a releasable state. Don’t create breaking changes that block the next release.
 1. Estimate and plan work before scheduling it for a release.
-1. Prefer to share context using Github Issues instead of Slack.
+1. Prefer to share context using GitHub Issues instead of Slack.
 1. Warning signs to be careful with adopted issues: missed estimates, being passed around, and fixed deadline.
 
 ## Background

--- a/pkg/extsvc/github/client.go
+++ b/pkg/extsvc/github/client.go
@@ -78,7 +78,7 @@ type Client struct {
 	RateLimit *ratelimit.Monitor
 }
 
-// APIError is an error type returned by Client when the Github API responds with
+// APIError is an error type returned by Client when the GitHub API responds with
 // an error.
 type APIError struct {
 	URL              string


### PR DESCRIPTION
This only changes docs and comments, not code, to avoid merge conflicts. Eventual consistency in the capitalization of GitHub is OK. :)

https://docs.sourcegraph.com/dev/style_guide