### PR TITLE
graphql: Add externalServices field to Repository

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -186,3 +186,28 @@ func (r *externalServiceConnectionResolver) PageInfo(ctx context.Context) (*grap
 	}
 	return graphqlutil.HasNextPage(r.opt.LimitOffset != nil && len(externalServices) >= r.opt.Limit), nil
 }
+
+type computedExternalServiceConnectionResolver struct {
+	args             graphqlutil.ConnectionArgs
+	externalServices []*types.ExternalService
+}
+
+func (r *computedExternalServiceConnectionResolver) Nodes(ctx context.Context) []*externalServiceResolver {
+	svcs := r.externalServices
+	if r.args.First != nil && int(*r.args.First) < len(svcs) {
+		svcs = svcs[:*r.args.First]
+	}
+	resolvers := make([]*externalServiceResolver, 0, len(svcs))
+	for _, svc := range svcs {
+		resolvers = append(resolvers, &externalServiceResolver{externalService: svc})
+	}
+	return resolvers
+}
+
+func (r *computedExternalServiceConnectionResolver) TotalCount(ctx context.Context) int32 {
+	return int32(len(r.externalServices))
+}
+
+func (r *computedExternalServiceConnectionResolver) PageInfo(ctx context.Context) *graphqlutil.PageInfo {
+	return graphqlutil.HasNextPage(r.args.First != nil && len(r.externalServices) >= int(*r.args.First))
+}

--- a/cmd/frontend/graphqlbackend/repository_external.go
+++ b/cmd/frontend/graphqlbackend/repository_external.go
@@ -1,5 +1,15 @@
 package graphqlbackend
 
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
+)
+
 func (r *repositoryResolver) ExternalRepository() *externalRepositoryResolver {
 	if r.repo.ExternalRepo == nil {
 		return nil
@@ -17,4 +27,43 @@ func (r *externalRepositoryResolver) ServiceType() string {
 }
 func (r *externalRepositoryResolver) ServiceID() string {
 	return r.repository.repo.ExternalRepo.ServiceID
+}
+
+func (r *repositoryResolver) ExternalServices(ctx context.Context, args *struct {
+	graphqlutil.ConnectionArgs
+}) (*computedExternalServiceConnectionResolver, error) {
+	// 🚨 SECURITY: Only site admins may read external services (they have secrets).
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	svcs, err := repoupdater.DefaultClient.RepoExternalServices(ctx, uint32(r.repo.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	return &computedExternalServiceConnectionResolver{
+		args:             args.ConnectionArgs,
+		externalServices: newExternalServices(svcs...),
+	}, nil
+}
+
+func newExternalServices(es ...api.ExternalService) []*types.ExternalService {
+	svcs := make([]*types.ExternalService, 0, len(es))
+
+	for _, e := range es {
+		svc := &types.ExternalService{
+			ID:          e.ID,
+			Kind:        e.Kind,
+			DisplayName: e.DisplayName,
+			Config:      e.Config,
+			CreatedAt:   e.CreatedAt,
+			UpdatedAt:   e.UpdatedAt,
+			DeletedAt:   e.DeletedAt,
+		}
+
+		svcs = append(svcs, svc)
+	}
+
+	return svcs
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -648,7 +648,7 @@ type Query {
     ): Repository
     # Lists all external services.
     externalServices(
-        # Returns the first n repositories from the list.
+        # Returns the first n external services from the list.
         first: Int
     ): ExternalServiceConnection!
     # List all repositories.
@@ -1132,6 +1132,11 @@ type Repository implements Node & GenericSearchResultInterface {
     # Information about this repository from the external service that it originates from (such as GitHub, GitLab,
     # Phabricator, etc.).
     externalRepository: ExternalRepository
+    # Lists all external services which yield this repository.
+    externalServices(
+        # Returns the first n external services from the list.
+        first: Int
+    ): ExternalServiceConnection!
     # Whether the repository is currently being cloned.
     cloneInProgress: Boolean! @deprecated(reason: "use Repository.mirrorInfo.cloneInProgress instead")
     # Information about the text search index for this repository, or null if text search indexing

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -655,7 +655,7 @@ type Query {
     ): Repository
     # Lists all external services.
     externalServices(
-        # Returns the first n repositories from the list.
+        # Returns the first n external services from the list.
         first: Int
     ): ExternalServiceConnection!
     # List all repositories.
@@ -1139,6 +1139,11 @@ type Repository implements Node & GenericSearchResultInterface {
     # Information about this repository from the external service that it originates from (such as GitHub, GitLab,
     # Phabricator, etc.).
     externalRepository: ExternalRepository
+    # Lists all external services which yield this repository.
+    externalServices(
+        # Returns the first n external services from the list.
+        first: Int
+    ): ExternalServiceConnection!
     # Whether the repository is currently being cloned.
     cloneInProgress: Boolean! @deprecated(reason: "use Repository.mirrorInfo.cloneInProgress instead")
     # Information about the text search index for this repository, or null if text search indexing

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -4,11 +4,12 @@ package repoupdater
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -163,7 +164,9 @@ func respond(w http.ResponseWriter, code int, v interface{}) {
 	case error:
 		if val != nil {
 			log15.Error(val.Error())
-			http.Error(w, val.Error(), code)
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(code)
+			fmt.Fprintf(w, "%v", val)
 		}
 	default:
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -70,7 +70,7 @@ func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Reque
 	}
 
 	if len(rs) == 0 {
-		respond(w, http.StatusOK, resp)
+		respond(w, http.StatusNotFound, errors.Errorf("repository with ID %v does not exist", req.ID))
 		return
 	}
 

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -448,6 +448,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 			}
 
 			srv := httptest.NewServer((&Server{Kinds: tc.kinds, Store: store}).Handler())
+			defer src.Close()
 			cli := repoupdater.Client{URL: srv.URL}
 
 			if tc.err == "" {
@@ -583,6 +584,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 	}}
 
 	srv := httptest.NewServer((&Server{Store: store}).Handler())
+	defer src.Close()
 	cli := repoupdater.Client{URL: srv.URL}
 	for _, tc := range testCases {
 		tc := tc

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -497,6 +497,108 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 	}
 }
 
+func TestServer_RepoExternalServices(t *testing.T) {
+	service1 := &repos.ExternalService{
+		ID:          1,
+		Kind:        "GITHUB",
+		DisplayName: "github.com - test",
+		Config: formatJSON(`
+		{
+			// Some comment
+			"url": "https://github.com",
+			"token": "secret"
+		}`),
+	}
+	service2 := &repos.ExternalService{
+		ID:          2,
+		Kind:        "GITHUB",
+		DisplayName: "github.com - test2",
+		Config: formatJSON(`
+		{
+			// Some comment
+			"url": "https://github.com",
+			"token": "secret"
+		}`),
+	}
+
+	// No sources are repos that are not managed by the syncer
+	repoNoSources := &repos.Repo{
+		Name: "gitolite.example.com/oldschool",
+	}
+
+	repoOneSource := (&repos.Repo{
+		Name: "github.com/foo/onesource",
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "onesource",
+			ServiceType: "github",
+			ServiceID:   "http://github.com",
+		},
+		Metadata: new(github.Repository),
+	}).With(repos.Opt.RepoSources(service1.URN()))
+
+	repoTwoSources := (&repos.Repo{
+		Name: "github.com/foo/twosources",
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "twosources",
+			ServiceType: "github",
+			ServiceID:   "http://github.com",
+		},
+		Metadata: new(github.Repository),
+	}).With(repos.Opt.RepoSources(service1.URN(), service2.URN()))
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// We share the store across test cases. Initialize now so we have IDs
+	// set for test cases.
+	ctx := context.Background()
+	store := new(repos.FakeStore)
+	must(store.UpsertExternalServices(ctx, service1, service2))
+	must(store.UpsertRepos(ctx, repoNoSources, repoOneSource, repoTwoSources))
+
+	testCases := []struct {
+		name   string
+		repoID uint32
+		svcs   []api.ExternalService
+	}{{
+		name:   "repo no sources",
+		repoID: repoNoSources.ID,
+		svcs:   nil,
+	}, {
+		name:   "repo one source",
+		repoID: repoOneSource.ID,
+		svcs:   apiExternalServices(service1),
+	}, {
+		name:   "repo two sources",
+		repoID: repoTwoSources.ID,
+		svcs:   apiExternalServices(service1, service2),
+	}, {
+		name:   "repo not in store",
+		repoID: 42,
+		svcs:   nil,
+	}}
+
+	srv := httptest.NewServer((&Server{Store: store}).Handler())
+	cli := repoupdater.Client{URL: srv.URL}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := cli.RepoExternalServices(ctx, tc.repoID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := res, tc.svcs; !reflect.DeepEqual(have, want) {
+				t.Errorf("response:\n%s", cmp.Diff(have, want))
+			}
+		})
+	}
+}
+
 func apiExternalServices(es ...*repos.ExternalService) []api.ExternalService {
 	if len(es) == 0 {
 		return nil

--- a/pkg/repoupdater/client.go
+++ b/pkg/repoupdater/client.go
@@ -189,6 +189,31 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 	return &result, nil
 }
 
+// RepoExternalServices requests the external services associated with a
+// repository with the given id.
+func (c *Client) RepoExternalServices(ctx context.Context, id uint32) ([]api.ExternalService, error) {
+	req := protocol.RepoExternalServicesRequest{ID: id}
+	resp, err := c.httpPost(ctx, "repo-external-services", &req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read response body")
+	}
+
+	var res protocol.RepoExternalServicesResponse
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, errors.New(string(bs))
+	} else if err = json.Unmarshal(bs, &res); err != nil {
+		return nil, err
+	}
+
+	return res.ExternalServices, nil
+}
+
 // ExcludeRepo adds the repository with the given id to all of the
 // external services exclude lists that match its kind.
 func (c *Client) ExcludeRepo(ctx context.Context, id uint32) (*protocol.ExcludeRepoResponse, error) {

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -31,6 +31,19 @@ type RepoQueueState struct {
 	Updating bool
 }
 
+// RepoExternalServicesRequest is a request for the external services
+// associated with a repository.
+type RepoExternalServicesRequest struct {
+	// ID of the repository being queried.
+	ID uint32
+}
+
+// RepoExternalServicesResponse is returned in response to an
+// RepoExternalServicesRequest.
+type RepoExternalServicesResponse struct {
+	ExternalServices []api.ExternalService
+}
+
 // ExcludeRepoRequest is a request to exclude a single repo from
 // being mirrored from any external service of its kind.
 type ExcludeRepoRequest struct {


### PR DESCRIPTION
This will be used to display links to the external services for a repository
on the repository settings page.

Test plan: Tests are added for the repo-updater API changes. Manual testing for GraphQL backend done in another PR which uses the new field.

Part of #2025