### PR TITLE
Add PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
+++ b/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
@@ -13,6 +13,7 @@ assignees: felixfbecker,lguychard
 
 - [ ] GitHub
 - [ ] GitHub Enterprise
+- [ ] Refined GitHub
 - [ ] Phabricator
 - [ ] Phabricator integration
 - [ ] Bitbucket

--- a/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
+++ b/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
@@ -1,0 +1,24 @@
+---
+name: Browser extension
+about: A change to the Sourcegraph browser extension
+title: ''
+labels: browser-extension
+assignees: felixfbecker,lguychard
+---
+
+
+#### Test Plan
+
+##### Code Hosts
+
+- [ ] GitHub
+- [ ] GitHub Enterprise
+- [ ] Phabricator
+- [ ] Phabricator integration
+- [ ] Bitbucket
+- [ ] Gitlab
+
+##### Browsers
+
+- [ ] Chrome
+- [ ] Firefox

--- a/.github/PULL_REQUEST_TEMPLATE/other.md
+++ b/.github/PULL_REQUEST_TEMPLATE/other.md
@@ -1,0 +1,7 @@
+---
+name: Other
+about: A change to documentation, tooling etc.
+title: ''
+labels: ''
+assignees: ''
+---

--- a/.github/PULL_REQUEST_TEMPLATE/sourcegraph.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sourcegraph.md
@@ -1,0 +1,11 @@
+---
+name: Sourcegraph web app and server
+about: A change to the Sourcegraph web app or the backend
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!-- Reminder: Have you updated the changelog? -->
+
+Test plan: <!-- Required: What is the test plan for this change? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-
-
-
-<!-- Reminder: Have you updated the changelog? -->
-
-Test plan: <!-- Required: What is the test plan for this change? -->


### PR DESCRIPTION
#3166 happened because both Loic and I forgot to test on Firefox.
In addition, for every browser extension PR I manually type a checklist to enumerate testing for all code hosts.
In the browser extension repo we used to have a PR template to remind of this and save typing.

This adds back such a template.
Upon opening a PR, we will be able to choose which PR template to chose.
I added
- one for the browser extension
- one for the current template with the changelog reminder and test plan
- one for everything else that does not need changelog/testing (docs, tooling, ...)