### PR TITLE
add extension API model service, separate models and editors

### DIFF
--- a/client/browser/src/libs/bitbucket/context.tsx
+++ b/client/browser/src/libs/bitbucket/context.tsx
@@ -29,7 +29,7 @@ function getRevSpecFromRevisionSelector(): RevSpec {
     let revisionRefInfo: RevisionRefInfo | null = null
     try {
         revisionRefInfo = revisionRefStr && JSON.parse(revisionRefStr)
-    } catch {
+    } catch (err) {
         throw new Error(`Could not parse revisionRefStr: ${revisionRefStr}`)
     }
     if (revisionRefInfo && revisionRefInfo.latestCommit) {

--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -188,11 +188,7 @@ describe('code_intelligence', () => {
             expect(editors).toEqual([
                 {
                     isActive: true,
-                    item: {
-                        languageId: 'typescript',
-                        text: undefined,
-                        uri: 'git://foo?1#/bar.ts',
-                    },
+                    resource: 'git://foo?1#/bar.ts',
                     selections: [],
                     type: 'CodeEditor',
                 },

--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -249,7 +249,7 @@ describe('code_intelligence', () => {
                 services.textDocumentDecoration
                     .getDecorations({ uri: 'git://foo?1#/bar.ts' })
                     .pipe(
-                        filter(decorations => decorations !== []),
+                        filter(decorations => Boolean(decorations && decorations.length > 0)),
                         take(1)
                     )
                     .toPromise()

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -525,7 +525,7 @@ export function handleCodeHost({
     // Update code editors as selections change
     subscriptions.add(
         selectionsChanges.subscribe(selections => {
-            extensionsController.services.editor.editors.next(
+            extensionsController.services.editor.nextEditors(
                 [...codeViewStates.values()].flatMap(state => state.editors).map(editor => ({ ...editor, selections }))
             )
         })
@@ -664,7 +664,7 @@ export function handleCodeHost({
             }
 
             // Apply added/removed roots/editors
-            extensionsController.services.editor.editors.next(
+            extensionsController.services.editor.nextEditors(
                 [...codeViewStates.values()].flatMap(state => state.editors)
             )
             extensionsController.services.workspace.roots.next(

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -1,8 +1,7 @@
 import * as comlink from '@sourcegraph/comlink'
-import { isEqual } from 'lodash'
 import { from, Subject, Subscription } from 'rxjs'
 import { concatMap } from 'rxjs/operators'
-import { ContextValues, Progress, ProgressOptions, TextDocument, Unsubscribable } from 'sourcegraph'
+import { ContextValues, Progress, ProgressOptions, Unsubscribable } from 'sourcegraph'
 import { EndpointPair } from '../../platform/context'
 import { ExtensionHostAPIFactory } from '../extension/api/api'
 import { InitData } from '../extension/extensionHost'
@@ -72,34 +71,15 @@ export async function createExtensionHostClientConnection(
     )
     subscription.add(clientContext)
 
-    // Sync visible views and text documents to the extension host
-    let visibleTextDocuments: Pick<TextDocument, 'uri' | 'languageId' | 'text'>[] = []
+    // Sync models and editors to the extension host
     subscription.add(
-        from(services.editor.editors)
-            .pipe(
-                concatMap(async editors => {
-                    // Important: Make sure documents were synced before syncing windows, as windows reference them
-                    const nextVisibleTextDocuments = editors ? editors.map(v => v.item) : []
-                    if (!isEqual(visibleTextDocuments, nextVisibleTextDocuments)) {
-                        visibleTextDocuments = nextVisibleTextDocuments
-                        await proxy.documents.$acceptDocumentData(nextVisibleTextDocuments)
-                    }
-                    await proxy.windows.$acceptWindowData(
-                        editors
-                            ? {
-                                  editors: editors.map(editor => ({
-                                      type: 'CodeEditor',
-                                      item: {
-                                          uri: editor.item.uri,
-                                      },
-                                      selections: editor.selections,
-                                      isActive: editor.isActive,
-                                  })),
-                              }
-                            : null
-                    )
-                })
-            )
+        from(services.model.models)
+            .pipe(concatMap(models => proxy.documents.$acceptDocumentData(models)))
+            .subscribe()
+    )
+    subscription.add(
+        from(services.editor.editorsWithModel)
+            .pipe(concatMap(editors => proxy.windows.$acceptWindowData({ editors })))
             .subscribe()
     )
 

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -1,6 +1,6 @@
 import { Selection } from '@sourcegraph/extension-api-types'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData } from '../services/editorService'
+import { CodeEditorDataWithModel } from '../services/editorService'
 import { applyContextUpdate, Context, getComputedContextProperty } from './context'
 
 describe('applyContextUpdate', () => {
@@ -30,10 +30,11 @@ describe('getComputedContextProperty', () => {
     })
 
     describe('with code editors', () => {
-        const editors: CodeEditorData[] = [
+        const editors: CodeEditorDataWithModel[] = [
             {
                 type: 'CodeEditor',
-                item: {
+                resource: 'file:///inactive',
+                model: {
                     uri: 'file:///inactive',
                     languageId: 'inactive',
                     text: 'inactive',
@@ -51,7 +52,8 @@ describe('getComputedContextProperty', () => {
             },
             {
                 type: 'CodeEditor',
-                item: {
+                resource: 'file:///a/b.c',
+                model: {
                     uri: 'file:///a/b.c',
                     languageId: 'l',
                     text: 't',
@@ -104,7 +106,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there are no code editors', () =>
                 expect(getComputedContextProperty([], EMPTY_SETTINGS_CASCADE, {}, 'component.type')).toBe(null))
 
-            function assertSelection(editors: CodeEditorData[], expr: string, expected: Selection): void {
+            function assertSelection(editors: CodeEditorDataWithModel[], expr: string, expected: Selection): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, expr)).toEqual(expected)
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, `${expr}.start`)).toEqual(
                     expected.start
@@ -148,7 +150,7 @@ describe('getComputedContextProperty', () => {
                     ]
                 ))
 
-            function assertNoSelection(editors: CodeEditorData[]): void {
+            function assertNoSelection(editors: CodeEditorDataWithModel[]): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, 'component.selection')).toBe(
                     null
                 )
@@ -181,7 +183,8 @@ describe('getComputedContextProperty', () => {
                 assertNoSelection([
                     {
                         type: 'CodeEditor',
-                        item: {
+                        resource: 'file:///a/b.c',
+                        model: {
                             uri: 'file:///a/b.c',
                             languageId: 'l',
                             text: 't',

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -1,7 +1,6 @@
 import { basename, dirname, extname } from 'path'
-import { TextDocument } from 'sourcegraph'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData } from '../services/editorService'
+import { CodeEditorDataWithModel } from '../services/editorService'
 
 /**
  * Returns a new context created by applying the update context to the base context. It is equivalent to `{...base,
@@ -33,8 +32,8 @@ export interface Context<T = never>
     > {}
 
 export type ContributionScope =
-    | (Pick<CodeEditorData, 'type' | 'selections'> & {
-          item: Pick<TextDocument, 'uri' | 'languageId'>
+    | (Pick<CodeEditorDataWithModel, 'type' | 'resource' | 'selections'> & {
+          model: Pick<CodeEditorDataWithModel['model'], 'uri' | 'languageId'>
       })
     | {
           type: 'panelView'
@@ -50,7 +49,7 @@ export type ContributionScope =
  * @param scope the user interface component in whose scope this computation should occur
  */
 export function getComputedContextProperty(
-    editors: readonly CodeEditorData[],
+    editors: readonly CodeEditorDataWithModel[],
     settings: SettingsCascadeOrError,
     context: Context<any>,
     key: string,
@@ -78,15 +77,15 @@ export function getComputedContextProperty(
         const prop = key.slice('resource.'.length)
         switch (prop) {
             case 'uri':
-                return component.item.uri
+                return component.resource
             case 'basename':
-                return basename(component.item.uri)
+                return basename(component.resource)
             case 'dirname':
-                return dirname(component.item.uri)
+                return dirname(component.resource)
             case 'extname':
-                return extname(component.item.uri)
+                return extname(component.resource)
             case 'language':
-                return component.item.languageId
+                return component.model.languageId
             case 'type':
                 return 'textDocument'
         }

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -8,6 +8,7 @@ import { createEditorService } from './services/editorService'
 import { ExtensionsService } from './services/extensionsService'
 import { TextDocumentHoverProviderRegistry } from './services/hover'
 import { TextDocumentLocationProviderIDRegistry, TextDocumentLocationProviderRegistry } from './services/location'
+import { createModelService } from './services/modelService'
 import { NotificationsService } from './services/notifications'
 import { QueryTransformerRegistry } from './services/queryTransformer'
 import { createSettingsService } from './services/settings'
@@ -33,7 +34,8 @@ export class Services {
     public readonly commands = new CommandRegistry()
     public readonly context = createContextService(this.platformContext)
     public readonly workspace = createWorkspaceService()
-    public readonly editor = createEditorService()
+    public readonly model = createModelService()
+    public readonly editor = createEditorService(this.model)
     public readonly notifications = new NotificationsService()
     public readonly settings = createSettingsService(this.platformContext)
     public readonly contribution = new ContributionRegistry(this.editor, this.settings, this.context.data)

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -12,7 +12,7 @@ import {
     filterContributions,
     mergeContributions,
 } from './contribution'
-import { CodeEditorData } from './editorService'
+import { CodeEditorDataWithModel } from './editorService'
 import { createTestEditorService } from './editorService.test'
 
 const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
@@ -160,7 +160,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editors: cold<readonly CodeEditorData[]>('-a-b-|', {
+                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
                                     a: [],
                                     b: [],
                                 }),
@@ -202,7 +202,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editors: cold<readonly CodeEditorData[]>('a', {
+                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('a', {
                                     a: [],
                                 }),
                             },

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -41,7 +41,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: Pick<EditorService, 'editors'>,
+        private editorService: Pick<EditorService, 'editorsWithModel'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}
@@ -114,7 +114,7 @@ export class ContributionRegistry {
                     )
                 )
             ),
-            this.editorService.editors,
+            this.editorService.editorsWithModel,
             this.settingsService.data,
             this.context
         ).pipe(

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -12,7 +12,7 @@ import {
 import { Context, ContributionScope, getComputedContextProperty } from '../context/context'
 import { ComputedContext, evaluate, evaluateTemplate } from '../context/expr/evaluator'
 import { TEMPLATE_BEGIN } from '../context/expr/lexer'
-import { ReadonlyEditorService } from './editorService'
+import { EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /** A registered set of contributions from an extension in the registry. */
@@ -41,7 +41,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: ReadonlyEditorService,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}

--- a/shared/src/api/client/services/editorService.test.ts
+++ b/shared/src/api/client/services/editorService.test.ts
@@ -1,9 +1,9 @@
 import { of, Subscribable } from 'rxjs'
-import { CodeEditorData, getActiveCodeEditorPosition, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService, getActiveCodeEditorPosition } from './editorService'
 
 export function createTestEditorService(
     editors: Subscribable<readonly CodeEditorData[]> = of([])
-): ReadonlyEditorService {
+): Pick<EditorService, 'editors'> {
     return { editors }
 }
 

--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -1,21 +1,25 @@
 import { Selection } from '@sourcegraph/extension-api-types'
-import { BehaviorSubject, Subscribable } from 'rxjs'
-import { TextDocument } from 'sourcegraph'
+import { BehaviorSubject, combineLatest, Subscribable } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { TextDocumentPositionParams } from '../../protocol'
+import { ModelService, TextModel } from './modelService'
 
 /**
  * Describes a code editor view component.
- *
- * @template D The type of text documents referred to by this data. If the document text is managed
- * out-of-band, this can just be an object containing the document URI.
  */
-export interface CodeEditorData<
-    D extends Pick<TextDocument, 'uri'> = Pick<TextDocument, 'uri' | 'languageId' | 'text'>
-> {
+export interface CodeEditorData {
     type: 'CodeEditor'
-    item: D
+
+    /** The URI of the model that this editor is displaying. */
+    resource: string
+
     selections: Selection[]
     isActive: boolean
+}
+
+/** Describes a code editor and includes its model content. */
+export interface CodeEditorDataWithModel extends CodeEditorData {
+    model: TextModel
 }
 
 /**
@@ -24,6 +28,9 @@ export interface CodeEditorData<
 export interface EditorService {
     /** All code editors. */
     readonly editors: Subscribable<readonly CodeEditorData[]>
+
+    /** All code editors, with each editor's model. */
+    readonly editorsWithModel: Subscribable<readonly CodeEditorDataWithModel[]>
 
     /** Transitional API for synchronously getting the list of code editors. */
     readonly editorsValue: readonly CodeEditorData[]
@@ -35,10 +42,21 @@ export interface EditorService {
 /**
  * Creates a {@link EditorService} instance.
  */
-export function createEditorService(): EditorService {
+export function createEditorService(modelService: Pick<ModelService, 'models'>): EditorService {
     const editors = new BehaviorSubject<readonly CodeEditorData[]>([])
     return {
         editors,
+        editorsWithModel: combineLatest(editors, modelService.models).pipe(
+            map(([editors, models]) =>
+                editors.map(editor => {
+                    const model = models.find(m => m.uri === editor.resource)
+                    if (!model) {
+                        throw new Error(`editor model not found: ${editor.resource}`)
+                    }
+                    return { ...editor, model }
+                })
+            )
+        ),
         get editorsValue(): readonly CodeEditorData[] {
             return editors.value
         },
@@ -53,9 +71,7 @@ export function createEditorService(): EditorService {
  * {@link EditorService#editors}. If there is no active editor or it has no position, it returns
  * null.
  */
-export function getActiveCodeEditorPosition<
-    D extends Pick<TextDocument, 'uri'> = Pick<TextDocument, 'uri' | 'languageId' | 'text'>
->(editors: readonly CodeEditorData<D>[]): (TextDocumentPositionParams & { textDocument: D }) | null {
+export function getActiveCodeEditorPosition(editors: readonly CodeEditorData[]): TextDocumentPositionParams | null {
     const activeEditor = editors.find(({ isActive }) => isActive)
     if (!activeEditor) {
         return null
@@ -74,7 +90,7 @@ export function getActiveCodeEditorPosition<
         return null
     }
     return {
-        textDocument: activeEditor.item,
+        textDocument: { uri: activeEditor.resource },
         position: sel.start,
     }
 }

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,7 +12,7 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: ReadonlyEditorService,
+        editorService: Pick<EditorService, 'editors'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData, EditorService } from './editorService'
+import { CodeEditorDataWithModel, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,11 +12,11 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: Pick<EditorService, 'editors'>,
+        editorService: Pick<EditorService, 'editorsWithModel'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],
-            editors: readonly CodeEditorData[]
+            editors: readonly CodeEditorDataWithModel[]
         ) => ConfiguredExtension[],
         sideloadedExtensionURL: Subscribable<string | null>,
         fetchSideloadedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
@@ -46,7 +46,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('-a-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('-a-|', {
                                 a: [],
                             })
                         ),
@@ -69,11 +69,12 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'x', manifest, rawManifest: null }, { id: 'y', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('-a-b-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
                                 a: [
                                     {
                                         type: 'CodeEditor',
-                                        item: { languageId: 'x', text: '', uri: '' },
+                                        resource: 'u',
+                                        model: { languageId: 'x', text: '', uri: 'u' },
                                         selections: [],
                                         isActive: true,
                                     },
@@ -81,7 +82,8 @@ describe('activeExtensions', () => {
                                 b: [
                                     {
                                         type: 'CodeEditor',
-                                        item: { languageId: 'y', text: '', uri: '' },
+                                        resource: 'u2',
+                                        model: { languageId: 'y', text: '', uri: 'u2' },
                                         selections: [],
                                         isActive: true,
                                     },
@@ -96,7 +98,7 @@ describe('activeExtensions', () => {
                         },
                         (enabledExtensions, editors) =>
                             enabledExtensions.filter(x =>
-                                editors.some(({ item: { languageId } }) => x.id === languageId)
+                                editors.some(({ model: { languageId } }) => x.id === languageId)
                             ),
                         cold('-a--|', { a: '' }),
                         () => of(null)
@@ -115,7 +117,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('a-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
                                 a: [],
                             })
                         ),
@@ -160,7 +162,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('a-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
                                 a: [],
                             })
                         ),

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -12,7 +12,7 @@ import { PlatformContext } from '../../../platform/context'
 import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
-import { CodeEditorData, EditorService } from './editorService'
+import { CodeEditorDataWithModel, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -55,7 +55,7 @@ interface PartialContext extends Pick<PlatformContext, 'queryGraphQL' | 'getScri
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: Pick<EditorService, 'editors'>,
+        private editorService: Pick<EditorService, 'editorsWithModel'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (
@@ -119,7 +119,7 @@ export class ExtensionsService {
         // Extensions that have been activated (including extensions with zero "activationEvents" that evaluate to
         // true currently).
         const activatedExtensionIDs: string[] = []
-        return combineLatest(from(this.editorService.editors), this.enabledExtensions).pipe(
+        return combineLatest(from(this.editorService.editorsWithModel), this.enabledExtensions).pipe(
             tap(([editors, enabledExtensions]) => {
                 const activeExtensions = this.extensionActivationFilter(enabledExtensions, editors)
                 for (const x of activeExtensions) {
@@ -169,7 +169,7 @@ function asObservable(input: string | ObservableInput<string>): Observable<strin
 
 function extensionsWithMatchedActivationEvent(
     enabledExtensions: ConfiguredExtension[],
-    editors: readonly CodeEditorData[]
+    editors: readonly CodeEditorDataWithModel[]
 ): ConfiguredExtension[] {
     return enabledExtensions.filter(x => {
         try {
@@ -194,7 +194,7 @@ function extensionsWithMatchedActivationEvent(
                 console.warn(`Extension ${x.id} has no activation events, so it will never be activated.`)
                 return false
             }
-            const visibleTextDocumentLanguages = editors.map(({ item: { languageId } }) => languageId)
+            const visibleTextDocumentLanguages = editors.map(({ model: { languageId } }) => languageId)
             return x.manifest.activationEvents.some(
                 e => e === '*' || visibleTextDocumentLanguages.some(l => e === `onLanguage:${l}`)
             )

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -12,7 +12,7 @@ import { PlatformContext } from '../../../platform/context'
 import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
-import { CodeEditorData, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -55,7 +55,7 @@ interface PartialContext extends Pick<PlatformContext, 'queryGraphQL' | 'getScri
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: ReadonlyEditorService,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -57,9 +57,10 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
-                            type: 'CodeEditor',
+                            type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
-                            item: { uri: 'u', languageId: 'l', text: 't' },
+                            resource: 'u',
+                            model: { uri: 'u', languageId: 'l', text: 't' },
                         },
                     ])
                 ).toBe('a', {
@@ -79,9 +80,10 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
-                            type: 'CodeEditor',
+                            type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
-                            item: { uri: 'u', languageId: 'l', text: 't' },
+                            resource: 'u',
+                            model: { uri: 'u', languageId: 'l', text: 't' },
                         },
                     ])
                 ).toBe('a', {

--- a/shared/src/api/client/services/location.ts
+++ b/shared/src/api/client/services/location.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
 import { TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
 import { match, TextDocumentIdentifier } from '../types/textDocument'
-import { CodeEditorData, getActiveCodeEditorPosition } from './editorService'
+import { CodeEditorDataWithModel } from './editorService'
 import { DocumentFeatureProviderRegistry } from './registry'
 import { flattenAndCompact } from './util'
 
@@ -45,17 +45,16 @@ export class TextDocumentLocationProviderRegistry<
      *
      * @param editors The code editors in {@link EditorService}.
      */
-    public hasProvidersForActiveTextDocument(editors: readonly CodeEditorData[]): Observable<boolean> {
+    public hasProvidersForActiveTextDocument(editors: readonly CodeEditorDataWithModel[]): Observable<boolean> {
         return this.entries.pipe(
             map(entries => {
-                const params = getActiveCodeEditorPosition(editors)
-                if (!params) {
+                const activeEditor = editors.find(({ isActive }) => isActive)
+                if (!activeEditor) {
                     return false
                 }
-
                 return (
                     entries.filter(({ registrationOptions }) =>
-                        match(registrationOptions.documentSelector, params.textDocument)
+                        match(registrationOptions.documentSelector, activeEditor.model)
                     ).length > 0
                 )
             })

--- a/shared/src/api/client/services/modelService.test.ts
+++ b/shared/src/api/client/services/modelService.test.ts
@@ -1,0 +1,76 @@
+import { from } from 'rxjs'
+import { first } from 'rxjs/operators'
+import { createModelService } from './modelService'
+
+describe('ModelService', () => {
+    describe('addModel', () => {
+        it('adds', async () => {
+            const modelService = createModelService()
+            modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+            expect(
+                await from(modelService.models)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([
+                {
+                    uri: 'u',
+                    text: 't',
+                    languageId: 'l',
+                },
+            ])
+        })
+        it('refuses to add model with duplicate URI', async () => {
+            const modelService = createModelService()
+            modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+            expect(() => {
+                modelService.addModel({ uri: 'u', text: 't2', languageId: 'l2' })
+            }).toThrowError('model already exists with URI u')
+            expect(
+                await from(modelService.models)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([
+                {
+                    uri: 'u',
+                    text: 't',
+                    languageId: 'l',
+                },
+            ])
+        })
+    })
+
+    describe('removeModel', () => {
+        test('removes', async () => {
+            const modelService = createModelService()
+            modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+            modelService.addModel({ uri: 'u2', text: 't2', languageId: 'l2' })
+            modelService.removeModel('u')
+            expect(
+                await from(modelService.models)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([
+                {
+                    uri: 'u2',
+                    text: 't2',
+                    languageId: 'l2',
+                },
+            ])
+        })
+        test('noop if model not found', () => {
+            const modelService = createModelService()
+            modelService.removeModel('x')
+        })
+    })
+
+    test('removeAllModels', async () => {
+        const modelService = createModelService()
+        modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+        modelService.removeAllModels()
+        expect(
+            await from(modelService.models)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([])
+    })
+})

--- a/shared/src/api/client/services/modelService.test.ts
+++ b/shared/src/api/client/services/modelService.test.ts
@@ -39,6 +39,13 @@ describe('ModelService', () => {
         })
     })
 
+    test('hasModel', () => {
+        const modelService = createModelService()
+        modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+        expect(modelService.hasModel('u')).toBeTruthy()
+        expect(modelService.hasModel('u2')).toBeFalsy()
+    })
+
     describe('removeModel', () => {
         test('removes', async () => {
             const modelService = createModelService()
@@ -61,16 +68,5 @@ describe('ModelService', () => {
             const modelService = createModelService()
             modelService.removeModel('x')
         })
-    })
-
-    test('removeAllModels', async () => {
-        const modelService = createModelService()
-        modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
-        modelService.removeAllModels()
-        expect(
-            await from(modelService.models)
-                .pipe(first())
-                .toPromise()
-        ).toEqual([])
     })
 })

--- a/shared/src/api/client/services/modelService.test.ts
+++ b/shared/src/api/client/services/modelService.test.ts
@@ -46,6 +46,24 @@ describe('ModelService', () => {
         expect(modelService.hasModel('u2')).toBeFalsy()
     })
 
+    describe('updateModel', () => {
+        test('existing model', async () => {
+            const modelService = createModelService()
+            modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+            modelService.updateModel('u', 't2')
+            expect(
+                await from(modelService.models)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([{ uri: 'u', text: 't2', languageId: 'l' }])
+        })
+
+        test('nonexistent model', async () => {
+            const modelService = createModelService()
+            expect(() => modelService.updateModel('x', 't2')).toThrowError('model does not exist with URI x')
+        })
+    })
+
     describe('removeModel', () => {
         test('removes', async () => {
             const modelService = createModelService()

--- a/shared/src/api/client/services/modelService.ts
+++ b/shared/src/api/client/services/modelService.ts
@@ -1,0 +1,60 @@
+import { BehaviorSubject, Subscribable } from 'rxjs'
+import { TextDocument } from 'sourcegraph'
+
+/**
+ * A text model is a text document and associated metadata.
+ *
+ * How does this relate to editors (in {@link EditorService}? A model is the file, an editor is the
+ * window that the file is shown in. Things like the content and language are properties of the
+ * model; things like decorations and the selection ranges are properties of the editor.
+ */
+export interface TextModel extends Pick<TextDocument, 'uri' | 'languageId' | 'text'> {}
+
+/**
+ * The model service manages document contents and metadata.
+ *
+ * See {@link Model} for an explanation of the difference between a model and an editor.
+ */
+export interface ModelService {
+    /** All known models. */
+    models: Subscribable<readonly TextModel[]>
+
+    /**
+     * Adds a model.
+     *
+     * @params model The model to add.
+     */
+    addModel(model: TextModel): void
+
+    /**
+     * Removes a model.
+     *
+     * @params uri The URI of the model to remove.
+     */
+    removeModel(uri: string): void
+
+    /**
+     * Removes all models.
+     */
+    removeAllModels(): void
+}
+
+/**
+ * Creates a new instance of {@link createModelService}.
+ */
+export function createModelService(): ModelService {
+    const models = new BehaviorSubject<readonly TextModel[]>([])
+    return {
+        models,
+        addModel: model => {
+            if (models.value.some(m => m.uri === model.uri)) {
+                throw new Error(`model already exists with URI ${model.uri}`)
+            }
+            models.next([...models.value, model])
+        },
+        removeModel: uri => {
+            models.next(models.value.filter(m => m.uri !== uri))
+        },
+        removeAllModels: () => models.next([]),
+    }
+}

--- a/shared/src/api/client/services/modelService.ts
+++ b/shared/src/api/client/services/modelService.ts
@@ -22,21 +22,21 @@ export interface ModelService {
     /**
      * Adds a model.
      *
-     * @params model The model to add.
+     * @param model The model to add.
      */
     addModel(model: TextModel): void
 
     /**
      * Reports whether a model with a given URI has already been added.
      *
-     * @params uri The model URI to check.
+     * @param uri The model URI to check.
      */
     hasModel(uri: string): boolean
 
     /**
      * Removes a model.
      *
-     * @params uri The URI of the model to remove.
+     * @param uri The URI of the model to remove.
      */
     removeModel(uri: string): void
 }

--- a/shared/src/api/client/services/modelService.ts
+++ b/shared/src/api/client/services/modelService.ts
@@ -27,6 +27,15 @@ export interface ModelService {
     addModel(model: TextModel): void
 
     /**
+     * Updates a model's text content.
+     *
+     * @param uri The URI of the model whose content to update.
+     * @param text The new text content (which will overwrite the model's previous content).
+     * @throws if the model does not exist.
+     */
+    updateModel(uri: string, text: string): void
+
+    /**
      * Reports whether a model with a given URI has already been added.
      *
      * @param uri The model URI to check.
@@ -54,6 +63,20 @@ export function createModelService(): ModelService {
                 throw new Error(`model already exists with URI ${model.uri}`)
             }
             models.next([...models.value, model])
+        },
+        updateModel: (uri, text) => {
+            const existing = models.value.find(m => m.uri === uri)
+            if (!existing) {
+                throw new Error(`model does not exist with URI ${uri}`)
+            }
+            models.next(
+                models.value.map(m => {
+                    if (m === existing) {
+                        return { ...existing, text }
+                    }
+                    return m
+                })
+            )
         },
         hasModel,
         removeModel: uri => {

--- a/shared/src/api/client/services/modelService.ts
+++ b/shared/src/api/client/services/modelService.ts
@@ -27,16 +27,18 @@ export interface ModelService {
     addModel(model: TextModel): void
 
     /**
+     * Reports whether a model with a given URI has already been added.
+     *
+     * @params uri The model URI to check.
+     */
+    hasModel(uri: string): boolean
+
+    /**
      * Removes a model.
      *
      * @params uri The URI of the model to remove.
      */
     removeModel(uri: string): void
-
-    /**
-     * Removes all models.
-     */
-    removeAllModels(): void
 }
 
 /**
@@ -44,17 +46,18 @@ export interface ModelService {
  */
 export function createModelService(): ModelService {
     const models = new BehaviorSubject<readonly TextModel[]>([])
+    const hasModel = (uri: string) => models.value.some(m => m.uri === uri)
     return {
         models,
         addModel: model => {
-            if (models.value.some(m => m.uri === model.uri)) {
+            if (hasModel(model.uri)) {
                 throw new Error(`model already exists with URI ${model.uri}`)
             }
             models.next([...models.value, model])
         },
+        hasModel,
         removeModel: uri => {
             models.next(models.value.filter(m => m.uri !== uri))
         },
-        removeAllModels: () => models.next([]),
     }
 }

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -17,11 +17,11 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
     private resource: string
 
     constructor(
-        data: CodeEditorData<Pick<sourcegraph.TextDocument, 'uri'>>,
+        data: CodeEditorData,
         private proxy: ProxyResult<ClientCodeEditorAPI>,
         private documents: ExtDocuments
     ) {
-        this.resource = data.item.uri
+        this.resource = data.resource
         this.update(data)
     }
 

--- a/shared/src/api/extension/api/documents.ts
+++ b/shared/src/api/extension/api/documents.ts
@@ -43,16 +43,6 @@ export class ExtDocuments implements ExtDocumentsAPI, ProxyValue {
             return doc
         }
         await this.sync()
-        // This 2nd sync is necessary after the monolithic model was split into ModelService and
-        // EditorService, which means that changes to the model/editor state are not atomic. Without
-        // the 2nd sync, the `document not found: ...` error above is thrown when the user navigates
-        // between files (e.g., using go-to-definition) because the hover is requested on the
-        // destination file before it has been added (because there are now more "steps" to adding
-        // the file: first clearing the current model and editor and then adding the new model and
-        // editor).
-        //
-        // TODO: add an atomic way to update the state to remove this hack
-        await this.sync()
         return this.get(resource)
     }
 

--- a/shared/src/api/extension/api/documents.ts
+++ b/shared/src/api/extension/api/documents.ts
@@ -1,11 +1,12 @@
 import { ProxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
 import { Subject } from 'rxjs'
 import { TextDocument } from 'sourcegraph'
+import { TextModel } from '../../client/services/modelService'
 import { ExtDocument } from './textDocument'
 
 /** @internal */
 export interface ExtDocumentsAPI extends ProxyValue {
-    $acceptDocumentData(doc: Pick<TextDocument, 'uri' | 'languageId' | 'text'>[]): void
+    $acceptDocumentData(models: readonly TextModel[]): void
 }
 
 /** @internal */
@@ -42,6 +43,16 @@ export class ExtDocuments implements ExtDocumentsAPI, ProxyValue {
             return doc
         }
         await this.sync()
+        // This 2nd sync is necessary after the monolithic model was split into ModelService and
+        // EditorService, which means that changes to the model/editor state are not atomic. Without
+        // the 2nd sync, the `document not found: ...` error above is thrown when the user navigates
+        // between files (e.g., using go-to-definition) because the hover is requested on the
+        // destination file before it has been added (because there are now more "steps" to adding
+        // the file: first clearing the current model and editor and then adding the new model and
+        // editor).
+        //
+        // TODO: add an atomic way to update the state to remove this hack
+        await this.sync()
         return this.get(resource)
     }
 
@@ -56,11 +67,7 @@ export class ExtDocuments implements ExtDocumentsAPI, ProxyValue {
 
     public openedTextDocuments = new Subject<TextDocument>()
 
-    public $acceptDocumentData(models: Pick<TextDocument, 'uri' | 'languageId' | 'text'>[] | null): void {
-        if (!models) {
-            // We don't ever (yet) communicate to the extension when docs are closed.
-            return
-        }
+    public $acceptDocumentData(models: readonly TextModel[]): void {
         for (const model of models) {
             const isNew = !this.documents.has(model.uri)
             const doc = new ExtDocument(model)

--- a/shared/src/api/extension/api/windows.test.ts
+++ b/shared/src/api/extension/api/windows.test.ts
@@ -10,28 +10,26 @@ describe('ExtWindow', () => {
 
     test('reuses ExtCodeEditor object when updated', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [
-                { type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [new Selection(1, 2, 3, 4)] },
-            ],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [new Selection(1, 2, 3, 4)] }],
         })
         expect(wins.activeViewComponent).toBe(origViewComponent)
     })
 
     test('creates new ExtCodeEditor object for a different resource URI', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u2' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: true, selections: [] }],
         })
         expect(wins.activeViewComponent).not.toBe(origViewComponent)
     })
@@ -46,18 +44,18 @@ describe('ExtWindows', () => {
     test('reuses ExtWindow object when updated', () => {
         const wins = new ExtWindows(NOOP_PROXY, documents)
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
         })
         const origWin = wins.activeWindow
         expect(origWin).toBeTruthy()
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u2' }, isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
     })

--- a/shared/src/api/extension/api/windows.ts
+++ b/shared/src/api/extension/api/windows.ts
@@ -10,7 +10,7 @@ import { ExtCodeEditor } from './codeEditor'
 import { ExtDocuments } from './documents'
 
 export interface WindowData {
-    editors: CodeEditorData<Pick<sourcegraph.TextDocument, 'uri'>>[]
+    editors: readonly CodeEditorData[]
 }
 
 interface WindowsProxyData {
@@ -96,7 +96,7 @@ export class ExtWindow implements sourcegraph.Window {
      * Perform a delta update (update/add/delete) of this window's view components.
      */
     public update(data: WindowData): void {
-        const getKey = (c: CodeEditorData<Pick<sourcegraph.TextDocument, 'uri'>>): string => `${c.type}:${c.item.uri}`
+        const getKey = (c: CodeEditorData): string => `${c.type}:${c.resource}`
 
         const seenKeys = new Set<string>()
         for (const c of data.editors) {

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -16,7 +16,7 @@ describe('CodeEditor (integration)', () => {
             } = await integrationTestContext()
 
             const setSelections = (selections: Selection[]) => {
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'foo', languageId: 'l1', text: 't1' },

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -18,7 +18,7 @@ describe('Documents (integration)', () => {
                 services: { editor: editorService },
                 extensionAPI,
             } = await integrationTestContext()
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
@@ -46,7 +46,7 @@ describe('Documents (integration)', () => {
             const values = collectSubscribableValues(extensionAPI.workspace.openedTextDocuments)
             expect(values).toEqual([] as TextDocument[])
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -15,17 +15,10 @@ describe('Documents (integration)', () => {
 
         test('adds new text documents', async () => {
             const {
-                services: { editor: editorService },
+                services: { model: modelService },
                 extensionAPI,
             } = await integrationTestContext()
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            modelService.addModel({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
             await from(extensionAPI.workspace.openedTextDocuments)
                 .pipe(take(1))
                 .toPromise()
@@ -39,21 +32,14 @@ describe('Documents (integration)', () => {
     describe('workspace.openedTextDocuments', () => {
         test('fires when a text document is opened', async () => {
             const {
-                services: { editor: editorService },
+                services: { model: modelService },
                 extensionAPI,
             } = await integrationTestContext()
 
             const values = collectSubscribableValues(extensionAPI.workspace.openedTextDocuments)
             expect(values).toEqual([] as TextDocument[])
 
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            modelService.addModel({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
             await from(extensionAPI.workspace.openedTextDocuments)
                 .pipe(take(1))
                 .toPromise()

--- a/shared/src/api/integration-test/languageFeatures.test.ts
+++ b/shared/src/api/integration-test/languageFeatures.test.ts
@@ -153,7 +153,6 @@ function testLocationProvider<P>({
                     isActive: true,
                 },
             ])
-            // await extensionAPI.internal.sync()
 
             expect(
                 await getResult(services, 'file:///f2')

--- a/shared/src/api/integration-test/languageFeatures.test.ts
+++ b/shared/src/api/integration-test/languageFeatures.test.ts
@@ -20,9 +20,9 @@ describe('LanguageFeatures (integration)', () => {
             contents: labels.map(label => ({ value: label, kind: sourcegraph.MarkupKind.PlainText })),
         }),
         providerWithImplementation: run => ({ provideHover: run } as sourcegraph.HoverProvider),
-        getResult: services =>
+        getResult: (services, uri) =>
             services.textDocumentHover.getHover({
-                textDocument: { uri: 'file:///f' },
+                textDocument: { uri },
                 position: { line: 1, character: 2 },
             }),
     })
@@ -35,10 +35,10 @@ describe('LanguageFeatures (integration)', () => {
         }),
         labeledProviderResults: labeledDefinitionResults,
         providerWithImplementation: run => ({ provideDefinition: run } as sourcegraph.DefinitionProvider),
-        getResult: services =>
+        getResult: (services, uri) =>
             services.textDocumentDefinition
                 .getLocations({
-                    textDocument: { uri: 'file:///f' },
+                    textDocument: { uri },
                     position: { line: 1, character: 2 },
                 })
                 .pipe(switchMap(locations => locations)),
@@ -62,10 +62,10 @@ describe('LanguageFeatures (integration)', () => {
                     _context: sourcegraph.ReferenceContext
                 ) => run(doc, pos),
             } as sourcegraph.ReferenceProvider),
-        getResult: services =>
+        getResult: (services, uri) =>
             services.textDocumentReferences
                 .getLocations({
-                    textDocument: { uri: 'file:///f' },
+                    textDocument: { uri },
                     position: { line: 1, character: 2 },
                     context: { includeDeclaration: true },
                 })
@@ -84,10 +84,10 @@ describe('LanguageFeatures (integration)', () => {
             ({
                 provideLocations: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => run(doc, pos),
             } as sourcegraph.LocationProvider),
-        getResult: services =>
+        getResult: (services, uri) =>
             services.textDocumentLocations
                 .getLocations('x', {
-                    textDocument: { uri: 'file:///f' },
+                    textDocument: { uri },
                     position: { line: 1, character: 2 },
                 })
                 .pipe(switchMap(x => x)),
@@ -113,7 +113,7 @@ function testLocationProvider<P>({
     labeledProvider: (label: string) => P
     labeledProviderResults: (labels: string[]) => any
     providerWithImplementation: (run: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => void) => P
-    getResult: (services: Services) => Observable<any>
+    getResult: (services: Services, uri: string) => Observable<any>
 }): void {
     describe(`languages.${name}`, () => {
         test('registers and unregisters a single provider', async () => {
@@ -123,7 +123,7 @@ function testLocationProvider<P>({
             const subscription = registerProvider(extensionAPI)(['*'], labeledProvider('a'))
             await extensionAPI.internal.sync()
             expect(
-                await getResult(services)
+                await getResult(services, 'file:///f')
                     .pipe(take(1))
                     .toPromise()
             ).toEqual(labeledProviderResults(['a']))
@@ -131,10 +131,37 @@ function testLocationProvider<P>({
             // Unregister the provider and ensure it's removed.
             subscription.unsubscribe()
             expect(
-                await getResult(services)
+                await getResult(services, 'file:///f')
                     .pipe(take(1))
                     .toPromise()
             ).toEqual(null)
+        })
+
+        test('syncs with models', async () => {
+            const { services, extensionAPI } = await integrationTestContext()
+
+            const subscription = registerProvider(extensionAPI)(['*'], labeledProvider('a'))
+            await extensionAPI.internal.sync()
+
+            services.editor.nextEditors([])
+            services.model.addModel({ uri: 'file:///f2', languageId: 'l1', text: 't1' })
+            services.editor.nextEditors([
+                {
+                    type: 'CodeEditor',
+                    resource: 'file:///f2',
+                    selections: [],
+                    isActive: true,
+                },
+            ])
+            // await extensionAPI.internal.sync()
+
+            expect(
+                await getResult(services, 'file:///f2')
+                    .pipe(take(1))
+                    .toPromise()
+            ).toEqual(labeledProviderResults(['a']))
+
+            subscription.unsubscribe()
         })
 
         test('supplies params to the provideXyz method', async () => {
@@ -149,7 +176,7 @@ function testLocationProvider<P>({
                 })
             )
             await extensionAPI.internal.sync()
-            await getResult(services)
+            await getResult(services, 'file:///f')
                 .pipe(take(1))
                 .toPromise()
             await wait
@@ -165,7 +192,7 @@ function testLocationProvider<P>({
 
             // Expect it to emit the first provider's result first (and not block on both providers being ready).
             expect(
-                await getResult(services)
+                await getResult(services, 'file:///f')
                     .pipe(
                         take(2),
                         toArray()

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -54,7 +54,7 @@ describe('Selections (integration)', () => {
                 [],
             ]
             for (const selections of testValues) {
-                editorService.editors.next([withSelections(...selections)])
+                editorService.nextEditors([withSelections(...selections)])
                 await extensionAPI.internal.sync()
             }
             await extensionAPI.internal.sync()

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -7,7 +7,7 @@ import { collectSubscribableValues, integrationTestContext } from './testHelpers
 
 const withSelections = (...selections: { start: number; end: number }[]): CodeEditorData => ({
     type: 'CodeEditor',
-    item: { uri: 'foo', languageId: 'l1', text: 't1' },
+    resource: 'file:///f',
     selections: selections.map(({ start, end }) => ({
         start: {
             line: start,
@@ -36,10 +36,7 @@ describe('Selections (integration)', () => {
             const {
                 services: { editor: editorService },
                 extensionAPI,
-            } = await integrationTestContext(undefined, {
-                roots: [],
-                editors: [],
-            })
+            } = await integrationTestContext()
             const selectionChanges = from(extensionAPI.app.activeWindowChanges).pipe(
                 filter(isDefined),
                 switchMap(window => window.activeViewComponentChanges),
@@ -56,11 +53,11 @@ describe('Selections (integration)', () => {
             for (const selections of testValues) {
                 editorService.nextEditors([withSelections(...selections)])
                 await extensionAPI.internal.sync()
+                await extensionAPI.internal.sync()
             }
-            await extensionAPI.internal.sync()
             assertToJSON(
                 selectionValues.map(selections => selections.map(s => ({ start: s.start.line, end: s.end.line }))),
-                testValues
+                [[], ...testValues]
             )
         })
     })

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -53,7 +53,6 @@ describe('Selections (integration)', () => {
             for (const selections of testValues) {
                 editorService.nextEditors([withSelections(...selections)])
                 await extensionAPI.internal.sync()
-                await extensionAPI.internal.sync()
             }
             assertToJSON(
                 selectionValues.map(selections => selections.map(s => ({ start: s.start.line, end: s.end.line }))),

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -1,7 +1,7 @@
 import 'message-port-polyfill'
 
 import { BehaviorSubject, from, NEVER, throwError } from 'rxjs'
-import { first, take } from 'rxjs/operators'
+import { first, switchMap, take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { EndpointPair, PlatformContext } from '../../platform/context'
 import { isDefined } from '../../util/types'
@@ -102,7 +102,11 @@ export async function integrationTestContext(
             .pipe(take(initModel.editors.length))
             .toPromise(),
         from(extensionAPI.app.activeWindowChanges)
-            .pipe(first(isDefined))
+            .pipe(
+                first(isDefined),
+                switchMap(activeWindow => activeWindow.activeViewComponentChanges),
+                first(isDefined)
+            )
             .toPromise(),
     ])
 

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -8,13 +8,13 @@ import { isDefined } from '../../util/types'
 import { ExtensionHostClient } from '../client/client'
 import { createExtensionHostClientConnection } from '../client/connection'
 import { Services } from '../client/services'
-import { CodeEditorData } from '../client/services/editorService'
+import { CodeEditorDataWithModel } from '../client/services/editorService'
 import { WorkspaceRootWithMetadata } from '../client/services/workspaceService'
 import { InitData, startExtensionHost } from '../extension/extensionHost'
 
 interface TestInitData {
     roots: readonly WorkspaceRootWithMetadata[]
-    editors: readonly CodeEditorData[]
+    editors: readonly CodeEditorDataWithModel[]
 }
 
 const FIXTURE_INIT_DATA: TestInitData = {
@@ -22,7 +22,8 @@ const FIXTURE_INIT_DATA: TestInitData = {
     editors: [
         {
             type: 'CodeEditor',
-            item: {
+            resource: 'file:///f',
+            model: {
                 uri: 'file:///f',
                 languageId: 'l',
                 text: 't',
@@ -89,6 +90,9 @@ export async function integrationTestContext(
     const client = await createExtensionHostClientConnection(clientEndpoints, services, initData)
 
     const extensionAPI = await extensionHost.extensionAPI
+    for (const { model } of initModel.editors) {
+        services.model.addModel(model)
+    }
     services.editor.nextEditors(initModel.editors)
     services.workspace.roots.next(initModel.roots)
 

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -1,7 +1,7 @@
 import 'message-port-polyfill'
 
 import { BehaviorSubject, from, NEVER, throwError } from 'rxjs'
-import { first, switchMap, take } from 'rxjs/operators'
+import { filter, first, switchMap, take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { EndpointPair, PlatformContext } from '../../platform/context'
 import { isDefined } from '../../util/types'
@@ -104,8 +104,12 @@ export async function integrationTestContext(
         from(extensionAPI.app.activeWindowChanges)
             .pipe(
                 first(isDefined),
-                switchMap(activeWindow => activeWindow.activeViewComponentChanges),
-                first(isDefined)
+                switchMap(activeWindow =>
+                    from(activeWindow.activeViewComponentChanges).pipe(
+                        filter(isDefined),
+                        take(initModel.editors.length)
+                    )
+                )
             )
             .toPromise(),
     ])

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -89,7 +89,7 @@ export async function integrationTestContext(
     const client = await createExtensionHostClientConnection(clientEndpoints, services, initData)
 
     const extensionAPI = await extensionHost.extensionAPI
-    services.editor.editors.next(initModel.editors)
+    services.editor.nextEditors(initModel.editors)
     services.workspace.roots.next(initModel.roots)
 
     // Wait for initModel to be initialized

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -9,7 +9,6 @@ describe('Windows (integration)', () => {
     describe('app.activeWindow', () => {
         test('returns the active window', async () => {
             const { extensionAPI } = await integrationTestContext()
-            await extensionAPI.internal.sync()
             const viewComponent: Pick<ViewComponent, 'type'> & {
                 document: TextModel
             } = {
@@ -67,7 +66,6 @@ describe('Windows (integration)', () => {
     describe('app.windows', () => {
         test('lists windows', async () => {
             const { extensionAPI } = await integrationTestContext()
-            await extensionAPI.internal.sync()
             const viewComponent: Pick<ViewComponent, 'type'> & {
                 document: TextModel
             } = {
@@ -180,8 +178,6 @@ describe('Windows (integration)', () => {
                     },
                     ...editorService.editorsValue,
                 ])
-                await extensionAPI.internal.sync()
-                await extensionAPI.internal.sync()
 
                 assertToJSON(extensionAPI.app.windows[0].activeViewComponent, {
                     type: 'CodeEditor' as const,

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -31,7 +31,7 @@ describe('Windows (integration)', () => {
                 roots: [],
                 editors: [],
             })
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'foo', languageId: 'l1', text: 't1' },
@@ -39,8 +39,8 @@ describe('Windows (integration)', () => {
                     isActive: true,
                 },
             ])
-            editorService.editors.next([])
-            editorService.editors.next([
+            editorService.nextEditors([])
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'bar', languageId: 'l2', text: 't2' },
@@ -82,7 +82,7 @@ describe('Windows (integration)', () => {
                 extensionAPI,
             } = await integrationTestContext()
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
@@ -119,7 +119,7 @@ describe('Windows (integration)', () => {
                 extensionAPI,
             } = await integrationTestContext()
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: {
@@ -130,7 +130,7 @@ describe('Windows (integration)', () => {
                     selections: [],
                     isActive: false,
                 },
-                ...editorService.editors.value,
+                ...editorService.editorsValue,
             ])
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
@@ -158,7 +158,7 @@ describe('Windows (integration)', () => {
                     extensionAPI,
                 } = await integrationTestContext()
 
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: {
@@ -169,7 +169,7 @@ describe('Windows (integration)', () => {
                         selections: [],
                         isActive: false,
                     },
-                    ...editorService.editors.value,
+                    ...editorService.editorsValue,
                 ])
                 await extensionAPI.internal.sync()
 
@@ -189,7 +189,7 @@ describe('Windows (integration)', () => {
                     roots: [],
                     editors: [],
                 })
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'foo', languageId: 'l1', text: 't1' },
@@ -197,8 +197,8 @@ describe('Windows (integration)', () => {
                         isActive: true,
                     },
                 ])
-                editorService.editors.next([])
-                editorService.editors.next([
+                editorService.nextEditors([])
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'bar', languageId: 'l2', text: 't2' },

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -1,6 +1,7 @@
 import { from } from 'rxjs'
-import { distinctUntilChanged, map, switchMap, take, toArray } from 'rxjs/operators'
+import { distinctUntilChanged, filter, map, switchMap, take, toArray } from 'rxjs/operators'
 import { NotificationType, ViewComponent, Window } from 'sourcegraph'
+import { isDefined } from '../../util/types'
 import { TextModel } from '../client/services/modelService'
 import { assertToJSON } from '../extension/types/testHelpers'
 import { collectSubscribableValues, integrationTestContext } from './testHelpers'
@@ -97,8 +98,10 @@ describe('Windows (integration)', () => {
             ])
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
-                    switchMap(w => (w ? w.activeViewComponentChanges : [])),
-                    take(4)
+                    filter(isDefined),
+                    switchMap(w => w.activeViewComponentChanges),
+                    filter(isDefined),
+                    take(3)
                 )
                 .toPromise()
 
@@ -140,8 +143,10 @@ describe('Windows (integration)', () => {
             ])
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
-                    switchMap(w => (w ? w.activeViewComponentChanges : [])),
-                    take(4)
+                    filter(isDefined),
+                    switchMap(w => w.activeViewComponentChanges),
+                    filter(isDefined),
+                    take(3)
                 )
                 .toPromise()
 

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -292,7 +292,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         // Update the Sourcegraph extensions model to reflect the current file.
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
-                this.props.extensionsController.services.editor.editors.next([
+                this.props.extensionsController.services.editor.nextEditors([
                     {
                         type: 'CodeEditor' as const,
                         item: {

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -292,14 +292,18 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         // Update the Sourcegraph extensions model to reflect the current file.
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
+                const uri = `git://${model.repoName}?${model.commitID}#${model.filePath}`
+                this.props.extensionsController.services.editor.nextEditors([])
+                this.props.extensionsController.services.model.removeAllModels()
+                this.props.extensionsController.services.model.addModel({
+                    uri,
+                    languageId: model.mode,
+                    text: model.content,
+                })
                 this.props.extensionsController.services.editor.nextEditors([
                     {
                         type: 'CodeEditor' as const,
-                        item: {
-                            uri: `git://${model.repoName}?${model.commitID}#${model.filePath}`,
-                            languageId: model.mode,
-                            text: model.content,
-                        },
+                        resource: uri,
                         selections: lprToSelectionsZeroIndexed(pos),
                         isActive: true,
                     },

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -293,13 +293,13 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
                 const uri = `git://${model.repoName}?${model.commitID}#${model.filePath}`
-                this.props.extensionsController.services.editor.nextEditors([])
-                this.props.extensionsController.services.model.removeAllModels()
-                this.props.extensionsController.services.model.addModel({
-                    uri,
-                    languageId: model.mode,
-                    text: model.content,
-                })
+                if (!this.props.extensionsController.services.model.hasModel(uri)) {
+                    this.props.extensionsController.services.model.addModel({
+                        uri,
+                        languageId: model.mode,
+                        text: model.content,
+                    })
+                }
                 this.props.extensionsController.services.editor.nextEditors([
                     {
                         type: 'CodeEditor' as const,

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -166,7 +166,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
         )
 
         // Clear the Sourcegraph extensions model's component when the blob is no longer shown.
-        this.subscriptions.add(() => this.props.extensionsController.services.editor.editors.next([]))
+        this.subscriptions.add(() => this.props.extensionsController.services.editor.nextEditors([]))
 
         this.propsUpdates.next(this.props)
     }

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -95,47 +95,45 @@ export class BlobPanel extends React.PureComponent<Props> {
             extraParams?: Pick<P, Exclude<keyof P, keyof TextDocumentPositionParams>>
         ): Entry<ViewProviderRegistrationOptions, ProvideViewSignature> => ({
             registrationOptions: { id, container: ContributableViewContainer.Panel },
-            provider: from(this.props.extensionsController.services.editor.editors).pipe(
+            provider: from(this.props.extensionsController.services.editor.editorsWithModel).pipe(
                 switchMap(editors =>
-                    registry
-                        .hasProvidersForActiveTextDocument(this.props.extensionsController.services.editor.editorsValue)
-                        .pipe(
-                            map(hasProviders => {
-                                if (!hasProviders) {
-                                    return null
-                                }
-                                const params: TextDocumentPositionParams | null = getActiveCodeEditorPosition(editors)
-                                if (!params) {
-                                    return null
-                                }
-                                return {
-                                    title,
-                                    content: '',
-                                    priority,
+                    registry.hasProvidersForActiveTextDocument(editors).pipe(
+                        map(hasProviders => {
+                            if (!hasProviders) {
+                                return null
+                            }
+                            const params: TextDocumentPositionParams | null = getActiveCodeEditorPosition(editors)
+                            if (!params) {
+                                return null
+                            }
+                            return {
+                                title,
+                                content: '',
+                                priority,
 
-                                    // This disable directive is necessary because TypeScript is not yet smart
-                                    // enough to know that (typeof params & typeof extraParams) is P.
-                                    //
-                                    // tslint:disable-next-line:no-object-literal-type-assertion
-                                    locationProvider: registry.getLocations({ ...params, ...extraParams } as P).pipe(
-                                        map(locationsObservable =>
-                                            locationsObservable.pipe(
-                                                tap(locations => {
-                                                    if (
-                                                        this.props.activation &&
-                                                        id === 'references' &&
-                                                        locations &&
-                                                        locations.length > 0
-                                                    ) {
-                                                        this.props.activation.update({ FoundReferences: true })
-                                                    }
-                                                })
-                                            )
+                                // This disable directive is necessary because TypeScript is not yet smart
+                                // enough to know that (typeof params & typeof extraParams) is P.
+                                //
+                                // tslint:disable-next-line:no-object-literal-type-assertion
+                                locationProvider: registry.getLocations({ ...params, ...extraParams } as P).pipe(
+                                    map(locationsObservable =>
+                                        locationsObservable.pipe(
+                                            tap(locations => {
+                                                if (
+                                                    this.props.activation &&
+                                                    id === 'references' &&
+                                                    locations &&
+                                                    locations.length > 0
+                                                ) {
+                                                    this.props.activation.update({ FoundReferences: true })
+                                                }
+                                            })
                                         )
-                                    ),
-                                }
-                            })
-                        )
+                                    )
+                                ),
+                            }
+                        })
+                    )
                 )
             ),
         })

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -98,9 +98,7 @@ export class BlobPanel extends React.PureComponent<Props> {
             provider: from(this.props.extensionsController.services.editor.editors).pipe(
                 switchMap(editors =>
                     registry
-                        .hasProvidersForActiveTextDocument(
-                            this.props.extensionsController.services.editor.editors.value
-                        )
+                        .hasProvidersForActiveTextDocument(this.props.extensionsController.services.editor.editorsValue)
                         .pipe(
                             map(hasProviders => {
                                 if (!hasProviders) {

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -70,6 +70,6 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                 }
             }
         }
-        this.props.extensionsController.services.editor.editors.next(editors)
+        this.props.extensionsController.services.editor.nextEditors(editors)
     }
 }

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -41,8 +41,6 @@ export class FileDiffConnection extends React.PureComponent<Props> {
         // API's support for diffs.
         const dummyText = ''
 
-        this.props.extensionsController.services.model.removeAllModels()
-
         const editors: CodeEditorData[] = []
         if (fileDiffsOrError && !isErrorLike(fileDiffsOrError)) {
             for (const fileDiff of fileDiffsOrError.nodes) {
@@ -54,11 +52,13 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                         selections: [],
                         isActive: false, // HACK: arbitrarily say that the base is inactive. TODO: support diffs first-class
                     })
-                    this.props.extensionsController.services.model.addModel({
-                        uri,
-                        languageId: getModeFromPath(fileDiff.oldPath),
-                        text: dummyText,
-                    })
+                    if (!this.props.extensionsController.services.model.hasModel(uri)) {
+                        this.props.extensionsController.services.model.addModel({
+                            uri,
+                            languageId: getModeFromPath(fileDiff.oldPath),
+                            text: dummyText,
+                        })
+                    }
                 }
                 if (fileDiff.newPath) {
                     const uri = `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`
@@ -68,11 +68,13 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                         selections: [],
                         isActive: true,
                     })
-                    this.props.extensionsController.services.model.addModel({
-                        uri,
-                        languageId: getModeFromPath(fileDiff.newPath),
-                        text: dummyText,
-                    })
+                    if (!this.props.extensionsController.services.model.hasModel(uri)) {
+                        this.props.extensionsController.services.model.addModel({
+                            uri,
+                            languageId: getModeFromPath(fileDiff.newPath),
+                            text: dummyText,
+                        })
+                    }
                 }
             }
         }

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -41,31 +41,37 @@ export class FileDiffConnection extends React.PureComponent<Props> {
         // API's support for diffs.
         const dummyText = ''
 
+        this.props.extensionsController.services.model.removeAllModels()
+
         const editors: CodeEditorData[] = []
         if (fileDiffsOrError && !isErrorLike(fileDiffsOrError)) {
             for (const fileDiff of fileDiffsOrError.nodes) {
                 if (fileDiff.oldPath) {
+                    const uri = `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`
                     editors.push({
                         type: 'CodeEditor',
-                        item: {
-                            uri: `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`,
-                            languageId: getModeFromPath(fileDiff.oldPath),
-                            text: dummyText,
-                        },
+                        resource: uri,
                         selections: [],
                         isActive: false, // HACK: arbitrarily say that the base is inactive. TODO: support diffs first-class
                     })
+                    this.props.extensionsController.services.model.addModel({
+                        uri,
+                        languageId: getModeFromPath(fileDiff.oldPath),
+                        text: dummyText,
+                    })
                 }
                 if (fileDiff.newPath) {
+                    const uri = `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`
                     editors.push({
                         type: 'CodeEditor',
-                        item: {
-                            uri: `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`,
-                            languageId: getModeFromPath(fileDiff.newPath),
-                            text: dummyText,
-                        },
+                        resource: uri,
                         selections: [],
                         isActive: true,
+                    })
+                    this.props.extensionsController.services.model.addModel({
+                        uri,
+                        languageId: getModeFromPath(fileDiff.newPath),
+                        text: dummyText,
                     })
                 }
             }


### PR DESCRIPTION
Previously, document contents and metadata were stored in the editor service. This was simple, but it made it hard to manage documents separately from editors, which is helpful when editors and documents are no longer 1-to-1 (as in the case of diff views, a future desired feature).

This is the 1st PR in the sequence #3322 #3323 (review in order).