### PR TITLE
show custom notices on the homepage (and consolidate motd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Enterprise admins can now customize the appearance of the homepage and search icon.
+- A new settings property `notices` allows showing custom informational messages on the homepage and at the top of each page.
 
 ### Changed
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -285,6 +285,11 @@ func (v *IdentityProvider) UnmarshalJSON(data []byte) error {
 type Log struct {
 	Sentry *Sentry `json:"sentry,omitempty"`
 }
+type Notice struct {
+	Dismissible bool   `json:"dismissible,omitempty"`
+	Location    string `json:"location"`
+	Message     string `json:"message"`
+}
 type OAuthIdentity struct {
 	Type string `json:"type"`
 }
@@ -378,6 +383,7 @@ type Sentry struct {
 type Settings struct {
 	Extensions             map[string]bool           `json:"extensions,omitempty"`
 	Motd                   []string                  `json:"motd,omitempty"`
+	Notices                []*Notice                 `json:"notices,omitempty"`
 	NotificationsSlack     *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
 	SearchContextLines     int                       `json:"search.contextLines,omitempty"`
 	SearchRepositoryGroups map[string][]string       `json:"search.repositoryGroups,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -65,9 +65,34 @@
       "$ref": "#/definitions/SlackNotificationsConfig"
     },
     "motd": {
-      "description": "An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
+      "description": "DEPRECATED: Use `notices` instead.\n\nAn array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
       "type": "array",
       "items": { "type": "string" }
+    },
+    "notices": {
+      "description": "Custom informational messages to display to users at specific locations in the Sourcegraph user interface.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.",
+      "type": "array",
+      "items": {
+        "title": "Notice",
+        "type": "object",
+        "required": ["message", "location"],
+        "properties": {
+          "message": {
+            "description": "The message to display. Markdown formatting is supported.",
+            "type": "string"
+          },
+          "location": {
+            "description": "The location where this notice is shown: \"top\" for the top of every page, \"home\" for the homepage.",
+            "type": "string",
+            "enum": ["top", "home"]
+          },
+          "dismissible": {
+            "description": "Whether this notice can be dismissed (closed) by the user.",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
     },
     "extensions": {
       "description": "The Sourcegraph extensions to use. Enable an extension by adding a property `\"my/extension\": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -70,9 +70,34 @@ const SettingsSchemaJSON = `{
       "$ref": "#/definitions/SlackNotificationsConfig"
     },
     "motd": {
-      "description": "An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
+      "description": "DEPRECATED: Use ` + "`" + `notices` + "`" + ` instead.\n\nAn array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
       "type": "array",
       "items": { "type": "string" }
+    },
+    "notices": {
+      "description": "Custom informational messages to display to users at specific locations in the Sourcegraph user interface.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.",
+      "type": "array",
+      "items": {
+        "title": "Notice",
+        "type": "object",
+        "required": ["message", "location"],
+        "properties": {
+          "message": {
+            "description": "The message to display. Markdown formatting is supported.",
+            "type": "string"
+          },
+          "location": {
+            "description": "The location where this notice is shown: \"top\" for the top of every page, \"home\" for the homepage.",
+            "type": "string",
+            "enum": ["top", "home"]
+          },
+          "dismissible": {
+            "description": "Whether this notice can be dismissed (closed) by the user.",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
     },
     "extensions": {
       "description": "The Sourcegraph extensions to use. Enable an extension by adding a property ` + "`" + `\"my/extension\": true` + "`" + ` (where ` + "`" + `my/extension` + "`" + ` is the extension ID). Override a previously enabled extension and disable it by setting its value to ` + "`" + `false` + "`" + `.",

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -234,6 +234,7 @@ hr {
 @import './extensions/extension/ExtensionArea';
 @import './global/GlobalAlerts';
 @import './global/GlobalDebug';
+@import './global/Notices';
 @import './search/input/ScopePage';
 @import './search/input/SearchPage';
 @import './search/results/SearchResults';

--- a/web/src/components/DismissibleAlert.scss
+++ b/web/src/components/DismissibleAlert.scss
@@ -1,8 +1,7 @@
 .dismissible-alert {
     display: flex;
     align-items: flex-start;
-    padding: 0.75rem;
-    margin-bottom: 0;
+    padding-right: 0.5rem;
 
     &__content {
         flex: 1 1 auto;

--- a/web/src/global/GlobalAlerts.scss
+++ b/web/src/global/GlobalAlerts.scss
@@ -4,15 +4,11 @@
 
     &__alert {
         width: 100%;
-        padding-top: 0.75rem;
-        padding-bottom: 0.75rem;
+        padding: 0.5rem !important;
         margin-bottom: 0 !important;
 
         border-radius: 0;
         border-width: 0 0 1px 0;
-
-        // stylelint-disable-next-line declaration-property-unit-whitelist
-        font-size: 16px;
 
         // The trailing after-paragraph/list margin looks unbalanced in MOTDs.
         p:last-child,

--- a/web/src/global/GlobalAlerts.tsx
+++ b/web/src/global/GlobalAlerts.tsx
@@ -12,6 +12,7 @@ import { NeedsRepositoryConfigurationAlert } from '../site/NeedsRepositoryConfig
 import { NoRepositoriesEnabledAlert } from '../site/NoRepositoriesEnabledAlert'
 import { UpdateAvailableAlert } from '../site/UpdateAvailableAlert'
 import { GlobalAlert } from './GlobalAlert'
+import { Notices } from './Notices'
 
 interface Props extends SettingsCascadeProps {
     isSiteAdmin: boolean
@@ -82,6 +83,11 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                             <Markdown dangerousInnerHTML={renderMarkdown(m)} />
                         </DismissibleAlert>
                     ))}
+                <Notices
+                    alertClassName="global-alerts__alert"
+                    location="top"
+                    settingsCascade={this.props.settingsCascade}
+                />
             </div>
         )
     }

--- a/web/src/global/Notices.scss
+++ b/web/src/global/Notices.scss
@@ -1,0 +1,5 @@
+.notices {
+    p:last-child {
+        margin-bottom: 0; // override Bootstrap to fix uneven spacing at end of alert
+    }
+}

--- a/web/src/global/Notices.test.tsx
+++ b/web/src/global/Notices.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Notices } from './Notices'
+
+describe('Notices', () => {
+    test('shows notices for location', () =>
+        expect(
+            renderer
+                .create(
+                    <Notices
+                        location="home"
+                        settingsCascade={{
+                            subjects: [],
+                            final: {
+                                notices: [
+                                    { message: 'a', location: 'home' },
+                                    { message: 'a', location: 'home', dismissible: true },
+                                    { message: 'b', location: 'top' },
+                                ],
+                            },
+                        }}
+                    />
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+
+    test('no notices', () =>
+        expect(
+            renderer
+                .create(<Notices location="home" settingsCascade={{ subjects: [], final: { notices: null } }} />)
+                .toJSON()
+        ).toMatchSnapshot())
+})

--- a/web/src/global/Notices.tsx
+++ b/web/src/global/Notices.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { Markdown } from '../../../shared/src/components/Markdown'
+import { isSettingsValid, SettingsCascadeProps } from '../../../shared/src/settings/settings'
+import { renderMarkdown } from '../../../shared/src/util/markdown'
+import { DismissibleAlert } from '../components/DismissibleAlert'
+import { Notice, Settings } from '../schema/settings.schema'
+
+const Notice: React.FunctionComponent<{ notice: Notice; className?: string }> = ({ notice, className = '' }) => {
+    const content = <Markdown dangerousInnerHTML={renderMarkdown(notice.message)} />
+    return !!notice.dismissible ? (
+        <DismissibleAlert className={`alert-info ${className}`} partialStorageKey={`notice.${notice.message}`}>
+            {content}
+        </DismissibleAlert>
+    ) : (
+        <div className={`alert alert-info ${className}`}>{content}</div>
+    )
+}
+
+interface Props extends SettingsCascadeProps {
+    className?: string
+
+    /** Apply this class name to each notice (alongside .alert). */
+    alertClassName?: string
+
+    /** Display notices for this location. */
+    location: Notice['location']
+}
+
+/**
+ * Displays notices from settings for a specific location.
+ */
+export const Notices: React.FunctionComponent<Props> = ({
+    className = '',
+    alertClassName,
+    settingsCascade,
+    location,
+}) => {
+    if (
+        !isSettingsValid<Settings>(settingsCascade) ||
+        !settingsCascade.final.notices ||
+        !Array.isArray(settingsCascade.final.notices)
+    ) {
+        return null
+    }
+    const notices = settingsCascade.final.notices.filter(n => n.location === location)
+    if (notices.length === 0) {
+        return null
+    }
+    return (
+        <div className={`notices ${className}`}>
+            {notices.map((notice, i) => (
+                <Notice key={i} className={alertClassName} notice={notice} />
+            ))}
+        </div>
+    )
+}

--- a/web/src/global/__snapshots__/Notices.test.tsx.snap
+++ b/web/src/global/__snapshots__/Notices.test.tsx.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notices no notices 1`] = `null`;
+
+exports[`Notices shows notices for location 1`] = `
+<div
+  className="notices "
+>
+  <div
+    className="alert alert-info "
+  >
+    <div
+      className="markdown undefined"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>a</p>
+",
+        }
+      }
+    />
+  </div>
+  <div
+    className="alert dismissible-alert alert-info "
+  >
+    <div
+      className="dismissible-alert__content"
+    >
+      <div
+        className="markdown undefined"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>a</p>
+",
+          }
+        }
+      />
+    </div>
+    <button
+      className="btn btn-icon"
+      onClick={[Function]}
+    >
+      <svg
+        className="mdi-icon icon-inline"
+        fill="currentColor"
+        height={24}
+        viewBox="0 0 24 24"
+        width={24}
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -6,6 +6,7 @@ import * as GQL from '../../../../shared/src/graphql/schema'
 import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { Form } from '../../components/Form'
 import { PageTitle } from '../../components/PageTitle'
+import { Notices } from '../../global/Notices'
 import { Settings } from '../../schema/settings.schema'
 import { ThemePreferenceProps, ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -123,6 +124,7 @@ export class SearchPage extends React.Component<Props, State> {
                             </div>
                         </>
                     )}
+                    <Notices className="my-3" location="home" settingsCascade={this.props.settingsCascade} />
                 </Form>
             </div>
         )


### PR DESCRIPTION
- Adds a new setting property `notices` that contains messages to be shown on the homepage and in the global alerts at the top of the page (like `motd`)
- Cleans up CSS to make the display of dismissible and non-dismissible alerts consistent (w.r.t. padding and sizing)

closes https://github.com/sourcegraph/sourcegraph/issues/653

![image](https://user-images.githubusercontent.com/1976/54886396-e6b9d280-4e87-11e9-858f-cf55e704a885.png)


Test plan:

Use the following user settings JSON and ensure that the global alerts and homepage notices are shown correctly, are consistently padded and sized, and are escaped.

```
{
 "notices": [
   {"location": "home", "message": "hello, world! **hello**", "dismissible": true},
      {"location": "top", "message": "<small>This is a message **at the top**</small>"},
      {
        "location": "home",
        "message": "Suspendisse potenti. Curabitur non sapien porttitor, euismod ligula quis, malesuada neque. Aliquam blandit nunc at quam consectetur dignissim at a dolor. Suspendisse nunc lacus, placerat nec ante non, tempus elementum nulla. Nunc aliquam justo dui, in elementum urna rhoncus non. Sed **egestas** [mattis](https://sourcegraph.com) <div classname='alert alert-danger'>hello</div> erat in congue. Integer quis ex ullamcorper, condimentum libero ut, elementum felis. Sed id sem tristique libero commodo eleifend in sed tellus. Fusce nisl ante, ullamcorper pulvinar accumsan non, vulputate quis nulla."
      }
 ],
 "motd": ["Hello, world!"]
}
```