### PR TITLE
Phabricator:  handle `repositoryPHID` being possibly `null`

### DIFF
--- a/client/browser/src/libs/phabricator/backend.tsx
+++ b/client/browser/src/libs/phabricator/backend.tsx
@@ -243,6 +243,7 @@ async function getRepoPHIDForDifferentialID(differentialID: number): Promise<str
     }
     const phid = responseJSON.result['0'].repositoryPHID
     if (!phid) {
+        // This happens for diffs that were created without an associated repository
         throw new Error(`no repositoryPHID for diff ${differentialID}`)
     }
     return phid

--- a/client/browser/src/libs/phabricator/backend.tsx
+++ b/client/browser/src/libs/phabricator/backend.tsx
@@ -223,7 +223,7 @@ interface ConduitDifferentialQueryResponse {
     error_info?: string
     result: {
         [index: string]: {
-            repositoryPHID: string
+            repositoryPHID: string | null
         }
     }
 }
@@ -241,7 +241,11 @@ async function getRepoPHIDForDifferentialID(differentialID: number): Promise<str
     if (responseJSON.error_code) {
         throw new Error(`error ${responseJSON.error_code}: ${responseJSON.error_info}`)
     }
-    return responseJSON.result['0'].repositoryPHID
+    const phid = responseJSON.result['0'].repositoryPHID
+    if (!phid) {
+        throw new Error(`no repositoryPHID for diff ${differentialID}`)
+    }
+    return phid
 }
 
 interface CreatePhabricatorRepoOptions {


### PR DESCRIPTION
Handles the Conduit API returning a `null` `repositoryPHID`. This can happen for diffs that were created without no associated repository.

This avoids making a follow-up bad request to the conduit API in `getRepoDetailsFromRepoPHID()`, which raises an exception on the Phabricator side:

```
[Tue Feb  5 13:22:52 2019] [2019-02-05 13:22:52] EXCEPTION: (Exception) Error while reading "phids[0]": Expected string, got something else. at [<phabricator>/src/applications/conduit/parametertype/ConduitParameterType.php:67]
[Tue Feb  5 13:22:52 2019] arcanist(head=master, ref.master=02f79e13c317), ...
[Tue Feb  5 13:22:52 2019]   #0 <#2> ConduitParameterType::raiseValidationException(array, string, string) called at [<phabricator>/src/applications/conduit/parametertype/ConduitParameterType.php:101]
[Tue Feb  5 13:22:52 2019]   #1 <#2> ConduitParameterType::parseStringValue(array, string, NULL, boolean) called at [<phabricator>/src/applications/conduit/parametertype/ConduitListParameterType.php:62]
[Tue Feb  5 13:22:52 2019]   #2 <#2> ConduitListParameterType::parseStringList(array, string, array, boolean) called at [<phabricator>/src/applications/conduit/parametertype/ConduitPHIDListParameterType.php:8]
[Tue Feb  5 13:22:52 2019]   #3 <#2> ConduitPHIDListParameterType::getParameterValue(array, string, boolean) called at [<phabricator>/src/applications/conduit/parametertype/ConduitParameterType.php:38]
[Tue Feb  5 13:22:52 2019]   #4 <#2> ConduitParameterType::getValue(array, string, boolean) called at [<phabricator>/src/applications/search/field/PhabricatorSearchField.php:368]
[Tue Feb  5 13:22:52 2019]   #5 <#2> PhabricatorSearchField::readValueFromConduitRequest(array, boolean) called at [<phabricator>/src/applications/search/engine/PhabricatorApplicationSearchEngine.php:1169]
[Tue Feb  5 13:22:52 2019]   #6 <#2> PhabricatorApplicationSearchEngine::buildConduitResponse(ConduitAPIRequest, DiffusionRepositorySearchConduitAPIMethod) called at [<phabricator>/src/applications/search/engine/PhabricatorSearchEngineAPIMethod.php:72]
[Tue Feb  5 13:22:52 2019]   #7 <#2> PhabricatorSearchEngineAPIMethod::execute(ConduitAPIRequest) called at [<phabricator>/src/applications/conduit/method/ConduitAPIMethod.php:123]
[Tue Feb  5 13:22:52 2019]   #8 <#2> ConduitAPIMethod::executeMethod(ConduitAPIRequest) called at [<phabricator>/src/applications/conduit/call/ConduitCall.php:131]
[Tue Feb  5 13:22:52 2019]   #9 <#2> ConduitCall::executeMethod() called at [<phabricator>/src/applications/conduit/call/ConduitCall.php:81]
[Tue Feb  5 13:22:52 2019]   #10 <#2> ConduitCall::execute() called at [<phabricator>/src/applications/conduit/controller/PhabricatorConduitAPIController.php:83]
[Tue Feb  5 13:22:52 2019]   #11 phlog(Exception) called at [<phabricator>/src/applications/conduit/controller/PhabricatorConduitAPIController.php:103]
[Tue Feb  5 13:22:52 2019]   #12 PhabricatorConduitAPIController::handleRequest(AphrontRequest) called at [<phabricator>/src/aphront/configuration/AphrontApplicationConfiguration.php:280]
[Tue Feb  5 13:22:52 2019]   #13 AphrontApplicationConfiguration::processRequest(AphrontRequest, PhutilDeferredLog, AphrontPHPHTTPSink, MultimeterControl) called at [<phabricator>/src/aphront/configuration/AphrontApplicationConfiguration.php:186]
[Tue Feb  5 13:22:52 2019]   #14 AphrontApplicationConfiguration::runHTTPRequest(AphrontPHPHTTPSink) called at [<phabricator>/webroot/index.php:17]
```