### PR TITLE
extract workspace roots from model

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -27,7 +27,8 @@ import {
     withLatestFrom,
 } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../../shared/src/actions/ActionItem'
-import { ViewComponentData, WorkspaceRootWithMetadata } from '../../../../../shared/src/api/client/model'
+import { ViewComponentData } from '../../../../../shared/src/api/client/model'
+import { WorkspaceRootWithMetadata } from '../../../../../shared/src/api/client/services/workspaceService'
 import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
 import { CommandListClassProps } from '../../../../../shared/src/commandPalette/CommandList'
 import { Controller } from '../../../../../shared/src/extensions/controller'
@@ -556,7 +557,6 @@ export function handleCodeHost({
     subscriptions.add(
         selectionsChanges.subscribe(selections => {
             extensionsController.services.model.model.next({
-                ...extensionsController.services.model.model.value,
                 visibleViewComponents: [...codeViewStates.values()]
                     .flatMap(state => state.visibleViewComponents)
                     .map(visibleViewComponent => ({ ...visibleViewComponent, selections })),
@@ -698,9 +698,11 @@ export function handleCodeHost({
 
             // Apply added/removed roots/visibleViewComponents
             extensionsController.services.model.model.next({
-                roots: uniqBy([...codeViewStates.values()].flatMap(state => state.roots), root => root.uri),
                 visibleViewComponents: [...codeViewStates.values()].flatMap(state => state.visibleViewComponents),
             })
+            extensionsController.services.workspace.roots.next(
+                uniqBy([...codeViewStates.values()].flatMap(state => state.roots), root => root.uri)
+            )
         })
     )
 

--- a/shared/src/api/client/api/roots.ts
+++ b/shared/src/api/client/api/roots.ts
@@ -1,15 +1,15 @@
 import { ProxyResult } from '@sourcegraph/comlink'
-import { WorkspaceRoot } from '@sourcegraph/extension-api-types'
-import { Observable, Subscription } from 'rxjs'
+import { Subscription } from 'rxjs'
 import { ExtRootsAPI } from '../../extension/api/roots'
+import { WorkspaceService } from '../services/workspaceService'
 
 /** @internal */
 export class ClientRoots {
     private subscriptions = new Subscription()
 
-    constructor(proxy: ProxyResult<ExtRootsAPI>, modelRoots: Observable<WorkspaceRoot[] | null>) {
+    constructor(proxy: ProxyResult<ExtRootsAPI>, workspaceService: WorkspaceService) {
         this.subscriptions.add(
-            modelRoots.subscribe(roots => {
+            workspaceService.roots.subscribe(roots => {
                 // tslint:disable-next-line: no-floating-promises
                 proxy.$acceptRoots(roots || [])
             })

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -135,15 +135,7 @@ export async function createExtensionHostClientConnection(
     )
     const clientSearch = new ClientSearch(services.queryTransformer)
     const clientCommands = new ClientCommands(services.commands)
-    subscription.add(
-        new ClientRoots(
-            proxy.roots,
-            from(services.model.model).pipe(
-                map(({ roots }) => roots),
-                distinctUntilChanged()
-            )
-        )
-    )
+    subscription.add(new ClientRoots(proxy.roots, services.workspace))
     subscription.add(new ClientExtensions(proxy.extensions, services.extensions))
 
     const clientAPI: ClientAPI = {

--- a/shared/src/api/client/model.ts
+++ b/shared/src/api/client/model.ts
@@ -1,4 +1,4 @@
-import { Selection, WorkspaceRoot } from '@sourcegraph/extension-api-types'
+import { Selection } from '@sourcegraph/extension-api-types'
 import { TextDocument } from 'sourcegraph'
 import { TextDocumentPositionParams } from '../protocol'
 
@@ -21,36 +21,12 @@ export interface CodeEditorViewComponentData<D extends Pick<TextDocument, 'uri'>
 }
 
 /**
- * A workspace root with additional metadata that is not exposed to extensions.
- */
-export interface WorkspaceRootWithMetadata extends WorkspaceRoot {
-    /**
-     * The original input Git revision that the user requested. The {@link WorkspaceRoot#uri} value will contain
-     * the Git commit SHA resolved from the input revision, but it is useful to also know the original revision
-     * (e.g., to construct URLs for the user that don't result in them navigating from a branch view to a commit
-     * SHA view).
-     *
-     * For example, if the user is viewing the web page https://github.com/alice/myrepo/blob/master/foo.js (note
-     * that the URL contains a Git revision "master"), the input revision is "master".
-     *
-     * The empty string is a valid value (meaning that the default should be used, such as "HEAD" in Git) and is
-     * distinct from undefined. If undefined, the Git commit SHA from {@link WorkspaceRoot#uri} should be used.
-     */
-    inputRevision?: string
-}
-
-/**
  * A description of the model represented by the Sourcegraph extension client application.
  *
  * This models the state of editor-like tools that display documents, allow selections and scrolling
  * in documents, and support extension configuration.
  */
 export interface Model {
-    /**
-     * The currently open workspace roots (typically a single repository).
-     */
-    readonly roots: WorkspaceRootWithMetadata[] | null
-
     /**
      * The view components that are currently visible. Each text document is represented as being in its own
      * visible CodeEditor.
@@ -60,7 +36,6 @@ export interface Model {
 
 /** An empty Sourcegraph extension client model. */
 export const EMPTY_MODEL: Model = {
-    roots: null,
     visibleViewComponents: null,
 }
 

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -12,6 +12,7 @@ import { NotificationsService } from './services/notifications'
 import { QueryTransformerRegistry } from './services/queryTransformer'
 import { createSettingsService } from './services/settings'
 import { ViewProviderRegistry } from './services/view'
+import { createWorkspaceService } from './services/workspaceService'
 
 /**
  * Services is a container for all services used by the client application.
@@ -32,6 +33,7 @@ export class Services {
     public readonly commands = new CommandRegistry()
     public readonly context = createContextService(this.platformContext)
     public readonly model = createModelService()
+    public readonly workspace = createWorkspaceService()
     public readonly notifications = new NotificationsService()
     public readonly settings = createSettingsService(this.platformContext)
     public readonly contribution = new ContributionRegistry(this.model.model, this.settings, this.context.data)

--- a/shared/src/api/client/services/workspaceService.test.ts
+++ b/shared/src/api/client/services/workspaceService.test.ts
@@ -1,0 +1,11 @@
+import { createWorkspaceService } from './workspaceService'
+
+describe('WorkspaceService', () => {
+    test('roots', () => {
+        const workspaceService = createWorkspaceService()
+        expect(workspaceService.roots.value).toEqual([])
+
+        workspaceService.roots.next([{ uri: 'a' }])
+        expect(workspaceService.roots.value).toEqual([{ uri: 'a' }])
+    })
+})

--- a/shared/src/api/client/services/workspaceService.ts
+++ b/shared/src/api/client/services/workspaceService.ts
@@ -1,0 +1,43 @@
+import { WorkspaceRoot } from '@sourcegraph/extension-api-types'
+import { BehaviorSubject, NextObserver, Subscribable } from 'rxjs'
+
+/**
+ * A workspace root with additional metadata that is not exposed to extensions.
+ */
+export interface WorkspaceRootWithMetadata extends WorkspaceRoot {
+    /**
+     * The original input Git revision that the user requested. The {@link WorkspaceRoot#uri} value will contain
+     * the Git commit SHA resolved from the input revision, but it is useful to also know the original revision
+     * (e.g., to construct URLs for the user that don't result in them navigating from a branch view to a commit
+     * SHA view).
+     *
+     * For example, if the user is viewing the web page https://github.com/alice/myrepo/blob/master/foo.js (note
+     * that the URL contains a Git revision "master"), the input revision is "master".
+     *
+     * The empty string is a valid value (meaning that the default should be used, such as "HEAD" in Git) and is
+     * distinct from undefined. If undefined, the Git commit SHA from {@link WorkspaceRoot#uri} should be used.
+     */
+    inputRevision?: string
+}
+
+/**
+ * The workspace service manages the workspace root folders.
+ */
+export interface WorkspaceService {
+    /**
+     * An observable whose value is the list of workspace root folder URIs.
+     */
+    readonly roots: Subscribable<readonly WorkspaceRootWithMetadata[]> & {
+        readonly value: readonly WorkspaceRootWithMetadata[]
+    } & NextObserver<readonly WorkspaceRootWithMetadata[]>
+}
+
+/**
+ * Creates a {@link WorkspaceService} instance.
+ */
+export function createWorkspaceService(): WorkspaceService {
+    const roots = new BehaviorSubject<readonly WorkspaceRootWithMetadata[]>([])
+    return {
+        roots,
+    }
+}

--- a/shared/src/api/extension/api/roots.ts
+++ b/shared/src/api/extension/api/roots.ts
@@ -5,7 +5,7 @@ import * as sourcegraph from 'sourcegraph'
 
 /** @internal */
 export interface ExtRootsAPI extends ProxyValue {
-    $acceptRoots(roots: clientType.WorkspaceRoot[]): void
+    $acceptRoots(roots: readonly clientType.WorkspaceRoot[]): void
 }
 
 /** @internal */

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -14,7 +14,6 @@ describe('CodeEditor (integration)', () => {
 
             const setSelections = (selections: Selection[]) => {
                 model.next({
-                    ...model.value,
                     visibleViewComponents: [
                         {
                             type: 'CodeEditor',

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -15,7 +15,6 @@ describe('Documents (integration)', () => {
         test('adds new text documents', async () => {
             const { model, extensionAPI } = await integrationTestContext()
             model.next({
-                ...model.value,
                 visibleViewComponents: [
                     {
                         type: 'CodeEditor',
@@ -43,7 +42,6 @@ describe('Documents (integration)', () => {
             expect(values).toEqual([] as TextDocument[])
 
             model.next({
-                ...model.value,
                 visibleViewComponents: [
                     {
                         type: 'CodeEditor',

--- a/shared/src/api/integration-test/roots.test.ts
+++ b/shared/src/api/integration-test/roots.test.ts
@@ -9,12 +9,12 @@ describe('Workspace roots (integration)', () => {
         })
 
         test('adds new text documents', async () => {
-            const { model, extensionAPI } = await integrationTestContext()
+            const {
+                services: { workspace },
+                extensionAPI,
+            } = await integrationTestContext()
 
-            model.next({
-                ...model.value,
-                roots: [{ uri: 'file:///a' }, { uri: 'file:///b' }],
-            })
+            workspace.roots.next([{ uri: 'file:///a' }, { uri: 'file:///b' }])
             await extensionAPI.internal.sync()
 
             expect(extensionAPI.workspace.roots).toEqual([
@@ -26,15 +26,15 @@ describe('Workspace roots (integration)', () => {
 
     describe('workspace.rootChanges', () => {
         test('fires when a root is added or removed', async () => {
-            const { model, extensionAPI } = await integrationTestContext()
+            const {
+                services: { workspace },
+                extensionAPI,
+            } = await integrationTestContext()
 
             const values = collectSubscribableValues(extensionAPI.workspace.rootChanges)
             expect(values).toEqual([] as void[])
 
-            model.next({
-                ...model.value,
-                roots: [{ uri: 'file:///a' }],
-            })
+            workspace.roots.next([{ uri: 'file:///a' }])
             await extensionAPI.internal.sync()
 
             expect(values).toEqual([void 0])

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -52,7 +52,6 @@ describe('Selections (integration)', () => {
             ]
             for (const selections of testValues) {
                 model.next({
-                    ...model.value,
                     visibleViewComponents: [withSelections(...selections)],
                 })
                 await extensionAPI.internal.sync()

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -9,9 +9,14 @@ import { ExtensionHostClient } from '../client/client'
 import { createExtensionHostClientConnection } from '../client/connection'
 import { Model } from '../client/model'
 import { Services } from '../client/services'
+import { WorkspaceRootWithMetadata } from '../client/services/workspaceService'
 import { InitData, startExtensionHost } from '../extension/extensionHost'
 
-const FIXTURE_MODEL: Model = {
+interface TestInitData extends Model {
+    roots: readonly WorkspaceRootWithMetadata[]
+}
+
+const FIXTURE_INIT_DATA: TestInitData = {
     roots: [{ uri: 'file:///' }],
     visibleViewComponents: [
         {
@@ -59,7 +64,7 @@ const NOOP_MOCKS: Mocks = {
  */
 export async function integrationTestContext(
     partialMocks: Partial<Mocks> = NOOP_MOCKS,
-    initModel: Model = FIXTURE_MODEL
+    initModel: TestInitData = FIXTURE_INIT_DATA
 ): Promise<
     TestContext & {
         model: Subscribable<Model> & { value: Model } & NextObserver<Model>
@@ -90,6 +95,7 @@ export async function integrationTestContext(
 
     const extensionAPI = await extensionHost.extensionAPI
     services.model.model.next(initModel)
+    services.workspace.roots.next(initModel.roots)
 
     // Wait for initModel to be initialized
     await Promise.all([

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -26,7 +26,6 @@ describe('Windows (integration)', () => {
                 visibleViewComponents: [],
             })
             model.next({
-                ...model.value,
                 visibleViewComponents: [
                     {
                         type: 'CodeEditor',
@@ -36,12 +35,8 @@ describe('Windows (integration)', () => {
                     },
                 ],
             })
+            model.next({ visibleViewComponents: [] })
             model.next({
-                ...model.value,
-                visibleViewComponents: [],
-            })
-            model.next({
-                ...model.value,
                 visibleViewComponents: [
                     {
                         type: 'CodeEditor',
@@ -80,7 +75,6 @@ describe('Windows (integration)', () => {
             const { model, extensionAPI } = await integrationTestContext()
 
             model.next({
-                ...model.value,
                 visibleViewComponents: [
                     {
                         type: 'CodeEditor',
@@ -115,7 +109,6 @@ describe('Windows (integration)', () => {
             const { model, extensionAPI } = await integrationTestContext()
 
             model.next({
-                ...model.value,
                 visibleViewComponents: [
                     {
                         type: 'CodeEditor',
@@ -154,7 +147,6 @@ describe('Windows (integration)', () => {
                 const { model, extensionAPI } = await integrationTestContext()
 
                 model.next({
-                    ...model.value,
                     visibleViewComponents: [
                         {
                             type: 'CodeEditor',
@@ -185,7 +177,6 @@ describe('Windows (integration)', () => {
                     visibleViewComponents: [],
                 })
                 model.next({
-                    ...model.value,
                     visibleViewComponents: [
                         {
                             type: 'CodeEditor',
@@ -195,12 +186,8 @@ describe('Windows (integration)', () => {
                         },
                     ],
                 })
+                model.next({ visibleViewComponents: [] })
                 model.next({
-                    ...model.value,
-                    visibleViewComponents: [],
-                })
-                model.next({
-                    ...model.value,
                     visibleViewComponents: [
                         {
                             type: 'CodeEditor',

--- a/shared/src/hover/actions.ts
+++ b/shared/src/hover/actions.ts
@@ -16,8 +16,8 @@ import {
 } from 'rxjs/operators'
 import { ActionItemAction } from '../actions/ActionItem'
 import { Context } from '../api/client/context/context'
-import { Model } from '../api/client/model'
 import { Services } from '../api/client/services'
+import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 import { ContributableMenu, TextDocumentPositionParams } from '../api/protocol'
 import { getContributedActionItems } from '../contributions/contributions'
 import { ExtensionsControllerProps } from '../extensions/controller'
@@ -75,8 +75,8 @@ export function getHoverActionsContext(
         | {
               extensionsController: {
                   services: {
-                      model: {
-                          model: { value: Pick<Model, 'roots'> }
+                      workspace: {
+                          roots: { value: readonly WorkspaceRootWithMetadata[] }
                       }
                       textDocumentDefinition: Pick<Services['textDocumentDefinition'], 'getLocations'>
                       textDocumentReferences: Pick<Services['textDocumentReferences'], 'providersForDocument'>
@@ -163,11 +163,11 @@ export function getHoverActionsContext(
 export function getDefinitionURL(
     { urlToFile }: Pick<PlatformContext, 'urlToFile'>,
     {
-        model,
+        workspace,
         textDocumentDefinition,
     }: {
-        model: {
-            model: { value: Pick<Model, 'roots'> }
+        workspace: {
+            roots: { value: readonly WorkspaceRootWithMetadata[] }
         }
         textDocumentDefinition: Pick<Services['textDocumentDefinition'], 'getLocations'>
     },
@@ -186,7 +186,7 @@ export function getDefinitionURL(
             if (definitions.length > 1) {
                 // Open the panel to show all definitions.
                 const uri = withWorkspaceRootInputRevision(
-                    model.model.value.roots || [],
+                    workspace.roots.value || [],
                     parseRepoURI(params.textDocument.uri)
                 )
                 return {
@@ -205,7 +205,7 @@ export function getDefinitionURL(
             // Preserve the input revision (e.g., a Git branch name instead of a Git commit SHA) if the result is
             // inside one of the current roots. This avoids navigating the user from (e.g.) a URL with a nice Git
             // branch name to a URL with a full Git commit SHA.
-            const uri = withWorkspaceRootInputRevision(model.model.value.roots || [], parseRepoURI(def.uri))
+            const uri = withWorkspaceRootInputRevision(workspace.roots.value || [], parseRepoURI(def.uri))
 
             if (def.range) {
                 uri.position = {
@@ -238,8 +238,8 @@ export function registerHoverContributions({
     | {
           extensionsController: {
               services: Pick<Services, 'commands' | 'contribution'> & {
-                  model: {
-                      model: { value: Pick<Model, 'roots'> }
+                  workspace: {
+                      roots: { value: readonly WorkspaceRootWithMetadata[] }
                   }
                   textDocumentDefinition: Pick<Services['textDocumentDefinition'], 'getLocations'>
               }

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -1,5 +1,5 @@
 import { Position, Range, Selection } from '@sourcegraph/extension-api-types'
-import { WorkspaceRootWithMetadata } from '../api/client/model'
+import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 
 export interface RepoSpec {
     /**
@@ -503,7 +503,7 @@ export function toURIWithPath(ctx: RepoSpec & ResolvedRevSpec & FileSpec): strin
  * is `git://r?a9cb9d#f`, it would be translated to `git://r?mybranch#f`.
  */
 export function withWorkspaceRootInputRevision(
-    workspaceRoots: WorkspaceRootWithMetadata[],
+    workspaceRoots: readonly WorkspaceRootWithMetadata[],
     uri: ParsedRepoURI
 ): ParsedRepoURI {
     const inWorkspaceRoot = workspaceRoots.find(root => {

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -293,7 +293,6 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
                 this.props.extensionsController.services.model.model.next({
-                    ...this.props.extensionsController.services.model.model.value,
                     visibleViewComponents: [
                         {
                             type: 'CodeEditor' as const,

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -167,10 +167,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
 
         // Clear the Sourcegraph extensions model's component when the blob is no longer shown.
         this.subscriptions.add(() =>
-            this.props.extensionsController.services.model.model.next({
-                ...this.props.extensionsController.services.model.model.value,
-                visibleViewComponents: null,
-            })
+            this.props.extensionsController.services.model.model.next({ visibleViewComponents: null })
         )
 
         this.propsUpdates.next(this.props)

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -70,9 +70,6 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                 }
             }
         }
-        this.props.extensionsController.services.model.model.next({
-            ...this.props.extensionsController.services.model.model.value,
-            visibleViewComponents,
-        })
+        this.props.extensionsController.services.model.model.next({ visibleViewComponents })
     }
 }


### PR DESCRIPTION
This is a step toward breaking apart the monolithic data "Model" for extensions. A monolithic data model makes it hard to perform updates of state on the client side (each call site must know how to make a deeply nested update to the big object) and is not the ideal data model for performance (given that it will be tracking a lot of state and will require very frequent updates, such as for each keystroke).

After this PR, the only thing in the model is the viewComponents array. Subsequent PRs in this series move that into an even simpler editor service.

This is the 1st PR in the series #3312 #3313 #3314. Review from left to right.