### PR TITLE
repo-updater: Exclude soft deleted services from listing

### DIFF
--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -62,7 +62,8 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 		}
 
 		stored, err := s.ListRepos(ctx, StoreListReposArgs{
-			Kinds: kinds,
+			Kinds:   kinds,
+			Deleted: true,
 		})
 
 		if err != nil {

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -318,7 +318,7 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 				}
 
 				if tc.repos != nil {
-					rs, err := tx.ListRepos(ctx, repos.StoreListReposArgs{})
+					rs, err := tx.ListRepos(ctx, repos.StoreListReposArgs{Deleted: true})
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -47,7 +47,7 @@ type StoreListReposArgs struct {
 type StoreListExternalServicesArgs struct {
 	// IDs of external services to list. When zero-valued, this is omitted from the predicate set.
 	IDs []int64
-	// Kinds of external services to list.
+	// Kinds of external services to list. When zero-valued, this is omitted from the predicate set.
 	Kinds []string
 	// If true, includes deleted services in the result set.
 	Deleted bool

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -48,8 +48,6 @@ type StoreListExternalServicesArgs struct {
 	IDs []int64
 	// Kinds of external services to list. When zero-valued, this is omitted from the predicate set.
 	Kinds []string
-	// If true, includes deleted services in the result set.
-	Deleted bool
 }
 
 // ErrNoResults is returned by Store method invocations that yield no result set.
@@ -177,9 +175,7 @@ func listExternalServicesQuery(args StoreListExternalServicesArgs) paginatedQuer
 			sqlf.Sprintf("LOWER(kind) IN (%s)", sqlf.Join(ks, ",")))
 	}
 
-	if !args.Deleted {
-		preds = append(preds, sqlf.Sprintf("deleted_at IS NULL"))
-	}
+	preds = append(preds, sqlf.Sprintf("deleted_at IS NULL"))
 
 	if len(preds) == 0 {
 		preds = append(preds, sqlf.Sprintf("TRUE"))

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -28,13 +28,12 @@ type Store interface {
 // the ListRepos method of Store implementations.
 //
 // Each defined argument must map to a disjunct (i.e. AND) filter predicate.
-// When zero-valued, an argument is ommited from the predicate set.
 type StoreListReposArgs struct {
-	// Names of repos to list.
+	// Names of repos to list. When zero-valued, this is omitted from the predicate set.
 	Names []string
-	// IDs of repos to list.
+	// IDs of repos to list. When zero-valued, this is omitted from the predicate set.
 	IDs []uint32
-	// Kinds of repos to list.
+	// Kinds of repos to list. When zero-valued, this is omitted from the predicate set.
 	Kinds []string
 	// If true, includes deleted repos in the result set.
 	Deleted bool

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -36,15 +36,22 @@ type StoreListReposArgs struct {
 	IDs []uint32
 	// Kinds of repos to list.
 	Kinds []string
+	// If true, includes deleted repos in the result set.
+	Deleted bool
 }
 
 // StoreListExternalServicesArgs is a query arguments type used by
 // the ListExternalServices method of Store implementations.
+//
+// Each defined argument must map to a disjunct (i.e. AND) filter predicate.
+// When zero-valued, an argument is ommited from the predicate set.
 type StoreListExternalServicesArgs struct {
 	// IDs of external services to list.
 	IDs []int64
 	// Kinds of external services to list.
 	Kinds []string
+	// If true, includes deleted services in the result set.
+	Deleted bool
 }
 
 // ErrNoResults is returned by Store method invocations that yield no result set.
@@ -170,6 +177,10 @@ func listExternalServicesQuery(args StoreListExternalServicesArgs) paginatedQuer
 		}
 		preds = append(preds,
 			sqlf.Sprintf("LOWER(kind) IN (%s)", sqlf.Join(ks, ",")))
+	}
+
+	if !args.Deleted {
+		preds = append(preds, sqlf.Sprintf("deleted_at IS NULL"))
 	}
 
 	if len(preds) == 0 {
@@ -320,6 +331,10 @@ func listReposQuery(args StoreListReposArgs) paginatedQuery {
 		}
 		preds = append(preds,
 			sqlf.Sprintf("LOWER(external_service_type) IN (%s)", sqlf.Join(ks, ",")))
+	}
+
+	if !args.Deleted {
+		preds = append(preds, sqlf.Sprintf("deleted_at IS NULL"))
 	}
 
 	if len(preds) == 0 {

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -46,7 +46,7 @@ type StoreListReposArgs struct {
 // Each defined argument must map to a disjunct (i.e. AND) filter predicate.
 // When zero-valued, an argument is ommited from the predicate set.
 type StoreListExternalServicesArgs struct {
-	// IDs of external services to list.
+	// IDs of external services to list. When zero-valued, this is omitted from the predicate set.
 	IDs []int64
 	// Kinds of external services to list.
 	Kinds []string

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -44,7 +44,6 @@ type StoreListReposArgs struct {
 // the ListExternalServices method of Store implementations.
 //
 // Each defined argument must map to a disjunct (i.e. AND) filter predicate.
-// When zero-valued, an argument is ommited from the predicate set.
 type StoreListExternalServicesArgs struct {
 	// IDs of external services to list. When zero-valued, this is omitted from the predicate set.
 	IDs []int64

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -114,19 +114,6 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 		},
 	)
 
-	{
-		stored := svcs.With(repos.Opt.ExternalServiceDeletedAt(now))
-		testCases = append(testCases, testCase{
-			name:   "includes soft deleted external services",
-			stored: stored,
-			args: func(repos.ExternalServices) (args repos.StoreListExternalServicesArgs) {
-				args.Deleted = true
-				return
-			},
-			assert: repos.Assert.ExternalServicesEqual(stored...),
-		})
-	}
-
 	testCases = append(testCases, testCase{
 		name:   "returns svcs by their ids",
 		stored: svcs,
@@ -262,13 +249,13 @@ func testStoreUpsertExternalServices(store repos.Store) func(*testing.T) {
 			}
 
 			want.Apply(repos.Opt.ExternalServiceDeletedAt(now))
-			args := repos.StoreListExternalServicesArgs{Deleted: true}
+			args := repos.StoreListExternalServicesArgs{}
 
 			if err = tx.UpsertExternalServices(ctx, want.Clone()...); err != nil {
 				t.Errorf("UpsertExternalServices error: %s", err)
 			} else if have, err = tx.ListExternalServices(ctx, args); err != nil {
 				t.Errorf("ListExternalServices error: %s", err)
-			} else if diff := pretty.Compare(have, want); diff != "" {
+			} else if diff := pretty.Compare(have, repos.ExternalServices{}); diff != "" {
 				t.Errorf("ListExternalServices:\n%s", diff)
 			}
 		}))

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -68,7 +68,8 @@ func (s *Syncer) Sync(ctx context.Context, kinds ...string) (_ Diff, err error) 
 	}
 
 	var stored Repos
-	if stored, err = store.ListRepos(ctx, StoreListReposArgs{Kinds: kinds}); err != nil {
+	args := StoreListReposArgs{Kinds: kinds, Deleted: true}
+	if stored, err = store.ListRepos(ctx, args); err != nil {
 		return Diff{}, errors.Wrap(err, "syncer.sync.store.list-repos")
 	}
 

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -371,7 +371,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				}
 
 				if st != nil {
-					have, _ := st.ListRepos(ctx, repos.StoreListReposArgs{})
+					have, _ := st.ListRepos(ctx, repos.StoreListReposArgs{Deleted: true})
 					for _, d := range have {
 						d.ID = 0 // Exclude auto-generated ID from comparisons
 					}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -121,7 +121,7 @@ func (s FakeStore) ListExternalServices(ctx context.Context, args StoreListExter
 		if !set[svc] &&
 			(len(kinds) == 0 || kinds[strings.ToLower(svc.Kind)]) &&
 			(len(ids) == 0 || ids[svc.ID]) &&
-			(args.Deleted || !svc.IsDeleted()) {
+			!svc.IsDeleted() {
 
 			svcs = append(svcs, svc)
 			set[svc] = true

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -120,7 +120,8 @@ func (s FakeStore) ListExternalServices(ctx context.Context, args StoreListExter
 	for _, svc := range s.svcByID {
 		if !set[svc] &&
 			(len(kinds) == 0 || kinds[strings.ToLower(svc.Kind)]) &&
-			(len(ids) == 0 || ids[svc.ID]) {
+			(len(ids) == 0 || ids[svc.ID]) &&
+			(args.Deleted || !svc.IsDeleted()) {
 
 			svcs = append(svcs, svc)
 			set[svc] = true
@@ -205,7 +206,8 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 		if !set[r] &&
 			(len(kinds) == 0 || kinds[strings.ToLower(r.ExternalRepo.ServiceType)]) &&
 			(len(names) == 0 || names[r.Name]) &&
-			(len(ids) == 0 || ids[r.ID]) {
+			(len(ids) == 0 || ids[r.ID]) &&
+			(args.Deleted || !r.IsDeleted()) {
 
 			repos = append(repos, r)
 			set[r] = true
@@ -268,9 +270,10 @@ var Assert = struct {
 	ExternalServicesOrderedBy func(func(a, b *ExternalService) bool) ExternalServicesAssertion
 }{
 	ReposEqual: func(rs ...*Repo) ReposAssertion {
-		want := Repos(rs).With(Opt.RepoID(0))
+		want := append(Repos{}, rs...).With(Opt.RepoID(0))
 		return func(t testing.TB, have Repos) {
 			t.Helper()
+			have = append(Repos{}, have...)
 			have.Apply(Opt.RepoID(0)) // Exclude auto-generated IDs from equality tests
 			if !reflect.DeepEqual(have, want) {
 				t.Errorf("repos: %s", cmp.Diff(have, want))


### PR DESCRIPTION
Including soft deleted services leads to us syncing deleted
external services. Additionally I went through each call site of
ListExternalServices and every one requires only active external
services. Migrations can run against soft-deleted external services as
well. However, they are just as good without them.

Test plan: go test

Part of #2025