### PR TITLE
remove never-used fallback for file mode

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -590,7 +590,7 @@ export function handleCodeHost({
                             type: 'CodeEditor' as const,
                             item: {
                                 uri: toURIWithPath(fileInfo),
-                                languageId: getModeFromPath(fileInfo.filePath) || 'could not determine mode',
+                                languageId: getModeFromPath(fileInfo.filePath),
                                 text: fileInfo.content,
                             },
                             selections,
@@ -611,7 +611,7 @@ export function handleCodeHost({
                                 commitID: fileInfo.baseCommitID,
                                 filePath: fileInfo.baseFilePath,
                             }),
-                            languageId: getModeFromPath(fileInfo.filePath) || 'could not determine mode',
+                            languageId: getModeFromPath(fileInfo.filePath),
                             text: fileInfo.baseContent,
                         },
                         // There is no notion of a selection on diff views yet, so this is empty.

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -71,7 +71,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                         type: 'CodeEditor',
                         item: {
                             uri: toURIWithPath(this.props),
-                            languageId: getModeFromPath(this.props.filePath) || 'could not determine mode',
+                            languageId: getModeFromPath(this.props.filePath),
                         },
                         selections: [],
                     }}


### PR DESCRIPTION
The `getModeFromPath` function already falls back to plaintext if no mode is detected in the filename.