### PR TITLE
Refactor inject.tsx

### DIFF
--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -85,7 +85,7 @@ async function main(): Promise<void> {
     // Add a marker to the DOM that the extension is loaded
     injectSourcegraphApp(extensionMarker)
 
-    // For the life time of the contetn script, add features in reaction to DOM changes
+    // For the life time of the content script, add features in reaction to DOM changes
     if (codeHost) {
         console.log('Detected code host', codeHost.name)
         subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost))

--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -2,23 +2,22 @@ import '../../config/polyfill'
 
 import * as H from 'history'
 import React from 'react'
-import { Observable } from 'rxjs'
+import { Observable, Subscription } from 'rxjs'
 import { startWith } from 'rxjs/operators'
 import { setLinkComponent } from '../../../../../shared/src/components/Link'
 import { getURL } from '../../browser/extension'
 import storage from '../../browser/storage'
 import { StorageItems } from '../../browser/types'
-import { checkIsBitbucket } from '../../libs/bitbucket/code_intelligence'
-import { injectCodeIntelligence } from '../../libs/code_intelligence'
-import { checkIsGitHub, checkIsGitHubEnterprise } from '../../libs/github/code_intelligence'
-import { checkIsGitlab } from '../../libs/gitlab/code_intelligence'
-import { checkIsPhabricator } from '../../libs/phabricator/code_intelligence'
+import { determineCodeHost as detectCodeHost, injectCodeIntelligenceToCodeHost } from '../../libs/code_intelligence'
 import { initSentry } from '../../libs/sentry'
-import { injectSourcegraphApp } from '../../libs/sourcegraph/inject'
+import { checkIsSourcegraph, injectSourcegraphApp } from '../../libs/sourcegraph/inject'
 import { setSourcegraphUrl } from '../../shared/util/context'
 import { MutationRecordLike, observeMutations } from '../../shared/util/dom'
 import { featureFlags } from '../../shared/util/featureFlags'
 import { assertEnv } from '../envAssertion'
+
+const subscriptions = new Subscription()
+window.addEventListener('unload', () => subscriptions.unsubscribe(), { once: true })
 
 assertEnv('CONTENT')
 
@@ -33,14 +32,18 @@ setLinkComponent(({ to, children, ...props }) => (
 /**
  * Main entry point into browser extension.
  */
-function observe(): void {
+async function main(): Promise<void> {
     console.log('Sourcegraph browser extension is running')
 
-    const mutations: Observable<MutationRecordLike[]> = observeMutations(document.body, {
-        childList: true,
-        subtree: true,
-    }).pipe(startWith([{ addedNodes: [document.body], removedNodes: [] }]))
+    // Make sure DOM is fully loaded
+    if (document.readyState !== 'complete' && document.readyState !== 'interactive') {
+        await new Promise<Event>(resolve => document.addEventListener('DOMContentLoaded', resolve, { once: true }))
+    }
 
+    // Allow users to set this via the console.
+    ;(window as any).sourcegraphFeatureFlags = featureFlags
+
+    // This is checked for in the webapp
     const extensionMarker = document.createElement('div')
     extensionMarker.id = 'sourcegraph-app-background'
     extensionMarker.style.display = 'none'
@@ -48,53 +51,45 @@ function observe(): void {
         return
     }
 
-    const handleGetStorage = async (items: StorageItems) => {
-        if (items.disableExtension) {
-            return
-        }
+    const mutations: Observable<MutationRecordLike[]> = observeMutations(document.body, {
+        childList: true,
+        subtree: true,
+    }).pipe(startWith([{ addedNodes: [document.body], removedNodes: [] }]))
 
-        const srcgEl = document.getElementById('sourcegraph-chrome-webstore-item')
-        const sourcegraphServerUrl = items.sourcegraphURL || 'https://sourcegraph.com'
-        const isSourcegraphServer = window.location.origin === sourcegraphServerUrl || !!srcgEl
-
-        const isPhabricator = await checkIsPhabricator()
-        const isGitHub = checkIsGitHub()
-        const isGitHubEnterprise = checkIsGitHubEnterprise()
-        const isBitbucket = checkIsBitbucket()
-        const isGitlab = checkIsGitlab()
-
-        if (!isSourcegraphServer && !document.getElementById('ext-style-sheet')) {
-            if (isPhabricator || isGitHub || isGitHubEnterprise || isBitbucket || isGitlab) {
-                const styleSheet = document.createElement('link')
-                styleSheet.id = 'ext-style-sheet'
-                styleSheet.rel = 'stylesheet'
-                styleSheet.type = 'text/css'
-                styleSheet.href = getURL('css/style.bundle.css')
-                document.head.appendChild(styleSheet)
-            }
-        }
-
-        injectSourcegraphApp(extensionMarker)
-        setSourcegraphUrl(sourcegraphServerUrl)
-
-        if (isGitHub || isGitHubEnterprise || isPhabricator || isGitlab || isBitbucket) {
-            const subscriptions = await injectCodeIntelligence(mutations)
-            window.addEventListener('unload', () => subscriptions.unsubscribe())
-        }
+    const items = await new Promise<StorageItems>(resolve => storage.getSync(resolve))
+    if (items.disableExtension) {
+        return
     }
 
-    storage.getSync(handleGetStorage)
+    const sourcegraphServerUrl = items.sourcegraphURL || 'https://sourcegraph.com'
+    setSourcegraphUrl(sourcegraphServerUrl)
 
-    document.addEventListener('sourcegraph:storage-init', () => {
-        storage.getSync(handleGetStorage)
-    })
-    // Allow users to set this via the console.
-    ;(window as any).sourcegraphFeatureFlags = featureFlags
+    const isSourcegraphServer = checkIsSourcegraph(sourcegraphServerUrl)
+
+    // Check which code host we are on
+    const codeHost = detectCodeHost()
+    if (!codeHost && !isSourcegraphServer) {
+        return
+    }
+
+    // Add style sheet
+    if (!isSourcegraphServer && !document.getElementById('ext-style-sheet')) {
+        const styleSheet = document.createElement('link')
+        styleSheet.id = 'ext-style-sheet'
+        styleSheet.rel = 'stylesheet'
+        styleSheet.type = 'text/css'
+        styleSheet.href = getURL('css/style.bundle.css')
+        document.head.appendChild(styleSheet)
+    }
+
+    // Add a marker to the DOM that the extension is loaded
+    injectSourcegraphApp(extensionMarker)
+
+    // For the life time of the contetn script, add features in reaction to DOM changes
+    if (codeHost) {
+        console.log('Detected code host', codeHost.name)
+        subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost))
+    }
 }
 
-if (document.readyState === 'complete' || document.readyState === 'interactive') {
-    // document is already ready to go
-    observe()
-} else {
-    document.addEventListener('DOMContentLoaded', observe)
-}
+main().catch(console.error.bind(console))

--- a/client/browser/src/libs/phabricator/code_intelligence.ts
+++ b/client/browser/src/libs/phabricator/code_intelligence.ts
@@ -4,7 +4,6 @@ import { of } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { convertSpacesToTabs, spacesToTabsAdjustment } from '.'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
-import storage from '../../browser/storage'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { CodeHost, CodeViewSpec, CodeViewSpecResolver, CodeViewSpecWithOutSelector } from '../code_intelligence'
 import { diffDomFunctions, diffusionDOMFns } from './dom_functions'
@@ -163,15 +162,7 @@ const phabCodeViews: CodeViewSpec[] = [
     },
 ]
 
-export function checkIsPhabricator(): Promise<boolean> {
-    if (document.querySelector('.phabricator-wordmark')) {
-        return Promise.resolve(true)
-    }
-
-    return new Promise<boolean>(resolve =>
-        storage.getSync(items => resolve(!!items.enterpriseUrls.find(url => url === window.location.origin)))
-    )
-}
+export const checkIsPhabricator = () => !!document.querySelector('.phabricator-wordmark')
 
 export const phabricatorCodeHost: CodeHost = {
     codeViewSpecs: phabCodeViews,

--- a/client/browser/src/libs/phabricator/extension.tsx
+++ b/client/browser/src/libs/phabricator/extension.tsx
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs'
 import { startWith } from 'rxjs/operators'
 import { setSourcegraphUrl } from '../../shared/util/context'
 import { MutationRecordLike, observeMutations } from '../../shared/util/dom'
-import { injectCodeIntelligence } from '../code_intelligence'
+import { determineCodeHost, injectCodeIntelligenceToCodeHost } from '../code_intelligence'
 import { getPhabricatorCSS, getSourcegraphURLFromConduit } from './backend'
 import { metaClickOverride } from './util'
 
@@ -27,7 +27,10 @@ async function injectModules(): Promise<void> {
     }).pipe(startWith([{ addedNodes: [document.body], removedNodes: [] }]))
 
     // TODO handle subscription
-    await injectCodeIntelligence(mutations)
+    const codeHost = await determineCodeHost()
+    if (codeHost) {
+        await injectCodeIntelligenceToCodeHost(mutations, codeHost)
+    }
 }
 
 function init(): void {

--- a/client/browser/src/libs/sourcegraph/inject.tsx
+++ b/client/browser/src/libs/sourcegraph/inject.tsx
@@ -18,3 +18,8 @@ function dispatchSourcegraphEvents(): void {
     // Send custom webapp <-> extension registration event in case webapp listener is attached first.
     document.dispatchEvent(new CustomEvent<{}>('sourcegraph:browser-extension-registration'))
 }
+
+export const checkIsSourcegraph = (sourcegraphServerUrl: string): boolean =>
+    window.location.origin === sourcegraphServerUrl ||
+    /^https?:\/\/(www.)?sourcegraph.com/.test(location.href) ||
+    !!document.getElementById('sourcegraph-chrome-webstore-item')


### PR DESCRIPTION
Refactors inject.tsx.
- Use async/await instead of callbacks and events
- Remove the `sourcegraph:storage-init` event, it used to be fired in Safari but that code doesn't exist anymore.
- Remove all the `is*` checks in favor of a function `determineCodeHost`
- Always call `setSourcegraphUrl` for all code hosts
- Always add the extension marker
- ⚠️ Do not make `isPhabricator` check depend on `storageItems.enterpriseUrls`. I can't imagine how Phabricator could not have the HTML element that is checked for, and if it doesn't, it seems wrong to report any URL that is in `enterpriseUrls` as Phabricator (@KattMingMing [indicated that it can contain GHE URLs](https://sourcegraph.slack.com/archives/C07KZF47K/p1554420623083300?thread_ts=1554420206.079000&cid=C07KZF47K))
- This allows making `CodeHost.check()` sync again
- Do not assign `window.SOURCEGRAPH_PHABRICATOR_EXTENSION` in the bext inject.tsx, instead in the Phabricator integration entry point. The reference to it from `getPlatformContext()` indicate that it is intended to mean that (this is only used for titles and user agent strings though, nothing critical).


#### Test Plan

##### Code Hosts

- [x] GitHub
- [ ] GitHub Enterprise
- [x] Phabricator
- [ ] Phabricator integration
- [x] Bitbucket
- [ ] Gitlab

##### Browsers

- [x] Chrome
- [ ] Firefox
