### PR TITLE
Extension API: add token type provider

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -958,6 +958,25 @@ declare module 'sourcegraph' {
         provideLocations(document: TextDocument, position: Position): ProviderResult<Location[]>
     }
 
+    /**
+     * The type of a token. TODO
+     */
+    export type TokenType = 'whitespace' | 'comment' | 'punctuation' | 'identifier' | 'string'
+
+    /**
+     * A toke type provider.
+     */
+    export interface TokenTypeProvider {
+        /**
+         * Provide the token type of the symbol at the given position and document. TODO
+         *
+         * @param document The document in which the command was invoked.
+         * @param position The position at which the command was invoked.
+         * @return The type of the token.
+         */
+        provideTokenType(document: TextDocument, position: Position): Promise<TokenType>
+    }
+
     export namespace languages {
         /**
          * Registers a hover provider, which returns a formatted hover message (intended for display in a tooltip)
@@ -1023,6 +1042,18 @@ declare module 'sourcegraph' {
             id: string,
             selector: DocumentSelector,
             provider: LocationProvider
+        ): Unsubscribable
+
+        /**
+         * Registers a toke type provider. TODO
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider A toke type provider.
+         * @return An unsubscribable to unregister this provider.
+         */
+        export function registerTokenTypeProvider(
+            selector: DocumentSelector,
+            provider: TokenTypeProvider
         ): Unsubscribable
     }
 

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -132,7 +132,8 @@ export async function createExtensionHostClientConnection(
         services.textDocumentHover,
         services.textDocumentDefinition,
         services.textDocumentReferences,
-        services.textDocumentLocations
+        services.textDocumentLocations,
+        services.textDocumentTokenTypes
     )
     const clientSearch = new ClientSearch(services.queryTransformer)
     const clientCommands = new ClientCommands(services.commands)

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -11,6 +11,7 @@ import { createModelService } from './services/modelService'
 import { NotificationsService } from './services/notifications'
 import { QueryTransformerRegistry } from './services/queryTransformer'
 import { createSettingsService } from './services/settings'
+import { TextDocumentTokenTypeProviderRegistry } from './services/tokenType'
 import { ViewProviderRegistry } from './services/view'
 
 /**
@@ -39,6 +40,7 @@ export class Services {
     public readonly textDocumentDefinition = new TextDocumentLocationProviderRegistry()
     public readonly textDocumentReferences = new TextDocumentLocationProviderRegistry<ReferenceParams>()
     public readonly textDocumentLocations = new TextDocumentLocationProviderIDRegistry()
+    public readonly textDocumentTokenTypes = new TextDocumentTokenTypeProviderRegistry()
     public readonly textDocumentHover = new TextDocumentHoverProviderRegistry()
     public readonly textDocumentDecoration = new TextDocumentDecorationProviderRegistry()
     public readonly queryTransformer = new QueryTransformerRegistry()

--- a/shared/src/api/client/services/tokenType.ts
+++ b/shared/src/api/client/services/tokenType.ts
@@ -1,0 +1,10 @@
+import { TokenType } from 'sourcegraph'
+import { TextDocumentPositionParams } from '../../protocol'
+import { DocumentFeatureProviderRegistry } from './registry'
+
+/**
+ * TODO
+ */
+export class TextDocumentTokenTypeProviderRegistry extends DocumentFeatureProviderRegistry<
+    (params: TextDocumentPositionParams) => Promise<TokenType>
+> {}

--- a/shared/src/api/extension/api/languageFeatures.ts
+++ b/shared/src/api/extension/api/languageFeatures.ts
@@ -8,6 +8,7 @@ import {
     Location,
     LocationProvider,
     ReferenceProvider,
+    TokenTypeProvider,
 } from 'sourcegraph'
 import { ClientLanguageFeaturesAPI } from '../../client/api/languageFeatures'
 import { ReferenceParams, TextDocumentPositionParams } from '../../protocol'
@@ -74,6 +75,17 @@ export class ExtLanguageFeatures {
             )
         )
         return syncSubscription(this.proxy.$registerLocationProvider(idStr, selector, proxyValue(providerFunction)))
+    }
+
+    public registerTokenTypeProvider(selector: DocumentSelector, provider: TokenTypeProvider): Unsubscribable {
+        return syncSubscription(
+            this.proxy.$registerTokenTypeProvider(
+                selector,
+                proxyValue(async ({ textDocument, position }: TextDocumentPositionParams) =>
+                    provider.provideTokenType(await this.documents.getSync(textDocument.uri), toPosition(position))
+                )
+            )
+        )
     }
 }
 

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -240,6 +240,11 @@ function createExtensionAPI(
                 selector: sourcegraph.DocumentSelector,
                 provider: sourcegraph.LocationProvider
             ) => languageFeatures.registerLocationProvider(id, selector, provider),
+
+            registerTokenTypeProvider: (
+                selector: sourcegraph.DocumentSelector,
+                provider: sourcegraph.TokenTypeProvider
+            ) => languageFeatures.registerTokenTypeProvider(selector, provider),
         },
 
         search: {


### PR DESCRIPTION
Prior to this change, hover tooltips (specifically the "Find references" button) would be shown even on comments, whitespace, etc. There was no way for extensions to prevent that from happening.

After this change, there will be a token type provider in the extension API that can be used to prevent hover tooltips from showing up on comments, whitespace, etc. Here's how you will be able to use it:

```typescript
        const identifier: sourcegraph.TokenType = 'identifier'
        const whitespace: sourcegraph.TokenType = 'whitespace'

        ctx.subscriptions.add(
            sourcegraph.languages.registerTokenTypeProvider(
                [{ pattern: '*.go' }],
                {
                    provideTokenType: (doc, pos) => {
                        // toy example: returns identifier on even lines and whitespace on odd
                        return Promise.resolve(pos.line % 2 === 0 ? identifier : whitespace)
                    },
                }
            )
        )
```

Test plan:

- Sideload an extension that registers a token type provider that emits `identifier` on even lines and `whitespace` on odd lines, make sure hover tooltips show up on even lines and not on odd lines
- Make sure existing extensions still show hover tooltips even though they haven't registered a token type provider

Previous implementation attempt https://github.com/sourcegraph/sourcegraph/pull/3188

TODO

- [ ] Add proper docstrings
- [ ] Add tests