### PR TITLE
repo-updater: Extend Store ListXXX methods with flexible query arguments

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -36,7 +36,6 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/Transact", testDBStoreTransact(store)},
 		{"DBStore/ListExternalServices", testStoreListExternalServices(store)},
 		{"DBStore/UpsertExternalServices", testStoreUpsertExternalServices(store)},
-		{"DBStore/GetRepoByName", testStoreGetRepoByName(store)},
 		{"DBStore/UpsertRepos", testStoreUpsertRepos(store)},
 		{"DBStore/ListRepos", testStoreListRepos(store)},
 		{"Syncer/Sync", testSyncerSync(store)},

--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -37,7 +37,10 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 	return migrate(func(ctx context.Context, s Store) error {
 		const prefix = "migrate.repos-enabled-state-deprecation"
 
-		es, err := s.ListExternalServices(ctx, kinds...)
+		es, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{
+			Kinds: kinds,
+		})
+
 		if err != nil {
 			return errors.Wrapf(err, "%s.list-external-services", prefix)
 		}
@@ -203,7 +206,10 @@ func GithubSetDefaultRepositoryQueryMigration(clock func() time.Time) Migration 
 	return migrate(func(ctx context.Context, s Store) error {
 		const prefix = "migrate.github-set-default-repository-query"
 
-		svcs, err := s.ListExternalServices(ctx, "github")
+		svcs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{
+			Kinds: []string{"github"},
+		})
+
 		if err != nil {
 			return errors.Wrapf(err, "%s.list-external-services", prefix)
 		}
@@ -255,7 +261,10 @@ func GitLabSetDefaultProjectQueryMigration(clock func() time.Time) Migration {
 	return migrate(func(ctx context.Context, s Store) error {
 		const prefix = "migrate.gitlab-set-default-project-query"
 
-		svcs, err := s.ListExternalServices(ctx, "gitlab")
+		svcs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{
+			Kinds: []string{"gitlab"},
+		})
+
 		if err != nil {
 			return errors.Wrapf(err, "%s.list-external-services", prefix)
 		}
@@ -298,7 +307,10 @@ func BitbucketServerSetDefaultRepositoryQueryMigration(clock func() time.Time) M
 	return migrate(func(ctx context.Context, s Store) error {
 		const prefix = "migrate.bitbucketserver-set-default-repository-query"
 
-		svcs, err := s.ListExternalServices(ctx, "bitbucketserver")
+		svcs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{
+			Kinds: []string{"bitbucketserver"},
+		})
+
 		if err != nil {
 			return errors.Wrapf(err, "%s.list-external-services", prefix)
 		}

--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -58,7 +58,10 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 			return errors.Wrapf(err, "%s.sources.list-repos", prefix)
 		}
 
-		stored, err := s.ListRepos(ctx, kinds...)
+		stored, err := s.ListRepos(ctx, StoreListReposArgs{
+			Kinds: kinds,
+		})
+
 		if err != nil {
 			return errors.Wrapf(err, "%s.store.list-repos", prefix)
 		}

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -311,7 +311,7 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 				}
 
 				if tc.svcs != nil {
-					svcs, err := tx.ListExternalServices(ctx)
+					svcs, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})
 					if err != nil {
 						t.Error(err)
 						return
@@ -461,7 +461,7 @@ func testGithubSetDefaultRepositoryQueryMigration(store repos.Store) func(*testi
 					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
 				}
 
-				es, err := tx.ListExternalServices(ctx)
+				es, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})
 				if err != nil {
 					t.Error(err)
 					return
@@ -579,7 +579,7 @@ func testGitLabSetDefaultProjectQueryMigration(store repos.Store) func(*testing.
 					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
 				}
 
-				es, err := tx.ListExternalServices(ctx)
+				es, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})
 				if err != nil {
 					t.Error(err)
 					return
@@ -694,7 +694,7 @@ func testBitbucketServerSetDefaultRepositoryQueryMigration(store repos.Store) fu
 					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
 				}
 
-				es, err := tx.ListExternalServices(ctx)
+				es, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})
 				if err != nil {
 					t.Error(err)
 					return

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -320,7 +320,7 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 				}
 
 				if tc.repos != nil {
-					rs, err := tx.ListRepos(ctx)
+					rs, err := tx.ListRepos(ctx, repos.StoreListReposArgs{})
 					if err != nil {
 						t.Error(err)
 						return

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -122,7 +122,10 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 					return
 				}
 
-				es, err := tx.ListExternalServices(ctx, tc.kinds...)
+				es, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{
+					Kinds: tc.kinds,
+				})
+
 				if have, want := fmt.Sprint(err), fmt.Sprint(tc.err); have != want {
 					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
 				}
@@ -198,7 +201,10 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 
 			sort.Sort(want)
 
-			have, err := tx.ListExternalServices(ctx, svcs.Kinds()...)
+			have, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{
+				Kinds: svcs.Kinds(),
+			})
+
 			if err != nil {
 				t.Errorf("ListExternalServices error: %s", err)
 				return
@@ -221,7 +227,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 
 			if err = tx.UpsertExternalServices(ctx, want...); err != nil {
 				t.Errorf("UpsertExternalServices error: %s", err)
-			} else if have, err = tx.ListExternalServices(ctx); err != nil {
+			} else if have, err = tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{}); err != nil {
 				t.Errorf("ListExternalServices error: %s", err)
 			} else if diff := pretty.Compare(have, want); diff != "" {
 				t.Errorf("ListExternalServices:\n%s", diff)
@@ -231,7 +237,7 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 
 			if err = tx.UpsertExternalServices(ctx, want.Clone()...); err != nil {
 				t.Errorf("UpsertExternalServices error: %s", err)
-			} else if have, err = tx.ListExternalServices(ctx); err != nil {
+			} else if have, err = tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{}); err != nil {
 				t.Errorf("ListExternalServices error: %s", err)
 			} else if diff := pretty.Compare(have, want); diff != "" {
 				t.Errorf("ListExternalServices:\n%s", diff)

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -3,14 +3,12 @@ package repos_test
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -28,9 +26,8 @@ func TestFakeStore(t *testing.T) {
 	}{
 		{"ListExternalServices", testStoreListExternalServices(new(repos.FakeStore))},
 		{"UpsertExternalServices", testStoreUpsertExternalServices(new(repos.FakeStore))},
-		{"GetRepoByName", testStoreGetRepoByName(new(repos.FakeStore))},
-		{"UpsertRepos", testStoreUpsertRepos(new(repos.FakeStore))},
 		{"ListRepos", testStoreListRepos(new(repos.FakeStore))},
+		{"UpsertRepos", testStoreUpsertRepos(new(repos.FakeStore))},
 	} {
 		t.Run(tc.name, tc.test)
 	}
@@ -341,7 +338,10 @@ func testStoreUpsertRepos(store repos.Store) func(*testing.T) {
 
 			sort.Sort(want)
 
-			have, err := tx.ListRepos(ctx, kinds...)
+			have, err := tx.ListRepos(ctx, repos.StoreListReposArgs{
+				Kinds: kinds,
+			})
+
 			if err != nil {
 				t.Errorf("ListRepos error: %s", err)
 				return
@@ -366,7 +366,7 @@ func testStoreUpsertRepos(store repos.Store) func(*testing.T) {
 
 			if err = tx.UpsertRepos(ctx, want.Clone()...); err != nil {
 				t.Errorf("UpsertRepos error: %s", err)
-			} else if have, err = tx.ListRepos(ctx); err != nil {
+			} else if have, err = tx.ListRepos(ctx, repos.StoreListReposArgs{}); err != nil {
 				t.Errorf("ListRepos error: %s", err)
 			} else if diff := pretty.Compare(have, want); diff != "" {
 				t.Errorf("ListRepos:\n%s", diff)
@@ -376,7 +376,7 @@ func testStoreUpsertRepos(store repos.Store) func(*testing.T) {
 
 			if err = tx.UpsertRepos(ctx, want.Clone()...); err != nil {
 				t.Errorf("UpsertRepos error: %s", err)
-			} else if have, err = tx.ListRepos(ctx); err != nil {
+			} else if have, err = tx.ListRepos(ctx, repos.StoreListReposArgs{}); err != nil {
 				t.Errorf("ListRepos error: %s", err)
 			} else if diff := pretty.Compare(have, want); diff != "" {
 				t.Errorf("ListRepos:\n%s", diff)
@@ -463,7 +463,7 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 
 	type testCase struct {
 		name   string
-		kinds  []string
+		args   func(stored repos.Repos) repos.StoreListReposArgs
 		stored repos.Repos
 		repos  repos.ReposAssertion
 		err    error
@@ -477,16 +477,22 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 		})
 
 		testCases = append(testCases, testCase{
-			name:   "case-insensitive kinds",
-			kinds:  []string{"GiThUb", "GitLab", "BitBucketServer"},
+			name: "case-insensitive kinds",
+			args: func(_ repos.Repos) repos.StoreListReposArgs {
+				return repos.StoreListReposArgs{
+					Kinds: []string{"GiThUb", "GitLab", "BitBucketServer"},
+				}
+			},
 			stored: stored,
 			repos:  repos.Assert.ReposEqual(stored...),
 		})
 	}
 
 	testCases = append(testCases, testCase{
-		name:   "ignores unmanaged",
-		kinds:  kinds,
+		name: "ignores unmanaged",
+		args: func(_ repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{Kinds: kinds}
+		},
 		stored: repos.Repos{&github, &gitlab, &unmanaged}.Clone(),
 		repos:  repos.Assert.ReposEqual(&github, &gitlab),
 	})
@@ -495,7 +501,6 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 		stored := repositories.With(repos.Opt.RepoDeletedAt(now))
 		testCases = append(testCases, testCase{
 			name:   "returns soft deleted repos",
-			kinds:  kinds,
 			stored: stored,
 			repos:  repos.Assert.ReposEqual(stored...),
 		})
@@ -503,11 +508,43 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 
 	testCases = append(testCases, testCase{
 		name:   "returns repos in ascending order by id",
-		kinds:  []string{}, // All kinds
 		stored: mkRepos(512, repositories...),
 		repos: repos.Assert.ReposOrderedBy(func(a, b *repos.Repo) bool {
 			return a.ID < b.ID
 		}),
+	})
+
+	testCases = append(testCases, testCase{
+		name:   "returns repos by their names",
+		stored: repositories,
+		args: func(_ repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				Names: []string{github.Name, gitlab.Name},
+			}
+		},
+		repos: repos.Assert.ReposEqual(&github, &gitlab),
+	})
+
+	testCases = append(testCases, testCase{
+		name:   "returns repos by their ids",
+		stored: repositories,
+		args: func(stored repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				IDs: []uint32{stored[0].ID, stored[1].ID},
+			}
+		},
+		repos: repos.Assert.ReposEqual(repositories[:2].Clone()...),
+	})
+
+	testCases = append(testCases, testCase{
+		name:   "limits repos to the given kinds",
+		stored: repositories,
+		args: func(repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				Kinds: []string{"github", "gitlab"},
+			}
+		},
+		repos: repos.Assert.ReposEqual(&github, &gitlab),
 	})
 
 	return func(t *testing.T) {
@@ -518,130 +555,24 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 			ctx := context.Background()
 
 			t.Run(tc.name, transact(ctx, store, func(t testing.TB, tx repos.Store) {
-				if err := tx.UpsertRepos(ctx, tc.stored.Clone()...); err != nil {
+				stored := tc.stored.Clone()
+				if err := tx.UpsertRepos(ctx, stored...); err != nil {
 					t.Errorf("failed to setup store: %v", err)
 					return
 				}
 
-				rs, err := tx.ListRepos(ctx, tc.kinds...)
+				var args repos.StoreListReposArgs
+				if tc.args != nil {
+					args = tc.args(stored)
+				}
+
+				rs, err := tx.ListRepos(ctx, args)
 				if have, want := fmt.Sprint(err), fmt.Sprint(tc.err); have != want {
 					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
 				}
 
 				if tc.repos != nil {
 					tc.repos(t, rs)
-				}
-			}))
-		}
-	}
-}
-
-func testStoreGetRepoByName(store repos.Store) func(*testing.T) {
-	github := repos.Repo{
-		Name: "github.com/bar/foo",
-		Sources: map[string]*repos.SourceInfo{
-			"extsvc:123": {
-				ID:       "extsvc:123",
-				CloneURL: "git@github.com:bar/foo.git",
-			},
-		},
-		Metadata: new(github.Repository),
-		ExternalRepo: api.ExternalRepoSpec{
-			ServiceType: "github",
-			ServiceID:   "https://github.com/",
-			ID:          "foo",
-		},
-	}
-
-	gitlab := repos.Repo{
-		Name: "gitlab.com/bar/foo",
-		Sources: map[string]*repos.SourceInfo{
-			"extsvc:123": {
-				ID:       "extsvc:123",
-				CloneURL: "git@gitlab.com:bar/foo.git",
-			},
-		},
-		Metadata: new(gitlab.Project),
-		ExternalRepo: api.ExternalRepoSpec{
-			ServiceType: "gitlab",
-			ServiceID:   "https://gitlab.com/",
-			ID:          "123",
-		},
-	}
-
-	bitbucketServer := repos.Repo{
-		Name: "bitbucketserver.mycorp.com/foo/bar",
-		Sources: map[string]*repos.SourceInfo{
-			"extsvc:123": {
-				ID:       "extsvc:123",
-				CloneURL: "git@bitbucketserver.mycorp.com:foo/bar.git",
-			},
-		},
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          "1234",
-			ServiceType: "bitbucketServer",
-			ServiceID:   "http://bitbucketserver.mycorp.com",
-		},
-		Metadata: new(bitbucketserver.Repo),
-	}
-
-	repositories := repos.Repos{
-		&github,
-		&gitlab,
-		&bitbucketServer,
-	}
-
-	type testCase struct {
-		test   string
-		name   string
-		stored repos.Repos
-		repo   *repos.Repo
-		err    error
-	}
-
-	testCases := []testCase{
-		{
-			test: "no results error",
-			name: "intergalatical repo lost in spaaaaaace",
-			err:  repos.ErrNoResults,
-		},
-	}
-
-	for _, repo := range repositories {
-		testCases = append(testCases, testCase{
-			test:   repo.ExternalRepo.ServiceType + "/found",
-			stored: repositories,
-			name:   repo.Name,
-			repo:   repo.Clone(),
-		})
-	}
-
-	return func(t *testing.T) {
-		t.Helper()
-
-		for _, tc := range testCases {
-			// NOTE: We use t.Errorf instead of t.Fatalf in order to run defers.
-
-			tc := tc
-			ctx := context.Background()
-
-			t.Run(tc.test, transact(ctx, store, func(t testing.TB, tx repos.Store) {
-				if err := tx.UpsertRepos(ctx, tc.stored...); err != nil {
-					t.Errorf("failed to setup store: %v", err)
-					return
-				}
-
-				repo, err := tx.GetRepoByName(ctx, tc.name)
-				if have, want := fmt.Sprint(err), fmt.Sprint(tc.err); have != want {
-					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
-				}
-
-				if repo != nil {
-					repo.ID = 0 // Exclude auto-generated IDs from equality tests
-				}
-
-				if have, want := repo, tc.repo; !reflect.DeepEqual(have, want) {
-					t.Errorf("repos: %s", cmp.Diff(have, want))
 				}
 			}))
 		}

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -212,7 +212,10 @@ func merge(o, n *Repo) {
 }
 
 func (s *Syncer) sourced(ctx context.Context, kinds ...string) ([]*Repo, error) {
-	svcs, err := s.store.ListExternalServices(ctx, kinds...)
+	svcs, err := s.store.ListExternalServices(ctx, StoreListExternalServicesArgs{
+		Kinds: kinds,
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -68,7 +68,7 @@ func (s *Syncer) Sync(ctx context.Context, kinds ...string) (_ Diff, err error) 
 	}
 
 	var stored Repos
-	if stored, err = store.ListRepos(ctx, kinds...); err != nil {
+	if stored, err = store.ListRepos(ctx, StoreListReposArgs{Kinds: kinds}); err != nil {
 		return Diff{}, errors.Wrap(err, "syncer.sync.store.list-repos")
 	}
 

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -371,7 +371,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				}
 
 				if st != nil {
-					have, _ := st.ListRepos(ctx)
+					have, _ := st.ListRepos(ctx, repos.StoreListReposArgs{})
 					for _, d := range have {
 						d.ID = 0 // Exclude auto-generated ID from comparisons
 					}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -165,8 +165,8 @@ func (s FakeStore) GetRepoByName(ctx context.Context, name string) (*Repo, error
 	return r, nil
 }
 
-// ListRepos lists all repos in the store that have one of the specified external service kinds.
-func (s FakeStore) ListRepos(ctx context.Context, kinds ...string) ([]*Repo, error) {
+// ListRepos lists all repos in the store that match the given arguments.
+func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*Repo, error) {
 	if s.ListReposError != nil {
 		return nil, s.ListReposError
 	}
@@ -175,15 +175,29 @@ func (s FakeStore) ListRepos(ctx context.Context, kinds ...string) ([]*Repo, err
 		s.repoByName = make(map[string]*Repo)
 	}
 
-	kindset := make(map[string]bool, len(kinds))
-	for _, kind := range kinds {
-		kindset[strings.ToLower(kind)] = true
+	kinds := make(map[string]bool, len(args.Kinds))
+	for _, kind := range args.Kinds {
+		kinds[strings.ToLower(kind)] = true
+	}
+
+	names := make(map[string]bool, len(args.Names))
+	for _, name := range args.Names {
+		names[name] = true
+	}
+
+	ids := make(map[uint32]bool, len(args.IDs))
+	for _, id := range args.IDs {
+		ids[id] = true
 	}
 
 	set := make(map[*Repo]bool, len(s.repoByName))
 	repos := make(Repos, 0, len(s.repoByName))
 	for _, r := range s.repoByName {
-		if !set[r] && len(kinds) == 0 || kindset[strings.ToLower(r.ExternalRepo.ServiceType)] {
+		if !set[r] &&
+			(len(kinds) == 0 || kinds[strings.ToLower(r.ExternalRepo.ServiceType)]) &&
+			(len(names) == 0 || names[r.Name]) &&
+			(len(ids) == 0 || ids[r.ID]) {
+
 			repos = append(repos, r)
 			set[r] = true
 		}
@@ -245,8 +259,7 @@ var Assert = struct {
 	ExternalServicesOrderedBy func(func(a, b *ExternalService) bool) ExternalServicesAssertion
 }{
 	ReposEqual: func(rs ...*Repo) ReposAssertion {
-		want := Repos(rs)
-		want.Apply(Opt.RepoID(0))
+		want := Repos(rs).With(Opt.RepoID(0))
 		return func(t testing.TB, have Repos) {
 			t.Helper()
 			have.Apply(Opt.RepoID(0)) // Exclude auto-generated IDs from equality tests
@@ -268,8 +281,7 @@ var Assert = struct {
 		}
 	},
 	ExternalServicesEqual: func(es ...*ExternalService) ExternalServicesAssertion {
-		want := append(ExternalServices{}, es...)
-		want.Apply(Opt.ExternalServiceID(0))
+		want := append(ExternalServices{}, es...).With(Opt.ExternalServiceID(0))
 		return func(t testing.TB, have ExternalServices) {
 			t.Helper()
 			have = append(ExternalServices{}, have...)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -170,12 +170,15 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 
 	if s.Store != nil && s.Syncer != nil {
 		fns = append(fns, getfn{"SYNCER", func(ctx context.Context, args protocol.RepoLookupArgs) (*protocol.RepoInfo, bool, error) {
-			repo, err := s.Store.GetRepoByName(ctx, string(args.Repo))
-			if err != nil {
+			repos, err := s.Store.ListRepos(ctx, repos.StoreListReposArgs{
+				Names: []string{string(args.Repo)},
+			})
+
+			if err != nil || len(repos) != 1 || repos[0].IsDeleted() {
 				return nil, false, err
 			}
 
-			info, err := newRepoInfo(repo)
+			info, err := newRepoInfo(repos[0])
 			if err != nil {
 				return nil, false, err
 			}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -320,12 +321,13 @@ func TestRepoLookup_syncer(t *testing.T) {
 	}
 
 	t.Run("not found", func(t *testing.T) {
-		result, err := s.repoLookup(ctx, protocol.RepoLookupArgs{Repo: "github.com/a/b"})
+		have, err := s.repoLookup(ctx, protocol.RepoLookupArgs{Repo: "github.com/a/b"})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want := (&protocol.RepoLookupResult{ErrorNotFound: true}); !reflect.DeepEqual(result, want) {
-			t.Errorf("got result %+v, want nil", result)
+		want := &protocol.RepoLookupResult{ErrorNotFound: true}
+		if !reflect.DeepEqual(have, want) {
+			t.Error(cmp.Diff(have, want))
 		}
 	})
 


### PR DESCRIPTION
This change set makes our Store ListXXX methods take in a query arguments struct. This allows us to make these methods more flexible and get rid of `GetXXXByYYY` type methods, which would only polute the interface.

This is a pre-cursor to solving #3162.

Part of #2025.