### PR TITLE
Do not show the "View file" button if repo is private but instance is public

### DIFF
--- a/client/browser/src/libs/bitbucket/file_info.ts
+++ b/client/browser/src/libs/bitbucket/file_info.ts
@@ -1,8 +1,6 @@
-import { forkJoin, Observable, of } from 'rxjs'
-import { concatMap, map } from 'rxjs/operators'
-import { fetchBlobContentLines } from '../../shared/repo/backend'
+import { Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { FileInfo } from '../code_intelligence'
-import { ensureRevisionsAreCloned } from '../code_intelligence/util/file_info'
 import { getBaseCommit, getCommitsForPR } from './api'
 import {
     getCommitInfoFromComparePage,
@@ -18,43 +16,8 @@ import {
  */
 export const resolveFileInfoForSingleFileSourceView = (codeView: HTMLElement): Observable<FileInfo> => {
     const fileInfo = getFileInfoFromSingleFileSourceCodeView(codeView)
-    return of(fileInfo).pipe(ensureRevisionsAreCloned)
+    return of(fileInfo)
 }
-
-/**
- * Fetches the contents for the given head and base revisions of a file.
- *
- * @returns The FileInfo including contents
- */
-const fetchDiffFiles = (
-    fileInfo: Pick<FileInfo, 'repoName' | 'commitID' | 'filePath' | 'baseRepoName' | 'baseCommitID' | 'baseFilePath'>
-): Observable<FileInfo> =>
-    forkJoin(
-        // Head
-        fetchBlobContentLines({
-            repoName: fileInfo.repoName,
-            commitID: fileInfo.commitID,
-            filePath: fileInfo.filePath,
-        }).pipe(
-            map(lines => ({
-                content: lines.join('\n'),
-                headHasFileContents: lines.length > 0,
-            }))
-        ),
-        // Base (if exists)
-        fileInfo.baseFilePath && fileInfo.baseRepoName && fileInfo.baseCommitID
-            ? fetchBlobContentLines({
-                  repoName: fileInfo.baseRepoName,
-                  commitID: fileInfo.baseCommitID,
-                  filePath: fileInfo.baseFilePath,
-              }).pipe(
-                  map(lines => ({
-                      baseContent: lines.join('\n'),
-                      baseHasFileContents: lines.length > 0,
-                  }))
-              )
-            : of<{ baseContent?: string; baseHasFileContents?: boolean }>({})
-    ).pipe(map(([headContents, baseContents]) => ({ ...fileInfo, ...headContents, ...baseContents })))
 
 /**
  * Gets the file info for a PR diff code view.
@@ -63,8 +26,7 @@ export const resolvePullRequestFileInfo = (codeView: HTMLElement): Observable<Fi
     const fileInfo = getFileInfoWithoutCommitIDsFromMultiFileDiffCodeView(codeView)
     const prID = getPRIDFromPathName()
     return getCommitsForPR({ ...fileInfo, prID }).pipe(
-        map(({ headCommitID, baseCommitID }) => ({ ...fileInfo, commitID: headCommitID, baseCommitID })),
-        concatMap(fetchDiffFiles)
+        map(({ headCommitID, baseCommitID }) => ({ ...fileInfo, commitID: headCommitID, baseCommitID }))
     )
 }
 
@@ -73,14 +35,11 @@ export const resolvePullRequestFileInfo = (codeView: HTMLElement): Observable<Fi
  */
 export const resolveSingleFileDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo> => {
     const fileInfo = getFileInfoFromSingleFileDiffCodeView(codeView)
-    return getBaseCommit(fileInfo).pipe(
-        map(baseCommitID => ({ baseCommitID, ...fileInfo })),
-        concatMap(fetchDiffFiles)
-    )
+    return getBaseCommit(fileInfo).pipe(map(baseCommitID => ({ baseCommitID, ...fileInfo })))
 }
 
 export const resolveCommitViewFileInfo = (codeView: HTMLElement): Observable<FileInfo> =>
-    fetchDiffFiles(getFileInfoFromCommitDiffCodeView(codeView))
+    of(getFileInfoFromCommitDiffCodeView(codeView))
 
 /**
  * Resolves the file info on a compare page.
@@ -94,6 +53,5 @@ export const resolveCompareFileInfo = (codeView: HTMLElement): Observable<FileIn
                 commitID: headCommitID,
                 baseCommitID,
             }
-        }),
-        concatMap(fetchDiffFiles)
+        })
     )

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -256,9 +256,8 @@ export interface FileInfo {
     commitID: string
     /**
      * `true` if this file is from a private repository,
-     * but the extension points to the public sourcegraph.com.
      */
-    privateRepoPublicSourcegraph?: boolean
+    privateRepo?: boolean
     /**
      * The revision the code view is at. If a `baseRev` is provided, this value is treated as the head rev.
      */

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -255,6 +255,11 @@ export interface FileInfo {
      */
     commitID: string
     /**
+     * `true` if this file is from a private repository,
+     * but the extension points to the public sourcegraph.com.
+     */
+    privateRepoPublicSourcegraph?: boolean
+    /**
      * The revision the code view is at. If a `baseRev` is provided, this value is treated as the head rev.
      */
     rev?: string
@@ -275,12 +280,6 @@ export interface FileInfo {
      * Revision for the BASE side of the diff.
      */
     baseRev?: string
-
-    headHasFileContents?: boolean
-    baseHasFileContents?: boolean
-
-    content?: string
-    baseContent?: string
 }
 
 interface CodeIntelligenceProps
@@ -446,7 +445,6 @@ export function handleCodeHost({
                 if (err.name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
                     return [false]
                 }
-
                 return [true]
             })
         )

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -255,10 +255,6 @@ export interface FileInfo {
      */
     commitID: string
     /**
-     * `true` if this file is from a private repository,
-     */
-    privateRepo?: boolean
-    /**
      * The revision the code view is at. If a `baseRev` is provided, this value is treated as the head rev.
      */
     rev?: string

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -440,12 +440,7 @@ export function handleCodeHost({
         resolveRev(context).pipe(
             retryWhenCloneInProgressError(),
             map(rev => !!rev),
-            catchError((err: Error) => {
-                if (err.name === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
-                    return [false]
-                }
-                return [true]
-            })
+            catchError(() => [false])
         )
 
     const openOptionsMenu = () => {

--- a/client/browser/src/libs/code_intelligence/code_views.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.ts
@@ -2,6 +2,7 @@ import { from, merge, Observable, of, zip } from 'rxjs'
 import { catchError, concatAll, filter, map, mergeMap, switchMap } from 'rxjs/operators'
 import { isDefined, isInstanceOf } from '../../../../../shared/src/util/types'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
+import { DEFAULT_SOURCEGRAPH_URL, sourcegraphUrl } from '../../shared/util/context'
 import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
 import { CodeHost, CodeViewSpec, CodeViewSpecResolver, FileInfo, ResolvedCodeView } from './code_intelligence'
 import { ensureRevisionsAreCloned } from './util/file_info'
@@ -96,11 +97,11 @@ export interface FileInfoWithContents extends FileInfo {
 
 export const fetchFileContents = (info: FileInfo): Observable<FileInfoWithContents> =>
     ensureRevisionsAreCloned(info).pipe(
-        switchMap(({ privateRepoPublicSourcegraph, ...rest }) => {
-            if (privateRepoPublicSourcegraph) {
+        switchMap(({ privateRepo, ...rest }) => {
+            if (privateRepo && sourcegraphUrl === DEFAULT_SOURCEGRAPH_URL) {
                 // This is a private repository, but the browser extension is pointing to
                 // the public Sourcegraph instance: we won't be able to fetch the file contents.
-                return [{ privateRepoPublicSourcegraph, ...rest }]
+                return [{ privateRepo, ...rest }]
             }
             const fetchingBaseFile = info.baseCommitID
                 ? fetchBlobContentLines({

--- a/client/browser/src/libs/code_intelligence/code_views.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.ts
@@ -1,8 +1,8 @@
 import { from, merge, Observable, of, zip } from 'rxjs'
 import { catchError, concatAll, filter, map, mergeMap, switchMap } from 'rxjs/operators'
 import { isDefined, isInstanceOf } from '../../../../../shared/src/util/types'
+import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM, isErrorLike } from '../../shared/backend/errors'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
-import { DEFAULT_SOURCEGRAPH_URL, sourcegraphUrl } from '../../shared/util/context'
 import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
 import { CodeHost, CodeViewSpec, CodeViewSpecResolver, FileInfo, ResolvedCodeView } from './code_intelligence'
 import { ensureRevisionsAreCloned } from './util/file_info'
@@ -97,12 +97,7 @@ export interface FileInfoWithContents extends FileInfo {
 
 export const fetchFileContents = (info: FileInfo): Observable<FileInfoWithContents> =>
     ensureRevisionsAreCloned(info).pipe(
-        switchMap(({ privateRepo, ...rest }) => {
-            if (privateRepo && sourcegraphUrl === DEFAULT_SOURCEGRAPH_URL) {
-                // This is a private repository, but the browser extension is pointing to
-                // the public Sourcegraph instance: we won't be able to fetch the file contents.
-                return [{ privateRepo, ...rest }]
-            }
+        switchMap(info => {
             const fetchingBaseFile = info.baseCommitID
                 ? fetchBlobContentLines({
                       repoName: info.repoName,
@@ -128,5 +123,11 @@ export const fetchFileContents = (info: FileInfo): Observable<FileInfoWithConten
                 ),
                 catchError(error => [info])
             )
+        }),
+        catchError((err: any) => {
+            if (isErrorLike(err) && err.code === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+                return [info]
+            }
+            throw err
         })
     )

--- a/client/browser/src/libs/code_intelligence/code_views.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.ts
@@ -1,9 +1,10 @@
 import { from, merge, Observable, of, zip } from 'rxjs'
-import { catchError, concatAll, filter, map, mergeMap } from 'rxjs/operators'
+import { catchError, concatAll, filter, map, mergeMap, switchMap } from 'rxjs/operators'
 import { isDefined, isInstanceOf } from '../../../../../shared/src/util/types'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
 import { CodeHost, CodeViewSpec, CodeViewSpecResolver, FileInfo, ResolvedCodeView } from './code_intelligence'
+import { ensureRevisionsAreCloned } from './util/file_info'
 
 export interface AddedCodeView extends ResolvedCodeView {
     type: 'added'
@@ -93,31 +94,38 @@ export interface FileInfoWithContents extends FileInfo {
     baseHasFileContents?: boolean
 }
 
-export const fetchFileContents = (info: FileInfo): Observable<FileInfoWithContents> => {
-    const fetchingBaseFile = info.baseCommitID
-        ? fetchBlobContentLines({
-              repoName: info.repoName,
-              filePath: info.baseFilePath || info.filePath,
-              commitID: info.baseCommitID,
-          })
-        : of(null)
+export const fetchFileContents = (info: FileInfo): Observable<FileInfoWithContents> =>
+    ensureRevisionsAreCloned(info).pipe(
+        switchMap(({ privateRepoPublicSourcegraph, ...rest }) => {
+            if (privateRepoPublicSourcegraph) {
+                // This is a private repository, but the browser extension is pointing to
+                // the public Sourcegraph instance: we won't be able to fetch the file contents.
+                return [{ privateRepoPublicSourcegraph, ...rest }]
+            }
+            const fetchingBaseFile = info.baseCommitID
+                ? fetchBlobContentLines({
+                      repoName: info.repoName,
+                      filePath: info.baseFilePath || info.filePath,
+                      commitID: info.baseCommitID,
+                  })
+                : of(null)
 
-    const fetchingHeadFile = fetchBlobContentLines({
-        repoName: info.repoName,
-        filePath: info.filePath,
-        commitID: info.commitID,
-    })
-
-    return zip(fetchingBaseFile, fetchingHeadFile).pipe(
-        map(
-            ([baseFileContent, headFileContent]): FileInfoWithContents => ({
-                ...info,
-                baseContent: baseFileContent ? baseFileContent.join('\n') : undefined,
-                content: headFileContent.join('\n'),
-                headHasFileContents: headFileContent.length > 0,
-                baseHasFileContents: baseFileContent ? baseFileContent.length > 0 : undefined,
+            const fetchingHeadFile = fetchBlobContentLines({
+                repoName: info.repoName,
+                filePath: info.filePath,
+                commitID: info.commitID,
             })
-        ),
-        catchError(error => [info])
+            return zip(fetchingBaseFile, fetchingHeadFile).pipe(
+                map(
+                    ([baseFileContent, headFileContent]): FileInfoWithContents => ({
+                        ...info,
+                        baseContent: baseFileContent ? baseFileContent.join('\n') : undefined,
+                        content: headFileContent.join('\n'),
+                        headHasFileContents: headFileContent.length > 0,
+                        baseHasFileContents: baseFileContent ? baseFileContent.length > 0 : undefined,
+                    })
+                ),
+                catchError(error => [info])
+            )
+        })
     )
-}

--- a/client/browser/src/libs/code_intelligence/util/file_info.ts
+++ b/client/browser/src/libs/code_intelligence/util/file_info.ts
@@ -11,7 +11,7 @@ export const ensureRevisionsAreCloned = ({
     baseCommitID,
     ...rest
 }: FileInfo): Observable<FileInfo> => {
-    // Although we get the commit SHA's from elesewhere, we still need to
+    // Although we get the commit SHA's from elsewhere, we still need to
     // use `resolveRev` otherwise we can't guarantee Sourcegraph has the
     // revision cloned.
 

--- a/client/browser/src/libs/code_intelligence/util/file_info.ts
+++ b/client/browser/src/libs/code_intelligence/util/file_info.ts
@@ -1,39 +1,39 @@
 import { Observable, zip } from 'rxjs'
-import { catchError, map, switchMap } from 'rxjs/operators'
+import { catchError, map } from 'rxjs/operators'
 
 import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../../shared/backend/errors'
 import { resolveRev, retryWhenCloneInProgressError } from '../../../shared/repo/backend'
 import { FileInfo } from '../code_intelligence'
 
-export const ensureRevisionsAreCloned = (files: Observable<FileInfo>): Observable<FileInfo> =>
-    files.pipe(
-        switchMap(({ repoName, commitID, baseCommitID, ...rest }) => {
-            // Although we get the commit SHA's from elesewhere, we still need to
-            // use `resolveRev` otherwise we can't guarantee Sourcegraph has the
-            // revision cloned.
+export const ensureRevisionsAreCloned = ({
+    repoName,
+    commitID,
+    baseCommitID,
+    ...rest
+}: FileInfo): Observable<FileInfo> => {
+    // Although we get the commit SHA's from elesewhere, we still need to
+    // use `resolveRev` otherwise we can't guarantee Sourcegraph has the
+    // revision cloned.
 
-            // Head
-            const resolvingHeadRev = resolveRev({ repoName, rev: commitID }).pipe(retryWhenCloneInProgressError())
+    // Head
+    const resolvingHeadRev = resolveRev({ repoName, rev: commitID }).pipe(retryWhenCloneInProgressError())
 
-            const requests = [resolvingHeadRev]
+    const requests = [resolvingHeadRev]
 
-            // If theres a base, resolve it as well.
-            if (baseCommitID) {
-                const resolvingBaseRev = resolveRev({ repoName, rev: baseCommitID }).pipe(
-                    retryWhenCloneInProgressError()
-                )
+    // If theres a base, resolve it as well.
+    if (baseCommitID) {
+        const resolvingBaseRev = resolveRev({ repoName, rev: baseCommitID }).pipe(retryWhenCloneInProgressError())
 
-                requests.push(resolvingBaseRev)
+        requests.push(resolvingBaseRev)
+    }
+
+    return zip(...requests).pipe(
+        map(() => ({ repoName, commitID, baseCommitID, ...rest })),
+        catchError(err => {
+            if (err.code === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
+                return [{ privateRepoPublicSourcegraph: true, repoName, commitID, baseCommitID, ...rest }]
             }
-
-            return zip(...requests).pipe(
-                map(() => ({ repoName, commitID, baseCommitID, ...rest })),
-                catchError(err => {
-                    if (err.code === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
-                        return [{ repoName, commitID, baseCommitID, ...rest }]
-                    }
-                    throw err
-                })
-            )
+            throw err
         })
     )
+}

--- a/client/browser/src/libs/code_intelligence/util/file_info.ts
+++ b/client/browser/src/libs/code_intelligence/util/file_info.ts
@@ -1,7 +1,6 @@
 import { Observable, zip } from 'rxjs'
-import { catchError, map } from 'rxjs/operators'
+import { map } from 'rxjs/operators'
 
-import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../../shared/backend/errors'
 import { resolveRev, retryWhenCloneInProgressError } from '../../../shared/repo/backend'
 import { FileInfo } from '../code_intelligence'
 
@@ -27,13 +26,5 @@ export const ensureRevisionsAreCloned = ({
         requests.push(resolvingBaseRev)
     }
 
-    return zip(...requests).pipe(
-        map(() => ({ repoName, commitID, baseCommitID, ...rest })),
-        catchError(err => {
-            if (err.code === ERPRIVATEREPOPUBLICSOURCEGRAPHCOM) {
-                return [{ privateRepoPublicSourcegraph: true, repoName, commitID, baseCommitID, ...rest }]
-            }
-            throw err
-        })
-    )
+    return zip(...requests).pipe(map(() => ({ repoName, commitID, baseCommitID, ...rest })))
 }

--- a/client/browser/src/libs/github/file_info.ts
+++ b/client/browser/src/libs/github/file_info.ts
@@ -4,7 +4,6 @@ import { filter, map, switchMap } from 'rxjs/operators'
 import { GitHubBlobUrl } from '.'
 import { resolveRev, retryWhenCloneInProgressError } from '../../shared/repo/backend'
 import { FileInfo } from '../code_intelligence'
-import { ensureRevisionsAreCloned } from '../code_intelligence/util/file_info'
 import { getCommitIDFromPermalink } from './scrape'
 import { getDeltaFileName, getDiffResolvedRev, getGitHubState, parseURL } from './util'
 
@@ -80,13 +79,12 @@ export const resolveFileInfo = (): Observable<FileInfo> => {
 
     try {
         const commitID = getCommitIDFromPermalink()
-
         return of({
             repoName,
             filePath,
             commitID,
             rev: rev || commitID,
-        }).pipe(ensureRevisionsAreCloned)
+        })
     } catch (error) {
         return throwError(error)
     }

--- a/client/browser/src/libs/gitlab/file_info.ts
+++ b/client/browser/src/libs/gitlab/file_info.ts
@@ -2,7 +2,6 @@ import { Observable, of, throwError } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 
 import { FileInfo } from '../code_intelligence'
-import { ensureRevisionsAreCloned } from '../code_intelligence/util/file_info'
 
 import { getBaseCommitIDForCommit, getBaseCommitIDForMergeRequest } from './api'
 import {
@@ -37,7 +36,7 @@ export const resolveFileInfo = (): Observable<FileInfo> => {
             filePath,
             commitID,
             rev,
-        }).pipe(ensureRevisionsAreCloned)
+        })
     } catch (error) {
         return throwError(error)
     }
@@ -81,8 +80,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
             // https://github.com/sourcegraph/browser-extensions/issues/185
             headHasFileContents: true,
             baseHasFileContents: true,
-        })),
-        ensureRevisionsAreCloned
+        }))
     )
 
 /**
@@ -109,6 +107,5 @@ export const resolveCommitFileInfo = (codeView: HTMLElement): Observable<FileInf
             // https://github.com/sourcegraph/browser-extensions/issues/185
             headHasFileContents: true,
             baseHasFileContents: true,
-        })),
-        ensureRevisionsAreCloned
+        }))
     )

--- a/client/browser/src/libs/phabricator/file_info.ts
+++ b/client/browser/src/libs/phabricator/file_info.ts
@@ -1,9 +1,7 @@
 import { from, Observable, zip } from 'rxjs'
 import { catchError, filter, map, switchMap } from 'rxjs/operators'
 import { DifferentialState, DiffusionState, PhabricatorMode, RevisionState } from '.'
-import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { FileInfo } from '../code_intelligence'
-import { ensureRevisionsAreCloned } from '../code_intelligence/util/file_info'
 import { resolveDiffRev } from './backend'
 import { getFilepathFromFileForDiff, getFilePathFromFileForRevision } from './scrape'
 import { getPhabricatorState } from './util'
@@ -19,30 +17,7 @@ export const resolveRevisionFileInfo = (codeView: HTMLElement): Observable<FileI
         map(info => ({
             ...info,
             filePath: getFilePathFromFileForRevision(codeView),
-        })),
-        switchMap(info => {
-            const fetchingBaseFile = fetchBlobContentLines({
-                repoName: info.repoName,
-                filePath: info.filePath,
-                commitID: info.baseCommitID,
-            })
-
-            const fetchingHeadFile = fetchBlobContentLines({
-                repoName: info.repoName,
-                filePath: info.filePath,
-                commitID: info.commitID,
-            })
-
-            return zip(fetchingBaseFile, fetchingHeadFile).pipe(
-                map(([baseFileContent, headFileContent]) => ({
-                    ...info,
-                    baseContent: baseFileContent.join('\n'),
-                    content: headFileContent.join('\n'),
-                    headHasFileContents: headFileContent.length > 0,
-                    baseHasFileContents: baseFileContent.length > 0,
-                }))
-            )
-        })
+        }))
     )
 
 export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo> =>
@@ -107,57 +82,20 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
                 }))
             )
         }),
-        switchMap(info => {
-            const fetchingBaseFile = fetchBlobContentLines({
-                repoName: info.baseRepoName,
-                filePath: info.baseFilePath || info.filePath,
-                commitID: info.baseCommitID,
-            })
-
-            const fetchingHeadFile = fetchBlobContentLines({
-                repoName: info.headRepoName,
-                filePath: info.filePath,
-                commitID: info.headCommitID,
-            })
-
-            return zip(fetchingBaseFile, fetchingHeadFile).pipe(
-                map(([baseFileContent, headFileContent]) => ({ ...info, baseFileContent, headFileContent }))
-            )
-        }),
         map(info => ({
             repoName: info.headRepoName,
             filePath: info.filePath,
             commitID: info.headCommitID,
             rev: info.headRev,
-
             baseRepoName: info.baseRepoName,
-            baseFilePath: info.baseFileContent ? info.baseFilePath || info.filePath : undefined,
+            baseFilePath: info.baseFilePath || info.filePath,
             baseCommitID: info.baseCommitID,
             baseRev: info.baseRev,
-
-            headHasFileContents: info.headFileContent.length > 0,
-            baseHasFileContents: info.baseFileContent.length > 0,
-
-            content: info.headFileContent.join('\n'),
-            baseContent: info.baseFileContent.join('\n'),
-        })),
-        ensureRevisionsAreCloned
+        }))
     )
 
 export const resolveDiffusionFileInfo = (codeView: HTMLElement): Observable<FileInfo> =>
     from(getPhabricatorState(window.location)).pipe(
         filter(state => state !== null && state.mode === PhabricatorMode.Diffusion),
-        map(state => state as DiffusionState),
-        switchMap(info => {
-            const fetchingBaseFile = fetchBlobContentLines({
-                repoName: info.repoName,
-                filePath: info.filePath,
-                commitID: info.commitID,
-            })
-
-            return fetchingBaseFile.pipe(
-                map(lines => lines.join('\n')),
-                map(content => ({ ...info, content }))
-            )
-        })
+        map(state => state as DiffusionState)
     )

--- a/client/browser/src/libs/phabricator/file_info.ts
+++ b/client/browser/src/libs/phabricator/file_info.ts
@@ -94,8 +94,7 @@ export const resolveDiffFileInfo = (codeView: HTMLElement): Observable<FileInfo>
         }))
     )
 
-export const resolveDiffusionFileInfo = (codeView: HTMLElement): Observable<FileInfo> =>
+export const resolveDiffusionFileInfo = (): Observable<FileInfo> =>
     from(getPhabricatorState(window.location)).pipe(
-        filter(state => state !== null && state.mode === PhabricatorMode.Diffusion),
-        map(state => state as DiffusionState)
+        filter((state): state is DiffusionState => state !== null && state.mode === PhabricatorMode.Diffusion)
     )

--- a/client/browser/src/platform/context.ts
+++ b/client/browser/src/platform/context.ts
@@ -22,10 +22,6 @@ import { createBlobURLForBundle } from './worker'
  * Creates the {@link PlatformContext} for the browser extension.
  */
 export function createPlatformContext({ urlToFile }: Pick<CodeHost, 'urlToFile'>): PlatformContext {
-    // TODO: support listening for changes to sourcegraphUrl
-    const sourcegraphLanguageServerURL = new URL(sourcegraphUrl)
-    sourcegraphLanguageServerURL.pathname = '.api/xlang'
-
     const updatedViewerSettings = new ReplaySubject<Pick<GQL.ISettingsCascade, 'subjects' | 'final'>>(1)
 
     const context: PlatformContext = {

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -10,7 +10,7 @@ import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import { toURIWithPath } from '../../../../../shared/src/util/url'
-import { FileInfo } from '../../libs/code_intelligence'
+import { FileInfoWithContents } from '../../libs/code_intelligence/code_views'
 import { fetchCurrentUser, fetchSite } from '../backend/server'
 import { OpenDiffOnSourcegraph } from './OpenDiffOnSourcegraph'
 import { OpenOnSourcegraph } from './OpenOnSourcegraph'
@@ -31,7 +31,7 @@ export interface CodeViewToolbarClassProps extends ActionNavItemsClassProps {
 export interface CodeViewToolbarProps
     extends PlatformContextProps<'forceUpdateTooltip'>,
         ExtensionsControllerProps,
-        FileInfo,
+        FileInfoWithContents,
         TelemetryProps,
         CodeViewToolbarClassProps {
     onEnabledChange?: (enabled: boolean) => void
@@ -102,7 +102,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                         />
                     </li>
                 )}{' '}
-                {!this.props.baseCommitID && (
+                {!this.props.baseCommitID && this.props.content !== undefined && (
                     <li className={classNames('code-view-toolbar__item', this.props.listItemClass)}>
                         <OpenOnSourcegraph
                             label="View file"

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -102,7 +102,9 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                         />
                     </li>
                 )}{' '}
-                {!this.props.baseCommitID && this.props.content !== undefined && (
+                {// Only show the "View file" button if we were able to fetch the file contents
+                // from the Sourcegraph instance
+                !this.props.baseCommitID && this.props.content !== undefined && (
                     <li className={classNames('code-view-toolbar__item', this.props.listItemClass)}>
                         <OpenOnSourcegraph
                             label="View file"

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -104,7 +104,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                 )}{' '}
                 {// Only show the "View file" button if we were able to fetch the file contents
                 // from the Sourcegraph instance
-                !this.props.baseCommitID && this.props.content !== undefined && (
+                !this.props.baseCommitID && (this.props.content !== undefined || this.props.baseContent !== undefined) && (
                     <li className={classNames('code-view-toolbar__item', this.props.listItemClass)}>
                         <OpenOnSourcegraph
                             label="View file"

--- a/client/browser/src/shared/repo/backend.tsx
+++ b/client/browser/src/shared/repo/backend.tsx
@@ -94,7 +94,7 @@ export function retryWhenCloneInProgressError<T>(): (v: Observable<T>) => Observ
                             return true
                         }
 
-                        // Don't swollow other errors.
+                        // Don't swallow other errors.
                         throw err
                     }),
                     delay(1000)


### PR DESCRIPTION
Fixes #3065

I originally started this branch to work on #3072, but realised that the solution to that was more complex than anticipated, because since extensions must work on private code, we can't just nuke hover/codeintel functionality if the repo doesn't exist on the Sourcegraph instance.

In any case, the changes I started allowed me to fix #3065, and also to deduplicate a lot of code in the browser extension:
- It was previously up to `CodeViewSpec.resolveFileInfo()` to call `ensureRevisionsAreCloned()`, making sure the code view's revision(s) existed on the Sourcegraph instance. This was error-prone - in several instances, `ensureRevisionsAreCloned()` was not called.
- Some instances of `CodeViewSpec.resolveFileInfo()` would also fetch the file contents, but the downstream code would [assume that the file contents needed to be fetched anyway](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/browser/src/libs/code_intelligence/code_intelligence.tsx#L533-537).
- I made sure that `ensureRevisionsAreCloned()` and `fetchFileContents()` were only called once per code view, in the `codeViews` observable.

With `ensureRevisionsAreCloned()` now being reliably called for every code view, I added `FileInfo.privateRepoPublicSourcegraph`, and used it to hide the "View File" button when the repo doesn't exist on the public sourcegraph instance. With a private Sourcegraph instance, `ensureRevisionsAreCloned()` will throw if the revision doesn't exist, and the code view event won't be emitted.
