### PR TITLE
pkg/tracer: allow Jaeger to be configured via standard JAEGER_* env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The symbols sidebar now only shows symbols defined in the current file or directory.
 - The dynamic filters on search results pages will now display `lang:` instead of `file:` filters for language/file-extension filter suggestions.
-
 - The default `github.repositoryQuery` of a [GitHub external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["affiliated", "public"]`).
 - The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
 
 ### Fixed
+
+- Jaeger tracing, once enabled, can now be configured via standard [environment variables](https://github.com/jaegertracing/jaeger-client-go/blob/v2.14.0/README.md#environment-variables).
 
 ### Removed
 


### PR DESCRIPTION
Prior to this change it was not possible to configure the Jaeger client using
[the standard JAEGER_* env vars](https://github.com/jaegertracing/jaeger-client-go/blob/v2.14.0/README.md#environment-variables).

After this change, behavior remains the same for all Jaeger users except
JAEGER_* env vars are now respected.

Without this change, it is impossible to configure Sourcegraph services to
communicate with a `jaeger-agent` running on the same host machine in the case
of deploy-sourcegraph-docker because the loopback interface does not work to
communicate with same-host containers there (while it does on Kubernetes), i.e.
we must use their actual domain name like `jaeger-agent`.

Helps #2873

Test plan: Visual logic verification + manual post-merge testing