### PR TITLE
add Range#toPlain

### DIFF
--- a/shared/src/api/extension/types/range.test.ts
+++ b/shared/src/api/extension/types/range.test.ts
@@ -26,6 +26,11 @@ describe('Range', () => {
         assertToJSON(range, { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } })
     })
 
+    test('toPlain', () => {
+        const range = new Range(1, 2, 3, 4)
+        expect(range.toPlain()).toEqual({ start: { line: 1, character: 2 }, end: { line: 3, character: 4 } })
+    })
+
     test('sorting', () => {
         // sorts start/end
         let range = new Range(1, 0, 0, 0)

--- a/shared/src/api/extension/types/range.ts
+++ b/shared/src/api/extension/types/range.ts
@@ -150,4 +150,8 @@ export class Range implements sourcegraph.Range {
             end: { line: this._end.line, character: this._end.character },
         }
     }
+
+    public static fromPlain(data: clientType.Range): Range {
+        return new Range(data.start.line, data.start.character, data.end.line, data.end.character)
+    }
 }


### PR DESCRIPTION
Selection has this. It is used when passing around the type to the client side of the extension system. It is not necessary to use toPlain, but it is useful in tests when checking for deep object equality from 2 range values (one which might be a "full" Range class instance, one which is just the plain old data object).