### PR TITLE
api: Ensure WaitForFrontend blocks

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -40,7 +40,10 @@ func main() {
 	clock := func() time.Time { return time.Now().UTC() }
 
 	// Syncing relies on access to frontend and git-server, so wait until they started up.
-	api.WaitForFrontend(ctx)
+	if err := api.InternalClient.WaitForFrontend(ctx); err != nil {
+		log.Fatalf("sourcegraph-frontend not reachable: %v", err)
+	}
+
 	gitserver.DefaultClient.WaitForGitServers(ctx)
 
 	db, err := repos.NewDB(repos.NewDSN().String())

--- a/pkg/api/internal_client.go
+++ b/pkg/api/internal_client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/schema"
 	"golang.org/x/net/context/ctxhttp"
-	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 var frontendInternal = env.Get("SRC_FRONTEND_INTERNAL", "sourcegraph-frontend-internal", "HTTP address for internal frontend HTTP API.")
@@ -27,20 +26,9 @@ type internalClient struct {
 
 var InternalClient = &internalClient{URL: "http://" + frontendInternal}
 
-// WaitForFrontend should be called by services that intend to wait for the
-// frontend to start. It uses a 5s timeout with the given context, and logs an
-// error if it fails.
-func WaitForFrontend(ctx context.Context) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if err := InternalClient.RetryPingUntilAvailable(ctx); err != nil {
-		log15.Warn("frontend not available at startup (will periodically try to reconnect)", "err", err)
-	}
-}
-
-// RetryPingUntilAvailable retries a noop request to the internal API until it is able to reach
-// the endpoint, indicating that the endpoint is available.
-func (c *internalClient) RetryPingUntilAvailable(ctx context.Context) error {
+// WaitForFrontend retries a noop request to the internal API until it is able to reach
+// the endpoint, indicating that the frontend is available.
+func (c *internalClient) WaitForFrontend(ctx context.Context) error {
 	ping := func(ctx context.Context) error {
 		resp, err := ctxhttp.Get(ctx, nil, c.URL+"/.internal/ping")
 		if err != nil {

--- a/pkg/gitserver/client.go
+++ b/pkg/gitserver/client.go
@@ -81,7 +81,9 @@ func updateGitServerAddrList() {
 		// ask the frontend for this information. This is generally the code
 		// path that all non-frontend services take.
 		ctx := context.Background()
-		api.WaitForFrontend(ctx)
+		if err := api.InternalClient.WaitForFrontend(ctx); err != nil {
+			log15.Error("failed to wait for frontend", "error", err)
+		}
 
 		fetchAddrsOnce := func() {
 			for {


### PR DESCRIPTION
This renames `RetryPingUntilAvailable` to `WaitForFrontend` which
replaces the previous package level functions of the same name.

That function was previously assumed to be blocking until the frontend
was available, but it instead timed out after 5 seconds.

We were seeing problems in development where repo-updater failed because
migrations hadn't been ran yet. This meant that we weren't waiting for
the frontend until it was actually ready.

This commit changes that.

Part of #2025