### PR TITLE
consistently use view component type "CodeEditor" not "textEditor"

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -212,7 +212,7 @@ describe('handleCodeHost()', () => {
                     uri: 'git://foo?1#/bar.ts',
                 },
                 selections: [],
-                type: 'textEditor',
+                type: 'CodeEditor',
             },
         ])
         expect(codeView.classList.contains('sg-mounted')).toBe(true)

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -587,7 +587,7 @@ export function handleCodeHost({
                     subscriptions: new Subscription(),
                     visibleViewComponents: [
                         {
-                            type: 'textEditor' as const,
+                            type: 'CodeEditor' as const,
                             item: {
                                 uri: toURIWithPath(fileInfo),
                                 languageId: getModeFromPath(fileInfo.filePath) || 'could not determine mode',
@@ -604,7 +604,7 @@ export function handleCodeHost({
                 // When codeView is a diff (and not an added file), add BASE too.
                 if (fileInfo.baseContent && fileInfo.baseRepoName && fileInfo.baseCommitID && fileInfo.baseFilePath) {
                     codeViewState.visibleViewComponents.push({
-                        type: 'textEditor' as const,
+                        type: 'CodeEditor' as const,
                         item: {
                             uri: toURIWithPath({
                                 repoName: fileInfo.baseRepoName,

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -68,7 +68,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                     platformContext={this.props.platformContext}
                     location={this.props.location}
                     scope={{
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: {
                             uri: toURIWithPath(this.props),
                             languageId: getModeFromPath(this.props.filePath) || 'could not determine mode',

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -34,7 +34,7 @@ describe('getComputedContextProperty', () => {
             ...EMPTY_MODEL,
             visibleViewComponents: [
                 {
-                    type: 'textEditor',
+                    type: 'CodeEditor',
                     item: {
                         uri: 'file:///inactive',
                         languageId: 'inactive',
@@ -52,7 +52,7 @@ describe('getComputedContextProperty', () => {
                     isActive: false,
                 },
                 {
-                    type: 'textEditor',
+                    type: 'CodeEditor',
                     item: {
                         uri: 'file:///a/b.c',
                         languageId: 'l',
@@ -99,7 +99,7 @@ describe('getComputedContextProperty', () => {
         describe('component', () => {
             test('provides component.type', () =>
                 expect(getComputedContextProperty(model, EMPTY_SETTINGS_CASCADE, {}, 'component.type')).toBe(
-                    'textEditor'
+                    'CodeEditor'
                 ))
 
             test('returns null when the model has no component', () =>
@@ -176,7 +176,7 @@ describe('getComputedContextProperty', () => {
                     ...EMPTY_MODEL,
                     visibleViewComponents: [
                         {
-                            type: 'textEditor',
+                            type: 'CodeEditor',
                             item: {
                                 uri: 'file:///a/b.c',
                                 languageId: 'l',

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -70,7 +70,7 @@ export function getComputedContextProperty(
         return !!component
     }
     if (key.startsWith('resource.')) {
-        if (!component || component.type !== 'textEditor') {
+        if (!component || component.type !== 'CodeEditor') {
             return null
         }
         // TODO(sqs): Define these precisely. If the resource is in a repository, what is the "path"? Is it the
@@ -93,13 +93,13 @@ export function getComputedContextProperty(
         }
     }
     if (key.startsWith('component.')) {
-        if (!component || component.type !== 'textEditor') {
+        if (!component || component.type !== 'CodeEditor') {
             return null
         }
         const prop = key.slice('component.'.length)
         switch (prop) {
             case 'type':
-                return 'textEditor'
+                return 'CodeEditor'
             case 'selections':
                 return component.selections
             case 'selection':

--- a/shared/src/api/client/model.test.ts
+++ b/shared/src/api/client/model.test.ts
@@ -11,7 +11,7 @@ describe('modelToTextDocumentPositionParams', () => {
             modelToTextDocumentPositionParams({
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         isActive: false,
                         selections: [],
                         item: { uri: 'u', text: 't', languageId: 'l' },
@@ -26,7 +26,7 @@ describe('modelToTextDocumentPositionParams', () => {
             modelToTextDocumentPositionParams({
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         isActive: true,
                         selections: [],
                         item: { uri: 'u', text: 't', languageId: 'l' },
@@ -41,7 +41,7 @@ describe('modelToTextDocumentPositionParams', () => {
             modelToTextDocumentPositionParams({
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         isActive: true,
                         selections: [
                             {
@@ -64,7 +64,7 @@ describe('modelToTextDocumentPositionParams', () => {
             modelToTextDocumentPositionParams({
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         isActive: true,
                         selections: [
                             {

--- a/shared/src/api/client/model.ts
+++ b/shared/src/api/client/model.ts
@@ -5,12 +5,12 @@ import { TextDocumentPositionParams } from '../protocol'
 /**
  * Describes a view component.
  *
- * @todo Currently the only view component is CodeEditor ("textEditor" as exposed in the API), so this type just
+ * @todo Currently the only view component is CodeEditor ("CodeEditor" as exposed in the API), so this type just
  * describes a CodeEditor. When more view components exist, this type will need to become a union type or add in
  * some other similar abstraction to support describing all types of view components.
  */
 export interface ViewComponentData {
-    type: 'textEditor'
+    type: 'CodeEditor'
     item: TextDocument
     selections: Selection[]
     isActive: boolean

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -69,7 +69,7 @@ describe('activeExtensions', () => {
                             a: {
                                 visibleViewComponents: [
                                     {
-                                        type: 'textEditor',
+                                        type: 'CodeEditor',
                                         item: { languageId: 'x', text: '', uri: '' },
                                         selections: [],
                                         isActive: true,
@@ -79,7 +79,7 @@ describe('activeExtensions', () => {
                             b: {
                                 visibleViewComponents: [
                                     {
-                                        type: 'textEditor',
+                                        type: 'CodeEditor',
                                         item: { languageId: 'y', text: '', uri: '' },
                                         selections: [],
                                         isActive: true,

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -57,7 +57,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                         visibleViewComponents: [
                             {
                                 isActive: true,
-                                type: 'textEditor',
+                                type: 'CodeEditor',
                                 selections: [],
                                 item: { uri: 'u', languageId: 'l', text: 't' },
                             },
@@ -81,7 +81,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                         visibleViewComponents: [
                             {
                                 isActive: true,
-                                type: 'textEditor',
+                                type: 'CodeEditor',
                                 selections: [],
                                 item: { uri: 'u', languageId: 'l', text: 't' },
                             },

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -18,7 +18,7 @@ describe('Documents (integration)', () => {
                 ...model.value,
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
                         selections: [],
                         isActive: true,
@@ -46,7 +46,7 @@ describe('Documents (integration)', () => {
                 ...model.value,
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
                         selections: [],
                         isActive: true,

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -6,7 +6,7 @@ import { assertToJSON } from '../extension/types/testHelpers'
 import { collectSubscribableValues, integrationTestContext } from './testHelpers'
 
 const withSelections = (...selections: { start: number; end: number }[]): ViewComponentData => ({
-    type: 'textEditor',
+    type: 'CodeEditor',
     item: { uri: 'foo', languageId: 'l1', text: 't1' },
     selections: selections.map(({ start, end }) => ({
         start: {

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -15,7 +15,7 @@ const FIXTURE_MODEL: Model = {
     roots: [{ uri: 'file:///' }],
     visibleViewComponents: [
         {
-            type: 'textEditor',
+            type: 'CodeEditor',
             item: {
                 uri: 'file:///f',
                 languageId: 'l',

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -29,7 +29,7 @@ describe('Windows (integration)', () => {
                 ...model.value,
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: { uri: 'foo', languageId: 'l1', text: 't1' },
                         selections: [],
                         isActive: true,
@@ -44,7 +44,7 @@ describe('Windows (integration)', () => {
                 ...model.value,
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: { uri: 'bar', languageId: 'l2', text: 't2' },
                         selections: [],
                         isActive: true,
@@ -88,7 +88,7 @@ describe('Windows (integration)', () => {
                 ...model.value,
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
                         selections: [],
                         isActive: true,
@@ -120,7 +120,7 @@ describe('Windows (integration)', () => {
                 ...model.value,
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: {
                             uri: 'file:///inactive',
                             languageId: 'inactive',
@@ -155,7 +155,7 @@ describe('Windows (integration)', () => {
                 ...model.value,
                 visibleViewComponents: [
                     {
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: {
                             uri: 'file:///inactive',
                             languageId: 'inactive',

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -296,7 +296,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                     ...this.props.extensionsController.services.model.model.value,
                     visibleViewComponents: [
                         {
-                            type: 'textEditor' as const,
+                            type: 'CodeEditor' as const,
                             item: {
                                 uri: `git://${model.repoName}?${model.commitID}#${model.filePath}`,
                                 languageId: model.mode,

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -46,7 +46,7 @@ export class FileDiffConnection extends React.PureComponent<Props> {
             for (const fileDiff of fileDiffsOrError.nodes) {
                 if (fileDiff.oldPath) {
                     visibleViewComponents.push({
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: {
                             uri: `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`,
                             languageId: getModeFromPath(fileDiff.oldPath),
@@ -58,7 +58,7 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                 }
                 if (fileDiff.newPath) {
                     visibleViewComponents.push({
-                        type: 'textEditor',
+                        type: 'CodeEditor',
                         item: {
                             uri: `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`,
                             languageId: getModeFromPath(fileDiff.newPath),


### PR DESCRIPTION
In sourcegraph.d.ts, the `CodeEditor#type` value is `CodeEditor`, but in context expressions and in the impl, the `type` is `textEditor`. This commit updates everywhere to use `CodeEditor` for consistency.

TODO:

- [x] All extensions with context expressions using the expression `component.type` need to be updated to check for `"CodeEditor"` not `"textEditor"` (and should be backcompat with older Sourcegraph versions, so both values should be supported and treated identically).