### PR TITLE
Support hyphens in Bitbucket repo names

### DIFF
--- a/client/browser/src/libs/bitbucket/context.tsx
+++ b/client/browser/src/libs/bitbucket/context.tsx
@@ -1,8 +1,8 @@
 import { RepoSpec, RevSpec } from '../../../../../shared/src/util/url'
 import { CodeHostContext } from '../code_intelligence/code_intelligence'
 
-// example pathname: /projects/TEST/repos/testing/browse/src/extension.ts
-const PATH_REGEX = /^\/projects\/(\w+)\/repos\/(\w+)\//
+// example pathname: /projects/TEST/repos/some-repo/browse/src/extension.ts
+const PATH_REGEX = /^\/projects\/([^\/]+)\/repos\/([^\/]+)\//
 
 function getRepoSpecFromLocation(location: Pick<Location, 'hostname' | 'pathname'>): RepoSpec {
     const { hostname, pathname } = location
@@ -10,8 +10,9 @@ function getRepoSpecFromLocation(location: Pick<Location, 'hostname' | 'pathname
     if (!match) {
         throw new Error(`location pathname does not match path regex: ${pathname}`)
     }
+    const [, projectName, repoName] = match
     return {
-        repoName: `${hostname}/${match[1]}/${match[2]}`,
+        repoName: `${hostname}/${projectName}/${repoName}`,
     }
 }
 


### PR DESCRIPTION
`\w` does not include hyphens.

Fixes #3068




<!-- Reminder: Have you updated the changelog? -->

Test plan: <!-- Required: What is the test plan for this change? -->
