### PR TITLE
make zoekt-wrapper a little more readable

### DIFF
--- a/dev/zoekt-wrapper
+++ b/dev/zoekt-wrapper
@@ -3,6 +3,8 @@
 set -euf -o pipefail
 
 # Sleep to allow frontend to start :'(
-[ "$1" != "zoekt-sourcegraph-indexserver" ] || sleep 5
+if [[ "$1" == "zoekt-sourcegraph-indexserver" ]]; then
+    sleep 5
+fi
 
 exec $@


### PR DESCRIPTION
Test plan: run ./dev/launch.sh and see it work as it normally does.
