### PR TITLE
make sourcegraph support redis password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614
 	github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e // indirect
 	github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff
+	github.com/stretchr/testify v1.3.0
 	github.com/stripe/stripe-go v0.0.0-20181128170521-1436b6008c5e
 	github.com/stvp/tempredis v0.0.0-20190104202742-b82af8480203 // indirect
 	github.com/temoto/robotstxt-go v0.0.0-20180810133444-97ee4a9ee6ea

--- a/pkg/redispool/redispool.go
+++ b/pkg/redispool/redispool.go
@@ -58,11 +58,18 @@ func connectRedis(redisUrl string) (redis.Conn, error) {
 		return nil, err
 	}
 
-	if parsedUrl.Scheme != "redis" {
+	if len(parsedUrl.Scheme) > 0 && parsedUrl.Scheme != "redis" {
 		return nil, errors.New(redisUrl + ", is not a valid redis protocol, redis://:password@host:port/db")
 	}
 
-	conn, err := redis.Dial("tcp", parsedUrl.Host); if err != nil {
+	var host string
+	if len(parsedUrl.Opaque) > 0 {
+		host = parsedUrl.Scheme + ":" + parsedUrl.Opaque
+	} else {
+		host = parsedUrl.Host
+	}
+
+	conn, err := redis.Dial("tcp", host); if err != nil {
 		return nil, err
 	}
 

--- a/pkg/redispool/redispool.go
+++ b/pkg/redispool/redispool.go
@@ -58,14 +58,13 @@ func connectRedis(redisUrl string) (redis.Conn, error) {
 		return nil, err
 	}
 
-	if len(parsedUrl.Scheme) > 0 && parsedUrl.Scheme != "redis" {
-		return nil, errors.New(redisUrl + ", is not a valid redis protocol, redis://:password@host:port/db")
-	}
-
 	var host string
 	if len(parsedUrl.Opaque) > 0 {
 		host = parsedUrl.Scheme + ":" + parsedUrl.Opaque
 	} else {
+		if parsedUrl.Scheme != "redis" {
+			return nil, errors.New(redisUrl + ", is not a valid redis protocol, redis://:password@host:port/db")
+		}
 		host = parsedUrl.Host
 	}
 

--- a/pkg/redispool/redispool_test.go
+++ b/pkg/redispool/redispool_test.go
@@ -1,0 +1,93 @@
+package redispool
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseRedisConnectionUrl(t *testing.T) {
+	redisConnectionConfiguration, err := ParseRedisConnectionUrl("")
+	assert.Error(t, err)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("localhost"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "localhost", redisConnectionConfiguration.Host)
+	assert.Equal(t, "6379", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "", redisConnectionConfiguration.Db)
+
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("localhost:8080"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "localhost", redisConnectionConfiguration.Host)
+	assert.Equal(t, "8080", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "", redisConnectionConfiguration.Db)
+
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("localhost:8080/5"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "localhost", redisConnectionConfiguration.Host)
+	assert.Equal(t, "8080", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "5", redisConnectionConfiguration.Db)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("notredis://localhost:8080/5"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "notredis", redisConnectionConfiguration.Host)
+	assert.Equal(t, "6379", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "", redisConnectionConfiguration.Db)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("redis://localhost"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "localhost", redisConnectionConfiguration.Host)
+	assert.Equal(t, "6379", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "", redisConnectionConfiguration.Db)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("redis://192.168.1.1"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "192.168.1.1", redisConnectionConfiguration.Host)
+	assert.Equal(t, "6379", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "", redisConnectionConfiguration.Db)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("redis://192.168.1.1:1000"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "192.168.1.1", redisConnectionConfiguration.Host)
+	assert.Equal(t, "1000", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "", redisConnectionConfiguration.Db)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("redis://192.168.1.1:1000/5"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "192.168.1.1", redisConnectionConfiguration.Host)
+	assert.Equal(t, "1000", redisConnectionConfiguration.Port)
+	assert.Equal(t, "", redisConnectionConfiguration.Password)
+	assert.Equal(t, "5", redisConnectionConfiguration.Db)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("redis://:test@192.168.1.1:1000/5"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "192.168.1.1", redisConnectionConfiguration.Host)
+	assert.Equal(t, "1000", redisConnectionConfiguration.Port)
+	assert.Equal(t, "test", redisConnectionConfiguration.Password)
+	assert.Equal(t, "5", redisConnectionConfiguration.Db)
+
+	redisConnectionConfiguration, err = ParseRedisConnectionUrl("redis://hello:test@192.168.1.1:1000/5"); if err != nil {
+		t.Fatalf("expected to parse localhost")
+	}
+	assert.Equal(t, "192.168.1.1", redisConnectionConfiguration.Host)
+	assert.Equal(t, "1000", redisConnectionConfiguration.Port)
+	assert.Equal(t, "test", redisConnectionConfiguration.Password)
+	assert.Equal(t, "5", redisConnectionConfiguration.Db)
+}


### PR DESCRIPTION


<!-- Reminder: Have you updated the changelog? -->

Test plan: <!-- Required: What is the test plan for this change? -->

sourcegraph should be able to support redis with authorization.

Note:
I failed to setup my dev environment to test on my own mac, as the dev setup is not that easy enough for only the server side.
Maybe this PR is an idea to show you that sourcegraph should be able to use password to connect redis. Because in my company, every redis server should use password to connect.
