### PR TITLE
upgrade to TypeScript 3.5.0 (dev) to fix `readonly` bug

### DIFF
--- a/client/browser/src/libs/bitbucket/api.ts
+++ b/client/browser/src/libs/bitbucket/api.ts
@@ -71,5 +71,6 @@ export const getBaseCommit: (info: GetBaseCommitInput) => Observable<string> = m
             map(({ parents }) => first(parents)),
             filter(isDefined),
             map(({ id }) => id)
-        )
+        ),
+    ({ project, repoSlug, commitID }) => `${project}:${repoSlug}:${commitID}`
 )

--- a/client/browser/src/libs/gitlab/api.ts
+++ b/client/browser/src/libs/gitlab/api.ts
@@ -71,8 +71,10 @@ export const getBaseCommitIDForCommit: ({
     commitID,
 }: Pick<GetBaseCommitIDInput, 'owner' | 'projectName'> & { commitID: string }) => Observable<
     string
-> = memoizeObservable(({ owner, projectName, commitID }) =>
-    get<CommitResponse>(buildURL(owner, projectName, `/repository/commits/${commitID}`)).pipe(
-        map(({ parent_ids }) => first(parent_ids)!) // ! because it'll always have a parent if we are looking at the commit page.
-    )
+> = memoizeObservable(
+    ({ owner, projectName, commitID }) =>
+        get<CommitResponse>(buildURL(owner, projectName, `/repository/commits/${commitID}`)).pipe(
+            map(({ parent_ids }) => first(parent_ids)!) // ! because it'll always have a parent if we are looking at the commit page.
+        ),
+    ({ owner, projectName, commitID }) => `${owner}:${projectName}:${commitID}`
 )

--- a/client/browser/src/shared/backend/diffs.tsx
+++ b/client/browser/src/shared/backend/diffs.tsx
@@ -46,5 +46,6 @@ export const queryRepositoryComparisonFileDiffs = memoizeObservable(
                 }
                 return repo.comparison.fileDiffs
             })
-        )
+        ),
+    ({ repo, base, head, first }) => `${repo}:${base}:${head}:${first}`
 )

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "tslint": "^5.15.0",
     "tslint-language-service": "^0.9.9",
     "typedoc": "^0.14.0",
-    "typescript": "^3.4.1",
+    "typescript": "3.5.0-dev.20190406",
     "utc-version": "^1.1.0",
     "webpack": "^4.28.2",
     "webpack-dev-server": "^3.1.13",

--- a/shared/src/util/memoizeObservable.ts
+++ b/shared/src/util/memoizeObservable.ts
@@ -18,12 +18,12 @@ export function resetAllMemoizationCaches(): void {
  * Creates a function that memoizes the observable result of func.
  * If the Observable errors, the value will not be cached.
  *
- * @param resolver If resolver provided, it determines the cache key for storing the result based on
+ * @param resolver Determines the cache key for storing the result based on
  * the first argument provided to the memoized function.
  */
 export function memoizeObservable<P, T>(
     func: (params: P) => Observable<T>,
-    resolver?: (params: P) => string
+    resolver: (params: P) => string
 ): (params: P, force?: boolean) => Observable<T> {
     const cache = new Map<string, Observable<T>>()
     let cacheResetSeq = allCachesResetSeq
@@ -34,7 +34,7 @@ export function memoizeObservable<P, T>(
             cacheResetSeq = allCachesResetSeq
         }
 
-        const key = resolver ? resolver(params) : params.toString()
+        const key = resolver(params)
         const hit = cache.get(key)
         if (!force && hit) {
             return hit

--- a/yarn.lock
+++ b/yarn.lock
@@ -14735,14 +14735,19 @@ typedoc@^0.14.0:
     typescript "3.2.x"
 
 typescript@3.2.x:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+  version "3.2.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typescript@3.4.1, typescript@^3.4.1:
+typescript@3.4.1:
   version "3.4.1"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
   integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
+
+typescript@3.5.0-dev.20190406:
+  version "3.5.0-dev.20190406"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.5.0-dev.20190406.tgz#9beda156dc682c342574796fa1212e13f5d0de2d"
+  integrity sha512-yBCj+5+CYlR+9tCP9IG784gcacpYNFNEQpXtwzONk7YonzT0KXn6qp2UhqpwKyJi0QC2f73k2LuVAsNwa/UXnA==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
Fix at https://github.com/Microsoft/TypeScript/pull/30734 for an issue with TypeScript 3.4.x and use of `readonly T[]`, which causes webpack to report the following error:

```
TypeError: Cannot read property 'instantiations' of undefined
```