### PR TITLE
all: Propagate opentracing headers

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -260,6 +260,9 @@ func textSearchURL(ctx context.Context, url string) ([]*fileMatchResolver, bool,
 		nethttp.ClientTrace(false))
 	defer ht.Finish()
 
+	// Do not lose the context returned by TraceRequest
+	ctx = req.Context()
+
 	// Limit number of outstanding searcher requests
 	if err := textSearchLimiter.Acquire(ctx); err != nil {
 		return nil, false, err

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -442,9 +442,6 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
-	span, ctx := opentracing.StartSpanFromContext(r.Context(), "Server.handleExec")
-	defer span.Finish()
-
 	var req protocol.ExecRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -458,7 +455,7 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 		defer fw.Close()
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(req.Args))
+	ctx, cancel := context.WithTimeout(r.Context(), shortGitCommandTimeout(req.Args))
 	defer cancel()
 
 	start := time.Now()

--- a/go.mod
+++ b/go.mod
@@ -90,8 +90,8 @@ require (
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
-	github.com/opentracing-contrib/go-stdlib v0.0.0-20190104202730-77df8e8e70b4
-	github.com/opentracing/opentracing-go v1.0.2
+	github.com/opentracing-contrib/go-stdlib v0.0.0-20190324214902-3020fec0e66b
+	github.com/opentracing/opentracing-go v1.1.0
 	github.com/peterhellberg/link v1.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,8 +412,12 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190104202730-77df8e8e70b4 h1:EhSaxex5Xvzs0xfbrCeaUfF8/jrY4yEm/v5b+HMYF5A=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190104202730-77df8e8e70b4/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
+github.com/opentracing-contrib/go-stdlib v0.0.0-20190324214902-3020fec0e66b h1:N/+vVH19UEwFml23XATspYXdbpBU/oPvXy3CnkODjc0=
+github.com/opentracing-contrib/go-stdlib v0.0.0-20190324214902-3020fec0e66b/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=

--- a/pkg/extsvc/bitbucketserver/client.go
+++ b/pkg/extsvc/bitbucketserver/client.go
@@ -157,6 +157,9 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 		nethttp.ClientTrace(false))
 	defer ht.Finish()
 
+	// Do not lose the context returned by TraceRequest
+	ctx = req.Context()
+
 	startWait := time.Now()
 	if err := c.RateLimit.Wait(ctx); err != nil {
 		return err

--- a/pkg/repoupdater/client.go
+++ b/pkg/repoupdater/client.go
@@ -211,7 +211,7 @@ func (c *Client) httpPost(ctx context.Context, method string, payload interface{
 
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(ctx)
-	req, ht := nethttp.TraceRequest(opentracing.GlobalTracer(), req,
+	req, ht := nethttp.TraceRequest(span.Tracer(), req,
 		nethttp.OperationName("RepoUpdater Client"),
 		nethttp.ClientTrace(false))
 	defer ht.Finish()

--- a/pkg/symbols/client.go
+++ b/pkg/symbols/client.go
@@ -139,10 +139,13 @@ func (c *Client) httpPost(ctx context.Context, method string, key key, payload i
 		span.LogKV("event", "Acquired HTTP limiter")
 	}
 
-	req, ht := nethttp.TraceRequest(opentracing.GlobalTracer(), req,
+	req, ht := nethttp.TraceRequest(span.Tracer(), req,
 		nethttp.OperationName("Symbols Client"),
 		nethttp.ClientTrace(false))
 	defer ht.Finish()
+
+	// Do not lose the context returned by TraceRequest
+	ctx = req.Context()
 
 	return ctxhttp.Do(ctx, c.HTTPClient, req)
 }


### PR DESCRIPTION
In an old refactor were we switched to using ctxhttp more, we regressed on
propogating the opentracing headers across RPC calls. This was due to
nethttp.TraceRequest modifying the request's context. However, we would then
do ctxhttp which would update the context before the call to
nethttp.TraceRequest. This lead to nethttp.Transport not finding the request
span to inject.

Also changed in this commit:

- Upgrade opentracing libraries
- Remove unneeded span from gitserver.exec

Fixes https://github.com/sourcegraph/sourcegraph/issues/3253