### PR TITLE
Browser extension: add GitLab.com permission to manifest

### DIFF
--- a/client/browser/src/extension/manifest.spec.json
+++ b/client/browser/src/extension/manifest.spec.json
@@ -81,6 +81,7 @@
       "storage",
       "contextMenus",
       "https://github.com/*",
+      "https://gitlab.com/*",
       "https://sourcegraph.com/*"
     ]
   }


### PR DESCRIPTION
This makes it easier to get code intel on GitLab (no need to click "Enable on this domain").

cc @lguychard @felixfbecker Do either of you recall if there was a reason why we didn't have GitLab.com in the manifest?