### PR TITLE
ci: Group log output for e2e on buildkite

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -16,7 +16,7 @@ export DOCKER_HOST="$E2E_DOCKER_HOST"
 export DOCKER_PASSWORD="$E2E_DOCKER_PASSWORD"
 export DOCKER_USERNAME="$E2E_DOCKER_USERNAME"
 
-echo "Copying $IMAGE to the dedicated e2e testing node..."
+echo "--- Copying $IMAGE to the dedicated e2e testing node..."
 env \
     DOCKER_HOST="$BUILD_DOCKER_HOST" \
     DOCKER_PASSWORD="$BUILD_DOCKER_PASSWORD" \
@@ -25,7 +25,7 @@ env \
     | docker load
 echo "Copying $IMAGE to the dedicated e2e testing node... done"
 
-echo "Running a daemonized $IMAGE as the test subject..."
+echo "--- Running a daemonized $IMAGE as the test subject..."
 CONTAINER="$(docker container run -d -e DEPLOY_TYPE=dev $IMAGE)"
 trap 'kill $(jobs -p)'" ; docker logs --timestamps $CONTAINER ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
 
@@ -43,6 +43,7 @@ timeout 30s bash -c "until curl --output /dev/null --silent --head --fail $URL; 
     sleep 5
 done"
 if [ $? -ne 0 ]; then
+    echo "^^^ +++"
     echo "$URL was not accessible within 30s. Here's the output of docker inspect and docker logs:"
     docker inspect "$CONTAINER"
     docker logs --timestamps "$CONTAINER"
@@ -51,8 +52,10 @@ fi
 set -e
 echo "Waiting for $URL... done"
 
+echo "--- yarn"
 yarn
 
+echo "--- yarn run test-e2e"
 pushd web
 # `-pix_fmt yuv420p` makes a QuickTime-compatible mp4.
 ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp4 > ffmpeg.log 2>&1 &


### PR DESCRIPTION
See https://buildkite.com/docs/pipelines/managing-log-output