### PR TITLE
Bitbucket server fixes

### DIFF
--- a/client/browser/src/libs/bitbucket/api.ts
+++ b/client/browser/src/libs/bitbucket/api.ts
@@ -5,7 +5,7 @@ import { ajax } from 'rxjs/ajax'
 import { filter, map } from 'rxjs/operators'
 
 import { memoizeObservable } from '../../../../../shared/src/util/memoizeObservable'
-import { PRPageInfo } from './scrape'
+import { BitbucketRepoInfo } from './scrape'
 
 //
 // PR API /rest/api/1.0/projects/SG/repos/go-langserver/pull-requests/1
@@ -39,16 +39,11 @@ interface PRResponse {
     toRef: Ref
 }
 
-interface GetCommitsForPRInput extends Pick<PRPageInfo, 'project' | 'repoSlug'> {
-    /** Required here. */
-    prID: number
-}
-
 /**
  * Get the base commit ID for a merge request.
  */
 export const getCommitsForPR: (
-    info: GetCommitsForPRInput
+    info: BitbucketRepoInfo & { prID: number }
 ) => Observable<{ baseCommitID: string; headCommitID: string }> = memoizeObservable(
     ({ project, repoSlug, prID }) =>
         get<PRResponse>(buildURL(project, repoSlug, `/pull-requests/${prID}`)).pipe(
@@ -57,7 +52,7 @@ export const getCommitsForPR: (
     ({ prID }) => prID.toString()
 )
 
-interface GetBaseCommitInput extends Pick<PRPageInfo, 'project' | 'repoSlug'> {
+interface GetBaseCommitInput extends BitbucketRepoInfo {
     commitID: string
 }
 

--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -136,7 +136,7 @@ function getViewContextOnSourcegraphMount(): HTMLElement | null {
     }
     const mount = document.createElement('span')
     mount.id = 'open-on-sourcegraph'
-    mount.className = 'open-on-sourcegraph__bitbucket-server'
+    mount.className = 'open-on-sourcegraph--bitbucket-server'
     branchSelectorButtons.insertAdjacentElement('beforeend', mount)
     return mount
 }

--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -2,6 +2,7 @@ import { AdjustmentDirection, DOMFunctions, PositionAdjuster } from '@sourcegrap
 import { of } from 'rxjs'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
 import { CodeHost, CodeViewResolver, CodeViewWithOutSelector } from '../code_intelligence'
+import { getContext } from './context'
 import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { resolveDiffFileInfo, resolveFileInfo } from './file_info'
 
@@ -115,6 +116,22 @@ function getCommandPaletteMount(): HTMLElement {
     return document.querySelector<HTMLElement>(commandListClasses.map(c => `.${c}`).join('')) || createCommandList()
 }
 
+function getViewContextOnSourcegraphMount(): HTMLElement | null {
+    const branchSelectorButtons = document.querySelector('.branch-selector-toolbar .aui-buttons')
+    if (!branchSelectorButtons) {
+        return null
+    }
+    const preexisting = branchSelectorButtons.querySelector('#open-on-sourcegraph') as HTMLElement | null
+    if (preexisting) {
+        return preexisting
+    }
+    const mount = document.createElement('span')
+    mount.id = 'open-on-sourcegraph'
+    mount.className = 'open-on-sourcegraph__bitbucket-server'
+    branchSelectorButtons.insertAdjacentElement('beforeend', mount)
+    return mount
+}
+
 export const bitbucketServerCodeHost: CodeHost = {
     name: 'bitbucket-server',
     check: () =>
@@ -127,4 +144,7 @@ export const bitbucketServerCodeHost: CodeHost = {
         actionItemClass: 'aui-button action-item__bitbucket-server',
     },
     codeViewToolbarClassName: 'code-view-toolbar__bitbucket-server',
+    getViewContextOnSourcegraphMount,
+    getContext,
+    contextButtonClassName: 'aui-button',
 }

--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -123,4 +123,8 @@ export const bitbucketServerCodeHost: CodeHost = {
     codeViewResolver,
     getCommandPaletteMount,
     commandPalettePopoverClassName: 'command-palette-popover__bitbucket-server',
+    actionNavItemClassProps: {
+        actionItemClass: 'aui-button action-item__bitbucket-server',
+    },
+    codeViewToolbarClassName: 'code-view-toolbar__bitbucket-server',
 }

--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -122,4 +122,5 @@ export const bitbucketServerCodeHost: CodeHost = {
         !!document.querySelector('.aui-header-logo.aui-header-logo-bitbucket'),
     codeViewResolver,
     getCommandPaletteMount,
+    commandPalettePopoverClassName: 'command-palette-popover__bitbucket-server',
 }

--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -4,7 +4,7 @@ import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../sha
 import { CodeHost, CodeViewResolver, CodeViewWithOutSelector } from '../code_intelligence'
 import { getContext } from './context'
 import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
-import { resolveDiffFileInfo, resolveFileInfo } from './file_info'
+import { resolveCompareFileInfo, resolveDiffFileInfo, resolveFileInfo } from './file_info'
 
 const createToolbarMount = (codeView: HTMLElement) => {
     const existingMount = codeView.querySelector<HTMLElement>('.sg-toolbar-mount')
@@ -81,12 +81,21 @@ const diffCodeView: CodeViewWithOutSelector = {
     },
 }
 
+const branchCompareCodeView: CodeViewWithOutSelector = {
+    ...diffCodeView,
+    resolveFileInfo: resolveCompareFileInfo,
+}
+
 const resolveCodeView: CodeViewResolver['resolveCodeView'] = codeView => {
     const contentView = codeView.querySelector('.content-view')
     if (!contentView) {
         return null
     }
 
+    const isBranchCompare = document.querySelector('#branch-compare')
+    if (isBranchCompare) {
+        return branchCompareCodeView
+    }
     const isDiff = contentView.classList.contains('diff-view')
 
     return isDiff ? diffCodeView : singleFileCodeView

--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -148,11 +148,11 @@ export const bitbucketServerCodeHost: CodeHost = {
         !!document.querySelector('.aui-header-logo.aui-header-logo-bitbucket'),
     codeViewResolver,
     getCommandPaletteMount,
-    commandPalettePopoverClassName: 'command-palette-popover__bitbucket-server',
+    commandPalettePopoverClassName: 'command-palette-popover--bitbucket-server',
     actionNavItemClassProps: {
         actionItemClass: 'aui-button action-item__bitbucket-server',
     },
-    codeViewToolbarClassName: 'code-view-toolbar__bitbucket-server',
+    codeViewToolbarClassName: 'code-view-toolbar--bitbucket-server',
     getViewContextOnSourcegraphMount,
     getContext,
     contextButtonClassName: 'aui-button',

--- a/client/browser/src/libs/bitbucket/context.tsx
+++ b/client/browser/src/libs/bitbucket/context.tsx
@@ -1,0 +1,55 @@
+import { RepoSpec, RevSpec } from '../../../../../shared/src/util/url'
+import { CodeHostContext } from '../code_intelligence/code_intelligence'
+
+// example pathname: /projects/TEST/repos/testing/browse/src/extension.ts
+const PATH_REGEX = /^\/projects\/(\w+)\/repos\/(\w+)\//
+
+function getRepoSpecFromLocation(location: Pick<Location, 'hostname' | 'pathname'>): RepoSpec | null {
+    const { hostname, pathname } = location
+    const match = pathname.match(PATH_REGEX)
+    if (!hostname || !match) {
+        return null
+    }
+    return {
+        repoName: `${hostname}/${match[1]}/${match[2]}`,
+    }
+}
+
+interface RevisionRefInfo {
+    latestCommit?: string
+}
+
+function getRevSpecFromRevisionSelector(): RevSpec | null {
+    const branchNameElement = document.querySelector(
+        '#repository-layout-revision-selector span.name[data-revision-ref]'
+    )
+    if (!branchNameElement) {
+        return null
+    }
+    const revisionRefStr = branchNameElement.getAttribute('data-revision-ref')
+    let revisionRefInfo: RevisionRefInfo | null = null
+    try {
+        revisionRefInfo = revisionRefStr && JSON.parse(revisionRefStr)
+    } catch {
+        return null
+    }
+    if (revisionRefInfo && revisionRefInfo.latestCommit) {
+        return {
+            rev: revisionRefInfo.latestCommit,
+        }
+    } else {
+        return null
+    }
+}
+
+export function getContext(): CodeHostContext {
+    const repoSpec = getRepoSpecFromLocation(window.location)
+    if (!repoSpec) {
+        throw new Error('Could not determine bitbucket code host context')
+    }
+    const revSpec = getRevSpecFromRevisionSelector() || {}
+    return {
+        ...repoSpec,
+        ...revSpec,
+    }
+}

--- a/client/browser/src/libs/bitbucket/context.tsx
+++ b/client/browser/src/libs/bitbucket/context.tsx
@@ -20,9 +20,7 @@ interface RevisionRefInfo {
 }
 
 function getRevSpecFromRevisionSelector(): RevSpec | null {
-    const branchNameElement = document.querySelector(
-        '#repository-layout-revision-selector span.name[data-revision-ref]'
-    )
+    const branchNameElement = document.querySelector('#repository-layout-revision-selector .name[data-revision-ref]')
     if (!branchNameElement) {
         return null
     }

--- a/client/browser/src/libs/bitbucket/context.tsx
+++ b/client/browser/src/libs/bitbucket/context.tsx
@@ -4,11 +4,11 @@ import { CodeHostContext } from '../code_intelligence/code_intelligence'
 // example pathname: /projects/TEST/repos/testing/browse/src/extension.ts
 const PATH_REGEX = /^\/projects\/(\w+)\/repos\/(\w+)\//
 
-function getRepoSpecFromLocation(location: Pick<Location, 'hostname' | 'pathname'>): RepoSpec | null {
+function getRepoSpecFromLocation(location: Pick<Location, 'hostname' | 'pathname'>): RepoSpec {
     const { hostname, pathname } = location
     const match = pathname.match(PATH_REGEX)
-    if (!hostname || !match) {
-        return null
+    if (!match) {
+        throw new Error(`location pathname does not match path regex: ${pathname}`)
     }
     return {
         repoName: `${hostname}/${match[1]}/${match[2]}`,
@@ -19,33 +19,36 @@ interface RevisionRefInfo {
     latestCommit?: string
 }
 
-function getRevSpecFromRevisionSelector(): RevSpec | null {
+function getRevSpecFromRevisionSelector(): RevSpec {
     const branchNameElement = document.querySelector('#repository-layout-revision-selector .name[data-revision-ref]')
     if (!branchNameElement) {
-        return null
+        throw new Error('branchNameElement not found')
     }
     const revisionRefStr = branchNameElement.getAttribute('data-revision-ref')
     let revisionRefInfo: RevisionRefInfo | null = null
     try {
         revisionRefInfo = revisionRefStr && JSON.parse(revisionRefStr)
     } catch {
-        return null
+        throw new Error(`Could not parse revisionRefStr: ${revisionRefStr}`)
     }
     if (revisionRefInfo && revisionRefInfo.latestCommit) {
         return {
             rev: revisionRefInfo.latestCommit,
         }
     } else {
-        return null
+        throw new Error(`revisionRefInfo is empty or has no latestCommit (revisionRefStr: ${revisionRefStr})`)
     }
 }
 
 export function getContext(): CodeHostContext {
     const repoSpec = getRepoSpecFromLocation(window.location)
-    if (!repoSpec) {
-        throw new Error('Could not determine bitbucket code host context')
+    let revSpec: Partial<RevSpec> = {}
+    try {
+        revSpec = getRevSpecFromRevisionSelector()
+    } catch (err) {
+        // RevSpec is optional in CodeHostContext, log the error for debug purposes
+        console.error('Could not determine revSpec from revision selector', err)
     }
-    const revSpec = getRevSpecFromRevisionSelector() || {}
     return {
         ...repoSpec,
         ...revSpec,

--- a/client/browser/src/libs/bitbucket/file_info.ts
+++ b/client/browser/src/libs/bitbucket/file_info.ts
@@ -59,9 +59,13 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                 return getBaseCommit({ commitID, project, repoSlug }).pipe(
                     map(baseCommitID => ({ baseCommitID, headCommitID: commitID, ...rest }))
                 )
+            } else if (prID) {
+                return getCommitsForPR({ project, repoSlug, prID: prID! }).pipe(
+                    map(commits => ({ ...rest, ...commits }))
+                )
+            } else {
+                throw new Error('Cannot resolve diff: no commitID or prID')
             }
-
-            return getCommitsForPR({ project, repoSlug, prID: prID! }).pipe(map(commits => ({ ...rest, ...commits })))
         }),
         switchMap(fetchDiffFiles)
     )

--- a/client/browser/src/libs/bitbucket/file_info.ts
+++ b/client/browser/src/libs/bitbucket/file_info.ts
@@ -60,9 +60,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                     map(baseCommitID => ({ baseCommitID, headCommitID: commitID, ...rest }))
                 )
             } else if (prID) {
-                return getCommitsForPR({ project, repoSlug, prID: prID! }).pipe(
-                    map(commits => ({ ...rest, ...commits }))
-                )
+                return getCommitsForPR({ project, repoSlug, prID }).pipe(map(commits => ({ ...rest, ...commits })))
             } else {
                 throw new Error('Cannot resolve diff: no commitID or prID')
             }

--- a/client/browser/src/libs/bitbucket/file_info.ts
+++ b/client/browser/src/libs/bitbucket/file_info.ts
@@ -8,9 +8,9 @@ import { FileInfo } from '../code_intelligence'
 import { ensureRevisionsAreCloned } from '../code_intelligence/util/file_info'
 import { getBaseCommit, getCommitsForPR } from './api'
 import {
+    getDiffFileInfoFromCodeView,
     getFileInfoFromCodeView,
     getPRIDFromPathName,
-    getDiffFileInfoFromCodeView,
     getResolvedDiffFromBranchComparePage,
 } from './scrape'
 

--- a/client/browser/src/libs/bitbucket/scrape.ts
+++ b/client/browser/src/libs/bitbucket/scrape.ts
@@ -1,4 +1,5 @@
 import { FileInfo } from '../code_intelligence'
+import { DiffResolvedRevSpec } from '../../shared/repo'
 
 interface PageInfo extends Pick<FileInfo, 'repoName' | 'filePath' | 'rev'> {
     project: string
@@ -163,5 +164,17 @@ export const getPRInfoFromCodeView = (codeView: HTMLElement): PRPageInfo => {
         prID: prIDMatch ? parseInt(prIDMatch[1], 10) : undefined,
         project: project!,
         repoSlug: repoSlug!,
+    }
+}
+
+export function getResolvedDiffFromBranchComparePage(): DiffResolvedRevSpec {
+    const headCommitElement = document.querySelector('#branch-compare .source-selector a.commitid[data-commitid]')
+    const baseCommitElement = document.querySelector('#branch-compare .target-selector a.commitid[data-commitid]')
+    if (!headCommitElement || !baseCommitElement) {
+        throw new Error('Could not resolve Bitbucket compare diff spec')
+    }
+    return {
+        headCommitID: headCommitElement.getAttribute('data-commitid')!,
+        baseCommitID: baseCommitElement.getAttribute('data-commitid')!,
     }
 }

--- a/client/browser/src/libs/bitbucket/scrape.ts
+++ b/client/browser/src/libs/bitbucket/scrape.ts
@@ -1,3 +1,4 @@
+import { createAggregateError } from '../../../../../shared/src/util/errors'
 import { DiffResolvedRevSpec } from '../../shared/repo'
 import { FileInfo } from '../code_intelligence'
 
@@ -65,7 +66,7 @@ const getFileInfoFromLink = (
             continue
         }
     }
-    throw new Error(`Could not parse file info from links in code view:\n${errors.map(e => `${e}`).join('\n')}`)
+    throw createAggregateError(errors)
 }
 
 /**
@@ -77,7 +78,7 @@ const getCommitIDFromLink = (): string => {
     if (!commitLink) {
         throw new Error('No element found matching a.commitid')
     }
-    const commitID = commitLink.dataset.commitid!
+    const commitID = commitLink.dataset.commitid
     if (!commitID) {
         throw new Error('Element matching a.commitid has no data-commitid')
     }

--- a/client/browser/src/libs/bitbucket/scrape.ts
+++ b/client/browser/src/libs/bitbucket/scrape.ts
@@ -1,5 +1,5 @@
-import { FileInfo } from '../code_intelligence'
 import { DiffResolvedRevSpec } from '../../shared/repo'
+import { FileInfo } from '../code_intelligence'
 
 interface PageInfo extends Pick<FileInfo, 'repoName' | 'filePath' | 'rev'> {
     project: string

--- a/client/browser/src/libs/bitbucket/scrape.ts
+++ b/client/browser/src/libs/bitbucket/scrape.ts
@@ -8,6 +8,17 @@ interface PageInfo extends Pick<FileInfo, 'repoName' | 'filePath' | 'rev'> {
 
 const LINK_SELECTORS = ['a.raw-view-link', 'a.source-view-link', 'a.mode-source']
 
+/**
+ * Attempts to parse the file info from a link element contained in the code view.
+ * Depending on the configuration of the page, this can be a link to the raw file,
+ * or to the original source view, so a few different selectors are tried.
+ *
+ * The href of these links contains:
+ * - project name
+ * - repo name
+ * - file path
+ * - rev (through the query parameter 'at')
+ */
 const getFileInfoFromLink = (codeView: HTMLElement): PageInfo => {
     const pageInfo = LINK_SELECTORS.map(
         (selector): PageInfo | null => {

--- a/client/browser/src/libs/bitbucket/style.scss
+++ b/client/browser/src/libs/bitbucket/style.scss
@@ -24,7 +24,7 @@
     border-radius: 3px;
 
     .command-list {
-        input {
+        &__input {
             height: 30px;
             border-radius: 3px;
             box-sizing: border-box;

--- a/client/browser/src/libs/bitbucket/style.scss
+++ b/client/browser/src/libs/bitbucket/style.scss
@@ -57,3 +57,7 @@
     background-color: #344563;
     color: #ffffff;
 }
+
+.open-on-sourcegraph__bitbucket-server {
+    margin-left: 2px;
+}

--- a/client/browser/src/libs/bitbucket/style.scss
+++ b/client/browser/src/libs/bitbucket/style.scss
@@ -38,3 +38,22 @@
         box-sizing: border-box;
     }
 }
+
+.code-view-toolbar__bitbucket-server {
+    ul {
+        list-style-type: none;
+    }
+
+    .open-on-sourcegraph {
+        margin-bottom: 10px;
+    }
+}
+
+.action-item__bitbucket-server {
+    margin-bottom: 10px !important;
+}
+
+.action-item__bitbucket-server.action-item--pressed {
+    background-color: #344563;
+    color: #ffffff;
+}

--- a/client/browser/src/libs/bitbucket/style.scss
+++ b/client/browser/src/libs/bitbucket/style.scss
@@ -20,7 +20,7 @@
     }
 }
 
-.command-palette-popover__bitbucket-server {
+.command-palette-popover--bitbucket-server {
     border-radius: 3px;
 
     .command-list {
@@ -39,7 +39,7 @@
     }
 }
 
-.code-view-toolbar__bitbucket-server {
+.code-view-toolbar--bitbucket-server {
     ul {
         list-style-type: none;
     }
@@ -51,11 +51,10 @@
 
 .action-item__bitbucket-server {
     margin-bottom: 10px !important;
-}
-
-.action-item__bitbucket-server.action-item--pressed {
-    background-color: #344563;
-    color: #ffffff;
+    &.action-item--pressed {
+        background-color: #344563;
+        color: #ffffff;
+    }
 }
 
 .open-on-sourcegraph--bitbucket-server {

--- a/client/browser/src/libs/bitbucket/style.scss
+++ b/client/browser/src/libs/bitbucket/style.scss
@@ -19,3 +19,22 @@
         display: block;
     }
 }
+
+.command-palette-popover__bitbucket-server {
+    border-radius: 3px;
+
+    .command-list {
+        input {
+            height: 30px;
+            border-radius: 3px;
+            box-sizing: border-box;
+            border: 1px solid #dfe1e6;
+            font-size: 14px;
+            margin-top: 0.5rem;
+        }
+    }
+
+    .action-item {
+        box-sizing: border-box;
+    }
+}

--- a/client/browser/src/libs/bitbucket/style.scss
+++ b/client/browser/src/libs/bitbucket/style.scss
@@ -58,6 +58,6 @@
     color: #ffffff;
 }
 
-.open-on-sourcegraph__bitbucket-server {
+.open-on-sourcegraph--bitbucket-server {
     margin-left: 2px;
 }

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -196,6 +196,9 @@ export interface CodeHost {
 
     /** Optional classes for ActionNavItems, useful to customize the style of buttons contributed to the code view toolbar */
     actionNavItemClassProps?: ActionNavItemsClassProps
+
+    /** Optional class to set on the command palette popover element */
+    commandPalettePopoverClassName?: string
 }
 
 export interface FileInfo {
@@ -447,7 +450,13 @@ export function handleCodeHost({
     subscriptions.add(hoverifier)
 
     // Inject UI components
-    injectCommandPalette({ extensionsController, platformContext, history, getMount: codeHost.getCommandPaletteMount })
+    injectCommandPalette({
+        extensionsController,
+        platformContext,
+        history,
+        getMount: codeHost.getCommandPaletteMount,
+        popoverClassName: codeHost.commandPalettePopoverClassName,
+    })
     injectGlobalDebug({
         extensionsController,
         platformContext,

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -199,6 +199,9 @@ export interface CodeHost {
 
     /** Optional class to set on the command palette popover element */
     commandPalettePopoverClassName?: string
+
+    /** Optional class to set on the code view toolbar element */
+    codeViewToolbarClassName?: string
 }
 
 export interface FileInfo {
@@ -607,6 +610,7 @@ export function handleCodeHost({
                                 }
                             }
                             location={H.createLocation(window.location)}
+                            className={codeHost.codeViewToolbarClassName}
                         />
                     </TelemetryContext.Provider>,
                     mount

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -43,12 +43,19 @@ interface InjectProps
     history: H.History
 }
 
-export function injectCommandPalette({ extensionsController, platformContext, getMount, history }: InjectProps): void {
+export function injectCommandPalette({
+    extensionsController,
+    platformContext,
+    getMount,
+    history,
+    popoverClassName,
+}: InjectProps & { popoverClassName?: string }): void {
     if (getMount) {
         render(
             <ShortcutProvider>
                 <TelemetryContext.Provider value={eventLogger}>
                     <CommandListPopoverButton
+                        popoverClassName={popoverClassName}
                         extensionsController={extensionsController}
                         menu={ContributableMenu.CommandPalette}
                         platformContext={platformContext}

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -28,6 +28,7 @@ interface CodeViewToolbarProps
 
     buttonProps: ButtonProps
     location: H.Location
+    className?: string
 }
 
 interface CodeViewToolbarState {
@@ -52,7 +53,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
     public render(): JSX.Element | null {
         return (
             <div
-                className="code-view-toolbar"
+                className={`code-view-toolbar ${this.props.className || ''}`}
                 style={{ display: 'inline-flex', verticalAlign: 'middle', alignItems: 'center' }}
             >
                 <ul className={`nav ${this.props.platformContext ? 'pr-1' : ''}`}>

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -17,6 +17,7 @@ import { PlatformContextProps } from '../platform/context'
 interface Props
     extends ExtensionsControllerProps<'services' | 'executeCommand'>,
         PlatformContextProps<'forceUpdateTooltip'> {
+    popoverClassName?: string
     /** The menu whose commands to display. */
     menu: ContributableMenu
 
@@ -271,7 +272,7 @@ export class CommandListPopoverButton extends React.PureComponent<
     public render(): JSX.Element | null {
         return (
             <PopoverButton
-                popoverClassName="rounded"
+                popoverClassName={this.props.popoverClassName || 'rounded'}
                 placement="auto-end"
                 toggleVisibilityKeybinding={this.props.toggleVisibilityKeybinding}
                 hideOnChange={this.state.hideOnChange}

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -272,7 +272,7 @@ export class CommandListPopoverButton extends React.PureComponent<
     public render(): JSX.Element | null {
         return (
             <PopoverButton
-                popoverClassName={this.props.popoverClassName || 'rounded'}
+                popoverClassName={`rounded ${this.props.popoverClassName || ''}`}
                 placement="auto-end"
                 toggleVisibilityKeybinding={this.props.toggleVisibilityKeybinding}
                 hideOnChange={this.state.hideOnChange}

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -131,7 +131,7 @@ export class CommandList extends React.PureComponent<Props, State> {
                             id="command-list__input"
                             ref={input => input && this.state.autoFocus && input.focus({ preventScroll: true })}
                             type="text"
-                            className="form-control px-2 py-1 rounded-0"
+                            className="form-control px-2 py-1 rounded-0 command-list__input"
                             value={this.state.input}
                             placeholder="Run Sourcegraph action..."
                             spellCheck={false}


### PR DESCRIPTION
This introduces several fixes for Bitbucket server v5.15.1

Related issue: #2917 

- Fixes styling of command palette and code view toolbar buttons
<details>
    <summary>screenshot</summary>

![image](https://user-images.githubusercontent.com/1741180/55172467-62fb3100-517a-11e9-9259-294b473e36ef.png)

</details>

- Adds a "View repository on Sourcegraph" button next to the branch selector / branch actions
<details>
    <summary>screenshot</summary>

![image](https://user-images.githubusercontent.com/1741180/55172501-6db5c600-517a-11e9-903f-2b61448c6068.png)

</details>

- Fixes code view resolution / code intelligence on branch compare pages
<details>
    <summary>screenshot</summary>

![image](https://user-images.githubusercontent.com/1741180/55172565-84f4b380-517a-11e9-9225-b826da1cba8f.png)

</details>

- Fixes code view resolution / code intelligence on single file "Diff to previous" views
<details>
    <summary>screenshot</summary>

![image](https://user-images.githubusercontent.com/1741180/55172604-963dc000-517a-11e9-8a20-a71f9e641bf3.png)

</details>
