### PR TITLE
Fix: show upgrade to cluster message for non-Sourcegraph.com, non-cluster instances

### DIFF
--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -405,7 +405,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                                         your query.
                                                     </>,
                                                     /* If running on non-cluster, give some smart advice */
-                                                    ...(this.props.isSourcegraphDotCom &&
+                                                    ...(!this.props.isSourcegraphDotCom &&
                                                     !window.context.isClusterDeployment
                                                         ? [
                                                               <>


### PR DESCRIPTION
Fixes incorrect logic, brought up by sqs here https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f6a6de81d2a24bb9cc14e4fae872b33bb6b35f13/-/blob/web/src/search/results/SearchResultsList.tsx#L408&tab=discussions&threadID=200