### PR TITLE
graphqlbackend: Sync external service after deletion

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -118,9 +118,19 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *struct {
 		return nil, err
 	}
 
+	externalService, err := db.ExternalServices.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := db.ExternalServices.Delete(ctx, id); err != nil {
 		return nil, err
 	}
+
+	if err = syncExternalService(ctx, externalService); err != nil {
+		return nil, errors.Wrap(err, "warning: external service deleted, but sync request failed")
+	}
+
 	return &EmptyResponse{}, nil
 }
 


### PR DESCRIPTION
This commit changes the resolver of external services deletion to
perform a sync in repo-updater after an external service is
successfully deleted.

This makes it so admins immediately see the results in the repos
listing page after this action.

Part of #2025

Tested manually.