### PR TITLE
only show Sourcegraph icon, no text, in "View file" buttons

### DIFF
--- a/client/browser/src/libs/code_intelligence/external_links.test.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.test.tsx
@@ -68,7 +68,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         expect(configureClickSpy.calledOnce).toBe(true)
     })
 
-    it('still renders "View Repository" if repo doesn\'t exist and its not pointed at .com', () => {
+    it("still renders if repo doesn't exist and its not pointed at .com", () => {
         const configureClickSpy = sinon.spy()
 
         renderViewContextOnSourcegraph({
@@ -86,6 +86,6 @@ describe('<ViewOnSourcegraphButton />', () => {
 
         const link = document.querySelector<HTMLAnchorElement>('.test')
         expect(link).toBeInstanceOf(HTMLAnchorElement)
-        expect(link!.textContent).toBe(' View Repository')
+        expect(link!.getAttribute('aria-label')).toBe('View repository on Sourcegraph')
     })
 })

--- a/client/browser/src/libs/code_intelligence/external_links.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.tsx
@@ -90,7 +90,6 @@ class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonPro
         return (
             <SourcegraphIconButton
                 url={this.getURL()}
-                label="View Repository"
                 ariaLabel="View repository on Sourcegraph"
                 className={classNames('open-on-sourcegraph', this.props.className)}
                 iconClassName={this.props.iconClassName}

--- a/client/browser/src/shared/components/Button.tsx
+++ b/client/browser/src/shared/components/Button.tsx
@@ -8,7 +8,7 @@ interface Props {
     ariaLabel?: string
     onClick?: (e: React.MouseEvent<HTMLElement>) => void
     target?: string
-    label: string
+    label?: string
 }
 
 export const SourcegraphIconButton: React.FunctionComponent<Props> = (props: Props) => (

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -79,7 +79,6 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                 {this.props.baseCommitID && this.props.baseHasFileContents && (
                     <li className={classNames('code-view-toolbar__item', this.props.listItemClass)}>
                         <OpenDiffOnSourcegraph
-                            label="View file diff"
                             ariaLabel="View file diff on Sourcegraph"
                             className={this.props.actionItemClass}
                             iconClassName={this.props.actionItemIconClass}
@@ -103,7 +102,6 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                 {!this.props.baseCommitID && (
                     <li className={classNames('code-view-toolbar__item', this.props.listItemClass)}>
                         <OpenOnSourcegraph
-                            label="View file"
                             ariaLabel="View file on Sourcegraph"
                             className={this.props.actionItemClass}
                             iconClassName={this.props.actionItemIconClass}

--- a/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
@@ -13,7 +13,6 @@ interface Props {
     iconClassName?: string
     ariaLabel?: string
     onClick?: (e: React.MouseEvent<HTMLElement>) => void
-    label: string
 }
 
 interface State {

--- a/client/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -9,7 +9,6 @@ interface Props {
     iconClassName?: string
     ariaLabel?: string
     onClick?: (e: any) => void
-    label: string
 }
 
 export class OpenOnSourcegraph extends React.Component<Props, {}> {


### PR DESCRIPTION
The browser extension's buttons on file and diff headers on code hosts currently read "View file" and "View file diff". These take up a lot of width (which creates jitter and sometimes means that the buttons can require more than 1 line, which causes even more UI jitter).

It is almost certainly clear enough to users that the buttons mean "View this thing on Sourcegraph". The buttons have tooltips that describe what they do, so users are unlikely to be confused.

## After

![image](https://user-images.githubusercontent.com/1976/55696825-8c367100-5973-11e9-83c8-91908c2851d5.png)

![image](https://user-images.githubusercontent.com/1976/55696835-95bfd900-5973-11e9-9057-e0038bdb1f8a.png)

---

## Before
![image](https://user-images.githubusercontent.com/1976/55696858-b38d3e00-5973-11e9-8ca0-5f193cabe55b.png)


![image](https://user-images.githubusercontent.com/1976/55696851-a96b3f80-5973-11e9-84e9-ec9b5dd1b4eb.png)



