### PR TITLE
repo-updater: Migrations improvements

### DIFF
--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -144,7 +144,7 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 				}
 				e.svc.UpdatedAt = now
 
-				log15.Info(prefix+".exclude", "service", e.svc.DisplayName, "repos", fmt.Sprint(len(e.exclude)))
+				log15.Info(prefix+".exclude", "service", e.svc.DisplayName, "repos", len(e.exclude))
 			}
 
 			if len(e.include) > 0 {
@@ -153,7 +153,7 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 				}
 				e.svc.UpdatedAt = now
 
-				log15.Info(prefix+".include", "service", e.svc.DisplayName, "repos", fmt.Sprint(len(e.include)))
+				log15.Info(prefix+".include", "service", e.svc.DisplayName, "repos", len(e.include))
 			}
 
 		}

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -111,19 +111,19 @@ func (s *Syncer) upserts(diff Diff) []*Repo {
 	for _, repo := range diff.Deleted {
 		repo.UpdatedAt, repo.DeletedAt = now, now
 		repo.Sources = map[string]*SourceInfo{}
-		repo.Enabled = false // Set for backwards compatibility
+		repo.Enabled = true
 		upserts = append(upserts, repo)
 	}
 
 	for _, repo := range diff.Modified {
 		repo.UpdatedAt, repo.DeletedAt = now, time.Time{}
-		repo.Enabled = true // Set for backwards compatibility
+		repo.Enabled = true
 		upserts = append(upserts, repo)
 	}
 
 	for _, repo := range diff.Added {
 		repo.CreatedAt, repo.UpdatedAt, repo.DeletedAt = now, now, time.Time{}
-		repo.Enabled = true // Set for backwards compatibility
+		repo.Enabled = true
 		upserts = append(upserts, repo)
 	}
 

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -221,8 +221,9 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				)},
 				now: clock.Now,
 				diff: repos.Diff{Deleted: repos.Repos{tc.repo.With(
-					repos.Opt.RepoDeletedAt(clock.Time(1))),
-				}},
+					repos.Opt.RepoDeletedAt(clock.Time(1)),
+					repos.Opt.RepoEnabled(true),
+				)}},
 				err: "<nil>",
 			},
 			testCase{

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -303,6 +303,7 @@ var Opt = struct {
 	RepoCreatedAt             func(time.Time) func(*Repo)
 	RepoModifiedAt            func(time.Time) func(*Repo)
 	RepoDeletedAt             func(time.Time) func(*Repo)
+	RepoEnabled               func(bool) func(*Repo)
 	RepoSources               func(...string) func(*Repo)
 	RepoMetadata              func(interface{}) func(*Repo)
 	RepoExternalID            func(string) func(*Repo)
@@ -354,7 +355,11 @@ var Opt = struct {
 			r.UpdatedAt = ts
 			r.DeletedAt = ts
 			r.Sources = map[string]*SourceInfo{}
-			r.Enabled = false
+		}
+	},
+	RepoEnabled: func(enabled bool) func(*Repo) {
+		return func(r *Repo) {
+			r.Enabled = enabled
 		}
 	},
 	RepoSources: func(srcs ...string) func(*Repo) {


### PR DESCRIPTION
This change set makes each migration be retried on all errors until completion as well as making the enabled state migration delete and enable the disabled repos.

Together with the upcoming UI changes that prevent admins disabling repos, as well as the
new enabled default of repos yielded by Sources, this ensures that they won't be touched a second
time a migration is ran.

The alternative of keeping track of which migrations already ran proved
to be more work than expected, so I'm putting this option forward for
review.

Part of #2025