### PR TITLE
search: remove dotGo hack

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"regexp"
 	"sort"
@@ -25,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
-	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
 	"github.com/sourcegraph/sourcegraph/pkg/trace"
 	"github.com/sourcegraph/sourcegraph/pkg/vcs"
 	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
@@ -236,29 +234,6 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		repoFilters = effectiveRepoFieldValues
 	}
 	repoGroupFilters, _ := r.query.StringValues(query.FieldRepoGroup)
-
-	// HACK: Demo mode for dotGo on 2019 Mar 25 to make it easier to use Sourcegraph.com as a demo
-	// of a self-hosted instance with a limited set of repositories. This limits a user to the
-	// repositories specified in their setting `search.defaultRepositories` if there are no
-	// repository filters in the search.
-	//
-	// TODO(sqs): Remove this after 2019 Mar 25.
-	if len(repoFilters) == 0 && len(repoGroupFilters) == 0 && envvar.SourcegraphDotComMode() {
-		final, err := viewerFinalSettings(ctx)
-		if err != nil {
-			log.Println(err)
-		} else {
-			var settings struct {
-				SearchDefaultRepositories []string `json:"search.defaultRepositories"`
-			}
-			if err := jsonc.Unmarshal(final.Contents(), &settings); err != nil {
-				log.Println(err)
-			}
-			if len(settings.SearchDefaultRepositories) > 0 {
-				repoFilters = settings.SearchDefaultRepositories
-			}
-		}
-	}
 
 	forkStr, _ := r.query.StringValue(query.FieldFork)
 	fork := parseYesNoOnly(forkStr)


### PR DESCRIPTION
A block of code was commented as a hack that should be removed after March 25, 2019. It's now after March 25, 2019.
