### PR TITLE
Fix bitbucket server getCommandPaletteMount idempotency

### DIFF
--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -102,17 +102,17 @@ function getCommandPaletteMount(): HTMLElement {
         throw new Error('Unable to find command palette mount')
     }
 
-    const commandListClass = 'command-palette-button command-palette-button__bitbucket-server'
+    const commandListClasses = ['command-palette-button', 'command-palette-button__bitbucket-server']
 
     const createCommandList = (): HTMLElement => {
         const commandListElem = document.createElement('li')
-        commandListElem.className = commandListClass
+        commandListElem.className = commandListClasses.join(' ')
         headerElem!.insertAdjacentElement('beforeend', commandListElem)
 
         return commandListElem
     }
 
-    return document.querySelector<HTMLElement>('.' + commandListClass) || createCommandList()
+    return document.querySelector<HTMLElement>(commandListClasses.map(c => `.${c}`).join('')) || createCommandList()
 }
 
 export const bitbucketServerCodeHost: CodeHost = {


### PR DESCRIPTION
Fixes #2977

`bitbucketServerCodeHost.getCommandPaletteMount()` would check for a broken selector when looking for a previously injected command palette mount.
