### PR TITLE
search: clean up / refactor search result merging code

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -552,7 +552,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		return nil, err
 	}
 
-	fileResults, _, err := searchFilesInRepos(ctx, &args)
+	fileResults, _, err := searchFilesInRepos(ctx, &args, r.maxResults())
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 	var suggestions []*searchSuggestionResolver
 	for i, result := range fileResults {
 		assumedScore := len(fileResults) - i // Greater score is first, so we inverse the index.
-		suggestions = append(suggestions, newSearchResultResolver(result.File(), assumedScore))
+		suggestions = append(suggestions, newSearchResultResolver(result.fileMatch.File(), assumedScore))
 	}
 	return suggestions, nil
 }

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -418,7 +418,7 @@ func highlightMatches(pattern *regexp.Regexp, data []byte) *highlightedString {
 var mockSearchCommitDiffsInRepos func(args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error)
 
 // searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error) {
+func searchCommitDiffsInRepos(ctx context.Context, args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitDiffsInRepos != nil {
 		return mockSearchCommitDiffsInRepos(args)
 	}
@@ -479,7 +479,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]*search
 var mockSearchCommitLogInRepos func(args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error)
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error) {
+func searchCommitLogInRepos(ctx context.Context, args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitLogInRepos != nil {
 		return mockSearchCommitLogInRepos(args)
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -887,14 +887,13 @@ optionalSearches:
 		multiErr = nil
 	}
 
-	resultsResolver := &searchResultsResolver{
+	sortResults(results)
+	return &searchResultsResolver{
 		start:               start,
 		searchResultsCommon: common,
 		results:             results,
 		alert:               alert,
-	}
-	sortResults(resultsResolver.results)
-	return resultsResolver, multiErr.ErrorOrNil()
+	}, multiErr.ErrorOrNil()
 }
 
 // isContextError returns true if ctx.Err() is not nil or if err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -803,7 +803,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			goroutine.Go(func() {
 				defer wg.Done()
 
-				symbolFileMatches, symbolsCommon, err := searchSymbols(ctx, &args, int(r.maxResults()))
+				symbolFileMatches, symbolsCommon, err := searchSymbols(ctx, &args, r.maxResults())
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
 				if err != nil && !isContextError(ctx, err) {
 					multiErrMu.Lock()
@@ -811,6 +811,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 					multiErrMu.Unlock()
 				}
 				for _, symbolFileMatch := range symbolFileMatches {
+					symbolFileMatch := symbolFileMatch.fileMatch
 					key := symbolFileMatch.uri
 					fileMatchesMu.Lock()
 					if m, ok := fileMatches[key]; ok {
@@ -840,7 +841,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			goroutine.Go(func() {
 				defer wg.Done()
 
-				fileResults, fileCommon, err := searchFilesInRepos(ctx, &args)
+				fileResults, fileCommon, err := searchFilesInRepos(ctx, &args, r.maxResults())
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
 				if err != nil && !isContextError(ctx, err) {
 					multiErrMu.Lock()
@@ -848,6 +849,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 					multiErrMu.Unlock()
 				}
 				for _, r := range fileResults {
+					r := r.fileMatch
 					key := r.uri
 					fileMatchesMu.Lock()
 					m, ok := fileMatches[key]
@@ -874,7 +876,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			wg.Add(1)
 			goroutine.Go(func() {
 				defer wg.Done()
-				diffResults, diffCommon, err := searchCommitDiffsInRepos(ctx, &args)
+				diffResults, diffCommon, err := searchCommitDiffsInRepos(ctx, &args, r.maxResults())
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
 				if err != nil && !isContextError(ctx, err) {
 					multiErrMu.Lock()
@@ -898,7 +900,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			goroutine.Go(func() {
 				defer wg.Done()
 
-				commitResults, commitCommon, err := searchCommitLogInRepos(ctx, &args)
+				commitResults, commitCommon, err := searchCommitLogInRepos(ctx, &args, r.maxResults())
 				// Timeouts are reported through searchResultsCommon so don't report an error for them
 				if err != nil && !isContextError(ctx, err) {
 					multiErrMu.Lock()

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -719,221 +719,157 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 
 	// Determine which types of results to return.
-	var resultTypes []string
+	var rawResultTypes []string
 	if forceOnlyResultType != "" {
-		resultTypes = []string{forceOnlyResultType}
+		rawResultTypes = []string{forceOnlyResultType}
 	} else {
-		resultTypes, _ = r.query.StringValues(query.FieldType)
-		if len(resultTypes) == 0 {
-			resultTypes = []string{"file", "path", "repo", "ref"}
+		rawResultTypes, _ = r.query.StringValues(query.FieldType)
+		if len(rawResultTypes) == 0 {
+			rawResultTypes = []string{"file", "path", "repo", "ref"}
 		}
 	}
-	seenResultTypes := make(map[string]struct{}, len(resultTypes))
-	for _, resultType := range resultTypes {
+	resultTypes := make(map[string]struct{}, len(rawResultTypes)) // deduplicated
+	for _, resultType := range rawResultTypes {
+		resultTypes[resultType] = struct{}{}
 		if resultType == "file" {
 			args.Pattern.PatternMatchesContent = true
 		} else if resultType == "path" {
 			args.Pattern.PatternMatchesPath = true
 		}
 	}
-	tr.LazyPrintf("resultTypes: %v", resultTypes)
+	tr.LazyPrintf("resultTypes: %v", rawResultTypes)
 
-	var (
-		requiredWg sync.WaitGroup
-		optionalWg sync.WaitGroup
-		results    []*searchResultResolver
-		resultsMu  sync.Mutex
-		common     = searchResultsCommon{maxResultsCount: r.maxResults()}
-		commonMu   sync.Mutex
-		multiErr   *multierror.Error
-		multiErrMu sync.Mutex
-		// fileMatches is a map from git:// URI of the file to FileMatch resolver
-		// to merge multiple results of different types for the same file
-		fileMatches   = make(map[string]*fileMatchResolver)
-		fileMatchesMu sync.Mutex
-	)
+	// A mapping of result types to functions that search for those result types.
+	searchers := map[string]struct {
+		search func(ctx context.Context, args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error)
 
-	waitGroup := func(required bool) *sync.WaitGroup {
-		if args.UseFullDeadline {
-			// When a custom timeout is specified, all searches are required and get the full timeout.
-			return &requiredWg
-		}
-		if required {
-			return &requiredWg
-		}
-		return &optionalWg
+		// When true, these results can optionally be left out of the response
+		// if they are not retrieved fast enough AND the user did not
+		// explicitly ask for this type of result.
+		optional bool
+	}{
+		"repo":   {searchRepositories, false},
+		"symbol": {searchSymbols, true},
+		"file":   {searchFilesInRepos, false},
+		"path":   {searchFilesInRepos, false},
+		"diff":   {searchCommitDiffsInRepos, true},
+		"commit": {searchCommitLogInRepos, true},
 	}
 
-	searchedFileContentsOrPaths := false
-	for _, resultType := range resultTypes {
-		resultType := resultType // shadow so it doesn't change in the goroutine
-		if _, seen := seenResultTypes[resultType]; seen {
-			continue
-		}
-		seenResultTypes[resultType] = struct{}{}
-		switch resultType {
-		case "repo":
-			// Search for repos
-			wg := waitGroup(true)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-
-				repoResults, repoCommon, err := searchRepositories(ctx, &args, r.maxResults())
-				// Timeouts are reported through searchResultsCommon so don't report an error for them
-				if err != nil && !isContextError(ctx, err) {
-					multiErrMu.Lock()
-					multiErr = multierror.Append(multiErr, errors.Wrap(err, "repository search failed"))
-					multiErrMu.Unlock()
-				}
-				if repoResults != nil {
-					resultsMu.Lock()
-					results = append(results, repoResults...)
-					resultsMu.Unlock()
-				}
-				if repoCommon != nil {
-					commonMu.Lock()
-					common.update(*repoCommon)
-					commonMu.Unlock()
-				}
-			})
-		case "symbol":
-			wg := waitGroup(len(resultTypes) == 1)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-
-				symbolFileMatches, symbolsCommon, err := searchSymbols(ctx, &args, r.maxResults())
-				// Timeouts are reported through searchResultsCommon so don't report an error for them
-				if err != nil && !isContextError(ctx, err) {
-					multiErrMu.Lock()
-					multiErr = multierror.Append(multiErr, errors.Wrap(err, "symbol search failed"))
-					multiErrMu.Unlock()
-				}
-				for _, symbolFileMatch := range symbolFileMatches {
-					symbolFileMatch := symbolFileMatch.fileMatch
-					key := symbolFileMatch.uri
-					fileMatchesMu.Lock()
-					if m, ok := fileMatches[key]; ok {
-						m.symbols = symbolFileMatch.symbols
-					} else {
-						fileMatches[key] = symbolFileMatch
-						resultsMu.Lock()
-						results = append(results, &searchResultResolver{fileMatch: symbolFileMatch})
-						resultsMu.Unlock()
-					}
-					fileMatchesMu.Unlock()
-				}
-				if symbolsCommon != nil {
-					commonMu.Lock()
-					common.update(*symbolsCommon)
-					commonMu.Unlock()
-				}
-			})
-		case "file", "path":
-			if searchedFileContentsOrPaths {
-				// type:file and type:path use same searchFilesInRepos, so don't call 2x.
+	// Start searchers in parallel, only for the types of results the user wants.
+	type searcherResult struct {
+		resultType string
+		results    []*searchResultResolver
+		common     *searchResultsCommon
+		err        error
+	}
+	var (
+		expectRequired, expectOptional int // How many required and optional results we can expect from the channel.
+		required                       = make(chan searcherResult, len(resultTypes))
+		optional                       = make(chan searcherResult, len(resultTypes))
+	)
+	for resultType := range resultTypes {
+		resultType := resultType // shadow variable for goroutine below
+		if resultType == "file" {
+			if _, ok := resultTypes["path"]; ok {
+				// We are searching for both file and path results. They are provided by the
+				// same searchFilesInRepos, so we would just end up with duplicate results if
+				// we called them 2x.
 				continue
 			}
-			searchedFileContentsOrPaths = true
-			wg := waitGroup(true)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-
-				fileResults, fileCommon, err := searchFilesInRepos(ctx, &args, r.maxResults())
-				// Timeouts are reported through searchResultsCommon so don't report an error for them
-				if err != nil && !isContextError(ctx, err) {
-					multiErrMu.Lock()
-					multiErr = multierror.Append(multiErr, errors.Wrap(err, "text search failed"))
-					multiErrMu.Unlock()
-				}
-				for _, r := range fileResults {
-					r := r.fileMatch
-					key := r.uri
-					fileMatchesMu.Lock()
-					m, ok := fileMatches[key]
-					if ok {
-						// merge line match results with an existing symbol result
-						m.JLimitHit = m.JLimitHit || r.JLimitHit
-						m.JLineMatches = r.JLineMatches
-					} else {
-						fileMatches[key] = r
-						resultsMu.Lock()
-						results = append(results, &searchResultResolver{fileMatch: r})
-						resultsMu.Unlock()
-					}
-					fileMatchesMu.Unlock()
-				}
-				if fileCommon != nil {
-					commonMu.Lock()
-					common.update(*fileCommon)
-					commonMu.Unlock()
-				}
-			})
-		case "diff":
-			wg := waitGroup(len(resultTypes) == 1)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-				diffResults, diffCommon, err := searchCommitDiffsInRepos(ctx, &args, r.maxResults())
-				// Timeouts are reported through searchResultsCommon so don't report an error for them
-				if err != nil && !isContextError(ctx, err) {
-					multiErrMu.Lock()
-					multiErr = multierror.Append(multiErr, errors.Wrap(err, "diff search failed"))
-					multiErrMu.Unlock()
-				}
-				if diffResults != nil {
-					resultsMu.Lock()
-					results = append(results, diffResults...)
-					resultsMu.Unlock()
-				}
-				if diffCommon != nil {
-					commonMu.Lock()
-					common.update(*diffCommon)
-					commonMu.Unlock()
-				}
-			})
-		case "commit":
-			wg := waitGroup(len(resultTypes) == 1)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-
-				commitResults, commitCommon, err := searchCommitLogInRepos(ctx, &args, r.maxResults())
-				// Timeouts are reported through searchResultsCommon so don't report an error for them
-				if err != nil && !isContextError(ctx, err) {
-					multiErrMu.Lock()
-					multiErr = multierror.Append(multiErr, errors.Wrap(err, "commit search failed"))
-					multiErrMu.Unlock()
-				}
-				if commitResults != nil {
-					resultsMu.Lock()
-					results = append(results, commitResults...)
-					resultsMu.Unlock()
-				}
-				if commitCommon != nil {
-					commonMu.Lock()
-					common.update(*commitCommon)
-					commonMu.Unlock()
-				}
-			})
 		}
+		searcher, ok := searchers[resultType]
+		if !ok {
+			// We don't have anything to handle this type of query.
+			continue
+		}
+		isOptional := searcher.optional
+		if args.UseFullDeadline {
+			// When a custom timeout is specified, all searches are required.
+			isOptional = false
+		}
+		if isOptional {
+			expectOptional++
+		} else {
+			expectRequired++
+		}
+		goroutine.Go(func() {
+			results, common, err := searcher.search(ctx, &args, r.maxResults())
+			if isOptional {
+				optional <- searcherResult{resultType, results, common, err}
+			} else {
+				required <- searcherResult{resultType, results, common, err}
+			}
+		})
 	}
 
-	// Wait for required searches.
-	requiredWg.Wait()
-
-	// Give optional searches some minimum budget in case required searches return quickly.
-	// Cancel all remaining searches after this minimum budget.
+	// Gather results from the workers. We do so in no particular order, as
+	// we will sort them later.
+	var searcherResults []searcherResult
+	for i := 0; i < expectRequired; i++ {
+		searcherResults = append(searcherResults, <-required)
+	}
+	// Optional search results only have 100ms (since the start of the search
+	// query) to return if we already got required search results. This is to
+	// prevent optional search results (which are often slower) from slowing
+	// down the overall search.
 	budget := 100 * time.Millisecond
 	elapsed := time.Since(start)
 	timer := time.AfterFunc(budget-elapsed, cancel)
-
-	// Wait for remaining optional searches to finish or get cancelled.
-	optionalWg.Wait()
-
+optionalSearches:
+	for i := 0; i < expectOptional; i++ {
+		select {
+		case r := <-optional:
+			searcherResults = append(searcherResults, r)
+		case <-timer.C:
+			break optionalSearches
+		}
+	}
 	timer.Stop()
+
+	// Handle the results from the workers, again in no particular order as we
+	// will sort later.
+	var (
+		results  []*searchResultResolver
+		common   = searchResultsCommon{maxResultsCount: r.maxResults()}
+		multiErr *multierror.Error
+
+		// fileMatches is a map from git:// URI of the file to FileMatch resolver
+		// to merge multiple results of different types for the same file
+		fileMatches = make(map[string]*fileMatchResolver)
+	)
+	for _, sr := range searcherResults {
+		// Timeouts are reported through searchResultsCommon so don't report an
+		// error for them (context errors).
+		if sr.err != nil && !isContextError(ctx, sr.err) {
+			multiErr = multierror.Append(multiErr, errors.Wrap(sr.err, sr.resultType+" search failed"))
+		}
+		if sr.common != nil {
+			common.update(*sr.common)
+		}
+		for _, result := range sr.results {
+			if result.fileMatch != nil {
+				// When we encounter file match results, we deduplicate them as the
+				// "symbol", "file", and "path" searchers registered above can produce
+				// duplicates as they aren't aware of eachother.
+				key := result.fileMatch.uri
+				if m, ok := fileMatches[key]; ok {
+					// Result for this file already exists, so merge it, so that we get
+					// the best result possible (i.e. because one searcher may produce
+					// nil line matches).
+					m.JLimitHit = m.JLimitHit || result.fileMatch.JLimitHit
+					if m.JLineMatches == nil {
+						m.JLineMatches = result.fileMatch.JLineMatches
+					}
+				} else {
+					fileMatches[key] = result.fileMatch
+					results = append(results, result)
+				}
+				continue
+			}
+			results = append(results, result)
+		}
+	}
 
 	tr.LazyPrintf("results=%d limitHit=%v cloning=%d missing=%d timedout=%d", len(results), common.limitHit, len(common.cloning), len(common.missing), len(common.timedout))
 
@@ -951,16 +887,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		multiErr = nil
 	}
 
-	sortResults(results)
-
-	resultsResolver := searchResultsResolver{
+	resultsResolver := &searchResultsResolver{
 		start:               start,
 		searchResultsCommon: common,
 		results:             results,
 		alert:               alert,
 	}
-
-	return &resultsResolver, multiErr.ErrorOrNil()
+	sortResults(resultsResolver.results)
+	return resultsResolver, multiErr.ErrorOrNil()
 }
 
 // isContextError returns true if ctx.Err() is not nil or if err

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -56,7 +56,7 @@ func TestSearchResults(t *testing.T) {
 		}
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
 
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 			return nil, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -88,7 +88,7 @@ func TestSearchResults(t *testing.T) {
 		defer func() { mockSearchRepositories = nil }()
 
 		calledSearchSymbols := false
-		mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int) (res []*fileMatchResolver, common *searchResultsCommon, err error) {
+		mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int32) (res []*searchResultResolver, common *searchResultsCommon, err error) {
 			calledSearchSymbols = true
 			if want := `(foo\d).*?(bar\*)`; args.Pattern.Pattern != want {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
@@ -99,13 +99,13 @@ func TestSearchResults(t *testing.T) {
 		defer func() { mockSearchSymbols = nil }()
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
 			if want := `(foo\d).*?(bar\*)`; args.Pattern.Pattern != want {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
 			}
-			return []*fileMatchResolver{
-				{uri: "git://repo?rev#dir/file", JPath: "dir/file", JLineMatches: []*lineMatch{{JLineNumber: 123}}},
+			return []*searchResultResolver{
+				{fileMatch: &fileMatchResolver{uri: "git://repo?rev#dir/file", JPath: "dir/file", JLineMatches: []*lineMatch{{JLineNumber: 123}}}},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -109,14 +109,14 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		fileMatches, _, err := searchSymbols(ctx, &search.Args{Pattern: p, Repos: repoRevs, Query: r.query}, 7)
+		fileMatchResults, _, err := searchSymbols(ctx, &search.Args{Pattern: p, Repos: repoRevs, Query: r.query}, 7)
 		if err != nil {
 			return nil, err
 		}
 
 		results = make([]*searchSuggestionResolver, 0)
-		for _, fileMatch := range fileMatches {
-			for _, sr := range fileMatch.symbols {
+		for _, fileMatchResult := range fileMatchResults {
+			for _, sr := range fileMatchResult.fileMatch.symbols {
 				score := 20
 				if sr.symbol.Parent == "" {
 					score++

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -42,7 +42,7 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 	}
 
-	mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int) (res []*fileMatchResolver, common *searchResultsCommon, err error) {
+	mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int32) (res []*searchResultResolver, common *searchResultsCommon, err error) {
 		// TODO test symbol suggestions
 		return nil, nil, nil
 	}
@@ -81,13 +81,13 @@ func TestSearchSuggestions(t *testing.T) {
 		defer git.ResetMocks()
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
 			if want := "foo"; args.Pattern.Pattern != want {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, want)
 			}
-			return []*fileMatchResolver{
-				{uri: "git://repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "repo"}, commitID: "rev"},
+			return []*searchResultResolver{
+				{fileMatch: &fileMatchResolver{uri: "git://repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "repo"}, commitID: "rev"}},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -137,17 +137,17 @@ func TestSearchSuggestions(t *testing.T) {
 		backend.Mocks.Repos.MockResolveRev_NoCheck(t, api.CommitID("deadbeef"))
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
 			if args.Pattern.Pattern != "." && args.Pattern.Pattern != "foo" {
 				t.Errorf("got %q, want %q", args.Pattern.Pattern, `"foo" or "."`)
 			}
-			return []*fileMatchResolver{
-				{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", repo: &types.Repo{Name: "repo3"}, commitID: "rev"},
-				{uri: "git://repo?rev#dir/foo-repo1-file-name-match", JPath: "dir/foo-repo1-file-name-match", repo: &types.Repo{Name: "repo1"}, commitID: "rev"},
-				{uri: "git://repo?rev#dir/file-content-match", JPath: "dir/file-content-match", repo: &types.Repo{Name: "repo"}, commitID: "rev"},
+			return []*searchResultResolver{
+				{fileMatch: &fileMatchResolver{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", repo: &types.Repo{Name: "repo3"}, commitID: "rev"}},
+				{fileMatch: &fileMatchResolver{uri: "git://repo?rev#dir/foo-repo1-file-name-match", JPath: "dir/foo-repo1-file-name-match", repo: &types.Repo{Name: "repo1"}, commitID: "rev"}},
+				{fileMatch: &fileMatchResolver{uri: "git://repo?rev#dir/file-content-match", JPath: "dir/file-content-match", repo: &types.Repo{Name: "repo"}, commitID: "rev"}},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -192,15 +192,15 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
 			if want := "foo-repo"; len(args.Repos) != 1 || string(args.Repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
-			return []*fileMatchResolver{
-				{uri: "git://foo-repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""},
+			return []*searchResultResolver{
+				{fileMatch: &fileMatchResolver{uri: "git://foo-repo?rev#dir/file", JPath: "dir/file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""}},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -230,15 +230,15 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { db.Mocks = db.MockStores{} }()
 
 		calledSearchFilesInRepos := false
-		mockSearchFilesInRepos = func(args *search.Args) ([]*fileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.Args, limit int32) ([]*searchResultResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
 			if want := "foo-repo"; len(args.Repos) != 1 || string(args.Repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
-			return []*fileMatchResolver{
-				{uri: "git://foo-repo?rev#dir/bar-file", JPath: "dir/bar-file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""},
+			return []*searchResultResolver{
+				{fileMatch: &fileMatchResolver{uri: "git://foo-repo?rev#dir/bar-file", JPath: "dir/bar-file", repo: &types.Repo{Name: "foo-repo"}, commitID: ""}},
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -26,13 +26,13 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-var mockSearchSymbols func(ctx context.Context, args *search.Args, limit int) (res []*fileMatchResolver, common *searchResultsCommon, err error)
+var mockSearchSymbols func(ctx context.Context, args *search.Args, limit int32) (res []*searchResultResolver, common *searchResultsCommon, err error)
 
 // searchSymbols searches the given repos in parallel for symbols matching the given search query
 // it can be used for both search suggestions and search results
 //
 // May return partial results and an error
-func searchSymbols(ctx context.Context, args *search.Args, limit int) (res []*fileMatchResolver, common *searchResultsCommon, err error) {
+func searchSymbols(ctx context.Context, args *search.Args, limit int32) (res []*searchResultResolver, common *searchResultsCommon, err error) {
 	if mockSearchSymbols != nil {
 		return mockSearchSymbols(ctx, args, limit)
 	}
@@ -72,7 +72,7 @@ func searchSymbols(ctx context.Context, args *search.Args, limit int) (res []*fi
 			}
 			mu.Lock()
 			defer mu.Unlock()
-			limitHit := len(res) > limit
+			limitHit := int32(len(res)) > limit
 			repoErr = handleRepoSearchResult(common, *repoRevs, limitHit, false, repoErr)
 			if repoErr != nil {
 				if ctx.Err() == nil || errors.Cause(repoErr) != ctx.Err() {
@@ -83,7 +83,9 @@ func searchSymbols(ctx context.Context, args *search.Args, limit int) (res []*fi
 				common.searched = append(common.searched, repoRevs.Repo)
 			}
 			if repoSymbols != nil {
-				res = append(res, repoSymbols...)
+				for _, fileMatch := range repoSymbols {
+					res = append(res, &searchResultResolver{fileMatch: fileMatch})
+				}
 				if limitHit {
 					cancelAll()
 				}
@@ -92,14 +94,14 @@ func searchSymbols(ctx context.Context, args *search.Args, limit int) (res []*fi
 	}
 	err = run.Wait()
 
-	if len(res) > limit {
+	if int32(len(res)) > limit {
 		common.limitHit = true
 		res = res[:limit]
 	}
 	return res, common, err
 }
 
-func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.PatternInfo, query *query.Query, limit int) (res []*fileMatchResolver, err error) {
+func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.PatternInfo, query *query.Query, limit int32) (res []*fileMatchResolver, err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Search symbols in repo")
 	defer func() {
 		if err != nil {
@@ -134,7 +136,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 		IsRegExp:        patternInfo.IsRegExp,
 		IncludePatterns: patternInfo.IncludePatterns,
 		ExcludePattern:  patternInfo.ExcludePattern,
-		First:           limit,
+		First:           int(limit),
 	})
 	fileMatchesByURI := make(map[string]*fileMatchResolver)
 	fileMatches := make([]*fileMatchResolver, 0)

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -171,7 +171,8 @@ func TestSearchFilesInRepos(t *testing.T) {
 		Repos: makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev"),
 		Query: q,
 	}
-	results, common, err := searchFilesInRepos(context.Background(), args)
+	limit := int32(5000)
+	results, common, err := searchFilesInRepos(context.Background(), args, limit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +200,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 		Repos: makeRepositoryRevisions("foo/no-rev@dev"),
 		Query: q,
 	}
-	_, _, err = searchFilesInRepos(context.Background(), args)
+	_, _, err = searchFilesInRepos(context.Background(), args, limit)
 	if !git.IsRevisionNotFound(errors.Cause(err)) {
 		t.Fatalf("searching non-existent rev expected to fail with RevisionNotFoundError got: %v", err)
 	}


### PR DESCRIPTION
Prior to this change, the `doResults` method suffered from:

1. Heavy use of mutexes
2. Deeply nested conditionals and large switch statements, making control flow hard to understand.
3. Maps being sprinkled in at multiple locations for data deduplication.
4. Lock contention: For every symbol result etc. we would re-acquire multiple mutexes.
5. Difficult to reason about optional search result logic involving conditionally-acquired `sync.WaitGroup`s.

After this change we:

1. Remove the use of mutexes and instead use channels as appropriate.
2. Remove deeply nested conditionals and large switch statements in favor of standardization of search functions and using a registration pattern.
3. Keep the use of maps for data deduplication close to the source (i.e. when we create the data, not when we read it).
4. Solve all lock contention thanks to channels and a clear worker approach.
5. No longer need complex conditionally-acquired `sync.WaitGroup`s` because channels work better for waiting on optional search results.

Knowing that others are working on search code heavily, I didn't want to make this change, but in researching adding search pagination I really had no choice: This code was a disaster and initially impossible to reason about.

TL;DR:

- No functionality changes.
- This code is well-tested already.
- This code is now MUCH easier to reason about and read.

Test plan: This code is well-tested already, I am confident this change won't introduce regressions.
