### PR TITLE
EditorService: expose operations instead of just the BehaviorSubject

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -144,7 +144,7 @@ describe('code_intelligence', () => {
         })
 
         test('detects code views based on selectors', async () => {
-            const { services } = await integrationTestContext()
+            const { services } = await integrationTestContext(undefined, { roots: [], editors: [] })
             const codeView = createTestElement()
             codeView.id = 'code'
             const toolbarMount = document.createElement('div')
@@ -181,14 +181,20 @@ describe('code_intelligence', () => {
             )
             const editors = await from(services.editor.editors)
                 .pipe(
-                    skip(1),
+                    skip(2),
                     take(1)
                 )
                 .toPromise()
             expect(editors).toEqual([
                 {
+                    editorId: 'editor#0',
                     isActive: true,
                     resource: 'git://foo?1#/bar.ts',
+                    model: {
+                        uri: 'git://foo?1#/bar.ts',
+                        text: undefined,
+                        languageId: 'typescript',
+                    },
                     selections: [],
                     type: 'CodeEditor',
                 },

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -78,7 +78,7 @@ export async function createExtensionHostClientConnection(
             .subscribe()
     )
     subscription.add(
-        from(services.editor.editorsWithModel)
+        from(services.editor.editors)
             .pipe(concatMap(editors => proxy.windows.$acceptWindowData({ editors })))
             .subscribe()
     )

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -1,7 +1,6 @@
 import { Selection } from '@sourcegraph/extension-api-types'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorDataWithModel } from '../services/editorService'
-import { applyContextUpdate, Context, getComputedContextProperty } from './context'
+import { applyContextUpdate, Context, getComputedContextProperty, PartialCodeEditor } from './context'
 
 describe('applyContextUpdate', () => {
     test('merges properties', () =>
@@ -30,14 +29,13 @@ describe('getComputedContextProperty', () => {
     })
 
     describe('with code editors', () => {
-        const editors: CodeEditorDataWithModel[] = [
+        const editors: PartialCodeEditor[] = [
             {
                 type: 'CodeEditor',
                 resource: 'file:///inactive',
                 model: {
                     uri: 'file:///inactive',
                     languageId: 'inactive',
-                    text: 'inactive',
                 },
                 selections: [
                     {
@@ -56,7 +54,6 @@ describe('getComputedContextProperty', () => {
                 model: {
                     uri: 'file:///a/b.c',
                     languageId: 'l',
-                    text: 't',
                 },
                 selections: [
                     {
@@ -106,7 +103,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there are no code editors', () =>
                 expect(getComputedContextProperty([], EMPTY_SETTINGS_CASCADE, {}, 'component.type')).toBe(null))
 
-            function assertSelection(editors: CodeEditorDataWithModel[], expr: string, expected: Selection): void {
+            function assertSelection(editors: PartialCodeEditor[], expr: string, expected: Selection): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, expr)).toEqual(expected)
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, `${expr}.start`)).toEqual(
                     expected.start
@@ -150,7 +147,7 @@ describe('getComputedContextProperty', () => {
                     ]
                 ))
 
-            function assertNoSelection(editors: CodeEditorDataWithModel[]): void {
+            function assertNoSelection(editors: PartialCodeEditor[]): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, 'component.selection')).toBe(
                     null
                 )
@@ -182,7 +179,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there is no selection', () => {
                 assertNoSelection([
                     {
-                        type: 'CodeEditor',
+                        type: 'CodeEditor' as const,
                         resource: 'file:///a/b.c',
                         model: {
                             uri: 'file:///a/b.c',

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname } from 'path'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorDataWithModel } from '../services/editorService'
+import { CodeEditor } from '../services/editorService'
 
 /**
  * Returns a new context created by applying the update context to the base context. It is equivalent to `{...base,
@@ -31,10 +31,12 @@ export interface Context<T = never>
         string | number | boolean | null | Context | T | (string | number | boolean | null | Context | T)[]
     > {}
 
+export type PartialCodeEditor = Pick<CodeEditor, 'type' | 'resource' | 'selections' | 'isActive'> & {
+    model: Pick<CodeEditor['model'], 'uri' | 'languageId'>
+}
+
 export type ContributionScope =
-    | (Pick<CodeEditorDataWithModel, 'type' | 'resource' | 'selections'> & {
-          model: Pick<CodeEditorDataWithModel['model'], 'uri' | 'languageId'>
-      })
+    | PartialCodeEditor
     | {
           type: 'panelView'
           id: string
@@ -49,7 +51,7 @@ export type ContributionScope =
  * @param scope the user interface component in whose scope this computation should occur
  */
 export function getComputedContextProperty(
-    editors: readonly CodeEditorDataWithModel[],
+    editors: readonly PartialCodeEditor[],
     settings: SettingsCascadeOrError,
     context: Context<any>,
     key: string,

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -12,7 +12,7 @@ import {
     filterContributions,
     mergeContributions,
 } from './contribution'
-import { CodeEditorDataWithModel } from './editorService'
+import { CodeEditor } from './editorService'
 import { createTestEditorService } from './editorService.test'
 
 const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
@@ -160,7 +160,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
+                                editors: cold<readonly CodeEditor[]>('-a-b-|', {
                                     a: [],
                                     b: [],
                                 }),
@@ -202,7 +202,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('a', {
+                                editors: cold<readonly CodeEditor[]>('a', {
                                     a: [],
                                 }),
                             },

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -41,7 +41,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: Pick<EditorService, 'editorsWithModel'>,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}
@@ -114,7 +114,7 @@ export class ContributionRegistry {
                     )
                 )
             ),
-            this.editorService.editorsWithModel,
+            this.editorService.editors,
             this.settingsService.data,
             this.context
         ).pipe(

--- a/shared/src/api/client/services/editorService.test.ts
+++ b/shared/src/api/client/services/editorService.test.ts
@@ -1,42 +1,105 @@
+import { Selection } from '@sourcegraph/extension-api-types'
 import { from, of, Subscribable } from 'rxjs'
+import { first, map } from 'rxjs/operators'
 import { TestScheduler } from 'rxjs/testing'
-import {
-    CodeEditorDataWithModel,
-    createEditorService,
-    EditorService,
-    getActiveCodeEditorPosition,
-} from './editorService'
+import { CodeEditor, createEditorService, EditorService, getActiveCodeEditorPosition } from './editorService'
 import { TextModel } from './modelService'
 
 export function createTestEditorService(
-    editorsWithModel: Subscribable<readonly CodeEditorDataWithModel[]> = of([])
-): Pick<EditorService, 'editors' | 'editorsWithModel'> {
-    return { editors: editorsWithModel, editorsWithModel }
+    editors: Subscribable<readonly CodeEditor[]> = of([])
+): Pick<EditorService, 'editors'> {
+    return { editors }
 }
 
 const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 
 describe('EditorService', () => {
-    describe('editorsWithModel', () => {
+    describe('editors', () => {
         test('merges in model data', () => {
             scheduler().run(({ cold, expectObservable }) => {
                 const editorService = createEditorService({
                     models: cold<TextModel[]>('a', { a: [{ uri: 'u', text: 't', languageId: 'l' }] }),
                 })
-                editorService.nextEditors([{ type: 'CodeEditor', resource: 'u', selections: [], isActive: true }])
-                expectObservable(from(editorService.editorsWithModel)).toBe('a', {
+                editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+                expectObservable(
+                    from(editorService.editors).pipe(
+                        map(editors => editors.map(e => ({ resource: e.resource, model: e.model })))
+                    )
+                ).toBe('a', {
                     a: [
                         {
-                            type: 'CodeEditor',
                             resource: 'u',
                             model: { uri: 'u', text: 't', languageId: 'l' },
-                            selections: [],
-                            isActive: true,
                         },
                     ],
                 })
             })
         })
+    })
+
+    test('addEditor', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        expect(editor.editorId).toEqual('editor#0')
+        expect(
+            await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([
+            {
+                type: 'CodeEditor',
+                editorId: 'editor#0',
+                resource: 'u',
+                selections: [],
+                isActive: true,
+                model: { uri: 'u', text: 't', languageId: 'l' },
+            },
+        ])
+    })
+
+    test('setSelections', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        const SELECTIONS: Selection[] = [
+            {
+                start: { line: 3, character: -1 },
+                end: { line: 3, character: -1 },
+                anchor: { line: 3, character: -1 },
+                active: { line: 3, character: -1 },
+                isReversed: false,
+            },
+        ]
+        editorService.setSelections(editor, SELECTIONS)
+        expect(
+            await from(editorService.editors)
+                .pipe(
+                    first(),
+                    map(editors => editors.map(e => e.selections))
+                )
+                .toPromise()
+        ).toEqual([SELECTIONS])
+    })
+
+    test('removeEditor', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        editorService.removeEditor(editor)
+        expect(
+            await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([])
+    })
+
+    test('removeAllEditors', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        editorService.removeAllEditors()
+        expect(
+            await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([])
     })
 })
 

--- a/shared/src/api/client/services/editorService.test.ts
+++ b/shared/src/api/client/services/editorService.test.ts
@@ -57,38 +57,60 @@ describe('EditorService', () => {
         ])
     })
 
-    test('setSelections', async () => {
-        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
-        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
-        const SELECTIONS: Selection[] = [
-            {
-                start: { line: 3, character: -1 },
-                end: { line: 3, character: -1 },
-                anchor: { line: 3, character: -1 },
-                active: { line: 3, character: -1 },
-                isReversed: false,
-            },
-        ]
-        editorService.setSelections(editor, SELECTIONS)
-        expect(
-            await from(editorService.editors)
-                .pipe(
-                    first(),
-                    map(editors => editors.map(e => e.selections))
-                )
-                .toPromise()
-        ).toEqual([SELECTIONS])
+    describe('setSelections', () => {
+        test('ok', async () => {
+            const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+            const editor = editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'u',
+                selections: [],
+                isActive: true,
+            })
+            const SELECTIONS: Selection[] = [
+                {
+                    start: { line: 3, character: -1 },
+                    end: { line: 3, character: -1 },
+                    anchor: { line: 3, character: -1 },
+                    active: { line: 3, character: -1 },
+                    isReversed: false,
+                },
+            ]
+            editorService.setSelections(editor, SELECTIONS)
+            expect(
+                await from(editorService.editors)
+                    .pipe(
+                        first(),
+                        map(editors => editors.map(e => e.selections))
+                    )
+                    .toPromise()
+            ).toEqual([SELECTIONS])
+        })
+        test('not found', () => {
+            const editorService = createEditorService({ models: of([]) })
+            expect(() => editorService.setSelections({ editorId: 'x' }, [])).toThrowError('editor not found: x')
+        })
     })
 
-    test('removeEditor', async () => {
-        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
-        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
-        editorService.removeEditor(editor)
-        expect(
-            await from(editorService.editors)
-                .pipe(first())
-                .toPromise()
-        ).toEqual([])
+    describe('removeEditor', () => {
+        test('ok', async () => {
+            const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+            const editor = editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'u',
+                selections: [],
+                isActive: true,
+            })
+            editorService.removeEditor(editor)
+            expect(
+                await from(editorService.editors)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([])
+        })
+        test('not found', () => {
+            const editorService = createEditorService({ models: of([]) })
+            expect(() => editorService.removeEditor({ editorId: 'x' })).toThrowError('editor not found: x')
+        })
     })
 
     test('removeAllEditors', async () => {

--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -75,6 +75,8 @@ export interface EditorService {
  * Creates a {@link EditorService} instance.
  */
 export function createEditorService(modelService: Pick<ModelService, 'models'>): EditorService {
+    // Don't use lodash.uniqueId because that makes it harder to hard-code expected ID values in
+    // test code (because the IDs change depending on test execution order).
     let id = 0
     const nextId = () => `editor#${id++}`
 

--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -104,7 +104,7 @@ export function createEditorService(modelService: Pick<ModelService, 'models'>):
         setSelections({ editorId }: EditorId, selections: Selection[]): void {
             editors.next([
                 ...editors.value.filter(e => e.editorId !== editorId),
-                ...editors.value.filter(e => e.editorId === editorId).map(e => ({ ...e, selections })),
+                { ...editors.value.find(e => e.editorId === editorId)!, selections },
             ])
         },
         removeEditor({ editorId }: EditorId): void {

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorDataWithModel, EditorService } from './editorService'
+import { CodeEditor, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,11 +12,11 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: Pick<EditorService, 'editorsWithModel'>,
+        editorService: Pick<EditorService, 'editors'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],
-            editors: readonly CodeEditorDataWithModel[]
+            editors: readonly CodeEditor[]
         ) => ConfiguredExtension[],
         sideloadedExtensionURL: Subscribable<string | null>,
         fetchSideloadedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
@@ -46,7 +46,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('-a-|', {
+                            cold<readonly CodeEditor[]>('-a-|', {
                                 a: [],
                             })
                         ),
@@ -69,10 +69,11 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'x', manifest, rawManifest: null }, { id: 'y', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
+                            cold<readonly CodeEditor[]>('-a-b-|', {
                                 a: [
                                     {
                                         type: 'CodeEditor',
+                                        editorId: 'editor#0',
                                         resource: 'u',
                                         model: { languageId: 'x', text: '', uri: 'u' },
                                         selections: [],
@@ -82,6 +83,7 @@ describe('activeExtensions', () => {
                                 b: [
                                     {
                                         type: 'CodeEditor',
+                                        editorId: 'editor#1',
                                         resource: 'u2',
                                         model: { languageId: 'y', text: '', uri: 'u2' },
                                         selections: [],
@@ -117,7 +119,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
+                            cold<readonly CodeEditor[]>('a-|', {
                                 a: [],
                             })
                         ),
@@ -162,7 +164,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
+                            cold<readonly CodeEditor[]>('a-|', {
                                 a: [],
                             })
                         ),

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -12,7 +12,7 @@ import { PlatformContext } from '../../../platform/context'
 import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
-import { CodeEditorDataWithModel, EditorService } from './editorService'
+import { CodeEditor, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -55,7 +55,7 @@ interface PartialContext extends Pick<PlatformContext, 'queryGraphQL' | 'getScri
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: Pick<EditorService, 'editorsWithModel'>,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (
@@ -119,7 +119,7 @@ export class ExtensionsService {
         // Extensions that have been activated (including extensions with zero "activationEvents" that evaluate to
         // true currently).
         const activatedExtensionIDs: string[] = []
-        return combineLatest(from(this.editorService.editorsWithModel), this.enabledExtensions).pipe(
+        return combineLatest(from(this.editorService.editors), this.enabledExtensions).pipe(
             tap(([editors, enabledExtensions]) => {
                 const activeExtensions = this.extensionActivationFilter(enabledExtensions, editors)
                 for (const x of activeExtensions) {
@@ -169,7 +169,7 @@ function asObservable(input: string | ObservableInput<string>): Observable<strin
 
 function extensionsWithMatchedActivationEvent(
     enabledExtensions: ConfiguredExtension[],
-    editors: readonly CodeEditorDataWithModel[]
+    editors: readonly CodeEditor[]
 ): ConfiguredExtension[] {
     return enabledExtensions.filter(x => {
         try {

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -57,6 +57,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
+                            editorId: 'editor#0',
                             type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
                             resource: 'u',
@@ -80,6 +81,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
+                            editorId: 'editor#0',
                             type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
                             resource: 'u',

--- a/shared/src/api/client/services/location.ts
+++ b/shared/src/api/client/services/location.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
 import { TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
 import { match, TextDocumentIdentifier } from '../types/textDocument'
-import { CodeEditorDataWithModel } from './editorService'
+import { CodeEditor } from './editorService'
 import { DocumentFeatureProviderRegistry } from './registry'
 import { flattenAndCompact } from './util'
 
@@ -45,7 +45,7 @@ export class TextDocumentLocationProviderRegistry<
      *
      * @param editors The code editors in {@link EditorService}.
      */
-    public hasProvidersForActiveTextDocument(editors: readonly CodeEditorDataWithModel[]): Observable<boolean> {
+    public hasProvidersForActiveTextDocument(editors: readonly CodeEditor[]): Observable<boolean> {
         return this.entries.pipe(
             map(entries => {
                 const activeEditor = editors.find(({ isActive }) => isActive)

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -3,7 +3,7 @@ import * as clientType from '@sourcegraph/extension-api-types'
 import { BehaviorSubject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { ClientCodeEditorAPI } from '../../client/api/codeEditor'
-import { CodeEditorData } from '../../client/services/editorService'
+import { CodeEditorData, EditorId } from '../../client/services/editorService'
 import { Range } from '../types/range'
 import { Selection } from '../types/selection'
 import { createDecorationType } from './decorations'
@@ -13,11 +13,11 @@ const DEFAULT_DECORATION_TYPE = createDecorationType()
 
 /** @internal */
 export class ExtCodeEditor implements sourcegraph.CodeEditor {
-    /** The URI of the text document shown in this code editor */
+    /** The URI of this editor's document. */
     private resource: string
 
     constructor(
-        data: CodeEditorData,
+        data: CodeEditorData & EditorId,
         private proxy: ProxyResult<ClientCodeEditorAPI>,
         private documents: ExtDocuments
     ) {

--- a/shared/src/api/extension/api/windows.test.ts
+++ b/shared/src/api/extension/api/windows.test.ts
@@ -10,26 +10,34 @@ describe('ExtWindow', () => {
 
     test('reuses ExtCodeEditor object when updated', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [new Selection(1, 2, 3, 4)] }],
+            editors: [
+                {
+                    type: 'CodeEditor',
+                    editorId: 'editor#0',
+                    resource: 'u',
+                    isActive: true,
+                    selections: [new Selection(1, 2, 3, 4)],
+                },
+            ],
         })
         expect(wins.activeViewComponent).toBe(origViewComponent)
     })
 
     test('creates new ExtCodeEditor object for a different resource URI', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#1', resource: 'u2', isActive: true, selections: [] }],
         })
         expect(wins.activeViewComponent).not.toBe(origViewComponent)
     })
@@ -44,18 +52,18 @@ describe('ExtWindows', () => {
     test('reuses ExtWindow object when updated', () => {
         const wins = new ExtWindows(NOOP_PROXY, documents)
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: true, selections: [] }],
         })
         const origWin = wins.activeWindow
         expect(origWin).toBeTruthy()
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#1', resource: 'u2', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
     })

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -15,19 +15,12 @@ describe('CodeEditor (integration)', () => {
                 services: { editor: editorService },
                 extensionAPI,
             } = await integrationTestContext()
+            const editors = await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
 
-            const setSelections = (selections: Selection[]) => {
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'file:///f',
-                        selections,
-                        isActive: true,
-                    },
-                ])
-            }
-            setSelections([new Selection(1, 2, 3, 4)])
-            setSelections([])
+            editorService.setSelections(editors[0], [new Selection(1, 2, 3, 4)])
+            editorService.setSelections(editors[0], [])
 
             const values = await from(extensionAPI.app.windows[0].activeViewComponentChanges)
                 .pipe(

--- a/shared/src/api/integration-test/languageFeatures.test.ts
+++ b/shared/src/api/integration-test/languageFeatures.test.ts
@@ -143,16 +143,13 @@ function testLocationProvider<P>({
             const subscription = registerProvider(extensionAPI)(['*'], labeledProvider('a'))
             await extensionAPI.internal.sync()
 
-            services.editor.nextEditors([])
             services.model.addModel({ uri: 'file:///f2', languageId: 'l1', text: 't1' })
-            services.editor.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'file:///f2',
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            services.editor.addEditor({
+                type: 'CodeEditor',
+                resource: 'file:///f2',
+                selections: [],
+                isActive: true,
+            })
 
             expect(
                 await getResult(services, 'file:///f2')

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -1,34 +1,8 @@
 import { from } from 'rxjs'
-import { distinctUntilChanged, filter, switchMap } from 'rxjs/operators'
+import { distinctUntilChanged, filter, first, switchMap } from 'rxjs/operators'
 import { isDefined } from '../../util/types'
-import { CodeEditorData } from '../client/services/editorService'
 import { assertToJSON } from '../extension/types/testHelpers'
 import { collectSubscribableValues, integrationTestContext } from './testHelpers'
-
-const withSelections = (...selections: { start: number; end: number }[]): CodeEditorData => ({
-    type: 'CodeEditor',
-    resource: 'file:///f',
-    selections: selections.map(({ start, end }) => ({
-        start: {
-            line: start,
-            character: 0,
-        },
-        end: {
-            line: end,
-            character: 0,
-        },
-        anchor: {
-            line: start,
-            character: 0,
-        },
-        active: {
-            line: end,
-            character: 0,
-        },
-        isReversed: false,
-    })),
-    isActive: true,
-})
 
 describe('Selections (integration)', () => {
     describe('editor.selectionsChanged', () => {
@@ -37,6 +11,9 @@ describe('Selections (integration)', () => {
                 services: { editor: editorService },
                 extensionAPI,
             } = await integrationTestContext()
+            const editor = (await from(editorService.editors)
+                .pipe(first())
+                .toPromise())[0]
             const selectionChanges = from(extensionAPI.app.activeWindowChanges).pipe(
                 filter(isDefined),
                 switchMap(window => window.activeViewComponentChanges),
@@ -51,7 +28,28 @@ describe('Selections (integration)', () => {
                 [],
             ]
             for (const selections of testValues) {
-                editorService.nextEditors([withSelections(...selections)])
+                editorService.setSelections(
+                    editor,
+                    selections.map(({ start, end }) => ({
+                        start: {
+                            line: start,
+                            character: 0,
+                        },
+                        end: {
+                            line: end,
+                            character: 0,
+                        },
+                        anchor: {
+                            line: start,
+                            character: 0,
+                        },
+                        active: {
+                            line: end,
+                            character: 0,
+                        },
+                        isReversed: false,
+                    }))
+                )
                 await extensionAPI.internal.sync()
             }
             assertToJSON(

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -8,13 +8,13 @@ import { isDefined } from '../../util/types'
 import { ExtensionHostClient } from '../client/client'
 import { createExtensionHostClientConnection } from '../client/connection'
 import { Services } from '../client/services'
-import { CodeEditorDataWithModel } from '../client/services/editorService'
+import { CodeEditor } from '../client/services/editorService'
 import { WorkspaceRootWithMetadata } from '../client/services/workspaceService'
 import { InitData, startExtensionHost } from '../extension/extensionHost'
 
 interface TestInitData {
     roots: readonly WorkspaceRootWithMetadata[]
-    editors: readonly CodeEditorDataWithModel[]
+    editors: readonly Pick<CodeEditor, Exclude<keyof CodeEditor, 'editorId'>>[]
 }
 
 const FIXTURE_INIT_DATA: TestInitData = {
@@ -90,10 +90,10 @@ export async function integrationTestContext(
     const client = await createExtensionHostClientConnection(clientEndpoints, services, initData)
 
     const extensionAPI = await extensionHost.extensionAPI
-    for (const { model } of initModel.editors) {
+    for (const { model, ...editor } of initModel.editors) {
         services.model.addModel(model)
+        services.editor.addEditor(editor)
     }
-    services.editor.nextEditors(initModel.editors)
     services.workspace.roots.next(initModel.roots)
 
     // Wait for initModel to be initialized

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -37,23 +37,12 @@ describe('Windows (integration)', () => {
                 languageId: 'l',
                 text: 't',
             })
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'u',
-                    selections: [],
-                    isActive: true,
-                },
-            ])
-            editorService.nextEditors([])
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'u2',
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'u',
+                selections: [],
+                isActive: true,
+            })
             const values = await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
                     take(1),
@@ -85,23 +74,21 @@ describe('Windows (integration)', () => {
             const {
                 services: { editor: editorService, model: modelService },
                 extensionAPI,
-            } = await integrationTestContext()
+            } = await integrationTestContext(undefined, { editors: [], roots: [] })
 
             modelService.addModel({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'file:///f2',
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'file:///f2',
+                selections: [],
+                isActive: true,
+            })
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
                     filter(isDefined),
                     switchMap(w => w.activeViewComponentChanges),
                     filter(isDefined),
-                    take(3)
+                    take(1)
                 )
                 .toPromise()
 
@@ -132,15 +119,12 @@ describe('Windows (integration)', () => {
                 languageId: 'inactive',
                 text: 'inactive',
             })
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'file:///inactive',
-                    selections: [],
-                    isActive: false,
-                },
-                ...editorService.editorsValue,
-            ])
+            editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'file:///inactive',
+                selections: [],
+                isActive: false,
+            })
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
                     filter(isDefined),
@@ -174,15 +158,12 @@ describe('Windows (integration)', () => {
                     languageId: 'inactive',
                     text: 'inactive',
                 })
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'file:///inactive',
-                        selections: [],
-                        isActive: false,
-                    },
-                    ...editorService.editorsValue,
-                ])
+                editorService.addEditor({
+                    type: 'CodeEditor',
+                    resource: 'file:///inactive',
+                    selections: [],
+                    isActive: false,
+                })
 
                 assertToJSON(extensionAPI.app.windows[0].activeViewComponent, {
                     type: 'CodeEditor' as const,
@@ -202,23 +183,19 @@ describe('Windows (integration)', () => {
                 })
                 modelService.addModel({ uri: 'foo', languageId: 'l1', text: 't1' })
                 modelService.addModel({ uri: 'bar', languageId: 'l2', text: 't2' })
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'foo',
-                        selections: [],
-                        isActive: true,
-                    },
-                ])
-                editorService.nextEditors([])
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'bar',
-                        selections: [],
-                        isActive: true,
-                    },
-                ])
+                editorService.addEditor({
+                    type: 'CodeEditor',
+                    resource: 'foo',
+                    selections: [],
+                    isActive: true,
+                })
+                editorService.removeAllEditors()
+                editorService.addEditor({
+                    type: 'CodeEditor',
+                    resource: 'bar',
+                    selections: [],
+                    isActive: true,
+                })
                 const values = await from(extensionAPI.app.windows[0].activeViewComponentChanges)
                     .pipe(
                         distinctUntilChanged(),

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -300,14 +300,13 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                         text: model.content,
                     })
                 }
-                this.props.extensionsController.services.editor.nextEditors([
-                    {
-                        type: 'CodeEditor' as const,
-                        resource: uri,
-                        selections: lprToSelectionsZeroIndexed(pos),
-                        isActive: true,
-                    },
-                ])
+                this.props.extensionsController.services.editor.removeAllEditors()
+                this.props.extensionsController.services.editor.addEditor({
+                    type: 'CodeEditor' as const,
+                    resource: uri,
+                    selections: lprToSelectionsZeroIndexed(pos),
+                    isActive: true,
+                })
             })
         )
 

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -166,7 +166,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
         )
 
         // Clear the Sourcegraph extensions model's component when the blob is no longer shown.
-        this.subscriptions.add(() => this.props.extensionsController.services.editor.nextEditors([]))
+        this.subscriptions.add(() => this.props.extensionsController.services.editor.removeAllEditors())
 
         this.propsUpdates.next(this.props)
     }

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -95,7 +95,7 @@ export class BlobPanel extends React.PureComponent<Props> {
             extraParams?: Pick<P, Exclude<keyof P, keyof TextDocumentPositionParams>>
         ): Entry<ViewProviderRegistrationOptions, ProvideViewSignature> => ({
             registrationOptions: { id, container: ContributableViewContainer.Panel },
-            provider: from(this.props.extensionsController.services.editor.editorsWithModel).pipe(
+            provider: from(this.props.extensionsController.services.editor.editors).pipe(
                 switchMap(editors =>
                     registry.hasProvidersForActiveTextDocument(editors).pipe(
                         map(hasProviders => {

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { CodeEditorData } from '../../../../shared/src/api/client/services/editorService'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { getModeFromPath } from '../../../../shared/src/languages'
@@ -41,17 +40,12 @@ export class FileDiffConnection extends React.PureComponent<Props> {
         // API's support for diffs.
         const dummyText = ''
 
-        const editors: CodeEditorData[] = []
+        this.props.extensionsController.services.editor.removeAllEditors()
+
         if (fileDiffsOrError && !isErrorLike(fileDiffsOrError)) {
             for (const fileDiff of fileDiffsOrError.nodes) {
                 if (fileDiff.oldPath) {
                     const uri = `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`
-                    editors.push({
-                        type: 'CodeEditor',
-                        resource: uri,
-                        selections: [],
-                        isActive: false, // HACK: arbitrarily say that the base is inactive. TODO: support diffs first-class
-                    })
                     if (!this.props.extensionsController.services.model.hasModel(uri)) {
                         this.props.extensionsController.services.model.addModel({
                             uri,
@@ -59,15 +53,15 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                             text: dummyText,
                         })
                     }
-                }
-                if (fileDiff.newPath) {
-                    const uri = `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`
-                    editors.push({
+                    this.props.extensionsController.services.editor.addEditor({
                         type: 'CodeEditor',
                         resource: uri,
                         selections: [],
-                        isActive: true,
+                        isActive: false, // HACK: arbitrarily say that the base is inactive. TODO: support diffs first-class
                     })
+                }
+                if (fileDiff.newPath) {
+                    const uri = `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`
                     if (!this.props.extensionsController.services.model.hasModel(uri)) {
                         this.props.extensionsController.services.model.addModel({
                             uri,
@@ -75,9 +69,14 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                             text: dummyText,
                         })
                     }
+                    this.props.extensionsController.services.editor.addEditor({
+                        type: 'CodeEditor',
+                        resource: uri,
+                        selections: [],
+                        isActive: true,
+                    })
                 }
             }
         }
-        this.props.extensionsController.services.editor.nextEditors(editors)
     }
 }


### PR DESCRIPTION
Refactor. Similar reasoning to #3322.

This is the 2nd PR in the sequence #3322 #3323 (review in order).