### PR TITLE
Activation flow: fix references check

### DIFF
--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -114,7 +114,7 @@ export class BlobPanel extends React.PureComponent<Props> {
                         //
                         // tslint:disable-next-line:no-object-literal-type-assertion
                         locationProvider: registry.getLocations({ ...params, ...extraParams } as P).pipe(
-                            tap(locationsObservable =>
+                            map(locationsObservable =>
                                 locationsObservable.pipe(
                                     tap(locations => {
                                         if (


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/2964, I broke activation flow for references in such a way that nobody could complete that part of the flow.

Fixes https://github.com/sourcegraph/sourcegraph/issues/2979