### PR TITLE
repo-updater: Handle renames in Git update scheduler

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -281,7 +281,7 @@ func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct 
 		if err != nil {
 			return nil, err
 		}
-		if err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo); err != nil {
+		if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -45,7 +45,10 @@ func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*
 
 func (r *repositoryMirrorInfoResolver) repoUpdateSchedulerInfo(ctx context.Context) (*repoupdaterprotocol.RepoUpdateSchedulerInfoResult, error) {
 	r.repoUpdateSchedulerInfoOnce.Do(func() {
-		args := repoupdaterprotocol.RepoUpdateSchedulerInfoArgs{RepoName: r.repository.repo.Name}
+		args := repoupdaterprotocol.RepoUpdateSchedulerInfoArgs{
+			RepoName: r.repository.repo.Name,
+			ID:       uint32(r.repository.repo.ID),
+		}
 		r.repoUpdateSchedulerInfoResult, r.repoUpdateSchedulerInfoErr = repoupdater.DefaultClient.RepoUpdateSchedulerInfo(ctx, args)
 	})
 	return r.repoUpdateSchedulerInfoResult, r.repoUpdateSchedulerInfoErr

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -247,7 +247,7 @@ func (r *schemaResolver) UpdateMirrorRepository(ctx context.Context, args *struc
 	if err != nil {
 		return nil, err
 	}
-	if err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo); err != nil {
+	if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil
@@ -273,7 +273,7 @@ func (r *schemaResolver) UpdateAllMirrorRepositories(ctx context.Context) (*Empt
 		if err != nil {
 			return nil, err
 		}
-		if err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo); err != nil {
+		if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 	"github.com/sourcegraph/sourcegraph/pkg/routevar"
 	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 
@@ -185,8 +186,15 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 		// Update gitserver contents for a repo whenever it is visited.
 		go func() {
 			ctx := context.Background()
-			if gitserverRepo, err := backend.GitRepo(ctx, common.Repo); err == nil {
-				repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo)
+			gitserverRepo, err := backend.GitRepo(ctx, common.Repo)
+			if err != nil {
+				log15.Error("backend.GitRepo", "error", err)
+				return
+			}
+
+			_, err = repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, gitserverRepo)
+			if err != nil {
+				log15.Error("EnqueueRepoUpdate", "error", err)
 			}
 		}()
 	}

--- a/cmd/frontend/internal/httpapi/repo_refresh.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh.go
@@ -23,8 +23,9 @@ func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	return repoupdater.DefaultClient.EnqueueRepoUpdate(context.Background(), gitserver.Repo{
+	_, err = repoupdater.DefaultClient.EnqueueRepoUpdate(context.Background(), gitserver.Repo{
 		Name: repo.Name,
 		URL:  repoMeta.Repo.VCS.URL,
 	})
+	return err
 }

--- a/cmd/frontend/internal/httpapi/repo_refresh_test.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh_test.go
@@ -16,12 +16,12 @@ func TestRepoRefresh(t *testing.T) {
 	c := newTest()
 
 	enqueueRepoUpdateCount := map[api.RepoName]int{}
-	repoupdater.MockEnqueueRepoUpdate = func(ctx context.Context, repo gitserver.Repo) error {
+	repoupdater.MockEnqueueRepoUpdate = func(ctx context.Context, repo gitserver.Repo) (*protocol.RepoUpdateResponse, error) {
 		if exp := "git@github.com:dummy-url"; repo.URL != exp {
 			t.Errorf("missing or incorrect clone URL, expected %q, got %q", exp, repo.URL)
 		}
 		enqueueRepoUpdateCount[repo.Name]++
-		return nil
+		return nil, nil
 	}
 	repoupdater.MockRepoLookup = func(args protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error) {
 		return &protocol.RepoLookupResult{

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -480,6 +480,10 @@ func (q *updateQueue) reset() {
 // If the given priority is higher than the one in the queue,
 // the repo's position in the queue is updated accordingly.
 func (q *updateQueue) enqueue(repo *configuredRepo2, p priority) (updated bool) {
+	if repo.ID == 0 {
+		panic("repo.id is zero")
+	}
+
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -521,6 +525,10 @@ func (q *updateQueue) nextSeq() uint64 {
 
 // remove removes the repo from the queue if the repo.Updating matches the updating argument.
 func (q *updateQueue) remove(repo *configuredRepo2, updating bool) (removed bool) {
+	if repo.ID == 0 {
+		panic("repo.id is zero")
+	}
+
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -614,6 +622,10 @@ type scheduledRepoUpdate struct {
 
 // upsert inserts or updates a repo in the schedule.
 func (s *schedule) upsert(repo *configuredRepo2) (updated bool) {
+	if repo.ID == 0 {
+		panic("repo.id is zero")
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -636,6 +648,10 @@ func (s *schedule) upsert(repo *configuredRepo2) (updated bool) {
 // updateInterval updates the update interval of a repo in the schedule.
 // It does nothing if the repo is not in the schedule.
 func (s *schedule) updateInterval(repo *configuredRepo2, interval time.Duration) {
+	if repo.ID == 0 {
+		panic("repo.id is zero")
+	}
+
 	s.mu.Lock()
 	if update := s.index[repo.ID]; update != nil {
 		switch {
@@ -656,6 +672,10 @@ func (s *schedule) updateInterval(repo *configuredRepo2, interval time.Duration)
 
 // remove removes a repo from the schedule.
 func (s *schedule) remove(repo *configuredRepo2) (removed bool) {
+	if repo.ID == 0 {
+		panic("repo.id is zero")
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -329,8 +329,9 @@ func (s *updateScheduler) updateSource(source string, newList sourceRepoMap) {
 
 // UpdateOnce causes a single update of the given repository.
 // It neither adds nor removes the repo from the schedule.
-func (s *updateScheduler) UpdateOnce(name api.RepoName, url string) {
+func (s *updateScheduler) UpdateOnce(id uint32, name api.RepoName, url string) {
 	repo := &configuredRepo2{
+		ID:   id,
 		Name: name,
 		URL:  url,
 	}

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -1340,14 +1340,13 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{
-							Name: "a", URL: "a.com", Enabled: false},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: false},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
 				},
 			},
 		},
@@ -1358,20 +1357,20 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 				},
 			},
 			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: false},
 			},
 			timeAfterFuncDelays: []time.Duration{minDelay},
 			expectedNotifications: func(s *updateScheduler) []chan struct{} {
@@ -1382,27 +1381,27 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			name: "update disabled repo",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: false},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
 				},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
 				},
 			},
 			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true}, Seq: 1, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Seq: 1, Updating: false},
 			},
 			timeAfterFuncDelays: []time.Duration{minDelay},
 			expectedNotifications: func(s *updateScheduler) []chan struct{} {
@@ -1413,26 +1412,26 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			name: "disabled repo removed from schedule and queue",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: false}, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false}, Updating: false},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: false},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: false},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
 				},
 			},
 		},
@@ -1440,14 +1439,14 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			name: "missing repo removed from schedule and queue",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true /* enabled state doesn't get updated once in the queue because concurrency nightmare */}, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true /* enabled state doesn't get updated once in the queue because concurrency nightmare */}, Updating: false},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
@@ -1463,29 +1462,29 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			name: "disabled repo not removed from queue when updating",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Updating: true},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: false},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
 					},
 				},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: false},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
 				},
 			},
 		},
@@ -1493,14 +1492,14 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			name: "missing repo not removed from queue when updating",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Updating: true},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
@@ -1509,7 +1508,7 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 				},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {},
@@ -1519,53 +1518,53 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			name: "enabled repo updated",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: false},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
 				},
 			},
 			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true}, Seq: 1, Updating: false},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Seq: 1, Updating: false},
 			},
 		},
 		{
 			name: "disabled repo updated",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: false},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: false},
 				},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: false},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: false},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: false},
 				},
 			},
 		},
@@ -1573,33 +1572,33 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			name: "update enabled repo while updating",
 			initialSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true},
 				},
 			},
 			initialSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			initialQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
 			},
 			updateSourceCalls: []*updateSourceCall{
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true},
+						api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
 					},
 				},
 			},
 			finalSourceRepos: map[string]sourceRepoMap{
 				"a": {
-					api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true},
+					api.RepoName("a/a"): &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true},
 				},
 			},
 			finalSchedule: []*scheduledRepoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "aa.com", Enabled: true}, Interval: minDelay, Due: defaultTime.Add(minDelay)},
 			},
 			finalQueue: []*repoUpdate{
-				{Repo: &configuredRepo2{Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
+				{Repo: &configuredRepo2{ID: 1, Name: "a", URL: "a.com", Enabled: true}, Seq: 1, Updating: true},
 			},
 		},
 	}

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -56,12 +56,12 @@ func startRecording() (*recording, func()) {
 }
 
 func TestUpdateQueue_enqueue(t *testing.T) {
-	a := configuredRepo2{Name: "a", URL: "a.com"}
-	a2 := configuredRepo2{Name: "a", URL: "a.com/v2"}
-	b := configuredRepo2{Name: "b", URL: "b.com"}
-	c := configuredRepo2{Name: "c", URL: "c.com"}
-	d := configuredRepo2{Name: "d", URL: "d.com"}
-	e := configuredRepo2{Name: "e", URL: "e.com"}
+	a := configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	a2 := configuredRepo2{ID: 1, Name: "a2", URL: "a2.com"}
+	b := configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	d := configuredRepo2{ID: 4, Name: "d", URL: "d.com"}
+	e := configuredRepo2{ID: 5, Name: "e", URL: "e.com"}
 
 	type enqueueCall struct {
 		repo     configuredRepo2
@@ -297,9 +297,9 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 }
 
 func TestUpdateQueue_remove(t *testing.T) {
-	a := &configuredRepo2{Name: "a", URL: "a.com"}
-	b := &configuredRepo2{Name: "b", URL: "b.com"}
-	c := &configuredRepo2{Name: "c", URL: "c.com"}
+	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
 
 	type removeCall struct {
 		repo     *configuredRepo2
@@ -457,8 +457,8 @@ func TestUpdateQueue_remove(t *testing.T) {
 }
 
 func TestUpdateQueue_acquireNext(t *testing.T) {
-	a := &configuredRepo2{Name: "a", URL: "a.com"}
-	b := &configuredRepo2{Name: "b", URL: "b.com"}
+	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
 
 	tests := []struct {
 		name           string
@@ -552,9 +552,9 @@ func verifyQueue(t *testing.T, s *updateScheduler, expected []*repoUpdate) {
 }
 
 func TestSchedule_upsert(t *testing.T) {
-	a := &configuredRepo2{Name: "a", URL: "a.com"}
-	a2 := &configuredRepo2{Name: "a", URL: "a.com/v2"}
-	b := &configuredRepo2{Name: "b", URL: "b.com"}
+	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	a2 := &configuredRepo2{ID: 1, Name: "a2", URL: "a2.com"}
+	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
 
 	type upsertCall struct {
 		time time.Time
@@ -700,11 +700,11 @@ func TestSchedule_upsert(t *testing.T) {
 }
 
 func TestSchedule_updateInterval(t *testing.T) {
-	a := &configuredRepo2{Name: "a", URL: "a.com"}
-	b := &configuredRepo2{Name: "b", URL: "b.com"}
-	c := &configuredRepo2{Name: "c", URL: "c.com"}
-	d := &configuredRepo2{Name: "d", URL: "d.com"}
-	e := &configuredRepo2{Name: "e", URL: "e.com"}
+	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	d := &configuredRepo2{ID: 4, Name: "d", URL: "d.com"}
+	e := &configuredRepo2{ID: 5, Name: "e", URL: "e.com"}
 
 	type updateCall struct {
 		time     time.Time
@@ -878,9 +878,9 @@ func TestSchedule_updateInterval(t *testing.T) {
 }
 
 func TestSchedule_remove(t *testing.T) {
-	a := &configuredRepo2{Name: "a", URL: "a.com"}
-	b := &configuredRepo2{Name: "b", URL: "b.com"}
-	c := &configuredRepo2{Name: "c", URL: "c.com"}
+	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
 
 	type removeCall struct {
 		time time.Time
@@ -1015,11 +1015,11 @@ func verifyScheduleRecording(t *testing.T, s *updateScheduler, timeAfterFuncDela
 }
 
 func TestUpdateScheduler_runSchedule(t *testing.T) {
-	a := &configuredRepo2{Name: "a", URL: "a.com"}
-	b := &configuredRepo2{Name: "b", URL: "b.com"}
-	c := &configuredRepo2{Name: "c", URL: "c.com"}
-	d := &configuredRepo2{Name: "d", URL: "d.com"}
-	e := &configuredRepo2{Name: "e", URL: "e.com"}
+	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
+	d := &configuredRepo2{ID: 4, Name: "d", URL: "d.com"}
+	e := &configuredRepo2{ID: 5, Name: "e", URL: "e.com"}
 
 	tests := []struct {
 		name                  string
@@ -1137,9 +1137,9 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 }
 
 func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
-	a := &configuredRepo2{Name: "a", URL: "a.com"}
-	b := &configuredRepo2{Name: "b", URL: "b.com"}
-	c := &configuredRepo2{Name: "c", URL: "c.com"}
+	a := &configuredRepo2{ID: 1, Name: "a", URL: "a.com"}
+	b := &configuredRepo2{ID: 2, Name: "b", URL: "b.com"}
+	c := &configuredRepo2{ID: 3, Name: "c", URL: "c.com"}
 
 	type mockRequestRepoUpdate struct {
 		repo *configuredRepo2
@@ -1340,7 +1340,8 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 				{
 					source: "a",
 					newList: sourceRepoMap{
-						api.RepoName("a/a"): &configuredRepo2{Name: "a", URL: "a.com", Enabled: false},
+						api.RepoName("a/a"): &configuredRepo2{
+							Name: "a", URL: "a.com", Enabled: false},
 					},
 				},
 			},

--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -120,6 +120,7 @@ func createEnableUpdateRepos(ctx context.Context, source string, repoChan <-chan
 
 		if !c.DisableAutoGitUpdates {
 			newMap[createdRepo.Name] = &configuredRepo2{
+				ID:      uint32(createdRepo.ID),
 				Name:    createdRepo.Name,
 				URL:     op.URL,
 				Enabled: createdRepo.Enabled,

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -212,7 +212,7 @@ func (s *Server) handleRepoUpdateSchedulerInfo(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	result := repos.Scheduler.ScheduleInfo(args.RepoName)
+	result := repos.Scheduler.ScheduleInfo(args.ID)
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -487,10 +487,6 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 
 	var testCases []testCase
 	testCases = append(testCases,
-		testCase{
-			name: "needs a store",
-			err:  `Can't lookup id of "" without a store. Set SRC_SYNCER_ENABLED=true`,
-		},
 		func() testCase {
 			err := errors.New("boom")
 			return testCase{

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -10,7 +10,10 @@ import (
 
 type RepoUpdateSchedulerInfoArgs struct {
 	// RepoName is the repository name to look up.
+	// XXX(tsenart): Depreacted. Remove after lookup by ID is rolled out.
 	RepoName api.RepoName
+	// The ID of the repo to lookup the schedule for.
+	ID uint32
 }
 
 type RepoUpdateSchedulerInfoResult struct {

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -152,6 +152,16 @@ type RepoUpdateRequest struct {
 	URL string `json:"url"`
 }
 
+// RepoUpdateResponse is a response type to a RepoUpdateRequest.
+type RepoUpdateResponse struct {
+	// ID of the repo that got an update request.
+	ID uint32 `json:"id"`
+	// Name of the repo that got an update request.
+	Name string `json:"name"`
+	// URL of the repo that got an update request.
+	URL string `json:"url"`
+}
+
 // ExternalServiceSyncRequest is a request to sync a specific external service eagerly.
 //
 // The FrontendAPI is one of the issuers of this request. It does so when creating or


### PR DESCRIPTION
This PR builds upon #3368. It makes the Git update scheduler handle renames of repos.

Part of #2025