### PR TITLE
Code intel: fix merging of locations

### DIFF
--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -101,7 +101,6 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                             locationsOrError: isErrorLike(locationsOrError)
                                 ? locationsOrError
                                 : { ...old.locationsOrError, ...locationsOrError },
-                            selectedGroups: old.selectedGroups,
                         })),
                     error => console.error(error)
                 )

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -78,7 +78,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                                 locations.pipe(
                                     map(result => ({ results: result || [], loading: true })),
                                     catchError((error): [ErrorLike] => [asError(error)]),
-                                    startWith<State['locationsOrError']>({ loading: true }),
+                                    startWith<State['locationsOrError']>({ results: undefined, loading: true }),
                                     tap(locationsOrError => {
                                         this.props.extensionsController.services.context.data.next({
                                             ...this.props.extensionsController.services.context.data.value,

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -76,10 +76,8 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                         locationProviderResults.pipe(
                             switchMap(locations =>
                                 locations.pipe(
+                                    map(result => ({ results: result || [], loading: true })),
                                     catchError((error): [ErrorLike] => [asError(error)]),
-                                    map(result =>
-                                        isErrorLike(result) ? result : { results: result || [], loading: true }
-                                    ),
                                     startWith<State['locationsOrError']>({ loading: true }),
                                     tap(locationsOrError => {
                                         this.props.extensionsController.services.context.data.next({


### PR DESCRIPTION
Previously, if an extension emitted from a references provider the locations `[A, B]` then `[C]`, the references panel would show `[C, B]` because it did component-wise merging of the arrays. This blames to https://github.com/sourcegraph/sourcegraph/pull/2271/files#diff-a156849c8d06dcc9cd46e215d155d5bdR101

Now, the entire array is replaced when a references provider emits.

I ran into this while implementing fallback to basic-code-intel if the language server takes >Nms to return references.