### PR TITLE
docs: add docker compose file to help constrain zoekt

### DIFF
--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '2.2'
 services:
     server:
         container_name: sourcegraph
-        image: 'sourcegraph/server-signed:3.2.1'
+        image: 'sourcegraph/server-signed:3.2.1@sha256:832bc27c36416b2524b78f62eb60cfd93f54a07eb66dbc45687239d8d3fe66b0'
         ports:
             - '7080:7080'
             - '2633:2633'

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
         image: 'sourcegraph/zoekt-indexserver:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f'
         networks:
             - sourcegraph
+
         # Restrict the container to use at most 3 gigs of RAM
         mem_limit: 3g
         # Restrict the container to use at most 2 full CPU cores
@@ -45,6 +46,7 @@ services:
         image: 'sourcegraph/zoekt-webserver:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205'
         networks:
             - sourcegraph
+
         # Restrict the container to use at most 3 gigs of RAM
         mem_limit: 3g
         # Restrict the container to use at most 2 full CPU cores

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '2.2'
 services:
     server:
         container_name: server
-        image: 'sourcegraph/server-signed:3.2.1@sha256:832bc27c36416b2524b78f62eb60cfd93f54a07eb66dbc45687239d8d3fe66b0'
+        image: 'sourcegraph/server-signed:3.2.2@sha256:30e27164231d602fba51053e85a7f1f0799297f4df44c565acd1922d96ef185d'
         ports:
             - '7080:7080'
             - '2633:2633'
@@ -38,8 +38,8 @@ services:
         environment:
             - 'SRC_FRONTEND_INTERNAL=http://server:3090'
         volumes:
-            # Replace ~/.zoekt with the host folder that you'd like the container to use
-            - '~/.zoekt:/data/index'
+            # Replace ~/.sourcegraph with the host folder that you'd like the container to use
+            - '~/.sourcegraph/data/zoekt:/data/index'
         restart: always
         depends_on:
             - server
@@ -58,8 +58,8 @@ services:
         cpu_shares: 512
 
         volumes:
-            # Replace ~/.zoekt with the host folder that you'd like the container to use
-            - '~/.zoekt:/data/index'
+            # Replace ~/.sourcegraph with the host folder that you'd like the container to use
+            - '~/.sourcegraph/data/zoekt:/data/index'
         restart: always
         depends_on:
             - zoekt-indexserver

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
         ports:
             - '7080:7080'
             - '2633:2633'
+        networks:
+            - sourcegraph
         environment:
             # Tell sourcegraph/server to use the external Zoekt containers
             - 'ZOEKT_HOST=zoekt-webserver:6070'
@@ -19,7 +21,8 @@ services:
     zoekt-indexserver:
         container_name: zoekt-indexserver
         image: 'sourcegraph/zoekt-indexserver:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f'
-
+        networks:
+            - sourcegraph
         # Restrict the container to use at most 3 gigs of RAM
         mem_limit: 3g
         # Restrict the container to use at most 2 full CPU cores
@@ -40,7 +43,8 @@ services:
     zoekt-webserver:
         container_name: zoekt-webserver
         image: 'sourcegraph/zoekt-webserver:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205'
-
+        networks:
+            - sourcegraph
         # Restrict the container to use at most 3 gigs of RAM
         mem_limit: 3g
         # Restrict the container to use at most 2 full CPU cores
@@ -55,3 +59,7 @@ services:
         restart: always
         depends_on:
             - zoekt-indexserver
+
+networks:
+    sourcegraph:
+        name: sourcegraph

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
 
     zoekt-indexserver:
         container_name: zoekt-indexserver
-        image: 'sourcegraph/zoekt-indexserver:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f'
+        image: 'sourcegraph/zoekt-indexserver-signed:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f'
         networks:
             - sourcegraph
 
@@ -43,7 +43,7 @@ services:
 
     zoekt-webserver:
         container_name: zoekt-webserver
-        image: 'sourcegraph/zoekt-webserver:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205'
+        image: 'sourcegraph/zoekt-webserver-signed:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205'
         networks:
             - sourcegraph
 

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
             - 'SRC_FRONTEND_INTERNAL=http://server:3090'
         volumes:
             # Replace ~/.sourcegraph with the host folder that you'd like the container to use
-            - '~/.sourcegraph/data/zoekt:/data/index'
+            - '~/.sourcegraph/data/zoekt:/data'
         restart: always
         depends_on:
             - server
@@ -59,7 +59,7 @@ services:
 
         volumes:
             # Replace ~/.sourcegraph with the host folder that you'd like the container to use
-            - '~/.sourcegraph/data/zoekt:/data/index'
+            - '~/.sourcegraph/data/zoekt:/data'
         restart: always
         depends_on:
             - zoekt-indexserver

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
         image: 'sourcegraph/zoekt-indexserver:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f'
         mem_limit: 3g
         cpus: 2
+        cpu_shares: 512
         environment:
             - 'SRC_FRONTEND_INTERNAL=http://sourcegraph:3090'
         volumes:
@@ -32,6 +33,7 @@ services:
         image: 'sourcegraph/zoekt-webserver:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205'
         mem_limit: 3g
         cpus: 2
+        cpu_shares: 512
         volumes:
             - '~/zoekt:/data/index'
         restart: always

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
         environment:
             - 'SRC_FRONTEND_INTERNAL=http://sourcegraph:3090'
         volumes:
-            - '~/zoekt:/data/index'
+            - '~/.zoekt:/data/index'
         restart: always
         depends_on:
             - server
@@ -35,7 +35,7 @@ services:
         cpus: 2
         cpu_shares: 512
         volumes:
-            - '~/zoekt:/data/index'
+            - '~/.zoekt:/data/index'
         restart: always
         depends_on:
             - zoekt-indexserver

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -2,14 +2,16 @@ version: '2.2'
 
 services:
     server:
-        container_name: sourcegraph
+        container_name: server
         image: 'sourcegraph/server-signed:3.2.1@sha256:832bc27c36416b2524b78f62eb60cfd93f54a07eb66dbc45687239d8d3fe66b0'
         ports:
             - '7080:7080'
             - '2633:2633'
         environment:
+            # Tell sourcegraph/server to use the external Zoekt containers
             - 'ZOEKT_HOST=zoekt-webserver:6070'
         volumes:
+            # Replace ~/.sourcegraph with the host folder that you'd like to mount for the container to use
             - '~/.sourcegraph/config:/etc/sourcegraph'
             - '~/.sourcegraph/data:/var/opt/sourcegraph'
         restart: always
@@ -17,12 +19,19 @@ services:
     zoekt-indexserver:
         container_name: zoekt-indexserver
         image: 'sourcegraph/zoekt-indexserver:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f'
+
+        # Restrict the container to use at most 3 gigs of RAM
         mem_limit: 3g
+        # Restrict the container to use at most 2 full CPU cores
         cpus: 2
+        # When the system is under-load, this container has 50% CPU priority when compared to
+        # the 'server' container
         cpu_shares: 512
+
         environment:
-            - 'SRC_FRONTEND_INTERNAL=http://sourcegraph:3090'
+            - 'SRC_FRONTEND_INTERNAL=http://server:3090'
         volumes:
+            # Replace ~/.zoekt with the host folder that you'd like the container to use
             - '~/.zoekt:/data/index'
         restart: always
         depends_on:
@@ -31,10 +40,17 @@ services:
     zoekt-webserver:
         container_name: zoekt-webserver
         image: 'sourcegraph/zoekt-webserver:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205'
+
+        # Restrict the container to use at most 3 gigs of RAM
         mem_limit: 3g
+        # Restrict the container to use at most 2 full CPU cores
         cpus: 2
+        # When the system is under-load, this container has 50% CPU priority when compared to
+        # the 'server' container
         cpu_shares: 512
+
         volumes:
+            # Replace ~/.zoekt with the host folder that you'd like the container to use
             - '~/.zoekt:/data/index'
         restart: always
         depends_on:

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -9,6 +9,10 @@ services:
             - '2633:2633'
         networks:
             - sourcegraph
+
+        # When the system is under-load, this container has 2x the CPU priorty of the Zoekt containers
+        cpu_shares: 1024
+
         environment:
             # Tell sourcegraph/server to use the external Zoekt containers
             - 'ZOEKT_HOST=zoekt-webserver:6070'
@@ -28,8 +32,7 @@ services:
         mem_limit: 3g
         # Restrict the container to use at most 2 full CPU cores
         cpus: 2
-        # When the system is under-load, this container has 50% CPU priority when compared to
-        # the 'server' container
+        # When the system is under-load, this container has 1/2 the CPU priority of the 'server' container
         cpu_shares: 512
 
         environment:
@@ -51,8 +54,7 @@ services:
         mem_limit: 3g
         # Restrict the container to use at most 2 full CPU cores
         cpus: 2
-        # When the system is under-load, this container has 50% CPU priority when compared to
-        # the 'server' container
+        # When the system is under-load, this container has 1/2 the CPU priority of the 'server' container
         cpu_shares: 512
 
         volumes:

--- a/doc/admin/install/docker/docker-compose.yaml
+++ b/doc/admin/install/docker/docker-compose.yaml
@@ -1,0 +1,39 @@
+version: '2.2'
+
+services:
+    server:
+        container_name: sourcegraph
+        image: 'sourcegraph/server-signed:3.2.1'
+        ports:
+            - '7080:7080'
+            - '2633:2633'
+        environment:
+            - 'ZOEKT_HOST=zoekt-webserver:6070'
+        volumes:
+            - '~/.sourcegraph/config:/etc/sourcegraph'
+            - '~/.sourcegraph/data:/var/opt/sourcegraph'
+        restart: always
+
+    zoekt-indexserver:
+        container_name: zoekt-indexserver
+        image: 'sourcegraph/zoekt-indexserver:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f'
+        mem_limit: 3g
+        cpus: 2
+        environment:
+            - 'SRC_FRONTEND_INTERNAL=http://sourcegraph:3090'
+        volumes:
+            - '~/zoekt:/data/index'
+        restart: always
+        depends_on:
+            - server
+
+    zoekt-webserver:
+        container_name: zoekt-webserver
+        image: 'sourcegraph/zoekt-webserver:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205'
+        mem_limit: 3g
+        cpus: 2
+        volumes:
+            - '~/zoekt:/data/index'
+        restart: always
+        depends_on:
+            - zoekt-indexserver


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/C0W2E592M/p1554755077006000

This PR adds a docker compose file to our docs that can limit the amount of CPU / RAM that Zoekt can use. 

I think the issues in https://github.com/sourcegraph/sourcegraph/issues/3294 are exacerbated by Zoekt's indexing process starving out the other processes in the sourcegraph/server image (e.g. Zoekt is starving out frontend/searcher). 

This alone won't fix the issue that the customer is experiencing, but adding resource isolation should help their system have more predictable performance. 
