### PR TITLE
github: Fail if search has incomplete results

### DIFF
--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 // SplitRepositoryNameWithOwner splits a GitHub repository's "owner/name" string into "owner" and "name", with
@@ -370,7 +370,7 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 		return nil, false, 1, err
 	}
 	if response.IncompleteResults {
-		log15.Error("GitHub repository search returned incomplete results, some repositories may have been skipped", "searchString", searchString, "page", page, "total repository count", response.TotalCount)
+		return nil, false, 1, errors.Errorf("github repository search returned incomplete results: query=%q page=%d total=%d", searchString, page, response.TotalCount)
 	}
 	repos = make([]*Repository, 0, len(response.Items))
 	for _, restRepo := range response.Items {


### PR DESCRIPTION
Our new syncer requires a source to return all repositories it is configured
to return. A repository not being listed by a source will be deleted by the
syncer. So in the case of incomplete results a repository will be
soft-deleted (and then likely be undeleted the next sync). Instead we just
fail the search if GitHub returns incomplete results.

Alternatively we could implemented logic to gracefully handle this response. Things like retries or a degraded mode for the syncer. For retries the syncer will retry at the next interval anyways. A degraded mode will be more tricky to implement, so is not worth it this close to the branch cut.

Test plan: unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/3363

Part of #2025
