### PR TITLE
let extensions show link previews

### DIFF
--- a/client/browser/src/browser/types.ts
+++ b/client/browser/src/browser/types.ts
@@ -30,12 +30,18 @@ export interface FeatureFlags {
      * @duration permanent
      */
     allowErrorReporting: boolean
+
+    /**
+     * Support link previews from extensions in content views (such as GitHub issues).
+     */
+    experimentalLinkPreviews: boolean
 }
 
 export const featureFlagDefaults: FeatureFlags = {
     newInject: false,
     inlineSymbolSearchEnabled: true,
     allowErrorReporting: false,
+    experimentalLinkPreviews: false,
 }
 
 // TODO(chris) Switch to Partial<StorageItems> to eliminate bugs caused by

--- a/client/browser/src/extension/scripts/options.tsx
+++ b/client/browser/src/extension/scripts/options.tsx
@@ -18,7 +18,7 @@ assertEnv('OPTIONS')
 
 initSentry('options')
 
-type State = Pick<FeatureFlags, 'allowErrorReporting'> & { sourcegraphURL: string | null }
+type State = Pick<FeatureFlags, 'allowErrorReporting' | 'experimentalLinkPreviews'> & { sourcegraphURL: string | null }
 
 const keyIsFeatureFlag = (key: string): key is keyof FeatureFlags =>
     !!Object.keys(featureFlagDefaults).find(k => key === k)
@@ -48,15 +48,17 @@ const fetchCurrentTabStatus = async (): Promise<OptionsMenuProps['currentTabStat
     return { host, protocol, hasPermissions }
 }
 class Options extends React.Component<{}, State> {
-    public state: State = { sourcegraphURL: null, allowErrorReporting: false }
+    public state: State = { sourcegraphURL: null, allowErrorReporting: false, experimentalLinkPreviews: false }
 
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            storage.observeSync('featureFlags').subscribe(({ allowErrorReporting }) => {
-                this.setState({ allowErrorReporting })
-            })
+            storage
+                .observeSync('featureFlags')
+                .subscribe(({ allowErrorReporting, experimentalLinkPreviews: experimentalLinkPreviews }) => {
+                    this.setState({ allowErrorReporting, experimentalLinkPreviews })
+                })
         )
 
         this.subscriptions.add(
@@ -94,7 +96,10 @@ class Options extends React.Component<{}, State> {
             },
 
             toggleFeatureFlag,
-            featureFlags: [{ key: 'allowErrorReporting', value: this.state.allowErrorReporting }],
+            featureFlags: [
+                { key: 'allowErrorReporting', value: this.state.allowErrorReporting },
+                { key: 'experimentalLinkPreviews', value: this.state.experimentalLinkPreviews },
+            ],
         }
 
         return <OptionsContainer {...props} />

--- a/client/browser/src/libs/code_intelligence/content_views.test.ts
+++ b/client/browser/src/libs/code_intelligence/content_views.test.ts
@@ -1,0 +1,175 @@
+import { uniqueId } from 'lodash'
+import { of, Subject, Subscription } from 'rxjs'
+import { first } from 'rxjs/operators'
+import { MarkupKind } from 'sourcegraph'
+import { LinkPreviewMerged } from '../../../../../shared/src/api/client/services/linkPreview'
+import { createBarrier } from '../../../../../shared/src/api/integration-test/testHelpers'
+import { handleContentViews } from './content_views'
+
+describe('content_views', () => {
+    beforeEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    describe('handleContentViews()', () => {
+        let subscriptions = new Subscription()
+
+        afterEach(() => {
+            subscriptions.unsubscribe()
+            subscriptions = new Subscription()
+        })
+
+        const createTestElement = () => {
+            const el = document.createElement('div')
+            el.className = `test test-${uniqueId()}`
+            document.body.appendChild(el)
+            return el
+        }
+
+        test('detects and annotates content views', async () => {
+            const element = createTestElement()
+            element.id = 'content-view'
+            element.innerHTML = '0 <a href=#foo>foo</a> 1 <a href=#bar>bar</a> 2 <a href=#qux>qux</a> 3'
+            const wait = new Subject<void>()
+            subscriptions.add(
+                handleContentViews(
+                    of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    {
+                        extensionsController: {
+                            services: {
+                                linkPreviews: {
+                                    provideLinkPreview: url => {
+                                        wait.next()
+                                        if (url.includes('bar')) {
+                                            return of(null)
+                                        }
+                                        return of<LinkPreviewMerged>({
+                                            content: [
+                                                {
+                                                    kind: 'markdown' as MarkupKind.Markdown,
+                                                    value: `**${url.slice(url.lastIndexOf('#') + 1)}** x`,
+                                                },
+                                            ],
+                                            hover: [
+                                                {
+                                                    kind: 'plaintext' as MarkupKind.PlainText,
+                                                    value: url.slice(url.lastIndexOf('#') + 1),
+                                                },
+                                            ],
+                                        })
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        contentViewResolvers: [{ selector: 'div', resolveView: () => ({ element }) }],
+                        setElementTooltip: (e, text) =>
+                            text !== null ? e.setAttribute('data-tooltip', text) : e.removeAttribute('data-tooltip'),
+                    }
+                )
+            )
+            await wait.pipe(first()).toPromise()
+            expect(element.classList.contains('sg-mounted')).toBe(true)
+            expect(element.innerHTML).toBe(
+                '0 <a href="#foo" data-tooltip="foo">foo</a><span class="sg-link-preview-content" data-tooltip="foo"><strong>foo</strong> x</span> 1 <a href="#bar">bar</a> 2 <a href="#qux" data-tooltip="qux">qux</a><span class="sg-link-preview-content" data-tooltip="qux"><strong>qux</strong> x</span> 3'
+            )
+
+            // Mutate content view.
+            element.innerHTML = '4 <a href=#zip>zip</a> 5'
+            await wait.pipe(first()).toPromise()
+            expect(element.classList.contains('sg-mounted')).toBe(true)
+            expect(element.innerHTML).toBe(
+                '4 <a href="#zip" data-tooltip="zip">zip</a><span class="sg-link-preview-content" data-tooltip="zip"><strong>zip</strong> x</span> 5'
+            )
+        })
+
+        test('handles multiple emissions', async () => {
+            const element = createTestElement()
+            element.id = 'content-view'
+            element.innerHTML = '0 <a href=#foo>foo</a> 1 <a href=#bar>bar</a> 2'
+            const originalInnerHTML = element.innerHTML
+            const fooLinkPreviewValues = new Subject<LinkPreviewMerged>()
+            const { wait, done } = createBarrier()
+            subscriptions.add(
+                handleContentViews(
+                    of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    {
+                        extensionsController: {
+                            services: {
+                                linkPreviews: {
+                                    provideLinkPreview: url => {
+                                        done()
+                                        return url.includes('bar') ? of(null) : fooLinkPreviewValues
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        contentViewResolvers: [{ selector: 'div', resolveView: () => ({ element }) }],
+                        setElementTooltip: (e, text) =>
+                            text !== null ? e.setAttribute('data-tooltip', text) : e.removeAttribute('data-tooltip'),
+                    }
+                )
+            )
+
+            await wait
+            expect(element.classList.contains('sg-mounted')).toBe(true)
+            expect(element.innerHTML).toBe(originalInnerHTML)
+
+            fooLinkPreviewValues.next({
+                content: [
+                    {
+                        kind: 'markdown' as MarkupKind.Markdown,
+                        value: `**foo**`,
+                    },
+                ],
+                hover: [
+                    {
+                        kind: 'plaintext' as MarkupKind.PlainText,
+                        value: 'foo',
+                    },
+                ],
+            })
+            expect(element.innerHTML).toBe(
+                '0 <a href="#foo" data-tooltip="foo">foo</a><span class="sg-link-preview-content" data-tooltip="foo"><strong>foo</strong></span> 1 <a href="#bar">bar</a> 2'
+            )
+
+            fooLinkPreviewValues.next({
+                content: [
+                    {
+                        kind: 'markdown' as MarkupKind.Markdown,
+                        value: `**foo2**`,
+                    },
+                ],
+                hover: [
+                    {
+                        kind: 'plaintext' as MarkupKind.PlainText,
+                        value: 'foo2',
+                    },
+                ],
+            })
+            expect(element.innerHTML).toBe(
+                '0 <a href="#foo" data-tooltip="foo2">foo</a><span class="sg-link-preview-content" data-tooltip="foo2"><strong>foo2</strong></span> 1 <a href="#bar">bar</a> 2'
+            )
+
+            fooLinkPreviewValues.next({
+                content: [],
+                hover: [
+                    {
+                        kind: 'plaintext' as MarkupKind.PlainText,
+                        value: 'foo2',
+                    },
+                ],
+            })
+            expect(element.innerHTML).toBe('0 <a href="#foo" data-tooltip="foo2">foo</a> 1 <a href="#bar">bar</a> 2')
+
+            fooLinkPreviewValues.next({
+                content: [],
+                hover: [],
+            })
+            expect(element.innerHTML).toBe('0 <a href="#foo">foo</a> 1 <a href="#bar">bar</a> 2')
+        })
+    })
+})

--- a/client/browser/src/libs/code_intelligence/content_views.ts
+++ b/client/browser/src/libs/code_intelligence/content_views.ts
@@ -1,0 +1,129 @@
+import { animationFrameScheduler, merge, Observable, of, Subject, Subscription, Unsubscribable } from 'rxjs'
+import { distinctUntilChanged, map, mapTo, mergeMap, observeOn, tap, throttleTime } from 'rxjs/operators'
+import { LinkPreviewProviderRegistry } from '../../../../../shared/src/api/client/services/linkPreview'
+import { applyLinkPreview } from '../../../../../shared/src/components/linkPreviews/linkPreviews'
+import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
+import { MutationRecordLike, observeMutations } from '../../shared/util/dom'
+import { CodeHost } from './code_intelligence'
+import { trackViews } from './views'
+
+/**
+ * Defines a content view that is present on a page and exposes operations for manipulating it.
+ */
+export interface ContentView {
+    /** The content view HTML element. */
+    element: HTMLElement
+}
+
+/**
+ * Handles added and removed content views according to the {@link CodeHost} configuration.
+ */
+export function handleContentViews(
+    mutations: Observable<MutationRecordLike[]>,
+    {
+        extensionsController,
+    }:
+        | ExtensionsControllerProps
+        | {
+              extensionsController: {
+                  services: { linkPreviews: Pick<LinkPreviewProviderRegistry, 'provideLinkPreview'> }
+              }
+          },
+    {
+        contentViewResolvers,
+        linkPreviewContentClass,
+        setElementTooltip,
+    }: Pick<CodeHost, 'contentViewResolvers' | 'linkPreviewContentClass' | 'setElementTooltip'>
+): Unsubscribable {
+    /** A stream of added or removed content views. */
+    const contentViews = mutations.pipe(
+        trackViews<ContentView>(contentViewResolvers || []),
+        observeOn(animationFrameScheduler)
+    )
+    interface ContentViewState {
+        subscriptions: Subscription
+    }
+    /** Map from content view element to the state associated with it (to be updated or removed). */
+    const contentViewStates = new Map<Element, ContentViewState>()
+
+    /** Pause DOM MutationObserver while we are making changes to avoid duplicating work. */
+    const pauseMutationObserver = new Subject<boolean>()
+
+    return contentViews
+        .pipe(
+            mergeMap(contentViewEvent => {
+                if (contentViewEvent.type === 'added') {
+                    return merge(
+                        of(contentViewEvent),
+
+                        /**
+                         * Observe updates to the element. Only emit on mutations that actually
+                         * change the innerHTML so that our own {@link applyLinkPreview} updates
+                         * don't trigger needless work. It is not sufficient to suppress observing
+                         * these changes using {@link MutationObserver#disconnect} because that does
+                         * not actually seem to suppress mutation notifications in tests when using
+                         * jsdom.
+                         */
+                        observeMutations(contentViewEvent.element, { childList: true }, pauseMutationObserver).pipe(
+                            observeOn(animationFrameScheduler),
+                            map(() => contentViewEvent.element.innerHTML),
+                            distinctUntilChanged(),
+                            mapTo({ type: 'updated' as const, element: contentViewEvent.element }),
+                            throttleTime(2000, undefined, { leading: true, trailing: true }) // reduce the harm from an infinite loop bug
+                        )
+                    )
+                }
+                return of(contentViewEvent)
+            }),
+            tap(contentViewEvent => console.log(`Content view ${contentViewEvent.type}`, { contentViewEvent })),
+            tap(contentViewEvent => {
+                // Handle added, updated, or removed content views.
+
+                if (contentViewEvent.type === 'removed' || contentViewEvent.type === 'updated') {
+                    const contentViewState = contentViewStates.get(contentViewEvent.element)
+                    if (contentViewState) {
+                        contentViewState.subscriptions.unsubscribe()
+                        contentViewStates.delete(contentViewEvent.element)
+                    }
+                }
+
+                if (contentViewEvent.type === 'added' || contentViewEvent.type === 'updated') {
+                    const { element } = contentViewEvent
+                    let contentViewState = contentViewStates.get(contentViewEvent.element)
+                    if (!contentViewState) {
+                        contentViewState = { subscriptions: new Subscription() }
+                    }
+
+                    // Add link preview content.
+                    for (const link of element.querySelectorAll<HTMLAnchorElement>('a[href]')) {
+                        contentViewState.subscriptions.add(
+                            extensionsController.services.linkPreviews
+                                .provideLinkPreview(link.href)
+                                // The nested subscribe cannot be replaced with a switchMap()
+                                // because we are managing a stateful Map. The subscription is
+                                // managed correctly.
+                                //
+                                // tslint:disable-next-line: rxjs-no-nested-subscribe
+                                .subscribe(linkPreview => {
+                                    try {
+                                        pauseMutationObserver.next(true) // ignore DOM mutations we make
+                                        applyLinkPreview(
+                                            { setElementTooltip, linkPreviewContentClass },
+                                            link,
+                                            linkPreview
+                                        )
+                                    } finally {
+                                        pauseMutationObserver.next(false) // stop ignoring DOM mutations
+                                    }
+                                })
+                        )
+                    }
+                }
+
+                if (contentViewEvent.type === 'added') {
+                    contentViewEvent.element.classList.add('sg-mounted')
+                }
+            })
+        )
+        .subscribe()
+}

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -12,12 +12,14 @@ import {
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { querySelectorOrSelf } from '../../shared/util/dom'
 import { toAbsoluteBlobURL } from '../../shared/util/url'
-import { MountGetter } from '../code_intelligence'
+import { CodeHost, MountGetter } from '../code_intelligence'
 import { CodeViewSpec, CodeViewSpecResolver } from '../code_intelligence/code_views'
 import { ViewResolver } from '../code_intelligence/views'
+import { markdownBodyViewResolver } from './content_views'
 import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { getCommandPaletteMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './file_info'
+import { setElementTooltip } from './tooltip'
 import { getFileContainers, parseURL } from './util'
 
 /**
@@ -252,10 +254,11 @@ export const createOpenOnSourcegraphIfNotExists: MountGetter = (container: HTMLE
     return mount
 }
 
-export const githubCodeHost = {
+export const githubCodeHost: CodeHost = {
     name: 'github',
     codeViewSpecs: [searchResultCodeView, commentSnippetCodeView, fileLineContainerCodeView],
     codeViewSpecResolver,
+    contentViewResolvers: [markdownBodyViewResolver],
     getContext: parseURL,
     getViewContextOnSourcegraphMount: createOpenOnSourcegraphIfNotExists,
     viewOnSourcegraphButtonClassProps: {
@@ -288,6 +291,8 @@ export const githubCodeHost = {
         actionItemPressedClassName: 'active',
         closeButtonClassName: 'btn',
     },
+    setElementTooltip,
+    linkPreviewContentClass: 'text-small text-gray p-1 mx-1 border rounded-1 bg-gray text-gray-dark',
     urlToFile: (
         location: RepoSpec & RevSpec & FileSpec & Partial<PositionSpec> & Partial<ViewStateSpec> & { part?: DiffPart }
     ) => {

--- a/client/browser/src/libs/github/content_views.ts
+++ b/client/browser/src/libs/github/content_views.ts
@@ -1,0 +1,11 @@
+import { ContentView } from '../code_intelligence/content_views'
+import { ViewResolver } from '../code_intelligence/views'
+
+/**
+ * Matches all GitHub Markdown body content, including comment bodies, issue/PR descriptions, review
+ * comments, and rendered Markdown files.
+ */
+export const markdownBodyViewResolver: ViewResolver<ContentView> = {
+    selector: '.markdown-body',
+    resolveView: element => ({ element }),
+}

--- a/client/browser/src/libs/github/tooltip.test.ts
+++ b/client/browser/src/libs/github/tooltip.test.ts
@@ -1,0 +1,20 @@
+import { setElementTooltip } from './tooltip'
+
+describe('setElementTooltip', () => {
+    test('sets', () => {
+        const template = document.createElement('span')
+        template.classList.add('foo')
+        template.append('bar')
+        setElementTooltip(template, 'tt')
+        expect(template.outerHTML).toBe('<span class="foo tooltipped tooltipped-n" aria-label="tt">bar</span>')
+    })
+
+    test('removes', () => {
+        const template = document.createElement('span')
+        template.classList.add('foo', 'tooltipped', 'tooltipped-n')
+        template.setAttribute('aria-label', 'tt')
+        template.append('bar')
+        setElementTooltip(template, null)
+        expect(template.outerHTML).toBe('<span class="foo">bar</span>')
+    })
+})

--- a/client/browser/src/libs/github/tooltip.ts
+++ b/client/browser/src/libs/github/tooltip.ts
@@ -1,0 +1,13 @@
+/** GitHub element classes for showing a tooltip above an element (n=north). */
+const TOOLTIP_CLASSES = ['tooltipped', 'tooltipped-n']
+
+/** Sets the GitHub native tooltip on the given element. */
+export function setElementTooltip(element: HTMLElement, tooltip: string | null): void {
+    if (typeof tooltip === 'string') {
+        element.classList.add(...TOOLTIP_CLASSES)
+        element.setAttribute('aria-label', tooltip)
+    } else {
+        element.classList.remove(...TOOLTIP_CLASSES)
+        element.removeAttribute('aria-label')
+    }
+}

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -65,6 +65,7 @@ const (
 	routeHelp           = "help"
 	routeExplore        = "explore"
 	routeWelcome        = "welcome"
+	routeSnippets       = "snippets"
 
 	// Legacy redirects
 	routeLegacyLogin                   = "login"
@@ -138,6 +139,7 @@ func newRouter() *mux.Router {
 	r.PathPrefix("/extensions").Methods("GET").Name(routeExtensions)
 	r.PathPrefix("/help").Methods("GET").Name(routeHelp)
 	r.PathPrefix("/explore").Methods("GET").Name(routeExplore)
+	r.PathPrefix("/snippets").Methods("GET").Name(routeSnippets)
 
 	// Legacy redirects
 	r.Path("/login").Methods("GET").Name(routeLegacyLogin)
@@ -213,6 +215,7 @@ func initRouter() {
 	router.Get(routeExtensions).Handler(handler(serveBasicPageString("Extensions - Sourcegraph")))
 	router.Get(routeExplore).Handler(handler(serveBasicPageString("Explore - Sourcegraph")))
 	router.Get(routeHelp).HandlerFunc(serveHelp)
+	router.Get(routeSnippets).Handler(handler(serveBasicPageString("Snippets - Sourcegraph")))
 
 	router.Get(routeUserSettings).Handler(handler(serveBasicPageString("User settings - Sourcegraph")))
 	router.Get(routeUserRedirect).Handler(handler(serveBasicPageString("User - Sourcegraph")))

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1137,6 +1137,65 @@ declare module 'sourcegraph' {
         export function executeCommand<T = any>(command: string, ...args: any[]): Promise<T>
     }
 
+    /**
+     * A description of the information available at a URL.
+     */
+    export interface LinkPreview {
+        /**
+         * The content of this link preview, which is shown next to the link.
+         */
+        content?: MarkupContent
+
+        /**
+         * The hover content of this link preview, which is shown when the cursor hovers the link.
+         *
+         * @todo Add support for Markdown. Currently only plain text is supported.
+         */
+        hover?: Pick<MarkupContent, 'value'> & { kind: MarkupKind.PlainText }
+    }
+
+    /**
+     * Called to obtain a preview of the information available at a URL.
+     */
+    export interface LinkPreviewProvider {
+        /**
+         * Provides a preview of the information available at the URL of a link in a document.
+         *
+         * @todo Add a `context` parameter so that the provider knows what document contains the
+         * link (so that it can handle links in code files differently from rendered Markdown
+         * documents, for example).
+         *
+         * @param url The URL of the link to preview.
+         */
+        provideLinkPreview(url: URL): ProviderResult<LinkPreview>
+    }
+
+    /**
+     * Extensions can customize how content is rendered.
+     */
+    export namespace content {
+        /**
+         * EXPERIMENTAL. This API is subject to change without notice and has no compatibility
+         * guarantees.
+         *
+         * Registers a provider for link previews ({@link LinkPreviewProvider}) for all URLs in a
+         * document matching the {@link urlMatchPattern}. A link preview is a description of the
+         * information available at a URL.
+         *
+         * @todo Support a more powerful syntax for URL match patterns, such as Chrome's
+         * (https://developer.chrome.com/extensions/match_patterns).
+         *
+         * @param urlMatchPattern A pattern that matches URLs for which the provider is called to
+         * obtain a preview. Currently it matches all URLs that start with the match pattern (i.e.,
+         * string prefix matches). No wildcards are supported.
+         * @param provider The link preview provider.
+         */
+        export function registerLinkPreviewProvider(
+            urlMatchPattern: string,
+            provider: LinkPreviewProvider
+        ): Unsubscribable
+    }
+
     export interface ContextValues {
         [key: string]: string | number | boolean | null
     }

--- a/shared/src/api/client/api/api.ts
+++ b/shared/src/api/client/api/api.ts
@@ -1,6 +1,7 @@
 import { ClientCodeEditorAPI } from './codeEditor'
 import { ClientCommandsAPI } from './commands'
 import { ClientConfigurationAPI } from './configuration'
+import { ClientContentAPI } from './content'
 import { ClientContextAPI } from './context'
 import { ClientLanguageFeaturesAPI } from './languageFeatures'
 import { ClientSearchAPI } from './search'
@@ -21,4 +22,5 @@ export interface ClientAPI {
     windows: ClientWindowsAPI
     codeEditor: ClientCodeEditorAPI
     views: ClientViewsAPI
+    content: ClientContentAPI
 }

--- a/shared/src/api/client/api/content.ts
+++ b/shared/src/api/client/api/content.ts
@@ -1,0 +1,24 @@
+import { ProxyResult, ProxyValue, proxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
+import { LinkPreview, Unsubscribable } from 'sourcegraph'
+import { ProxySubscribable } from '../../extension/api/common'
+import { LinkPreviewProviderRegistry } from '../services/linkPreview'
+import { wrapRemoteObservable } from './common'
+
+/** @internal */
+export interface ClientContentAPI extends ProxyValue {
+    $registerLinkPreviewProvider(
+        urlMatchPattern: string,
+        provider: ProxyResult<((url: string) => ProxySubscribable<LinkPreview | null | undefined>) & ProxyValue>
+    ): Unsubscribable & ProxyValue
+}
+
+/** @internal */
+export function createClientContent(registry: LinkPreviewProviderRegistry): ClientContentAPI & ProxyValue {
+    return {
+        [proxyValueSymbol]: true,
+        $registerLinkPreviewProvider: (urlMatchPattern, providerFunction) =>
+            proxyValue(
+                registry.registerProvider({ urlMatchPattern }, url => wrapRemoteObservable(providerFunction(url)))
+            ),
+    }
+}

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -9,6 +9,7 @@ import { ClientAPI } from './api/api'
 import { ClientCodeEditor } from './api/codeEditor'
 import { ClientCommands } from './api/commands'
 import { ClientConfiguration } from './api/configuration'
+import { createClientContent } from './api/content'
 import { ClientContext } from './api/context'
 import { ClientExtensions } from './api/extensions'
 import { ClientLanguageFeatures } from './api/languageFeatures'
@@ -116,6 +117,8 @@ export async function createExtensionHostClientConnection(
     subscription.add(new ClientRoots(proxy.roots, services.workspace))
     subscription.add(new ClientExtensions(proxy.extensions, services.extensions))
 
+    const clientContent = createClientContent(services.linkPreviews)
+
     const clientAPI: ClientAPI = {
         ping: () => 'pong',
         context: clientContext,
@@ -126,6 +129,7 @@ export async function createExtensionHostClientConnection(
         windows: clientWindows,
         codeEditor: clientCodeEditor,
         views: clientViews,
+        content: clientContent,
     }
     comlink.expose(clientAPI, endpoints.expose)
 

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -7,6 +7,7 @@ import { TextDocumentDecorationProviderRegistry } from './services/decoration'
 import { createEditorService } from './services/editorService'
 import { ExtensionsService } from './services/extensionsService'
 import { TextDocumentHoverProviderRegistry } from './services/hover'
+import { LinkPreviewProviderRegistry } from './services/linkPreview'
 import { TextDocumentLocationProviderIDRegistry, TextDocumentLocationProviderRegistry } from './services/location'
 import { createModelService } from './services/modelService'
 import { NotificationsService } from './services/notifications'
@@ -40,6 +41,7 @@ export class Services {
     public readonly settings = createSettingsService(this.platformContext)
     public readonly contribution = new ContributionRegistry(this.editor, this.settings, this.context.data)
     public readonly extensions = new ExtensionsService(this.platformContext, this.editor, this.settings)
+    public readonly linkPreviews = new LinkPreviewProviderRegistry()
     public readonly textDocumentDefinition = new TextDocumentLocationProviderRegistry()
     public readonly textDocumentReferences = new TextDocumentLocationProviderRegistry<ReferenceParams>()
     public readonly textDocumentLocations = new TextDocumentLocationProviderIDRegistry()

--- a/shared/src/api/client/services/linkPreview.test.ts
+++ b/shared/src/api/client/services/linkPreview.test.ts
@@ -1,0 +1,207 @@
+import { Observable, of, throwError } from 'rxjs'
+import { TestScheduler } from 'rxjs/testing'
+import * as sourcegraph from 'sourcegraph'
+import {
+    LinkPreviewMerged,
+    LinkPreviewProviderRegistrationOptions,
+    LinkPreviewProviderRegistry,
+    provideLinkPreview,
+    ProvideLinkPreviewSignature,
+    renderMarkupContents,
+} from './linkPreview'
+import { Entry } from './registry'
+
+const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
+
+const FIXTURE_LINK_PREVIEW: sourcegraph.LinkPreview = {
+    content: { value: 'x', kind: sourcegraph.MarkupKind.PlainText },
+    hover: { value: 'y', kind: sourcegraph.MarkupKind.PlainText },
+}
+const FIXTURE_LINK_PREVIEW_MERGED: LinkPreviewMerged = {
+    content: [{ value: 'x', kind: sourcegraph.MarkupKind.PlainText }],
+    hover: [{ value: 'y', kind: sourcegraph.MarkupKind.PlainText }],
+}
+
+describe('LinkPreviewProviderRegistry', () => {
+    /**
+     * Allow overriding {@link LinkPreviewProviderRegistry#entries} for tests.
+     */
+    class TestLinkPreviewProviderRegistry extends LinkPreviewProviderRegistry {
+        constructor(
+            entries?: Observable<Entry<LinkPreviewProviderRegistrationOptions, ProvideLinkPreviewSignature>[]>
+        ) {
+            super()
+            if (entries) {
+                entries.subscribe(entries => this.entries.next(entries))
+            }
+        }
+
+        /** Make public for tests. */
+        public observeProvidersForLink(url: string): Observable<ProvideLinkPreviewSignature[]> {
+            return super.observeProvidersForLink(url)
+        }
+    }
+
+    describe('observeProvidersForLink', () => {
+        const PROVIDER: ProvideLinkPreviewSignature = () =>
+            of<sourcegraph.LinkPreview>({ hover: { value: 'x', kind: sourcegraph.MarkupKind.PlainText } })
+
+        test('prefix match', () => {
+            scheduler().run(({ cold, expectObservable }) => {
+                const registry = new TestLinkPreviewProviderRegistry(
+                    cold<Entry<LinkPreviewProviderRegistrationOptions, ProvideLinkPreviewSignature>[]>('a', {
+                        a: [{ provider: PROVIDER, registrationOptions: { urlMatchPattern: 'http://example.com' } }],
+                    })
+                )
+                expectObservable(registry.observeProvidersForLink('http://example.com')).toBe('a', {
+                    a: [PROVIDER],
+                })
+            })
+        })
+
+        test('no prefix match', () => {
+            scheduler().run(({ cold, expectObservable }) => {
+                const registry = new TestLinkPreviewProviderRegistry(
+                    cold<Entry<LinkPreviewProviderRegistrationOptions, ProvideLinkPreviewSignature>[]>('a', {
+                        a: [{ provider: PROVIDER, registrationOptions: { urlMatchPattern: 'http://example.com' } }],
+                    })
+                )
+                expectObservable(registry.observeProvidersForLink('http://other.example.com/foo')).toBe('a', {
+                    a: [],
+                })
+            })
+        })
+    })
+})
+
+describe('provideLinkPreview', () => {
+    describe('0 providers', () => {
+        test('returns null', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    provideLinkPreview(cold<ProvideLinkPreviewSignature[]>('-a-|', { a: [] }), 'http://example.com/foo')
+                ).toBe('-a-|', {
+                    a: null,
+                })
+            ))
+    })
+
+    describe('1 provider', () => {
+        test('returns null result from provider', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    provideLinkPreview(
+                        cold<ProvideLinkPreviewSignature[]>('-a-|', { a: [() => of(null)] }),
+                        'http://example.com/foo'
+                    )
+                ).toBe('-a-|', {
+                    a: null,
+                })
+            ))
+
+        test('returns result from provider', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    provideLinkPreview(
+                        cold<ProvideLinkPreviewSignature[]>('-a-|', {
+                            a: [() => of(FIXTURE_LINK_PREVIEW)],
+                        }),
+                        'http://example.com/foo'
+                    )
+                ).toBe('-a-|', {
+                    a: FIXTURE_LINK_PREVIEW_MERGED,
+                })
+            ))
+    })
+
+    test('errors do not propagate', () =>
+        scheduler().run(({ cold, expectObservable }) =>
+            expectObservable(
+                provideLinkPreview(
+                    cold<ProvideLinkPreviewSignature[]>('-a-|', {
+                        a: [() => of(FIXTURE_LINK_PREVIEW), () => throwError(new Error('x'))],
+                    }),
+                    'http://example.com/foo',
+                    false
+                )
+            ).toBe('-a-|', {
+                a: FIXTURE_LINK_PREVIEW_MERGED,
+            })
+        ))
+
+    describe('2 providers', () => {
+        test('returns null result if both providers return null', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    provideLinkPreview(
+                        cold<ProvideLinkPreviewSignature[]>('-a-|', {
+                            a: [() => of(null), () => of(null)],
+                        }),
+                        'http://example.com/foo'
+                    )
+                ).toBe('-a-|', {
+                    a: null,
+                })
+            ))
+
+        test('omits null result from 1 provider', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    provideLinkPreview(
+                        cold<ProvideLinkPreviewSignature[]>('-a-|', {
+                            a: [() => of(FIXTURE_LINK_PREVIEW), () => of(null)],
+                        }),
+                        'http://example.com/foo'
+                    )
+                ).toBe('-a-|', {
+                    a: FIXTURE_LINK_PREVIEW_MERGED,
+                })
+            ))
+
+        test('merges results from providers', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    provideLinkPreview(
+                        cold<ProvideLinkPreviewSignature[]>('-a-|', {
+                            a: [() => of(FIXTURE_LINK_PREVIEW), () => of(FIXTURE_LINK_PREVIEW)],
+                        }),
+                        'http://example.com/foo'
+                    )
+                ).toBe('-a-|', {
+                    a: {
+                        content: [FIXTURE_LINK_PREVIEW.content, FIXTURE_LINK_PREVIEW.content],
+                        hover: [FIXTURE_LINK_PREVIEW.hover, FIXTURE_LINK_PREVIEW.hover],
+                    },
+                })
+            ))
+    })
+
+    describe('multiple emissions', () => {
+        test('returns stream of results', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    provideLinkPreview(
+                        cold<ProvideLinkPreviewSignature[]>('-a-b-|', {
+                            a: [() => of(FIXTURE_LINK_PREVIEW)],
+                            b: [() => of(null)],
+                        }),
+                        'http://example.com/foo'
+                    )
+                ).toBe('-a-b-|', {
+                    a: FIXTURE_LINK_PREVIEW_MERGED,
+                    b: null,
+                })
+            ))
+    })
+})
+
+describe('renderMarkupContents', () => {
+    test('renders', () =>
+        expect(
+            renderMarkupContents([
+                { value: '*a*' },
+                { kind: sourcegraph.MarkupKind.PlainText, value: 'b' },
+                { kind: sourcegraph.MarkupKind.Markdown, value: '*c*' },
+            ])
+        ).toEqual([{ html: '<em>a</em>' }, 'b', { html: '<em>c</em>' }]))
+})

--- a/shared/src/api/client/services/linkPreview.ts
+++ b/shared/src/api/client/services/linkPreview.ts
@@ -1,0 +1,133 @@
+import { isEqual } from 'lodash'
+import { from, Observable } from 'rxjs'
+import { catchError, defaultIfEmpty, distinctUntilChanged, map, switchMap } from 'rxjs/operators'
+import * as sourcegraph from 'sourcegraph'
+import { renderMarkdown } from '../../../util/markdown'
+import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
+import { propertyIsDefined } from '../../../util/types'
+import { FeatureProviderRegistry } from './registry'
+
+interface MarkupContentPlainTextOnly extends Pick<sourcegraph.MarkupContent, 'value'> {
+    kind: sourcegraph.MarkupKind.PlainText
+}
+
+/**
+ * Represents one or more {@link sourcegraph.LinkPreview} values merged together.
+ */
+export interface LinkPreviewMerged {
+    /** The content of the merged {@link sourcegraph.LinkPreview} values. */
+    content: sourcegraph.MarkupContent[]
+
+    /** The hover content of the merged {@link sourcegraph.LinkPreview} values. */
+    hover: MarkupContentPlainTextOnly[]
+}
+
+/**
+ * Provider registration options for a {@link sourcegraph.PreviewLinkProvider}.
+ */
+export interface LinkPreviewProviderRegistrationOptions {
+    /**
+     * @see {@link sourcegraph.content.registerLinkPreviewProvider#urlMatchPattern}
+     */
+    urlMatchPattern: string
+}
+
+export type ProvideLinkPreviewSignature = (url: string) => Observable<sourcegraph.LinkPreview | null | undefined>
+
+/**
+ * Manages {@link sourcegraph.LinkPreviewProvider} registrations.
+ */
+export class LinkPreviewProviderRegistry extends FeatureProviderRegistry<
+    LinkPreviewProviderRegistrationOptions,
+    ProvideLinkPreviewSignature
+> {
+    /**
+     * Returns an observable that emits all providers' link previews whenever any of the
+     * last-emitted set of providers emits link previews. If any provider emits an error, the error
+     * is logged and the provider's result is omitted from the emission of the observable (the
+     * observable does not emit the error).
+     */
+    public provideLinkPreview(url: string): Observable<LinkPreviewMerged | null> {
+        return provideLinkPreview(this.observeProvidersForLink(url), url)
+    }
+
+    /**
+     * Return an observable that emits all providers whose
+     * {@link LinkPreviewProviderRegistrationOptions} match `url` upon subscription and whenever the
+     * set of registered providers changes.
+     */
+    protected observeProvidersForLink(url: string): Observable<ProvideLinkPreviewSignature[]> {
+        return this.entries.pipe(
+            map(entries =>
+                entries
+                    .filter(entry => url.startsWith(entry.registrationOptions.urlMatchPattern))
+                    .map(({ provider }) => provider)
+            )
+        )
+    }
+}
+
+/**
+ * Returns an observable that emits all providers' link previews whenever any of the last-emitted
+ * set of providers emits link previews. If any provider emits an error, the error is logged and the
+ * provider's result is omitted from the emission of the observable (the observable does not emit
+ * the error).
+ *
+ * Most callers should use {@link LinkPreviewProviderRegistry#provideLinkPreview} method, which uses
+ * the registered providers.
+ */
+export function provideLinkPreview(
+    providers: Observable<ProvideLinkPreviewSignature[]>,
+    url: string,
+    logErrors = true
+): Observable<LinkPreviewMerged | null> {
+    return providers.pipe(
+        switchMap(providers =>
+            combineLatestOrDefault(
+                providers.map(provider =>
+                    from(
+                        provider(url).pipe(
+                            catchError(err => {
+                                if (logErrors) {
+                                    console.error(err)
+                                }
+                                return [null]
+                            })
+                        )
+                    )
+                )
+            ).pipe(
+                map(mergeLinkPreviews),
+                defaultIfEmpty<LinkPreviewMerged | null>(null),
+                distinctUntilChanged((a, b) => isEqual(a, b))
+            )
+        )
+    )
+}
+
+function mergeLinkPreviews(values: (sourcegraph.LinkPreview | null | undefined)[]): LinkPreviewMerged | null {
+    const nonemptyValues = values.filter((p): p is sourcegraph.LinkPreview => !!p)
+    const contentValues = nonemptyValues.filter(propertyIsDefined('content'))
+    const hoverValues = nonemptyValues.filter(propertyIsDefined('hover'))
+    if (hoverValues.length === 0 && contentValues.length === 0) {
+        return null
+    }
+    return { content: contentValues.map(({ content }) => content), hover: hoverValues.map(({ hover }) => hover) }
+}
+
+/**
+ * Renders an array of {@link sourcegraph.MarkupContent} to its HTML or plaintext contents. The HTML
+ * contents are wrapped in an object `{ html: string }` so that callers can differentiate them from
+ * plaintext contents.
+ */
+export function renderMarkupContents(contents: sourcegraph.MarkupContent[]): ({ html: string } | string)[] {
+    return contents.map(({ kind, value }) => {
+        if (kind === undefined || kind === 'markdown') {
+            const html = renderMarkdown(value)
+                .replace(/^<p>/, '')
+                .replace(/<\/p>\s*$/, '') // remove <p> wrapper
+            return { html }
+        }
+        return value // plaintext
+    })
+}

--- a/shared/src/api/client/types/textDocument.ts
+++ b/shared/src/api/client/types/textDocument.ts
@@ -3,6 +3,17 @@ import minimatch from 'minimatch'
 import { DocumentFilter, DocumentSelector, TextDocument } from 'sourcegraph'
 
 /**
+ * The URI scheme for the resources that hold the body of comments (such as comments on a GitHub
+ * issue).
+ */
+export const COMMENT_URI_SCHEME = 'comment'
+
+/**
+ * The URI scheme for the resources that hold the body of snippets.
+ */
+export const SNIPPET_URI_SCHEME = 'snippet'
+
+/**
  * A literal to identify a text document in the client.
  */
 export interface TextDocumentIdentifier {

--- a/shared/src/api/extension/api/content.ts
+++ b/shared/src/api/extension/api/content.ts
@@ -1,0 +1,20 @@
+import { ProxyInput, ProxyResult, proxyValue } from '@sourcegraph/comlink'
+import { Unsubscribable } from 'rxjs'
+import { LinkPreviewProvider } from 'sourcegraph'
+import { ClientContentAPI } from '../../client/api/content'
+import { syncSubscription } from '../../util'
+import { toProxyableSubscribable } from './common'
+
+/** @internal */
+export class ExtContent {
+    constructor(private proxy: ProxyResult<ClientContentAPI>) {}
+
+    public registerLinkPreviewProvider(urlMatchPattern: string, provider: LinkPreviewProvider): Unsubscribable {
+        const providerFunction: ProxyInput<
+            Parameters<ClientContentAPI['$registerLinkPreviewProvider']>[1]
+        > = proxyValue(async (url: string) =>
+            toProxyableSubscribable(provider.provideLinkPreview(new URL(url)), preview => preview)
+        )
+        return syncSubscription(this.proxy.$registerLinkPreviewProvider(urlMatchPattern, providerFunction))
+    }
+}

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -7,6 +7,7 @@ import { NotificationType } from '../client/services/notifications'
 import { ExtensionHostAPI, ExtensionHostAPIFactory } from './api/api'
 import { ExtCommands } from './api/commands'
 import { ExtConfiguration } from './api/configuration'
+import { ExtContent } from './api/content'
 import { ExtContext } from './api/context'
 import { createDecorationType } from './api/decorations'
 import { ExtDocuments } from './api/documents'
@@ -139,6 +140,7 @@ function createExtensionAPI(
     const languageFeatures = new ExtLanguageFeatures(proxy.languageFeatures, documents)
     const search = new ExtSearch(proxy.search)
     const commands = new ExtCommands(proxy.commands)
+    const content = new ExtContent(proxy.content)
 
     // Expose the extension host API to the client (main thread)
     const extensionHostAPI: ExtensionHostAPI = {
@@ -252,6 +254,11 @@ function createExtensionAPI(
                 commands.registerCommand({ command, callback }),
 
             executeCommand: (command: string, ...args: any[]) => commands.executeCommand(command, args),
+        },
+
+        content: {
+            registerLinkPreviewProvider: (urlMatchPattern: string, provider: sourcegraph.LinkPreviewProvider) =>
+                content.registerLinkPreviewProvider(urlMatchPattern, provider),
         },
 
         internal: {

--- a/shared/src/api/integration-test/content.test.ts
+++ b/shared/src/api/integration-test/content.test.ts
@@ -1,0 +1,71 @@
+import { take } from 'rxjs/operators'
+import * as sourcegraph from 'sourcegraph'
+import { integrationTestContext } from './testHelpers'
+
+describe('content (integration)', () => {
+    test('registers a link preview provider', async () => {
+        const { services, extensionAPI } = await integrationTestContext()
+
+        // Register the provider and call it.
+        extensionAPI.content.registerLinkPreviewProvider('http://example.com', {
+            provideLinkPreview: url => ({
+                content: { value: `xyz ${url.toString()}`, kind: sourcegraph.MarkupKind.PlainText },
+            }),
+        })
+        await extensionAPI.internal.sync()
+        expect(
+            await services.linkPreviews
+                .provideLinkPreview('http://example.com/foo')
+                .pipe(take(1))
+                .toPromise()
+        ).toEqual({
+            content: [{ value: 'xyz http://example.com/foo', kind: sourcegraph.MarkupKind.PlainText }],
+            hover: [],
+        })
+    })
+
+    test('unregisters a link preview provider', async () => {
+        const { services, extensionAPI } = await integrationTestContext()
+
+        // Register the provider and call it.
+        const subscription = extensionAPI.content.registerLinkPreviewProvider('http://example.com', {
+            provideLinkPreview: () => ({ content: { value: 'bar', kind: sourcegraph.MarkupKind.PlainText } }),
+        })
+        await extensionAPI.internal.sync()
+
+        // Unregister the provider and ensure it's removed.
+        subscription.unsubscribe()
+        await extensionAPI.internal.sync()
+        expect(
+            await services.linkPreviews
+                .provideLinkPreview('http://example.com/foo')
+                .pipe(take(1))
+                .toPromise()
+        ).toEqual(null)
+    })
+
+    test('supports multiple link preview providers', async () => {
+        const { services, extensionAPI } = await integrationTestContext()
+
+        // Register the provider and call it
+        extensionAPI.content.registerLinkPreviewProvider('http://example.com', {
+            provideLinkPreview: () => ({ content: { value: 'qux', kind: sourcegraph.MarkupKind.PlainText } }),
+        })
+        extensionAPI.content.registerLinkPreviewProvider('http://example.com', {
+            provideLinkPreview: () => ({ content: { value: 'zip', kind: sourcegraph.MarkupKind.PlainText } }),
+        })
+        await extensionAPI.internal.sync()
+        expect(
+            await services.linkPreviews
+                .provideLinkPreview('http://example.com/foo')
+                .pipe(take(1))
+                .toPromise()
+        ).toEqual({
+            content: [
+                { value: 'qux', kind: sourcegraph.MarkupKind.PlainText },
+                { value: 'zip', kind: sourcegraph.MarkupKind.PlainText },
+            ],
+            hover: [],
+        })
+    })
+})

--- a/shared/src/components/editorTextField/EditorTextField.test.tsx
+++ b/shared/src/components/editorTextField/EditorTextField.test.tsx
@@ -1,0 +1,162 @@
+import { of } from 'rxjs'
+import { CodeEditor } from '../../api/client/services/editorService'
+import { EditorTextFieldUtils } from './EditorTextField'
+
+describe('EditorTextFieldUtils', () => {
+    describe('getEditorDataFromElement', () => {
+        test('empty selection', () => {
+            const e = document.createElement('textarea')
+            e.value = 'abc'
+            e.setSelectionRange(2, 2)
+            expect(EditorTextFieldUtils.getEditorDataFromElement(e)).toEqual({
+                text: 'abc',
+                selections: [
+                    {
+                        anchor: { line: 0, character: 2 },
+                        active: { line: 0, character: 2 },
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 2 },
+                        isReversed: false,
+                    },
+                ],
+            })
+        })
+        test('forward selection', () => {
+            const e = document.createElement('textarea')
+            e.value = 'abc'
+            e.setSelectionRange(2, 3)
+            expect(EditorTextFieldUtils.getEditorDataFromElement(e)).toEqual({
+                text: 'abc',
+                selections: [
+                    {
+                        anchor: { line: 0, character: 2 },
+                        active: { line: 0, character: 3 },
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                        isReversed: false,
+                    },
+                ],
+            })
+        })
+        test('backward selection', () => {
+            const e = document.createElement('textarea')
+            e.value = 'abc'
+            e.setSelectionRange(2, 3, 'backward')
+            expect(EditorTextFieldUtils.getEditorDataFromElement(e)).toEqual({
+                text: 'abc',
+                selections: [
+                    {
+                        anchor: { line: 0, character: 3 },
+                        active: { line: 0, character: 2 },
+                        start: { line: 0, character: 3 },
+                        end: { line: 0, character: 2 },
+                        isReversed: true,
+                    },
+                ],
+            })
+        })
+    })
+
+    test('updateEditorSelectionFromElement', () => {
+        const e = document.createElement('textarea')
+        e.value = 'abc'
+        e.setSelectionRange(2, 3, 'backward')
+        const setSelections = jest.fn()
+        EditorTextFieldUtils.updateEditorSelectionFromElement({ setSelections }, { editorId: 'e' }, e)
+        expect(setSelections.mock.calls.length).toBe(1)
+        expect(setSelections.mock.calls[0][0]).toEqual({ editorId: 'e' })
+        expect(setSelections.mock.calls[0][1]).toEqual([
+            {
+                anchor: { line: 0, character: 3 },
+                active: { line: 0, character: 2 },
+                start: { line: 0, character: 3 },
+                end: { line: 0, character: 2 },
+                isReversed: true,
+            },
+        ])
+    })
+
+    test('updateModelFromElement', () => {
+        const e = document.createElement('textarea')
+        e.value = 'abc'
+        e.setSelectionRange(2, 3, 'backward')
+        const updateModel = jest.fn()
+        EditorTextFieldUtils.updateModelFromElement({ updateModel }, 'u', e)
+        expect(updateModel.mock.calls.length).toBe(1)
+        expect(updateModel.mock.calls[0][0]).toEqual('u')
+        expect(updateModel.mock.calls[0][1]).toEqual('abc')
+    })
+
+    describe('updateElementOnEditorOrModelChanges', () => {
+        test('forward selection', () => {
+            const e = document.createElement('textarea')
+            e.value = 'abc'
+            const setValue = jest.fn()
+            const subscription = EditorTextFieldUtils.updateElementOnEditorOrModelChanges(
+                {
+                    editors: of<readonly CodeEditor[]>([
+                        {
+                            editorId: 'e',
+                            type: 'CodeEditor',
+                            resource: 'u',
+                            model: { uri: 'u', languageId: 'l', text: 'xyz' },
+                            selections: [
+                                {
+                                    anchor: { line: 0, character: 2 },
+                                    active: { line: 0, character: 3 },
+                                    start: { line: 0, character: 2 },
+                                    end: { line: 0, character: 3 },
+                                    isReversed: false,
+                                },
+                            ],
+                            isActive: true,
+                        },
+                    ]),
+                },
+                { editorId: 'e' },
+                setValue,
+                { current: e }
+            )
+            expect(setValue.mock.calls.length).toBe(1)
+            expect(setValue.mock.calls[0][0]).toEqual('xyz')
+            expect(e.selectionStart).toBe(2)
+            expect(e.selectionEnd).toBe(3)
+            expect(e.selectionDirection).toBe('forward')
+            subscription.unsubscribe()
+        })
+        test('backward selection', () => {
+            const e = document.createElement('textarea')
+            e.value = 'abc'
+            const setValue = jest.fn()
+            const subscription = EditorTextFieldUtils.updateElementOnEditorOrModelChanges(
+                {
+                    editors: of<readonly CodeEditor[]>([
+                        {
+                            editorId: 'e',
+                            type: 'CodeEditor',
+                            resource: 'u',
+                            model: { uri: 'u', languageId: 'l', text: 'xyz' },
+                            selections: [
+                                {
+                                    anchor: { line: 0, character: 3 },
+                                    active: { line: 0, character: 2 },
+                                    start: { line: 0, character: 3 },
+                                    end: { line: 0, character: 2 },
+                                    isReversed: true,
+                                },
+                            ],
+                            isActive: true,
+                        },
+                    ]),
+                },
+                { editorId: 'e' },
+                setValue,
+                { current: e }
+            )
+            expect(e.selectionStart).toBe(2)
+            expect(e.selectionEnd).toBe(3)
+            expect(e.selectionDirection).toBe('backward')
+            subscription.unsubscribe()
+        })
+    })
+})

--- a/shared/src/components/editorTextField/EditorTextField.tsx
+++ b/shared/src/components/editorTextField/EditorTextField.tsx
@@ -1,0 +1,205 @@
+import { isEqual } from 'lodash'
+import React, { createRef, TextareaHTMLAttributes, useEffect, useState } from 'react'
+import { from, Subscription, Unsubscribable } from 'rxjs'
+import { distinctUntilChanged, filter, map } from 'rxjs/operators'
+import { CodeEditor, CodeEditorData, EditorId, EditorService } from '../../api/client/services/editorService'
+import { ModelService, TextModel } from '../../api/client/services/modelService'
+import { offsetToPosition, positionToOffset } from '../../api/client/types/textDocument'
+import { ExtensionsControllerProps } from '../../extensions/controller'
+import { isDefined } from '../../util/types'
+
+/**
+ * Utilities for 2-way syncing an HTMLTextAreaElement with an editor and model. These are factored
+ * out of the {@link EditorTextField} component so that they can be used in other places, such as in
+ * the browser extension.
+ */
+export const EditorTextFieldUtils = {
+    /**
+     * Reads the current selections and value from the element.
+     */
+    getEditorDataFromElement: (
+        element: HTMLTextAreaElement
+    ): Pick<TextModel, 'text'> & Pick<CodeEditorData, 'selections'> => {
+        const isReversed = element.selectionDirection === 'backward'
+        const selectionStart = isReversed ? element.selectionEnd : element.selectionStart
+        const selectionEnd = isReversed ? element.selectionStart : element.selectionEnd
+        const start = offsetToPosition(element.value, selectionStart)
+        const end = selectionStart === selectionEnd ? start : offsetToPosition(element.value, selectionEnd)
+        return {
+            text: element.value,
+            selections: [{ anchor: start, active: end, start, end, isReversed }],
+        }
+    },
+
+    /**
+     * Update the editor's selection from the element's selection.
+     */
+    updateEditorSelectionFromElement: (
+        editorService: Pick<EditorService, 'setSelections'>,
+        editor: EditorId,
+        element: HTMLTextAreaElement
+    ): void => {
+        editorService.setSelections(editor, EditorTextFieldUtils.getEditorDataFromElement(element).selections)
+    },
+
+    /**
+     * Update the model from the element's value.
+     */
+    updateModelFromElement: (
+        modelService: Pick<ModelService, 'updateModel'>,
+        modelUri: string,
+        element: HTMLTextAreaElement
+    ): void => {
+        modelService.updateModel(modelUri, element.value)
+    },
+
+    /**
+     * Update the element's value (via {@link setValue}) and selection range whenever the editor or
+     * model change.
+     */
+    updateElementOnEditorOrModelChanges: (
+        editorService: Pick<EditorService, 'editors'>,
+        editor: EditorId,
+        setValue: (text: string) => void,
+        textAreaRef: React.RefObject<Pick<HTMLTextAreaElement, 'value' | 'setSelectionRange'>>
+    ): Unsubscribable => {
+        const subscriptions = new Subscription()
+
+        const editorChanges = from(editorService.editors).pipe(map(editors => findEditor(editors, editor.editorId)))
+        const modelTextChanges = editorChanges.pipe(
+            map(editor => editor.model.text),
+            distinctUntilChanged(),
+            filter(isDefined)
+        )
+
+        // Update text.
+        subscriptions.add(modelTextChanges.subscribe(text => setValue(text)))
+
+        // Update selection.
+        subscriptions.add(
+            editorChanges
+                .pipe(
+                    map(editor => editor.selections),
+                    distinctUntilChanged((a, b) => isEqual(a, b)),
+                    filter(selections => selections.length !== 0)
+                )
+                .subscribe(selections => {
+                    const textArea = textAreaRef.current
+                    if (textArea) {
+                        const sel = selections[0] // TODO: Only a single selection is supported.
+                        const start = positionToOffset(textArea.value, sel.start)
+                        const isEmpty = sel.start.line === sel.end.line && sel.start.character === sel.end.character
+                        const end = isEmpty ? start : positionToOffset(textArea.value, sel.end)
+                        textArea.setSelectionRange(
+                            sel.isReversed ? end : start,
+                            sel.isReversed ? start : end,
+                            sel.isReversed ? 'backward' : 'forward'
+                        )
+                    }
+                })
+        )
+
+        return subscriptions
+    },
+}
+
+interface Props
+    extends ExtensionsControllerProps,
+        Pick<
+            TextareaHTMLAttributes<HTMLTextAreaElement>,
+            'className' | 'placeholder' | 'autoFocus' | 'onKeyDown' | 'rows' | 'spellCheck'
+        > {
+    /**
+     * The ID of the editor that this component is backed by.
+     */
+    editorId: EditorId['editorId']
+
+    /**
+     * The URI of the model that this component is backed by.
+     */
+    modelUri: TextModel['uri']
+
+    /**
+     * Called when the textarea value (editor model content) changes.
+     */
+    onValueChange?: (value: string) => void
+
+    /**
+     * A ref to the HTMLTextAreaElement.
+     */
+    textAreaRef?: React.RefObject<HTMLTextAreaElement>
+}
+
+/**
+ * An HTML textarea that is backed by (and 2-way-synced with) a {@link sourcegraph.CodeEditor}.
+ */
+export const EditorTextField: React.FunctionComponent<Props> = ({
+    editorId,
+    modelUri,
+    onValueChange,
+    textAreaRef: _textAreaRef,
+    className,
+    extensionsController: {
+        services: { editor: editorService, model: modelService },
+    },
+    onKeyDown: parentOnKeyDown,
+    ...textAreaProps
+}: Props) => {
+    // The new, preferred React hooks API requires use of lambdas.
+    //
+    // tslint:disable: jsx-no-lambda
+
+    const textAreaRef = _textAreaRef || createRef<HTMLTextAreaElement>()
+
+    const [value, setValue] = useState<string>()
+    useEffect(() => {
+        const subscription = EditorTextFieldUtils.updateElementOnEditorOrModelChanges(
+            editorService,
+            { editorId },
+            text => {
+                setValue(text)
+
+                // Forward changes.
+                if (onValueChange) {
+                    onValueChange(text)
+                }
+            },
+            textAreaRef
+        )
+        return () => subscription.unsubscribe()
+    }, [editorId])
+
+    return (
+        <textarea
+            className={className}
+            value={value}
+            onInput={e => {
+                EditorTextFieldUtils.updateModelFromElement(modelService, modelUri, e.currentTarget)
+                EditorTextFieldUtils.updateEditorSelectionFromElement(editorService, { editorId }, e.currentTarget)
+            }}
+            // Listen on keyup and keydown to get the cursor position when the cursor moves due to
+            // the arrow keys. For a single keypress, keyup is used. If the user holds down the
+            // arrow key, keydown lets us get the key repeat for (most) intermediate positions so we
+            // can be more responsive to user input instead of waiting for keyup.
+            onKeyDown={e => {
+                EditorTextFieldUtils.updateEditorSelectionFromElement(editorService, { editorId }, e.currentTarget)
+                if (parentOnKeyDown && !e.isPropagationStopped()) {
+                    parentOnKeyDown(e)
+                }
+            }}
+            onKeyUp={e => {
+                EditorTextFieldUtils.updateEditorSelectionFromElement(editorService, { editorId }, e.currentTarget)
+            }}
+            ref={textAreaRef}
+            {...textAreaProps}
+        />
+    )
+}
+
+function findEditor(editors: readonly CodeEditor[], editorId: EditorId['editorId']): CodeEditor {
+    const editor = editors.find(e => e.editorId === editorId)
+    if (!editor) {
+        throw new Error(`editor not found: ${editorId}`)
+    }
+    return editor
+}

--- a/shared/src/components/linkPreviews/WithLinkPreviews.tsx
+++ b/shared/src/components/linkPreviews/WithLinkPreviews.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react'
+import { Subscription } from 'rxjs'
+import { ExtensionsControllerProps } from '../../extensions/controller'
+import { applyLinkPreview, ApplyLinkPreviewOptions } from './linkPreviews'
+
+interface Props extends ExtensionsControllerProps, ApplyLinkPreviewOptions {
+    /**
+     * The HTML content to render (and to which link previews will be added).
+     */
+    dangerousInnerHTML: string
+
+    /**
+     * The "render prop" that is called to render the component with the HTML (after the link
+     * previews have been added).
+     */
+    children: (props: { dangerousInnerHTML: string }) => JSX.Element
+}
+
+/**
+ * Renders HTML in a component with link previews applied from providers registered with
+ * {@link sourcegraph.content.registerLinkPreviewProvider}.
+ */
+export const WithLinkPreviews: React.FunctionComponent<Props> = props => {
+    const [html, setHTML] = useState<string>(props.dangerousInnerHTML)
+    useEffect(() => {
+        const container = document.createElement('div')
+        container.innerHTML = props.dangerousInnerHTML
+        setHTML(props.dangerousInnerHTML)
+
+        const subscriptions = new Subscription()
+        for (const link of container.querySelectorAll<HTMLAnchorElement>('a[href]')) {
+            props.extensionsController.services.linkPreviews.provideLinkPreview(link.href).subscribe(linkPreview => {
+                applyLinkPreview(props, link, linkPreview)
+                setHTML(container.innerHTML)
+            })
+        }
+        return () => subscriptions.unsubscribe()
+    }, [props.dangerousInnerHTML, props.setElementTooltip, props.linkPreviewContentClass])
+
+    return props.children({ dangerousInnerHTML: html })
+}

--- a/shared/src/components/linkPreviews/linkPreviews.test.ts
+++ b/shared/src/components/linkPreviews/linkPreviews.test.ts
@@ -1,0 +1,41 @@
+import { MarkupKind } from 'sourcegraph'
+import { LinkPreviewMerged } from '../../api/client/services/linkPreview'
+import { applyLinkPreview, ApplyLinkPreviewOptions } from './linkPreviews'
+
+const OPTIONS: ApplyLinkPreviewOptions = {
+    setElementTooltip: (e, text) =>
+        text !== null ? e.setAttribute('data-tooltip', text) : e.removeAttribute('data-tooltip'),
+}
+
+describe('applyLinkPreview', () => {
+    test('annotates element and is idempotent', async () => {
+        const div = document.createElement('div')
+        const link = document.createElement('a')
+        link.href = 'u'
+        link.innerText = 'b'
+        div.append(link)
+
+        const LINK_PREVIEW_MERGED: LinkPreviewMerged = {
+            content: [
+                {
+                    kind: 'markdown' as MarkupKind.Markdown,
+                    value: '**x**',
+                },
+            ],
+            hover: [
+                {
+                    kind: 'plaintext' as MarkupKind.PlainText,
+                    value: 'y',
+                },
+            ],
+        }
+        applyLinkPreview(OPTIONS, link, LINK_PREVIEW_MERGED)
+        const WANT =
+            '<a href="u" data-tooltip="y"></a><span class="sg-link-preview-content" data-tooltip="y"><strong>x</strong></span>'
+        expect(div.innerHTML).toBe(WANT)
+
+        // Check for idempotence.
+        applyLinkPreview(OPTIONS, link, LINK_PREVIEW_MERGED)
+        expect(div.innerHTML).toBe(WANT)
+    })
+})

--- a/shared/src/components/linkPreviews/linkPreviews.ts
+++ b/shared/src/components/linkPreviews/linkPreviews.ts
@@ -1,0 +1,84 @@
+import { LinkPreviewMerged, renderMarkupContents } from '../../api/client/services/linkPreview'
+
+/** Options for {@link applyLinkPreview}. */
+export interface ApplyLinkPreviewOptions {
+    /**
+     * CSS classes for the link preview content element to customize styling.
+     */
+    linkPreviewContentClass?: string
+
+    /**
+     * Sets or removes a plain-text tooltip on the HTML element using the native style.
+     *
+     * @param element The HTML element whose tooltip to set or remove.
+     * @param tooltip The tooltip plain-text content (to add the tooltip) or `null` (to remove the
+     * tooltip).
+     */
+    setElementTooltip?: (element: HTMLElement, tooltip: string | null) => void
+}
+
+/**
+ * Updates the DOM surrounding {@link} to reflect the link preview for a single link. This operation
+ * is idempotent.
+ *
+ * @param link The <a> element in the content view.
+ * @param linkPreview The link preview to display.
+ */
+export function applyLinkPreview(
+    { setElementTooltip, linkPreviewContentClass }: ApplyLinkPreviewOptions,
+    link: HTMLAnchorElement,
+    linkPreview: LinkPreviewMerged | null
+): void {
+    const LINK_PREVIEW_CONTENT_ELEMENT_CLASS_NAME = 'sg-link-preview-content'
+    let afterElement: HTMLElement | undefined
+    if (
+        link.nextSibling instanceof HTMLElement &&
+        link.nextSibling.classList.contains(LINK_PREVIEW_CONTENT_ELEMENT_CLASS_NAME)
+    ) {
+        afterElement = link.nextSibling
+    }
+
+    if (linkPreview && linkPreview.content && linkPreview.content.length > 0) {
+        if (afterElement) {
+            afterElement.innerHTML = '' // clear for updated content
+        } else {
+            afterElement = document.createElement('span')
+            afterElement.classList.add(LINK_PREVIEW_CONTENT_ELEMENT_CLASS_NAME)
+            if (linkPreviewContentClass) {
+                afterElement.classList.add(...linkPreviewContentClass.split(' '))
+            }
+            link.insertAdjacentElement('afterend', afterElement)
+        }
+        for (const c of renderMarkupContents(linkPreview.content)) {
+            if (typeof c === 'string') {
+                afterElement.append(c)
+            } else {
+                const span = document.createElement('span')
+                span.innerHTML = c.html
+                // Use while-loop instead of iterating over span.childNodes because the loop body
+                // mutates span.childNodes, so nodes would be skipped.
+                while (span.hasChildNodes()) {
+                    afterElement.appendChild(span.childNodes[0])
+                }
+            }
+        }
+    } else if (afterElement) {
+        afterElement.remove()
+        afterElement = undefined
+    }
+
+    if (setElementTooltip) {
+        setElementTooltip(link, getHoverText(linkPreview))
+        if (afterElement) {
+            setElementTooltip(afterElement, getHoverText(linkPreview))
+        }
+    }
+}
+
+function getHoverText(linkPreview: LinkPreviewMerged | null): string | null {
+    if (!linkPreview) {
+        return null
+    }
+    const hoverValues = linkPreview.hover.map(({ value }) => value).filter(v => !!v)
+    return hoverValues.length > 0 ? hoverValues.join(' ') : null
+}

--- a/web/src/components/tooltip/Tooltip.tsx
+++ b/web/src/components/tooltip/Tooltip.tsx
@@ -125,3 +125,19 @@ export class Tooltip extends React.PureComponent<Props, State> {
         return subject.getAttribute(Tooltip.SUBJECT_ATTRIBUTE) || undefined
     }
 }
+
+/**
+ * Sets or removes a plain-text tooltip on the HTML element using the native style for Sourcegraph
+ * web app.
+ *
+ * @param element The HTML element whose tooltip to set or remove.
+ * @param tooltip The tooltip plain-text content (to add the tooltip) or `null` (to remove the
+ * tooltip).
+ */
+export function setElementTooltip(element: HTMLElement, tooltip: string | null): void {
+    if (tooltip) {
+        element.setAttribute('data-tooltip', tooltip)
+    } else {
+        element.removeAttribute('data-tooltip')
+    }
+}

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -42,6 +42,9 @@ const RedirectToUserPage = React.lazy(async () => ({
 const RedirectToUserSettings = React.lazy(async () => ({
     default: (await import('./user/settings/RedirectToUserSettings')).RedirectToUserSettings,
 }))
+const SnippetsPage = React.lazy(async () => ({
+    default: (await import('./snippets/SnippetsPage')).SnippetsPage,
+}))
 
 export interface LayoutRouteComponentProps extends RouteComponentProps<any>, LayoutProps {}
 
@@ -201,6 +204,10 @@ export const routes: ReadonlyArray<LayoutRouteProps> = [
             window.location.reload()
             return null
         },
+    },
+    {
+        path: '/snippets',
+        render: props => <SnippetsPage {...props} />,
     },
     repoRevRoute,
 ]

--- a/web/src/snippets/SnippetsPage.tsx
+++ b/web/src/snippets/SnippetsPage.tsx
@@ -1,0 +1,126 @@
+import H from 'history'
+import { uniqueId } from 'lodash'
+import React, { useEffect, useState } from 'react'
+import { from } from 'rxjs'
+import { filter, map } from 'rxjs/operators'
+import { EditorId } from '../../../shared/src/api/client/services/editorService'
+import { TextModel } from '../../../shared/src/api/client/services/modelService'
+import { PanelViewWithComponent } from '../../../shared/src/api/client/services/view'
+import { SNIPPET_URI_SCHEME } from '../../../shared/src/api/client/types/textDocument'
+import { ContributableViewContainer } from '../../../shared/src/api/protocol'
+import { EditorTextField } from '../../../shared/src/components/editorTextField/EditorTextField'
+import { WithLinkPreviews } from '../../../shared/src/components/linkPreviews/WithLinkPreviews'
+import { Markdown } from '../../../shared/src/components/Markdown'
+import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
+import { createLinkClickHandler } from '../../../shared/src/util/linkClickHandler'
+import { renderMarkdown } from '../../../shared/src/util/markdown'
+import { isDefined } from '../../../shared/src/util/types'
+import { setElementTooltip } from '../components/tooltip/Tooltip'
+
+interface Props extends ExtensionsControllerProps {
+    location: H.Location
+    history: H.History
+}
+
+/**
+ * Shows a text field for a snippet. This functionality is currently incomplete and is intended only
+ * to allow experimentation with extensions that listen for changes in documents and display
+ * Markdown-formatted text.
+ */
+export const SnippetsPage: React.FunctionComponent<Props> = props => {
+    const [editorId, setEditorId] = useState<EditorId | null>(null)
+    const [modelUri, setModelUri] = useState<string | null>(null)
+
+    const urlQuery = new URLSearchParams(props.location.search)
+
+    const textAreaClassName = urlQuery.has('mono') ? 'text-monospace' : ''
+
+    const initialModelUriScheme = urlQuery.get('scheme') || SNIPPET_URI_SCHEME
+    const initialModelLanguageId = urlQuery.get('languageId') || 'plaintext'
+    const initialModelText = urlQuery.get('text') || ''
+    useEffect(() => {
+        const model: TextModel = {
+            uri: uniqueId(`${initialModelUriScheme}://`),
+            languageId: initialModelLanguageId,
+            text: initialModelText,
+        }
+        props.extensionsController.services.model.addModel(model)
+        setModelUri(model.uri)
+        const editor = props.extensionsController.services.editor.addEditor({
+            type: 'CodeEditor',
+            resource: model.uri,
+            selections: [],
+            isActive: true,
+        })
+        setEditorId(editor)
+        return () => {
+            props.extensionsController.services.editor.removeEditor(editor)
+            props.extensionsController.services.model.removeModel(model.uri)
+        }
+    }, [initialModelUriScheme, initialModelLanguageId, initialModelText])
+
+    const [panelViews, setPanelViews] = useState<PanelViewWithComponent[] | null>(null)
+    useEffect(() => {
+        const subscription = props.extensionsController.services.views
+            .getViews(ContributableViewContainer.Panel)
+            .subscribe(views => setPanelViews(views))
+        return () => subscription.unsubscribe()
+    }, [])
+
+    // Add Markdown panel for Markdown snippets.
+    const [modelText, setModelText] = useState<string | null>(null)
+    useEffect(() => {
+        if (!editorId) {
+            return () => void 0
+        }
+        const subscription = from(props.extensionsController.services.editor.editors)
+            .pipe(
+                map(editors => editors.find(e => e.editorId === editorId.editorId)),
+                filter(isDefined),
+                map(editor => editor.model.text)
+            )
+            .subscribe(text => setModelText(text || null))
+        return () => subscription.unsubscribe()
+    }, [editorId, initialModelLanguageId])
+    const allPanelViews: PanelViewWithComponent[] | null =
+        initialModelLanguageId === 'markdown' && modelText !== null
+            ? [...(panelViews || []), { title: 'Preview', content: modelText, priority: 0 }]
+            : panelViews
+
+    return (
+        <div className="container mt-3">
+            <h1>
+                Snippet editor <span className="badge badge-warning">Experimental</span>
+            </h1>
+            {editorId && modelUri && (
+                <EditorTextField
+                    className={`form-control ${textAreaClassName || ''}`}
+                    placeholder="Type a snippet"
+                    editorId={editorId.editorId}
+                    modelUri={modelUri}
+                    autoFocus={true}
+                    spellCheck={false}
+                    rows={12}
+                    extensionsController={props.extensionsController}
+                />
+            )}
+            {allPanelViews &&
+                allPanelViews.length > 0 &&
+                allPanelViews.map((view, i) => (
+                    <div key={i} className="mt-3 card">
+                        <h3 className="card-header">{view.title}</h3>
+                        <div className="card-body" onClick={createLinkClickHandler(props.history)}>
+                            <WithLinkPreviews
+                                dangerousInnerHTML={renderMarkdown(view.content)}
+                                extensionsController={props.extensionsController}
+                                setElementTooltip={setElementTooltip}
+                                linkPreviewContentClass="mx-1 rounded border p-1 small bg-secondary text-muted"
+                            >
+                                {props => <Markdown {...props} />}
+                            </WithLinkPreviews>
+                        </div>
+                    </div>
+                ))}
+        </div>
+    )
+}


### PR DESCRIPTION
Adds a new extension API `sourcegraph.content.registerLinkPreviewProvider` that can be used to annotate links in a GitHub issue (or other comment) with hover and after content. This can be used, e.g., to show preview cards for JIRA issues (not just other GitHub issues), customer names for private CRM links (to track which customers care about an issue), thumbnails of designs on Figma/Zeplin, etc.

This is only implemented for GitHub now, but the hooks in the `CodeHost` interface can be used to add support for other code hosts.


## Test plan

See test plan for https://github.com/sourcegraph/sourcegraph/pull/3392.

---

The extension API is marked as experimental for now. It is also behind a feature flag in the browser extension (off by default):

![image](https://user-images.githubusercontent.com/1976/56017836-48b26e80-5cb5-11e9-9f3c-d3158e06d63f.png)

