### PR TITLE
migrate settings "motd" -> "notices"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - In search queries, treat `foo(` as `foo\(` and `bar[` as `bar\[` rather than failing with an error message.
 - Enterprise admins can now customize the appearance of the homepage and search icon.
-- A new settings property `notices` allows showing custom informational messages on the homepage and at the top of each page.
+- A new settings property `notices` allows showing custom informational messages on the homepage and at the top of each page. The `motd` property is deprecated and its value is automatically migrated to the new `notices` property.
 - The new `gitlab.exclude` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to exclude specific repositories matched by `gitlab.projectQuery` and `gitlab.projects` (so that they won't be synced).
 - The new `gitlab.projects` setting in [GitLab external service config](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) allows you to select specific repositories to be synced.
 - The new `bitbucketserver.exclude` setting in [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) allows you to exclude specific repositories matched by `bitbucketserver.repositoryQuery` and `bitbucketserver.repos` (so that they won't be synced).

--- a/cmd/frontend/db/settings_test.go
+++ b/cmd/frontend/db/settings_test.go
@@ -23,18 +23,33 @@ func TestSettings_ListAll(t *testing.T) {
 	}
 
 	// Try creating both with non-nil author and nil author.
-	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user1.ID}, nil, &user1.ID, "{}"); err != nil {
+	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user1.ID}, nil, &user1.ID, `{"abc": 1}`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user2.ID}, nil, nil, "{}"); err != nil {
+	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user2.ID}, nil, nil, `{"xyz": 2}`); err != nil {
 		t.Fatal(err)
 	}
 
-	settings, err := Settings.ListAll(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := 2; len(settings) != want {
-		t.Errorf("got %d settings, want %d", len(settings), want)
-	}
+	t.Run("all", func(t *testing.T) {
+		settings, err := Settings.ListAll(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := 2; len(settings) != want {
+			t.Errorf("got %d settings, want %d", len(settings), want)
+		}
+	})
+
+	t.Run("impreciseSubstring", func(t *testing.T) {
+		settings, err := Settings.ListAll(ctx, "xyz")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := 1; len(settings) != want {
+			t.Errorf("got %d settings, want %d", len(settings), want)
+		}
+		if want := `{"xyz": 2}`; settings[0].Contents != want {
+			t.Errorf("got contents %q, want %q", settings[0].Contents, want)
+		}
+	})
 }

--- a/cmd/frontend/internal/bg/db_test.go
+++ b/cmd/frontend/internal/bg/db_test.go
@@ -1,0 +1,7 @@
+package bg
+
+import "github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
+
+func init() {
+	dbtesting.DBNameSuffix = "bgdb"
+}

--- a/cmd/frontend/internal/bg/migrate_settings_motd_to_notices.go
+++ b/cmd/frontend/internal/bg/migrate_settings_motd_to_notices.go
@@ -1,0 +1,133 @@
+package bg
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/jsonx"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
+	"github.com/sourcegraph/sourcegraph/schema"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+// MigrateAllSettingsMOTDToNotices migrates the deprecated "motd" settings property to the new
+// "notices" settings property.
+//
+// TODO: Remove this migration code in Sourcegraph 3.4, which is one minor release after Sourcegraph
+// 3.3 (which introduces the "motd" deprecation and this migration).
+func MigrateAllSettingsMOTDToNotices(ctx context.Context) {
+	// It is not necessary to run this immediately because the old "motd" property is still
+	// supported. In case the DB query is computationally intensive, wait for a random delay to
+	// avoid a thundering herd.
+	time.Sleep(time.Duration(rand.Intn(300)) * time.Second)
+
+	if err := doMigrateAllSettingsMOTDToNotices(ctx, 60*time.Second); err != nil {
+		log15.Error(`Warning: unable to migrate settings ("motd" to "notices"). Please report this issue. The "motd" settings property has been deprecated in favor of "notices", and future versions of Sourcegraph will remove support for "motd".`, "error", err)
+	}
+}
+
+func doMigrateAllSettingsMOTDToNotices(ctx context.Context, iterationDelay time.Duration) (err error) {
+rerun:
+	settingsWithMOTD, err := db.Settings.ListAll(ctx, "motd")
+	if err != nil {
+		return err
+	}
+	count := 0
+	for _, s := range settingsWithMOTD {
+		changed, err := migrateSettingsMOTDToNotices(ctx, s.Subject)
+		if err != nil {
+			return errors.WithMessagef(err, "in settings for %s", s.Subject)
+		}
+		if changed {
+			count++
+		}
+	}
+
+	// To reduce the (small) chance of a race condition whereby a new settings document can have an
+	// "motd" added without reporting a validation error (e.g., by an older deployed version while
+	// this migration is running), rerun until we have nothing else to do.
+	if count > 0 {
+		log15.Info(`Migrated settings "motd" to "notices".`, "count", count)
+		time.Sleep(iterationDelay)
+		goto rerun
+	}
+
+	return nil
+}
+
+// migrateSettingsMOTDToNotices migrates a single settings document (for the subject) from using
+// "motd" to "notices". It reports whether the settings actually were changed.
+func migrateSettingsMOTDToNotices(ctx context.Context, settingsSubject api.SettingsSubject) (changed bool, err error) {
+	// Refetch the settings to reduce the risk of a race condition where the user edited their
+	// settings between the time we fetched the entire list and when we are processing migrating
+	// this one.
+	settings, err := db.Settings.GetLatest(ctx, settingsSubject)
+	if err != nil {
+		return false, err
+	}
+
+	newContents, err := migrateSettingsMOTDToNoticesJSON(settings.Contents)
+	if err != nil {
+		return false, err
+	}
+	if newContents == settings.Contents {
+		return false, nil // nothing to do
+	}
+
+	// Write migrated settings to DB.
+	var lastID *int32
+	if settings != nil {
+		lastID = &settings.ID
+	}
+	_, err = db.Settings.CreateIfUpToDate(ctx, settingsSubject, lastID, nil, newContents)
+	return true, err
+}
+
+// migrateSettingsMOTDToNoticesJSON returns the migrated JSON from the input, with the "motd"
+// property migrated to "notices".
+func migrateSettingsMOTDToNoticesJSON(text string) (string, error) {
+	var parsed schema.Settings
+	if err := jsonc.Unmarshal(text, &parsed); err != nil {
+		return "", err
+	}
+	if len(parsed.Motd) == 0 {
+		return text, nil // no change needed
+	}
+	migratedNotices := make([]schema.Notice, len(parsed.Motd))
+	for i, motd := range parsed.Motd {
+		migratedNotices[i] = schema.Notice{
+			Location:    "top",
+			Message:     motd,
+			Dismissible: true,
+		}
+	}
+
+	// Remove "motd".
+	edits, _, err := jsonx.ComputePropertyRemoval(text, jsonx.MakePath("motd"), conf.FormatOptions)
+	if err != nil {
+		return "", err
+	}
+	text, err = jsonx.ApplyEdits(text, edits...)
+	if err != nil {
+		return "", err
+	}
+
+	// Append notices one-by-one (because the ComputePropertyEdit API does not let you append
+	// multiple array elements in one call).
+	for _, migratedNotice := range migratedNotices {
+		edits, _, err := jsonx.ComputePropertyEdit(text, jsonx.MakePath("notices", -1), migratedNotice, nil, conf.FormatOptions)
+		if err != nil {
+			return "", err
+		}
+		text, err = jsonx.ApplyEdits(text, edits...)
+		if err != nil {
+			return "", err
+		}
+	}
+	return text, nil
+}

--- a/cmd/frontend/internal/bg/migrate_settings_motd_to_notices_test.go
+++ b/cmd/frontend/internal/bg/migrate_settings_motd_to_notices_test.go
@@ -1,0 +1,260 @@
+package bg
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
+)
+
+func TestMigrateAllSettingsMOTDToNotices(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := dbtesting.TestContext(t)
+
+	// In TestMigrateSettingsMOTDToNotices below, we test the actual migration in more detail. Here
+	// we add 2 settings document that need migration (1 valid, 1 with an error). This makes this
+	// test into an integration test, albeit one that's fast and simple. This is better than truly
+	// mocking out the underlying migration func, which would add more complexity to the impl than
+	// is warranted.
+
+	t.Run("valid", func(t *testing.T) {
+		u, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, `{"motd": ["a",], "notices": []}`); err != nil {
+			t.Fatal(err)
+		}
+		if err := doMigrateAllSettingsMOTDToNotices(ctx, 0); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		u, err := db.Users.Create(ctx, db.NewUser{Username: "u2"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, `{"motd": [1]}`); err != nil {
+			t.Fatal(err)
+		}
+		if err := doMigrateAllSettingsMOTDToNotices(ctx, 0); err == nil {
+			t.Error("want error due to invalid settings JSON")
+		}
+	})
+}
+
+func TestMigrateSettingsMOTDToNotices(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := dbtesting.TestContext(t)
+
+	check := func(t *testing.T, subject api.SettingsSubject, wantChanged bool, wantContents string) {
+		t.Helper()
+		if changed, err := migrateSettingsMOTDToNotices(ctx, subject); err != nil {
+			t.Fatal(err)
+		} else if changed != wantChanged {
+			t.Errorf("got changed %v, want %v", changed, wantChanged)
+		}
+		if !wantChanged {
+			return
+		}
+		s, err := db.Settings.GetLatest(ctx, subject)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.Contents != wantContents {
+			t.Errorf("got contents %q, want %q", s.Contents, wantContents)
+		}
+	}
+
+	t.Run("user needing migration", func(t *testing.T) {
+		u, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		subject := api.SettingsSubject{User: &u.ID}
+		if _, err := db.Settings.CreateIfUpToDate(ctx, subject, nil, nil, `{"motd": ["a",], "notices": []}`); err != nil {
+			t.Fatal(err)
+		}
+		check(t, subject, true, `{
+  "notices": [
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "a"
+    }
+  ]}`)
+	})
+	t.Run("user not needing migration", func(t *testing.T) {
+		u, err := db.Users.Create(ctx, db.NewUser{Username: "u2"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		subject := api.SettingsSubject{User: &u.ID}
+		if _, err := db.Settings.CreateIfUpToDate(ctx, subject, nil, nil, `{}`); err != nil {
+			t.Fatal(err)
+		}
+		check(t, subject, false, "")
+	})
+	t.Run("user with invalid settings JSON", func(t *testing.T) {
+		u, err := db.Users.Create(ctx, db.NewUser{Username: "u3"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		subject := api.SettingsSubject{User: &u.ID}
+		const invalidSettingsJSON = `{"motd": [1]}`
+		if _, err := db.Settings.CreateIfUpToDate(ctx, subject, nil, nil, invalidSettingsJSON); err != nil {
+			t.Fatal(err)
+		}
+		if changed, err := migrateSettingsMOTDToNotices(ctx, subject); err == nil {
+			t.Fatal("want error")
+		} else if changed {
+			t.Error("want unchanged")
+		}
+		// Ensure the settings were not changed (and remain in the original invalid state).
+		s, err := db.Settings.GetLatest(ctx, subject)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.Contents != invalidSettingsJSON {
+			t.Errorf("got contents %q, want to be unchanged from %q", s.Contents, invalidSettingsJSON)
+		}
+	})
+	t.Run("org needing migration", func(t *testing.T) {
+		org, err := db.Orgs.Create(ctx, "myorg", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		subject := api.SettingsSubject{Org: &org.ID}
+		if _, err := db.Settings.CreateIfUpToDate(ctx, subject, nil, nil, `{"motd": ["b",]}`); err != nil {
+			t.Fatal(err)
+		}
+		check(t, subject, true, `{
+  "notices": [
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "b"
+    }
+  ]
+}`)
+	})
+	t.Run("global settings needing migration", func(t *testing.T) {
+		subject := api.SettingsSubject{} // global settings subject
+		if _, err := db.Settings.CreateIfUpToDate(ctx, subject, nil, nil, `{"motd": ["c",], "notices": []}`); err != nil {
+			t.Fatal(err)
+		}
+		check(t, subject, true, `{
+  "notices": [
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "c"
+    }
+  ]}`)
+	})
+}
+
+func TestMigrateSettingsMOTDToNoticesJSON(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"empty": {
+			input: `{}`,
+			want:  `{}`,
+		},
+		"neither motd nor notices": {
+			input: `/* z */{"abc": 1 /* c */}`,
+			want:  `/* z */{"abc": 1 /* c */}`,
+		},
+		"motd only": {
+			input: `{"motd": ["x"]}`,
+			want: `{
+  "notices": [
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "x"
+    }
+  ]
+}`,
+		},
+		"2 motds": {
+			input: `{"motd": ["x", "z"]}`,
+			want: `{
+  "notices": [
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "x"
+    },
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "z"
+    }
+  ]
+}`,
+		},
+		"motd and notices": {
+			input: `{"motd": ["x"], "notices": [{"location": "top", "message": "y"}]}`,
+			want: `{
+  "notices": [
+    {
+      "location": "top",
+      "message": "y"
+    },
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "x"
+    }
+  ]}`,
+		},
+		"2 motds and notices": {
+			input: `{"motd": ["x", "z"], "notices": [{"location": "top", "message": "y"}]}`,
+			want: `{
+  "notices": [
+    {
+      "location": "top",
+      "message": "y"
+    },
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "x"
+    },
+    {
+      "dismissible": true,
+      "location": "top",
+      "message": "z"
+    }
+  ]}`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := migrateSettingsMOTDToNoticesJSON(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("got:\n%s\n\nwant:\n%s", got, test.want)
+			}
+		})
+	}
+
+	t.Run("error", func(t *testing.T) {
+		_, err := migrateSettingsMOTDToNoticesJSON(`{`)
+		if err == nil {
+			t.Fatal()
+		}
+	})
+}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/pkg/updatecheck"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/loghandlers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/discussions/mailreply"
@@ -167,6 +168,7 @@ func Main() error {
 		select {}
 	}
 
+	goroutine.Go(func() { bg.MigrateAllSettingsMOTDToNotices(context.Background()) })
 	goroutine.Go(mailreply.StartWorker)
 	go updatecheck.Start()
 	if hooks.AfterDBInit != nil {

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -214,7 +214,7 @@ func serveReposListEnabled(w http.ResponseWriter, r *http.Request) error {
 
 func serveSavedQueriesListAll(w http.ResponseWriter, r *http.Request) error {
 	// List settings for all users, orgs, etc.
-	settings, err := db.Settings.ListAll(r.Context())
+	settings, err := db.Settings.ListAll(r.Context(), "")
 	if err != nil {
 		return errors.Wrap(err, "db.Settings.ListAll")
 	}


### PR DESCRIPTION
closes #2960

Updates all settings (global/org/user) to use the new "notices" setting, which lets you show messages at the top of the page and on the homepage. Previously only "motd" was supported, which only supported showing messages at the top of the page (and did not support non-dismissible messages).

This PR can be used as a guide for other people who need to write settings migrations.

Test plan: There are extensive integration and unit tests. We will also run this on Sourcegraph.com, which has a lot of user accounts and therefore will surface unexpected issues when there are a lot of settings documents to scan for possible migration. (I don't anticipate any issues, but the fact that this isn't ONLY being run on self-hosted instances gives me more confidence we would spot unexpected issues before customers do.)