### PR TITLE
repo-updater: Implement GitLab exclude feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Enterprise admins can now customize the appearance of the homepage and search icon.
 - A new settings property `notices` allows showing custom informational messages on the homepage and at the top of each page.
-- The new `gitlab.exclude` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to exclude specific repositories matched by `gitlab.projectQuery` (so that they won't be synced).
+- The new `gitlab.exclude` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to exclude specific repositories matched by `gitlab.projectQuery` and `gitlab.projects` (so that they won't be synced).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Enterprise admins can now customize the appearance of the homepage and search icon.
 - A new settings property `notices` allows showing custom informational messages on the homepage and at the top of each page.
-- The `gitlab.exclude` setting was added to the [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) to allow excluding repositories yielded by `gitlab.projectQuery` from being synced.
+- The new `gitlab.exclude` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to exclude specific repositories matched by `gitlab.projectQuery` (so that they won't be synced).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Enterprise admins can now customize the appearance of the homepage and search icon.
 - A new settings property `notices` allows showing custom informational messages on the homepage and at the top of each page.
+- The `gitlab.exclude` setting was added to the [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) to allow excluding repositories yielded by `gitlab.projectQuery` from being synced.
 
 ### Changed
 

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -172,7 +172,7 @@ func TestSources_ListRepos(t *testing.T) {
 						"sourcegraph/Sourcegraph",
 						"tsenart/VEGETA",
 					},
-					Exclude: []*schema.Exclude{
+					Exclude: []*schema.ExcludedGitHubRepo{
 						{Name: "tsenart/Vegeta"},
 						{Id: "MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU="}, // tsenart/patrol ID
 					},
@@ -186,7 +186,7 @@ func TestSources_ListRepos(t *testing.T) {
 						"?search=gokulkarthick",
 						"?search=dotfiles-vegetableman",
 					},
-					Exclude: []*schema.Exclude{
+					Exclude: []*schema.ExcludedGitLabProject{
 						{Name: "gokulkarthick/gokulkarthick"},
 						{Id: "7789240"},
 					},
@@ -207,24 +207,32 @@ func TestSources_ListRepos(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					var exclude []*schema.Exclude
-					switch cfg := c.(type) {
-					case *schema.GitHubConnection:
-						exclude = cfg.Exclude
-					case *schema.GitLabConnection:
-						exclude = cfg.Exclude
+					type excluded struct {
+						name, id string
 					}
 
-					if len(exclude) == 0 {
+					var ex []excluded
+					switch cfg := c.(type) {
+					case *schema.GitHubConnection:
+						for _, e := range cfg.Exclude {
+							ex = append(ex, excluded{name: e.Name, id: e.Id})
+						}
+					case *schema.GitLabConnection:
+						for _, e := range cfg.Exclude {
+							ex = append(ex, excluded{name: e.Name, id: e.Id})
+						}
+					}
+
+					if len(ex) == 0 {
 						t.Fatal("exclude list must not be empty")
 					}
 
-					for _, e := range exclude {
-						name := e.Name
+					for _, e := range ex {
+						name := e.name
 						if s.Kind == "GITHUB" {
 							name = strings.ToLower(name)
 						}
-						set[name], set[e.Id] = true, true
+						set[name], set[e.id] = true, true
 					}
 				}
 

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -122,7 +122,7 @@ func TestSources_ListRepos(t *testing.T) {
 					Url:   "https://gitlab.com",
 					Token: os.Getenv("GITLAB_ACCESS_TOKEN"),
 					ProjectQuery: []string{
-						"?search=vegeta",
+						"?search=gokulkarthick",
 					},
 				}),
 			},
@@ -178,6 +178,20 @@ func TestSources_ListRepos(t *testing.T) {
 					},
 				}),
 			},
+			{
+				Kind: "GITLAB",
+				Config: marshalJSON(t, &schema.GitLabConnection{
+					Url: "https://gitlab.com",
+					ProjectQuery: []string{
+						"?search=gokulkarthick",
+						"?search=dotfiles-vegetableman",
+					},
+					Exclude: []*schema.Exclude{
+						{Name: "gokulkarthick/gokulkarthick"},
+						{Id: "7789240"},
+					},
+				}),
+			},
 		}
 
 		testCases = append(testCases, testCase{
@@ -196,6 +210,8 @@ func TestSources_ListRepos(t *testing.T) {
 					var exclude []*schema.Exclude
 					switch cfg := c.(type) {
 					case *schema.GitHubConnection:
+						exclude = cfg.Exclude
+					case *schema.GitLabConnection:
 						exclude = cfg.Exclude
 					}
 

--- a/cmd/repo-updater/repos/testdata/github/yielded-repos-are-always-enabled.yaml
+++ b/cmd/repo-updater/repos/testdata/github/yielded-repos-are-always-enabled.yaml
@@ -9,6 +9,26 @@ interactions:
       - application/vnd.github.jean-grey-preview+json
       Content-Type:
       - application/json; charset=utf-8
+    url: http://api.github.com/repos/sourcegraph/sourcegraph
+    method: GET
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Location:
+      - https://api.github.com/repos/sourcegraph/sourcegraph
+    status: 301 Moved Permanently
+    code: 301
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
     url: http://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol
     method: GET
   response:
@@ -29,88 +49,13 @@ interactions:
       - application/vnd.github.jean-grey-preview+json
       Content-Type:
       - application/json; charset=utf-8
-    url: http://api.github.com/repos/sourcegraph/sourcegraph
-    method: GET
-  response:
-    body: ""
-    headers:
-      Content-Length:
-      - "0"
-      Location:
-      - https://api.github.com/repos/sourcegraph/sourcegraph
-    status: 301 Moved Permanently
-    code: 301
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://gitlab.com/api/v4/projects?order_by=last_activity_at&per_page=100&search=gokulkarthick
-    method: GET
-  response:
-    body: '[{"id":927197,"description":"","name":"gokulkarthick","name_with_namespace":"Gokul
-      Karthick / gokulkarthick","path":"gokulkarthick","path_with_namespace":"gokulkarthick/gokulkarthick","created_at":"2016-03-02T10:30:48.552Z","default_branch":"master","tag_list":[],"ssh_url_to_repo":"git@gitlab.com:gokulkarthick/gokulkarthick.git","http_url_to_repo":"https://gitlab.com/gokulkarthick/gokulkarthick.git","web_url":"https://gitlab.com/gokulkarthick/gokulkarthick","readme_url":"https://gitlab.com/gokulkarthick/gokulkarthick/blob/master/README.md","avatar_url":null,"star_count":0,"forks_count":0,"last_activity_at":"2016-03-02T10:30:49.086Z","namespace":{"id":509170,"name":"gokulkarthick","path":"gokulkarthick","kind":"user","full_path":"gokulkarthick","parent_id":null}}]'
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "773"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 28 Mar 2019 14:01:12 GMT
-      Etag:
-      - W/"2e213a0bf612bec448cc4972d255ca73"
-      Link:
-      - <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
-        rel="first", <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
-        rel="last"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Origin
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Next-Page:
-      - ""
-      X-Page:
-      - "1"
-      X-Per-Page:
-      - "100"
-      X-Prev-Page:
-      - ""
-      X-Request-Id:
-      - JqABVBokUb4
-      X-Runtime:
-      - "0.094537"
-      X-Total:
-      - "1"
-      X-Total-Pages:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
       Referer:
       - http://api.github.com/repos/sourcegraph/sourcegraph
     url: https://api.github.com/repos/sourcegraph/sourcegraph
     method: GET
   response:
     body: '{"id":41288708,"node_id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","name":"sourcegraph","full_name":"sourcegraph/sourcegraph","private":false,"owner":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/sourcegraph/sourcegraph","description":"Code
-      search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2019-03-28T11:14:01Z","pushed_at":"2019-03-28T13:59:34Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":276197,"stargazers_count":1864,"watchers_count":1864,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":121,"mirror_url":null,"archived":false,"open_issues_count":675,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"forks":121,"open_issues":675,"watchers":1864,"default_branch":"master","organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":121,"subscribers_count":40}'
+      search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2019-03-27T18:25:56Z","pushed_at":"2019-03-27T18:25:53Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":276149,"stargazers_count":1861,"watchers_count":1861,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":121,"mirror_url":null,"archived":false,"open_issues_count":674,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"forks":121,"open_issues":674,"watchers":1861,"default_branch":"master","organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":121,"subscribers_count":40}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -125,11 +70,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2019 14:01:12 GMT
+      - Wed, 27 Mar 2019 18:34:43 GMT
       Etag:
-      - W/"daca3ab52958e88fcff83fe792b0f8b4"
+      - W/"b6f8017024cfb6ba427186499a09b5d5"
       Last-Modified:
-      - Thu, 28 Mar 2019 11:14:01 GMT
+      - Wed, 27 Mar 2019 18:25:56 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -147,7 +92,7 @@ interactions:
       X-Github-Media-Type:
       - github.v3; param=jean-grey-preview; format=json
       X-Github-Request-Id:
-      - F6BD:3571:2CECC9:6FA8C7:5C9CD3A8
+      - D636:4B49:16B1D3:2E3058:5C9BC242
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -169,7 +114,7 @@ interactions:
     body: '{"total_count":1,"incomplete_results":false,"items":[{"id":153657245,"node_id":"MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU=","name":"patrol","full_name":"tsenart/patrol","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/patrol","description":"Patrol
       is an operator friendly distributed rate limiting HTTP API with strong eventually
       consistent CvRDT based replication.","fork":false,"url":"https://api.github.com/repos/tsenart/patrol","forks_url":"https://api.github.com/repos/tsenart/patrol/forks","keys_url":"https://api.github.com/repos/tsenart/patrol/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/patrol/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/patrol/teams","hooks_url":"https://api.github.com/repos/tsenart/patrol/hooks","issue_events_url":"https://api.github.com/repos/tsenart/patrol/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/patrol/events","assignees_url":"https://api.github.com/repos/tsenart/patrol/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/patrol/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/patrol/tags","blobs_url":"https://api.github.com/repos/tsenart/patrol/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/patrol/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/patrol/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/patrol/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/patrol/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/patrol/languages","stargazers_url":"https://api.github.com/repos/tsenart/patrol/stargazers","contributors_url":"https://api.github.com/repos/tsenart/patrol/contributors","subscribers_url":"https://api.github.com/repos/tsenart/patrol/subscribers","subscription_url":"https://api.github.com/repos/tsenart/patrol/subscription","commits_url":"https://api.github.com/repos/tsenart/patrol/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/patrol/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/patrol/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/patrol/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/patrol/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/patrol/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/patrol/merges","archive_url":"https://api.github.com/repos/tsenart/patrol/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/patrol/downloads","issues_url":"https://api.github.com/repos/tsenart/patrol/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/patrol/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/patrol/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/patrol/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/patrol/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/patrol/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/patrol/deployments","created_at":"2018-10-18T16:50:37Z","updated_at":"2019-03-04T11:30:11Z","pushed_at":"2018-11-13T14:57:15Z","git_url":"git://github.com/tsenart/patrol.git","ssh_url":"git@github.com:tsenart/patrol.git","clone_url":"https://github.com/tsenart/patrol.git","svn_url":"https://github.com/tsenart/patrol","homepage":"","size":95,"stargazers_count":20,"watchers_count":20,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"open_issues_count":1,"license":{"key":"mit","name":"MIT
-      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"forks":2,"open_issues":1,"watchers":20,"default_branch":"master","score":46.13497}]}'
+      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"forks":2,"open_issues":1,"watchers":20,"default_branch":"master","score":46.11905}]}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -184,7 +129,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2019 14:01:12 GMT
+      - Wed, 27 Mar 2019 18:34:43 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -200,7 +145,7 @@ interactions:
       X-Github-Media-Type:
       - github.v3; param=jean-grey-preview; format=json
       X-Github-Request-Id:
-      - 39FE:7CE0:1566CE:37F5F4:5C9CD3A8
+      - 157F:67C1:16E415:2E2555:5C9BC242
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -254,7 +199,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2019 14:01:12 GMT
+      - Wed, 27 Mar 2019 18:34:43 GMT
       Link:
       - <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
         rel="prev", <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
@@ -275,7 +220,7 @@ interactions:
       X-Github-Media-Type:
       - github.v3; param=jean-grey-preview; format=json
       X-Github-Request-Id:
-      - 39FE:7CE0:1566D7:37F60A:5C9CD3A8
+      - 157F:67C1:16E432:2E2574:5C9BC243
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/cmd/repo-updater/repos/testdata/gitlab/excluded-repos-are-never-yielded.yaml
+++ b/cmd/repo-updater/repos/testdata/gitlab/excluded-repos-are-never-yielded.yaml
@@ -1,0 +1,114 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects?order_by=last_activity_at&per_page=100&search=gokulkarthick
+    method: GET
+  response:
+    body: '[{"id":927197,"description":"","name":"gokulkarthick","name_with_namespace":"Gokul
+      Karthick / gokulkarthick","path":"gokulkarthick","path_with_namespace":"gokulkarthick/gokulkarthick","created_at":"2016-03-02T10:30:48.552Z","default_branch":"master","tag_list":[],"ssh_url_to_repo":"git@gitlab.com:gokulkarthick/gokulkarthick.git","http_url_to_repo":"https://gitlab.com/gokulkarthick/gokulkarthick.git","web_url":"https://gitlab.com/gokulkarthick/gokulkarthick","readme_url":"https://gitlab.com/gokulkarthick/gokulkarthick/blob/master/README.md","avatar_url":null,"star_count":0,"forks_count":0,"last_activity_at":"2016-03-02T10:30:49.086Z","namespace":{"id":509170,"name":"gokulkarthick","path":"gokulkarthick","kind":"user","full_path":"gokulkarthick","parent_id":null}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "773"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 27 Mar 2019 18:34:44 GMT
+      Etag:
+      - W/"2e213a0bf612bec448cc4972d255ca73"
+      Link:
+      - <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="first", <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="last"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "100"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - VBag3Vvtq27
+      X-Runtime:
+      - "0.134465"
+      X-Total:
+      - "1"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects?order_by=last_activity_at&per_page=100&search=dotfiles-vegetableman
+    method: GET
+  response:
+    body: '[{"id":8781514,"description":null,"name":"dotfiles-vegetableman","name_with_namespace":"guld
+      / dotfiles-vegetableman","path":"dotfiles-vegetableman","path_with_namespace":"guld/dotfiles-vegetableman","created_at":"2018-10-09T18:35:47.619Z","default_branch":null,"tag_list":[],"ssh_url_to_repo":"git@gitlab.com:guld/dotfiles-vegetableman.git","http_url_to_repo":"https://gitlab.com/guld/dotfiles-vegetableman.git","web_url":"https://gitlab.com/guld/dotfiles-vegetableman","readme_url":null,"avatar_url":null,"star_count":0,"forks_count":0,"last_activity_at":"2018-10-09T18:35:47.619Z","namespace":{"id":3017680,"name":"guld","path":"guld","kind":"group","full_path":"guld","parent_id":null}},{"id":7789240,"description":null,"name":"dotfiles-vegetableman","name_with_namespace":"Ira
+      Miller / dotfiles-vegetableman","path":"dotfiles-vegetableman","path_with_namespace":"isysd/dotfiles-vegetableman","created_at":"2018-08-07T02:51:02.979Z","default_branch":"vegetableman","tag_list":[],"ssh_url_to_repo":"git@gitlab.com:isysd/dotfiles-vegetableman.git","http_url_to_repo":"https://gitlab.com/isysd/dotfiles-vegetableman.git","web_url":"https://gitlab.com/isysd/dotfiles-vegetableman","readme_url":null,"avatar_url":null,"star_count":0,"forks_count":0,"last_activity_at":"2018-08-07T02:51:02.979Z","namespace":{"id":2068545,"name":"isysd","path":"isysd","kind":"user","full_path":"isysd","parent_id":null}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "1403"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 27 Mar 2019 18:34:45 GMT
+      Etag:
+      - W/"eb30d4732d45f891427aa7d203c2e072"
+      Link:
+      - <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=dotfiles-vegetableman&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="first", <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=dotfiles-vegetableman&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="last"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "100"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - OF2vSI9X5W6
+      X-Runtime:
+      - "0.312934"
+      X-Total:
+      - "2"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/cmd/repo-updater/repos/testdata/sources/excluded-repos-are-never-yielded.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/excluded-repos-are-never-yielded.yaml
@@ -45,56 +45,54 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json
       Content-Type:
       - application/json; charset=utf-8
-      Referer:
-      - http://api.github.com/repos/sourcegraph/Sourcegraph
-    url: https://api.github.com/repos/sourcegraph/Sourcegraph
+    url: https://gitlab.com/api/v4/projects?order_by=last_activity_at&per_page=100&search=gokulkarthick
     method: GET
   response:
-    body: '{"id":41288708,"node_id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","name":"sourcegraph","full_name":"sourcegraph/sourcegraph","private":false,"owner":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/sourcegraph/sourcegraph","description":"Code
-      search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2019-03-28T11:14:01Z","pushed_at":"2019-03-28T13:33:52Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":276197,"stargazers_count":1864,"watchers_count":1864,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":121,"mirror_url":null,"archived":false,"open_issues_count":675,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"forks":121,"open_issues":675,"watchers":1864,"default_branch":"master","organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":121,"subscribers_count":40}'
+    body: '[{"id":927197,"description":"","name":"gokulkarthick","name_with_namespace":"Gokul
+      Karthick / gokulkarthick","path":"gokulkarthick","path_with_namespace":"gokulkarthick/gokulkarthick","created_at":"2016-03-02T10:30:48.552Z","default_branch":"master","tag_list":[],"ssh_url_to_repo":"git@gitlab.com:gokulkarthick/gokulkarthick.git","http_url_to_repo":"https://gitlab.com/gokulkarthick/gokulkarthick.git","web_url":"https://gitlab.com/gokulkarthick/gokulkarthick","readme_url":"https://gitlab.com/gokulkarthick/gokulkarthick/blob/master/README.md","avatar_url":null,"star_count":0,"forks_count":0,"last_activity_at":"2016-03-02T10:30:49.086Z","namespace":{"id":509170,"name":"gokulkarthick","path":"gokulkarthick","kind":"user","full_path":"gokulkarthick","parent_id":null}}]'
     headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
       Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Content-Security-Policy:
-      - default-src 'none'
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "773"
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Date:
-      - Thu, 28 Mar 2019 13:54:32 GMT
+      - Thu, 28 Mar 2019 14:01:12 GMT
       Etag:
-      - W/"1aec660091379e580d3770a4c0277bbd"
-      Last-Modified:
-      - Thu, 28 Mar 2019 11:14:01 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
+      - W/"2e213a0bf612bec448cc4972d255ca73"
+      Link:
+      - <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="first", <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="last"
       Server:
-      - GitHub.com
-      Status:
-      - 200 OK
+      - nginx
       Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
+      - max-age=31536000
       Vary:
-      - Accept
+      - Origin
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json
-      X-Github-Request-Id:
-      - 2FD3:4BF0:4B3C78:A01049:5C9CD216
-      X-Xss-Protection:
-      - 1; mode=block
+      - SAMEORIGIN
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "100"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - RIKEYsDsoI1
+      X-Runtime:
+      - "0.093201"
+      X-Total:
+      - "1"
+      X-Total-Pages:
+      - "1"
     status: 200 OK
     code: 200
     duration: ""
@@ -114,7 +112,7 @@ interactions:
     body: '{"total_count":1,"incomplete_results":false,"items":[{"id":153657245,"node_id":"MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU=","name":"patrol","full_name":"tsenart/patrol","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/patrol","description":"Patrol
       is an operator friendly distributed rate limiting HTTP API with strong eventually
       consistent CvRDT based replication.","fork":false,"url":"https://api.github.com/repos/tsenart/patrol","forks_url":"https://api.github.com/repos/tsenart/patrol/forks","keys_url":"https://api.github.com/repos/tsenart/patrol/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/patrol/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/patrol/teams","hooks_url":"https://api.github.com/repos/tsenart/patrol/hooks","issue_events_url":"https://api.github.com/repos/tsenart/patrol/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/patrol/events","assignees_url":"https://api.github.com/repos/tsenart/patrol/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/patrol/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/patrol/tags","blobs_url":"https://api.github.com/repos/tsenart/patrol/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/patrol/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/patrol/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/patrol/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/patrol/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/patrol/languages","stargazers_url":"https://api.github.com/repos/tsenart/patrol/stargazers","contributors_url":"https://api.github.com/repos/tsenart/patrol/contributors","subscribers_url":"https://api.github.com/repos/tsenart/patrol/subscribers","subscription_url":"https://api.github.com/repos/tsenart/patrol/subscription","commits_url":"https://api.github.com/repos/tsenart/patrol/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/patrol/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/patrol/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/patrol/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/patrol/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/patrol/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/patrol/merges","archive_url":"https://api.github.com/repos/tsenart/patrol/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/patrol/downloads","issues_url":"https://api.github.com/repos/tsenart/patrol/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/patrol/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/patrol/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/patrol/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/patrol/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/patrol/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/patrol/deployments","created_at":"2018-10-18T16:50:37Z","updated_at":"2019-03-04T11:30:11Z","pushed_at":"2018-11-13T14:57:15Z","git_url":"git://github.com/tsenart/patrol.git","ssh_url":"git@github.com:tsenart/patrol.git","clone_url":"https://github.com/tsenart/patrol.git","svn_url":"https://github.com/tsenart/patrol","homepage":"","size":95,"stargazers_count":20,"watchers_count":20,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"open_issues_count":1,"license":{"key":"mit","name":"MIT
-      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"forks":2,"open_issues":1,"watchers":20,"default_branch":"master","score":46.30867}]}'
+      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"forks":2,"open_issues":1,"watchers":20,"default_branch":"master","score":46.13497}]}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -129,7 +127,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2019 13:54:32 GMT
+      - Thu, 28 Mar 2019 14:01:12 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -145,11 +143,88 @@ interactions:
       X-Github-Media-Type:
       - github.v3; param=jean-grey-preview; format=json
       X-Github-Request-Id:
-      - 1450:3570:15BB7B:3A9C3A:5C9CD218
+      - 39FE:7CE0:1566DF:37F626:5C9CD3A8
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+      Referer:
+      - http://api.github.com/repos/sourcegraph/Sourcegraph
+    url: https://api.github.com/repos/sourcegraph/Sourcegraph
+    method: GET
+  response:
+    body: '{"id":41288708,"node_id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","name":"sourcegraph","full_name":"sourcegraph/sourcegraph","private":false,"owner":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/sourcegraph/sourcegraph","description":"Code
+      search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2019-03-28T11:14:01Z","pushed_at":"2019-03-28T13:59:34Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":276197,"stargazers_count":1864,"watchers_count":1864,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":121,"mirror_url":null,"archived":false,"open_issues_count":675,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"forks":121,"open_issues":675,"watchers":1864,"default_branch":"master","organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":121,"subscribers_count":40}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Mar 2019 14:01:13 GMT
+      Etag:
+      - W/"daca3ab52958e88fcff83fe792b0f8b4"
+      Last-Modified:
+      - Thu, 28 Mar 2019 11:14:01 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json
+      X-Github-Request-Id:
+      - F6BD:3571:2CECE1:6FA8E0:5C9CD3A8
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: http://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
+    method: GET
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Location:
+      - https://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
+    status: 301 Moved Permanently
+    code: 301
     duration: ""
 - request:
     body: ""
@@ -179,17 +254,108 @@ interactions:
       - application/vnd.github.jean-grey-preview+json
       Content-Type:
       - application/json; charset=utf-8
-    url: http://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
+      Referer:
+      - http://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
+    url: https://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
     method: GET
   response:
-    body: ""
+    body: '{"total_count":1,"incomplete_results":false,"items":[]}'
     headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Mar 2019 14:01:13 GMT
+      Link:
+      - <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
+        rel="prev", <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
+        rel="last", <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
+        rel="first"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json
+      X-Github-Request-Id:
+      - F6BD:3571:2CECF2:6FA936:5C9CD3A9
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects?order_by=last_activity_at&per_page=100&search=dotfiles-vegetableman
+    method: GET
+  response:
+    body: '[{"id":8781514,"description":null,"name":"dotfiles-vegetableman","name_with_namespace":"guld
+      / dotfiles-vegetableman","path":"dotfiles-vegetableman","path_with_namespace":"guld/dotfiles-vegetableman","created_at":"2018-10-09T18:35:47.619Z","default_branch":null,"tag_list":[],"ssh_url_to_repo":"git@gitlab.com:guld/dotfiles-vegetableman.git","http_url_to_repo":"https://gitlab.com/guld/dotfiles-vegetableman.git","web_url":"https://gitlab.com/guld/dotfiles-vegetableman","readme_url":null,"avatar_url":null,"star_count":0,"forks_count":0,"last_activity_at":"2018-10-09T18:35:47.619Z","namespace":{"id":3017680,"name":"guld","path":"guld","kind":"group","full_path":"guld","parent_id":null}},{"id":7789240,"description":null,"name":"dotfiles-vegetableman","name_with_namespace":"Ira
+      Miller / dotfiles-vegetableman","path":"dotfiles-vegetableman","path_with_namespace":"isysd/dotfiles-vegetableman","created_at":"2018-08-07T02:51:02.979Z","default_branch":"vegetableman","tag_list":[],"ssh_url_to_repo":"git@gitlab.com:isysd/dotfiles-vegetableman.git","http_url_to_repo":"https://gitlab.com/isysd/dotfiles-vegetableman.git","web_url":"https://gitlab.com/isysd/dotfiles-vegetableman","readme_url":null,"avatar_url":null,"star_count":0,"forks_count":0,"last_activity_at":"2018-08-07T02:51:02.979Z","namespace":{"id":2068545,"name":"isysd","path":"isysd","kind":"user","full_path":"isysd","parent_id":null}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
       Content-Length:
-      - "0"
-      Location:
-      - https://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
-    status: 301 Moved Permanently
-    code: 301
+      - "1403"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 28 Mar 2019 14:01:13 GMT
+      Etag:
+      - W/"eb30d4732d45f891427aa7d203c2e072"
+      Link:
+      - <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=dotfiles-vegetableman&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="first", <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=dotfiles-vegetableman&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+        rel="last"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "100"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - ZVoc3QBPgp1
+      X-Runtime:
+      - "0.240406"
+      X-Total:
+      - "2"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -221,7 +387,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2019 13:54:32 GMT
+      - Thu, 28 Mar 2019 14:01:13 GMT
       Etag:
       - W/"0a576e75d536ab4b373922aad552546e"
       Last-Modified:
@@ -243,62 +409,7 @@ interactions:
       X-Github-Media-Type:
       - github.v3; param=jean-grey-preview; format=json
       X-Github-Request-Id:
-      - 1450:3570:15BB86:3A9C59:5C9CD218
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
-      Referer:
-      - http://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
-    url: https://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
-    method: GET
-  response:
-    body: '{"total_count":1,"incomplete_results":false,"items":[]}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - no-cache
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 28 Mar 2019 13:54:32 GMT
-      Link:
-      - <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
-        rel="prev", <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
-        rel="last", <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
-        rel="first"
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json
-      X-Github-Request-Id:
-      - 2FD3:4BF0:4B3C9A:A01170:5C9CD218
+      - 39FE:7CE0:1566EA:37F640:5C9CD3A8
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -118,7 +118,7 @@ func (e *ExternalService) ExcludeGithubRepos(rs ...*Repo) error {
 			name := githubNameWithOwner(r.Name)
 
 			if !set[name] && !set[id] {
-				c.Exclude = append(c.Exclude, &schema.Exclude{
+				c.Exclude = append(c.Exclude, &schema.ExcludedGitHubRepo{
 					Name: name,
 					Id:   id,
 				})

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -321,6 +321,104 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "GITLAB",
+			desc:   "invalid empty exclude",
+			config: `{"exclude": []}`,
+			assert: includes(`exclude: Array must have at least 1 items`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid empty exclude item",
+			config: `{"exclude": [{}]}`,
+			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid exclude item",
+			config: `{"exclude": [{"foo": "bar"}]}`,
+			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid exclude item name",
+			config: `{"exclude": [{"name": "bar"}]}`,
+			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid empty exclude item id",
+			config: `{"exclude": [{"id": ""}]}`,
+			assert: includes(`exclude.0.id: String length must be greater than or equal to 1`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid additional exclude item properties",
+			config: `{"exclude": [{"id": "foo", "bar": "baz"}]}`,
+			assert: includes(`bar: Additional property bar is not allowed`),
+		},
+		{
+			kind: "GITLAB",
+			desc: "both name and id can be specified in exclude",
+			config: `
+			{
+				"url": "https://gitlab.corp.com",
+				"token": "very-secret-token",
+				"exclude": [
+					{"name": "foo/bar", "id": "AAAAA="}
+				]
+			}`,
+			assert: equals(`<nil>`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid empty projects",
+			config: `{"projects": []}`,
+			assert: includes(`projects: Array must have at least 1 items`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid empty projects item",
+			config: `{"projects": [{}]}`,
+			assert: includes(`projects.0: Must validate at least one schema (anyOf)`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid projects item",
+			config: `{"projects": [{"foo": "bar"}]}`,
+			assert: includes(`projects.0: Must validate at least one schema (anyOf)`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid projects item name",
+			config: `{"projects": [{"name": "bar"}]}`,
+			assert: includes(`projects.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid empty projects item id",
+			config: `{"projects": [{"id": ""}]}`,
+			assert: includes(`projects.0.id: String length must be greater than or equal to 1`),
+		},
+		{
+			kind:   "GITLAB",
+			desc:   "invalid additional projects item properties",
+			config: `{"projects": [{"id": "foo", "bar": "baz"}]}`,
+			assert: includes(`bar: Additional property bar is not allowed`),
+		},
+		{
+			kind: "GITLAB",
+			desc: "both name and id can be specified in projects",
+			config: `
+			{
+				"url": "https://gitlab.corp.com",
+				"token": "very-secret-token",
+				"projects": [
+					{"name": "foo/bar", "id": "AAAAA="}
+				]
+			}`,
+			assert: equals(`<nil>`),
+		},
+		{
+			kind:   "GITLAB",
 			desc:   "without url nor token",
 			config: `{}`,
 			assert: includes(

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -45,6 +45,7 @@
       "minItems": 1,
       "items": {
         "type": "object",
+        "title": "ExcludedGitHubRepo",
         "additionalProperties": false,
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -50,6 +50,7 @@ const GitHubSchemaJSON = `{
       "minItems": 1,
       "items": {
         "type": "object",
+        "title": "ExcludedGitHubRepo",
         "additionalProperties": false,
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -62,6 +62,7 @@
       "minItems": 1,
       "items": {
         "type": "object",
+        "title": "ExcludedGitLabProject",
         "additionalProperties": false,
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -34,6 +34,50 @@
       "type": "string",
       "pattern": "^-----BEGIN CERTIFICATE-----\n"
     },
+    "projects": {
+      "description": "A list of projects to mirror from this GitLab instance.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "properties": {
+          "name": {
+            "description": "The name of a GitLab project (\"owner/name\") to mirror.",
+            "type": "string",
+            "pattern": "^[\\w-]+/[\\w.-]+$"
+          },
+          "id": {
+            "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to mirror.",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "exclude": {
+      "description": "A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "properties": {
+          "name": {
+            "description": "The name of a GitLab project (\"owner/name\") to exclude from mirroring.",
+            "type": "string",
+            "pattern": "^[\\w-]+/[\\w.-]+$"
+          },
+          "id": {
+            "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to exclude from mirroring.",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "projectQuery": {
       "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL query string for the GitLab projects API, such as \"?membership=true&search=foo\".\n\nThe query string is passed directly to GitLab to retrieve the list of projects. The special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. See https://docs.gitlab.com/ee/api/projects.html#list-all-projects for available query string options.",
       "type": "array",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -67,6 +67,7 @@ const GitLabSchemaJSON = `{
       "minItems": 1,
       "items": {
         "type": "object",
+        "title": "ExcludedGitLabProject",
         "additionalProperties": false,
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -39,6 +39,50 @@ const GitLabSchemaJSON = `{
       "type": "string",
       "pattern": "^-----BEGIN CERTIFICATE-----\n"
     },
+    "projects": {
+      "description": "A list of projects to mirror from this GitLab instance.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "properties": {
+          "name": {
+            "description": "The name of a GitLab project (\"owner/name\") to mirror.",
+            "type": "string",
+            "pattern": "^[\\w-]+/[\\w.-]+$"
+          },
+          "id": {
+            "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to mirror.",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "exclude": {
+      "description": "A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "properties": {
+          "name": {
+            "description": "The name of a GitLab project (\"owner/name\") to exclude from mirroring.",
+            "type": "string",
+            "pattern": "^[\\w-]+/[\\w.-]+$"
+          },
+          "id": {
+            "description": "The ID of a GitLab project (as returned by the GitLab instance's API) to exclude from mirroring.",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "projectQuery": {
       "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL query string for the GitLab projects API, such as \"?membership=true&search=foo\".\n\nThe query string is passed directly to GitLab to retrieve the list of projects. The special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. See https://docs.gitlab.com/ee/api/projects.html#list-all-projects for available query string options.",
       "type": "array",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -213,9 +213,11 @@ type GitLabAuthorization struct {
 type GitLabConnection struct {
 	Authorization               *GitLabAuthorization `json:"authorization,omitempty"`
 	Certificate                 string               `json:"certificate,omitempty"`
+	Exclude                     []*Exclude           `json:"exclude,omitempty"`
 	GitURLType                  string               `json:"gitURLType,omitempty"`
 	InitialRepositoryEnablement bool                 `json:"initialRepositoryEnablement,omitempty"`
 	ProjectQuery                []string             `json:"projectQuery,omitempty"`
+	Projects                    []*Projects          `json:"projects,omitempty"`
 	RepositoryPathPattern       string               `json:"repositoryPathPattern,omitempty"`
 	Token                       string               `json:"token"`
 	Url                         string               `json:"url"`
@@ -328,6 +330,10 @@ type PhabricatorConnection struct {
 	Repos []*Repos `json:"repos,omitempty"`
 	Token string   `json:"token,omitempty"`
 	Url   string   `json:"url,omitempty"`
+}
+type Projects struct {
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 type Repos struct {
 	Callsign string `json:"callsign"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -142,7 +142,11 @@ type Discussions struct {
 	AbuseEmails     []string `json:"abuseEmails,omitempty"`
 	AbuseProtection bool     `json:"abuseProtection,omitempty"`
 }
-type Exclude struct {
+type ExcludedGitHubRepo struct {
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+type ExcludedGitLabProject struct {
 	Id   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
 }
@@ -182,16 +186,16 @@ type GitHubAuthorization struct {
 
 // GitHubConnection description: Configuration for a connection to GitHub or GitHub Enterprise.
 type GitHubConnection struct {
-	Authorization               *GitHubAuthorization `json:"authorization,omitempty"`
-	Certificate                 string               `json:"certificate,omitempty"`
-	Exclude                     []*Exclude           `json:"exclude,omitempty"`
-	GitURLType                  string               `json:"gitURLType,omitempty"`
-	InitialRepositoryEnablement bool                 `json:"initialRepositoryEnablement,omitempty"`
-	Repos                       []string             `json:"repos,omitempty"`
-	RepositoryPathPattern       string               `json:"repositoryPathPattern,omitempty"`
-	RepositoryQuery             []string             `json:"repositoryQuery,omitempty"`
-	Token                       string               `json:"token"`
-	Url                         string               `json:"url"`
+	Authorization               *GitHubAuthorization  `json:"authorization,omitempty"`
+	Certificate                 string                `json:"certificate,omitempty"`
+	Exclude                     []*ExcludedGitHubRepo `json:"exclude,omitempty"`
+	GitURLType                  string                `json:"gitURLType,omitempty"`
+	InitialRepositoryEnablement bool                  `json:"initialRepositoryEnablement,omitempty"`
+	Repos                       []string              `json:"repos,omitempty"`
+	RepositoryPathPattern       string                `json:"repositoryPathPattern,omitempty"`
+	RepositoryQuery             []string              `json:"repositoryQuery,omitempty"`
+	Token                       string                `json:"token"`
+	Url                         string                `json:"url"`
 }
 
 // GitLabAuthProvider description: Configures the GitLab OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitLab instance: https://docs.gitlab.com/ee/integration/oauth_provider.html. The application should have `api` and `read_user` scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and "/.auth/gitlab/callback".
@@ -211,16 +215,16 @@ type GitLabAuthorization struct {
 
 // GitLabConnection description: Configuration for a connection to GitLab (GitLab.com or GitLab self-managed).
 type GitLabConnection struct {
-	Authorization               *GitLabAuthorization `json:"authorization,omitempty"`
-	Certificate                 string               `json:"certificate,omitempty"`
-	Exclude                     []*Exclude           `json:"exclude,omitempty"`
-	GitURLType                  string               `json:"gitURLType,omitempty"`
-	InitialRepositoryEnablement bool                 `json:"initialRepositoryEnablement,omitempty"`
-	ProjectQuery                []string             `json:"projectQuery,omitempty"`
-	Projects                    []*Projects          `json:"projects,omitempty"`
-	RepositoryPathPattern       string               `json:"repositoryPathPattern,omitempty"`
-	Token                       string               `json:"token"`
-	Url                         string               `json:"url"`
+	Authorization               *GitLabAuthorization     `json:"authorization,omitempty"`
+	Certificate                 string                   `json:"certificate,omitempty"`
+	Exclude                     []*ExcludedGitLabProject `json:"exclude,omitempty"`
+	GitURLType                  string                   `json:"gitURLType,omitempty"`
+	InitialRepositoryEnablement bool                     `json:"initialRepositoryEnablement,omitempty"`
+	ProjectQuery                []string                 `json:"projectQuery,omitempty"`
+	Projects                    []*Projects              `json:"projects,omitempty"`
+	RepositoryPathPattern       string                   `json:"repositoryPathPattern,omitempty"`
+	Token                       string                   `json:"token"`
+	Url                         string                   `json:"url"`
 }
 
 // GitoliteConnection description: Configuration for a connection to Gitolite.


### PR DESCRIPTION
This commit implements the `gitlab.exclude` feature.

Part of #2025

- [ ] GitLab support
   - [x]  Implement GitLabSource and enable new syncer for GitLab external services (Pending review #3008)
   - [ ] --> **THIS PR** <-- Implement `gitlab.projects` to support enabled state deprecation.
   - [ ] Implement `gitlab.exclude` to support enabled state deprecation.
   - [ ] Change default `gitlab.projectQuery` to `["none"]`
   - [ ] Extend enabled state deprecation migration with GitLab external services