### PR TITLE
Use mutation events for injections mounts too

### DIFF
--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -32,6 +32,8 @@ setLinkComponent(({ to, children, ...props }) => (
  * Main entry point into browser extension.
  */
 function observe(): void {
+    console.log('Sourcegraph browser extension is running')
+
     const mutations: Observable<MutationRecordLike[]> = observeMutations(document.body, {
         childList: true,
         subtree: true,

--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -1,6 +1,6 @@
 import '../../config/polyfill'
 
-import H from 'history'
+import * as H from 'history'
 import React from 'react'
 import { Observable } from 'rxjs'
 import { startWith } from 'rxjs/operators'

--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -1,7 +1,8 @@
 import { AdjustmentDirection, DOMFunctions, PositionAdjuster } from '@sourcegraph/codeintellify'
 import { of } from 'rxjs'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
-import { CodeHost, CodeViewSpecResolver, CodeViewSpecWithOutSelector } from '../code_intelligence'
+import { querySelectorOrSelf } from '../../shared/util/dom'
+import { CodeHost, CodeViewSpecResolver, CodeViewSpecWithOutSelector, MountGetter } from '../code_intelligence'
 import { getContext } from './context'
 import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import {
@@ -146,27 +147,24 @@ const codeViewSpecResolver: CodeViewSpecResolver = {
     },
 }
 
-function getCommandPaletteMount(): HTMLElement {
-    const headerElem = document.querySelector('.aui-header-primary .aui-nav')
-    if (!headerElem) {
-        throw new Error('Unable to find command palette mount')
+const getCommandPaletteMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
+    const headerElement = querySelectorOrSelf(container, '.aui-header-primary .aui-nav')
+    if (!headerElement) {
+        return null
     }
-
-    const commandListClasses = ['command-palette-button', 'command-palette-button__bitbucket-server']
-
-    const createCommandList = (): HTMLElement => {
-        const commandListElem = document.createElement('li')
-        commandListElem.className = commandListClasses.join(' ')
-        headerElem.insertAdjacentElement('beforeend', commandListElem)
-
-        return commandListElem
+    const classes = ['command-palette-button', 'command-palette-button__bitbucket-server']
+    const create = (): HTMLElement => {
+        const mount = document.createElement('li')
+        mount.className = classes.join(' ')
+        headerElement.insertAdjacentElement('beforeend', mount)
+        return mount
     }
-
-    return document.querySelector<HTMLElement>(commandListClasses.map(c => `.${c}`).join('')) || createCommandList()
+    const preexisting = headerElement.querySelector<HTMLElement>(classes.map(c => `.${c}`).join(''))
+    return preexisting || create()
 }
 
-function getViewContextOnSourcegraphMount(): HTMLElement | null {
-    const branchSelectorButtons = document.querySelector('.branch-selector-toolbar .aui-buttons')
+function getViewContextOnSourcegraphMount(container: HTMLElement): HTMLElement | null {
+    const branchSelectorButtons = querySelectorOrSelf(container, '.branch-selector-toolbar .aui-buttons')
     if (!branchSelectorButtons) {
         return null
     }

--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -80,7 +80,7 @@ describe('handleCodeHost()', () => {
         return el
     }
 
-    test('renders the hoverlay container', async () => {
+    test('renders the hover overlay mount', async () => {
         const { services } = await integrationTestContext()
         subscriptions.add(
             handleCodeHost({
@@ -95,7 +95,7 @@ describe('handleCodeHost()', () => {
             })
         )
         const overlayMount = document.body.firstChild! as HTMLElement
-        expect(overlayMount.className).toBe('overlay-mount-container')
+        expect(overlayMount.className).toBe('hover-overlay-mount hover-overlay-mount__test')
         const renderedOverlay = elementRenderedAtMount(overlayMount)
         expect(renderedOverlay).not.toBeUndefined()
     })

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -203,7 +203,7 @@ export interface CodeHost {
     /**
      * Mount getter for the command palette button for extensions.
      *
-     * If undefined, won't render a command palette button on the code host.
+     * If undefined, the command palette button won't be rendered on the code host.
      */
     getCommandPaletteMount?: MountGetter
 

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -154,7 +154,7 @@ export interface CodeHost {
     /**
      * Mount getter for the repository "View on Sourcegraph" button.
      *
-     * If undefined, won't render a repository "View on Sourcegraph" button on the code host.
+     * If undefined, the "View on Sourcegraph" button won't be rendered on the code host.
      */
     getViewContextOnSourcegraphMount?: MountGetter
 

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -424,6 +424,8 @@ export function handleCodeHost({
     platformContext,
     showGlobalDebug,
 }: CodeIntelligenceProps & { mutations: Observable<MutationRecordLike[]> }): Subscription {
+    console.log('Handling code host', codeHost.name)
+
     const history = H.createBrowserHistory()
     const subscriptions = new Subscription()
 
@@ -569,6 +571,8 @@ export function handleCodeHost({
 
     subscriptions.add(
         codeViews.pipe(withLatestFrom(selectionsChanges)).subscribe(([codeViewEvent, selections]) => {
+            console.log(`Code view ${codeViewEvent.type}`)
+
             // Handle added or removed view component, workspace root and subscriptions
             if (codeViewEvent.type === 'added' && !codeViewStates.has(codeViewEvent.codeViewElement)) {
                 const { codeViewElement, fileInfo, adjustPosition, getToolbarMount, toolbarButtonProps } = codeViewEvent

--- a/client/browser/src/libs/code_intelligence/code_views.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.ts
@@ -1,6 +1,6 @@
 import { from, merge, Observable, of, zip } from 'rxjs'
 import { catchError, concatAll, filter, map, mergeMap } from 'rxjs/operators'
-import { isDefined } from '../../../../../shared/src/util/types'
+import { isDefined, isInstanceOf } from '../../../../../shared/src/util/types'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
 import { CodeHost, CodeViewSpec, CodeViewSpecResolver, FileInfo, ResolvedCodeView } from './code_intelligence'
@@ -14,8 +14,6 @@ export interface RemovedCodeView extends Pick<ResolvedCodeView, 'codeViewElement
 }
 
 export type CodeViewEvent = AddedCodeView | RemovedCodeView
-
-const isHTMLElement = (node: unknown): node is HTMLElement => node instanceof HTMLElement
 
 /** Converts a static CodeViewSpec to a dynamic CodeViewSpecResolver */
 const toCodeViewResolver = ({ selector, ...spec }: CodeViewSpec): CodeViewSpecResolver => ({
@@ -47,7 +45,7 @@ export const trackCodeViews = ({
                 // Find all new code views within the added nodes
                 // (MutationObservers don't emit all descendant nodes of an addded node recursively)
                 from(mutation.addedNodes).pipe(
-                    filter(isHTMLElement),
+                    filter(isInstanceOf(HTMLElement)),
                     mergeMap(addedElement =>
                         from(codeViewSpecResolvers).pipe(
                             mergeMap(spec =>
@@ -69,7 +67,7 @@ export const trackCodeViews = ({
                 ),
                 // For removed nodes, find the removed elements, but don't resolve the kind (it's not relevant)
                 from(mutation.removedNodes).pipe(
-                    filter(isHTMLElement),
+                    filter(isInstanceOf(HTMLElement)),
                     mergeMap(removedElement =>
                         from(codeViewSpecResolvers).pipe(
                             mergeMap(

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -16,12 +16,10 @@ import {
     ExtensionsControllerProps,
 } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
-import { TelemetryContext } from '../../../../../shared/src/telemetry/telemetryContext'
+import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
 import { createPlatformContext } from '../../platform/context'
 import { GlobalDebug } from '../../shared/components/GlobalDebug'
 import { ShortcutProvider } from '../../shared/components/ShortcutProvider'
-import { eventLogger } from '../../shared/util/context'
-import { getGlobalDebugMount } from '../github/extensions'
 import { CodeHost } from './code_intelligence'
 
 /**
@@ -39,53 +37,44 @@ export function initializeExtensions({
 interface InjectProps
     extends PlatformContextProps<'forceUpdateTooltip' | 'sideloadedExtensionURL'>,
         ExtensionsControllerProps {
-    getMount?: () => HTMLElement
     history: H.History
 }
 
-export function injectCommandPalette({
+export const renderCommandPalette = ({
     extensionsController,
     platformContext,
-    getMount,
     history,
     popoverClassName,
-}: InjectProps & { popoverClassName?: string }): void {
-    if (getMount) {
-        render(
-            <ShortcutProvider>
-                <TelemetryContext.Provider value={eventLogger}>
-                    <CommandListPopoverButton
-                        popoverClassName={popoverClassName}
-                        extensionsController={extensionsController}
-                        menu={ContributableMenu.CommandPalette}
-                        platformContext={platformContext}
-                        location={history.location}
-                    />
-                    <Notifications extensionsController={extensionsController} />
-                </TelemetryContext.Provider>
-            </ShortcutProvider>,
-            getMount()
-        )
-    }
+}: InjectProps & { popoverClassName?: string }) => (mount: HTMLElement): void => {
+    render(
+        <ShortcutProvider>
+            <CommandListPopoverButton
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                popoverClassName={popoverClassName}
+                extensionsController={extensionsController}
+                menu={ContributableMenu.CommandPalette}
+                platformContext={platformContext}
+                location={history.location}
+            />
+            <Notifications extensionsController={extensionsController} />
+        </ShortcutProvider>,
+        mount
+    )
 }
 
-export function injectGlobalDebug({
+export const renderGlobalDebug = ({
     extensionsController,
     platformContext,
     history,
-    showGlobalDebug,
-    getMount = getGlobalDebugMount,
-}: InjectProps & { showGlobalDebug?: boolean }): void {
-    if (showGlobalDebug) {
-        render(
-            <GlobalDebug
-                extensionsController={extensionsController}
-                location={history.location}
-                platformContext={platformContext}
-            />,
-            getMount()
-        )
-    }
+}: InjectProps & { showGlobalDebug?: boolean }) => (mount: HTMLElement): void => {
+    render(
+        <GlobalDebug
+            extensionsController={extensionsController}
+            location={history.location}
+            platformContext={platformContext}
+        />,
+        mount
+    )
 }
 
 const IS_LIGHT_THEME = true // assume all code hosts have a light theme (correct for now)

--- a/client/browser/src/libs/code_intelligence/external_links.test.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.test.tsx
@@ -1,32 +1,23 @@
 import { fireEvent } from 'react-testing-library'
 import { of } from 'rxjs'
 import * as sinon from 'sinon'
-import { injectViewContextOnSourcegraph } from './external_links'
+import { renderViewContextOnSourcegraph } from './external_links'
 
 describe('<ViewOnSourcegraphButton />', () => {
+    let mount: HTMLElement
     beforeEach(() => {
-        for (const test of document.querySelectorAll('.test')) {
-            test.remove()
-        }
+        document.body.innerHTML = ''
+        mount = document.createElement('div')
+        document.body.append(mount)
     })
 
     it('renders a link', () => {
-        injectViewContextOnSourcegraph(
-            'https://test.com',
-            {
-                getContext: () => ({
-                    repoName: 'test',
-                }),
-                getViewContextOnSourcegraphMount: () => {
-                    const div = document.createElement('div')
-                    document.body.appendChild(div)
-                    return div
-                },
-                contextButtonClassName: 'test',
-            },
-            () => of(true),
-            undefined
-        )
+        renderViewContextOnSourcegraph({
+            sourcegraphUrl: 'https://test.com',
+            getContext: () => ({ repoName: 'test' }),
+            contextButtonClassName: 'test',
+            ensureRepoExists: () => of(true),
+        })(mount)
 
         const link = document.querySelector<HTMLAnchorElement>('.test')
         expect(link).toBeInstanceOf(HTMLAnchorElement)
@@ -34,23 +25,15 @@ describe('<ViewOnSourcegraphButton />', () => {
     })
 
     it('renders a link with the rev when provided', () => {
-        injectViewContextOnSourcegraph(
-            'https://test.com',
-            {
-                getContext: () => ({
-                    repoName: 'test',
-                    rev: 'test',
-                }),
-                getViewContextOnSourcegraphMount: () => {
-                    const div = document.createElement('div')
-                    document.body.appendChild(div)
-                    return div
-                },
-                contextButtonClassName: 'test',
-            },
-            () => of(true),
-            undefined
-        )
+        renderViewContextOnSourcegraph({
+            sourcegraphUrl: 'https://test.com',
+            getContext: () => ({
+                repoName: 'test',
+                rev: 'test',
+            }),
+            contextButtonClassName: 'test',
+            ensureRepoExists: () => of(true),
+        })(mount)
 
         const link = document.querySelector<HTMLAnchorElement>('.test')
         expect(link).toBeInstanceOf(HTMLAnchorElement)
@@ -60,23 +43,16 @@ describe('<ViewOnSourcegraphButton />', () => {
     it('renders configure sourcegraph button when pointing at sourcegraph.com', () => {
         const configureClickSpy = sinon.spy()
 
-        injectViewContextOnSourcegraph(
-            'https://sourcegraph.com',
-            {
-                getContext: () => ({
-                    repoName: 'test',
-                    rev: 'test',
-                }),
-                getViewContextOnSourcegraphMount: () => {
-                    const div = document.createElement('div')
-                    document.body.appendChild(div)
-                    return div
-                },
-                contextButtonClassName: 'test',
-            },
-            () => of(false),
-            configureClickSpy
-        )
+        renderViewContextOnSourcegraph({
+            sourcegraphUrl: 'https://sourcegraph.com',
+            getContext: () => ({
+                repoName: 'test',
+                rev: 'test',
+            }),
+            contextButtonClassName: 'test',
+            ensureRepoExists: () => of(false),
+            onConfigureSourcegraphClick: configureClickSpy,
+        })(mount)
 
         const link = document.querySelector<HTMLAnchorElement>('.test')
         expect(link).toBeInstanceOf(HTMLAnchorElement)
@@ -89,23 +65,16 @@ describe('<ViewOnSourcegraphButton />', () => {
     it('still renders "View Repository" if repo doesn\'t exist and its not pointed at .com', () => {
         const configureClickSpy = sinon.spy()
 
-        injectViewContextOnSourcegraph(
-            'https://test.com',
-            {
-                getContext: () => ({
-                    repoName: 'test',
-                    rev: 'test',
-                }),
-                getViewContextOnSourcegraphMount: () => {
-                    const div = document.createElement('div')
-                    document.body.appendChild(div)
-                    return div
-                },
-                contextButtonClassName: 'test',
-            },
-            () => of(false),
-            configureClickSpy
-        )
+        renderViewContextOnSourcegraph({
+            sourcegraphUrl: 'https://test.com',
+            getContext: () => ({
+                repoName: 'test',
+                rev: 'test',
+            }),
+            contextButtonClassName: 'test',
+            ensureRepoExists: () => of(false),
+            onConfigureSourcegraphClick: configureClickSpy,
+        })(mount)
 
         const link = document.querySelector<HTMLAnchorElement>('.test')
         expect(link).toBeInstanceOf(HTMLAnchorElement)

--- a/client/browser/src/libs/code_intelligence/external_links.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.tsx
@@ -51,6 +51,10 @@ class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonPro
         this.componentUpdates.next(this.props)
     }
 
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
     public render(): React.ReactNode {
         if (this.state.repoExists === undefined) {
             return null

--- a/client/browser/src/libs/code_intelligence/external_links.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.tsx
@@ -92,28 +92,18 @@ class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonPro
     }
 }
 
-/**
- * Idempotent.
- */
-export function injectViewContextOnSourcegraph(
-    sourcegraphUrl: string,
-    {
-        getContext,
-        getViewContextOnSourcegraphMount,
-        contextButtonClassName,
-    }: Pick<CodeHost, 'getContext' | 'getViewContextOnSourcegraphMount' | 'contextButtonClassName'>,
-    ensureRepoExists: ViewOnSourcegraphButtonProps['ensureRepoExists'],
+export const renderViewContextOnSourcegraph = ({
+    sourcegraphUrl,
+    getContext,
+    contextButtonClassName,
+    ensureRepoExists,
+    onConfigureSourcegraphClick,
+}: {
+    sourcegraphUrl: string
+    ensureRepoExists: ViewOnSourcegraphButtonProps['ensureRepoExists']
     onConfigureSourcegraphClick?: ViewOnSourcegraphButtonProps['onConfigureSourcegraphClick']
-): void {
-    if (!getContext || !getViewContextOnSourcegraphMount) {
-        return
-    }
-
-    const mount = getViewContextOnSourcegraphMount()
-    if (!mount) {
-        return
-    }
-
+} & Required<Pick<CodeHost, 'getContext'>> &
+    Pick<CodeHost, 'contextButtonClassName'>) => (mount: HTMLElement): void => {
     render(
         <ViewOnSourcegraphButton
             context={getContext()}

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -10,8 +10,15 @@ import {
     ViewStateSpec,
 } from '../../../../../shared/src/util/url'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
+import { querySelectorOrSelf } from '../../shared/util/dom'
 import { toAbsoluteBlobURL } from '../../shared/util/url'
-import { CodeHost, CodeViewSpec, CodeViewSpecResolver, CodeViewSpecWithOutSelector } from '../code_intelligence'
+import {
+    CodeHost,
+    CodeViewSpec,
+    CodeViewSpecResolver,
+    CodeViewSpecWithOutSelector,
+    MountGetter,
+} from '../code_intelligence'
 import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { getCommandPaletteMount, getGlobalDebugMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './file_info'
@@ -169,15 +176,18 @@ function checkIsGithub(): boolean {
     return isGithub || isGitHubEnterprise
 }
 
-const getOverlayMount = () => {
-    const container = document.querySelector('#js-repo-pjax-container')
-    if (!container) {
-        throw new Error('unable to find repo pjax container')
+const getOverlayMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
+    const jsRepoPjaxContainer = querySelectorOrSelf(container, '#js-repo-pjax-container')
+    if (!jsRepoPjaxContainer) {
+        return null
     }
-
-    const mount = document.createElement('div')
-    container.appendChild(mount)
-
+    let mount = jsRepoPjaxContainer.querySelector<HTMLElement>('.hover-overlay-mount')
+    if (mount) {
+        return mount
+    }
+    mount = document.createElement('div')
+    mount.className = 'hover-overlay-mount'
+    jsRepoPjaxContainer.appendChild(mount)
     return mount
 }
 

--- a/client/browser/src/libs/github/extensions.tsx
+++ b/client/browser/src/libs/github/extensions.tsx
@@ -1,32 +1,32 @@
-export function getCommandPaletteMount(): HTMLElement {
-    const headerElem = document.querySelector('div.HeaderMenu>div:last-child')
-    if (!headerElem) {
-        throw new Error('Unable to find command palette mount')
+import { querySelectorOrSelf } from '../../shared/util/dom'
+import { MountGetter } from '../code_intelligence'
+
+export const getCommandPaletteMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
+    const headerElement = querySelectorOrSelf(container, 'div.HeaderMenu > div:last-child')
+    if (!headerElement) {
+        return null
     }
-
-    const commandListClass = 'command-palette-button'
-
-    const createCommandList = (): HTMLElement => {
-        const commandListElem = document.createElement('div')
-        commandListElem.className = commandListClass
-        headerElem.insertAdjacentElement('afterbegin', commandListElem)
-
-        return commandListElem
+    const className = 'command-palette-button'
+    const createCommandPaletteMount = (): HTMLElement => {
+        const mount = document.createElement('div')
+        mount.className = className
+        headerElement.insertAdjacentElement('afterbegin', mount)
+        return mount
     }
-
-    return document.querySelector<HTMLElement>('.' + commandListClass) || createCommandList()
+    return headerElement.querySelector<HTMLElement>('.' + className) || createCommandPaletteMount()
 }
 
-export function getGlobalDebugMount(): HTMLElement {
+export const getGlobalDebugMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
     const globalDebugClass = 'global-debug'
-
-    const createGlobalDebugMount = (): HTMLElement => {
-        const globalDebugElem = document.createElement('div')
-        globalDebugElem.className = globalDebugClass
-        document.body.appendChild(globalDebugElem)
-
-        return globalDebugElem
+    const parentElement = querySelectorOrSelf(container, 'body')
+    if (!parentElement) {
+        return null
     }
-
-    return document.querySelector<HTMLElement>('.' + globalDebugClass) || createGlobalDebugMount()
+    const createGlobalDebugMount = (): HTMLElement => {
+        const mount = document.createElement('div')
+        mount.className = globalDebugClass
+        parentElement.appendChild(mount)
+        return mount
+    }
+    return container.querySelector<HTMLElement>('.' + globalDebugClass) || createGlobalDebugMount()
 }

--- a/client/browser/src/libs/gitlab/extensions.ts
+++ b/client/browser/src/libs/gitlab/extensions.ts
@@ -1,18 +1,17 @@
-export function getCommandPaletteMount(): HTMLElement {
-    const headerElem = document.querySelector('.navbar-collapse')
+import { querySelectorOrSelf } from '../../shared/util/dom'
+import { MountGetter } from '../code_intelligence'
+
+export const getCommandPaletteMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
+    const headerElem = querySelectorOrSelf(container, '.navbar-collapse')
     if (!headerElem) {
-        throw new Error('Unable to find command palette mount')
+        return null
     }
-
     const commandListClass = 'command-palette-button'
-
     const createCommandList = (): HTMLElement => {
-        const commandListElem = document.createElement('div')
-        commandListElem.className = commandListClass
-        headerElem.insertAdjacentElement('afterbegin', commandListElem)
-
-        return commandListElem
+        const mount = document.createElement('div')
+        mount.className = commandListClass
+        headerElem.insertAdjacentElement('afterbegin', mount)
+        return mount
     }
-
     return document.querySelector<HTMLElement>('.' + commandListClass) || createCommandList()
 }

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -7,6 +7,7 @@ import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/
 import { ISite, IUser } from '../../../../../shared/src/graphql/schema'
 import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
+import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import { toURIWithPath } from '../../../../../shared/src/util/url'
 import { FileInfo } from '../../libs/code_intelligence'
 import { fetchCurrentUser, fetchSite } from '../backend/server'
@@ -23,6 +24,7 @@ interface CodeViewToolbarProps
     extends PlatformContextProps<'forceUpdateTooltip'>,
         ExtensionsControllerProps,
         FileInfo,
+        TelemetryProps,
         ActionNavItemsClassProps {
     onEnabledChange?: (enabled: boolean) => void
 

--- a/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
@@ -62,6 +62,11 @@ export class OpenDiffOnSourcegraph extends React.Component<Props, State> {
         )
         this.componentUpdates.next(this.props)
     }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
     public render(): JSX.Element {
         const url = this.getOpenInSourcegraphUrl(this.props.openProps)
         return <Button {...this.props} className={`open-on-sourcegraph ${this.props.className}`} url={url} />

--- a/client/browser/src/shared/util/dom.tsx
+++ b/client/browser/src/shared/util/dom.tsx
@@ -91,3 +91,19 @@ export function querySelectorAllOrSelf(element: Element, selectors: string): Ite
 export function querySelectorAllOrSelf(element: Element, selectors: string): Iterable<Element> {
     return element.matches(selectors) ? [element] : element.querySelectorAll(selectors)
 }
+
+/**
+ * Like `element.querySelector()`, but will return the element itself if it matches the selector.
+ */
+export function querySelectorOrSelf<K extends keyof HTMLElementTagNameMap>(
+    element: Element,
+    selectors: K
+): HTMLElementTagNameMap[K] | null
+export function querySelectorOrSelf<K extends keyof SVGElementTagNameMap>(
+    element: Element,
+    selectors: K
+): SVGElementTagNameMap[K] | null
+export function querySelectorOrSelf<E extends Element = Element>(element: Element, selectors: string): E | null
+export function querySelectorOrSelf(element: Element, selectors: string): Element | null {
+    return element.matches(selectors) ? element : element.querySelector(selectors)
+}

--- a/shared/src/actions/ActionItem.story.tsx
+++ b/shared/src/actions/ActionItem.story.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react'
 import * as H from 'history'
 import React from 'react'
 import { setLinkComponent } from '../components/Link'
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import { ActionItem, ActionItemComponentProps } from './ActionItem'
 
 setLinkComponent(({ to, children, ...props }) => (
@@ -31,6 +32,7 @@ const { add } = storiesOf('ActionItem', module)
 add('noop action', () => (
     <ActionItem
         action={{ id: 'a', command: undefined, actionItem: { label: 'Hello' } }}
+        telemetryService={NOOP_TELEMETRY_SERVICE}
         variant="actionItem"
         location={LOCATION}
         extensionsController={EXTENSIONS_CONTROLLER}
@@ -41,6 +43,7 @@ add('noop action', () => (
 add('command action', () => (
     <ActionItem
         action={{ id: 'a', command: 'c', title: 'Hello', iconURL: ICON_URL }}
+        telemetryService={NOOP_TELEMETRY_SERVICE}
         disabledDuringExecution={true}
         showLoadingSpinnerDuringExecution={true}
         showInlineError={true}
@@ -59,6 +62,7 @@ add('link action', () => (
             commandArguments: ['javascript:alert("link clicked")'],
             actionItem: { label: 'Hello' },
         }}
+        telemetryService={NOOP_TELEMETRY_SERVICE}
         variant="actionItem"
         onDidExecute={onDidExecute}
         location={LOCATION}
@@ -77,6 +81,7 @@ add('executing', () => {
     return (
         <ActionItemExecuting
             action={{ id: 'a', command: 'c', title: 'Hello', iconURL: ICON_URL }}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
             disabledDuringExecution={true}
             showLoadingSpinnerDuringExecution={true}
             showInlineError={true}
@@ -99,6 +104,7 @@ add(
         return (
             <ActionItemWithError
                 action={{ id: 'a', command: 'c', title: 'Hello', iconURL: ICON_URL }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 disabledDuringExecution={true}
                 showLoadingSpinnerDuringExecution={true}
                 showInlineError={true}

--- a/shared/src/actions/ActionItem.test.tsx
+++ b/shared/src/actions/ActionItem.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { createBarrier } from '../api/integration-test/testHelpers'
 import { setLinkComponent } from '../components/Link'
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import { ActionItem } from './ActionItem'
 
 describe('ActionItem', () => {
@@ -14,6 +15,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 location={history.location}
                 extensionsController={NOOP_EXTENSIONS_CONTROLLER}
                 platformContext={NOOP_PLATFORM_CONTEXT}
@@ -26,6 +28,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 variant="actionItem"
                 location={history.location}
                 extensionsController={NOOP_EXTENSIONS_CONTROLLER}
@@ -39,6 +42,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 location={history.location}
                 extensionsController={NOOP_EXTENSIONS_CONTROLLER}
                 platformContext={NOOP_PLATFORM_CONTEXT}
@@ -51,6 +55,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'a', command: 'c', actionItem: { pressed: true, label: 'b' } }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 variant="actionItem"
                 location={history.location}
                 extensionsController={NOOP_EXTENSIONS_CONTROLLER}
@@ -64,6 +69,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 variant="actionItem"
                 title={<span>t2</span>}
                 location={history.location}
@@ -80,6 +86,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 variant="actionItem"
                 disabledDuringExecution={true}
                 location={history.location}
@@ -108,6 +115,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 variant="actionItem"
                 showLoadingSpinnerDuringExecution={true}
                 location={history.location}
@@ -134,6 +142,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 variant="actionItem"
                 disabledDuringExecution={true}
                 location={history.location}
@@ -158,6 +167,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'c', title: 't', description: 'd', iconURL: 'u', category: 'g' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 variant="actionItem"
                 showInlineError={true}
                 location={history.location}
@@ -185,6 +195,7 @@ describe('ActionItem', () => {
         const component = renderer.create(
             <ActionItem
                 action={{ id: 'c', command: 'open', commandArguments: ['https://example.com'], title: 't' }}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 location={history.location}
                 extensionsController={NOOP_EXTENSIONS_CONTROLLER}
                 platformContext={NOOP_PLATFORM_CONTEXT}

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -10,7 +10,7 @@ import { urlForOpenPanel } from '../commands/commands'
 import { LinkOrButton } from '../components/LinkOrButton'
 import { ExtensionsControllerProps } from '../extensions/controller'
 import { PlatformContextProps } from '../platform/context'
-import { TelemetryContext } from '../telemetry/telemetryContext'
+import { TelemetryProps } from '../telemetry/telemetryService'
 import { asError, ErrorLike, isErrorLike } from '../util/errors'
 
 export interface ActionItemProps {
@@ -67,7 +67,7 @@ export interface ActionItemComponentProps
     location: H.Location
 }
 
-interface Props extends ActionItemProps, ActionItemComponentProps {}
+interface Props extends ActionItemProps, ActionItemComponentProps, TelemetryProps {}
 
 const LOADING: 'loading' = 'loading'
 
@@ -78,9 +78,6 @@ interface State {
 
 export class ActionItem extends React.PureComponent<Props, State> {
     public state: State = { actionOrError: null }
-
-    public static contextType = TelemetryContext
-    public context!: React.ContextType<typeof TelemetryContext>
 
     private commandExecutions = new Subject<ExecuteCommandParams>()
     private subscriptions = new Subscription()
@@ -230,7 +227,7 @@ export class ActionItem extends React.PureComponent<Props, State> {
         }
 
         // Record action ID (but not args, which might leak sensitive data).
-        this.context.log(action.id)
+        this.props.telemetryService.log(action.id)
 
         if (urlForClientCommandOpen(action, this.props.location)) {
             if (e.currentTarget.tagName === 'A' && e.currentTarget.hasAttribute('href')) {

--- a/shared/src/actions/ActionsContainer.tsx
+++ b/shared/src/actions/ActionsContainer.tsx
@@ -7,6 +7,7 @@ import { ContributableMenu } from '../api/protocol'
 import { getContributedActionItems } from '../contributions/contributions'
 import { ExtensionsControllerProps } from '../extensions/controller'
 import { PlatformContextProps } from '../platform/context'
+import { TelemetryProps } from '../telemetry/telemetryService'
 import { ActionItem, ActionItemProps } from './ActionItem'
 import { ActionsState } from './actions'
 
@@ -19,7 +20,7 @@ export interface ActionsProps
     listClass?: string
     location: H.Location
 }
-interface Props extends ActionsProps {
+interface Props extends ActionsProps, TelemetryProps {
     /**
      * Called with the array of contributed items to produce the rendered component. If not set, uses a default
      * render function that renders a <ActionItem> for each item.
@@ -76,13 +77,7 @@ export class ActionsContainer extends React.PureComponent<Props, ActionsState> {
     private defaultRenderItems = (items: ActionItemProps[]): JSX.Element | null => (
         <>
             {items.map((item, i) => (
-                <ActionItem
-                    key={i}
-                    {...item}
-                    extensionsController={this.props.extensionsController}
-                    platformContext={this.props.platformContext}
-                    location={this.props.location}
-                />
+                <ActionItem {...this.props} key={i} {...item} />
             ))}
         </>
     )

--- a/shared/src/actions/ActionsNavItems.tsx
+++ b/shared/src/actions/ActionsNavItems.tsx
@@ -3,6 +3,7 @@ import { Subject, Subscription } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 import { ContributionScope } from '../api/client/context/context'
 import { getContributedActionItems } from '../contributions/contributions'
+import { TelemetryProps } from '../telemetry/telemetryService'
 import { ActionItem } from './ActionItem'
 import { ActionsState } from './actions'
 import { ActionsProps } from './ActionsContainer'
@@ -13,11 +14,11 @@ export interface ActionNavItemsClassProps {
     listItemClass?: string
 }
 
-interface Props extends ActionsProps, ActionNavItemsClassProps {
+interface Props extends ActionsProps, ActionNavItemsClassProps, TelemetryProps {
     /**
-     * If true, it renders a <ul className="nav">...</ul> around the items. If there are no items, it renders null.
+     * If true, it renders a `<ul className="nav">...</ul>` around the items. If there are no items, it renders `null`.
      *
-     * If falsey (the default behavior), it emits a fragment of just the <li>s.
+     * If falsey (the default behavior), it emits a fragment of just the `<li>`s.
      */
     wrapInList?: boolean
 
@@ -63,12 +64,10 @@ export class ActionsNavItems extends React.PureComponent<Props, ActionsState> {
                 <ActionItem
                     key={i}
                     {...item}
+                    {...this.props}
                     variant="actionItem"
-                    extensionsController={this.props.extensionsController}
-                    platformContext={this.props.platformContext}
                     className={this.props.actionItemClass}
                     pressedClassName={this.props.actionItemPressedClass}
-                    location={this.props.location}
                 />
             </li>
         ))

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -13,10 +13,12 @@ import { PopoverButton } from '../components/PopoverButton'
 import { getContributedActionItems } from '../contributions/contributions'
 import { ExtensionsControllerProps } from '../extensions/controller'
 import { PlatformContextProps } from '../platform/context'
+import { TelemetryProps } from '../telemetry/telemetryService'
 
 interface Props
     extends ExtensionsControllerProps<'services' | 'executeCommand'>,
-        PlatformContextProps<'forceUpdateTooltip'> {
+        PlatformContextProps<'forceUpdateTooltip'>,
+        TelemetryProps {
     popoverClassName?: string
     /** The menu whose commands to display. */
     menu: ContributableMenu
@@ -145,6 +147,7 @@ export class CommandList extends React.PureComponent<Props, State> {
                 {items.length > 0 ? (
                     items.map((item, i) => (
                         <ActionItem
+                            {...this.props}
                             className={`list-group-item list-group-item-action px-3 ${
                                 i === selectedIndex ? 'active border-primary' : ''
                             }`}
@@ -159,9 +162,6 @@ export class CommandList extends React.PureComponent<Props, State> {
                                 />
                             }
                             onDidExecute={this.onActionDidExecute}
-                            extensionsController={this.props.extensionsController}
-                            platformContext={this.props.platformContext}
-                            location={this.props.location}
                         />
                     ))
                 ) : (

--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -7,14 +7,12 @@ import renderer from 'react-test-renderer'
 import { createRenderer } from 'react-test-renderer/shallow'
 import { MarkupKind } from 'sourcegraph'
 import { HoverMerged } from '../api/client/types/hover'
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import { HoverOverlay, HoverOverlayProps } from './HoverOverlay'
 
 const renderShallow = (element: React.ReactElement<HoverOverlayProps>): React.ReactElement<any> => {
     const renderer = createRenderer()
     renderer.render(element)
-    // Render again because the first render call only renders the <TelemetryContext.Consumer> element, whose child
-    // is a render prop that returns what we actually want.
-    renderer.render(renderer.getRenderOutput().props.children())
     return renderer.getRenderOutput()
 }
 
@@ -24,6 +22,7 @@ describe('HoverOverlay', () => {
     const history = H.createMemoryHistory({ keyLength: 0 })
     const commonProps: HoverOverlayProps = {
         location: history.location,
+        telemetryService: NOOP_TELEMETRY_SERVICE,
         extensionsController: NOOP_EXTENSIONS_CONTROLLER,
         platformContext: NOOP_PLATFORM_CONTEXT,
         showCloseButton: false,
@@ -192,9 +191,18 @@ describe('HoverOverlay', () => {
 
     describe('hover content rendering', () => {
         const renderMarkdownHover = (hover: HoverAttachment & HoverMerged) => {
-            const contents = castArray(
-                renderShallow(<HoverOverlay {...commonProps} hoverOrError={hover} />).props.children
-            ).find(e => e.props && e.props.className && e.props.className.includes('hover-overlay__contents'))
+            // TODO this test depends on internals of the HoverOverlay.
+            // If we want to test this rendering, it would be better to
+            // extract the markdown rendering into another small component
+            // and unit test that in isolation
+            const r = renderShallow(<HoverOverlay {...commonProps} hoverOrError={hover} />)
+            const contents = castArray(r.props.children).find(
+                element =>
+                    element &&
+                    element.props &&
+                    element.props.className &&
+                    element.props.className.includes('hover-overlay__contents')
+            )
             if (!contents) {
                 return null
             }

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -132,6 +132,11 @@ exports[`HoverOverlay actions and hover present 1`] = `
       }
       showInlineError={true}
       showLoadingSpinnerDuringExecution={true}
+      telemetryService={
+        Object {
+          "log": [Function],
+        }
+      }
       variant="actionItem"
     />
   </div>
@@ -254,6 +259,11 @@ exports[`HoverOverlay actions present 1`] = `
       }
       showInlineError={true}
       showLoadingSpinnerDuringExecution={true}
+      telemetryService={
+        Object {
+          "log": [Function],
+        }
+      }
       variant="actionItem"
     />
   </div>
@@ -315,6 +325,11 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
       }
       showInlineError={true}
       showLoadingSpinnerDuringExecution={true}
+      telemetryService={
+        Object {
+          "log": [Function],
+        }
+      }
       variant="actionItem"
     />
   </div>
@@ -414,6 +429,11 @@ exports[`HoverOverlay hover error, actions present 1`] = `
       }
       showInlineError={true}
       showLoadingSpinnerDuringExecution={true}
+      telemetryService={
+        Object {
+          "log": [Function],
+        }
+      }
       variant="actionItem"
     />
   </div>

--- a/shared/src/panel/Panel.tsx
+++ b/shared/src/panel/Panel.tsx
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators'
 import { PanelViewWithComponent, ViewProviderRegistrationOptions } from '../../../shared/src/api/client/services/view'
 import { ContributableMenu, ContributableViewContainer } from '../../../shared/src/api/protocol/contribution'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
+import { ThemeProps } from '../../../web/src/theme'
 import { ActionsNavItems } from '../actions/ActionsNavItems'
 import { ActivationProps } from '../components/activation/Activation'
 import { FetchFileCtx } from '../components/CodeExcerpt'
@@ -13,14 +14,20 @@ import { Resizable } from '../components/Resizable'
 import { Spacer, Tab, TabsWithURLViewStatePersistence } from '../components/Tabs'
 import { PlatformContextProps } from '../platform/context'
 import { SettingsCascadeProps } from '../settings/settings'
+import { TelemetryProps } from '../telemetry/telemetryService'
 import { EmptyPanelView } from './views/EmptyPanelView'
 import { PanelView } from './views/PanelView'
 
-interface Props extends ExtensionsControllerProps, PlatformContextProps, SettingsCascadeProps, ActivationProps {
+interface Props
+    extends ExtensionsControllerProps,
+        PlatformContextProps,
+        SettingsCascadeProps,
+        ActivationProps,
+        TelemetryProps,
+        ThemeProps {
     location: H.Location
     history: H.History
     repoName?: string
-    isLightTheme: boolean
     fetchHighlightedFileLines: (ctx: FetchFileCtx, force?: boolean) => Observable<string[]>
 }
 

--- a/shared/src/telemetry/telemetryContext.ts
+++ b/shared/src/telemetry/telemetryContext.ts
@@ -1,7 +1,0 @@
-import React from 'react'
-import { NOOP_TELEMETRY_SERVICE, TelemetryService } from './telemetryService'
-
-/**
- * A React context that holds the telemetry service (for logging telemetry events).
- */
-export const TelemetryContext = React.createContext<TelemetryService>(NOOP_TELEMETRY_SERVICE)

--- a/shared/src/telemetry/telemetryService.ts
+++ b/shared/src/telemetry/telemetryService.ts
@@ -1,4 +1,14 @@
 /**
+ * Props interface that can be extended by React components depending on the TelemetryService.
+ */
+export interface TelemetryProps {
+    /**
+     * A telemetry service implementation to log events.
+     */
+    telemetryService: TelemetryService
+}
+
+/**
  * The telemetry service logs events.
  */
 export interface TelemetryService {

--- a/shared/src/util/types.ts
+++ b/shared/src/util/types.ts
@@ -11,3 +11,11 @@ export const isDefined = <T>(val: T): val is NonNullable<T> => val !== undefined
 export const propertyIsDefined = <T extends object, K extends keyof T>(key: K) => (
     val: T
 ): val is K extends unknown ? T & { [k in K]-?: NonNullable<T[k]> } : never => isDefined(val[key])
+
+/**
+ * Returns a function that returns `true` if the given value is an instance of the given class.
+ *
+ * @param of A reference to a class, e.g. `HTMLElement`
+ */
+export const isInstanceOf = <C extends new () => object>(of: C) => (val: unknown): val is InstanceType<C> =>
+    val instanceof of

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -31,7 +31,7 @@ import { parseSearchURLQuery } from './search'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { ThemePreferenceProps, ThemeProps } from './theme'
-import { EventLogger } from './tracking/eventLogger'
+import { EventLogger, EventLoggerProps } from './tracking/eventLogger'
 import { UserAccountAreaRoute } from './user/account/UserAccountArea'
 import { UserAccountSidebarItems } from './user/account/UserAccountSidebar'
 import { UserAreaRoute } from './user/area/UserArea'
@@ -45,6 +45,7 @@ export interface LayoutProps
         ExtensionsControllerProps,
         KeybindingsProps,
         ThemeProps,
+        EventLoggerProps,
         ThemePreferenceProps,
         ActivationProps {
     exploreSections: ReadonlyArray<ExploreSectionDescriptor>
@@ -71,7 +72,7 @@ export interface LayoutProps
      */
     viewerSubject: Pick<GQL.ISettingsSubject, 'id' | 'viewerCanAdminister'>
 
-    eventLogger: EventLogger
+    telemetryService: EventLogger
 
     // Search
     navbarSearchQuery: string

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -14,7 +14,6 @@ import * as GQL from '../../shared/src/graphql/schema'
 import { Notifications } from '../../shared/src/notifications/Notifications'
 import { PlatformContextProps } from '../../shared/src/platform/context'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '../../shared/src/settings/settings'
-import { TelemetryContext } from '../../shared/src/telemetry/telemetryContext'
 import { isErrorLike } from '../../shared/src/util/errors'
 import { authenticatedUser } from './auth'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -235,39 +234,37 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
         return (
             <ErrorBoundary location={null}>
                 <ShortcutProvider>
-                    <TelemetryContext.Provider value={eventLogger}>
-                        <BrowserRouter key={0}>
-                            <Route
-                                path="/"
-                                // tslint:disable-next-line:jsx-no-lambda RouteProps.render is an exception
-                                render={routeComponentProps => (
-                                    <LayoutWithActivation
-                                        {...props}
-                                        {...routeComponentProps}
-                                        authenticatedUser={authenticatedUser}
-                                        viewerSubject={this.state.viewerSubject}
-                                        settingsCascade={this.state.settingsCascade}
-                                        // Theme
-                                        isLightTheme={this.isLightTheme()}
-                                        themePreference={this.state.themePreference}
-                                        onThemePreferenceChange={this.onThemePreferenceChange}
-                                        // Search query
-                                        navbarSearchQuery={this.state.navbarSearchQuery}
-                                        onNavbarQueryChange={this.onNavbarQueryChange}
-                                        fetchHighlightedFileLines={fetchHighlightedFileLines}
-                                        searchRequest={search}
-                                        // Extensions
-                                        platformContext={this.state.platformContext}
-                                        extensionsController={this.state.extensionsController}
-                                        eventLogger={eventLogger}
-                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                    />
-                                )}
-                            />
-                        </BrowserRouter>
-                        <Tooltip key={1} />
-                        <Notifications key={2} extensionsController={this.state.extensionsController} />
-                    </TelemetryContext.Provider>
+                    <BrowserRouter key={0}>
+                        <Route
+                            path="/"
+                            // tslint:disable-next-line:jsx-no-lambda RouteProps.render is an exception
+                            render={routeComponentProps => (
+                                <LayoutWithActivation
+                                    {...props}
+                                    {...routeComponentProps}
+                                    authenticatedUser={authenticatedUser}
+                                    viewerSubject={this.state.viewerSubject}
+                                    settingsCascade={this.state.settingsCascade}
+                                    // Theme
+                                    isLightTheme={this.isLightTheme()}
+                                    themePreference={this.state.themePreference}
+                                    onThemePreferenceChange={this.onThemePreferenceChange}
+                                    // Search query
+                                    navbarSearchQuery={this.state.navbarSearchQuery}
+                                    onNavbarQueryChange={this.onNavbarQueryChange}
+                                    fetchHighlightedFileLines={fetchHighlightedFileLines}
+                                    searchRequest={search}
+                                    // Extensions
+                                    platformContext={this.state.platformContext}
+                                    extensionsController={this.state.extensionsController}
+                                    telemetryService={eventLogger}
+                                    isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                />
+                            )}
+                        />
+                    </BrowserRouter>
+                    <Tooltip key={1} />
+                    <Notifications key={2} extensionsController={this.state.extensionsController} />
                 </ShortcutProvider>
             </ErrorBoundary>
         )

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -12,14 +12,15 @@ import { KeybindingsProps } from '../keybindings'
 import { parseSearchURLQuery } from '../search'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
 import { ThemePreferenceProps, ThemeProps } from '../theme'
+import { EventLoggerProps } from '../tracking/eventLogger'
 import { showDotComMarketing } from '../util/features'
 import { NavLinks } from './NavLinks'
-
 interface Props
     extends SettingsCascadeProps,
         PlatformContextProps,
         ExtensionsControllerProps,
         KeybindingsProps,
+        EventLoggerProps,
         ThemeProps,
         ThemePreferenceProps,
         ActivationProps {

--- a/web/src/nav/NavLinks.test.tsx
+++ b/web/src/nav/NavLinks.test.tsx
@@ -8,6 +8,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { KeybindingsProps } from '../keybindings'
 import { ThemePreference } from '../theme'
+import { eventLogger } from '../tracking/eventLogger'
 import { NavLinks } from './NavLinks'
 
 // Renders a human-readable list of the NavLinks' contents so that humans can more easily diff
@@ -53,6 +54,7 @@ describe('NavLinks', () => {
     const commonProps = {
         extensionsController: NOOP_EXTENSIONS_CONTROLLER,
         platformContext: NOOP_PLATFORM_CONTEXT,
+        telemetryService: eventLogger,
         isLightTheme: true,
         themePreference: ThemePreference.Light,
         onThemePreferenceChange: noop,

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -14,6 +14,7 @@ import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { isDiscussionsEnabled } from '../discussions'
 import { KeybindingsProps } from '../keybindings'
 import { ThemePreferenceProps, ThemeProps } from '../theme'
+import { EventLoggerProps } from '../tracking/eventLogger'
 import { UserNavItem } from './UserNavItem'
 
 interface Props
@@ -23,6 +24,7 @@ interface Props
         PlatformContextProps<'forceUpdateTooltip'>,
         ThemeProps,
         ThemePreferenceProps,
+        EventLoggerProps,
         ActivationProps {
     location: H.Location
     history: H.History

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -17,6 +17,7 @@ import { HeroPage } from '../components/HeroPage'
 import { searchQueryForRepoRev } from '../search'
 import { queryUpdates } from '../search/input/QueryInput'
 import { ThemeProps } from '../theme'
+import { EventLoggerProps } from '../tracking/eventLogger'
 import { parseBrowserRepoURL, ParsedRepoRev, parseRepoRev } from '../util/url'
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
 import { EREPONOTFOUND, EREPOSEEOTHER, fetchRepository, RepoSeeOtherError, ResolvedRev } from './backend'
@@ -40,6 +41,7 @@ export interface RepoContainerProps
     extends RouteComponentProps<{ repoRevAndRest: string }>,
         SettingsCascadeProps,
         PlatformContextProps,
+        EventLoggerProps,
         ExtensionsControllerProps,
         ThemeProps {
     repoRevContainerRoutes: ReadonlyArray<RepoRevContainerRoute>
@@ -224,6 +226,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
             repo: this.state.repoOrError,
             authenticatedUser: this.props.authenticatedUser,
             isLightTheme: this.props.isLightTheme,
+            telemetryService: this.props.telemetryService,
             repoMatchURL,
             settingsCascade: this.props.settingsCascade,
             platformContext: this.props.platformContext,
@@ -238,15 +241,12 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
         return (
             <div className="repo-container w-100 d-flex flex-column">
                 <RepoHeader
+                    {...this.props}
                     actionButtons={this.props.repoHeaderActionButtons}
                     rev={this.state.rev}
                     repo={this.state.repoOrError}
                     resolvedRev={this.state.resolvedRevOrError}
-                    platformContext={this.props.platformContext}
-                    extensionsController={this.props.extensionsController}
                     onLifecyclePropsChange={this.onRepoHeaderContributionsLifecyclePropsChange}
-                    location={this.props.location}
-                    history={this.props.history}
                 />
                 <RepoHeaderContributionPortal
                     position="right"

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -11,6 +11,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { PopoverButton } from '../components/PopoverButton'
+import { EventLoggerProps } from '../tracking/eventLogger'
 import { ActionButtonDescriptor } from '../util/contributions'
 import { ResolvedRev } from './backend'
 import { RepositoriesPopover } from './RepositoriesPopover'
@@ -120,7 +121,7 @@ export interface RepoHeaderContext {
 
 export interface RepoHeaderActionButton extends ActionButtonDescriptor<RepoHeaderContext> {}
 
-interface Props extends PlatformContextProps, ExtensionsControllerProps {
+interface Props extends PlatformContextProps, ExtensionsControllerProps, EventLoggerProps {
     /**
      * An array of render functions for action buttons that can be configured *in addition* to action buttons
      * contributed through {@link RepoHeaderContributionsLifecycleProps} and through extensions.
@@ -237,13 +238,7 @@ export class RepoHeader extends React.PureComponent<Props, State> {
                 </ul>
                 <div className="repo-header__spacer" />
                 <ul className="navbar-nav navbar-nav__action-items">
-                    <ActionsNavItems
-                        menu={ContributableMenu.EditorTitle}
-                        actionItemClass="nav-link"
-                        extensionsController={this.props.extensionsController}
-                        platformContext={this.props.platformContext}
-                        location={this.props.location}
-                    />
+                    <ActionsNavItems {...this.props} menu={ContributableMenu.EditorTitle} actionItemClass="nav-link" />
                 </ul>
                 <ul className="navbar-nav">
                     {this.props.actionButtons.map(

--- a/web/src/repo/RepoRevContainer.tsx
+++ b/web/src/repo/RepoRevContainer.tsx
@@ -17,6 +17,7 @@ import { ChromeExtensionToast } from '../marketing/BrowserExtensionToast'
 import { SurveyToast } from '../marketing/SurveyToast'
 import { IS_CHROME } from '../marketing/util'
 import { ThemeProps } from '../theme'
+import { EventLoggerProps } from '../tracking/eventLogger'
 import { RouteDescriptor } from '../util/contributions'
 import { CopyLinkAction } from './actions/CopyLinkAction'
 import { GoToPermalinkAction } from './actions/GoToPermalinkAction'
@@ -32,6 +33,7 @@ export interface RepoRevContainerContext
         ExtensionsControllerProps,
         PlatformContextProps,
         ThemeProps,
+        EventLoggerProps,
         ActivationProps {
     repo: GQL.IRepository
     rev: string
@@ -47,6 +49,7 @@ interface RepoRevContainerProps
         RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
         PlatformContextProps,
+        EventLoggerProps,
         ExtensionsControllerProps,
         ThemeProps,
         ActivationProps {
@@ -195,6 +198,7 @@ export class RepoRevContainer extends React.PureComponent<RepoRevContainerProps,
             platformContext: this.props.platformContext,
             extensionsController: this.props.extensionsController,
             isLightTheme: this.props.isLightTheme,
+            telemetryService: this.props.telemetryService,
             activation: this.props.activation,
             repo: this.props.repo,
             repoHeaderContributionsLifecycleProps: this.props.repoHeaderContributionsLifecycleProps,

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -35,7 +35,7 @@ import { submitSearch } from '../search/helpers'
 import { QueryInput } from '../search/input/QueryInput'
 import { SearchButton } from '../search/input/SearchButton'
 import { ThemeProps } from '../theme'
-import { eventLogger } from '../tracking/eventLogger'
+import { eventLogger, EventLoggerProps } from '../tracking/eventLogger'
 import { basename } from '../util/path'
 import { fetchTree } from './backend'
 import { GitCommitNode, GitCommitNodeProps } from './commits/GitCommitNode'
@@ -126,6 +126,7 @@ interface Props
         ExtensionsControllerProps,
         PlatformContextProps,
         ThemeProps,
+        EventLoggerProps,
         ActivationProps {
     repoName: string
     repoID: GQL.ID

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -33,6 +33,7 @@ import {
 import { getHover } from '../../backend/features'
 import { isDiscussionsEnabled } from '../../discussions'
 import { ThemeProps } from '../../theme'
+import { EventLoggerProps } from '../../tracking/eventLogger'
 import { DiscussionsGutterOverlay } from './discussions/DiscussionsGutterOverlay'
 import { LineDecorationAttachment } from './LineDecorationAttachment'
 
@@ -46,6 +47,7 @@ interface BlobProps
         ModeSpec,
         SettingsCascadeProps,
         PlatformContextProps,
+        EventLoggerProps,
         ExtensionsControllerProps,
         ThemeProps {
     /** The raw content of the blob. */
@@ -464,12 +466,11 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                 />
                 {this.state.hoverOverlayProps && (
                     <HoverOverlay
+                        {...this.props}
                         {...this.state.hoverOverlayProps}
                         hoverRef={this.nextOverlayElement}
+                        telemetryService={this.props.telemetryService}
                         onCloseButtonClick={this.nextCloseButtonClick}
-                        extensionsController={this.props.extensionsController}
-                        platformContext={this.props.platformContext}
-                        location={this.props.location}
                     />
                 )}
                 {this.state.decorationsOrError &&

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -24,7 +24,7 @@ import { HeroPage } from '../../components/HeroPage'
 import { PageTitle } from '../../components/PageTitle'
 import { isDiscussionsEnabled } from '../../discussions'
 import { ThemeProps } from '../../theme'
-import { eventLogger } from '../../tracking/eventLogger'
+import { eventLogger, EventLoggerProps } from '../../tracking/eventLogger'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
 import { RepoHeaderContributionPortal } from '../RepoHeaderContributionPortal'
 import { ToggleDiscussionsPanel } from './actions/ToggleDiscussions'
@@ -94,6 +94,7 @@ interface Props
         RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
         PlatformContextProps,
+        EventLoggerProps,
         ExtensionsControllerProps,
         ThemeProps {
     location: H.Location

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -21,7 +21,7 @@ import { FileSpec, ModeSpec, PositionSpec, RepoSpec, ResolvedRevSpec, RevSpec } 
 import { getHover } from '../../backend/features'
 import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
-import { eventLogger } from '../../tracking/eventLogger'
+import { eventLogger, EventLoggerProps } from '../../tracking/eventLogger'
 import { GitCommitNode } from '../commits/GitCommitNode'
 import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
 import { FileDiffConnection } from '../compare/FileDiffConnection'
@@ -60,7 +60,11 @@ const queryCommit = memoizeObservable(
     args => `${args.repo}:${args.revspec}`
 )
 
-interface Props extends RouteComponentProps<{ revspec: string }>, PlatformContextProps, ExtensionsControllerProps {
+interface Props
+    extends RouteComponentProps<{ revspec: string }>,
+        EventLoggerProps,
+        PlatformContextProps,
+        ExtensionsControllerProps {
     repo: GQL.IRepository
 
     onDidUpdateExternalLinks: (externalLinks: GQL.IExternalLink[] | undefined) => void
@@ -248,11 +252,10 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                 </div>
                 {this.state.hoverOverlayProps && (
                     <HoverOverlay
+                        {...this.props}
                         {...this.state.hoverOverlayProps}
+                        telemetryService={this.props.telemetryService}
                         hoverRef={this.nextOverlayElement}
-                        extensionsController={this.props.extensionsController}
-                        platformContext={this.props.platformContext}
-                        location={this.props.location}
                         onCloseButtonClick={this.nextCloseButtonClick}
                     />
                 )}

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../../shared/src/util/url'
 import { getHover } from '../../backend/features'
 import { HeroPage } from '../../components/HeroPage'
+import { EventLoggerProps } from '../../tracking/eventLogger'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
 import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
 import { RepoHeaderContributionPortal } from '../RepoHeaderContributionPortal'
@@ -40,10 +41,11 @@ const NotFoundPage = () => (
     />
 )
 
-interface Props
+interface RepositoryCompareAreaProps
     extends RouteComponentProps<{ spec: string }>,
         RepoHeaderContributionsLifecycleProps,
         PlatformContextProps,
+        EventLoggerProps,
         ExtensionsControllerProps {
     repo: GQL.IRepository
 }
@@ -72,8 +74,8 @@ export interface RepositoryCompareAreaPageProps extends PlatformContextProps {
 /**
  * Renders pages related to a repository comparison.
  */
-export class RepositoryCompareArea extends React.Component<Props, State> {
-    private componentUpdates = new Subject<Props>()
+export class RepositoryCompareArea extends React.Component<RepositoryCompareAreaProps, State> {
+    private componentUpdates = new Subject<RepositoryCompareAreaProps>()
 
     /** Emits whenever the ref callback for the hover element is called */
     private hoverOverlayElements = new Subject<HTMLElement | null>()
@@ -91,7 +93,7 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
     private subscriptions = new Subscription()
     private hoverifier: Hoverifier<RepoSpec & RevSpec & FileSpec & ResolvedRevSpec, HoverMerged, ActionItemProps>
 
-    constructor(props: Props) {
+    constructor(props: RepositoryCompareAreaProps) {
         super(props)
         this.hoverifier = createHoverifier<
             RepoSpec & RevSpec & FileSpec & ResolvedRevSpec,
@@ -135,7 +137,7 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
         this.componentUpdates.next(this.props)
     }
 
-    public shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>): boolean {
+    public shouldComponentUpdate(nextProps: Readonly<RepositoryCompareAreaProps>, nextState: Readonly<State>): boolean {
         return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState)
     }
 
@@ -204,11 +206,10 @@ export class RepositoryCompareArea extends React.Component<Props, State> {
                 </div>
                 {this.state.hoverOverlayProps && (
                     <HoverOverlay
+                        {...this.props}
                         {...this.state.hoverOverlayProps}
+                        telemetryService={this.props.telemetryService}
                         hoverRef={this.nextOverlayElement}
-                        extensionsController={this.props.extensionsController}
-                        platformContext={this.props.platformContext}
-                        location={this.props.location}
                         onCloseButtonClick={this.nextCloseButtonClick}
                     />
                 )}

--- a/web/src/search/results/SearchResults.test.tsx
+++ b/web/src/search/results/SearchResults.test.tsx
@@ -10,7 +10,7 @@ import {
     NOOP_SETTINGS_CASCADE,
     OBSERVABLE_SEARCH_REQUEST,
 } from '../testHelpers'
-import { SearchResults } from './SearchResults'
+import { SearchResults, SearchResultsProps } from './SearchResults'
 
 describe('SearchResults', () => {
     setLinkComponent((props: any) => <a {...props} />)
@@ -23,7 +23,7 @@ describe('SearchResults', () => {
     const history = createBrowserHistory()
     history.replace({ search: 'q=r:golang/oauth2+test+f:travis' })
 
-    const defaultProps = {
+    const defaultProps: SearchResultsProps = {
         authenticatedUser: null,
         location: history.location,
         history,
@@ -33,9 +33,8 @@ describe('SearchResults', () => {
         isLightTheme: true,
         settingsCascade: NOOP_SETTINGS_CASCADE,
         extensionsController,
-        platformContext: {},
         isSourcegraphDotCom: false,
-        eventLogger: { log: noop, logViewEvent: noop },
+        telemetryService: { log: noop, logViewEvent: noop },
     }
 
     it('calls the search request once', () => {

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -26,12 +26,12 @@ import { SearchResultsList } from './SearchResultsList'
 
 const UI_PAGE_SIZE = 75
 
-interface SearchResultsProps extends ExtensionsControllerProps<'services'>, SettingsCascadeProps, ThemeProps {
+export interface SearchResultsProps extends ExtensionsControllerProps<'services'>, SettingsCascadeProps, ThemeProps {
     authenticatedUser: GQL.IUser | null
     location: H.Location
     history: H.History
     navbarSearchQuery: string
-    eventLogger: Pick<EventLogger, 'log' | 'logViewEvent'>
+    telemetryService: Pick<EventLogger, 'log' | 'logViewEvent'>
     fetchHighlightedFileLines: (ctx: FetchFileCtx, force?: boolean) => Observable<string[]>
     searchRequest: (
         query: string,
@@ -72,7 +72,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        this.props.eventLogger.logViewEvent('SearchResults')
+        this.props.telemetryService.logViewEvent('SearchResults')
 
         this.subscriptions.add(
             this.componentUpdates
@@ -83,7 +83,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                     distinctUntilChanged((a, b) => isEqual(a, b)),
                     filter((query): query is string => !!query),
                     tap(query => {
-                        this.props.eventLogger.log('SearchResultsQueried', {
+                        this.props.telemetryService.log('SearchResultsQueried', {
                             code_search: { query_data: queryTelemetryData(query) },
                         })
                     }),
@@ -96,7 +96,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                                 // Log telemetry
                                 tap(
                                     results =>
-                                        this.props.eventLogger.log('SearchResultsFetched', {
+                                        this.props.telemetryService.log('SearchResultsFetched', {
                                             code_search: {
                                                 // 🚨 PRIVACY: never provide any private data in { code_search: { results } }.
                                                 results: {
@@ -108,7 +108,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                                             },
                                         }),
                                     error => {
-                                        this.props.eventLogger.log('SearchResultsFetchFailed', {
+                                        this.props.telemetryService.log('SearchResultsFetchFailed', {
                                             code_search: { error_message: error.message },
                                         })
                                         console.error(error)
@@ -142,12 +142,12 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
     }
 
     private onDidCreateSavedQuery = () => {
-        this.props.eventLogger.log('SavedQueryCreated')
+        this.props.telemetryService.log('SavedQueryCreated')
         this.setState({ showSavedQueryModal: false, didSaveQuery: true })
     }
 
     private onModalClose = () => {
-        this.props.eventLogger.log('SavedQueriesToggleCreating', { queries: { creating: false } })
+        this.props.telemetryService.log('SavedQueriesToggleCreating', { queries: { creating: false } })
         this.setState({ didSaveQuery: false, showSavedQueryModal: false })
     }
 
@@ -312,13 +312,13 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         this.setState(
             state => ({ allExpanded: !state.allExpanded }),
             () => {
-                this.props.eventLogger.log(this.state.allExpanded ? 'allResultsExpanded' : 'allResultsCollapsed')
+                this.props.telemetryService.log(this.state.allExpanded ? 'allResultsExpanded' : 'allResultsCollapsed')
             }
         )
     }
 
     private onDynamicFilterClicked = (value: string) => {
-        this.props.eventLogger.log('DynamicFilterClicked', {
+        this.props.telemetryService.log('DynamicFilterClicked', {
             search_filter: { value },
         })
 

--- a/web/src/tracking/eventLogger.tsx
+++ b/web/src/tracking/eventLogger.tsx
@@ -12,6 +12,17 @@ import { telligent } from './services/telligentWrapper'
 
 const uidKey = 'sourcegraphAnonymousUid'
 
+/**
+ * Props interface that can be extended by React components that need access to the full webapp EventLogger.
+ * The EventLogger provides more functionality than TelemetryService, but can only be used in the webapp.
+ */
+export interface EventLoggerProps {
+    /**
+     * The full webapp EventLogger to log telemetry events.
+     */
+    telemetryService: EventLogger
+}
+
 export class EventLogger implements TelemetryService {
     private hasStrippedQueryParameters = false
     private user?: GQL.IUser | null


### PR DESCRIPTION
#2909 used a mutation observer for code view detection, but still called the `inject*` functions on every mutation event. It turns out `ReactDOM.render()` is not idempotent and triggered mutation events in Firefox, resulting in an infinite loop of mutation events.
The solution is to only re-render the mounts when a node was added to the DOM that should contain a mount, which means the render only happens once.

To accomplish that, this PR changes all `get*Mount` functions to receive a container. The mount getter needs to check if the mount belongs into the container, if yes get or create the mount inside, otherwise return `null`.
The mount getters are then called with `addedNodes` from mutation events.

This necessitates other changes:
- We can't use React context for telemetry anymore, see #3180. This refactors the webapp to use props instead (also renames `eventLogger` to `telemetryService` for consistency / easier passing).
- The `HoverOverlayContainer` component had unneeded code in it (portals, hover overlay mount container container) that I removed
- `componentWillUnmount()` and handling Subscriptions was missing in some places

Fixes #3180 
Fixes #3166 

<!-- Reminder: Have you updated the changelog? -->

Test plan: <!-- Required: What is the test plan for this change? -->
- [x] GitHub
- [x] GHE
- [x] Gitlab
- [x] Phabricator
- [x] Bitbucket

x (Chrome, Firefox)
