### PR TITLE
make CodeEditor#type readonly in extension API

### DIFF
--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -569,7 +569,7 @@ declare module 'sourcegraph' {
      */
     export interface CodeEditor {
         /** The type tag for this kind of {@link ViewComponent}. */
-        type: 'CodeEditor'
+        readonly type: 'CodeEditor'
 
         /**
          * The text document that is open in this editor. The document remains the same for the entire lifetime of


### PR DESCRIPTION
This is a union tag and should never be changed at runtime.