### PR TITLE
Make username required on Bitbucket Server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The dynamic filters on search results pages will now display `lang:` instead of `file:` filters for language/file-extension filter suggestions.
 - The default `github.repositoryQuery` of a [GitHub external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["affiliated", "public"]`).
 - The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
+- The `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) is now **required**. This is field is necessary to authenticate with the Bitbucket Server API with either `password` or `token`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The dynamic filters on search results pages will now display `lang:` instead of `file:` filters for language/file-extension filter suggestions.
 - The default `github.repositoryQuery` of a [GitHub external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["affiliated", "public"]`).
 - The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
-- The `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) is now **required**. This is field is necessary to authenticate with the Bitbucket Server API with either `password` or `token`.
+- The `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) is now **required**. This field is necessary to authenticate with the Bitbucket Server API with either `password` or `token`.
 
 ### Fixed
 

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -103,6 +103,7 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 		{
 			// Some comment
 			"url": "https://bitbucketserver.mycorp.com",
+			"username": "admin",
 			"token": "secret"
 		}`),
 	}
@@ -606,7 +607,9 @@ func testBitbucketServerSetDefaultRepositoryQueryMigration(store repos.Store) fu
 		Config: formatJSON(`
 			{
 				// Some comment
-				"url": "https://bitbucketserver.mycorp.com"
+				"url": "https://bitbucketserver.mycorp.com",
+				"username": "admin",
+				"token": "secret"
 			}
 		`),
 	}
@@ -618,6 +621,8 @@ func testBitbucketServerSetDefaultRepositoryQueryMigration(store repos.Store) fu
 			{
 				// Some comment
 				"url": "https://bitbucketserver.mycorp.com",
+				"username": "admin",
+				"token": "secret",
 				"repositoryQuery": ["none"]
 			}
 		`),

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -49,6 +49,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 		Config: `{
 			// Some comment
 			"url": "https://bitbucketserver.mycorp.com",
+			"username: "admin",
 			"token": "secret"
 		}`,
 		CreatedAt: now,
@@ -135,6 +136,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 				{
 					// Some comment
 					"url": "https://bitbucketserver.mycorp.com",
+					"username": "admin",
 					"token": "secret",
 					"exclude": [
 						{"id": 1},
@@ -181,6 +183,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 				{
 					// Some comment
 					"url": "https://gitlab.com",
+					"username": "admin",
 					"token": "secret",
 					"exclude": [
 						{"name": "org/boo"},
@@ -226,6 +229,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					{
 						// Some comment
 						"url": "https://gitlab.com",
+						"username": "admin",
 						"token": "secret",
 						"exclude": [
 							{"name": "org/boo"},
@@ -268,6 +272,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 				{
 					// Some comment
 					"url": "https://bitbucketserver.mycorp.com",
+					"username": "admin",
 					"token": "secret",
 					"repos": [
 						"org/FOO",
@@ -315,6 +320,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 				{
 					// Some comment
 					"url": "https://bitbucketserver.mycorp.com",
+					"username": "admin",
 					"token": "secret",
 					"repos": [
 						"org/boo"
@@ -360,6 +366,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					{
 						// Some comment
 						"url": "https://bitbucketserver.mycorp.com",
+						"username": "admin",
 						"token": "secret",
 						"repos": [
 							"org/boo",

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -146,6 +146,12 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "BITBUCKETSERVER",
+			desc:   "without username",
+			config: `{}`,
+			assert: includes("username: username is required"),
+		},
+		{
+			kind:   "BITBUCKETSERVER",
 			desc:   "example url",
 			config: `{"url": "https://bitbucket.example.com"}`,
 			assert: includes("url: Must not validate the schema (not)"),
@@ -155,21 +161,6 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			desc:   "bad url scheme",
 			config: `{"url": "badscheme://bitbucket.com"}`,
 			assert: includes("url: Does not match pattern '^https?://'"),
-		},
-		{
-			kind:   "BITBUCKETSERVER",
-			desc:   "with token AND username / password",
-			config: `{"token": "foo", "username": "bar", "password": "baz"}`,
-			assert: includes("(root): Must validate one and only one schema (oneOf)"),
-		},
-		{
-			kind:   "BITBUCKETSERVER",
-			desc:   "with token AND username",
-			config: `{"token": "foo", "username": "bar"}`,
-			assert: includes(
-				"(root): Must validate one and only one schema (oneOf)",
-				"username: Invalid type. Expected: null, given: string",
-			),
 		},
 		{
 			kind:   "BITBUCKETSERVER",
@@ -201,7 +192,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		{
 			kind:   "BITBUCKETSERVER",
 			desc:   "valid",
-			config: `{"url": "https://bitbucket.com/", "token": "secret-token"}`,
+			config: `{"url": "https://bitbucket.com/", "username": "admin", "token": "secret-token"}`,
 			assert: equals("<nil>"),
 		},
 		{
@@ -252,6 +243,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			config: `
 			{
 				"url": "https://bitbucketserver.corp.com",
+				"username": "admin",
 				"token": "very-secret-token",
 				"exclude": [
 					{"name": "foo/bar", "id": 1234}
@@ -277,6 +269,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			config: `
 			{
 				"url": "https://bitbucketserver.corp.com",
+				"username": "admin",
 				"token": "very-secret-token",
 				"repos": [
 					"foo/bar",

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -5,17 +5,16 @@
   "description": "Configuration for a connection to Bitbucket Server.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["url"],
+  "required": ["username", "url"],
   "oneOf": [
     {
       "required": ["token"],
       "properties": {
-        "username": { "type": "null" },
         "password": { "type": "null" }
       }
     },
     {
-      "required": ["username", "password"],
+      "required": ["password"],
       "properties": {
         "token": { "type": "null" }
       }

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -10,17 +10,16 @@ const BitbucketServerSchemaJSON = `{
   "description": "Configuration for a connection to Bitbucket Server.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["url"],
+  "required": ["username", "url"],
   "oneOf": [
     {
       "required": ["token"],
       "properties": {
-        "username": { "type": "null" },
         "password": { "type": "null" }
       }
     },
     {
-      "required": ["username", "password"],
+      "required": ["password"],
       "properties": {
         "token": { "type": "null" }
       }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -93,7 +93,7 @@ type BitbucketServerConnection struct {
 	RepositoryQuery             []string                       `json:"repositoryQuery,omitempty"`
 	Token                       string                         `json:"token,omitempty"`
 	Url                         string                         `json:"url"`
-	Username                    string                         `json:"username,omitempty"`
+	Username                    string                         `json:"username"`
 }
 type BrandAssets struct {
 	Logo   string `json:"logo,omitempty"`

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -261,6 +261,9 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
 
   "url": "https://bitbucket.example.com",
 
+  // The username of the user that owns the token defined below.
+  "username": "",
+
   // Create a personal access token with read scope at
   // https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add
   "token": ""


### PR DESCRIPTION
This change set makes the `username` field of Bitbucket Server config
required.

Previously, it wasn't accepted when setting a token, but this behaviour
is wrong. The Bitbucket Server API needs both the username and the token
to authenticate clone URLs.

Part of #2025
Fixes #2514
