### PR TITLE
return clone URL for Gitolite repositories

### DIFF
--- a/cmd/frontend/internal/httpapi/repo_refresh.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/handlerutil"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 )
@@ -15,5 +16,8 @@ func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	return repoupdater.DefaultClient.EnqueueRepoUpdate(context.Background(), gitserver.Repo{Name: repo.Name})
+	return repoupdater.DefaultClient.EnqueueRepoUpdate(context.Background(), gitserver.Repo{
+		Name: repo.Name,
+		URL:  gitolite.CloneURL(repo.ExternalRepo),
+	})
 }

--- a/cmd/frontend/internal/httpapi/repo_refresh.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/handlerutil"
-	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
+	"github.com/sourcegraph/sourcegraph/pkg/repoupdater/protocol"
 )
 
 func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
@@ -16,8 +16,15 @@ func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
+	repoMeta, err := repoupdater.DefaultClient.RepoLookup(context.Background(), protocol.RepoLookupArgs{
+		Repo:         repo.Name,
+		ExternalRepo: repo.ExternalRepo,
+	})
+	if err != nil {
+		return err
+	}
 	return repoupdater.DefaultClient.EnqueueRepoUpdate(context.Background(), gitserver.Repo{
 		Name: repo.Name,
-		URL:  gitolite.CloneURL(repo.ExternalRepo),
+		URL:  repoMeta.Repo.VCS.URL,
 	})
 }

--- a/cmd/frontend/internal/httpapi/repo_refresh_test.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
+	"github.com/sourcegraph/sourcegraph/pkg/repoupdater/protocol"
 )
 
 func TestRepoRefresh(t *testing.T) {
@@ -16,8 +17,21 @@ func TestRepoRefresh(t *testing.T) {
 
 	enqueueRepoUpdateCount := map[api.RepoName]int{}
 	repoupdater.MockEnqueueRepoUpdate = func(ctx context.Context, repo gitserver.Repo) error {
+		if exp := "git@github.com:dummy-url"; repo.URL != exp {
+			t.Errorf("missing or incorrect clone URL, expected %q, got %q", exp, repo.URL)
+		}
 		enqueueRepoUpdateCount[repo.Name]++
 		return nil
+	}
+	repoupdater.MockRepoLookup = func(args protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error) {
+		return &protocol.RepoLookupResult{
+			Repo: &protocol.RepoInfo{
+				Name: args.Repo,
+				VCS: protocol.VCSInfo{
+					URL: "git@github.com:dummy-url",
+				},
+			},
+		}, nil
 	}
 
 	backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -67,6 +67,9 @@ func GetGitoliteRepository(ctx context.Context, args protocol.RepoLookupArgs) (r
 			return &protocol.RepoInfo{
 				Name:         args.Repo,
 				ExternalRepo: args.ExternalRepo,
+				VCS: protocol.VCSInfo{
+					URL: gitolite.CloneURL(args.ExternalRepo),
+				},
 			}, true, nil
 		}
 	}

--- a/pkg/extsvc/gitolite/codehost.go
+++ b/pkg/extsvc/gitolite/codehost.go
@@ -17,3 +17,14 @@ func ExternalRepoSpec(repo *Repo, serviceID string) *api.ExternalRepoSpec {
 func ServiceID(gitoliteHost string) string {
 	return gitoliteHost
 }
+
+// CloneURL returns the clone URL of the external repository. The external repo spec must be of type
+// "gitolite"; otherwise, this will return an empty string.
+func CloneURL(externalRepoSpec *api.ExternalRepoSpec) string {
+	if externalRepoSpec == nil || externalRepoSpec.ServiceType != ServiceType {
+		return ""
+	}
+	host := externalRepoSpec.ServiceID
+	gitoliteName := externalRepoSpec.ID
+	return host + ":" + gitoliteName
+}


### PR DESCRIPTION
What I've learned:
• `disableAutoGitUpdates` doesn't affect the behavior of navigating directly to a repo to get it to clone
• The need for a clone URL to be set the first time gitserver clones a repository is documented in the code, but it's unclear where this clone URL actually comes from. Perhaps it would be useful for repo-updater to expose this and serve as the source of truth for such repository metadata? If that *shouldn't* be repo-updater, what should it be?
• Three code paths that might require a new repo to be cloned to gitserver are (1) repo-updater loop, (2) direct user navigation to a repo page, (3) triggering a repo-update by the `$REPO/-/refresh` endpoint. Any others we might have to cover?
• Maybe it's worth changing the interface of `EnqueueRepoUpdate` (https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/pkg/repoupdater/client.go#L145:0) to make it more explicit when the expectation is that a repo is cloned if it doesn't exist already. The current behavior of needing to set `Repo.URL` is a bit hidden. 

Fixes #3336