### PR TITLE
fix hasProvidersForActiveTextDocument test

### DIFF
--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -1,6 +1,7 @@
 import { Location } from '@sourcegraph/extension-api-types'
 import { Observable, of, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
+import { Selection } from '../../extension/types/selection'
 import { TextDocumentRegistrationOptions } from '../../protocol'
 import {
     getLocationsFromProviders,
@@ -58,13 +59,13 @@ describe('TextDocumentLocationProviderRegistry', () => {
                             {
                                 isActive: true,
                                 type: 'CodeEditor',
-                                selections: [],
+                                selections: [new Selection(1, 2, 3, 4).toPlain()],
                                 item: { uri: 'u', languageId: 'l', text: 't' },
                             },
                         ],
                     })
                 ).toBe('a', {
-                    a: false,
+                    a: true,
                 })
             })
         })
@@ -82,7 +83,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                             {
                                 isActive: true,
                                 type: 'CodeEditor',
-                                selections: [],
+                                selections: [new Selection(1, 2, 3, 4).toPlain()],
                                 item: { uri: 'u', languageId: 'l', text: 't' },
                             },
                         ],


### PR DESCRIPTION
The `hasProvidersForActiveTextDocument` method returns false when there are no selections. The test name indicates that it should be testing when there IS a match, but the test code itself checked for false and set up a scenario where there was no match. This fixes the test code to match its name.