### PR TITLE
Remove getOverlayMount() and getGlobalDebugMount()

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -15,7 +15,8 @@ import { integrationTestContext } from '../../../../../shared/src/api/integratio
 import { Controller } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { isDefined } from '../../../../../shared/src/util/types'
-import { FileInfo, handleCodeHost } from './code_intelligence'
+import { FileInfo, getOverlayMount, handleCodeHost } from './code_intelligence'
+import { testMountGetter } from './code_intelligence_test_utils'
 
 const elementRenderedAtMount = (mount: Element): renderer.ReactTestRendererJSON | undefined => {
     const call = RENDER.mock.calls.find(call => call[1] === mount)
@@ -42,6 +43,16 @@ const createMockPlatformContext = (
         sideloadedExtensionURL: new Subject<string | null>(),
         ...partialMocks,
     },
+})
+
+describe('getOverlayMount()', () => {
+    testMountGetter(
+        // The overlay mount is appended to <body>, so it doesn't matter which fixture we use.
+        `${__dirname}/../github/__fixtures__/github.com/pull-request/vanilla/unified/page.html`,
+        getOverlayMount('github'),
+        true,
+        true
+    )
 })
 
 describe('handleCodeHost()', () => {

--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -15,7 +15,7 @@ import { integrationTestContext } from '../../../../../shared/src/api/integratio
 import { Controller } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { isDefined } from '../../../../../shared/src/util/types'
-import { FileInfo, getOverlayMount, handleCodeHost } from './code_intelligence'
+import { FileInfo, getGlobalDebugMount, getOverlayMount, handleCodeHost } from './code_intelligence'
 import { testMountGetter } from './code_intelligence_test_utils'
 
 const elementRenderedAtMount = (mount: Element): renderer.ReactTestRendererJSON | undefined => {
@@ -50,6 +50,16 @@ describe('getOverlayMount()', () => {
         // The overlay mount is appended to <body>, so it doesn't matter which fixture we use.
         `${__dirname}/../github/__fixtures__/github.com/pull-request/vanilla/unified/page.html`,
         getOverlayMount('github'),
+        true,
+        true
+    )
+})
+
+describe('getGlobalDebugMount()', () => {
+    testMountGetter(
+        // The overlay mount is appended to <body>, so it doesn't matter which fixture we use.
+        `${__dirname}/../github/__fixtures__/github.com/pull-request/vanilla/unified/page.html`,
+        getGlobalDebugMount,
         true,
         true
     )
@@ -131,26 +141,6 @@ describe('handleCodeHost()', () => {
         const globalDebugMount = document.querySelector('.global-debug')
         expect(globalDebugMount).not.toBeUndefined()
         const renderedDebugElement = elementRenderedAtMount(globalDebugMount!)
-        expect(renderedDebugElement).not.toBeUndefined()
-    })
-
-    test('renders the debug palette to the provided mount if codeHost.globalDebugMount is defined', async () => {
-        const { services } = await integrationTestContext()
-        const globalDebugMount = createTestElement()
-        subscriptions.add(
-            handleCodeHost({
-                mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
-                codeHost: {
-                    name: 'test',
-                    check: () => true,
-                    getGlobalDebugMount: () => globalDebugMount,
-                },
-                extensionsController: createMockController(services),
-                showGlobalDebug: true,
-                ...createMockPlatformContext(),
-            })
-        )
-        const renderedDebugElement = elementRenderedAtMount(globalDebugMount)
         expect(renderedDebugElement).not.toBeUndefined()
     })
 

--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -44,243 +44,246 @@ const createMockPlatformContext = (
     },
 })
 
-describe('createOverlayMount()', () => {
-    it('should create the overlay mount', () => {
+describe('code_intelligence', () => {
+    beforeEach(() => {
         document.body.innerHTML = ''
-        createOverlayMount('some-code-host')
-        const mount = document.body.querySelector('.hover-overlay-mount')
-        expect(mount).toBeDefined()
-        expect(mount!.className).toBe('hover-overlay-mount hover-overlay-mount__some-code-host')
-    })
-})
-
-describe('createGlobalDebugMount()', () => {
-    it('should create the debug menu mount', () => {
-        document.body.innerHTML = ''
-        createGlobalDebugMount()
-        const mount = document.body.querySelector('.global-debug')
-        expect(mount).toBeDefined()
-    })
-})
-
-describe('handleCodeHost()', () => {
-    let subscriptions = new Subscription()
-
-    afterEach(() => {
-        document.body.innerHTML = ''
-        RENDER.mockClear()
-        subscriptions.unsubscribe()
-        subscriptions = new Subscription()
     })
 
-    const createTestElement = () => {
-        const el = document.createElement('div')
-        el.className = `test test-${uniqueId()}`
-        document.body.appendChild(el)
-        return el
-    }
-
-    test('renders the hover overlay mount', async () => {
-        const { services } = await integrationTestContext()
-        subscriptions.add(
-            handleCodeHost({
-                mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
-                codeHost: {
-                    name: 'test',
-                    check: () => true,
-                },
-                extensionsController: createMockController(services),
-                showGlobalDebug: false,
-                ...createMockPlatformContext(),
-            })
-        )
-        const overlayMount = document.body.querySelector('.hover-overlay-mount')
-        expect(overlayMount).toBeDefined()
-        expect(overlayMount!.className).toBe('hover-overlay-mount hover-overlay-mount__test')
-        const renderedOverlay = elementRenderedAtMount(overlayMount!)
-        expect(renderedOverlay).not.toBeUndefined()
-    })
-
-    test('renders the command palette if codeHost.getCommandPaletteMount is defined', async () => {
-        const { services } = await integrationTestContext()
-        const commandPaletteMount = createTestElement()
-        subscriptions.add(
-            handleCodeHost({
-                mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
-                codeHost: {
-                    name: 'test',
-                    check: () => true,
-                    getCommandPaletteMount: () => commandPaletteMount,
-                },
-                extensionsController: createMockController(services),
-                showGlobalDebug: false,
-                ...createMockPlatformContext(),
-            })
-        )
-        const renderedCommandPalette = elementRenderedAtMount(commandPaletteMount)
-        expect(renderedCommandPalette).not.toBeUndefined()
-    })
-
-    test('creates a .global-debug element and renders the debug menu if showGlobalDebug is true', async () => {
-        const { services } = await integrationTestContext()
-        subscriptions.add(
-            handleCodeHost({
-                mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
-                codeHost: {
-                    name: 'test',
-                    check: () => true,
-                },
-                extensionsController: createMockController(services),
-                showGlobalDebug: true,
-                ...createMockPlatformContext(),
-            })
-        )
-        const globalDebugMount = document.body.querySelector('.global-debug')
-        expect(globalDebugMount).toBeDefined()
-        const renderedDebugElement = elementRenderedAtMount(globalDebugMount!)
-        expect(renderedDebugElement).toBeDefined()
-    })
-
-    test('detects code views based on selectors', async () => {
-        const { services } = await integrationTestContext()
-        const codeView = createTestElement()
-        codeView.id = 'code'
-        const toolbarMount = document.createElement('div')
-        codeView.appendChild(toolbarMount)
-        const fileInfo: FileInfo = {
-            repoName: 'foo',
-            filePath: '/bar.ts',
-            commitID: '1',
-        }
-        subscriptions.add(
-            handleCodeHost({
-                mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
-                codeHost: {
-                    name: 'test',
-                    check: () => true,
-                    codeViewSpecs: [
-                        {
-                            selector: `#code`,
-                            dom: {
-                                getCodeElementFromTarget: jest.fn(),
-                                getCodeElementFromLineNumber: jest.fn(),
-                                getLineNumberFromCodeElement: jest.fn(),
-                            },
-                            resolveFileInfo: codeView => of(fileInfo),
-                            getToolbarMount: () => toolbarMount,
-                        },
-                    ],
-                    selectionsChanges: () => of([]),
-                },
-                extensionsController: createMockController(services),
-                showGlobalDebug: true,
-                ...createMockPlatformContext(),
-            })
-        )
-        const editors = await from(services.editor.editors)
-            .pipe(
-                skip(1),
-                take(1)
-            )
-            .toPromise()
-        expect(editors).toEqual([
-            {
-                isActive: true,
-                item: {
-                    languageId: 'typescript',
-                    text: undefined,
-                    uri: 'git://foo?1#/bar.ts',
-                },
-                selections: [],
-                type: 'CodeEditor',
-            },
-        ])
-        expect(codeView.classList.contains('sg-mounted')).toBe(true)
-        const toolbar = elementRenderedAtMount(toolbarMount)
-        expect(toolbar).not.toBeUndefined()
-    })
-
-    test('decorates a code view', async () => {
-        const { extensionAPI, services } = await integrationTestContext(undefined, {
-            roots: [],
-            editors: [],
+    describe('createOverlayMount()', () => {
+        it('should create the overlay mount', () => {
+            createOverlayMount('some-code-host')
+            const mount = document.body.querySelector('.hover-overlay-mount')
+            expect(mount).toBeDefined()
+            expect(mount!.className).toBe('hover-overlay-mount hover-overlay-mount__some-code-host')
         })
-        const codeView = createTestElement()
-        codeView.id = 'code'
-        const fileInfo: FileInfo = {
-            repoName: 'foo',
-            filePath: '/bar.ts',
-            commitID: '1',
+    })
+
+    describe('createGlobalDebugMount()', () => {
+        it('should create the debug menu mount', () => {
+            createGlobalDebugMount()
+            const mount = document.body.querySelector('.global-debug')
+            expect(mount).toBeDefined()
+        })
+    })
+
+    describe('handleCodeHost()', () => {
+        let subscriptions = new Subscription()
+
+        afterEach(() => {
+            RENDER.mockClear()
+            subscriptions.unsubscribe()
+            subscriptions = new Subscription()
+        })
+
+        const createTestElement = () => {
+            const el = document.createElement('div')
+            el.className = `test test-${uniqueId()}`
+            document.body.appendChild(el)
+            return el
         }
-        const line = document.createElement('div')
-        codeView.appendChild(line)
-        subscriptions.add(
-            handleCodeHost({
-                mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
-                codeHost: {
-                    name: 'test',
-                    check: () => true,
-                    codeViewSpecs: [
-                        {
-                            selector: `#code`,
-                            dom: {
-                                getCodeElementFromTarget: jest.fn(),
-                                getCodeElementFromLineNumber: () => line,
-                                getLineNumberFromCodeElement: jest.fn(),
-                            },
-                            resolveFileInfo: codeView => of(fileInfo),
-                        },
-                    ],
-                    selectionsChanges: () => of([]),
-                },
-                extensionsController: createMockController(services),
-                showGlobalDebug: true,
-                ...createMockPlatformContext(),
-            })
-        )
-        const activeEditor = await from(extensionAPI.app.activeWindowChanges)
-            .pipe(
-                filter(isDefined),
-                switchMap(window => window.activeViewComponentChanges),
-                filter(isDefined),
-                take(1)
+
+        test('renders the hover overlay mount', async () => {
+            const { services } = await integrationTestContext()
+            subscriptions.add(
+                handleCodeHost({
+                    mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    codeHost: {
+                        name: 'test',
+                        check: () => true,
+                    },
+                    extensionsController: createMockController(services),
+                    showGlobalDebug: false,
+                    ...createMockPlatformContext(),
+                })
             )
-            .toPromise()
-        const decorationType = extensionAPI.app.createDecorationType()
-        const decorated = () =>
-            services.textDocumentDecoration
-                .getDecorations({ uri: 'git://foo?1#/bar.ts' })
+            const overlayMount = document.body.querySelector('.hover-overlay-mount')
+            expect(overlayMount).toBeDefined()
+            expect(overlayMount!.className).toBe('hover-overlay-mount hover-overlay-mount__test')
+            const renderedOverlay = elementRenderedAtMount(overlayMount!)
+            expect(renderedOverlay).not.toBeUndefined()
+        })
+
+        test('renders the command palette if codeHost.getCommandPaletteMount is defined', async () => {
+            const { services } = await integrationTestContext()
+            const commandPaletteMount = createTestElement()
+            subscriptions.add(
+                handleCodeHost({
+                    mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    codeHost: {
+                        name: 'test',
+                        check: () => true,
+                        getCommandPaletteMount: () => commandPaletteMount,
+                    },
+                    extensionsController: createMockController(services),
+                    showGlobalDebug: false,
+                    ...createMockPlatformContext(),
+                })
+            )
+            const renderedCommandPalette = elementRenderedAtMount(commandPaletteMount)
+            expect(renderedCommandPalette).not.toBeUndefined()
+        })
+
+        test('creates a .global-debug element and renders the debug menu if showGlobalDebug is true', async () => {
+            const { services } = await integrationTestContext()
+            subscriptions.add(
+                handleCodeHost({
+                    mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    codeHost: {
+                        name: 'test',
+                        check: () => true,
+                    },
+                    extensionsController: createMockController(services),
+                    showGlobalDebug: true,
+                    ...createMockPlatformContext(),
+                })
+            )
+            const globalDebugMount = document.body.querySelector('.global-debug')
+            expect(globalDebugMount).toBeDefined()
+            const renderedDebugElement = elementRenderedAtMount(globalDebugMount!)
+            expect(renderedDebugElement).toBeDefined()
+        })
+
+        test('detects code views based on selectors', async () => {
+            const { services } = await integrationTestContext()
+            const codeView = createTestElement()
+            codeView.id = 'code'
+            const toolbarMount = document.createElement('div')
+            codeView.appendChild(toolbarMount)
+            const fileInfo: FileInfo = {
+                repoName: 'foo',
+                filePath: '/bar.ts',
+                commitID: '1',
+            }
+            subscriptions.add(
+                handleCodeHost({
+                    mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    codeHost: {
+                        name: 'test',
+                        check: () => true,
+                        codeViewSpecs: [
+                            {
+                                selector: `#code`,
+                                dom: {
+                                    getCodeElementFromTarget: jest.fn(),
+                                    getCodeElementFromLineNumber: jest.fn(),
+                                    getLineNumberFromCodeElement: jest.fn(),
+                                },
+                                resolveFileInfo: codeView => of(fileInfo),
+                                getToolbarMount: () => toolbarMount,
+                            },
+                        ],
+                        selectionsChanges: () => of([]),
+                    },
+                    extensionsController: createMockController(services),
+                    showGlobalDebug: true,
+                    ...createMockPlatformContext(),
+                })
+            )
+            const editors = await from(services.editor.editors)
                 .pipe(
-                    filter(decorations => decorations !== []),
+                    skip(1),
                     take(1)
                 )
                 .toPromise()
-
-        // Set decorations and verify that a decoration attachment has been added
-        activeEditor.setDecorations(decorationType, [
-            {
-                range: new Range(0, 0, 0, 0),
-                after: {
-                    contentText: 'test decoration',
+            expect(editors).toEqual([
+                {
+                    isActive: true,
+                    item: {
+                        languageId: 'typescript',
+                        text: undefined,
+                        uri: 'git://foo?1#/bar.ts',
+                    },
+                    selections: [],
+                    type: 'CodeEditor',
                 },
-            },
-        ])
-        await decorated()
-        expect(line.querySelectorAll('.line-decoration-attachment').length).toBe(1)
-        expect(line.querySelector('.line-decoration-attachment')!.textContent).toEqual('test decoration')
+            ])
+            expect(codeView.classList.contains('sg-mounted')).toBe(true)
+            const toolbar = elementRenderedAtMount(toolbarMount)
+            expect(toolbar).not.toBeUndefined()
+        })
 
-        // Decorate the code view again, and verify that previous decorations
-        // are cleaned up and replaced by the new decorations.
-        activeEditor.setDecorations(decorationType, [
-            {
-                range: new Range(0, 0, 0, 0),
-                after: {
-                    contentText: 'test decoration 2',
+        test('decorates a code view', async () => {
+            const { extensionAPI, services } = await integrationTestContext(undefined, {
+                roots: [],
+                editors: [],
+            })
+            const codeView = createTestElement()
+            codeView.id = 'code'
+            const fileInfo: FileInfo = {
+                repoName: 'foo',
+                filePath: '/bar.ts',
+                commitID: '1',
+            }
+            const line = document.createElement('div')
+            codeView.appendChild(line)
+            subscriptions.add(
+                handleCodeHost({
+                    mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    codeHost: {
+                        name: 'test',
+                        check: () => true,
+                        codeViewSpecs: [
+                            {
+                                selector: `#code`,
+                                dom: {
+                                    getCodeElementFromTarget: jest.fn(),
+                                    getCodeElementFromLineNumber: () => line,
+                                    getLineNumberFromCodeElement: jest.fn(),
+                                },
+                                resolveFileInfo: codeView => of(fileInfo),
+                            },
+                        ],
+                        selectionsChanges: () => of([]),
+                    },
+                    extensionsController: createMockController(services),
+                    showGlobalDebug: true,
+                    ...createMockPlatformContext(),
+                })
+            )
+            const activeEditor = await from(extensionAPI.app.activeWindowChanges)
+                .pipe(
+                    filter(isDefined),
+                    switchMap(window => window.activeViewComponentChanges),
+                    filter(isDefined),
+                    take(1)
+                )
+                .toPromise()
+            const decorationType = extensionAPI.app.createDecorationType()
+            const decorated = () =>
+                services.textDocumentDecoration
+                    .getDecorations({ uri: 'git://foo?1#/bar.ts' })
+                    .pipe(
+                        filter(decorations => decorations !== []),
+                        take(1)
+                    )
+                    .toPromise()
+
+            // Set decorations and verify that a decoration attachment has been added
+            activeEditor.setDecorations(decorationType, [
+                {
+                    range: new Range(0, 0, 0, 0),
+                    after: {
+                        contentText: 'test decoration',
+                    },
                 },
-            },
-        ])
-        await decorated()
-        expect(line.querySelectorAll('.line-decoration-attachment').length).toBe(1)
-        expect(line.querySelector('.line-decoration-attachment')!.textContent).toEqual('test decoration 2')
+            ])
+            await decorated()
+            expect(line.querySelectorAll('.line-decoration-attachment').length).toBe(1)
+            expect(line.querySelector('.line-decoration-attachment')!.textContent).toEqual('test decoration')
+
+            // Decorate the code view again, and verify that previous decorations
+            // are cleaned up and replaced by the new decorations.
+            activeEditor.setDecorations(decorationType, [
+                {
+                    range: new Range(0, 0, 0, 0),
+                    after: {
+                        contentText: 'test decoration 2',
+                    },
+                },
+            ])
+            await decorated()
+            expect(line.querySelectorAll('.line-decoration-attachment').length).toBe(1)
+            expect(line.querySelector('.line-decoration-attachment')!.textContent).toEqual('test decoration 2')
+        })
     })
 })

--- a/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
+++ b/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
@@ -3,7 +3,7 @@ import { readFile } from 'mz/fs'
 import { SetIntersection } from 'utility-types'
 import { CodeHost, CodeViewSpec, MountGetter } from './code_intelligence'
 
-const mountGetterKeys = ['getCommandPaletteMount', 'getGlobalDebugMount', 'getViewContextOnSourcegraphMount'] as const
+const mountGetterKeys = ['getCommandPaletteMount', 'getViewContextOnSourcegraphMount'] as const
 type MountGetterKey = (typeof mountGetterKeys)[number]
 
 export function testCodeHostMountGetters<C extends CodeHost>(

--- a/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
+++ b/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
@@ -3,12 +3,7 @@ import { readFile } from 'mz/fs'
 import { SetIntersection } from 'utility-types'
 import { CodeHost, CodeViewSpec, MountGetter } from './code_intelligence'
 
-const mountGetterKeys = [
-    'getCommandPaletteMount',
-    'getGlobalDebugMount',
-    'getOverlayMount',
-    'getViewContextOnSourcegraphMount',
-] as const
+const mountGetterKeys = ['getCommandPaletteMount', 'getGlobalDebugMount', 'getViewContextOnSourcegraphMount'] as const
 type MountGetterKey = (typeof mountGetterKeys)[number]
 
 export function testCodeHostMountGetters<C extends CodeHost>(
@@ -42,7 +37,7 @@ export function testToolbarMountGetter(
  * @param mayReturnNull Whether the mount getter might be called with containers where the mount does not belong.
  * It will be tested to return `null` in that case.
  */
-function testMountGetter(
+export function testMountGetter(
     containerHTMLPath: string,
     getMount: MountGetter,
     isFullDocument: boolean,

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -14,7 +14,7 @@ import { querySelectorOrSelf } from '../../shared/util/dom'
 import { toAbsoluteBlobURL } from '../../shared/util/url'
 import { CodeViewSpec, CodeViewSpecResolver, CodeViewSpecWithOutSelector, MountGetter } from '../code_intelligence'
 import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions } from './dom_functions'
-import { getCommandPaletteMount, getGlobalDebugMount } from './extensions'
+import { getCommandPaletteMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './file_info'
 import { getFileContainers, parseURL } from './util'
 
@@ -262,7 +262,6 @@ export const githubCodeHost = {
     },
     check: checkIsGitHub,
     getCommandPaletteMount,
-    getGlobalDebugMount,
     commandPaletteClassProps: {
         popoverClassName: 'Box',
         formClassName: 'p-1',

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -230,21 +230,6 @@ export const checkIsGitHubDotCom = (): boolean => /^https?:\/\/(www.)?github.com
  */
 export const checkIsGitHub = (): boolean => checkIsGitHubDotCom() || checkIsGitHubEnterprise()
 
-const getOverlayMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
-    const jsRepoPjaxContainer = querySelectorOrSelf(container, '#js-repo-pjax-container')
-    if (!jsRepoPjaxContainer) {
-        return null
-    }
-    let mount = jsRepoPjaxContainer.querySelector<HTMLElement>('.hover-overlay-mount')
-    if (mount) {
-        return mount
-    }
-    mount = document.createElement('div')
-    mount.className = 'hover-overlay-mount'
-    jsRepoPjaxContainer.appendChild(mount)
-    return mount
-}
-
 const OPEN_ON_SOURCEGRAPH_ID = 'open-on-sourcegraph'
 
 export const createOpenOnSourcegraphIfNotExists: MountGetter = (container: HTMLElement): HTMLElement | null => {
@@ -276,7 +261,6 @@ export const githubCodeHost = {
         iconClassName: 'action-item__icon--github v-align-text-bottom',
     },
     check: checkIsGitHub,
-    getOverlayMount,
     getCommandPaletteMount,
     getGlobalDebugMount,
     commandPaletteClassProps: {

--- a/client/browser/src/libs/github/extensions.tsx
+++ b/client/browser/src/libs/github/extensions.tsx
@@ -33,18 +33,3 @@ export const getCommandPaletteMount: MountGetter = (container: HTMLElement): HTM
     }
     return null
 }
-
-export const getGlobalDebugMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
-    const globalDebugClass = 'global-debug'
-    const parentElement = querySelectorOrSelf(container, 'body')
-    if (!parentElement) {
-        return null
-    }
-    const createGlobalDebugMount = (): HTMLElement => {
-        const mount = document.createElement('div')
-        mount.className = globalDebugClass
-        parentElement.appendChild(mount)
-        return mount
-    }
-    return container.querySelector<HTMLElement>('.' + globalDebugClass) || createGlobalDebugMount()
-}


### PR DESCRIPTION
Fixes #3228.

Only GitHub used this, but shouldn't, see #3228.
After removing, they always append to `document.body`, so there is not reason to have them configurable or subscribe to the mutations (which has a perf impact). It's safe to assume `document.body` never gets removed from any code host DOM.

#### Test Plan

##### Code Hosts

- [x] GitHub
- [ ] GitHub Enterprise
- [ ] Refined GitHub
- [ ] Phabricator
- [ ] Phabricator integration
- [ ] Bitbucket
- [ ] Gitlab

##### Browsers

- [x] Chrome
- [ ] Firefox
