### PR TITLE
prevent query field from being autofilled with password

### DIFF
--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -292,6 +292,8 @@ export class QueryInput extends React.Component<Props, State> {
                     autoCapitalize="off"
                     placeholder={this.props.placeholder === undefined ? 'Search code...' : this.props.placeholder}
                     ref={ref => (this.inputElement = ref!)}
+                    name="query"
+                    autoComplete="off"
                 />
                 {showSuggestions && (
                     <ul className="query-input2__suggestions" ref={this.setSuggestionListElement}>


### PR DESCRIPTION
Chrome was autofilling the query input with my password for some reason. This should prevent that from occurring.