### PR TITLE
repo-updater: Integrate exclude repos server endpoint

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -260,7 +260,7 @@ func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct 
 	// the enabled state regardless.
 	var done bool
 	if !args.Enabled {
-		resp, err := repoupdater.DefaultClient.ExcludeRepos(ctx, uint32(repo.repo.ID))
+		resp, err := repoupdater.DefaultClient.ExcludeRepo(ctx, uint32(repo.repo.ID))
 		if err != nil {
 			return nil, errors.Wrapf(err, "repo-updater.exclude-repos")
 		}

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -159,6 +159,7 @@ func main() {
 
 	// Start up handler that frontend relies on
 	repoupdater := repoupdater.Server{
+		Kinds:            kinds,
 		Store:            store,
 		Syncer:           syncer,
 		OtherReposSyncer: otherSyncer,

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -26,6 +26,9 @@ type Store interface {
 
 // StoreListReposArgs is a query arguments type used by
 // the ListRepos method of Store implementations.
+//
+// Each defined argument must map to a disjunct (i.e. AND) filter predicate.
+// When zero-valued, an argument is ommited from the predicate set.
 type StoreListReposArgs struct {
 	// Names of repos to list.
 	Names []string

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -529,6 +529,16 @@ func (r *Repo) CloneURLs() []string {
 	return urls
 }
 
+// ExternalServiceIDs returns the IDs of the external services this
+// repo belongs to.
+func (r *Repo) ExternalServiceIDs() []int64 {
+	ids := make([]int64, 0, len(r.Sources))
+	for _, src := range r.Sources {
+		ids = append(ids, src.ExternalServiceID())
+	}
+	return ids
+}
+
 // IsDeleted returns true if the repo is deleted.
 func (r *Repo) IsDeleted() bool { return !r.DeletedAt.IsZero() }
 
@@ -609,6 +619,28 @@ func (rs Repos) Names() []string {
 		names[i] = rs[i].Name
 	}
 	return names
+}
+
+// IDs returns the list of ids from all Repos.
+func (rs Repos) IDs() []uint32 {
+	ids := make([]uint32, len(rs))
+	for i := range rs {
+		ids[i] = rs[i].ID
+	}
+	return ids
+}
+
+// Kinds returns the unique set of kinds from all Repos.
+func (rs Repos) Kinds() (kinds []string) {
+	set := map[string]bool{}
+	for _, r := range rs {
+		kind := strings.ToUpper(r.ExternalRepo.ServiceType)
+		if !set[kind] {
+			kinds = append(kinds, kind)
+			set[kind] = true
+		}
+	}
+	return kinds
 }
 
 func (rs Repos) Len() int {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -138,8 +138,11 @@ func respond(w http.ResponseWriter, code int, v interface{}) {
 			respond(w, http.StatusInternalServerError, err)
 			return
 		}
+
 		w.WriteHeader(code)
-		w.Write(bs)
+		if _, err = w.Write(bs); err != nil {
+			log15.Error("failed to write response", "error", err)
+		}
 	}
 }
 

--- a/pkg/repoupdater/client.go
+++ b/pkg/repoupdater/client.go
@@ -189,15 +189,15 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 	return &result, nil
 }
 
-// ExcludeRepos adds the repositories with the given ids to all of their respective
-// external services exclude lists.
-func (c *Client) ExcludeRepos(ctx context.Context, ids ...uint32) (*protocol.ExcludeReposResponse, error) {
-	if len(ids) == 0 {
-		return &protocol.ExcludeReposResponse{}, nil
+// ExcludeRepo adds the repository with the given id to all of the
+// external services exclude lists that match its kind.
+func (c *Client) ExcludeRepo(ctx context.Context, id uint32) (*protocol.ExcludeRepoResponse, error) {
+	if id == 0 {
+		return &protocol.ExcludeRepoResponse{}, nil
 	}
 
-	req := protocol.ExcludeReposRequest{IDs: ids}
-	resp, err := c.httpPost(ctx, "exclude-repos", &req)
+	req := protocol.ExcludeRepoRequest{ID: id}
+	resp, err := c.httpPost(ctx, "exclude-repo", &req)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (c *Client) ExcludeRepos(ctx context.Context, ids ...uint32) (*protocol.Exc
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
 
-	var res protocol.ExcludeReposResponse
+	var res protocol.ExcludeRepoResponse
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return nil, errors.New(string(bs))
 	} else if err = json.Unmarshal(bs, &res); err != nil {

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -31,15 +31,15 @@ type RepoQueueState struct {
 	Updating bool
 }
 
-// ExcludeReposRequest is a request to exclude a list of repos from
-// being mirrored from any of their external services.
-type ExcludeReposRequest struct {
-	// IDs of the repositories to be excluded.
-	IDs []uint32
+// ExcludeRepoRequest is a request to exclude a single repo from
+// being mirrored from any external service of its kind.
+type ExcludeRepoRequest struct {
+	// ID of the repository to be excluded.
+	ID uint32
 }
 
-// ExcludeReposResponse is returned in response to an ExcludeReposRequest.
-type ExcludeReposResponse struct {
+// ExcludeRepoResponse is returned in response to an ExcludeRepoRequest.
+type ExcludeRepoResponse struct {
 	ExternalServices []api.ExternalService
 }
 

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -31,6 +31,18 @@ type RepoQueueState struct {
 	Updating bool
 }
 
+// ExcludeReposRequest is a request to exclude a list of repos from
+// being mirrored from any of their external services.
+type ExcludeReposRequest struct {
+	// IDs of the repositories to be excluded.
+	IDs []uint32
+}
+
+// ExcludeReposResponse is returned in response to an ExcludeReposRequest.
+type ExcludeReposResponse struct {
+	ExternalServices []api.ExternalService
+}
+
 // RepoLookupArgs is a request for information about a repository on repoupdater.
 //
 // Exactly one of Repo and ExternalRepo should be set.


### PR DESCRIPTION
This commit implements an endpoint in repo-updater which updates the
configuration of all external services of a repo's kind to exclude that
repo from being synced.

The graphql mutatation resolver for `setRepositoryEnabled` is changed to call this
endpoint appropriately.

Part of #2025
Fixes #3162
