### PR TITLE
correct opsgenie command for one-off alerts

### DIFF
--- a/doc/dev/incidents.md
+++ b/doc/dev/incidents.md
@@ -39,7 +39,7 @@ The goal of triage is to either quickly resolve the incident using basic procedu
     - The person who owns the affected product/code/system.
     - The on-call engineer.
         - You can find out who is on-call by typing `/genie whoisoncall` in Slack.
-        - If you are not able to immediately get in contact with the on-call engineer, then manually create a new OpsGenie alert by typing `/genie alert <description of incident and link to Slack thread> for ops_team`.
+        - If you are not able to immediately get in contact with the on-call engineer, then manually create a new OpsGenie alert by typing `/genie alert "description of incident and link to Slack thread" for ops_team`.
 
 ## Go-to-market (license and subscription) issues
 

--- a/doc/dev/incidents.md
+++ b/doc/dev/incidents.md
@@ -39,7 +39,7 @@ The goal of triage is to either quickly resolve the incident using basic procedu
     - The person who owns the affected product/code/system.
     - The on-call engineer.
         - You can find out who is on-call by typing `/genie whoisoncall` in Slack.
-        - If you are not able to immediately get in contact with the on-call engineer, then manually create a new OpsGenie alert by typing `/genie <description of incident and link to Slack thread> with ops_team`.
+        - If you are not able to immediately get in contact with the on-call engineer, then manually create a new OpsGenie alert by typing `/genie alert <description of incident and link to Slack thread> for ops_team`.
 
 ## Go-to-market (license and subscription) issues
 


### PR DESCRIPTION
Fixes the opsgenie command to ping on call engineer with one-off alerts.

- https://sourcegraph.slack.com/archives/C0J618TTM/p1554482438002800?thread_ts=1554482000.001900&cid=C0J618TTM
- https://sourcegraph.slack.com/archives/C08JA8Q1H/p1554481628055700