### PR TITLE
fix certain broken regular expressions by quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - The symbols sidebar now only shows symbols defined in the current file or directory.
-
 - The default `github.repositoryQuery` of a [GitHub external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["affiliated", "public"]`).
+- Certain invalid regular expressions are automatically treated as string literals. [See the issue for more information.](https://github.com/sourcegraph/sourcegraph/issues/2125)
 
 ### Fixed
 

--- a/cmd/frontend/internal/pkg/search/query/types/check_test.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check_test.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"regexp"
 	"testing"
@@ -185,4 +186,56 @@ func TestSetValue(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TODO(isaac): remove this test before PR is merged. It's here as a proof.
+func TestCheckNeedToQuoteCurlyBraces(t *testing.T) {
+	tests := []struct {
+		regexp  string
+		sub     string
+		matches []string
+	}{
+		{
+			regexp:  "foo{",
+			sub:     "foo",
+			matches: []string{},
+		},
+		{
+			regexp:  "foo{",
+			sub:     "foo{",
+			matches: []string{"foo{"},
+		},
+		{
+			regexp:  "foo{0,1}",
+			sub:     "foo{",
+			matches: []string{"foo"},
+		},
+		{
+			regexp:  "foo{0,1}",
+			sub:     "",
+			matches: []string{},
+		},
+		{
+			regexp:  "foo{0,1}",
+			sub:     "foo",
+			matches: []string{"foo"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("regepx %s; sub %s", test.regexp, test.sub), func(t *testing.T) {
+			p, _ := regexp.Compile(test.regexp)
+			matches := p.FindAllString(test.sub, -1)
+
+			if len(matches) != len(test.matches) {
+				t.Fatalf("unexpected FindAllString results\ngot: %v\nwant: %v\n", matches, test.matches)
+			}
+
+			for i := range matches {
+				if matches[i] != test.matches[i] {
+					t.Errorf("unexpected FindAllString results\ngot: %v\nwant: %v\n", matches, test.matches)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR addresses https://github.com/sourcegraph/sourcegraph/issues/2125. The query parser now places quotation marks around search queries (treats as a string literal) if they are a regular expression and are invalid for one of the following reasons:

- There is an unclosed `(`
- There is an unclosed `[`

Closes https://github.com/sourcegraph/sourcegraph/issues/2125.

The issue description currently says that we should also treat queries with unclosed `{` as well. However, I have determined that we do not need to do this. `foo{` is a valid regular expression and behaves as expected. [See this commit/test for proof.](https://github.com/sourcegraph/sourcegraph/pull/2999/commits/65b600ca741d94e8170b65e12a69f3bda8405ff7)

Before merging, we should revert https://github.com/sourcegraph/sourcegraph/pull/2999/commits/65b600ca741d94e8170b65e12a69f3bda8405ff7.

Test plan: A test was added to the code.
