### PR TITLE
cmd/server: don't spin up zoekt if using an external host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The default `github.repositoryQuery` of a [GitHub external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["affiliated", "public"]`).
 - The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
 - The `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) is now **required**. This field is necessary to authenticate with the Bitbucket Server API with either `password` or `token`.
+- When using an external Zoekt instance (specified via the `ZOEKT_HOST` environment variable), sourcegraph/server no longer spins up a redundant internal Zoekt instance.
 
 ### Removed
 

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -5,7 +5,6 @@ package shared
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -18,9 +17,6 @@ import (
 
 // FrontendInternalHost is the value of SRC_FRONTEND_INTERNAL.
 const FrontendInternalHost = "127.0.0.1:3090"
-
-// zoektHost is the address zoekt webserver is listening on.
-const zoektHost = "127.0.0.1:3070"
 
 // defaultEnv is environment variables that will be set if not already set.
 var defaultEnv = map[string]string{
@@ -35,7 +31,6 @@ var defaultEnv = map[string]string{
 	"SRC_HTTPS_ADDR":        ":8443",
 	"SRC_FRONTEND_INTERNAL": FrontendInternalHost,
 	"GITHUB_BASE_URL":       "http://127.0.0.1:3180", // points to github-proxy
-	"ZOEKT_HOST":            zoektHost,
 
 	// Limit our cache size to 100GB, same as prod. We should probably update
 	// searcher/symbols to ensure this value isn't larger than the volume for
@@ -137,12 +132,6 @@ func Main() {
 		log.Fatal("Failed to setup nginx:", err)
 	}
 
-	zoektIndexDir := filepath.Join(DataDir, "zoekt/index")
-	debugFlag := ""
-	if verbose {
-		debugFlag = "-debug"
-	}
-
 	procfile := []string{
 		nginx,
 		`frontend: env CONFIGURATION_MODE=server frontend`,
@@ -154,8 +143,6 @@ func Main() {
 		`github-proxy: github-proxy`,
 		`repo-updater: repo-updater`,
 		`syntect_server: sh -c 'env QUIET=true ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_PORT=9238 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' ROCKET_ENV=production syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"'`,
-		fmt.Sprintf("zoekt-indexserver: zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 %s", FrontendInternalHost, zoektIndexDir, debugFlag),
-		fmt.Sprintf("zoekt-webserver: zoekt-webserver -rpc -pprof -listen %s -index %s", zoektHost, zoektIndexDir),
 	}
 	procfile = append(procfile, ProcfileAdditions...)
 	if line, err := maybeRedisProcFile(); err != nil {
@@ -167,6 +154,10 @@ func Main() {
 		log.Fatal(err)
 	} else if line != "" {
 		procfile = append(procfile, line)
+	}
+
+	if lines := maybeZoektProcFile(); lines != nil {
+		procfile = append(procfile, lines...)
 	}
 
 	const goremanAddr = "127.0.0.1:5005"

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -156,9 +156,7 @@ func Main() {
 		procfile = append(procfile, line)
 	}
 
-	if lines := maybeZoektProcFile(); lines != nil {
-		procfile = append(procfile, lines...)
-	}
+	procfile = append(procfile, maybeZoektProcFile()...)
 
 	const goremanAddr = "127.0.0.1:5005"
 	if err := os.Setenv("GOREMAN_RPC_ADDR", goremanAddr); err != nil {

--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -1,0 +1,30 @@
+package shared
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func maybeZoektProcFile() []string {
+	// Zoekt is alreay configured
+	if os.Getenv("ZOEKT_HOST") != "" {
+		return nil
+	}
+
+	defaultHost := "127.0.0.1:3070"
+	SetDefaultEnv("ZOEKT_HOST", defaultHost)
+
+	frontendInternalHost := os.Getenv("SRC_FRONTEND_INTERNAL")
+	indexDir := filepath.Join(DataDir, "zoekt/index")
+
+	debugFlag := ""
+	if verbose {
+		debugFlag = "-debug"
+	}
+
+	return []string{
+		fmt.Sprintf("zoekt-indexserver: zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 %s", frontendInternalHost, indexDir, debugFlag),
+		fmt.Sprintf("zoekt-webserver: zoekt-webserver -rpc -pprof -listen %s -index %s", defaultHost, indexDir),
+	}
+}


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/pull/3332#discussion_r273723359

When using an external Zoekt instance (specified via `ZOEKT_HOST`), sourcegraph/server shouldn't spin up its own (redundant) internal Zoekt instance. This PR resolves that. 