### PR TITLE
Code intel: only show the "Find references" button when a definition is found

### DIFF
--- a/shared/src/hover/actions.test.ts
+++ b/shared/src/hover/actions.test.ts
@@ -421,7 +421,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([GO_TO_DEFINITION_ACTION, FIND_REFERENCES_ACTION]))
 
-        test('shows findReferences when the definition was not found', async () =>
+        test('does not show findReferences when the definition was not found', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': false,
@@ -431,7 +431,7 @@ describe('registerHoverContributions', () => {
                     'findReferences.url': '/r@v/-/blob/f#L2:2&tab=references',
                     hoverPosition: FIXTURE_PARAMS,
                 })
-            ).resolves.toEqual([FIND_REFERENCES_ACTION]))
+            ).resolves.toEqual([]))
     })
 
     describe('goToDefinition command', () => {

--- a/shared/src/hover/actions.ts
+++ b/shared/src/hover/actions.ts
@@ -364,7 +364,7 @@ export function registerHoverContributions({
                         {
                             action: 'findReferences',
                             when:
-                                'findReferences.url && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error || goToDefinition.notFound)',
+                                'findReferences.url && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)',
                         },
                     ],
                 },


### PR DESCRIPTION
Prior to this change, the "Find references" button would show up everywhere: on whitespace, comments, and punctuation.

![2019-04-02 19 30 16](https://user-images.githubusercontent.com/1387653/55448814-24041b80-557e-11e9-89e0-250f29c9836d.gif)

After this change, the "Find references" button will only appear when a definition is found.

![2019-04-02 19 41 22](https://user-images.githubusercontent.com/1387653/55449168-55c9b200-557f-11e9-822b-6b9306f2c342.gif)

Pros/cons:

- Pro: "Find references" will never appear by itself, and will likely be accompanied by a hover tooltip
- Pro: "Find references" won't show up on whitespace or punctuation
- Con: you won't be able to find references on legitimate tokens for which a definition couldn't be found (basic-code-intel is susceptible to this, language servers less so)
- Con: "Find references" won't show up until the definition is found (currently it shows up after a delay even if the definition is still loading)

Alternatively, this could be implemented by adding `hasReferences(pos): boolean` to the Sourcegraph extension API, which would give more control to extensions. The implementation in this PR was dead easy, so I thought I'd propose it first.

Code nav team (@lguychard @felixfbecker @vanesa) I'm curious if you have thoughts on this 💭 