### PR TITLE
refactor: rename codeViewElement -> element

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -423,7 +423,7 @@ export function initCodeIntelligence({
  */
 export interface ResolvedCodeView extends CodeViewSpecWithOutSelector {
     /** The code view DOM element. */
-    codeViewElement: HTMLElement
+    element: HTMLElement
 }
 
 export function handleCodeHost({
@@ -535,7 +535,7 @@ export function handleCodeHost({
         trackCodeViews(codeHost),
         mergeMap(codeViewEvent =>
             codeViewEvent.type === 'added'
-                ? codeViewEvent.resolveFileInfo(codeViewEvent.codeViewElement).pipe(
+                ? codeViewEvent.resolveFileInfo(codeViewEvent.element).pipe(
                       mergeMap(fileInfo =>
                           fetchFileContents(fileInfo).pipe(
                               map(fileInfoWithContents => ({
@@ -581,8 +581,8 @@ export function handleCodeHost({
             console.log(`Code view ${codeViewEvent.type}`)
 
             // Handle added or removed view component, workspace root and subscriptions
-            if (codeViewEvent.type === 'added' && !codeViewStates.has(codeViewEvent.codeViewElement)) {
-                const { codeViewElement, fileInfo, adjustPosition, getToolbarMount, toolbarButtonProps } = codeViewEvent
+            if (codeViewEvent.type === 'added' && !codeViewStates.has(codeViewEvent.element)) {
+                const { element, fileInfo, adjustPosition, getToolbarMount, toolbarButtonProps } = codeViewEvent
                 const codeViewState: CodeViewState = {
                     subscriptions: new Subscription(),
                     visibleViewComponents: [
@@ -599,7 +599,7 @@ export function handleCodeHost({
                     ],
                     roots: [{ uri: toRootURI(fileInfo), inputRevision: fileInfo.rev || '' }],
                 }
-                codeViewStates.set(codeViewElement, codeViewState)
+                codeViewStates.set(element, codeViewState)
 
                 // When codeView is a diff (and not an added file), add BASE too.
                 if (fileInfo.baseContent && fileInfo.baseRepoName && fileInfo.baseCommitID && fileInfo.baseFilePath) {
@@ -652,7 +652,7 @@ export function handleCodeHost({
                             .subscribe(decorations => {
                                 decoratedLines = applyDecorations(
                                     domFunctions,
-                                    codeViewElement,
+                                    element,
                                     decorations || [],
                                     decoratedLines
                                 )
@@ -675,17 +675,17 @@ export function handleCodeHost({
                 codeViewState.subscriptions.add(
                     hoverifier.hoverify({
                         dom: domFunctions,
-                        positionEvents: of(codeViewElement).pipe(findPositionsFromEvents(domFunctions)),
+                        positionEvents: of(element).pipe(findPositionsFromEvents(domFunctions)),
                         resolveContext,
                         adjustPosition,
                     })
                 )
 
-                codeViewElement.classList.add('sg-mounted')
+                element.classList.add('sg-mounted')
 
                 // Render toolbar
                 if (getToolbarMount) {
-                    const mount = getToolbarMount(codeViewElement)
+                    const mount = getToolbarMount(element)
                     render(
                         <CodeViewToolbar
                             {...fileInfo}
@@ -700,10 +700,10 @@ export function handleCodeHost({
                     )
                 }
             } else if (codeViewEvent.type === 'removed') {
-                const codeViewState = codeViewStates.get(codeViewEvent.codeViewElement)
+                const codeViewState = codeViewStates.get(codeViewEvent.element)
                 if (codeViewState) {
                     codeViewState.subscriptions.unsubscribe()
-                    codeViewStates.delete(codeViewEvent.codeViewElement)
+                    codeViewStates.delete(codeViewEvent.element)
                 }
             }
 

--- a/client/browser/src/libs/code_intelligence/code_views.test.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.test.ts
@@ -24,9 +24,9 @@ describe('code_views', () => {
             resolveFileInfo: () => of(fileInfo),
         }
         it('should detect added code views from specs', async () => {
-            const codeViewElement = document.createElement('div')
-            codeViewElement.className = 'test-code-view'
-            document.body.append(codeViewElement)
+            const element = document.createElement('div')
+            element.className = 'test-code-view'
+            document.body.append(element)
             const selector = '.test-code-view'
             const detected = await of([{ addedNodes: [document.body], removedNodes: [] }])
                 .pipe(
@@ -36,12 +36,12 @@ describe('code_views', () => {
                     toArray()
                 )
                 .toPromise()
-            expect(detected).toEqual([{ ...codeViewSpec, codeViewElement, type: 'added' }])
+            expect(detected).toEqual([{ ...codeViewSpec, element, type: 'added' }])
         })
         it('should detect added code views from resolver', async () => {
-            const codeViewElement = document.createElement('div')
-            codeViewElement.className = 'test-code-view'
-            document.body.append(codeViewElement)
+            const element = document.createElement('div')
+            element.className = 'test-code-view'
+            document.body.append(element)
             const selector = '.test-code-view'
             const codeViewSpecResolver = { selector, resolveCodeViewSpec: sinon.spy(() => codeViewSpec) }
             const detected = await of([{ addedNodes: [document.body], removedNodes: [] }])
@@ -50,16 +50,16 @@ describe('code_views', () => {
                     toArray()
                 )
                 .toPromise()
-            expect(detected).toEqual([{ ...codeViewSpec, codeViewElement, type: 'added' }])
+            expect(detected).toEqual([{ ...codeViewSpec, element, type: 'added' }])
             sinon.assert.calledOnce(codeViewSpecResolver.resolveCodeViewSpec)
-            sinon.assert.calledWith(codeViewSpecResolver.resolveCodeViewSpec, codeViewElement)
+            sinon.assert.calledWith(codeViewSpecResolver.resolveCodeViewSpec, element)
         })
         it('should detect an added code view if it is the added element itself', async () => {
-            const codeViewElement = document.createElement('div')
-            codeViewElement.className = 'test-code-view'
-            document.body.append(codeViewElement)
+            const element = document.createElement('div')
+            element.className = 'test-code-view'
+            document.body.append(element)
             const selector = '.test-code-view'
-            const detected = await of([{ addedNodes: [codeViewElement], removedNodes: [] }])
+            const detected = await of([{ addedNodes: [element], removedNodes: [] }])
                 .pipe(
                     trackCodeViews({
                         codeViewSpecs: [{ selector, ...codeViewSpec }],
@@ -67,7 +67,7 @@ describe('code_views', () => {
                     toArray()
                 )
                 .toPromise()
-            expect(detected).toEqual([{ ...codeViewSpec, codeViewElement, type: 'added' }])
+            expect(detected).toEqual([{ ...codeViewSpec, element, type: 'added' }])
         })
         it('should detect added code views added later', async () => {
             const selector = '.test-code-view'
@@ -78,12 +78,12 @@ describe('code_views', () => {
             mutations.next([{ addedNodes: [document.body], removedNodes: [] }])
 
             // Add code view to DOM
-            const codeViewElement = document.createElement('div')
-            codeViewElement.className = 'test-code-view'
-            document.body.append(codeViewElement)
-            mutations.next([{ addedNodes: [codeViewElement], removedNodes: [] }])
+            const element = document.createElement('div')
+            element.className = 'test-code-view'
+            document.body.append(element)
+            mutations.next([{ addedNodes: [element], removedNodes: [] }])
             sinon.assert.calledOnce(subscriber)
-            expect(subscriber.args[0]).toEqual([{ ...codeViewSpec, codeViewElement, type: 'added' }])
+            expect(subscriber.args[0]).toEqual([{ ...codeViewSpec, element, type: 'added' }])
         })
         it('should detect nested added code views added later', async () => {
             const selector = '.test-code-view'
@@ -94,18 +94,18 @@ describe('code_views', () => {
             mutations.next([{ addedNodes: [], removedNodes: [] }])
 
             // Add code view to DOM
-            const codeViewElement = document.createElement('div')
-            codeViewElement.className = 'test-code-view'
-            document.body.append(codeViewElement)
+            const element = document.createElement('div')
+            element.className = 'test-code-view'
+            document.body.append(element)
             mutations.next([{ addedNodes: [document.body], removedNodes: [] }])
             sinon.assert.calledOnce(subscriber)
-            expect(subscriber.args[0]).toEqual([{ ...codeViewSpec, codeViewElement, type: 'added' }])
+            expect(subscriber.args[0]).toEqual([{ ...codeViewSpec, element, type: 'added' }])
         })
         it('should detect removed code views', async () => {
             const selector = '.test-code-view'
-            const codeViewElement = document.createElement('div')
-            codeViewElement.className = 'test-code-view'
-            document.body.append(codeViewElement)
+            const element = document.createElement('div')
+            element.className = 'test-code-view'
+            document.body.append(element)
             const subscriber = sinon.spy()
             const mutations = new Subject<MutationRecordLike[]>()
             mutations.pipe(trackCodeViews({ codeViewSpecs: [{ selector, ...codeViewSpec }] })).subscribe(subscriber)
@@ -113,20 +113,20 @@ describe('code_views', () => {
             sinon.assert.calledOnce(subscriber)
 
             // Remove code view from DOM
-            codeViewElement.remove()
-            mutations.next([{ addedNodes: [], removedNodes: [codeViewElement] }])
+            element.remove()
+            mutations.next([{ addedNodes: [], removedNodes: [element] }])
             sinon.assert.calledTwice(subscriber)
             expect(subscriber.args).toEqual([
-                [{ ...codeViewSpec, codeViewElement, type: 'added' }],
-                [{ codeViewElement, type: 'removed' }],
+                [{ ...codeViewSpec, element, type: 'added' }],
+                [{ element, type: 'removed' }],
             ])
         })
         it('should detect nested removed code views', async () => {
             const selector = '.test-code-view'
-            const codeViewElement = document.createElement('div')
-            codeViewElement.className = 'test-code-view'
+            const element = document.createElement('div')
+            element.className = 'test-code-view'
             const container = document.body.appendChild(document.createElement('div'))
-            container.append(codeViewElement)
+            container.append(element)
             const subscriber = sinon.spy()
             const mutations = new Subject<MutationRecordLike[]>()
             mutations.pipe(trackCodeViews({ codeViewSpecs: [{ selector, ...codeViewSpec }] })).subscribe(subscriber)
@@ -138,8 +138,8 @@ describe('code_views', () => {
             mutations.next([{ addedNodes: [], removedNodes: [container] }])
             sinon.assert.calledTwice(subscriber)
             expect(subscriber.args).toEqual([
-                [{ ...codeViewSpec, codeViewElement, type: 'added' }],
-                [{ codeViewElement, type: 'removed' }],
+                [{ ...codeViewSpec, element, type: 'added' }],
+                [{ element, type: 'removed' }],
             ])
         })
     })

--- a/client/browser/src/libs/code_intelligence/code_views.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.ts
@@ -9,7 +9,7 @@ export interface AddedCodeView extends ResolvedCodeView {
     type: 'added'
 }
 
-export interface RemovedCodeView extends Pick<ResolvedCodeView, 'codeViewElement'> {
+export interface RemovedCodeView extends Pick<ResolvedCodeView, 'element'> {
     type: 'removed'
 }
 
@@ -50,12 +50,12 @@ export const trackCodeViews = ({
                         from(codeViewSpecResolvers).pipe(
                             mergeMap(spec =>
                                 [...(querySelectorAllOrSelf(addedElement, spec.selector) as Iterable<HTMLElement>)]
-                                    .map(codeViewElement => {
-                                        const codeViewSpec = spec.resolveCodeViewSpec(codeViewElement)
+                                    .map(element => {
+                                        const codeViewSpec = spec.resolveCodeViewSpec(element)
                                         return (
                                             codeViewSpec && {
                                                 ...codeViewSpec,
-                                                codeViewElement,
+                                                element,
                                                 type: 'added' as const,
                                             }
                                         )
@@ -74,8 +74,8 @@ export const trackCodeViews = ({
                                 ({ selector }) =>
                                     querySelectorAllOrSelf(removedElement, selector) as Iterable<HTMLElement>
                             ),
-                            map(codeViewElement => ({
-                                codeViewElement,
+                            map(element => ({
+                                element,
                                 type: 'removed' as const,
                             }))
                         )


### PR DESCRIPTION
This makes a future change (adding diff view specs) have an easier-to-read diff.

This commit was approved by @felixfbecker in a separate PR at https://github.com/sourcegraph/sourcegraph/pull/3266#pullrequestreview-223543334.