### PR TITLE
WIP DONOTREVIEW add 1st-class support for diff views

### DIFF
--- a/client/browser/scripts/dev.ts
+++ b/client/browser/scripts/dev.ts
@@ -10,7 +10,7 @@ signale.config({ displayTimestamp: true })
 const triggerReload = process.env.AUTO_RELOAD === 'false' ? noop : autoReloading.initializeServer()
 
 const buildChrome = tasks.buildChrome('dev')
-const buildFirefox = tasks.buildFirefox('dev')
+///////////// const buildFirefox = tasks.buildFirefox('dev')
 
 tasks.copyAssets('dev')
 
@@ -34,8 +34,8 @@ compiler.watch(
         signale.success('Webpack compilation done')
 
         buildChrome()
-        buildFirefox()
-        tasks.copyPhabricator()
+        ///////// buildFirefox()
+        /////////// tasks.copyPhabricator()
         triggerReload()
     }
 )

--- a/client/browser/src/libs/bitbucket/context.tsx
+++ b/client/browser/src/libs/bitbucket/context.tsx
@@ -29,7 +29,7 @@ function getRevSpecFromRevisionSelector(): RevSpec {
     let revisionRefInfo: RevisionRefInfo | null = null
     try {
         revisionRefInfo = revisionRefStr && JSON.parse(revisionRefStr)
-    } catch {
+    } catch (err) {
         throw new Error(`Could not parse revisionRefStr: ${revisionRefStr}`)
     }
     if (revisionRefInfo && revisionRefInfo.latestCommit) {

--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -188,11 +188,7 @@ describe('handleCodeHost()', () => {
         expect(editors).toEqual([
             {
                 isActive: true,
-                item: {
-                    languageId: 'typescript',
-                    text: undefined,
-                    uri: 'git://foo?1#/bar.ts',
-                },
+                resource: 'git://foo?1#/bar.ts',
                 selections: [],
                 type: 'CodeEditor',
             },

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -28,6 +28,7 @@ import {
 } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../../shared/src/actions/ActionItem'
 import { CodeEditorData } from '../../../../../shared/src/api/client/services/editorService'
+import { TextModel } from '../../../../../shared/src/api/client/services/modelService'
 import { WorkspaceRootWithMetadata } from '../../../../../shared/src/api/client/services/workspaceService'
 import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
 import { CommandListClassProps } from '../../../../../shared/src/commandPalette/CommandList'
@@ -569,16 +570,19 @@ export function handleCodeHost({
             // Handle added or removed view component, workspace root and subscriptions
             if (codeViewEvent.type === 'added' && !codeViewStates.has(codeViewEvent.element)) {
                 const { element, fileInfo, adjustPosition, getToolbarMount, toolbarButtonProps } = codeViewEvent
+                const uri = toURIWithPath(fileInfo)
+                const model: TextModel = {
+                    uri,
+                    languageId: getModeFromPath(fileInfo.filePath),
+                    text: fileInfo.content,
+                }
+                extensionsController.services.model.addModel(model)
                 const codeViewState: CodeViewState = {
                     subscriptions: new Subscription(),
                     editors: [
                         {
                             type: 'CodeEditor' as const,
-                            item: {
-                                uri: toURIWithPath(fileInfo),
-                                languageId: getModeFromPath(fileInfo.filePath),
-                                text: fileInfo.content,
-                            },
+                            resource: uri,
                             selections,
                             isActive: true,
                         },
@@ -589,20 +593,22 @@ export function handleCodeHost({
 
                 // When codeView is a diff (and not an added file), add BASE too.
                 if (fileInfo.baseContent && fileInfo.baseRepoName && fileInfo.baseCommitID && fileInfo.baseFilePath) {
+                    const uri = toURIWithPath({
+                        repoName: fileInfo.baseRepoName,
+                        commitID: fileInfo.baseCommitID,
+                        filePath: fileInfo.baseFilePath,
+                    })
                     codeViewState.editors.push({
                         type: 'CodeEditor' as const,
-                        item: {
-                            uri: toURIWithPath({
-                                repoName: fileInfo.baseRepoName,
-                                commitID: fileInfo.baseCommitID,
-                                filePath: fileInfo.baseFilePath,
-                            }),
-                            languageId: getModeFromPath(fileInfo.filePath),
-                            text: fileInfo.baseContent,
-                        },
+                        resource: uri,
                         // There is no notion of a selection on diff views yet, so this is empty.
                         selections: [],
                         isActive: true,
+                    })
+                    extensionsController.services.model.addModel({
+                        uri,
+                        languageId: getModeFromPath(fileInfo.filePath),
+                        text: fileInfo.baseContent,
                     })
                     codeViewState.roots.push({
                         uri: toRootURI({
@@ -681,7 +687,7 @@ export function handleCodeHost({
                             extensionsController={extensionsController}
                             buttonProps={toolbarButtonProps}
                             location={H.createLocation(window.location)}
-                            scope={codeViewState.editors[0]}
+                            scope={{ ...codeViewState.editors[0], model }}
                         />,
                         mount
                     )
@@ -695,11 +701,11 @@ export function handleCodeHost({
             }
 
             // Apply added/removed roots/editors
-            extensionsController.services.editor.nextEditors(
-                [...codeViewStates.values()].flatMap(state => state.editors)
-            )
             extensionsController.services.workspace.roots.next(
                 uniqBy([...codeViewStates.values()].flatMap(state => state.roots), root => root.uri)
+            )
+            extensionsController.services.editor.nextEditors(
+                [...codeViewStates.values()].flatMap(state => state.editors)
             )
         })
     )

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -27,7 +27,7 @@ import {
     withLatestFrom,
 } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../../shared/src/actions/ActionItem'
-import { CodeEditorData } from '../../../../../shared/src/api/client/services/editorService'
+import { CodeEditorData, EditorId } from '../../../../../shared/src/api/client/services/editorService'
 import { TextModel } from '../../../../../shared/src/api/client/services/modelService'
 import { WorkspaceRootWithMetadata } from '../../../../../shared/src/api/client/services/workspaceService'
 import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
@@ -548,7 +548,7 @@ export function handleCodeHost({
 
     interface CodeViewState {
         subscriptions: Subscription
-        editors: CodeEditorData[]
+        editors: EditorId[]
         roots: WorkspaceRootWithMetadata[]
     }
     /** Map from code view element to the state associated with it (to be updated or removed) */
@@ -557,9 +557,12 @@ export function handleCodeHost({
     // Update code editors as selections change
     subscriptions.add(
         selectionsChanges.subscribe(selections => {
-            extensionsController.services.editor.nextEditors(
-                [...codeViewStates.values()].flatMap(state => state.editors).map(editor => ({ ...editor, selections }))
-            )
+            for (const { editors } of codeViewStates.values()) {
+                for (const editor of editors) {
+                    // TODO(sqs): only set for the single relevant editor
+                    extensionsController.services.editor.setSelections(editor, selections)
+                }
+            }
         })
     )
 
@@ -577,16 +580,15 @@ export function handleCodeHost({
                     text: fileInfo.content,
                 }
                 extensionsController.services.model.addModel(model)
+                const editorData: CodeEditorData = {
+                    type: 'CodeEditor' as const,
+                    resource: uri,
+                    selections,
+                    isActive: true,
+                }
                 const codeViewState: CodeViewState = {
                     subscriptions: new Subscription(),
-                    editors: [
-                        {
-                            type: 'CodeEditor' as const,
-                            resource: uri,
-                            selections,
-                            isActive: true,
-                        },
-                    ],
+                    editors: [extensionsController.services.editor.addEditor(editorData)],
                     roots: [{ uri: toRootURI(fileInfo), inputRevision: fileInfo.rev || '' }],
                 }
                 codeViewStates.set(element, codeViewState)
@@ -598,18 +600,20 @@ export function handleCodeHost({
                         commitID: fileInfo.baseCommitID,
                         filePath: fileInfo.baseFilePath,
                     })
-                    codeViewState.editors.push({
-                        type: 'CodeEditor' as const,
-                        resource: uri,
-                        // There is no notion of a selection on diff views yet, so this is empty.
-                        selections: [],
-                        isActive: true,
-                    })
                     extensionsController.services.model.addModel({
                         uri,
                         languageId: getModeFromPath(fileInfo.filePath),
                         text: fileInfo.baseContent,
                     })
+                    codeViewState.editors.push(
+                        extensionsController.services.editor.addEditor({
+                            type: 'CodeEditor' as const,
+                            resource: uri,
+                            // There is no notion of a selection on diff views yet, so this is empty.
+                            selections: [],
+                            isActive: true,
+                        })
+                    )
                     codeViewState.roots.push({
                         uri: toRootURI({
                             repoName: fileInfo.baseRepoName,
@@ -687,7 +691,7 @@ export function handleCodeHost({
                             extensionsController={extensionsController}
                             buttonProps={toolbarButtonProps}
                             location={H.createLocation(window.location)}
-                            scope={{ ...codeViewState.editors[0], model }}
+                            scope={{ ...editorData, model }}
                         />,
                         mount
                     )
@@ -697,15 +701,17 @@ export function handleCodeHost({
                 if (codeViewState) {
                     codeViewState.subscriptions.unsubscribe()
                     codeViewStates.delete(codeViewEvent.element)
+
+                    // Remove editors.
+                    for (const editor of codeViewState.editors) {
+                        extensionsController.services.editor.removeEditor(editor)
+                    }
                 }
             }
 
-            // Apply added/removed roots/editors
+            // Apply added/removed roots
             extensionsController.services.workspace.roots.next(
                 uniqBy([...codeViewStates.values()].flatMap(state => state.roots), root => root.uri)
-            )
-            extensionsController.services.editor.nextEditors(
-                [...codeViewStates.values()].flatMap(state => state.editors)
             )
         })
     )

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -556,7 +556,7 @@ export function handleCodeHost({
     // Update code editors as selections change
     subscriptions.add(
         selectionsChanges.subscribe(selections => {
-            extensionsController.services.editor.editors.next(
+            extensionsController.services.editor.nextEditors(
                 [...codeViewStates.values()].flatMap(state => state.editors).map(editor => ({ ...editor, selections }))
             )
         })
@@ -695,7 +695,7 @@ export function handleCodeHost({
             }
 
             // Apply added/removed roots/editors
-            extensionsController.services.editor.editors.next(
+            extensionsController.services.editor.nextEditors(
                 [...codeViewStates.values()].flatMap(state => state.editors)
             )
             extensionsController.services.workspace.roots.next(

--- a/client/browser/src/libs/code_intelligence/diff_views.ts
+++ b/client/browser/src/libs/code_intelligence/diff_views.ts
@@ -1,0 +1,109 @@
+import { from, merge, Observable, of, zip } from 'rxjs'
+import { catchError, concatAll, filter, map, mergeMap } from 'rxjs/operators'
+import { isDefined, isInstanceOf } from '../../../../../shared/src/util/types'
+import { fetchBlobContentLines } from '../../shared/repo/backend'
+import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
+import { DiffViewSpecResolver, FileInfo, ResolvedDiffView } from './code_intelligence'
+
+export interface AddedDiffView extends ResolvedDiffView {
+    type: 'added'
+}
+
+export interface RemovedDiffView extends Pick<ResolvedDiffView, 'diffViewElement'> {
+    type: 'removed'
+}
+
+export type DiffViewEvent = AddedDiffView | RemovedDiffView
+
+/**
+ * Find all the code views on a page given a CodeHostSpec from DOM mutations.
+ *
+ * Emits every code view that gets added or removed.
+ *
+ * At any given time, there can be 0-n code views on a page.
+ */
+export const trackDiffViews = (diffViewSpecResolvers: DiffViewSpecResolver[]) => (
+    mutations: Observable<MutationRecordLike[]>
+): Observable<DiffViewEvent> =>
+    mutations.pipe(
+        concatAll(),
+        mergeMap(mutation =>
+            merge(
+                // Find all new code views within the added nodes
+                // (MutationObservers don't emit all descendant nodes of an addded node recursively)
+                from(mutation.addedNodes).pipe(
+                    filter(isInstanceOf(HTMLElement)),
+                    mergeMap(addedElement =>
+                        from(diffViewSpecResolvers).pipe(
+                            mergeMap(spec =>
+                                [...(querySelectorAllOrSelf(addedElement, spec.selector) as Iterable<HTMLElement>)]
+                                    .map(diffViewElement => {
+                                        const diffViewSpec = spec.resolveDiffViewSpec(diffViewElement)
+                                        return (
+                                            diffViewSpec && {
+                                                ...diffViewSpec,
+                                                diffViewElement,
+                                                type: 'added' as const,
+                                            }
+                                        )
+                                    })
+                                    .filter(isDefined)
+                            )
+                        )
+                    )
+                ),
+                // For removed nodes, find the removed elements, but don't resolve the kind (it's not relevant)
+                from(mutation.removedNodes).pipe(
+                    filter(isInstanceOf(HTMLElement)),
+                    mergeMap(removedElement =>
+                        from(diffViewSpecResolvers).pipe(
+                            mergeMap(
+                                ({ selector }) =>
+                                    querySelectorAllOrSelf(removedElement, selector) as Iterable<HTMLElement>
+                            ),
+                            map(diffViewElement => ({
+                                diffViewElement,
+                                type: 'removed' as const,
+                            }))
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+export interface FileInfoWithContents extends FileInfo {
+    content?: string
+    baseContent?: string
+    headHasFileContents?: boolean
+    baseHasFileContents?: boolean
+}
+
+export const fetchFileContents = (info: FileInfo): Observable<FileInfoWithContents> => {
+    const fetchingBaseFile = info.baseCommitID
+        ? fetchBlobContentLines({
+              repoName: info.repoName,
+              filePath: info.baseFilePath || info.filePath,
+              commitID: info.baseCommitID,
+          })
+        : of(null)
+
+    const fetchingHeadFile = fetchBlobContentLines({
+        repoName: info.repoName,
+        filePath: info.filePath,
+        commitID: info.commitID,
+    })
+
+    return zip(fetchingBaseFile, fetchingHeadFile).pipe(
+        map(
+            ([baseFileContent, headFileContent]): FileInfoWithContents => ({
+                ...info,
+                baseContent: baseFileContent ? baseFileContent.join('\n') : undefined,
+                content: headFileContent.join('\n'),
+                headHasFileContents: headFileContent.length > 0,
+                baseHasFileContents: baseFileContent ? baseFileContent.length > 0 : undefined,
+            })
+        ),
+        catchError(error => [info])
+    )
+}

--- a/client/browser/src/libs/github/diff_views.ts
+++ b/client/browser/src/libs/github/diff_views.ts
@@ -1,0 +1,36 @@
+import { Observable } from 'rxjs'
+import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators'
+import { observeMutations } from '../../shared/util/dom'
+
+export function observeDiffViewVisibleRanges(elem: HTMLElement): Observable<boolean> {
+    return observeMutations(elem, { attributes: true }).pipe(
+        switchMap(mutations => mutations),
+        filter(
+            mutation =>
+                mutation.type === 'attributes' &&
+                mutation.attributeName === 'class' &&
+                mutation.attributeNamespace === null
+        ),
+        map(() => getDiffViewCollapsed(elem)),
+        distinctUntilChanged()
+    )
+}
+
+export function setDiffViewCollapsed(elem: HTMLElement, collapsed: boolean): void {
+    const toggleButton = elem.querySelector<HTMLElement>('button[aria-label="Toggle diff contents"]')
+    if (!toggleButton) {
+        throw new Error('Unable to set diff view visible range (no toggle button found)')
+    }
+
+    // const isCollapsed = toggleButton.getAttribute('aria-expanded') !== 'true'
+    if (getDiffViewCollapsed(elem) !== collapsed) {
+        // Only toggle if the want state != current state.
+        toggleButton.click()
+    }
+}
+
+function getDiffViewCollapsed(elem: HTMLElement): boolean {
+    // On GitHub: `.file.open` means open (non-collapsed), `.file:not(.open)` means
+    // collapsed.
+    return !elem.classList.contains('open')
+}

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -123,3 +123,6 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
         )
     }
 }
+
+/* Same as {@link CodeViewToolbar} for now. */
+export const DiffViewToolbar = CodeViewToolbar

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -476,7 +476,7 @@ declare module 'sourcegraph' {
      * Each {@link ViewComponent} has a distinct {@link ViewComponent#type} value that indicates what kind of
      * component it is ({@link CodeEditor}, etc.).
      */
-    export type ViewComponent = CodeEditor
+    export type ViewComponent = CodeEditor | DiffEditor
 
     /**
      * A style for a {@link TextDocumentDecoration}.
@@ -564,10 +564,26 @@ declare module 'sourcegraph' {
     }
 
     /**
+     * An interface implemented by editors that can be collapsed (meaning that only the editor title
+     * bar is shown).
+     */
+    export interface CollapsibleEditor {
+        /**
+         * Whether this editor is collapsed (meaning that only the editor title bar is shown). Not
+         * all editors support collapsing. If an editor doesn't support collapsing, setting this
+         * property value is a no-op.
+         */
+        collapsed: boolean
+
+        /** An observable that emits when the collapsed state of the editor changes. */
+        readonly collapsedChanges: Subscribable<boolean>
+    }
+
+    /**
      * A text editor for code files (as opposed to a rich text editor for documents or other kinds of file format
      * editors).
      */
-    export interface CodeEditor {
+    export interface CodeEditor extends CollapsibleEditor {
         /** The type tag for this kind of {@link ViewComponent}. */
         readonly type: 'CodeEditor'
 
@@ -600,16 +616,6 @@ declare module 'sourcegraph' {
         readonly selectionsChanges: Subscribable<Selection[]>
 
         /**
-         * Whether this editor is collapsed (meaning that only the editor title bar is shown). Not
-         * all editors support collapsing. If an editor doesn't support collapsing, setting this
-         * property value is a no-op.
-         */
-        collapsed: boolean
-
-        /** An observable that emits when the collapsed state of the editor changes. */
-        readonly collapsedChanges: Subscribable<boolean>
-
-        /**
          * Add a set of decorations to this editor. If a set of decorations already exists with the given
          * {@link TextDocumentDecorationType}, they will be replaced.
          *
@@ -618,6 +624,40 @@ declare module 'sourcegraph' {
          *
          */
         setDecorations(decorationType: TextDocumentDecorationType, decorations: TextDocumentDecoration[]): void
+    }
+
+    /**
+     * A diff editor for code diffs.
+     */
+    export interface DiffEditor extends CollapsibleEditor {
+        /** The type tag for this kind of {@link ViewComponent}. */
+        readonly type: 'DiffEditor'
+
+        /**
+         * The text document that is the left-hand (original) side of the diff. The document remains
+         * the same for the entire lifetime of this editor.
+         */
+        readonly originalDocument: TextDocument
+
+        /**
+         * The text document that is the right-hand (modified) side of the diff. The document
+         * remains the same for the entire lifetime of this editor.
+         */
+        readonly modifiedDocument: TextDocument
+
+        /**
+         * The raw content of the diff (in unified diff format).
+         *
+         * The value is undefined if it is not available (e.g., it is too large to retrieve).
+         */
+        readonly rawDiff: string | undefined
+
+        /**
+         * An event that is fired when the raw diff in this diff editor changes. This can occur when
+         * the diff is updated by the author or when the user expands/collapses it in the view
+         * (e.g., to show more or less context around hunks).
+         */
+        readonly rawDiffChanges: Subscribable<string | undefined>
     }
 
     /**

--- a/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -600,6 +600,16 @@ declare module 'sourcegraph' {
         readonly selectionsChanges: Subscribable<Selection[]>
 
         /**
+         * Whether this editor is collapsed (meaning that only the editor title bar is shown). Not
+         * all editors support collapsing. If an editor doesn't support collapsing, setting this
+         * property value is a no-op.
+         */
+        collapsed: boolean
+
+        /** An observable that emits when the collapsed state of the editor changes. */
+        readonly collapsedChanges: Subscribable<boolean>
+
+        /**
          * Add a set of decorations to this editor. If a set of decorations already exists with the given
          * {@link TextDocumentDecorationType}, they will be replaced.
          *

--- a/shared/src/api/client/api/api.ts
+++ b/shared/src/api/client/api/api.ts
@@ -4,9 +4,9 @@ import { ClientConfigurationAPI } from './configuration'
 import { ClientContextAPI } from './context'
 import { ClientLanguageFeaturesAPI } from './languageFeatures'
 import { ClientSearchAPI } from './search'
+import { ClientEditorAPI } from './viewComponents/editor'
 import { ClientViewsAPI } from './views'
 import { ClientWindowsAPI } from './windows'
-
 /**
  * The API that is exposed from the client (main thread) to the extension host (worker)
  */
@@ -19,6 +19,7 @@ export interface ClientAPI {
     languageFeatures: ClientLanguageFeaturesAPI
     commands: ClientCommandsAPI
     windows: ClientWindowsAPI
+    editor: ClientEditorAPI
     codeEditor: ClientCodeEditorAPI
     views: ClientViewsAPI
 }

--- a/shared/src/api/client/api/codeEditor.ts
+++ b/shared/src/api/client/api/codeEditor.ts
@@ -3,14 +3,12 @@ import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
 import { flatten, values } from 'lodash'
 import { BehaviorSubject, Observable, Subscription } from 'rxjs'
 import { ProvideTextDocumentDecorationSignature } from '../services/decoration'
-import { EditorService } from '../services/editorService'
 import { FeatureProviderRegistry } from '../services/registry'
 import { TextDocumentIdentifier } from '../types/textDocument'
 
 /** @internal */
 export interface ClientCodeEditorAPI extends ProxyValue {
     $setDecorations(resource: string, decorationType: string, decorations: TextDocumentDecoration[]): void
-    $setCollapsed(editorId: string, collapsed: boolean): void
 }
 
 interface PreviousDecorations {
@@ -30,10 +28,7 @@ export class ClientCodeEditor implements ClientCodeEditorAPI {
 
     private previousDecorations: PreviousDecorations = {}
 
-    constructor(
-        private registry: FeatureProviderRegistry<undefined, ProvideTextDocumentDecorationSignature>,
-        private editorService: EditorService
-    ) {
+    constructor(private registry: FeatureProviderRegistry<undefined, ProvideTextDocumentDecorationSignature>) {
         this.subscriptions.add(
             this.registry.registerProvider(
                 undefined,
@@ -68,10 +63,6 @@ export class ClientCodeEditor implements ClientCodeEditorAPI {
             subject.next(nextDecorations)
         }
         return subject
-    }
-
-    public $setCollapsed(editorId: string, collapsed: boolean): void {
-        this.editorService.setCollapsed({ editorId }, collapsed)
     }
 
     public unsubscribe(): void {

--- a/shared/src/api/client/api/codeEditor.ts
+++ b/shared/src/api/client/api/codeEditor.ts
@@ -3,12 +3,14 @@ import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
 import { flatten, values } from 'lodash'
 import { BehaviorSubject, Observable, Subscription } from 'rxjs'
 import { ProvideTextDocumentDecorationSignature } from '../services/decoration'
+import { EditorService } from '../services/editorService'
 import { FeatureProviderRegistry } from '../services/registry'
 import { TextDocumentIdentifier } from '../types/textDocument'
 
 /** @internal */
 export interface ClientCodeEditorAPI extends ProxyValue {
     $setDecorations(resource: string, decorationType: string, decorations: TextDocumentDecoration[]): void
+    $setCollapsed(editorId: string, collapsed: boolean): void
 }
 
 interface PreviousDecorations {
@@ -28,7 +30,10 @@ export class ClientCodeEditor implements ClientCodeEditorAPI {
 
     private previousDecorations: PreviousDecorations = {}
 
-    constructor(private registry: FeatureProviderRegistry<undefined, ProvideTextDocumentDecorationSignature>) {
+    constructor(
+        private registry: FeatureProviderRegistry<undefined, ProvideTextDocumentDecorationSignature>,
+        private editorService: EditorService
+    ) {
         this.subscriptions.add(
             this.registry.registerProvider(
                 undefined,
@@ -63,6 +68,10 @@ export class ClientCodeEditor implements ClientCodeEditorAPI {
             subject.next(nextDecorations)
         }
         return subject
+    }
+
+    public $setCollapsed(editorId: string, collapsed: boolean): void {
+        this.editorService.setCollapsed({ editorId }, collapsed)
     }
 
     public unsubscribe(): void {

--- a/shared/src/api/client/api/viewComponents/editor.ts
+++ b/shared/src/api/client/api/viewComponents/editor.ts
@@ -1,0 +1,18 @@
+import { ProxyValue, proxyValueSymbol } from '@sourcegraph/comlink'
+import { EditorService } from '../../services/editorService'
+
+/** @internal */
+export interface ClientEditorAPI extends ProxyValue {
+    $setCollapsed(editorId: string, collapsed: boolean): void
+}
+
+/** @internal */
+export class ClientEditor implements ClientEditorAPI {
+    public readonly [proxyValueSymbol] = true
+
+    constructor(private editorService: EditorService) {}
+
+    public $setCollapsed(editorId: string, collapsed: boolean): void {
+        this.editorService.setCollapsed({ editorId }, collapsed)
+    }
+}

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -14,6 +14,7 @@ import { ClientExtensions } from './api/extensions'
 import { ClientLanguageFeatures } from './api/languageFeatures'
 import { ClientRoots } from './api/roots'
 import { ClientSearch } from './api/search'
+import { ClientEditor } from './api/viewComponents/editor'
 import { ClientViews } from './api/views'
 import { ClientWindows } from './api/windows'
 import { applyContextUpdate } from './context/context'
@@ -78,6 +79,7 @@ export async function createExtensionHostClientConnection(
             .subscribe()
     )
     subscription.add(
+        // TODO!(sqs): also sync diff editor models
         from(services.editor.editors)
             .pipe(concatMap(editors => proxy.windows.$acceptWindowData({ editors })))
             .subscribe()
@@ -102,7 +104,9 @@ export async function createExtensionHostClientConnection(
 
     const clientViews = new ClientViews(services.views, services.textDocumentLocations, services.editor)
 
-    const clientCodeEditor = new ClientCodeEditor(services.textDocumentDecoration, services.editor)
+    const clientEditor = new ClientEditor(services.editor)
+
+    const clientCodeEditor = new ClientCodeEditor(services.textDocumentDecoration)
     subscription.add(clientCodeEditor)
 
     const clientLanguageFeatures = new ClientLanguageFeatures(
@@ -124,6 +128,7 @@ export async function createExtensionHostClientConnection(
         languageFeatures: clientLanguageFeatures,
         commands: clientCommands,
         windows: clientWindows,
+        editor: clientEditor,
         codeEditor: clientCodeEditor,
         views: clientViews,
     }

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -1,8 +1,7 @@
 import * as comlink from '@sourcegraph/comlink'
-import { isEqual } from 'lodash'
 import { from, Subject, Subscription } from 'rxjs'
 import { concatMap } from 'rxjs/operators'
-import { ContextValues, Progress, ProgressOptions, TextDocument, Unsubscribable } from 'sourcegraph'
+import { ContextValues, Progress, ProgressOptions, Unsubscribable } from 'sourcegraph'
 import { EndpointPair } from '../../platform/context'
 import { ExtensionHostAPIFactory } from '../extension/api/api'
 import { InitData } from '../extension/extensionHost'
@@ -72,34 +71,15 @@ export async function createExtensionHostClientConnection(
     )
     subscription.add(clientContext)
 
-    // Sync visible views and text documents to the extension host
-    let visibleTextDocuments: TextDocument[] = []
+    // Sync models and editors to the extension host
     subscription.add(
-        from(services.editor.editors)
-            .pipe(
-                concatMap(async editors => {
-                    // Important: Make sure documents were synced before syncing windows, as windows reference them
-                    const nextVisibleTextDocuments = editors ? editors.map(v => v.item) : []
-                    if (!isEqual(visibleTextDocuments, nextVisibleTextDocuments)) {
-                        visibleTextDocuments = nextVisibleTextDocuments
-                        await proxy.documents.$acceptDocumentData(nextVisibleTextDocuments)
-                    }
-                    await proxy.windows.$acceptWindowData(
-                        editors
-                            ? {
-                                  editors: editors.map(editor => ({
-                                      type: 'CodeEditor',
-                                      item: {
-                                          uri: editor.item.uri,
-                                      },
-                                      selections: editor.selections,
-                                      isActive: editor.isActive,
-                                  })),
-                              }
-                            : null
-                    )
-                })
-            )
+        from(services.model.models)
+            .pipe(concatMap(models => proxy.documents.$acceptDocumentData(models)))
+            .subscribe()
+    )
+    subscription.add(
+        from(services.editor.editorsWithModel)
+            .pipe(concatMap(editors => proxy.windows.$acceptWindowData({ editors })))
             .subscribe()
     )
 

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -102,7 +102,7 @@ export async function createExtensionHostClientConnection(
 
     const clientViews = new ClientViews(services.views, services.textDocumentLocations, services.editor)
 
-    const clientCodeEditor = new ClientCodeEditor(services.textDocumentDecoration)
+    const clientCodeEditor = new ClientCodeEditor(services.textDocumentDecoration, services.editor)
     subscription.add(clientCodeEditor)
 
     const clientLanguageFeatures = new ClientLanguageFeatures(

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -78,7 +78,7 @@ export async function createExtensionHostClientConnection(
             .subscribe()
     )
     subscription.add(
-        from(services.editor.editorsWithModel)
+        from(services.editor.editors)
             .pipe(concatMap(editors => proxy.windows.$acceptWindowData({ editors })))
             .subscribe()
     )

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -1,7 +1,6 @@
 import { Selection } from '@sourcegraph/extension-api-types'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorDataWithModel } from '../services/editorService'
-import { applyContextUpdate, Context, getComputedContextProperty } from './context'
+import { applyContextUpdate, Context, getComputedContextProperty, PartialCodeEditor } from './context'
 
 describe('applyContextUpdate', () => {
     test('merges properties', () =>
@@ -30,14 +29,13 @@ describe('getComputedContextProperty', () => {
     })
 
     describe('with code editors', () => {
-        const editors: CodeEditorDataWithModel[] = [
+        const editors: PartialCodeEditor[] = [
             {
                 type: 'CodeEditor',
                 resource: 'file:///inactive',
                 model: {
                     uri: 'file:///inactive',
                     languageId: 'inactive',
-                    text: 'inactive',
                 },
                 selections: [
                     {
@@ -56,7 +54,6 @@ describe('getComputedContextProperty', () => {
                 model: {
                     uri: 'file:///a/b.c',
                     languageId: 'l',
-                    text: 't',
                 },
                 selections: [
                     {
@@ -106,7 +103,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there are no code editors', () =>
                 expect(getComputedContextProperty([], EMPTY_SETTINGS_CASCADE, {}, 'component.type')).toBe(null))
 
-            function assertSelection(editors: CodeEditorDataWithModel[], expr: string, expected: Selection): void {
+            function assertSelection(editors: PartialCodeEditor[], expr: string, expected: Selection): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, expr)).toEqual(expected)
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, `${expr}.start`)).toEqual(
                     expected.start
@@ -150,7 +147,7 @@ describe('getComputedContextProperty', () => {
                     ]
                 ))
 
-            function assertNoSelection(editors: CodeEditorDataWithModel[]): void {
+            function assertNoSelection(editors: PartialCodeEditor[]): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, 'component.selection')).toBe(
                     null
                 )
@@ -182,7 +179,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there is no selection', () => {
                 assertNoSelection([
                     {
-                        type: 'CodeEditor',
+                        type: 'CodeEditor' as const,
                         resource: 'file:///a/b.c',
                         model: {
                             uri: 'file:///a/b.c',

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -1,6 +1,6 @@
 import { Selection } from '@sourcegraph/extension-api-types'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData } from '../services/editorService'
+import { CodeEditorDataWithModel } from '../services/editorService'
 import { applyContextUpdate, Context, getComputedContextProperty } from './context'
 
 describe('applyContextUpdate', () => {
@@ -30,10 +30,11 @@ describe('getComputedContextProperty', () => {
     })
 
     describe('with code editors', () => {
-        const editors: CodeEditorData[] = [
+        const editors: CodeEditorDataWithModel[] = [
             {
                 type: 'CodeEditor',
-                item: {
+                resource: 'file:///inactive',
+                model: {
                     uri: 'file:///inactive',
                     languageId: 'inactive',
                     text: 'inactive',
@@ -51,7 +52,8 @@ describe('getComputedContextProperty', () => {
             },
             {
                 type: 'CodeEditor',
-                item: {
+                resource: 'file:///a/b.c',
+                model: {
                     uri: 'file:///a/b.c',
                     languageId: 'l',
                     text: 't',
@@ -104,7 +106,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there are no code editors', () =>
                 expect(getComputedContextProperty([], EMPTY_SETTINGS_CASCADE, {}, 'component.type')).toBe(null))
 
-            function assertSelection(editors: CodeEditorData[], expr: string, expected: Selection): void {
+            function assertSelection(editors: CodeEditorDataWithModel[], expr: string, expected: Selection): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, expr)).toEqual(expected)
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, `${expr}.start`)).toEqual(
                     expected.start
@@ -148,7 +150,7 @@ describe('getComputedContextProperty', () => {
                     ]
                 ))
 
-            function assertNoSelection(editors: CodeEditorData[]): void {
+            function assertNoSelection(editors: CodeEditorDataWithModel[]): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, 'component.selection')).toBe(
                     null
                 )
@@ -181,7 +183,8 @@ describe('getComputedContextProperty', () => {
                 assertNoSelection([
                     {
                         type: 'CodeEditor',
-                        item: {
+                        resource: 'file:///a/b.c',
+                        model: {
                             uri: 'file:///a/b.c',
                             languageId: 'l',
                             text: 't',

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -32,6 +32,7 @@ describe('getComputedContextProperty', () => {
         const editors: PartialCodeEditor[] = [
             {
                 type: 'CodeEditor',
+                editorId: 'editor#0',
                 resource: 'file:///inactive',
                 model: {
                     uri: 'file:///inactive',
@@ -50,6 +51,7 @@ describe('getComputedContextProperty', () => {
             },
             {
                 type: 'CodeEditor',
+                editorId: 'editor#1',
                 resource: 'file:///a/b.c',
                 model: {
                     uri: 'file:///a/b.c',
@@ -98,6 +100,11 @@ describe('getComputedContextProperty', () => {
             test('provides component.type', () =>
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, 'component.type')).toBe(
                     'CodeEditor'
+                ))
+
+            test('provides component.editorId', () =>
+                expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, 'component.editorId')).toBe(
+                    'editor#0'
                 ))
 
             test('returns null when there are no code editors', () =>
@@ -180,6 +187,7 @@ describe('getComputedContextProperty', () => {
                 assertNoSelection([
                     {
                         type: 'CodeEditor' as const,
+                        editorId: 'editor#0',
                         resource: 'file:///a/b.c',
                         model: {
                             uri: 'file:///a/b.c',

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname } from 'path'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditor } from '../services/editorService'
+import { CodeEditor, DiffEditorData, EditorId } from '../services/editorService'
 
 /**
  * Returns a new context created by applying the update context to the base context. It is equivalent to `{...base,
@@ -31,12 +31,14 @@ export interface Context<T = never>
         string | number | boolean | null | Context | T | (string | number | boolean | null | Context | T)[]
     > {}
 
-export type PartialCodeEditor = Pick<CodeEditor, 'type' | 'resource' | 'selections' | 'isActive'> & {
-    model: Pick<CodeEditor['model'], 'uri' | 'languageId'>
-}
+export type PartialCodeEditor = EditorId &
+    Pick<CodeEditor, 'type' | 'resource' | 'selections' | 'isActive'> & {
+        model: Pick<CodeEditor['model'], 'uri' | 'languageId'>
+    }
 
 export type ContributionScope =
-    | PartialCodeEditor
+    | (EditorId & PartialCodeEditor)
+    | (EditorId & Pick<DiffEditorData, 'type'>)
     | {
           type: 'panelView'
           id: string
@@ -51,7 +53,7 @@ export type ContributionScope =
  * @param scope the user interface component in whose scope this computation should occur
  */
 export function getComputedContextProperty(
-    editors: readonly PartialCodeEditor[],
+    editors: readonly (EditorId & (PartialCodeEditor | Pick<DiffEditorData, 'type' | 'isActive'>))[],
     settings: SettingsCascadeOrError,
     context: Context<any>,
     key: string,
@@ -93,29 +95,42 @@ export function getComputedContextProperty(
         }
     }
     if (key.startsWith('component.')) {
-        if (!component || component.type !== 'CodeEditor') {
+        if (!component) {
             return null
         }
         const prop = key.slice('component.'.length)
-        switch (prop) {
-            case 'type':
-                return 'CodeEditor'
-            case 'selections':
-                return component.selections
-            case 'selection':
-                return component.selections[0] || null
-            case 'selection.start':
-                return component.selections[0] ? component.selections[0].start : null
-            case 'selection.end':
-                return component.selections[0] ? component.selections[0].end : null
-            case 'selection.start.line':
-                return component.selections[0] ? component.selections[0].start.line : null
-            case 'selection.start.character':
-                return component.selections[0] ? component.selections[0].start.character : null
-            case 'selection.end.line':
-                return component.selections[0] ? component.selections[0].end.line : null
-            case 'selection.end.character':
-                return component.selections[0] ? component.selections[0].end.character : null
+        if (prop === 'type') {
+            return component.type
+        }
+        switch (component.type) {
+            case 'CodeEditor':
+                switch (prop) {
+                    case 'editorId':
+                        return component.editorId
+                    case 'selections':
+                        return component.selections
+                    case 'selection':
+                        return component.selections[0] || null
+                    case 'selection.start':
+                        return component.selections[0] ? component.selections[0].start : null
+                    case 'selection.end':
+                        return component.selections[0] ? component.selections[0].end : null
+                    case 'selection.start.line':
+                        return component.selections[0] ? component.selections[0].start.line : null
+                    case 'selection.start.character':
+                        return component.selections[0] ? component.selections[0].start.character : null
+                    case 'selection.end.line':
+                        return component.selections[0] ? component.selections[0].end.line : null
+                    case 'selection.end.character':
+                        return component.selections[0] ? component.selections[0].end.character : null
+                }
+                break
+            case 'DiffEditor':
+                switch (prop) {
+                    case 'editorId':
+                        return component.editorId
+                }
+                break
         }
     }
     if (key.startsWith('panel.activeView.')) {

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname } from 'path'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorDataWithModel } from '../services/editorService'
+import { CodeEditor } from '../services/editorService'
 
 /**
  * Returns a new context created by applying the update context to the base context. It is equivalent to `{...base,
@@ -31,10 +31,12 @@ export interface Context<T = never>
         string | number | boolean | null | Context | T | (string | number | boolean | null | Context | T)[]
     > {}
 
+export type PartialCodeEditor = Pick<CodeEditor, 'type' | 'resource' | 'selections' | 'isActive'> & {
+    model: Pick<CodeEditor['model'], 'uri' | 'languageId'>
+}
+
 export type ContributionScope =
-    | (Pick<CodeEditorDataWithModel, 'type' | 'resource' | 'selections'> & {
-          model: Pick<CodeEditorDataWithModel['model'], 'uri' | 'languageId'>
-      })
+    | PartialCodeEditor
     | {
           type: 'panelView'
           id: string
@@ -49,7 +51,7 @@ export type ContributionScope =
  * @param scope the user interface component in whose scope this computation should occur
  */
 export function getComputedContextProperty(
-    editors: readonly CodeEditorDataWithModel[],
+    editors: readonly PartialCodeEditor[],
     settings: SettingsCascadeOrError,
     context: Context<any>,
     key: string,

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -1,7 +1,6 @@
 import { basename, dirname, extname } from 'path'
-import { TextDocument } from 'sourcegraph'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData } from '../services/editorService'
+import { CodeEditorDataWithModel } from '../services/editorService'
 
 /**
  * Returns a new context created by applying the update context to the base context. It is equivalent to `{...base,
@@ -33,8 +32,8 @@ export interface Context<T = never>
     > {}
 
 export type ContributionScope =
-    | (Pick<CodeEditorData, 'type' | 'selections'> & {
-          item: Pick<TextDocument, 'uri' | 'languageId'>
+    | (Pick<CodeEditorDataWithModel, 'type' | 'resource' | 'selections'> & {
+          model: Pick<CodeEditorDataWithModel['model'], 'uri' | 'languageId'>
       })
     | {
           type: 'panelView'
@@ -50,7 +49,7 @@ export type ContributionScope =
  * @param scope the user interface component in whose scope this computation should occur
  */
 export function getComputedContextProperty(
-    editors: readonly CodeEditorData[],
+    editors: readonly CodeEditorDataWithModel[],
     settings: SettingsCascadeOrError,
     context: Context<any>,
     key: string,
@@ -78,15 +77,15 @@ export function getComputedContextProperty(
         const prop = key.slice('resource.'.length)
         switch (prop) {
             case 'uri':
-                return component.item.uri
+                return component.resource
             case 'basename':
-                return basename(component.item.uri)
+                return basename(component.resource)
             case 'dirname':
-                return dirname(component.item.uri)
+                return dirname(component.resource)
             case 'extname':
-                return extname(component.item.uri)
+                return extname(component.resource)
             case 'language':
-                return component.item.languageId
+                return component.model.languageId
             case 'type':
                 return 'textDocument'
         }

--- a/shared/src/api/client/services.ts
+++ b/shared/src/api/client/services.ts
@@ -8,6 +8,7 @@ import { createEditorService } from './services/editorService'
 import { ExtensionsService } from './services/extensionsService'
 import { TextDocumentHoverProviderRegistry } from './services/hover'
 import { TextDocumentLocationProviderIDRegistry, TextDocumentLocationProviderRegistry } from './services/location'
+import { createModelService } from './services/modelService'
 import { NotificationsService } from './services/notifications'
 import { QueryTransformerRegistry } from './services/queryTransformer'
 import { createSettingsService } from './services/settings'
@@ -33,7 +34,8 @@ export class Services {
     public readonly commands = new CommandRegistry()
     public readonly context = createContextService(this.platformContext)
     public readonly workspace = createWorkspaceService()
-    public readonly editor = createEditorService()
+    public readonly model = createModelService()
+    public readonly editor = createEditorService(this.model)
     public readonly notifications = new NotificationsService()
     public readonly settings = createSettingsService(this.platformContext)
     public readonly contribution = new ContributionRegistry(this.editor, this.settings, this.context.data)

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -12,7 +12,7 @@ import {
     filterContributions,
     mergeContributions,
 } from './contribution'
-import { CodeEditorData } from './editorService'
+import { CodeEditorDataWithModel } from './editorService'
 import { createTestEditorService } from './editorService.test'
 
 const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
@@ -160,7 +160,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editors: cold<readonly CodeEditorData[]>('-a-b-|', {
+                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
                                     a: [],
                                     b: [],
                                 }),
@@ -202,7 +202,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editors: cold<readonly CodeEditorData[]>('a', {
+                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('a', {
                                     a: [],
                                 }),
                             },

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -12,7 +12,7 @@ import {
     filterContributions,
     mergeContributions,
 } from './contribution'
-import { CodeEditorDataWithModel } from './editorService'
+import { CodeEditor } from './editorService'
 import { createTestEditorService } from './editorService.test'
 
 const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
@@ -160,7 +160,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
+                                editors: cold<readonly CodeEditor[]>('-a-b-|', {
                                     a: [],
                                     b: [],
                                 }),
@@ -202,7 +202,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editorsWithModel: cold<readonly CodeEditorDataWithModel[]>('a', {
+                                editors: cold<readonly CodeEditor[]>('a', {
                                     a: [],
                                 }),
                             },

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -41,7 +41,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: Pick<EditorService, 'editors'>,
+        private editorService: Pick<EditorService, 'editorsWithModel'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}
@@ -114,7 +114,7 @@ export class ContributionRegistry {
                     )
                 )
             ),
-            this.editorService.editors,
+            this.editorService.editorsWithModel,
             this.settingsService.data,
             this.context
         ).pipe(

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -12,7 +12,7 @@ import {
 import { Context, ContributionScope, getComputedContextProperty } from '../context/context'
 import { ComputedContext, evaluate, evaluateTemplate } from '../context/expr/evaluator'
 import { TEMPLATE_BEGIN } from '../context/expr/lexer'
-import { ReadonlyEditorService } from './editorService'
+import { EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /** A registered set of contributions from an extension in the registry. */
@@ -41,7 +41,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: ReadonlyEditorService,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -41,7 +41,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: Pick<EditorService, 'editorsWithModel'>,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}
@@ -114,7 +114,7 @@ export class ContributionRegistry {
                     )
                 )
             ),
-            this.editorService.editorsWithModel,
+            this.editorService.editors,
             this.settingsService.data,
             this.context
         ).pipe(

--- a/shared/src/api/client/services/editorService.test.ts
+++ b/shared/src/api/client/services/editorService.test.ts
@@ -1,42 +1,105 @@
+import { Selection } from '@sourcegraph/extension-api-types'
 import { from, of, Subscribable } from 'rxjs'
+import { first, map } from 'rxjs/operators'
 import { TestScheduler } from 'rxjs/testing'
-import {
-    CodeEditorDataWithModel,
-    createEditorService,
-    EditorService,
-    getActiveCodeEditorPosition,
-} from './editorService'
+import { CodeEditor, createEditorService, EditorService, getActiveCodeEditorPosition } from './editorService'
 import { TextModel } from './modelService'
 
 export function createTestEditorService(
-    editorsWithModel: Subscribable<readonly CodeEditorDataWithModel[]> = of([])
-): Pick<EditorService, 'editors' | 'editorsWithModel'> {
-    return { editors: editorsWithModel, editorsWithModel }
+    editors: Subscribable<readonly CodeEditor[]> = of([])
+): Pick<EditorService, 'editors'> {
+    return { editors }
 }
 
 const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 
 describe('EditorService', () => {
-    describe('editorsWithModel', () => {
+    describe('editors', () => {
         test('merges in model data', () => {
             scheduler().run(({ cold, expectObservable }) => {
                 const editorService = createEditorService({
                     models: cold<TextModel[]>('a', { a: [{ uri: 'u', text: 't', languageId: 'l' }] }),
                 })
-                editorService.nextEditors([{ type: 'CodeEditor', resource: 'u', selections: [], isActive: true }])
-                expectObservable(from(editorService.editorsWithModel)).toBe('a', {
+                editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+                expectObservable(
+                    from(editorService.editors).pipe(
+                        map(editors => editors.map(e => ({ resource: e.resource, model: e.model })))
+                    )
+                ).toBe('a', {
                     a: [
                         {
-                            type: 'CodeEditor',
                             resource: 'u',
                             model: { uri: 'u', text: 't', languageId: 'l' },
-                            selections: [],
-                            isActive: true,
                         },
                     ],
                 })
             })
         })
+    })
+
+    test('addEditor', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        expect(editor.editorId).toEqual('editor#0')
+        expect(
+            await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([
+            {
+                type: 'CodeEditor',
+                editorId: 'editor#0',
+                resource: 'u',
+                selections: [],
+                isActive: true,
+                model: { uri: 'u', text: 't', languageId: 'l' },
+            },
+        ])
+    })
+
+    test('setSelections', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        const SELECTIONS: Selection[] = [
+            {
+                start: { line: 3, character: -1 },
+                end: { line: 3, character: -1 },
+                anchor: { line: 3, character: -1 },
+                active: { line: 3, character: -1 },
+                isReversed: false,
+            },
+        ]
+        editorService.setSelections(editor, SELECTIONS)
+        expect(
+            await from(editorService.editors)
+                .pipe(
+                    first(),
+                    map(editors => editors.map(e => e.selections))
+                )
+                .toPromise()
+        ).toEqual([SELECTIONS])
+    })
+
+    test('removeEditor', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        editorService.removeEditor(editor)
+        expect(
+            await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([])
+    })
+
+    test('removeAllEditors', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        editorService.removeAllEditors()
+        expect(
+            await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([])
     })
 })
 

--- a/shared/src/api/client/services/editorService.test.ts
+++ b/shared/src/api/client/services/editorService.test.ts
@@ -1,9 +1,9 @@
 import { of, Subscribable } from 'rxjs'
-import { CodeEditorData, getActiveCodeEditorPosition, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService, getActiveCodeEditorPosition } from './editorService'
 
 export function createTestEditorService(
     editors: Subscribable<readonly CodeEditorData[]> = of([])
-): ReadonlyEditorService {
+): Pick<EditorService, 'editors'> {
     return { editors }
 }
 

--- a/shared/src/api/client/services/editorService.test.ts
+++ b/shared/src/api/client/services/editorService.test.ts
@@ -101,6 +101,20 @@ describe('EditorService', () => {
                 .toPromise()
         ).toEqual([])
     })
+
+    test('setCollapsed', async () => {
+        const editorService = createEditorService({ models: of([{ uri: 'u', text: 't', languageId: 'l' }]) })
+        const editor = editorService.addEditor({ type: 'CodeEditor', resource: 'u', selections: [], isActive: true })
+        editorService.setCollapsed(editor, true)
+        expect(
+            await from(editorService.editors)
+                .pipe(
+                    first(),
+                    map(editors => editors.map(e => e.collapsed))
+                )
+                .toPromise()
+        ).toEqual([true])
+    })
 })
 
 describe('getActiveCodeEditorPosition', () => {

--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -21,6 +21,7 @@ export interface CodeEditorData {
     readonly resource: string
 
     readonly selections: Selection[]
+    readonly collapsed?: boolean
     readonly isActive: boolean
 }
 
@@ -69,6 +70,14 @@ export interface EditorService {
      * Remove all editors.
      */
     removeAllEditors(): void
+
+    /**
+     * Collapse or expand an editor.
+     *
+     * @param editor The editor to collapse or expand.
+     * @param collapsed The desired state.
+     */
+    setCollapsed(editor: EditorId, collapsed: boolean): void
 }
 
 /**
@@ -110,6 +119,12 @@ export function createEditorService(modelService: Pick<ModelService, 'models'>):
         },
         removeAllEditors(): void {
             editors.next([])
+        },
+        setCollapsed({ editorId }: EditorId, collapsed: boolean): void {
+            editors.next([
+                ...editors.value.filter(e => e.resource !== editorId),
+                ...editors.value.filter(e => e.resource === editorId).map(e => ({ ...e, collapsed })),
+            ])
         },
     }
 }

--- a/shared/src/api/client/services/editorService.ts
+++ b/shared/src/api/client/services/editorService.ts
@@ -1,5 +1,5 @@
 import { Selection } from '@sourcegraph/extension-api-types'
-import { BehaviorSubject, NextObserver, Subscribable } from 'rxjs'
+import { BehaviorSubject, Subscribable } from 'rxjs'
 import { TextDocument } from 'sourcegraph'
 import { TextDocumentPositionParams } from '../../protocol'
 
@@ -16,27 +16,33 @@ export interface CodeEditorData<D extends Pick<TextDocument, 'uri'> = TextDocume
     isActive: boolean
 }
 
-/** For callers that only need to subscribe to this value. */
-export interface ReadonlyEditorService {
-    readonly editors: Subscribable<readonly CodeEditorData[]>
-}
-
 /**
  * The editor service manages editors and documents.
  */
-export interface EditorService extends ReadonlyEditorService {
+export interface EditorService {
     /** All code editors. */
-    readonly editors: Subscribable<readonly CodeEditorData[]> & { value: readonly CodeEditorData[] } & NextObserver<
-            readonly CodeEditorData[]
-        >
+    readonly editors: Subscribable<readonly CodeEditorData[]>
+
+    /** Transitional API for synchronously getting the list of code editors. */
+    readonly editorsValue: readonly CodeEditorData[]
+
+    /** Transitional API for setting the list of code editors. */
+    nextEditors(value: readonly CodeEditorData[]): void
 }
 
 /**
  * Creates a {@link EditorService} instance.
  */
 export function createEditorService(): EditorService {
+    const editors = new BehaviorSubject<readonly CodeEditorData[]>([])
     return {
-        editors: new BehaviorSubject<readonly CodeEditorData[]>([]),
+        editors,
+        get editorsValue(): readonly CodeEditorData[] {
+            return editors.value
+        },
+        nextEditors(value: readonly CodeEditorData[]): void {
+            editors.next(value)
+        },
     }
 }
 

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorDataWithModel, EditorService } from './editorService'
+import { CodeEditor, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,11 +12,11 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: Pick<EditorService, 'editorsWithModel'>,
+        editorService: Pick<EditorService, 'editors'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],
-            editors: readonly CodeEditorDataWithModel[]
+            editors: readonly CodeEditor[]
         ) => ConfiguredExtension[],
         sideloadedExtensionURL: Subscribable<string | null>,
         fetchSideloadedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
@@ -46,7 +46,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('-a-|', {
+                            cold<readonly CodeEditor[]>('-a-|', {
                                 a: [],
                             })
                         ),
@@ -69,10 +69,11 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'x', manifest, rawManifest: null }, { id: 'y', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
+                            cold<readonly CodeEditor[]>('-a-b-|', {
                                 a: [
                                     {
                                         type: 'CodeEditor',
+                                        editorId: 'editor#0',
                                         resource: 'u',
                                         model: { languageId: 'x', text: '', uri: 'u' },
                                         selections: [],
@@ -82,6 +83,7 @@ describe('activeExtensions', () => {
                                 b: [
                                     {
                                         type: 'CodeEditor',
+                                        editorId: 'editor#1',
                                         resource: 'u2',
                                         model: { languageId: 'y', text: '', uri: 'u2' },
                                         selections: [],
@@ -117,7 +119,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
+                            cold<readonly CodeEditor[]>('a-|', {
                                 a: [],
                             })
                         ),
@@ -162,7 +164,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
+                            cold<readonly CodeEditor[]>('a-|', {
                                 a: [],
                             })
                         ),

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,7 +12,7 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: ReadonlyEditorService,
+        editorService: Pick<EditorService, 'editors'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditorData, EditorService } from './editorService'
+import { CodeEditorDataWithModel, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,11 +12,11 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: Pick<EditorService, 'editors'>,
+        editorService: Pick<EditorService, 'editorsWithModel'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],
-            editors: readonly CodeEditorData[]
+            editors: readonly CodeEditorDataWithModel[]
         ) => ConfiguredExtension[],
         sideloadedExtensionURL: Subscribable<string | null>,
         fetchSideloadedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
@@ -46,7 +46,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('-a-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('-a-|', {
                                 a: [],
                             })
                         ),
@@ -69,11 +69,12 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'x', manifest, rawManifest: null }, { id: 'y', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('-a-b-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('-a-b-|', {
                                 a: [
                                     {
                                         type: 'CodeEditor',
-                                        item: { languageId: 'x', text: '', uri: '' },
+                                        resource: 'u',
+                                        model: { languageId: 'x', text: '', uri: 'u' },
                                         selections: [],
                                         isActive: true,
                                     },
@@ -81,7 +82,8 @@ describe('activeExtensions', () => {
                                 b: [
                                     {
                                         type: 'CodeEditor',
-                                        item: { languageId: 'y', text: '', uri: '' },
+                                        resource: 'u2',
+                                        model: { languageId: 'y', text: '', uri: 'u2' },
                                         selections: [],
                                         isActive: true,
                                     },
@@ -96,7 +98,7 @@ describe('activeExtensions', () => {
                         },
                         (enabledExtensions, editors) =>
                             enabledExtensions.filter(x =>
-                                editors.some(({ item: { languageId } }) => x.id === languageId)
+                                editors.some(({ model: { languageId } }) => x.id === languageId)
                             ),
                         cold('-a--|', { a: '' }),
                         () => of(null)
@@ -115,7 +117,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('a-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
                                 a: [],
                             })
                         ),
@@ -160,7 +162,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditorData[]>('a-|', {
+                            cold<readonly CodeEditorDataWithModel[]>('a-|', {
                                 a: [],
                             })
                         ),

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditor, EditorService } from './editorService'
+import { CodeEditor, Editor, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -16,7 +16,7 @@ class TestExtensionsService extends ExtensionsService {
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],
-            editors: readonly CodeEditor[]
+            editors: readonly Editor[]
         ) => ConfiguredExtension[],
         sideloadedExtensionURL: Subscribable<string | null>,
         fetchSideloadedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
@@ -100,7 +100,9 @@ describe('activeExtensions', () => {
                         },
                         (enabledExtensions, editors) =>
                             enabledExtensions.filter(x =>
-                                editors.some(({ model: { languageId } }) => x.id === languageId)
+                                editors
+                                    .filter((e): e is CodeEditor => e.type === 'CodeEditor')
+                                    .some(({ model: { languageId } }) => x.id === languageId)
                             ),
                         cold('-a--|', { a: '' }),
                         () => of(null)

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -12,7 +12,7 @@ import { PlatformContext } from '../../../platform/context'
 import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
-import { CodeEditorData, EditorService } from './editorService'
+import { CodeEditorDataWithModel, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -55,7 +55,7 @@ interface PartialContext extends Pick<PlatformContext, 'queryGraphQL' | 'getScri
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: Pick<EditorService, 'editors'>,
+        private editorService: Pick<EditorService, 'editorsWithModel'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (
@@ -119,7 +119,7 @@ export class ExtensionsService {
         // Extensions that have been activated (including extensions with zero "activationEvents" that evaluate to
         // true currently).
         const activatedExtensionIDs: string[] = []
-        return combineLatest(from(this.editorService.editors), this.enabledExtensions).pipe(
+        return combineLatest(from(this.editorService.editorsWithModel), this.enabledExtensions).pipe(
             tap(([editors, enabledExtensions]) => {
                 const activeExtensions = this.extensionActivationFilter(enabledExtensions, editors)
                 for (const x of activeExtensions) {
@@ -169,7 +169,7 @@ function asObservable(input: string | ObservableInput<string>): Observable<strin
 
 function extensionsWithMatchedActivationEvent(
     enabledExtensions: ConfiguredExtension[],
-    editors: readonly CodeEditorData[]
+    editors: readonly CodeEditorDataWithModel[]
 ): ConfiguredExtension[] {
     return enabledExtensions.filter(x => {
         try {
@@ -194,7 +194,7 @@ function extensionsWithMatchedActivationEvent(
                 console.warn(`Extension ${x.id} has no activation events, so it will never be activated.`)
                 return false
             }
-            const visibleTextDocumentLanguages = editors.map(({ item: { languageId } }) => languageId)
+            const visibleTextDocumentLanguages = editors.map(({ model: { languageId } }) => languageId)
             return x.manifest.activationEvents.some(
                 e => e === '*' || visibleTextDocumentLanguages.some(l => e === `onLanguage:${l}`)
             )

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -12,7 +12,7 @@ import { PlatformContext } from '../../../platform/context'
 import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
-import { CodeEditorDataWithModel, EditorService } from './editorService'
+import { CodeEditor, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -55,7 +55,7 @@ interface PartialContext extends Pick<PlatformContext, 'queryGraphQL' | 'getScri
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: Pick<EditorService, 'editorsWithModel'>,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (
@@ -119,7 +119,7 @@ export class ExtensionsService {
         // Extensions that have been activated (including extensions with zero "activationEvents" that evaluate to
         // true currently).
         const activatedExtensionIDs: string[] = []
-        return combineLatest(from(this.editorService.editorsWithModel), this.enabledExtensions).pipe(
+        return combineLatest(from(this.editorService.editors), this.enabledExtensions).pipe(
             tap(([editors, enabledExtensions]) => {
                 const activeExtensions = this.extensionActivationFilter(enabledExtensions, editors)
                 for (const x of activeExtensions) {
@@ -169,7 +169,7 @@ function asObservable(input: string | ObservableInput<string>): Observable<strin
 
 function extensionsWithMatchedActivationEvent(
     enabledExtensions: ConfiguredExtension[],
-    editors: readonly CodeEditorDataWithModel[]
+    editors: readonly CodeEditor[]
 ): ConfiguredExtension[] {
     return enabledExtensions.filter(x => {
         try {

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -12,7 +12,7 @@ import { PlatformContext } from '../../../platform/context'
 import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
-import { CodeEditorData, ReadonlyEditorService } from './editorService'
+import { CodeEditorData, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -55,7 +55,7 @@ interface PartialContext extends Pick<PlatformContext, 'queryGraphQL' | 'getScri
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: ReadonlyEditorService,
+        private editorService: Pick<EditorService, 'editors'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -57,6 +57,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
+                            editorId: 'editor#0',
                             type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
                             resource: 'u',
@@ -80,6 +81,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
+                            editorId: 'editor#0',
                             type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
                             resource: 'u',

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -57,9 +57,10 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
-                            type: 'CodeEditor',
+                            type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
-                            item: { uri: 'u', languageId: 'l', text: 't' },
+                            resource: 'u',
+                            model: { uri: 'u', languageId: 'l', text: 't' },
                         },
                     ])
                 ).toBe('a', {
@@ -79,9 +80,10 @@ describe('TextDocumentLocationProviderRegistry', () => {
                     registry.hasProvidersForActiveTextDocument([
                         {
                             isActive: true,
-                            type: 'CodeEditor',
+                            type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
-                            item: { uri: 'u', languageId: 'l', text: 't' },
+                            resource: 'u',
+                            model: { uri: 'u', languageId: 'l', text: 't' },
                         },
                     ])
                 ).toBe('a', {

--- a/shared/src/api/client/services/location.ts
+++ b/shared/src/api/client/services/location.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
 import { TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
 import { match, TextDocumentIdentifier } from '../types/textDocument'
-import { CodeEditorDataWithModel } from './editorService'
+import { CodeEditor } from './editorService'
 import { DocumentFeatureProviderRegistry } from './registry'
 import { flattenAndCompact } from './util'
 
@@ -45,7 +45,7 @@ export class TextDocumentLocationProviderRegistry<
      *
      * @param editors The code editors in {@link EditorService}.
      */
-    public hasProvidersForActiveTextDocument(editors: readonly CodeEditorDataWithModel[]): Observable<boolean> {
+    public hasProvidersForActiveTextDocument(editors: readonly CodeEditor[]): Observable<boolean> {
         return this.entries.pipe(
             map(entries => {
                 const activeEditor = editors.find(({ isActive }) => isActive)

--- a/shared/src/api/client/services/location.ts
+++ b/shared/src/api/client/services/location.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
 import { TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
 import { match, TextDocumentIdentifier } from '../types/textDocument'
-import { CodeEditorData, getActiveCodeEditorPosition } from './editorService'
+import { CodeEditorDataWithModel } from './editorService'
 import { DocumentFeatureProviderRegistry } from './registry'
 import { flattenAndCompact } from './util'
 
@@ -45,17 +45,16 @@ export class TextDocumentLocationProviderRegistry<
      *
      * @param editors The code editors in {@link EditorService}.
      */
-    public hasProvidersForActiveTextDocument(editors: readonly CodeEditorData[]): Observable<boolean> {
+    public hasProvidersForActiveTextDocument(editors: readonly CodeEditorDataWithModel[]): Observable<boolean> {
         return this.entries.pipe(
             map(entries => {
-                const params = getActiveCodeEditorPosition(editors)
-                if (!params) {
+                const activeEditor = editors.find(({ isActive }) => isActive)
+                if (!activeEditor) {
                     return false
                 }
-
                 return (
                     entries.filter(({ registrationOptions }) =>
-                        match(registrationOptions.documentSelector, params.textDocument)
+                        match(registrationOptions.documentSelector, activeEditor.model)
                     ).length > 0
                 )
             })

--- a/shared/src/api/client/services/modelService.test.ts
+++ b/shared/src/api/client/services/modelService.test.ts
@@ -1,0 +1,76 @@
+import { from } from 'rxjs'
+import { first } from 'rxjs/operators'
+import { createModelService } from './modelService'
+
+describe('ModelService', () => {
+    describe('addModel', () => {
+        it('adds', async () => {
+            const modelService = createModelService()
+            modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+            expect(
+                await from(modelService.models)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([
+                {
+                    uri: 'u',
+                    text: 't',
+                    languageId: 'l',
+                },
+            ])
+        })
+        it('refuses to add model with duplicate URI', async () => {
+            const modelService = createModelService()
+            modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+            expect(() => {
+                modelService.addModel({ uri: 'u', text: 't2', languageId: 'l2' })
+            }).toThrowError('model already exists with URI u')
+            expect(
+                await from(modelService.models)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([
+                {
+                    uri: 'u',
+                    text: 't',
+                    languageId: 'l',
+                },
+            ])
+        })
+    })
+
+    describe('removeModel', () => {
+        test('removes', async () => {
+            const modelService = createModelService()
+            modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+            modelService.addModel({ uri: 'u2', text: 't2', languageId: 'l2' })
+            modelService.removeModel('u')
+            expect(
+                await from(modelService.models)
+                    .pipe(first())
+                    .toPromise()
+            ).toEqual([
+                {
+                    uri: 'u2',
+                    text: 't2',
+                    languageId: 'l2',
+                },
+            ])
+        })
+        test('noop if model not found', () => {
+            const modelService = createModelService()
+            modelService.removeModel('x')
+        })
+    })
+
+    test('removeAllModels', async () => {
+        const modelService = createModelService()
+        modelService.addModel({ uri: 'u', text: 't', languageId: 'l' })
+        modelService.removeAllModels()
+        expect(
+            await from(modelService.models)
+                .pipe(first())
+                .toPromise()
+        ).toEqual([])
+    })
+})

--- a/shared/src/api/client/services/modelService.ts
+++ b/shared/src/api/client/services/modelService.ts
@@ -1,0 +1,60 @@
+import { BehaviorSubject, Subscribable } from 'rxjs'
+import { TextDocument } from 'sourcegraph'
+
+/**
+ * A text model is a text document and associated metadata.
+ *
+ * How does this relate to editors (in {@link EditorService}? A model is the file, an editor is the
+ * window that the file is shown in. Things like the content and language are properties of the
+ * model; things like decorations and the selection ranges are properties of the editor.
+ */
+export interface TextModel extends TextDocument {}
+
+/**
+ * The model service manages document contents and metadata.
+ *
+ * See {@link Model} for an explanation of the difference between a model and an editor.
+ */
+export interface ModelService {
+    /** All known models. */
+    models: Subscribable<readonly TextModel[]>
+
+    /**
+     * Adds a model.
+     *
+     * @params model The model to add.
+     */
+    addModel(model: TextModel): void
+
+    /**
+     * Removes a model.
+     *
+     * @params uri The URI of the model to remove.
+     */
+    removeModel(uri: string): void
+
+    /**
+     * Removes all models.
+     */
+    removeAllModels(): void
+}
+
+/**
+ * Creates a new instance of {@link createModelService}.
+ */
+export function createModelService(): ModelService {
+    const models = new BehaviorSubject<readonly TextModel[]>([])
+    return {
+        models,
+        addModel: model => {
+            if (models.value.some(m => m.uri === model.uri)) {
+                throw new Error(`model already exists with URI ${model.uri}`)
+            }
+            models.next([...models.value, model])
+        },
+        removeModel: uri => {
+            models.next(models.value.filter(m => m.uri !== uri))
+        },
+        removeAllModels: () => models.next([]),
+    }
+}

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -17,11 +17,11 @@ export class ExtCodeEditor implements sourcegraph.CodeEditor {
     private resource: string
 
     constructor(
-        data: CodeEditorData<Pick<sourcegraph.TextDocument, 'uri'>>,
+        data: CodeEditorData,
         private proxy: ProxyResult<ClientCodeEditorAPI>,
         private documents: ExtDocuments
     ) {
-        this.resource = data.item.uri
+        this.resource = data.resource
         this.update(data)
     }
 

--- a/shared/src/api/extension/api/codeEditor.ts
+++ b/shared/src/api/extension/api/codeEditor.ts
@@ -3,7 +3,7 @@ import * as clientType from '@sourcegraph/extension-api-types'
 import { BehaviorSubject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { ClientCodeEditorAPI } from '../../client/api/codeEditor'
-import { CodeEditorData } from '../../client/services/editorService'
+import { CodeEditorData, EditorId } from '../../client/services/editorService'
 import { Range } from '../types/range'
 import { Selection } from '../types/selection'
 import { createDecorationType } from './decorations'
@@ -13,11 +13,11 @@ const DEFAULT_DECORATION_TYPE = createDecorationType()
 
 /** @internal */
 export class ExtCodeEditor implements sourcegraph.CodeEditor {
-    /** The URI of the text document shown in this code editor */
+    /** The URI of this editor's document. */
     private resource: string
 
     constructor(
-        data: CodeEditorData,
+        data: CodeEditorData & EditorId,
         private proxy: ProxyResult<ClientCodeEditorAPI>,
         private documents: ExtDocuments
     ) {

--- a/shared/src/api/extension/api/viewComponents/diffEditor.ts
+++ b/shared/src/api/extension/api/viewComponents/diffEditor.ts
@@ -1,0 +1,56 @@
+import { ProxyResult } from '@sourcegraph/comlink'
+import { BehaviorSubject } from 'rxjs'
+import * as sourcegraph from 'sourcegraph'
+import { ClientEditorAPI } from '../../../client/api/viewComponents/editor'
+import { DiffEditorData, EditorDataCommon, EditorId } from '../../../client/services/editorService'
+import { ExtDocuments } from '../documents'
+import { ExtEditorCommon } from './editor'
+
+/** @internal */
+export class ExtDiffEditorViewComponent extends ExtEditorCommon implements sourcegraph.DiffEditor {
+    /** The URI of this editor's original document (on the left-hand side). */
+    private originalResource: string
+
+    /** The URI of this editor's modified document (on the right-hand side). */
+    private modifiedResource: string
+
+    constructor(
+        data: DiffEditorData & EditorId,
+        editorProxy: ProxyResult<ClientEditorAPI>,
+        private documents: ExtDocuments
+    ) {
+        super(data.editorId, editorProxy)
+        this.originalResource = data.originalResource
+        this.modifiedResource = data.modifiedResource
+        this.update(data)
+    }
+
+    public readonly type = 'DiffEditor'
+
+    public get originalDocument(): sourcegraph.TextDocument {
+        return this.documents.get(this.originalResource)
+    }
+
+    public get modifiedDocument(): sourcegraph.TextDocument {
+        return this.documents.get(this.modifiedResource)
+    }
+
+    public get rawDiff(): string | undefined {
+        return this.rawDiffChanges.value
+    }
+
+    public readonly rawDiffChanges = new BehaviorSubject<string | undefined>(undefined)
+
+    public update(data: Pick<DiffEditorData, 'rawDiff'> & EditorDataCommon): void {
+        this.rawDiffChanges.next(data.rawDiff)
+        super.update(data)
+    }
+
+    public toJSON(): any {
+        return {
+            type: this.type,
+            originalDocument: this.originalDocument,
+            modifiedDocument: this.modifiedDocument,
+        }
+    }
+}

--- a/shared/src/api/extension/api/viewComponents/editor.ts
+++ b/shared/src/api/extension/api/viewComponents/editor.ts
@@ -1,0 +1,40 @@
+import { ProxyResult } from '@sourcegraph/comlink'
+import { BehaviorSubject, Subscribable } from 'rxjs'
+import * as sourcegraph from 'sourcegraph'
+import { ClientEditorAPI } from '../../../client/api/viewComponents/editor'
+import { EditorDataCommon, EditorId } from '../../../client/services/editorService'
+
+/**
+ * @internal
+ * @template D The editor data type.
+ */
+export abstract class ExtEditorCommon implements Pick<sourcegraph.CodeEditor, 'collapsed' | 'collapsedChanges'> {
+    constructor(
+        /** The unique ID of this editor. */
+        protected readonly editorId: EditorId['editorId'],
+        private _proxy: ProxyResult<ClientEditorAPI>
+    ) {}
+
+    public abstract readonly type: string
+
+    private _collapsedChanges = new BehaviorSubject<boolean>(false)
+
+    public get collapsed(): boolean {
+        return this._collapsedChanges.value
+    }
+
+    public set collapsed(value: boolean) {
+        this._collapsedChanges.next(Boolean(value))
+        // tslint:disable-next-line: no-floating-promises
+        this._proxy.$setCollapsed(this.editorId, value)
+    }
+
+    public get collapsedChanges(): Subscribable<boolean> {
+        return this._collapsedChanges
+    }
+
+    /** Subclasses should override this method and then call `super.update(data)`. */
+    public update(data: EditorDataCommon): void {
+        this._collapsedChanges.next(Boolean(data.collapsed))
+    }
+}

--- a/shared/src/api/extension/api/windows.test.ts
+++ b/shared/src/api/extension/api/windows.test.ts
@@ -10,28 +10,26 @@ describe('ExtWindow', () => {
 
     test('reuses ExtCodeEditor object when updated', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [
-                { type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [new Selection(1, 2, 3, 4)] },
-            ],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [new Selection(1, 2, 3, 4)] }],
         })
         expect(wins.activeViewComponent).toBe(origViewComponent)
     })
 
     test('creates new ExtCodeEditor object for a different resource URI', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u2' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: true, selections: [] }],
         })
         expect(wins.activeViewComponent).not.toBe(origViewComponent)
     })
@@ -46,18 +44,18 @@ describe('ExtWindows', () => {
     test('reuses ExtWindow object when updated', () => {
         const wins = new ExtWindows(NOOP_PROXY, documents)
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
         })
         const origWin = wins.activeWindow
         expect(origWin).toBeTruthy()
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u' }, isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', item: { uri: 'u2' }, isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
     })

--- a/shared/src/api/extension/api/windows.test.ts
+++ b/shared/src/api/extension/api/windows.test.ts
@@ -10,26 +10,34 @@ describe('ExtWindow', () => {
 
     test('reuses ExtCodeEditor object when updated', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [new Selection(1, 2, 3, 4)] }],
+            editors: [
+                {
+                    type: 'CodeEditor',
+                    editorId: 'editor#0',
+                    resource: 'u',
+                    isActive: true,
+                    selections: [new Selection(1, 2, 3, 4)],
+                },
+            ],
         })
         expect(wins.activeViewComponent).toBe(origViewComponent)
     })
 
     test('creates new ExtCodeEditor object for a different resource URI', () => {
         const wins = new ExtWindow(NOOP_PROXY, DOCUMENTS, {
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: true, selections: [] }],
         })
         const origViewComponent = wins.activeViewComponent
         expect(origViewComponent).toBeTruthy()
 
         wins.update({
-            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#1', resource: 'u2', isActive: true, selections: [] }],
         })
         expect(wins.activeViewComponent).not.toBe(origViewComponent)
     })
@@ -44,18 +52,18 @@ describe('ExtWindows', () => {
     test('reuses ExtWindow object when updated', () => {
         const wins = new ExtWindows(NOOP_PROXY, documents)
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: true, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: true, selections: [] }],
         })
         const origWin = wins.activeWindow
         expect(origWin).toBeTruthy()
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', resource: 'u', isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#0', resource: 'u', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
 
         wins.$acceptWindowData({
-            editors: [{ type: 'CodeEditor', resource: 'u2', isActive: false, selections: [] }],
+            editors: [{ type: 'CodeEditor', editorId: 'editor#1', resource: 'u2', isActive: false, selections: [] }],
         })
         expect(wins.activeWindow).toBe(origWin)
     })

--- a/shared/src/api/extension/api/windows.ts
+++ b/shared/src/api/extension/api/windows.ts
@@ -10,7 +10,7 @@ import { ExtCodeEditor } from './codeEditor'
 import { ExtDocuments } from './documents'
 
 export interface WindowData {
-    editors: CodeEditorData<Pick<sourcegraph.TextDocument, 'uri'>>[]
+    editors: readonly CodeEditorData[]
 }
 
 interface WindowsProxyData {
@@ -96,7 +96,7 @@ export class ExtWindow implements sourcegraph.Window {
      * Perform a delta update (update/add/delete) of this window's view components.
      */
     public update(data: WindowData): void {
-        const getKey = (c: CodeEditorData<Pick<sourcegraph.TextDocument, 'uri'>>): string => `${c.type}:${c.item.uri}`
+        const getKey = (c: CodeEditorData): string => `${c.type}:${c.resource}`
 
         const seenKeys = new Set<string>()
         for (const c of data.editors) {

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -1,6 +1,6 @@
 import * as clientType from '@sourcegraph/extension-api-types'
 import { from } from 'rxjs'
-import { distinctUntilChanged, first, map, switchMap, take, toArray } from 'rxjs/operators'
+import { distinctUntilChanged, first, switchMap, take, toArray } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { isDefined } from '../../util/types'
 import { Range } from '../extension/types/range'
@@ -15,19 +15,12 @@ describe('CodeEditor (integration)', () => {
                 services: { editor: editorService },
                 extensionAPI,
             } = await integrationTestContext()
+            const editors = await from(editorService.editors)
+                .pipe(first())
+                .toPromise()
 
-            const setSelections = (selections: Selection[]) => {
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'file:///f',
-                        selections,
-                        isActive: true,
-                    },
-                ])
-            }
-            setSelections([new Selection(1, 2, 3, 4)])
-            setSelections([])
+            editorService.setSelections(editors[0], [new Selection(1, 2, 3, 4)])
+            editorService.setSelections(editors[0], [])
 
             const values = await from(extensionAPI.app.windows[0].activeViewComponentChanges)
                 .pipe(

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -1,6 +1,6 @@
 import * as clientType from '@sourcegraph/extension-api-types'
 import { from } from 'rxjs'
-import { distinctUntilChanged, first, switchMap, take, toArray } from 'rxjs/operators'
+import { distinctUntilChanged, filter, first, switchMap, take, toArray } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { isDefined } from '../../util/types'
 import { Range } from '../extension/types/range'
@@ -24,6 +24,7 @@ describe('CodeEditor (integration)', () => {
 
             const values = await from(extensionAPI.app.windows[0].activeViewComponentChanges)
                 .pipe(
+                    filter((c): c is sourcegraph.CodeEditor => Boolean(c && c.type === 'CodeEditor')),
                     switchMap(c => (c ? c.selectionsChanges : [])),
                     distinctUntilChanged(),
                     take(3),
@@ -255,7 +256,8 @@ async function getFirstCodeEditor(extensionAPI: typeof sourcegraph): Promise<sou
         .pipe(
             first(isDefined),
             switchMap(win => win.activeViewComponentChanges),
-            first(isDefined)
+            filter((c): c is sourcegraph.CodeEditor => Boolean(c && c.type === 'CodeEditor')),
+            first()
         )
         .toPromise()
 }

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -16,7 +16,7 @@ describe('CodeEditor (integration)', () => {
             } = await integrationTestContext()
 
             const setSelections = (selections: Selection[]) => {
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'foo', languageId: 'l1', text: 't1' },

--- a/shared/src/api/integration-test/codeEditor.test.ts
+++ b/shared/src/api/integration-test/codeEditor.test.ts
@@ -1,6 +1,7 @@
 import * as clientType from '@sourcegraph/extension-api-types'
 import { from } from 'rxjs'
-import { first, switchMap, take, toArray } from 'rxjs/operators'
+import { distinctUntilChanged, first, map, switchMap, take, toArray } from 'rxjs/operators'
+import * as sourcegraph from 'sourcegraph'
 import { isDefined } from '../../util/types'
 import { Range } from '../extension/types/range'
 import { Selection } from '../extension/types/selection'
@@ -19,7 +20,7 @@ describe('CodeEditor (integration)', () => {
                 editorService.nextEditors([
                     {
                         type: 'CodeEditor',
-                        item: { uri: 'foo', languageId: 'l1', text: 't1' },
+                        resource: 'file:///f',
                         selections,
                         isActive: true,
                     },
@@ -31,6 +32,7 @@ describe('CodeEditor (integration)', () => {
             const values = await from(extensionAPI.app.windows[0].activeViewComponentChanges)
                 .pipe(
                     switchMap(c => (c ? c.selectionsChanges : [])),
+                    distinctUntilChanged(),
                     take(3),
                     toArray()
                 )
@@ -49,10 +51,7 @@ describe('CodeEditor (integration)', () => {
             const dt = extensionAPI.app.createDecorationType()
 
             // Set some decorations and check they are present on the client.
-            const activeWindow = await from(extensionAPI.app.activeWindowChanges)
-                .pipe(first(isDefined))
-                .toPromise()
-            const editor = activeWindow.visibleViewComponents[0]
+            const editor = await getFirstCodeEditor(extensionAPI)
             editor.setDecorations(dt, [
                 {
                     range: new Range(1, 2, 3, 4),
@@ -87,10 +86,7 @@ describe('CodeEditor (integration)', () => {
             const { services, extensionAPI } = await integrationTestContext()
             const [dt1, dt2] = [extensionAPI.app.createDecorationType(), extensionAPI.app.createDecorationType()]
 
-            const activeWindow = await from(extensionAPI.app.activeWindowChanges)
-                .pipe(first(isDefined))
-                .toPromise()
-            const editor = activeWindow.visibleViewComponents[0]
+            const editor = await getFirstCodeEditor(extensionAPI)
             editor.setDecorations(dt1, [
                 {
                     range: new Range(1, 2, 3, 4),
@@ -181,10 +177,7 @@ describe('CodeEditor (integration)', () => {
             const dt = extensionAPI.app.createDecorationType()
 
             // Set some decorations and check they are present on the client.
-            const activeWindow = await from(extensionAPI.app.activeWindowChanges)
-                .pipe(first(isDefined))
-                .toPromise()
-            const editor = activeWindow.visibleViewComponents[0]
+            const editor = await getFirstCodeEditor(extensionAPI)
             editor.setDecorations(dt, [
                 {
                     range: new Range(1, 2, 3, 4),
@@ -225,3 +218,13 @@ describe('CodeEditor (integration)', () => {
         })
     })
 })
+
+async function getFirstCodeEditor(extensionAPI: typeof sourcegraph): Promise<sourcegraph.CodeEditor> {
+    return from(extensionAPI.app.activeWindowChanges)
+        .pipe(
+            first(isDefined),
+            switchMap(win => win.activeViewComponentChanges),
+            first(isDefined)
+        )
+        .toPromise()
+}

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -17,7 +17,7 @@ describe('Documents (integration)', () => {
                 services: { editor: editorService },
                 extensionAPI,
             } = await integrationTestContext()
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
@@ -45,7 +45,7 @@ describe('Documents (integration)', () => {
             const values = collectSubscribableValues(extensionAPI.workspace.openedTextDocuments)
             expect(values).toEqual([] as TextDocument[])
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },

--- a/shared/src/api/integration-test/documents.test.ts
+++ b/shared/src/api/integration-test/documents.test.ts
@@ -14,17 +14,10 @@ describe('Documents (integration)', () => {
 
         test('adds new text documents', async () => {
             const {
-                services: { editor: editorService },
+                services: { model: modelService },
                 extensionAPI,
             } = await integrationTestContext()
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            modelService.addModel({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
             await from(extensionAPI.workspace.openedTextDocuments)
                 .pipe(take(1))
                 .toPromise()
@@ -38,21 +31,14 @@ describe('Documents (integration)', () => {
     describe('workspace.openedTextDocuments', () => {
         test('fires when a text document is opened', async () => {
             const {
-                services: { editor: editorService },
+                services: { model: modelService },
                 extensionAPI,
             } = await integrationTestContext()
 
             const values = collectSubscribableValues(extensionAPI.workspace.openedTextDocuments)
             expect(values).toEqual([] as TextDocument[])
 
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            modelService.addModel({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
             await from(extensionAPI.workspace.openedTextDocuments)
                 .pipe(take(1))
                 .toPromise()

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -54,7 +54,7 @@ describe('Selections (integration)', () => {
                 [],
             ]
             for (const selections of testValues) {
-                editorService.editors.next([withSelections(...selections)])
+                editorService.nextEditors([withSelections(...selections)])
                 await extensionAPI.internal.sync()
             }
             await extensionAPI.internal.sync()

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -1,5 +1,6 @@
 import { from } from 'rxjs'
 import { distinctUntilChanged, filter, first, switchMap } from 'rxjs/operators'
+import { CodeEditor } from 'sourcegraph'
 import { isDefined } from '../../util/types'
 import { assertToJSON } from '../extension/types/testHelpers'
 import { collectSubscribableValues, integrationTestContext } from './testHelpers'
@@ -17,6 +18,7 @@ describe('Selections (integration)', () => {
             const selectionChanges = from(extensionAPI.app.activeWindowChanges).pipe(
                 filter(isDefined),
                 switchMap(window => window.activeViewComponentChanges),
+                filter((c): c is CodeEditor => Boolean(c && c.type === 'CodeEditor')),
                 filter(isDefined),
                 distinctUntilChanged(),
                 switchMap(editor => editor.selectionsChanges)

--- a/shared/src/api/integration-test/selections.test.ts
+++ b/shared/src/api/integration-test/selections.test.ts
@@ -7,7 +7,7 @@ import { collectSubscribableValues, integrationTestContext } from './testHelpers
 
 const withSelections = (...selections: { start: number; end: number }[]): CodeEditorData => ({
     type: 'CodeEditor',
-    item: { uri: 'foo', languageId: 'l1', text: 't1' },
+    resource: 'file:///f',
     selections: selections.map(({ start, end }) => ({
         start: {
             line: start,
@@ -36,10 +36,7 @@ describe('Selections (integration)', () => {
             const {
                 services: { editor: editorService },
                 extensionAPI,
-            } = await integrationTestContext(undefined, {
-                roots: [],
-                editors: [],
-            })
+            } = await integrationTestContext()
             const selectionChanges = from(extensionAPI.app.activeWindowChanges).pipe(
                 filter(isDefined),
                 switchMap(window => window.activeViewComponentChanges),
@@ -56,11 +53,11 @@ describe('Selections (integration)', () => {
             for (const selections of testValues) {
                 editorService.nextEditors([withSelections(...selections)])
                 await extensionAPI.internal.sync()
+                await extensionAPI.internal.sync()
             }
-            await extensionAPI.internal.sync()
             assertToJSON(
                 selectionValues.map(selections => selections.map(s => ({ start: s.start.line, end: s.end.line }))),
-                testValues
+                [[], ...testValues]
             )
         })
     })

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -8,13 +8,13 @@ import { isDefined } from '../../util/types'
 import { ExtensionHostClient } from '../client/client'
 import { createExtensionHostClientConnection } from '../client/connection'
 import { Services } from '../client/services'
-import { CodeEditorDataWithModel } from '../client/services/editorService'
+import { CodeEditor } from '../client/services/editorService'
 import { WorkspaceRootWithMetadata } from '../client/services/workspaceService'
 import { InitData, startExtensionHost } from '../extension/extensionHost'
 
 interface TestInitData {
     roots: readonly WorkspaceRootWithMetadata[]
-    editors: readonly CodeEditorDataWithModel[]
+    editors: readonly Pick<CodeEditor, Exclude<keyof CodeEditor, 'editorId'>>[]
 }
 
 const FIXTURE_INIT_DATA: TestInitData = {
@@ -90,10 +90,10 @@ export async function integrationTestContext(
     const client = await createExtensionHostClientConnection(clientEndpoints, services, initData)
 
     const extensionAPI = await extensionHost.extensionAPI
-    for (const { model } of initModel.editors) {
+    for (const { model, ...editor } of initModel.editors) {
         services.model.addModel(model)
+        services.editor.addEditor(editor)
     }
-    services.editor.nextEditors(initModel.editors)
     services.workspace.roots.next(initModel.roots)
 
     // Wait for initModel to be initialized

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -8,13 +8,13 @@ import { isDefined } from '../../util/types'
 import { ExtensionHostClient } from '../client/client'
 import { createExtensionHostClientConnection } from '../client/connection'
 import { Services } from '../client/services'
-import { CodeEditorData } from '../client/services/editorService'
+import { CodeEditorDataWithModel } from '../client/services/editorService'
 import { WorkspaceRootWithMetadata } from '../client/services/workspaceService'
 import { InitData, startExtensionHost } from '../extension/extensionHost'
 
 interface TestInitData {
     roots: readonly WorkspaceRootWithMetadata[]
-    editors: readonly CodeEditorData[]
+    editors: readonly CodeEditorDataWithModel[]
 }
 
 const FIXTURE_INIT_DATA: TestInitData = {
@@ -22,7 +22,8 @@ const FIXTURE_INIT_DATA: TestInitData = {
     editors: [
         {
             type: 'CodeEditor',
-            item: {
+            resource: 'file:///f',
+            model: {
                 uri: 'file:///f',
                 languageId: 'l',
                 text: 't',
@@ -89,6 +90,9 @@ export async function integrationTestContext(
     const client = await createExtensionHostClientConnection(clientEndpoints, services, initData)
 
     const extensionAPI = await extensionHost.extensionAPI
+    for (const { model } of initModel.editors) {
+        services.model.addModel(model)
+    }
     services.editor.nextEditors(initModel.editors)
     services.workspace.roots.next(initModel.roots)
 

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -89,7 +89,7 @@ export async function integrationTestContext(
     const client = await createExtensionHostClientConnection(clientEndpoints, services, initData)
 
     const extensionAPI = await extensionHost.extensionAPI
-    services.editor.editors.next(initModel.editors)
+    services.editor.nextEditors(initModel.editors)
     services.workspace.roots.next(initModel.roots)
 
     // Wait for initModel to be initialized

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -35,23 +35,12 @@ describe('Windows (integration)', () => {
                 languageId: 'l',
                 text: 't',
             })
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'u',
-                    selections: [],
-                    isActive: true,
-                },
-            ])
-            editorService.nextEditors([])
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'u2',
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'u',
+                selections: [],
+                isActive: true,
+            })
             const values = await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
                     take(1),
@@ -83,21 +72,19 @@ describe('Windows (integration)', () => {
             const {
                 services: { editor: editorService, model: modelService },
                 extensionAPI,
-            } = await integrationTestContext()
+            } = await integrationTestContext(undefined, { editors: [], roots: [] })
 
             modelService.addModel({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'file:///f2',
-                    selections: [],
-                    isActive: true,
-                },
-            ])
+            editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'file:///f2',
+                selections: [],
+                isActive: true,
+            })
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
                     switchMap(w => (w ? w.activeViewComponentChanges : [])),
-                    take(4)
+                    take(3)
                 )
                 .toPromise()
 
@@ -126,15 +113,12 @@ describe('Windows (integration)', () => {
                 languageId: 'inactive',
                 text: 'inactive',
             })
-            editorService.nextEditors([
-                {
-                    type: 'CodeEditor',
-                    resource: 'file:///inactive',
-                    selections: [],
-                    isActive: false,
-                },
-                ...editorService.editorsValue,
-            ])
+            editorService.addEditor({
+                type: 'CodeEditor',
+                resource: 'file:///inactive',
+                selections: [],
+                isActive: false,
+            })
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
                     switchMap(w => (w ? w.activeViewComponentChanges : [])),
@@ -166,15 +150,12 @@ describe('Windows (integration)', () => {
                     languageId: 'inactive',
                     text: 'inactive',
                 })
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'file:///inactive',
-                        selections: [],
-                        isActive: false,
-                    },
-                    ...editorService.editorsValue,
-                ])
+                editorService.addEditor({
+                    type: 'CodeEditor',
+                    resource: 'file:///inactive',
+                    selections: [],
+                    isActive: false,
+                })
                 await extensionAPI.internal.sync()
                 await extensionAPI.internal.sync()
 
@@ -196,23 +177,19 @@ describe('Windows (integration)', () => {
                 })
                 modelService.addModel({ uri: 'foo', languageId: 'l1', text: 't1' })
                 modelService.addModel({ uri: 'bar', languageId: 'l2', text: 't2' })
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'foo',
-                        selections: [],
-                        isActive: true,
-                    },
-                ])
-                editorService.nextEditors([])
-                editorService.nextEditors([
-                    {
-                        type: 'CodeEditor',
-                        resource: 'bar',
-                        selections: [],
-                        isActive: true,
-                    },
-                ])
+                editorService.addEditor({
+                    type: 'CodeEditor',
+                    resource: 'foo',
+                    selections: [],
+                    isActive: true,
+                })
+                editorService.removeAllEditors()
+                editorService.addEditor({
+                    type: 'CodeEditor',
+                    resource: 'bar',
+                    selections: [],
+                    isActive: true,
+                })
                 const values = await from(extensionAPI.app.windows[0].activeViewComponentChanges)
                     .pipe(
                         distinctUntilChanged(),

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -1,6 +1,6 @@
 import { from } from 'rxjs'
 import { distinctUntilChanged, map, switchMap, take, toArray } from 'rxjs/operators'
-import { NotificationType, ViewComponent, Window } from 'sourcegraph'
+import { CodeEditor, NotificationType, ViewComponent, Window } from 'sourcegraph'
 import { assertToJSON } from '../extension/types/testHelpers'
 import { collectSubscribableValues, integrationTestContext } from './testHelpers'
 
@@ -10,7 +10,7 @@ describe('Windows (integration)', () => {
             const { extensionAPI } = await integrationTestContext()
             await extensionAPI.internal.sync()
             await extensionAPI.internal.sync()
-            const viewComponent: Pick<ViewComponent, 'type' | 'document'> = {
+            const viewComponent: Pick<CodeEditor, 'type' | 'document'> = {
                 type: 'CodeEditor' as const,
                 document: { uri: 'file:///f', languageId: 'l', text: 't' },
             }
@@ -56,7 +56,7 @@ describe('Windows (integration)', () => {
             const { extensionAPI } = await integrationTestContext()
             await extensionAPI.internal.sync()
             await extensionAPI.internal.sync()
-            const viewComponent: Pick<ViewComponent, 'type' | 'document'> = {
+            const viewComponent: Pick<CodeEditor, 'type' | 'document'> = {
                 type: 'CodeEditor' as const,
                 document: { uri: 'file:///f', languageId: 'l', text: 't' },
             }
@@ -88,7 +88,7 @@ describe('Windows (integration)', () => {
                 )
                 .toPromise()
 
-            const viewComponent: Pick<ViewComponent, 'type' | 'document'> = {
+            const viewComponent: Pick<CodeEditor, 'type' | 'document'> = {
                 type: 'CodeEditor' as const,
                 document: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
             }
@@ -197,7 +197,12 @@ describe('Windows (integration)', () => {
                         toArray()
                     )
                     .toPromise()
-                assertToJSON(values.map(c => (c ? c.document.uri : null)), [null, 'foo', null, 'bar'])
+                assertToJSON(values.map(c => (c && c.type === 'CodeEditor' ? c.document.uri : null)), [
+                    null,
+                    'foo',
+                    null,
+                    'bar',
+                ])
             })
         })
 

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -29,7 +29,7 @@ describe('Windows (integration)', () => {
                 roots: [],
                 editors: [],
             })
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'foo', languageId: 'l1', text: 't1' },
@@ -37,8 +37,8 @@ describe('Windows (integration)', () => {
                     isActive: true,
                 },
             ])
-            editorService.editors.next([])
-            editorService.editors.next([
+            editorService.nextEditors([])
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'bar', languageId: 'l2', text: 't2' },
@@ -78,7 +78,7 @@ describe('Windows (integration)', () => {
                 extensionAPI,
             } = await integrationTestContext()
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: { uri: 'file:///f2', languageId: 'l2', text: 't2' },
@@ -113,7 +113,7 @@ describe('Windows (integration)', () => {
                 extensionAPI,
             } = await integrationTestContext()
 
-            editorService.editors.next([
+            editorService.nextEditors([
                 {
                     type: 'CodeEditor',
                     item: {
@@ -124,7 +124,7 @@ describe('Windows (integration)', () => {
                     selections: [],
                     isActive: false,
                 },
-                ...editorService.editors.value,
+                ...editorService.editorsValue,
             ])
             await from(extensionAPI.app.activeWindowChanges)
                 .pipe(
@@ -152,7 +152,7 @@ describe('Windows (integration)', () => {
                     extensionAPI,
                 } = await integrationTestContext()
 
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: {
@@ -163,7 +163,7 @@ describe('Windows (integration)', () => {
                         selections: [],
                         isActive: false,
                     },
-                    ...editorService.editors.value,
+                    ...editorService.editorsValue,
                 ])
                 await extensionAPI.internal.sync()
 
@@ -183,7 +183,7 @@ describe('Windows (integration)', () => {
                     roots: [],
                     editors: [],
                 })
-                editorService.editors.next([
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'foo', languageId: 'l1', text: 't1' },
@@ -191,8 +191,8 @@ describe('Windows (integration)', () => {
                         isActive: true,
                     },
                 ])
-                editorService.editors.next([])
-                editorService.editors.next([
+                editorService.nextEditors([])
+                editorService.nextEditors([
                     {
                         type: 'CodeEditor',
                         item: { uri: 'bar', languageId: 'l2', text: 't2' },

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -292,7 +292,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         // Update the Sourcegraph extensions model to reflect the current file.
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
-                this.props.extensionsController.services.editor.editors.next([
+                this.props.extensionsController.services.editor.nextEditors([
                     {
                         type: 'CodeEditor' as const,
                         item: {

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -293,21 +293,19 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
                 const uri = `git://${model.repoName}?${model.commitID}#${model.filePath}`
-                this.props.extensionsController.services.editor.nextEditors([])
+                this.props.extensionsController.services.editor.removeAllEditors()
                 this.props.extensionsController.services.model.removeAllModels()
                 this.props.extensionsController.services.model.addModel({
                     uri,
                     languageId: model.mode,
                     text: model.content,
                 })
-                this.props.extensionsController.services.editor.nextEditors([
-                    {
-                        type: 'CodeEditor' as const,
-                        resource: uri,
-                        selections: lprToSelectionsZeroIndexed(pos),
-                        isActive: true,
-                    },
-                ])
+                this.props.extensionsController.services.editor.addEditor({
+                    type: 'CodeEditor' as const,
+                    resource: uri,
+                    selections: lprToSelectionsZeroIndexed(pos),
+                    isActive: true,
+                })
             })
         )
 

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -292,14 +292,18 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         // Update the Sourcegraph extensions model to reflect the current file.
         this.subscriptions.add(
             combineLatest(modelChanges, locationPositions).subscribe(([model, pos]) => {
+                const uri = `git://${model.repoName}?${model.commitID}#${model.filePath}`
+                this.props.extensionsController.services.editor.nextEditors([])
+                this.props.extensionsController.services.model.removeAllModels()
+                this.props.extensionsController.services.model.addModel({
+                    uri,
+                    languageId: model.mode,
+                    text: model.content,
+                })
                 this.props.extensionsController.services.editor.nextEditors([
                     {
                         type: 'CodeEditor' as const,
-                        item: {
-                            uri: `git://${model.repoName}?${model.commitID}#${model.filePath}`,
-                            languageId: model.mode,
-                            text: model.content,
-                        },
+                        resource: uri,
                         selections: lprToSelectionsZeroIndexed(pos),
                         isActive: true,
                     },

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -166,7 +166,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
         )
 
         // Clear the Sourcegraph extensions model's component when the blob is no longer shown.
-        this.subscriptions.add(() => this.props.extensionsController.services.editor.nextEditors([]))
+        this.subscriptions.add(() => this.props.extensionsController.services.editor.removeAllEditors())
 
         this.propsUpdates.next(this.props)
     }

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -166,7 +166,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
         )
 
         // Clear the Sourcegraph extensions model's component when the blob is no longer shown.
-        this.subscriptions.add(() => this.props.extensionsController.services.editor.editors.next([]))
+        this.subscriptions.add(() => this.props.extensionsController.services.editor.nextEditors([]))
 
         this.propsUpdates.next(this.props)
     }

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -95,47 +95,45 @@ export class BlobPanel extends React.PureComponent<Props> {
             extraParams?: Pick<P, Exclude<keyof P, keyof TextDocumentPositionParams>>
         ): Entry<ViewProviderRegistrationOptions, ProvideViewSignature> => ({
             registrationOptions: { id, container: ContributableViewContainer.Panel },
-            provider: from(this.props.extensionsController.services.editor.editors).pipe(
+            provider: from(this.props.extensionsController.services.editor.editorsWithModel).pipe(
                 switchMap(editors =>
-                    registry
-                        .hasProvidersForActiveTextDocument(this.props.extensionsController.services.editor.editorsValue)
-                        .pipe(
-                            map(hasProviders => {
-                                if (!hasProviders) {
-                                    return null
-                                }
-                                const params: TextDocumentPositionParams | null = getActiveCodeEditorPosition(editors)
-                                if (!params) {
-                                    return null
-                                }
-                                return {
-                                    title,
-                                    content: '',
-                                    priority,
+                    registry.hasProvidersForActiveTextDocument(editors).pipe(
+                        map(hasProviders => {
+                            if (!hasProviders) {
+                                return null
+                            }
+                            const params: TextDocumentPositionParams | null = getActiveCodeEditorPosition(editors)
+                            if (!params) {
+                                return null
+                            }
+                            return {
+                                title,
+                                content: '',
+                                priority,
 
-                                    // This disable directive is necessary because TypeScript is not yet smart
-                                    // enough to know that (typeof params & typeof extraParams) is P.
-                                    //
-                                    // tslint:disable-next-line:no-object-literal-type-assertion
-                                    locationProvider: registry.getLocations({ ...params, ...extraParams } as P).pipe(
-                                        map(locationsObservable =>
-                                            locationsObservable.pipe(
-                                                tap(locations => {
-                                                    if (
-                                                        this.props.activation &&
-                                                        id === 'references' &&
-                                                        locations &&
-                                                        locations.length > 0
-                                                    ) {
-                                                        this.props.activation.update({ FoundReferences: true })
-                                                    }
-                                                })
-                                            )
+                                // This disable directive is necessary because TypeScript is not yet smart
+                                // enough to know that (typeof params & typeof extraParams) is P.
+                                //
+                                // tslint:disable-next-line:no-object-literal-type-assertion
+                                locationProvider: registry.getLocations({ ...params, ...extraParams } as P).pipe(
+                                    map(locationsObservable =>
+                                        locationsObservable.pipe(
+                                            tap(locations => {
+                                                if (
+                                                    this.props.activation &&
+                                                    id === 'references' &&
+                                                    locations &&
+                                                    locations.length > 0
+                                                ) {
+                                                    this.props.activation.update({ FoundReferences: true })
+                                                }
+                                            })
                                         )
-                                    ),
-                                }
-                            })
-                        )
+                                    )
+                                ),
+                            }
+                        })
+                    )
                 )
             ),
         })

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -95,7 +95,7 @@ export class BlobPanel extends React.PureComponent<Props> {
             extraParams?: Pick<P, Exclude<keyof P, keyof TextDocumentPositionParams>>
         ): Entry<ViewProviderRegistrationOptions, ProvideViewSignature> => ({
             registrationOptions: { id, container: ContributableViewContainer.Panel },
-            provider: from(this.props.extensionsController.services.editor.editorsWithModel).pipe(
+            provider: from(this.props.extensionsController.services.editor.editors).pipe(
                 switchMap(editors =>
                     registry.hasProvidersForActiveTextDocument(editors).pipe(
                         map(hasProviders => {

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -98,9 +98,7 @@ export class BlobPanel extends React.PureComponent<Props> {
             provider: from(this.props.extensionsController.services.editor.editors).pipe(
                 switchMap(editors =>
                     registry
-                        .hasProvidersForActiveTextDocument(
-                            this.props.extensionsController.services.editor.editors.value
-                        )
+                        .hasProvidersForActiveTextDocument(this.props.extensionsController.services.editor.editorsValue)
                         .pipe(
                             map(hasProviders => {
                                 if (!hasProviders) {

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -70,6 +70,6 @@ export class FileDiffConnection extends React.PureComponent<Props> {
                 }
             }
         }
-        this.props.extensionsController.services.editor.editors.next(editors)
+        this.props.extensionsController.services.editor.nextEditors(editors)
     }
 }

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { CodeEditorData } from '../../../../shared/src/api/client/services/editorService'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { getModeFromPath } from '../../../../shared/src/languages'
@@ -42,40 +41,39 @@ export class FileDiffConnection extends React.PureComponent<Props> {
         const dummyText = ''
 
         this.props.extensionsController.services.model.removeAllModels()
+        this.props.extensionsController.services.editor.removeAllEditors()
 
-        const editors: CodeEditorData[] = []
         if (fileDiffsOrError && !isErrorLike(fileDiffsOrError)) {
             for (const fileDiff of fileDiffsOrError.nodes) {
                 if (fileDiff.oldPath) {
                     const uri = `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`
-                    editors.push({
-                        type: 'CodeEditor',
-                        resource: uri,
-                        selections: [],
-                        isActive: false, // HACK: arbitrarily say that the base is inactive. TODO: support diffs first-class
-                    })
                     this.props.extensionsController.services.model.addModel({
                         uri,
                         languageId: getModeFromPath(fileDiff.oldPath),
                         text: dummyText,
                     })
-                }
-                if (fileDiff.newPath) {
-                    const uri = `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`
-                    editors.push({
+                    this.props.extensionsController.services.editor.addEditor({
                         type: 'CodeEditor',
                         resource: uri,
                         selections: [],
-                        isActive: true,
+                        isActive: false, // HACK: arbitrarily say that the base is inactive. TODO: support diffs first-class
                     })
+                }
+                if (fileDiff.newPath) {
+                    const uri = `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`
                     this.props.extensionsController.services.model.addModel({
                         uri,
                         languageId: getModeFromPath(fileDiff.newPath),
                         text: dummyText,
                     })
+                    this.props.extensionsController.services.editor.addEditor({
+                        type: 'CodeEditor',
+                        resource: uri,
+                        selections: [],
+                        isActive: true,
+                    })
                 }
             }
         }
-        this.props.extensionsController.services.editor.nextEditors(editors)
     }
 }

--- a/web/src/repo/compare/FileDiffConnection.tsx
+++ b/web/src/repo/compare/FileDiffConnection.tsx
@@ -41,31 +41,37 @@ export class FileDiffConnection extends React.PureComponent<Props> {
         // API's support for diffs.
         const dummyText = ''
 
+        this.props.extensionsController.services.model.removeAllModels()
+
         const editors: CodeEditorData[] = []
         if (fileDiffsOrError && !isErrorLike(fileDiffsOrError)) {
             for (const fileDiff of fileDiffsOrError.nodes) {
                 if (fileDiff.oldPath) {
+                    const uri = `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`
                     editors.push({
                         type: 'CodeEditor',
-                        item: {
-                            uri: `git://${nodeProps.base.repoName}?${nodeProps.base.commitID}#${fileDiff.oldPath}`,
-                            languageId: getModeFromPath(fileDiff.oldPath),
-                            text: dummyText,
-                        },
+                        resource: uri,
                         selections: [],
                         isActive: false, // HACK: arbitrarily say that the base is inactive. TODO: support diffs first-class
                     })
+                    this.props.extensionsController.services.model.addModel({
+                        uri,
+                        languageId: getModeFromPath(fileDiff.oldPath),
+                        text: dummyText,
+                    })
                 }
                 if (fileDiff.newPath) {
+                    const uri = `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`
                     editors.push({
                         type: 'CodeEditor',
-                        item: {
-                            uri: `git://${nodeProps.head.repoName}?${nodeProps.head.commitID}#${fileDiff.newPath}`,
-                            languageId: getModeFromPath(fileDiff.newPath),
-                            text: dummyText,
-                        },
+                        resource: uri,
                         selections: [],
                         isActive: true,
+                    })
+                    this.props.extensionsController.services.model.addModel({
+                        uri,
+                        languageId: getModeFromPath(fileDiff.newPath),
+                        text: dummyText,
                     })
                 }
             }


### PR DESCRIPTION
# *DONOTREVIEW*

This makes (will make) it so that extensions can work with diff views:

- Add decorations to the raw diff content, not just the base/head documents (eg to make computing things like code churn easier)
- Contribute actions to diffs and diff hunks, not just the base/head documents (eg to implement "approve this hunk" or "approve this file's changes")
- Collapse and expand diff editors (eg to implement "show me only the parts of this PR that change code I own" or "...only hunks in this PR that nobody has approved yet")
- Add extra information about the PR, such as a nicer rendering of Codecov stats and a listing of all Datadog/LightStep metrics/traces affected by the PR