### PR TITLE
better error message

### DIFF
--- a/pkg/gitserver/client.go
+++ b/pkg/gitserver/client.go
@@ -485,6 +485,9 @@ func (c *Client) IsRepoCloneable(ctx context.Context, repo Repo) error {
 	if err != nil {
 		return err
 	}
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("gitserver error (status code %d): %s", r.StatusCode, string(body))
+	}
 
 	// Try unmarshaling new response format (?v=2) first.
 	var resp protocol.IsRepoCloneableResponse


### PR DESCRIPTION
Previously, the error message was the JSON parsing one that you'd hit later in the method. This error gets shown in the UI and thus was confusing.