### PR TITLE
Follow up to styling refactor

### DIFF
--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -204,7 +204,7 @@ export const bitbucketServerCodeHost: CodeHost = {
     },
     hoverOverlayClassProps: {
         actionItemClassName: 'aui-button hover-action-item--bitbucket-server',
-        actionItemPressedClassName: 'aui-button-primary',
+        closeButtonClassName: 'aui-button',
     },
     getViewContextOnSourcegraphMount,
     getContext,

--- a/client/browser/src/libs/bitbucket/style.scss
+++ b/client/browser/src/libs/bitbucket/style.scss
@@ -16,4 +16,11 @@
 // Hover overlay buttons
 .hover-action-item--bitbucket-server {
     margin: 0 !important;
+    border-radius: 0 !important;
+    border-bottom: none !important;
+    border-top: none !important;
+    border-right: none !important;
+    &:first-child {
+        border-left: none !important;
+    }
 }

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -33,7 +33,7 @@ import { CommandListClassProps } from '../../../../../shared/src/commandPalette/
 import { Controller } from '../../../../../shared/src/extensions/controller'
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
 import { getHoverActions, registerHoverContributions } from '../../../../../shared/src/hover/actions'
-import { HoverContext, HoverOverlay, HoverOverlayProps } from '../../../../../shared/src/hover/HoverOverlay'
+import { HoverContext, HoverOverlay, HoverOverlayClassProps } from '../../../../../shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '../../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
@@ -179,7 +179,7 @@ export interface CodeHost {
     /**
      * CSS classes for ActionItem buttons in the hover overlay to customize styling
      */
-    hoverOverlayClassProps?: Pick<HoverOverlayProps, 'actionItemClassName' | 'actionItemPressedClassName'>
+    hoverOverlayClassProps?: HoverOverlayClassProps
 
     /**
      * The list of types of code views to try to annotate.
@@ -695,12 +695,7 @@ export function handleCodeHost({
                             telemetryService={NOOP_TELEMETRY_SERVICE}
                             platformContext={platformContext}
                             extensionsController={extensionsController}
-                            buttonProps={
-                                toolbarButtonProps || {
-                                    className: '',
-                                    style: {},
-                                }
-                            }
+                            buttonProps={toolbarButtonProps}
                             location={H.createLocation(window.location)}
                         />,
                         mount

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -258,6 +258,7 @@ export const githubCodeHost: CodeHost = {
     hoverOverlayClassProps: {
         actionItemClassName: 'btn btn-secondary',
         actionItemPressedClassName: 'active',
+        closeButtonClassName: 'btn',
     },
     urlToFile: (
         location: RepoSpec & RevSpec & FileSpec & Partial<PositionSpec> & Partial<ViewStateSpec> & { part?: DiffPart }

--- a/client/browser/src/libs/gitlab/code_intelligence.ts
+++ b/client/browser/src/libs/gitlab/code_intelligence.ts
@@ -106,5 +106,6 @@ export const gitlabCodeHost: CodeHost = {
     hoverOverlayClassProps: {
         actionItemClassName: 'btn btn-secondary action-item--gitlab',
         actionItemPressedClassName: 'active',
+        closeButtonClassName: 'btn',
     },
 }

--- a/client/browser/src/libs/phabricator/code_intelligence.ts
+++ b/client/browser/src/libs/phabricator/code_intelligence.ts
@@ -78,8 +78,6 @@ const adjustPosition: PositionAdjuster<RepoSpec & RevSpec & FileSpec & ResolvedR
 
 const toolbarButtonProps = {
     className: 'button grey button-grey has-icon has-text phui-button-default msl',
-    iconStyle: { marginTop: '-1px', paddingRight: '4px', fontSize: '18px', height: '.8em', width: '.8em' },
-    style: {},
 }
 const commitCodeView: CodeViewSpecWithOutSelector = {
     dom: diffDomFunctions,

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -17,8 +17,6 @@ import { OpenOnSourcegraph } from './OpenOnSourcegraph'
 
 export interface ButtonProps {
     className?: string
-    style?: React.CSSProperties
-    iconStyle?: React.CSSProperties
 }
 
 export interface CodeViewToolbarClassProps extends ActionNavItemsClassProps {

--- a/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
@@ -9,8 +9,6 @@ import { SourcegraphIconButton } from './Button'
 
 interface Props {
     openProps: OpenDiffInSourcegraphProps
-    style?: React.CSSProperties
-    iconStyle?: React.CSSProperties
     className?: string
     iconClassName?: string
     ariaLabel?: string

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -24,12 +24,6 @@
         border: none;
         opacity: 0;
         transition: opacity $animation-duration ease-in-out;
-        &:focus {
-            outline: none; // override GitHub style
-        }
-        &:active {
-            box-shadow: none; // override GitHub style
-        }
     }
     &:hover &__close-button {
         opacity: 1;

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -24,18 +24,22 @@ export type HoverContext = RepoSpec & RevSpec & FileSpec & ResolvedRevSpec
 
 export type HoverData = HoverMerged
 
-export interface HoverOverlayProps
-    extends GenericHoverOverlayProps<HoverContext, HoverData, ActionItemAction>,
-        ActionItemComponentProps,
-        TelemetryProps {
-    /** A ref callback to get the root overlay element. Use this to calculate the position. */
-    hoverRef?: React.Ref<HTMLDivElement>
-
+export interface HoverOverlayClassProps {
     /** An optional class name to apply to the outermost element of the HoverOverlay */
     className?: string
+    closeButtonClassName?: string
 
     actionItemClassName?: string
     actionItemPressedClassName?: string
+}
+
+export interface HoverOverlayProps
+    extends GenericHoverOverlayProps<HoverContext, HoverData, ActionItemAction>,
+        ActionItemComponentProps,
+        HoverOverlayClassProps,
+        TelemetryProps {
+    /** A ref callback to get the root overlay element. Use this to calculate the position. */
+    hoverRef?: React.Ref<HTMLDivElement>
 
     /** Called when the close button is clicked */
     onCloseButtonClick?: (event: MouseEvent) => void
@@ -103,7 +107,7 @@ export class HoverOverlay extends React.PureComponent<HoverOverlayProps> {
             >
                 {showCloseButton && (
                     <button
-                        className="hover-overlay__close-button btn btn-icon"
+                        className={classNames('hover-overlay__close-button', this.props.closeButtonClassName)}
                         onClick={onCloseButtonClick ? transformMouseEvent(onCloseButtonClick) : undefined}
                     >
                         <CloseIcon className="icon-inline" />

--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -7,7 +7,7 @@ import { HoverOverlay, HoverOverlayProps } from '../../../shared/src/hover/Hover
 // Components from shared with web-styling class names applied
 
 export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps> = props => (
-    <HoverOverlay actionItemClassName="btn btn-secondary" {...props} />
+    <HoverOverlay closeButtonClassName="btn btn-icon" actionItemClassName="btn btn-secondary" {...props} />
 )
 WebHoverOverlay.displayName = 'WebHoverOverlay'
 


### PR DESCRIPTION
Remove a few more inline styles, improve the close button per code host and the Bitbucket HoverOverlay buttons.

Tested on all code hosts.
