### PR TITLE
perform in-place delta updates of extension API ExtWindow and ExtCodeEditor

### DIFF
--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -88,18 +88,17 @@ export async function createExtensionHostClientConnection(
                     }
                     await proxy.windows.$acceptWindowData(
                         viewComponents
-                            ? [
-                                  {
-                                      visibleViewComponents: viewComponents.map(viewComponent => ({
-                                          item: {
-                                              uri: viewComponent.item.uri,
-                                          },
-                                          selections: viewComponent.selections,
-                                          isActive: viewComponent.isActive,
-                                      })),
-                                  },
-                              ]
-                            : []
+                            ? {
+                                  visibleViewComponents: viewComponents.map(viewComponent => ({
+                                      type: 'CodeEditor',
+                                      item: {
+                                          uri: viewComponent.item.uri,
+                                      },
+                                      selections: viewComponent.selections,
+                                      isActive: viewComponent.isActive,
+                                  })),
+                              }
+                            : null
                     )
                 })
             )

--- a/shared/src/api/client/model.ts
+++ b/shared/src/api/client/model.ts
@@ -3,15 +3,19 @@ import { TextDocument } from 'sourcegraph'
 import { TextDocumentPositionParams } from '../protocol'
 
 /**
- * Describes a view component.
+ * Describes all possible view components.
  *
- * @todo Currently the only view component is CodeEditor ("CodeEditor" as exposed in the API), so this type just
- * describes a CodeEditor. When more view components exist, this type will need to become a union type or add in
- * some other similar abstraction to support describing all types of view components.
+ * @template D The type of text documents referred to by this data. If the document text is managed
+ * out-of-band, this can just be an object containing the document URI.
  */
-export interface ViewComponentData {
+export type ViewComponentData<D extends Pick<TextDocument, 'uri'> = TextDocument> = CodeEditorViewComponentData<D>
+
+/**
+ * Describes a code editor view component.
+ */
+export interface CodeEditorViewComponentData<D extends Pick<TextDocument, 'uri'> = TextDocument> {
     type: 'CodeEditor'
-    item: TextDocument
+    item: D
     selections: Selection[]
     isActive: boolean
 }

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -13,6 +13,7 @@ const DEFAULT_DECORATION_TYPE = createDecorationType()
 
 /** @internal */
 export class ExtCodeEditor implements sourcegraph.CodeEditor {
+    /** The URI of the text document shown in this code editor */
     private resource: string
 
     constructor(
@@ -21,7 +22,7 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
         private documents: ExtDocuments
     ) {
         this.resource = data.item.uri
-        this._update(data)
+        this.update(data)
     }
 
     public readonly selectionsChanges = new BehaviorSubject<sourcegraph.Selection[]>([])
@@ -51,7 +52,7 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
         this.proxy.$setDecorations(this.resource, decorationType.key, decorations.map(fromTextDocumentDecoration))
     }
 
-    public _update(data: Pick<CodeEditorViewComponentData, 'selections'>): void {
+    public update(data: Pick<CodeEditorViewComponentData, 'selections'>): void {
         this.selectionsChanges.next(data.selections.map(s => Selection.fromPlain(s)))
     }
 

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -1,8 +1,9 @@
 import { ProxyResult } from '@sourcegraph/comlink'
 import * as clientType from '@sourcegraph/extension-api-types'
-import { of } from 'rxjs'
+import { BehaviorSubject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { ClientCodeEditorAPI } from '../../client/api/codeEditor'
+import { CodeEditorViewComponentData } from '../../client/model'
 import { Range } from '../types/range'
 import { Selection } from '../types/selection'
 import { createDecorationType } from './decorations'
@@ -12,15 +13,18 @@ const DEFAULT_DECORATION_TYPE = createDecorationType()
 
 /** @internal */
 export class ExtCodeEditor implements sourcegraph.CodeEditor {
+    private resource: string
+
     constructor(
-        private resource: string,
-        public _selections: clientType.Selection[],
-        public readonly isActive: boolean,
+        data: CodeEditorViewComponentData<Pick<sourcegraph.TextDocument, 'uri'>>,
         private proxy: ProxyResult<ClientCodeEditorAPI>,
         private documents: ExtDocuments
-    ) {}
+    ) {
+        this.resource = data.item.uri
+        this._update(data)
+    }
 
-    public readonly selectionsChanges = of(this.selections)
+    public readonly selectionsChanges = new BehaviorSubject<sourcegraph.Selection[]>([])
 
     public readonly type = 'CodeEditor'
 
@@ -29,11 +33,11 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
     }
 
     public get selection(): sourcegraph.Selection | null {
-        return this._selections.length > 0 ? Selection.fromPlain(this._selections[0]) : null
+        return this.selectionsChanges.value.length > 0 ? this.selectionsChanges.value[0] : null
     }
 
     public get selections(): sourcegraph.Selection[] {
-        return this._selections.map(data => Selection.fromPlain(data))
+        return this.selectionsChanges.value
     }
 
     public setDecorations(
@@ -45,6 +49,10 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
         decorationType = decorationType || DEFAULT_DECORATION_TYPE
         // tslint:disable-next-line: no-floating-promises
         this.proxy.$setDecorations(this.resource, decorationType.key, decorations.map(fromTextDocumentDecoration))
+    }
+
+    public _update(data: Pick<CodeEditorViewComponentData, 'selections'>): void {
+        this.selectionsChanges.next(data.selections.map(s => Selection.fromPlain(s)))
     }
 
     public toJSON(): any {

--- a/shared/src/api/extension/api/windows.test.ts
+++ b/shared/src/api/extension/api/windows.test.ts
@@ -1,0 +1,64 @@
+import { Selection } from '../types/selection'
+import { ExtDocuments } from './documents'
+import { ExtWindow, ExtWindows } from './windows'
+
+describe('ExtWindow', () => {
+    const NOOP_PROXY = {} as any
+
+    const DOCUMENTS = new ExtDocuments(async () => void 0)
+    DOCUMENTS.$acceptDocumentData([{ uri: 'u', text: 't', languageId: 'l' }])
+
+    test('reuses ExtCodeEditor object when updated', () => {
+        const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
+            visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+        })
+        const origViewComponent = wins.activeViewComponent
+        expect(origViewComponent).toBeTruthy()
+
+        wins._update({
+            visibleViewComponents: [
+                { type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [new Selection(1, 2, 3, 4)] },
+            ],
+        })
+        expect(wins.activeViewComponent).toBe(origViewComponent)
+    })
+
+    test('creates new ExtCodeEditor object for a different resource URI', () => {
+        const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
+            visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+        })
+        const origViewComponent = wins.activeViewComponent
+        expect(origViewComponent).toBeTruthy()
+
+        wins._update({
+            visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u2' }, isActive: true, selections: [] }],
+        })
+        expect(wins.activeViewComponent).not.toBe(origViewComponent)
+    })
+})
+
+describe('ExtWindows', () => {
+    const NOOP_PROXY = {} as any
+
+    const DOCUMENTS = new ExtDocuments(async () => void 0)
+    DOCUMENTS.$acceptDocumentData([{ uri: 'u', text: 't', languageId: 'l' }])
+
+    test('reuses ExtWindow object when updated', () => {
+        const wins = new ExtWindows(NOOP_PROXY, DOCUMENTS)
+        wins.$acceptWindowData({
+            visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+        })
+        const origWin = wins.activeWindow
+        expect(origWin).toBeTruthy()
+
+        wins.$acceptWindowData({
+            visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: false, selections: [] }],
+        })
+        expect(wins.activeWindow).toBe(origWin)
+
+        wins.$acceptWindowData({
+            visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u2' }, isActive: false, selections: [] }],
+        })
+        expect(wins.activeWindow).toBe(origWin)
+    })
+})

--- a/shared/src/api/extension/api/windows.test.ts
+++ b/shared/src/api/extension/api/windows.test.ts
@@ -15,7 +15,7 @@ describe('ExtWindow', () => {
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
-        wins._update({
+        wins.update({
             visibleViewComponents: [
                 { type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [new Selection(1, 2, 3, 4)] },
             ],
@@ -30,7 +30,7 @@ describe('ExtWindow', () => {
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
-        wins._update({
+        wins.update({
             visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u2' }, isActive: true, selections: [] }],
         })
         expect(wins.activeViewComponent).not.toBe(origViewComponent)
@@ -40,11 +40,11 @@ describe('ExtWindow', () => {
 describe('ExtWindows', () => {
     const NOOP_PROXY = {} as any
 
-    const DOCUMENTS = new ExtDocuments(async () => void 0)
-    DOCUMENTS.$acceptDocumentData([{ uri: 'u', text: 't', languageId: 'l' }])
+    const documents = new ExtDocuments(async () => void 0)
+    documents.$acceptDocumentData([{ uri: 'u', text: 't', languageId: 'l' }])
 
     test('reuses ExtWindow object when updated', () => {
-        const wins = new ExtWindows(NOOP_PROXY, DOCUMENTS)
+        const wins = new ExtWindows(NOOP_PROXY, documents)
         wins.$acceptWindowData({
             visibleViewComponents: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
         })

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -179,7 +179,7 @@ function createExtensionAPI(
         app: {
             activeWindowChanges: windows.activeWindowChanges,
             get activeWindow(): sourcegraph.Window | undefined {
-                return windows.getActive()
+                return windows.activeWindow
             },
             get windows(): sourcegraph.Window[] {
                 return windows.getAll()

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -1,5 +1,5 @@
 import { from } from 'rxjs'
-import { filter, switchMap } from 'rxjs/operators'
+import { distinctUntilChanged, filter, switchMap } from 'rxjs/operators'
 import { isDefined } from '../../util/types'
 import { ViewComponentData } from '../client/model'
 import { assertToJSON } from '../extension/types/testHelpers'
@@ -41,6 +41,7 @@ describe('Selections (integration)', () => {
                 filter(isDefined),
                 switchMap(window => window.activeViewComponentChanges),
                 filter(isDefined),
+                distinctUntilChanged(),
                 switchMap(editor => editor.selectionsChanges)
             )
             const selectionValues = collectSubscribableValues(selectionChanges)


### PR DESCRIPTION
This allows holders of references to these objects to actually listen for changes, instead of having the objects wiped away.

For example, take `CodeEditor#selectionsChanges`. Right now, this is defined as `public readonly selectionsChanges = of(this._selections)`, so it only emits once. You can construct an RxJS pipe to make this work as intended (to listen for selections changes), but there are 2 limitations:

1. If you have `const editor = activeWindow.activeViewComponent`, then `editor.selectionsChanges` will get stale when the selection actually changes. You *need* to use RxJS pipes, which is unintuitive. Authors assume the `editor` object will be updated in-place.
1. If there is a more expensive observable, such as `editor.visibleRangesChanges` (which would rely on a DOM MutationObserver), then you don't want to resubscribe *every time* any small change is made to the editor (like its content changes).

This addresses those issues without any regressions to existing behavior and makes the extension API work slightly more in line with the author's expectations.