### PR TITLE
graphqlbackend: Fix TestSearchCommitsInRepo

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -20,7 +20,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	ctx := context.Background()
 
 	var calledVCSRawLogDiffSearch bool
-	gitSignatureWithDate := git.Signature{Date: time.Now().AddDate(0, 0, -1)}
+	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
 	git.Mocks.RawLogDiffSearch = func(opt git.RawLogDiffSearchOptions) ([]*git.LogCommitSearchResult, bool, error) {
 		calledVCSRawLogDiffSearch = true
 		if want := "p"; opt.Query.Pattern != want {


### PR DESCRIPTION
This fixed this test failure for me:

```
sourcegraph:master* λ go test ./...
?       github.com/sourcegraph/sourcegraph      [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend [no test files]
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/auth    (cached)
?       github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers  [no test files]
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/authz   (cached)
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/backend (cached)
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/db      (cached)
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/db/query        (cached)
?       github.com/sourcegraph/sourcegraph/cmd/frontend/db/schemadoc    [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend/docsite [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend/envvar  [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend/external        [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend/external/app    [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend/external/globals        [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend/external/session        [no test files]
?       github.com/sourcegraph/sourcegraph/cmd/frontend/globals [no test files]
--- FAIL: TestSearchCommitsInRepo (0.00s)
    search_commits_test.go:84: results
        got  [{commit: &{repo:0xc000a98c80 inputRev:<nil> oid:c1 once:{m:{state:0 sema:0} done:1} onceErr:<nil> author:{person:0xc000aaa500 date:{wall:793310839 ext:63689541259 loc:0x1c25ca0}} committer:<nil> message: parents:[]} diffPreview: &{value:x highlights:[]} messagePreview: <nil>}]
        want [{commit: &{repo:0xc0009c49c0 inputRev:<nil> oid:c1 once:{m:{state:0 sema:0} done:1} onceErr:<nil> author:{person:0xc000aaa5f0 date:{wall:793310839 ext:63689541259 loc:0x1c25ca0}} committer:<nil> message: parents:[]} diffPreview: &{value:x highlights:[]} messagePreview: <nil>}]
        diff:  [
          {
           commit: {
            repo: {
             repo: {
              ID: 1,
              ExternalRepo: nil,
              Name: "repo",
              Description: "",
              Language: "",
              Enabled: false,
              Fork: false,
              CreatedAt: {
               wall: 0,
               ext: 0,
               loc: nil,
              },
              UpdatedAt: nil,
             },
             redirectURL: nil,
             icon: "",
             matches: [
             ],
            },
            inputRev: nil,
            oid: "c1",
            once: {
             m: {
              state: 0,
              sema: 0,
             },
             done: 1,
            },
            onceErr: nil,
            author: {
             person: {
              name: "",
              email: "",
              once: {
               m: {
                state: 0,
                sema: 0,
               },
               done: 0,
              },
              user: nil,
              err: nil,
             },
             date: {
                ELIDED, TOO LONG
             },
            },
            committer: nil,
            message: "",
            parents: [
            ],
           },
           refs: [
           ],
           sourceRefs: [
           ],
           messagePreview: nil,
           diffPreview: {
            value: "x",
            highlights: [
            ],
           },
           icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
           label: "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
           url: "/repo/-/commit/c1",
        -  detail: "[`c1` 23 hours ago](/repo/-/commit/c1)",
        +  detail: "[`c1` one day ago](/repo/-/commit/c1)",
           matches: [
            {
             url: "/repo/-/commit/c1",
             body: "```diff\nx```",
             highlights: [
             ],
            },
           ],
          },
         ]
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="adding query to searches table" error="db connection is nil"
t=2019-03-31T12:14:19+0200 lvl=eror msg="deleting excess rows from searches table" error="db connection is nil"
FAIL
```