### PR TITLE
Frontend: allow requests from browser extension origins by default

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -142,12 +142,10 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 		if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" || isExtensionRequest {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 
-			allowOrigin := corsOrigin
 			if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
-				allowOrigin = headerOrigin
+				w.Header().Set("Access-Control-Allow-Origin", headerOrigin)
 			}
 
-			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 			if r.Method == "OPTIONS" {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization")

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -133,10 +133,21 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 		// no cache by default
 		w.Header().Set("Cache-Control", "no-cache, max-age=0")
 
-		if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" {
-			w.Header().Set("Access-Control-Allow-Credentials", "true")
-			w.Header().Set("Access-Control-Allow-Origin", corsOrigin)
+		// CORS
+		// If the headerOrigin is the development or production Chrome Extension explicitly set the Allow-Control-Allow-Origin
+		// to the incoming header URL. Otherwise use the configured CORS origin.
+		headerOrigin := r.Header.Get("Origin")
+		isExtensionRequest := headerOrigin == devExtension || headerOrigin == prodExtension
 
+		if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" || isExtensionRequest {
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+			allowOrigin := corsOrigin
+			if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
+				allowOrigin = headerOrigin
+			}
+
+			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 			if r.Method == "OPTIONS" {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization")
@@ -154,6 +165,8 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 func isTrustedOrigin(r *http.Request) bool {
 	requestOrigin := r.Header.Get("Origin")
 
+	isExtensionRequest := requestOrigin == devExtension || requestOrigin == prodExtension
+
 	var isCORSAllowedRequest bool
 	if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" {
 		isCORSAllowedRequest = isAllowedOrigin(requestOrigin, strings.Fields(corsOrigin))
@@ -163,5 +176,5 @@ func isTrustedOrigin(r *http.Request) bool {
 		isCORSAllowedRequest = true
 	}
 
-	return isCORSAllowedRequest
+	return isExtensionRequest || isCORSAllowedRequest
 }

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -44,6 +44,11 @@ var (
 	httpAddrInternal = env.Get("SRC_HTTP_ADDR_INTERNAL", ":3090", "HTTP listen address for internal HTTP API. This should never be exposed externally, as it lacks certain authz checks.")
 
 	nginxAddr = env.Get("SRC_NGINX_HTTP_ADDR", "", "HTTP listen address for nginx reverse proxy to SRC_HTTP_ADDR. Has preference over SRC_HTTP_ADDR for ExternalURL.")
+
+	// dev browser browser extension ID. You can find this by going to chrome://extensions
+	devExtension = "chrome-extension://bmfbcejdknlknpncfpeloejonjoledha"
+	// production browser extension ID. This is found by viewing our extension in the chrome store.
+	prodExtension = "chrome-extension://dgjhfomjieaadpoljlnidmbgkdffpack"
 )
 
 func init() {


### PR DESCRIPTION
Before this change, the frontend responded to the `OPTIONS` request of cross-origin (e.g. browser extension) requests with the `Access-Control-Allow-Origin` header set to the value of `corsOrigin` from site config. That behavior prevented the browser extension from communicating with the Sourcegraph instance in the situation where the browser extension did not have permission to the Sourcegraph URL for two reasons:

- The frontend did not special case the browser extension IDs, which meant that a site admin would need to enter the bundle ID into the `corsOrigin` in site config
- Chrome only allows one value in the `Access-Control-Allow-Origin` header, not a space-separated list

Neither of these problems would have been caught in the "Test plan" section of https://github.com/sourcegraph/sourcegraph/pull/2689 (which removed the browser extension bundle IDs) unless all sites were disabled (they probably weren't) because Chrome only makes a preflighted cross-origin request instead of a simple cross-origin request when the browser extension doesn't have permission on the remote origin. cc @sqs Does this make sense?

After this change, the frontend will respond to cross-origin requests by echoing the `Origin` request header in the `Access-Control-Allow-Origin` response header and always allow the browser extension bundle IDs as a special case.

@lguychard I'd like your review on this because this is relevant to https://github.com/sourcegraph/sourcegraph/issues/2799

Fixes https://github.com/sourcegraph/sourcegraph/issues/3056