### PR TITLE
Revert "Revert "repo-updater: Dev friendly DSN (#3007)" (#3019)"

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -43,7 +43,7 @@ func main() {
 	api.WaitForFrontend(ctx)
 	gitserver.DefaultClient.WaitForGitServers(ctx)
 
-	db, err := repos.NewDB(repos.NewDSNFromEnv())
+	db, err := repos.NewDB(repos.NewDSN().String())
 	if err != nil {
 		log.Fatalf("failed to initialize db store: %v", err)
 	}


### PR DESCRIPTION
This reverts commit 695b2e89f675173003828e56366469c39a932ac4.

This issue was missing PGDATABASE environment variables in the repo-updater deployment manifest. I fixed this in these commits:

sourcegraph/deploy-sourcegraph@8a94564
sourcegraph/deploy-sourcegraph-dot-com@d1a7ab3

Fixes #3020


