### PR TITLE
Add a warning alert when usage exceeds the limit of free user accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-
 ## 3.2.2
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The new required `bitbucketserver.repositoryQuery` setting in [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) allows you to use Bitbucket API repository search queries to select repos to be synced. Existing configurations will be migrate to have it set to `["?visibility=public", "?visibility=private"]` which is equivalent to the previous implicit behaviour that this setting supersedes.
 - "Quick configure" buttons for common actions have been added to the config editor for all external services.
 - Site-admins now receive an alert every day for the seven days before their license key expires.
+- All users on an instance now see a non-dismissable alert when when there's no license key in use and the limit of free user accounts is exceeded.
 
 ### Changed
 
@@ -31,7 +32,6 @@ All notable changes to Sourcegraph are documented in this file.
 - The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]` and is now a required field. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
 - The `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) is now **required**. This field is necessary to authenticate with the Bitbucket Server API with either `password` or `token`.
 - The settings and account pages for users and organizations are now combined into a single tab.
-- All users on an instance now see a non-dismissable alert when when there's no license key in use and the limit of free user accounts is exceeded.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,14 @@ All notable changes to Sourcegraph are documented in this file.
 - The default `gitlab.projectQuery` of a [GitLab external service configuration](https://docs.sourcegraph.com/admin/external_service/gitlab#configuration) has been changed to `["none"]` and is now a required field. Existing configurations that had this field unset will be migrated to have the previous default explicitly set (`["?membership=true"]`).
 - The `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) is now **required**. This field is necessary to authenticate with the Bitbucket Server API with either `password` or `token`.
 - The settings and account pages for users and organizations are now combined into a single tab.
+- All users on an instance now see a non-dismissable alert when when there's no license key in use and the limit of free user accounts is exceeded.
 
 ### Removed
 
 - Removed the option to show saved searches on the Sourcegraph homepage.
 
 ### Fixed
+
 
 ## 3.2.2
 

--- a/cmd/frontend/graphqlbackend/product_subscription_status.go
+++ b/cmd/frontend/graphqlbackend/product_subscription_status.go
@@ -26,6 +26,10 @@ var ActualUserCountDate = func(ctx context.Context) (string, error) {
 // nil if there is no limit.
 var NoLicenseMaximumAllowedUserCount *int32
 
+// NoLicenseWarningUserCount is the user count at which point a warning is shown to all users when
+// there is no license, or nil if there is no limit.
+var NoLicenseWarningUserCount *int32
+
 // productSubscriptionStatus implements the GraphQL type ProductSubscriptionStatus.
 type productSubscriptionStatus struct{}
 
@@ -48,6 +52,14 @@ func (productSubscriptionStatus) ActualUserCount(ctx context.Context) (int32, er
 
 func (productSubscriptionStatus) ActualUserCountDate(ctx context.Context) (string, error) {
 	return ActualUserCountDate(ctx)
+}
+
+func (productSubscriptionStatus) NoLicenseWarningUserCount(ctx context.Context) (*int32, error) {
+	if info, err := GetConfiguredProductLicenseInfo(); info != nil {
+		// if a license exists, warnings never need to be shown.
+		return nil, err
+	}
+	return NoLicenseWarningUserCount, nil
 }
 
 func (productSubscriptionStatus) MaximumAllowedUserCount(ctx context.Context) (*int32, error) {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2995,7 +2995,8 @@ type ProductSubscriptionStatus {
     # The number of users allowed. If there is a license, this is equal to ProductLicenseInfo.userCount. Otherwise,
     # it is the user limit for instances without a license, or null if there is no limit.
     maximumAllowedUserCount: Int
-    # The number of free users allowed on a site without a license before a warning is shown to all users.
+    # The number of free users allowed on a site without a license before a warning is shown to all users, or null
+    # if a valid license is in use.
     noLicenseWarningUserCount: Int
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2712,6 +2712,9 @@ type Site implements SettingsSubject {
     updateCheck: UpdateCheck!
     # Whether the site needs to be configured to add repositories.
     needsRepositoryConfiguration: Boolean!
+    # Whether the site is over the limit for free user accounts, and a warning needs to be shown to all users.
+    # Only applies if the site does not have a valid license.
+    freeUsersExceeded: Boolean!
     # Whether the site has zero access-enabled repositories.
     noRepositoriesEnabled: Boolean!
     # Alerts to display to the viewer.
@@ -2992,6 +2995,8 @@ type ProductSubscriptionStatus {
     # The number of users allowed. If there is a license, this is equal to ProductLicenseInfo.userCount. Otherwise,
     # it is the user limit for instances without a license, or null if there is no limit.
     maximumAllowedUserCount: Int
+    # The number of free users allowed on a site without a license before a warning is shown to all users.
+    noLicenseWarningUserCount: Int
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3002,7 +3002,8 @@ type ProductSubscriptionStatus {
     # The number of users allowed. If there is a license, this is equal to ProductLicenseInfo.userCount. Otherwise,
     # it is the user limit for instances without a license, or null if there is no limit.
     maximumAllowedUserCount: Int
-    # The number of free users allowed on a site without a license before a warning is shown to all users.
+    # The number of free users allowed on a site without a license before a warning is shown to all users, or null
+    # if a valid license is in use.
     noLicenseWarningUserCount: Int
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2719,6 +2719,9 @@ type Site implements SettingsSubject {
     updateCheck: UpdateCheck!
     # Whether the site needs to be configured to add repositories.
     needsRepositoryConfiguration: Boolean!
+    # Whether the site is over the limit for free user accounts, and a warning needs to be shown to all users.
+    # Only applies if the site does not have a valid license.
+    freeUsersExceeded: Boolean!
     # Whether the site has zero access-enabled repositories.
     noRepositoriesEnabled: Boolean!
     # Alerts to display to the viewer.
@@ -2999,6 +3002,8 @@ type ProductSubscriptionStatus {
     # The number of users allowed. If there is a license, this is equal to ProductLicenseInfo.userCount. Otherwise,
     # it is the user limit for instances without a license, or null if there is no limit.
     maximumAllowedUserCount: Int
+    # The number of free users allowed on a site without a license before a warning is shown to all users.
+    noLicenseWarningUserCount: Int
     # The product license associated with this subscription, if any.
     license: ProductLicenseInfo
 }

--- a/doc/adopt/trial/index.md
+++ b/doc/adopt/trial/index.md
@@ -50,7 +50,7 @@ As mentioned above, Sourcegraph trials are most successful when they start with 
   (1) investing in the product and exploring features, as they don't expect it to stick around, and;
   (2) sharing links, telling others about it, posting search results, and other socializing.
 
-If you want to run a trial with more than 100 users on your instance, just [reach out](https://about.sourcegraph.com/contact) and we'll provide an unlimited license key for up to a month, no questions asked.
+If you want to run a trial with more than 10 users on your instance, just [reach out](https://about.sourcegraph.com/contact) and we'll provide an unlimited license key for up to a month, no questions asked.
 
 A typical message to the team looks like:
 

--- a/doc/adopt/trial/index.md
+++ b/doc/adopt/trial/index.md
@@ -50,7 +50,7 @@ As mentioned above, Sourcegraph trials are most successful when they start with 
   (1) investing in the product and exploring features, as they don't expect it to stick around, and;
   (2) sharing links, telling others about it, posting search results, and other socializing.
 
-If you want to run a trial with more than 10 users on your instance, just [reach out](https://about.sourcegraph.com/contact) and we'll provide an unlimited license key for up to a month, no questions asked.
+If you want to run a trial with more than the limit of free users on your instance, just [reach out](https://about.sourcegraph.com/contact) and we'll provide an unlimited license key for up to a month, no questions asked.
 
 A typical message to the team looks like:
 

--- a/enterprise/cmd/frontend/internal/licensing/enforcement.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement.go
@@ -39,7 +39,7 @@ func NewPreCreateUserHook(s UsersStore) func(context.Context) error {
 			} else {
 				message := "Unable to create user account: "
 				if info == nil {
-					message = fmt.Sprintf("a Sourcegraph subscription is required to exceed %d users. A site admin must purchase a subscription at https://sourcegraph.com/user/settings/subscriptions/new. Enter the license key in the Sourcegraph management console.", NoLicenseMaximumAllowedUserCount)
+					message = fmt.Sprintf("a Sourcegraph subscription is required to exceed %d users, and new users can not be created above %d (this instance now has %d users). A site admin must purchase a subscription at https://sourcegraph.com/user/settings/subscriptions/new. Enter the license key in the Sourcegraph management console.", NoLicenseWarningUserCount, NoLicenseMaximumAllowedUserCount, userCount)
 				} else {
 					message += "the Sourcegraph subscription's maximum user count has been reached. A site admin must upgrade the Sourcegraph subscription to allow for more users. Enter the license key in the Sourcegraph management console (https://docs.sourcegraph.com/admin/management_console)."
 				}

--- a/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
+++ b/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
@@ -161,4 +161,4 @@ const NoLicenseMaximumAllowedUserCount int32 = 50
 
 // NoLicenseWarningUserCount is the number of user accounts that may exist on Sourcegraph Core
 // (i.e., when running without a license) before all users are shown a warning.
-const NoLicenseWarningUserCount int32 = 10
+const NoLicenseWarningUserCount int32 = 20

--- a/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
+++ b/enterprise/cmd/frontend/internal/licensing/licenseusercount.go
@@ -157,4 +157,8 @@ func StartMaxUserCount(s UsersStore) {
 // NoLicenseMaximumAllowedUserCount is the maximum number of user accounts that may exist on Sourcegraph Core
 // (i.e., when running without a license). Exceeding this number of user accounts requires a
 // license.
-const NoLicenseMaximumAllowedUserCount int32 = 100
+const NoLicenseMaximumAllowedUserCount int32 = 50
+
+// NoLicenseWarningUserCount is the number of user accounts that may exist on Sourcegraph Core
+// (i.e., when running without a license) before all users are shown a warning.
+const NoLicenseWarningUserCount int32 = 10

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -73,6 +73,9 @@ func initLicensing() {
 	noLicenseMaximumAllowedUserCount := licensing.NoLicenseMaximumAllowedUserCount
 	graphqlbackend.NoLicenseMaximumAllowedUserCount = &noLicenseMaximumAllowedUserCount
 
+	noLicenseWarningUserCount := licensing.NoLicenseWarningUserCount
+	graphqlbackend.NoLicenseWarningUserCount = &noLicenseWarningUserCount
+
 	// Make the Site.productSubscription GraphQL field return the actual info about the product license,
 	// if any.
 	graphqlbackend.GetConfiguredProductLicenseInfo = func() (*graphqlbackend.ProductLicenseInfo, error) {

--- a/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -68,7 +68,7 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
             productNameWithBrand,
             actualUserCount,
             actualUserCountDate,
-            maximumAllowedUserCount,
+            noLicenseWarningUserCount,
             license,
         } = this.state.statusOrError
 
@@ -112,8 +112,8 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
                                 <>
                                     <div className="mr-2">
                                         Add a license key to activate Sourcegraph Enterprise features{' '}
-                                        {typeof maximumAllowedUserCount === 'number'
-                                            ? `or to exceed ${maximumAllowedUserCount} users`
+                                        {typeof noLicenseWarningUserCount === 'number'
+                                            ? `or to exceed ${noLicenseWarningUserCount} users`
                                             : ''}
                                     </div>
                                     <div className="text-nowrap flex-wrap-reverse">
@@ -163,7 +163,7 @@ export class ProductSubscriptionStatus extends React.Component<Props, State> {
                         productNameWithBrand
                         actualUserCount
                         actualUserCountDate
-                        maximumAllowedUserCount
+                        noLicenseWarningUserCount
                         license {
                             tags
                             userCount

--- a/web/src/global/GlobalAlerts.tsx
+++ b/web/src/global/GlobalAlerts.tsx
@@ -88,6 +88,7 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                                             Date.now()
                                         )
                                     )}
+                                    className="global-alerts__alert"
                                 />
                             )}
                     </>

--- a/web/src/global/GlobalAlerts.tsx
+++ b/web/src/global/GlobalAlerts.tsx
@@ -9,6 +9,7 @@ import { Settings } from '../schema/settings.schema'
 import { SiteFlags } from '../site'
 import { siteFlags } from '../site/backend'
 import { DockerForMacAlert } from '../site/DockerForMacAlert'
+import { FreeUsersExceededAlert } from '../site/FreeUsersExceededAlert'
 import { LicenseExpirationAlert } from '../site/LicenseExpirationAlert'
 import { NeedsRepositoryConfigurationAlert } from '../site/NeedsRepositoryConfigurationAlert'
 import { NoRepositoriesEnabledAlert } from '../site/NoRepositoriesEnabledAlert'
@@ -52,7 +53,6 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                                 <NoRepositoriesEnabledAlert className="global-alerts__alert" />
                             )
                         )}
-
                         {this.props.isSiteAdmin &&
                             this.state.siteFlags.updateCheck &&
                             !this.state.siteFlags.updateCheck.errorMessage &&
@@ -62,16 +62,21 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                                     updateVersionAvailable={this.state.siteFlags.updateCheck.updateVersionAvailable}
                                 />
                             )}
-
+                        {this.state.siteFlags.freeUsersExceeded && (
+                            <FreeUsersExceededAlert
+                                noLicenseWarningUserCount={
+                                    this.state.siteFlags.productSubscription.noLicenseWarningUserCount
+                                }
+                                className="global-alerts__alert"
+                            />
+                        )}
                         {/* Only show if the user has already enabled repositories; if not yet, the user wouldn't experience any Docker for Mac perf issues anyway. */}
                         {window.context.likelyDockerOnMac && !this.state.siteFlags.noRepositoriesEnabled && (
                             <DockerForMacAlert className="global-alerts__alert" />
                         )}
-
                         {this.state.siteFlags.alerts.map((alert, i) => (
                             <GlobalAlert key={i} alert={alert} className="global-alerts__alert" />
                         ))}
-
                         {this.state.siteFlags.productSubscription.license &&
                             differenceInDays(this.state.siteFlags.productSubscription.license.expiresAt, Date.now()) <=
                                 7 && (

--- a/web/src/site/FreeUsersExceededAlert.tsx
+++ b/web/src/site/FreeUsersExceededAlert.tsx
@@ -1,0 +1,23 @@
+import WarningIcon from 'mdi-react/WarningIcon'
+import * as React from 'react'
+
+/**
+ * A global alert that appears telling all users that they have exceeded the limit of free users allowed.
+ */
+export const FreeUsersExceededAlert: React.FunctionComponent<{
+    noLicenseWarningUserCount: number | null
+    className?: string
+}> = ({ noLicenseWarningUserCount, className = '' }) => (
+    <div className={`alert alert-danger alert-animated-bg d-flex align-items-center ${className}`}>
+        <WarningIcon className="icon-inline mr-2 flex-shrink-0" />
+        You have exceeded {noLicenseWarningUserCount === null ? 'the limit for' : noLicenseWarningUserCount} free users,
+        and need to&nbsp;
+        <a className="site-alert__link" href="https://sourcegraph.com/user/subscriptions/new">
+            <span className="underline">purchase a license</span>
+        </a>
+        &nbsp;or&nbsp;
+        <a className="site-alert__link" href="https://about.sourcegraph.com/contact/sales">
+            <span className="underline">contact us for a free trial</span>
+        </a>
+    </div>
+)

--- a/web/src/site/FreeUsersExceededAlert.tsx
+++ b/web/src/site/FreeUsersExceededAlert.tsx
@@ -8,14 +8,14 @@ export const FreeUsersExceededAlert: React.FunctionComponent<{
     noLicenseWarningUserCount: number | null
     className?: string
 }> = ({ noLicenseWarningUserCount, className = '' }) => (
-    <div className={`alert alert-danger alert-animated-bg d-flex align-items-center ${className}`}>
+    <div className={`alert alert-danger alert-animated-bg align-items-center ${className}`}>
         <WarningIcon className="icon-inline mr-2 flex-shrink-0" />
         You have exceeded {noLicenseWarningUserCount === null ? 'the limit for' : noLicenseWarningUserCount} free users,
-        and need to&nbsp;
+        and need to{' '}
         <a className="site-alert__link" href="https://sourcegraph.com/user/subscriptions/new">
             <span className="underline">purchase a license</span>
-        </a>
-        &nbsp;or&nbsp;
+        </a>{' '}
+        or{' '}
         <a className="site-alert__link" href="https://about.sourcegraph.com/contact/sales">
             <span className="underline">contact us for a free trial</span>
         </a>

--- a/web/src/site/FreeUsersExceededAlert.tsx
+++ b/web/src/site/FreeUsersExceededAlert.tsx
@@ -10,14 +10,14 @@ export const FreeUsersExceededAlert: React.FunctionComponent<{
 }> = ({ noLicenseWarningUserCount, className = '' }) => (
     <div className={`alert alert-danger alert-animated-bg ${className}`}>
         <WarningIcon className="icon-inline mr-2" />
-        You have exceeded {noLicenseWarningUserCount === null ? 'the limit for' : noLicenseWarningUserCount} free users,
-        and need to{' '}
+        This Sourcegraph instance has exceeded{' '}
+        {noLicenseWarningUserCount === null ? 'the limit for' : noLicenseWarningUserCount} free users, and an admin must{' '}
         <a className="site-alert__link" href="https://sourcegraph.com/user/subscriptions/new">
             <span className="underline">purchase a license</span>
         </a>{' '}
         or{' '}
         <a className="site-alert__link" href="https://about.sourcegraph.com/contact/sales">
-            <span className="underline">contact us for a free trial</span>
+            <span className="underline">contact Sourcegraph for a free trial</span>
         </a>
     </div>
 )

--- a/web/src/site/FreeUsersExceededAlert.tsx
+++ b/web/src/site/FreeUsersExceededAlert.tsx
@@ -8,8 +8,8 @@ export const FreeUsersExceededAlert: React.FunctionComponent<{
     noLicenseWarningUserCount: number | null
     className?: string
 }> = ({ noLicenseWarningUserCount, className = '' }) => (
-    <div className={`alert alert-danger alert-animated-bg align-items-center ${className}`}>
-        <WarningIcon className="icon-inline mr-2 flex-shrink-0" />
+    <div className={`alert alert-danger alert-animated-bg ${className}`}>
+        <WarningIcon className="icon-inline mr-2" />
         You have exceeded {noLicenseWarningUserCount === null ? 'the limit for' : noLicenseWarningUserCount} free users,
         and need to{' '}
         <a className="site-alert__link" href="https://sourcegraph.com/user/subscriptions/new">

--- a/web/src/site/LicenseExpirationAlert.tsx
+++ b/web/src/site/LicenseExpirationAlert.tsx
@@ -15,7 +15,7 @@ export const LicenseExpirationAlert: React.FunctionComponent<{
 }> = ({ expiresAt, daysLeft, className = '' }) => (
     <DismissibleAlert
         partialStorageKey={`licenseExpiring.${daysLeft}`}
-        className={`alert alert-warning d-flex align-items-center ${className}`}
+        className={`alert alert-warning align-items-center ${className}`}
     >
         <WarningIcon className="icon-inline mr-2 flex-shrink-0" />
         Your Sourcegraph license will expire in {formatDistanceStrict(expiresAt, Date.now())}.&nbsp;

--- a/web/src/site/backend.tsx
+++ b/web/src/site/backend.tsx
@@ -24,6 +24,7 @@ export function refreshSiteFlags(): Observable<never> {
                 query SiteFlags {
                     site {
                         needsRepositoryConfiguration
+                        freeUsersExceeded
                         noRepositoriesEnabled
                         alerts {
                             type
@@ -52,6 +53,7 @@ export function refreshSiteFlags(): Observable<never> {
                             license {
                                 expiresAt
                             }
+                            noLicenseWarningUserCount
                         }
                     }
                 }

--- a/web/src/site/index.ts
+++ b/web/src/site/index.ts
@@ -3,6 +3,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 export type SiteFlags = Pick<
     GQL.ISite,
     | 'needsRepositoryConfiguration'
+    | 'freeUsersExceeded'
     | 'noRepositoriesEnabled'
     | 'alerts'
     | 'authProviders'


### PR DESCRIPTION
A new non-dismissable alert is now shown to all users on an instance when there's no valid license in use, and the count of users exceeds the free user limit (20, see https://github.com/sourcegraph/about/pull/104, as well as https://docs.google.com/document/d/1L72XF8EY5i0QL8b338j0g7ERrgNruXDvvhZjadcOFZc/edit#, internally).

The _hard_ pay wall now appears at 50 users, rather than 100 (this may be a pain for some users — we should update the paywall page to make it more obvious how to mitigate the issue (e.g. a link to the management console docs if there isn't one, a link to get a free trial, etc.).