### PR TITLE
extract EditorService#editors into subscribable, next, and value for easier future refactoring

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -556,7 +556,7 @@ export function handleCodeHost({
     // Update code editors as selections change
     subscriptions.add(
         selectionsChanges.subscribe(selections => {
-            extensionsController.services.editor.editors.next(
+            extensionsController.services.editor.nextEditors(
                 [...codeViewStates.values()].flatMap(state => state.editors).map(editor => ({ ...editor, selections }))
             )
         })
@@ -695,7 +695,7 @@ export function handleCodeHost({
             }
 
             // Apply added/removed roots/editors
-            extensionsController.services.editor.editors.next(
+            extensionsController.services.editor.nextEditors(
                 [...codeViewStates.values()].flatMap(state => state.editors)
             )
             extensionsController.services.workspace.roots.next(

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -12,7 +12,7 @@ import {
 import { Context, ContributionScope, getComputedContextProperty } from '../context/context'
 import { ComputedContext, evaluate, evaluateTemplate } from '../context/expr/evaluator'
 import { TEMPLATE_BEGIN } from '../context/expr/lexer'
-import { ReadonlyEditorService } from './editorService'
+import { EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /** A registered set of contributions from an extension in the registry. */
@@ -41,7 +41,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: ReadonlyEditorService,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}

--- a/shared/src/api/client/services/editorService.test.ts
+++ b/shared/src/api/client/services/editorService.test.ts
@@ -1,9 +1,9 @@
 import { of, Subscribable } from 'rxjs'
-import { CodeEditorData, getActiveCodeEditorPosition, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService, getActiveCodeEditorPosition } from './editorService'
 
 export function createTestEditorService(
     editors: Subscribable<readonly CodeEditorData[]> = of([])
-): ReadonlyEditorService {
+): Pick<EditorService, 'editors'> {
     return { editors }
 }
 

--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -1,5 +1,5 @@
 import { Selection } from '@sourcegraph/extension-api-types'
-import { BehaviorSubject, NextObserver, Subscribable } from 'rxjs'
+import { BehaviorSubject, Subscribable } from 'rxjs'
 import { TextDocument } from 'sourcegraph'
 import { TextDocumentPositionParams } from '../../protocol'
 
@@ -16,27 +16,33 @@ export interface CodeEditorData<D extends Pick<TextDocument, 'uri'> = TextDocume
     isActive: boolean
 }
 
-/** For callers that only need to subscribe to this value. */
-export interface ReadonlyEditorService {
-    readonly editors: Subscribable<readonly CodeEditorData[]>
-}
-
 /**
  * The editor service manages editors and documents.
  */
-export interface EditorService extends ReadonlyEditorService {
+export interface EditorService {
     /** All code editors. */
-    readonly editors: Subscribable<readonly CodeEditorData[]> & { value: readonly CodeEditorData[] } & NextObserver<
-            readonly CodeEditorData[]
-        >
+    readonly editors: Subscribable<readonly CodeEditorData[]>
+
+    /** Transitional API for synchronously getting the list of code editors. */
+    readonly editorsValue: readonly CodeEditorData[]
+
+    /** Transitional API for setting the list of code editors. */
+    nextEditors(value: readonly CodeEditorData[]): void
 }
 
 /**
  * Creates a {@link EditorService} instance.
  */
 export function createEditorService(): EditorService {
+    const editors = new BehaviorSubject<readonly CodeEditorData[]>([])
     return {
-        editors: new BehaviorSubject<readonly CodeEditorData[]>([]),
+        editors,
+        get editorsValue(): readonly CodeEditorData[] {
+            return editors.value
+        },
+        nextEditors(value: readonly CodeEditorData[]): void {
+            editors.next(value)
+        },
     }
 }
 

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,7 +12,7 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: ReadonlyEditorService,
+        editorService: Pick<EditorService, 'editors'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -12,7 +12,7 @@ import { PlatformContext } from '../../../platform/context'
 import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
-import { CodeEditorData, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -55,7 +55,7 @@ interface PartialContext extends Pick<PlatformContext, 'queryGraphQL' | 'getScri
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: ReadonlyEditorService,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -16,7 +16,7 @@ describe('CodeEditor (integration)', () => {
             } = await integrationTestContext()
 
             const setSelections = (selections: Selection[]) => {
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'foo', languageId: 'l1', text: 't1' },

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -17,7 +17,7 @@ describe('Documents (integration)', () => {
                 services: { editor: editorService },
                 extensionAPI,
             } = await integrationTestContext()
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
@@ -45,7 +45,7 @@ describe('Documents (integration)', () => {
             const values = collectSubscribableValues(extensionAPI.workspace.openedTextDocuments)
             expect(values).toEqual([] as TextDocument[])
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -54,7 +54,7 @@ describe('Selections (integration)', () => {
                 [],
             ]
             for (const selections of testValues) {
-                editorService.editors.next([withSelections(...selections)])
+                editorService.nextEditors([withSelections(...selections)])
                 await extensionAPI.internal.sync()
             }
             await extensionAPI.internal.sync()

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -89,7 +89,7 @@ export async function integrationTestContext(
     const client = await createExtensionHostClientConnection(clientEndpoints, services, initData)
 
     const extensionAPI = await extensionHost.extensionAPI
-    services.editor.editors.next(initModel.editors)
+    services.editor.nextEditors(initModel.editors)
     services.workspace.roots.next(initModel.roots)
 
     // Wait for initModel to be initialized

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -29,7 +29,7 @@ describe('Windows (integration)', () => {
                 roots: [],
                 editors: [],
             })
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'foo', languageId: 'l1', text: 't1' },
@@ -37,8 +37,8 @@ describe('Windows (integration)', () => {
                     isActive: true,
                 },
             ])
-            editorService.editors.next([])
-            editorService.editors.next([
+            editorService.nextEditors([])
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'bar', languageId: 'l2', text: 't2' },
@@ -78,7 +78,7 @@ describe('Windows (integration)', () => {
                 extensionAPI,
             } = await integrationTestContext()
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
@@ -113,7 +113,7 @@ describe('Windows (integration)', () => {
                 extensionAPI,
             } = await integrationTestContext()
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: {
@@ -124,7 +124,7 @@ describe('Windows (integration)', () => {
                     selections: [],
                     isActive: false,
                 },
-                ...editorService.editors.value,
+                ...editorService.editorsValue,
             ])
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
@@ -152,7 +152,7 @@ describe('Windows (integration)', () => {
                     extensionAPI,
                 } = await integrationTestContext()
 
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: {
@@ -163,7 +163,7 @@ describe('Windows (integration)', () => {
                         selections: [],
                         isActive: false,
                     },
-                    ...editorService.editors.value,
+                    ...editorService.editorsValue,
                 ])
                 await extensionAPI.internal.sync()
 
@@ -183,7 +183,7 @@ describe('Windows (integration)', () => {
                     roots: [],
                     editors: [],
                 })
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'foo', languageId: 'l1', text: 't1' },
@@ -191,8 +191,8 @@ describe('Windows (integration)', () => {
                         isActive: true,
                     },
                 ])
-                editorService.editors.next([])
-                editorService.editors.next([
+                editorService.nextEditors([])
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'bar', languageId: 'l2', text: 't2' },

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -292,7 +292,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         // Update the Sourcegraph extensions model to reflect the current file.
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
-                this.props.extensionsController.services.editor.editors.next([
+                this.props.extensionsController.services.editor.nextEditors([
                     {
                         type: 'CodeEditor' as const,
                         item: {

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -166,7 +166,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
         )
 
         // Clear the Sourcegraph extensions model's component when the blob is no longer shown.
-        this.subscriptions.add(() => this.props.extensionsController.services.editor.editors.next([]))
+        this.subscriptions.add(() => this.props.extensionsController.services.editor.nextEditors([]))
 
         this.propsUpdates.next(this.props)
     }

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -98,9 +98,7 @@ export class BlobPanel extends React.PureComponent<Props> {
             provider: from(this.props.extensionsController.services.editor.editors).pipe(
                 switchMap(editors =>
                     registry
-                        .hasProvidersForActiveTextDocument(
-                            this.props.extensionsController.services.editor.editors.value
-                        )
+                        .hasProvidersForActiveTextDocument(this.props.extensionsController.services.editor.editorsValue)
                         .pipe(
                             map(hasProviders => {
                                 if (!hasProviders) {

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -70,6 +70,6 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                 }
             }
         }
-        this.props.extensionsController.services.editor.editors.next(editors)
+        this.props.extensionsController.services.editor.nextEditors(editors)
     }
 }


### PR DESCRIPTION
Refactor. This will let us make the subscribable merge in data from other sources (while still keeping the next/value APIs only dealing with normalized data).

This is the 1st PR in the sequence #3320 #3322 #3323  (review in order).