### PR TITLE
debugserver: Add zoekt services to debug server

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -34,7 +34,11 @@ func addDebugHandlers(r *mux.Router) {
 
 	index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for _, svc := range debugserver.Services {
-			fmt.Fprintf(w, `<a href="%s/">%s</a><br>`, svc.Name, svc.Name)
+			path := "/"
+			if svc.DefaultPath != "" {
+				path = svc.DefaultPath
+			}
+			fmt.Fprintf(w, `<a href="%s%s">%s</a><br>`, svc.Name, path, svc.Name)
 		}
 		fmt.Fprintf(w, `<a href="headers">headers</a><br>`)
 

--- a/cmd/server/shared/globals.go
+++ b/cmd/server/shared/globals.go
@@ -17,6 +17,8 @@ var SrcProfServices = []map[string]string{
 	{"Name": "symbols", "Host": "127.0.0.1:6071"},
 	{"Name": "repo-updater", "Host": "127.0.0.1:6074"},
 	{"Name": "query-runner", "Host": "127.0.0.1:6067"},
+	{"Name": "zoekt-indexserver", "Host": "127.0.0.1:6072"},
+	{"Name": "zoekt-webserver", "Host": "127.0.0.1:3070"},
 }
 
 // ProcfileAdditions is a list of Procfile lines that should be added to the emitted Procfile that

--- a/cmd/server/shared/globals.go
+++ b/cmd/server/shared/globals.go
@@ -18,7 +18,7 @@ var SrcProfServices = []map[string]string{
 	{"Name": "repo-updater", "Host": "127.0.0.1:6074"},
 	{"Name": "query-runner", "Host": "127.0.0.1:6067"},
 	{"Name": "zoekt-indexserver", "Host": "127.0.0.1:6072"},
-	{"Name": "zoekt-webserver", "Host": "127.0.0.1:3070"},
+	{"Name": "zoekt-webserver", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/"},
 }
 
 // ProcfileAdditions is a list of Procfile lines that should be added to the emitted Procfile that

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -10,7 +10,7 @@ nginx: nginx -p . -g 'daemon off;' -c $PWD/dev/nginx.conf | grep -v 'could not o
 web: ./node_modules/.bin/gulp --color watch
 syntect_server: ./dev/syntect_server
 zoekt-indexserver: ./dev/zoekt-wrapper zoekt-sourcegraph-indexserver -sourcegraph_url http://localhost:3090 -index $HOME/.sourcegraph/zoekt/index -interval 1m -listen :6072
-zoekt-webserver: ./dev/zoekt-wrapper zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc
+zoekt-webserver: ./dev/zoekt-wrapper zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc -listen :3070
 management-console: PROJECT_ROOT=./cmd/management-console TLS_CERT=$HOME/.sourcegraph/management/cert.pem TLS_KEY=$HOME/.sourcegraph/management/key.pem management-console
 management-console-web: cd ./cmd/management-console/web && ./serve.sh
 # jaeger: docker run --name=jaeger --rm -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest

--- a/dev/launch.sh
+++ b/dev/launch.sh
@@ -57,7 +57,7 @@ export SRC_PROF_HTTP=
 export SRC_PROF_SERVICES=$(cat dev/src-prof-services.json)
 export OVERRIDE_AUTH_SECRET=sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ
 export DEPLOY_TYPE=dev
-export ZOEKT_HOST=localhost:6070
+export ZOEKT_HOST=localhost:3070
 
 # webpack-dev-server is a proxy running on port 3080 that (1) serves assets, waiting to respond
 # until they are (re)built and (2) otherwise proxies to nginx running on port 3081 (which proxies to

--- a/dev/src-prof-services.json
+++ b/dev/src-prof-services.json
@@ -4,5 +4,7 @@
   { "Name": "searcher", "Host": "127.0.0.1:6069" },
   { "Name": "symbols", "Host": "127.0.0.1:6071" },
   { "Name": "repo-updater", "Host": "127.0.0.1:6074" },
-  { "Name": "query-runner", "Host": "127.0.0.1:6067" }
+  { "Name": "query-runner", "Host": "127.0.0.1:6067" },
+  { "Name": "zoekt-indexserver", "Host": "127.0.0.1:6072" },
+  { "Name": "zoekt-webserver", "Host": "127.0.0.1:3070" }
 ]

--- a/dev/src-prof-services.json
+++ b/dev/src-prof-services.json
@@ -6,5 +6,5 @@
   { "Name": "repo-updater", "Host": "127.0.0.1:6074" },
   { "Name": "query-runner", "Host": "127.0.0.1:6067" },
   { "Name": "zoekt-indexserver", "Host": "127.0.0.1:6072" },
-  { "Name": "zoekt-webserver", "Host": "127.0.0.1:3070" }
+  { "Name": "zoekt-webserver", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" }
 ]

--- a/pkg/debugserver/debug.go
+++ b/pkg/debugserver/debug.go
@@ -62,6 +62,9 @@ type Service struct {
 	// Host is the host:port for the services SRC_PROF_HTTP. example:
 	// "127.0.0.1:6060"
 	Host string
+
+	// DefaultPath is the path to the service we should link to.
+	DefaultPath string
 }
 
 // Start runs a debug server (pprof, prometheus, etc) if it is configured (via


### PR DESCRIPTION
We have a convenience page at http://sourcegraph.example/com/-/debug/ for site
admins to view individual service's debug pages. This adds zoekt to the list.

See individual commits for more details.

Test plan: Visited http://localhost:3080/-/debug/ and clicked through to the zoekt services as well as others. See screenshots below

Part of #3294

![image](https://user-images.githubusercontent.com/187831/55950512-6819af00-5c55-11e9-9eb5-023b4a41b711.png)
![image](https://user-images.githubusercontent.com/187831/55950548-72d44400-5c55-11e9-8944-375d3b47e926.png)
![image](https://user-images.githubusercontent.com/187831/55950561-7e276f80-5c55-11e9-81ea-fa5ae48e5676.png)
