### PR TITLE
Extensions: respect allowRemoteExtensions in default settings

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -37,7 +37,16 @@ func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
 
 func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	contents, err := json.Marshal(map[string]map[string]bool{"extensions": builtinExtensions})
+	extensionIDs := []string{}
+	for id := range builtinExtensions {
+		extensionIDs = append(extensionIDs, id)
+	}
+	extensionIDs = ExtensionRegistry.FilterRemoteExtensions(extensionIDs)
+	extensions := map[string]bool{}
+	for _, id := range extensionIDs {
+		extensions[id] = true
+	}
+	contents, err := json.Marshal(map[string]map[string]bool{"extensions": extensions})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -44,7 +44,8 @@ type ExtensionRegistryResolver interface {
 	DeleteExtension(context.Context, *ExtensionRegistryDeleteExtensionArgs) (*EmptyResponse, error)
 	LocalExtensionIDPrefix() *string
 
-	ImplementsLocalExtensionRegistry() bool // not exposed via GraphQL
+	ImplementsLocalExtensionRegistry() bool   // not exposed via GraphQL
+	FilterRemoteExtensions([]string) []string // not exposed via GraphQL
 }
 
 type RegistryExtensionConnectionArgs struct {

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -44,7 +44,11 @@ type ExtensionRegistryResolver interface {
 	DeleteExtension(context.Context, *ExtensionRegistryDeleteExtensionArgs) (*EmptyResponse, error)
 	LocalExtensionIDPrefix() *string
 
-	ImplementsLocalExtensionRegistry() bool   // not exposed via GraphQL
+	ImplementsLocalExtensionRegistry() bool // not exposed via GraphQL
+	// FilterRemoteExtensions enforces `allowRemoteExtensions` by returning a
+	// new slice with extension IDs that were present in
+	// `allowRemoteExtensions`. It returns the original extension IDs if
+	// `allowRemoteExtensions` is not set.
 	FilterRemoteExtensions([]string) []string // not exposed via GraphQL
 }
 

--- a/cmd/frontend/registry/registry_graphql.go
+++ b/cmd/frontend/registry/registry_graphql.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/pkg/registry"
 )
 
 func init() {
@@ -104,6 +105,19 @@ func (*extensionRegistryResolver) LocalExtensionIDPrefix() *string {
 // registry (which is a Sourcegraph Enterprise feature).
 func (r *extensionRegistryResolver) ImplementsLocalExtensionRegistry() bool {
 	return r.ViewerPublishersFunc != nil && r.PublishersFunc != nil && r.CreateExtensionFunc != nil && r.UpdateExtensionFunc != nil && r.PublishExtensionFunc != nil && r.DeleteExtensionFunc != nil
+}
+
+func (r *extensionRegistryResolver) FilterRemoteExtensions(ids []string) []string {
+	var extensions []*registry.Extension
+	for _, id := range ids {
+		extensions = append(extensions, &registry.Extension{ExtensionID: id})
+	}
+	keepExtensions := FilterRemoteExtensions(extensions)
+	keep := []string{}
+	for _, extension := range keepExtensions {
+		keep = append(keep, extension.ExtensionID)
+	}
+	return keep
 }
 
 type ExtensionRegistryMutationResult struct {

--- a/cmd/frontend/registry/registry_graphql.go
+++ b/cmd/frontend/registry/registry_graphql.go
@@ -108,14 +108,14 @@ func (r *extensionRegistryResolver) ImplementsLocalExtensionRegistry() bool {
 }
 
 func (r *extensionRegistryResolver) FilterRemoteExtensions(ids []string) []string {
-	var extensions []*registry.Extension
-	for _, id := range ids {
-		extensions = append(extensions, &registry.Extension{ExtensionID: id})
+	extensions := make([]*registry.Extension, len(ids))
+	for i, id := range ids {
+		extensions[i] = &registry.Extension{ExtensionID: id}
 	}
 	keepExtensions := FilterRemoteExtensions(extensions)
-	keep := []string{}
-	for _, extension := range keepExtensions {
-		keep = append(keep, extension.ExtensionID)
+	keep := make([]string, len(keepExtensions))
+	for i, extension := range keepExtensions {
+		keep[i] = extension.ExtensionID
 	}
 	return keep
 }


### PR DESCRIPTION
Prior to this change, `allowRemoteExtensions` would not have any effect on default settings, causing the browser to log a warning when it couldn't find the manifest for extensions that are enabled by default.

After this change, the default settings will be filtered using `allowRemoteExtensions` so that no warnings are logged.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3351

Test plan: follow repro steps in https://github.com/sourcegraph/sourcegraph/issues/3351 and notice no warnings get logged