### PR TITLE
repo-updater: Leverage always set pre-condition

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -415,13 +415,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 	ch := make(chan batch)
 
 	var wg sync.WaitGroup
-
-	repositoryQueries := c.config.RepositoryQuery
-	if len(repositoryQueries) == 0 {
-		repositoryQueries = append(repositoryQueries, "none")
-	}
-
-	for _, repositoryQuery := range repositoryQueries {
+	for _, repositoryQuery := range c.config.RepositoryQuery {
 		wg.Add(1)
 		go func(repositoryQuery string) {
 			defer wg.Done()

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -321,11 +321,6 @@ func (c *gitlabConnection) listAllProjects(ctx context.Context) ([]*gitlab.Proje
 
 	ch := make(chan batch)
 
-	configProjectQuery := c.config.ProjectQuery
-	if len(configProjectQuery) == 0 {
-		configProjectQuery = []string{"?membership=true"}
-	}
-
 	var wg sync.WaitGroup
 
 	projch := make(chan *schema.GitLabProject)
@@ -370,7 +365,7 @@ func (c *gitlabConnection) listAllProjects(ctx context.Context) ([]*gitlab.Proje
 		}
 	}()
 
-	for _, projectQuery := range configProjectQuery {
+	for _, projectQuery := range c.config.ProjectQuery {
 		if projectQuery == "none" {
 			continue
 		}


### PR DESCRIPTION
These two settings now are always set and this is validated at config
submission time, so we don't have to fill in defaults here.

Part of #2025 
