### PR TITLE
Fix wide Firefox options page

### DIFF
--- a/client/browser/src/libs/options/Header.scss
+++ b/client/browser/src/libs/options/Header.scss
@@ -16,17 +16,17 @@
 
         font-weight: 600;
         color: $color-light-bg-5;
+    }
 
-        &__settings {
-            background-color: transparent;
-            color: inherit;
+    &__settings {
+        background-color: transparent;
+        color: inherit;
 
-            padding: 0.5rem;
+        padding: 0.5rem;
 
-            &:hover,
-            &:focus {
-                color: $gray-23;
-            }
+        &:hover,
+        &:focus {
+            color: $gray-23;
         }
     }
 }

--- a/client/browser/src/libs/options/Header.tsx
+++ b/client/browser/src/libs/options/Header.tsx
@@ -18,7 +18,7 @@ export const OptionsHeader: React.FunctionComponent<OptionsHeaderProps> = ({
         <img src={`${assetsDir || ''}/img/sourcegraph-logo.svg`} className="options-header__logo" />
         <div className="options-header__right">
             <span>v{version}</span>
-            <button className="options-header__right__settings btn btn-icon" onClick={onSettingsClick}>
+            <button className="options-header__settings btn btn-icon" onClick={onSettingsClick}>
                 <SettingsOutlineIcon className="icon-inline" />
             </button>
         </div>

--- a/client/browser/src/libs/options/Menu.scss
+++ b/client/browser/src/libs/options/Menu.scss
@@ -1,22 +1,16 @@
 .options-menu {
-    min-width: 400px;
-
-    &__section {
-        padding: 0.85rem 1rem;
-        border-top: 1px solid #e4e9f1;
-
-        &__button {
-            margin-top: 1rem;
-        }
-    }
-
-    &__no-border {
-        border-top: none;
-    }
+    width: 25rem;
 
     &--full {
-        max-width: 400px;
         margin: 8rem auto;
         box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.15);
+    }
+
+    &__section {
+        padding: 1rem;
+        border-top: 1px solid $gray-02;
+        &:first-child {
+            border-top: none;
+        }
     }
 }

--- a/client/browser/src/libs/options/Menu.tsx
+++ b/client/browser/src/libs/options/Menu.tsx
@@ -36,7 +36,7 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
     ...props
 }) => (
     <div className={`options-menu ${isFullPage() ? 'options-menu--full' : ''}`}>
-        <OptionsHeader {...props} className="options-menu__section options-menu__no-border" />
+        <OptionsHeader {...props} className="options-menu__section" />
         <ServerURLForm
             {...props}
             value={sourcegraphURL}


### PR DESCRIPTION
Fixes #3195 

Sets `width` instead of `min-width`.
Also corrects BEM usage.