### PR TITLE
1624 index large files

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -93,6 +93,7 @@ func NewInternalHandler(m *mux.Router) http.Handler {
 	m.Get(apirouter.Telemetry).Handler(trace.TraceRoute(telemetryHandler))
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL)))
 	m.Get(apirouter.Configuration).Handler(trace.TraceRoute(handler(serveConfiguration)))
+	m.Get(apirouter.SearchConfiguration).Handler(trace.TraceRoute(handler(serveSearchConfiguration)))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -186,7 +186,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 	}
 	err := json.NewEncoder(w).Encode(opts)
 	if err != nil {
-		return errors.Wrap(err, "Encode")
+		return errors.Wrap(err, "encode")
 	}
 	return nil
 }

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -171,7 +171,7 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 }
 
 type searchOptions struct {
-	LargeFiles *[]string
+	LargeFiles []string
 }
 
 func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -174,6 +174,11 @@ type searchOptions struct {
 	LargeFiles []string
 }
 
+// serveSearchConfiguration is _only_ used by the zoekt index server. Zoekt does
+// not depend on frontend and therefore does not have access to `conf.Watch`.
+// Additionally, it only cares about certain search specific settings so this
+// search specific endpoint is used rather than serving the entire site settings
+// from /.internal/configuration.
 func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 	largeFiles := conf.Get().SearchLargeFiles
 	opts := searchOptions{

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -170,10 +170,6 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-type searchOptions struct {
-	LargeFiles []string
-}
-
 // serveSearchConfiguration is _only_ used by the zoekt index server. Zoekt does
 // not depend on frontend and therefore does not have access to `conf.Watch`.
 // Additionally, it only cares about certain search specific settings so this
@@ -181,7 +177,9 @@ type searchOptions struct {
 // from /.internal/configuration.
 func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 	largeFiles := conf.Get().SearchLargeFiles
-	opts := searchOptions{
+	opts := struct {
+		LargeFiles []string
+	}{
 		LargeFiles: largeFiles,
 	}
 	err := json.NewEncoder(w).Encode(opts)

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -170,6 +170,22 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
+type searchOptions struct {
+	LargeFiles *[]string
+}
+
+func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
+	largeFiles := conf.Get().SearchLargeFiles
+	opts := searchOptions{
+		LargeFiles: largeFiles,
+	}
+	err := json.NewEncoder(w).Encode(opts)
+	if err != nil {
+		return errors.Wrap(err, "Encode")
+	}
+	return nil
+}
+
 func serveReposList(w http.ResponseWriter, r *http.Request) error {
 	var opt db.ReposListOptions
 	err := json.NewDecoder(r.Body).Decode(&opt)

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -40,6 +40,7 @@ const (
 	ReposListEnabled       = "internal.repos.list-enabled"
 	ReposUpdateMetadata    = "internal.repos.update-metadata"
 	Configuration          = "internal.configuration"
+	SearchConfiguration    = "internal.search-configuration"
 	ExternalServiceConfigs = "internal.external-services.configs"
 	ExternalServicesList   = "internal.external-services.list"
 )
@@ -104,6 +105,7 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/repos/update-metadata").Methods("POST").Name(ReposUpdateMetadata)
 	base.Path("/repos/{RepoName:.*}").Methods("POST").Name(ReposGetByName)
 	base.Path("/configuration").Methods("POST").Name(Configuration)
+	base.Path("/search/configuration").Methods("GET").Name(SearchConfiguration)
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
 	addTelemetryRoute(base)

--- a/cmd/searcher/search/store.go
+++ b/cmd/searcher/search/store.go
@@ -72,7 +72,7 @@ type Store struct {
 	// largeFilesPatterns is a list of large file glob patterns where files that
 	// match any pattern in the list should be searched regardless of their size.
 	largeFilePatterns []string
-	lfMu              sync.Mutex
+	lfMu              sync.RWMutex
 }
 
 // SetMaxConcurrentFetchTar sets the maximum number of concurrent calls allowed
@@ -352,6 +352,8 @@ func (s *Store) watchAndEvict() {
 // ignoreSizeMax determines whether the max size should be ignored. It uses
 // the glob syntax found here: https://golang.org/pkg/path/filepath/#Match.
 func (s *Store) ignoreSizeMax(name string) bool {
+	s.lfMu.RLock()
+	defer s.lfMu.RUnlock()
 	for _, pattern := range s.largeFilePatterns {
 		pattern = strings.TrimSpace(pattern)
 		if m, _ := filepath.Match(pattern, name); m {

--- a/cmd/searcher/search/store.go
+++ b/cmd/searcher/search/store.go
@@ -102,6 +102,7 @@ func (s *Store) Start() {
 			BeforeEvict:       s.zipCache.delete,
 		}
 		go s.watchAndEvict()
+		go s.watchLargeFilesChange()
 	})
 }
 

--- a/cmd/searcher/search/store_test.go
+++ b/cmd/searcher/search/store_test.go
@@ -94,6 +94,37 @@ func TestPrepareZip_fetchTarFail(t *testing.T) {
 	}
 }
 
+func TestIngoreSizeMax(t *testing.T) {
+	patterns := []string{
+		"foo",
+		"foo.*",
+		"foo_*",
+		"*.foo",
+		"bar.baz",
+	}
+	tests := []struct {
+		name    string
+		ignored bool
+	}{
+		// Pass
+		{"foo", true},
+		{"foo.bar", true},
+		{"foo_bar", true},
+		{"bar.baz", true},
+		{"bar.foo", true},
+		// Fail
+		{"baz.foo.bar", false},
+		{"bar_baz", false},
+		{"bar.foo", false},
+	}
+
+	for _, test := range tests {
+		if got, want := ignoreSizeMax(test.name, patterns), test.ignored; got != want {
+			t.Errorf("got %v want %v", got, want)
+		}
+	}
+}
+
 func tmpStore(t *testing.T) (*Store, func()) {
 	d, err := ioutil.TempDir("", "search_test")
 	if err != nil {

--- a/cmd/searcher/search/store_test.go
+++ b/cmd/searcher/search/store_test.go
@@ -115,12 +115,12 @@ func TestIngoreSizeMax(t *testing.T) {
 		// Fail
 		{"baz.foo.bar", false},
 		{"bar_baz", false},
-		{"bar.foo", false},
+		{"baz.baz", false},
 	}
 
 	for _, test := range tests {
 		if got, want := ignoreSizeMax(test.name, patterns), test.ignored; got != want {
-			t.Errorf("got %v want %v", got, want)
+			t.Errorf("case %s got %v want %v", test.name, got, want)
 		}
 	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -432,6 +432,7 @@ type SiteConfiguration struct {
 	ParentSourcegraph                 *ParentSourcegraph          `json:"parentSourcegraph,omitempty"`
 	RepoListUpdateInterval            int                         `json:"repoListUpdateInterval,omitempty"`
 	SearchIndexEnabled                *bool                       `json:"search.index.enabled,omitempty"`
+	SearchLargeFiles                  *[]string                   `json:"search.largeFiles,omitempty"`
 }
 
 // SlackNotificationsConfig description: Configuration for sending notifications to Slack.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -432,7 +432,7 @@ type SiteConfiguration struct {
 	ParentSourcegraph                 *ParentSourcegraph          `json:"parentSourcegraph,omitempty"`
 	RepoListUpdateInterval            int                         `json:"repoListUpdateInterval,omitempty"`
 	SearchIndexEnabled                *bool                       `json:"search.index.enabled,omitempty"`
-	SearchLargeFiles                  *[]string                   `json:"search.largeFiles,omitempty"`
+	SearchLargeFiles                  []string                    `json:"search.largeFiles,omitempty"`
 }
 
 // SlackNotificationsConfig description: Configuration for sending notifications to Slack.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -28,7 +28,6 @@
       "items": {
         "type": "string"
       },
-      "!go": { "pointer": true },
       "group": "Search"
     },
     "experimentalFeatures": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -23,12 +23,13 @@
       "group": "Search"
     },
     "search.largeFiles": {
-      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size.",
+      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.",
       "type": "array",
       "items": {
         "type": "string"
       },
-      "group": "Search"
+      "group": "Search",
+      "examples": [["go.sum", "package-lock.json", "*.thrift"]]
     },
     "experimentalFeatures": {
       "description": "Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -22,6 +22,15 @@
       "!go": { "pointer": true },
       "group": "Search"
     },
+    "search.largeFiles": {
+      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "!go": { "pointer": true },
+      "group": "Search"
+    },
     "experimentalFeatures": {
       "description": "Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.",
       "type": "object",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -33,7 +33,6 @@ const SiteSchemaJSON = `{
       "items": {
         "type": "string"
       },
-      "!go": { "pointer": true },
       "group": "Search"
     },
     "experimentalFeatures": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -28,12 +28,13 @@ const SiteSchemaJSON = `{
       "group": "Search"
     },
     "search.largeFiles": {
-      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size.",
+      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.",
       "type": "array",
       "items": {
         "type": "string"
       },
-      "group": "Search"
+      "group": "Search",
+      "examples": [["go.sum", "package-lock.json", "*.thrift"]]
     },
     "experimentalFeatures": {
       "description": "Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -27,6 +27,15 @@ const SiteSchemaJSON = `{
       "!go": { "pointer": true },
       "group": "Search"
     },
+    "search.largeFiles": {
+      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "!go": { "pointer": true },
+      "group": "Search"
+    },
     "experimentalFeatures": {
       "description": "Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.",
       "type": "object",


### PR DESCRIPTION
This PR is part of the solution for #1624. We are adding a configuration option called "search.largeFiles" which is a list of glob patterns. Any files matching the patterns in the list will be indexed and searched regardless of the size.

This PR:
- adds the setting
- adds an internal endpoint that serves this setting for zoekt to consume
- uses the setting in searcher

Test plan: 

Testing searcher implementation:

* Run sourcegraph
* Make sure basic text search is ran by disabling indexing `"search.index.enabled": false,`
* Add a large file to a repo. (e.g. [ijsnow/tmp](https://github.com/ijsnow/tmp))
* Make sure we don't search it
* Add `"search.largeFiles": ["bigfile.txt"]` to config
* Make sure it is in search results