### PR TITLE
Add alerts to site-admins when license keys are about to expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The new `gitlab.exclude` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to exclude specific repositories matched by `gitlab.projectQuery` and `gitlab.projects` (so that they won't be synced).
 - The new `gitlab.projects` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to select specific repositories to be synced.
 - "Quick configure" buttons for common actions have been added to the config editor for all external services.
+- Site-admins now receive an alert every day for the seven days before their license key expires.
 
 ### Changed
 

--- a/web/src/global/GlobalAlerts.tsx
+++ b/web/src/global/GlobalAlerts.tsx
@@ -1,3 +1,4 @@
+import differenceInDays from 'date-fns/differenceInDays'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
 import { Markdown } from '../../../shared/src/components/Markdown'
@@ -8,6 +9,7 @@ import { Settings } from '../schema/settings.schema'
 import { SiteFlags } from '../site'
 import { siteFlags } from '../site/backend'
 import { DockerForMacAlert } from '../site/DockerForMacAlert'
+import { LicenseExpirationAlert } from '../site/LicenseExpirationAlert'
 import { NeedsRepositoryConfigurationAlert } from '../site/NeedsRepositoryConfigurationAlert'
 import { NoRepositoriesEnabledAlert } from '../site/NoRepositoriesEnabledAlert'
 import { UpdateAvailableAlert } from '../site/UpdateAvailableAlert'
@@ -69,6 +71,20 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                         {this.state.siteFlags.alerts.map((alert, i) => (
                             <GlobalAlert key={i} alert={alert} className="global-alerts__alert" />
                         ))}
+
+                        {this.state.siteFlags.productSubscription.license &&
+                            differenceInDays(this.state.siteFlags.productSubscription.license.expiresAt, Date.now()) <=
+                                365 && (
+                                <LicenseExpirationAlert
+                                    expiresAt={this.state.siteFlags.productSubscription.license.expiresAt}
+                                    daysLeft={Math.floor(
+                                        differenceInDays(
+                                            this.state.siteFlags.productSubscription.license.expiresAt,
+                                            Date.now()
+                                        )
+                                    )}
+                                />
+                            )}
                     </>
                 )}
                 {isSettingsValid<Settings>(this.props.settingsCascade) &&

--- a/web/src/global/GlobalAlerts.tsx
+++ b/web/src/global/GlobalAlerts.tsx
@@ -74,7 +74,7 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
 
                         {this.state.siteFlags.productSubscription.license &&
                             differenceInDays(this.state.siteFlags.productSubscription.license.expiresAt, Date.now()) <=
-                                365 && (
+                                7 && (
                                 <LicenseExpirationAlert
                                     expiresAt={this.state.siteFlags.productSubscription.license.expiresAt}
                                     daysLeft={Math.floor(

--- a/web/src/site/LicenseExpirationAlert.tsx
+++ b/web/src/site/LicenseExpirationAlert.tsx
@@ -1,0 +1,30 @@
+import formatDistanceStrict from 'date-fns/formatDistanceStrict'
+import WarningIcon from 'mdi-react/WarningIcon'
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+import { DismissibleAlert } from '../components/DismissibleAlert'
+
+/**
+ * A global alert that appears telling the site admin that their license key is about to expire. Even after being dismissed,
+ * it reappears every day.
+ */
+export const LicenseExpirationAlert: React.FunctionComponent<{
+    expiresAt: string
+    daysLeft: number
+    className?: string
+}> = ({ expiresAt, daysLeft, className = '' }) => (
+    <DismissibleAlert
+        partialStorageKey={`licenseExpiring.${daysLeft}`}
+        className={`alert alert-warning d-flex align-items-center ${className}`}
+    >
+        <WarningIcon className="icon-inline mr-2 flex-shrink-0" />
+        Your Sourcegraph license will expire in {formatDistanceStrict(expiresAt, Date.now())}.&nbsp;
+        <Link className="site-alert__link" to="/site-admin/license">
+            <span className="underline">Renew now</span>
+        </Link>
+        &nbsp;or&nbsp;
+        <a className="site-alert__link" href="https://about.sourcegraph.com/contact">
+            <span className="underline">contact Sourcegraph</span>
+        </a>
+    </DismissibleAlert>
+)

--- a/web/src/site/backend.tsx
+++ b/web/src/site/backend.tsx
@@ -48,6 +48,11 @@ export function refreshSiteFlags(): Observable<never> {
                             errorMessage
                             updateVersionAvailable
                         }
+                        productSubscription {
+                            license {
+                                expiresAt
+                            }
+                        }
                     }
                 }
             `)

--- a/web/src/site/index.ts
+++ b/web/src/site/index.ts
@@ -9,4 +9,5 @@ export type SiteFlags = Pick<
     | 'disableBuiltInSearches'
     | 'sendsEmailVerificationEmails'
     | 'updateCheck'
+    | 'productSubscription'
 >


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/issues/3016
~Addresses first item from https://github.com/sourcegraph/sourcegraph/pull/2894~ 

Instead of making it a non-dismissable alert, I made it re-appear every day from 7 days out.

While this example shows "7 months", it really will only appear when there are 7 or fewer days left.

![image](https://user-images.githubusercontent.com/5589410/54936452-be5dc280-4edf-11e9-9c5f-4bc134c7712a.png)
