### PR TITLE
web: Add external service cards to repo settings page

### DIFF
--- a/web/src/components/ExternalServiceCard.tsx
+++ b/web/src/components/ExternalServiceCard.tsx
@@ -1,4 +1,5 @@
 import H from 'history'
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import React from 'react'
 import { LinkOrButton } from '../../../shared/src/components/LinkOrButton'
 
@@ -47,6 +48,7 @@ export class ExternalServiceCard extends React.PureComponent<ExternalServiceCard
                     <h3 className="external-service-card__main-header">{this.props.title}</h3>
                     <p className="external-service-card__main-body">{this.props.shortDescription}</p>
                 </div>
+                {this.props.to && <ChevronRightIcon className="align-self-center" />}
             </div>
         )
         if (this.props.to) {

--- a/web/src/repo/settings/RepoSettingsOptionsPage.scss
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.scss
@@ -1,1 +1,6 @@
 @import './components/ActionContainer';
+
+.repo-settings-options-page__card {
+    display: block;
+    margin-bottom: 1rem;
+}

--- a/web/src/repo/settings/RepoSettingsOptionsPage.scss
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.scss
@@ -1,6 +1,1 @@
 @import './components/ActionContainer';
-
-.repo-settings-options-page__card {
-    display: block;
-    margin-bottom: 1rem;
-}

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -70,8 +70,8 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                 {this.state.error && <div className="alert alert-danger">{upperFirst(this.state.error)}</div>}
                 {services.length > 0 && (
                     <div className="mb-4">
-                        {services.map((service, i) => (
-                            <div className="mb-3" key={i}>
+                        {services.map(service => (
+                            <div className="mb-3" key={service.id}>
                                 <ExternalServiceCard
                                     {...getExternalService(service.kind)}
                                     title={service.displayName}

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -69,9 +69,9 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
                 {this.state.error && <div className="alert alert-danger">{upperFirst(this.state.error)}</div>}
                 {services.length > 0 && (
-                    <div className="mb-3">
+                    <div className="mb-4">
                         {services.map((service, i) => (
-                            <div className="repo-settings-options-page__card" key={i}>
+                            <div className="mb-3" key={i}>
                                 <ExternalServiceCard
                                     {...getExternalService(service.kind)}
                                     title={service.displayName}

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -6,9 +6,11 @@ import { Subject, Subscription } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 import { REPO_DELETE_CONFIRMATION_MESSAGE } from '.'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { ExternalServiceCard } from '../../components/ExternalServiceCard'
 import { Form } from '../../components/Form'
 import { PageTitle } from '../../components/PageTitle'
 import { deleteRepository, setRepositoryEnabled } from '../../site-admin/backend'
+import { getExternalService } from '../../site-admin/externalServices'
 import { eventLogger } from '../../tracking/eventLogger'
 import { fetchRepository } from './backend'
 import { ActionContainer } from './components/ActionContainer'
@@ -59,12 +61,33 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
     }
 
     public render(): JSX.Element | null {
+        const services = this.state.repo.externalServices.nodes
         return (
             <div className="repo-settings-options-page">
                 <PageTitle title="Repository settings" />
                 <h2>Settings</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
                 {this.state.error && <div className="alert alert-danger">{upperFirst(this.state.error)}</div>}
+                {services.length > 0 && (
+                    <div className="mb-3">
+                        {services.map((service, i) => (
+                            <div className="repo-settings-options-page__card" key={i}>
+                                <ExternalServiceCard
+                                    {...getExternalService(service.kind)}
+                                    title={service.displayName}
+                                    shortDescription="Update this external service configuration to manage repository mirroring."
+                                    to={`/site-admin/external-services/${service.id}`}
+                                />
+                            </div>
+                        ))}
+                        {services.length > 1 && (
+                            <p>
+                                This repository is mirrored by multiple external services. To change access, disable, or
+                                remove this repository, the configuration must be updated on all external services.
+                            </p>
+                        )}
+                    </div>
+                )}
                 <Form>
                     <div className="form-group">
                         <label htmlFor="repo-settings-options-page__name">Repository name</label>
@@ -83,25 +106,27 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                         />
                     </div>
                 </Form>
-                <ActionContainer
-                    title={this.state.repo.enabled ? 'Disable access' : 'Enable access'}
-                    description={
-                        this.state.repo.enabled
-                            ? 'Disable access to the repository to prevent users from searching and browsing the repository.'
-                            : 'The repository is disabled. Enable it to allow users to search and view the repository.'
-                    }
-                    buttonClassName={this.state.repo.enabled ? 'btn-danger' : 'btn-success'}
-                    buttonLabel={this.state.repo.enabled ? 'Disable access' : 'Enable access'}
-                    flashText="Updated"
-                    run={this.state.repo.enabled ? this.disableRepository : this.enableRepository}
-                />
-                <ActionContainer
-                    title="Delete repository"
-                    description="Permanently removes this repository and all associated data from Sourcegraph. The original repository on the code host is not affected. If this repository was added by a configured code host, then it will be re-added during the next sync."
-                    buttonClassName="btn-danger"
-                    buttonLabel="Delete this repository"
-                    run={this.deleteRepository}
-                />
+                {services.length === 0 && [
+                    <ActionContainer
+                        title={this.state.repo.enabled ? 'Disable access' : 'Enable access'}
+                        description={
+                            this.state.repo.enabled
+                                ? 'Disable access to the repository to prevent users from searching and browsing the repository.'
+                                : 'The repository is disabled. Enable it to allow users to search and view the repository.'
+                        }
+                        buttonClassName={this.state.repo.enabled ? 'btn-danger' : 'btn-success'}
+                        buttonLabel={this.state.repo.enabled ? 'Disable access' : 'Enable access'}
+                        flashText="Updated"
+                        run={this.state.repo.enabled ? this.disableRepository : this.enableRepository}
+                    />,
+                    <ActionContainer
+                        title="Delete repository"
+                        description="Permanently removes this repository and all associated data from Sourcegraph. The original repository on the code host is not affected. If this repository was added by a configured code host, then it will be re-added during the next sync."
+                        buttonClassName="btn-danger"
+                        buttonLabel="Delete this repository"
+                        run={this.deleteRepository}
+                    />,
+                ]}
             </div>
         )
     }

--- a/web/src/repo/settings/backend.tsx
+++ b/web/src/repo/settings/backend.tsx
@@ -34,7 +34,7 @@ export function fetchRepository(name: string): Observable<GQL.IRepository> {
                             total
                         }
                     }
-                    externalServices() {
+                    externalServices {
                         nodes {
                             id
                             kind

--- a/web/src/repo/settings/backend.tsx
+++ b/web/src/repo/settings/backend.tsx
@@ -34,6 +34,13 @@ export function fetchRepository(name: string): Observable<GQL.IRepository> {
                             total
                         }
                     }
+                    externalServices() {
+                        nodes {
+                            id
+                            kind
+                            displayName
+                        }
+                    }
                 }
             }
         `,


### PR DESCRIPTION
We include links to the external service settings for a repository. This is
only shown on the repository settings page, which is only visible to
admins. The list of external services returned from the backend is non-empty
iff the repository is managed by our new syncer. For repositories not managed
by our new syncer, we still show the disable and delete repository actions.

Test plan: Locally had GitHub repositories with a single external service and two external services. Visited the repository settings page for those repositories and clicked through to the external services. Additionally tested against a gitolite repository to ensure it still showed the disable/delete actions.

Part of #2025

#### Mocks

- Sourcegraph Engineer / Design Spec Link: https://zpl.io/anpXvGr
- Public / Non-Engineer Design Link: https://sketch.cloud/s/wwoGV/Axae1bR/play
serving requests.

#### State

- This PR does not implement the collapsing of the settings page. That is for another PR.
- [x] Need to add the `>` to the end of the card to indicate it is clickable. See mocks.

![image](https://user-images.githubusercontent.com/187831/55869170-456c9500-5b86-11e9-87eb-2459e7104d76.png)

![image](https://user-images.githubusercontent.com/187831/55869189-51f0ed80-5b86-11e9-8ae1-5e0a141a640a.png)

![image](https://user-images.githubusercontent.com/187831/55869214-5fa67300-5b86-11e9-9d36-8eb890d698d4.png)
