### PR TITLE
schema: Make (repository|project)Query required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The symbols sidebar now only shows symbols defined in the current file or directory.
 - The dynamic filters on search results pages will now display `lang:` instead of `file:` filters for language/file-extension filter suggestions.
-- The default `github.repositoryQuery` of a [GitHub external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["affiliated", "public"]`).
-- The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]`. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
+- The default `github.repositoryQuery` of a [GitHub external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration) has been changed to `["none"]` and is now a required field. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["affiliated", "public"]`).
+- The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]` and is now a required field. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
 - The `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) is now **required**. This field is necessary to authenticate with the Bitbucket Server API with either `password` or `token`.
 
 ### Removed

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -55,7 +55,8 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 		{
 			// Some comment
 			"url": "https://github.com",
-			"token": "secret"
+			"token": "secret",
+			"repositoryQuery": ["none"]
 		}`),
 	}
 
@@ -79,7 +80,8 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 		{
 			// Some comment
 			"url": "https://gitlab.com",
-			"token": "secret"
+			"token": "secret",
+			"projectQuery": ["none"]
 		}`),
 	}
 
@@ -104,7 +106,8 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 			// Some comment
 			"url": "https://bitbucketserver.mycorp.com",
 			"username": "admin",
-			"token": "secret"
+			"token": "secret",
+			"repositoryQuery": ["none"]
 		}`),
 	}
 

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -25,7 +25,8 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 		Config: `{
 			// Some comment
 			"url": "https://github.com",
-			"token": "secret"
+			"token": "secret",
+			"repositoryQuery": ["none"]
 		}`,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -37,7 +38,8 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 		Config: `{
 			// Some comment
 			"url": "https://gitlab.com",
-			"token": "secret"
+			"token": "secret",
+			"projectQuery": ["none"]
 		}`,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -50,7 +52,8 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 			// Some comment
 			"url": "https://bitbucketserver.mycorp.com",
 			"username: "admin",
-			"token": "secret"
+			"token": "secret",
+			"repositoryQuery": ["none"]
 		}`,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -113,6 +116,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					// Some comment
 					"url": "https://github.com",
 					"token": "secret",
+					"repositoryQuery": ["none"],
 					"exclude": [
 						{"id": "foo"},
 						{"name": "org/BAZ"}
@@ -125,6 +129,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					// Some comment
 					"url": "https://gitlab.com",
 					"token": "secret",
+					"projectQuery": ["none"],
 					"exclude": [
 						{"id": 1},
 						{"name": "org/baz"}
@@ -138,6 +143,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					"url": "https://bitbucketserver.mycorp.com",
 					"username": "admin",
 					"token": "secret",
+					"repositoryQuery": ["none"],
 					"exclude": [
 						{"id": 1},
 						{"name": "org/baz"}
@@ -162,6 +168,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					// Some comment
 					"url": "https://github.com",
 					"token": "secret",
+					"repositoryQuery": ["none"],
 					"exclude": [
 						{"name": "org/boo"},
 					]
@@ -173,6 +180,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					// Some comment
 					"url": "https://gitlab.com",
 					"token": "secret",
+					"projectQuery": ["none"],
 					"exclude": [
 						{"name": "org/boo"},
 					]
@@ -185,6 +193,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					"url": "https://gitlab.com",
 					"username": "admin",
 					"token": "secret",
+					"repositoryQuery": ["none"],
 					"exclude": [
 						{"name": "org/boo"},
 					]
@@ -204,6 +213,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 						// Some comment
 						"url": "https://github.com",
 						"token": "secret",
+						"repositoryQuery": ["none"],
 						"exclude": [
 							{"name": "org/boo"},
 							{"id": "foo", "name": "org/foo"},
@@ -217,6 +227,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 						// Some comment
 						"url": "https://gitlab.com",
 						"token": "secret",
+						"projectQuery": ["none"],
 						"exclude": [
 							{"name": "org/boo"},
 							{"id": 1, "name": "org/foo"},
@@ -231,6 +242,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 						"url": "https://gitlab.com",
 						"username": "admin",
 						"token": "secret",
+						"repositoryQuery": ["none"],
 						"exclude": [
 							{"name": "org/boo"},
 							{"id": 1, "name": "org/foo"},
@@ -249,6 +261,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 						// Some comment
 						"url": "https://github.com",
 						"token": "secret",
+						"repositoryQuery": ["none"],
 						"repos": [
 							"org/FOO",
 							"org/baz"
@@ -261,6 +274,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					// Some comment
 					"url": "https://gitlab.com",
 					"token": "secret",
+					"projectQuery": ["none"],
 					"projects": [
 						{"id": 1},
 						{"name": "org/baz"}
@@ -274,6 +288,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					"url": "https://bitbucketserver.mycorp.com",
 					"username": "admin",
 					"token": "secret",
+					"repositoryQuery": ["none"],
 					"repos": [
 						"org/FOO",
 						"org/baz"
@@ -299,6 +314,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					// Some comment
 					"url": "https://github.com",
 					"token": "secret",
+					"repositoryQuery": ["none"],
 					"repos": [
 						"org/boo"
 					]
@@ -310,6 +326,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					// Some comment
 					"url": "https://gitlab.com",
 					"token": "secret",
+					"projectQuery": ["none"],
 					"projects": [
 						{"name": "org/boo"},
 					]
@@ -322,6 +339,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 					"url": "https://bitbucketserver.mycorp.com",
 					"username": "admin",
 					"token": "secret",
+					"repositoryQuery": ["none"],
 					"repos": [
 						"org/boo"
 					]
@@ -341,6 +359,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 						// Some comment
 						"url": "https://github.com",
 						"token": "secret",
+						"repositoryQuery": ["none"],
 						"repos": [
 							"org/boo",
 							"org/foo",
@@ -354,6 +373,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 						// Some comment
 						"url": "https://gitlab.com",
 						"token": "secret",
+						"projectQuery": ["none"],
 						"projects": [
 							{"name": "org/boo"},
 							{"id": 1, "name": "org/foo"},
@@ -368,6 +388,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 						"url": "https://bitbucketserver.mycorp.com",
 						"username": "admin",
 						"token": "secret",
+						"repositoryQuery": ["none"],
 						"repos": [
 							"org/boo",
 							"org/foo",

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -293,6 +293,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 		{
 			// Some comment
 			"url": "https://github.com",
+			"repositoryQuery": ["none"],
 			"token": "secret"
 		}`),
 	}
@@ -317,6 +318,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 		{
 			// Some comment
 			"url": "https://gitlab.com",
+			"projectQuery": ["none"],
 			"token": "secret"
 		}`),
 	}
@@ -342,7 +344,8 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 			// Some comment
 			"url": "https://bitbucketserver.mycorp.com",
 			"token": "secret",
-			"username": "alice"
+			"username": "alice",
+			"repositoryQuery": ["none"]
 		}`),
 	}
 

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -140,9 +140,13 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "BITBUCKETSERVER",
-			desc:   "without url",
+			desc:   "without url, username nor repositoryQuery",
 			config: `{}`,
-			assert: includes("url: url is required"),
+			assert: includes(
+				"url: url is required",
+				"username: username is required",
+				"repositoryQuery: repositoryQuery is required",
+			),
 		},
 		{
 			kind:   "BITBUCKETSERVER",
@@ -190,9 +194,15 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes("certificate: Does not match pattern '^-----BEGIN CERTIFICATE-----\n'"),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
-			desc:   "valid",
-			config: `{"url": "https://bitbucket.com/", "username": "admin", "token": "secret-token"}`,
+			kind: "BITBUCKETSERVER",
+			desc: "valid",
+			config: `
+			{
+				"url": "https://bitbucket.com/",
+				"username": "admin",
+				"token": "secret-token",
+				"repositoryQuery": ["none"]
+			}`,
 			assert: equals("<nil>"),
 		},
 		{
@@ -245,6 +255,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				"url": "https://bitbucketserver.corp.com",
 				"username": "admin",
 				"token": "very-secret-token",
+				"repositoryQuery": ["none"],
 				"exclude": [
 					{"name": "foo/bar", "id": 1234}
 				]
@@ -271,6 +282,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				"url": "https://bitbucketserver.corp.com",
 				"username": "admin",
 				"token": "very-secret-token",
+				"repositoryQuery": ["none"],
 				"repos": [
 					"foo/bar",
 					"bar/baz"
@@ -280,11 +292,12 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "GITHUB",
-			desc:   "without url nor token",
+			desc:   "without url, token nor repositoryQuery",
 			config: `{}`,
 			assert: includes(
 				"url: url is required",
 				"token: token is required",
+				"repositoryQuery: repositoryQuery is required",
 			),
 		},
 		{
@@ -387,6 +400,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			{
 				"url": "https://github.corp.com",
 				"token": "very-secret-token",
+				"repositoryQuery": ["none"],
 				"exclude": [
 					{"name": "foo/bar", "id": "AAAAA="}
 				]
@@ -442,6 +456,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			{
 				"url": "https://gitlab.corp.com",
 				"token": "very-secret-token",
+				"projectQuery": ["none"],
 				"exclude": [
 					{"name": "foo/bar", "id": 1234}
 				]
@@ -485,6 +500,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			{
 				"url": "https://gitlab.corp.com",
 				"token": "very-secret-token",
+				"projectQuery": ["none"],
 				"projects": [
 					{"name": "foo/bar", "id": 1234}
 				]
@@ -493,11 +509,12 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "GITLAB",
-			desc:   "without url nor token",
+			desc:   "without url, token nor projectQuery",
 			config: `{}`,
 			assert: includes(
 				"url: url is required",
 				"token: token is required",
+				"projectQuery: projectQuery is required",
 			),
 		},
 		{
@@ -641,6 +658,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			{
 				"url": "https://gitlab.foo.bar",
 				"token": "super-secret-token",
+				"projectQuery": ["none"],
 				"authorization": {
 					"identityProvider": {
 						"type": "username",

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -5,7 +5,7 @@
   "description": "Configuration for a connection to Bitbucket Server.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["username", "url"],
+  "required": ["username", "url", "repositoryQuery"],
   "oneOf": [
     {
       "required": ["token"],

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -10,7 +10,7 @@ const BitbucketServerSchemaJSON = `{
   "description": "Configuration for a connection to Bitbucket Server.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["username", "url"],
+  "required": ["username", "url", "repositoryQuery"],
   "oneOf": [
     {
       "required": ["token"],

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -5,7 +5,7 @@
   "description": "Configuration for a connection to GitHub or GitHub Enterprise.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["url", "token"],
+  "required": ["url", "token", "repositoryQuery"],
   "properties": {
     "url": {
       "description": "URL of a GitHub instance, such as https://github.com or https://github-enterprise.example.com.",

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -10,7 +10,7 @@ const GitHubSchemaJSON = `{
   "description": "Configuration for a connection to GitHub or GitHub Enterprise.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["url", "token"],
+  "required": ["url", "token", "repositoryQuery"],
   "properties": {
     "url": {
       "description": "URL of a GitHub instance, such as https://github.com or https://github-enterprise.example.com.",

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -5,7 +5,7 @@
   "description": "Configuration for a connection to GitLab (GitLab.com or GitLab self-managed).",
   "type": "object",
   "additionalProperties": false,
-  "required": ["url", "token"],
+  "required": ["url", "token", "projectQuery"],
   "properties": {
     "url": {
       "description": "URL of a GitLab instance, such as https://gitlab.example.com or (for GitLab.com) https://gitlab.com.",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -10,7 +10,7 @@ const GitLabSchemaJSON = `{
   "description": "Configuration for a connection to GitLab (GitLab.com or GitLab self-managed).",
   "type": "object",
   "additionalProperties": false,
-  "required": ["url", "token"],
+  "required": ["url", "token", "projectQuery"],
   "properties": {
     "url": {
       "description": "URL of a GitLab instance, such as https://gitlab.example.com or (for GitLab.com) https://gitlab.com.",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -90,7 +90,7 @@ type BitbucketServerConnection struct {
 	Password                    string                         `json:"password,omitempty"`
 	Repos                       []string                       `json:"repos,omitempty"`
 	RepositoryPathPattern       string                         `json:"repositoryPathPattern,omitempty"`
-	RepositoryQuery             []string                       `json:"repositoryQuery,omitempty"`
+	RepositoryQuery             []string                       `json:"repositoryQuery"`
 	Token                       string                         `json:"token,omitempty"`
 	Url                         string                         `json:"url"`
 	Username                    string                         `json:"username"`
@@ -200,7 +200,7 @@ type GitHubConnection struct {
 	InitialRepositoryEnablement bool                  `json:"initialRepositoryEnablement,omitempty"`
 	Repos                       []string              `json:"repos,omitempty"`
 	RepositoryPathPattern       string                `json:"repositoryPathPattern,omitempty"`
-	RepositoryQuery             []string              `json:"repositoryQuery,omitempty"`
+	RepositoryQuery             []string              `json:"repositoryQuery"`
 	Token                       string                `json:"token"`
 	Url                         string                `json:"url"`
 }
@@ -227,7 +227,7 @@ type GitLabConnection struct {
 	Exclude                     []*ExcludedGitLabProject `json:"exclude,omitempty"`
 	GitURLType                  string                   `json:"gitURLType,omitempty"`
 	InitialRepositoryEnablement bool                     `json:"initialRepositoryEnablement,omitempty"`
-	ProjectQuery                []string                 `json:"projectQuery,omitempty"`
+	ProjectQuery                []string                 `json:"projectQuery"`
 	Projects                    []*GitLabProject         `json:"projects,omitempty"`
 	RepositoryPathPattern       string                   `json:"repositoryPathPattern,omitempty"`
 	Token                       string                   `json:"token"`

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -302,7 +302,8 @@ describe('e2e test suite', function(this: any): void {
             // Type in a new external service configuration.
             await replaceText({
                 selector: '.view-line',
-                newText: '{"url": "https://github.myenterprise.com", "token": "second-token", "repositoryQuery": ["none"]}',
+                newText:
+                    '{"url": "https://github.myenterprise.com", "token": "second-token", "repositoryQuery": ["none"]}',
                 method: 'keyboard',
             })
             await page.click('.e2e-update-external-service-button')

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -58,6 +58,7 @@ describe('e2e test suite', function(this: any): void {
                 url: 'https://github.com',
                 token: gitHubToken,
                 repos: repoSlugs,
+                repositoryQuery: ['none'],
             }),
             repoSlugs
         )
@@ -291,7 +292,7 @@ describe('e2e test suite', function(this: any): void {
             await ensureHasExternalService(
                 'github',
                 displayName,
-                '{"url": "https://github.myenterprise.com", "token": "initial-token"}'
+                '{"url": "https://github.myenterprise.com", "token": "initial-token", "repositoryQuery": ["none"]}'
             )
             await page.goto(baseURL + '/site-admin/external-services')
             await (await page.waitForSelector(
@@ -301,7 +302,7 @@ describe('e2e test suite', function(this: any): void {
             // Type in a new external service configuration.
             await replaceText({
                 selector: '.view-line',
-                newText: '{"url": "https://github.myenterprise.com", "token": "second-token"}',
+                newText: '{"url": "https://github.myenterprise.com", "token": "second-token", "repositoryQuery": ["none"]}',
                 method: 'keyboard',
             })
             await page.click('.e2e-update-external-service-button')


### PR DESCRIPTION
We previously assumed that the default field would populate the
respective setting when unmarshalled, but this is not the case, so we
need to make this field required so that the migrations setting these
fields to ["none"] don't run one new configs.

Part of #2025

