### PR TITLE
search: show "deadline exceeded" error instead of "No results" when index searches time out

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -871,7 +871,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		if limitHit {
 			common.limitHit = true
 		}
-		tr.LazyPrintf("searchErr: %v, err: %v, overLimitCanceled: %v", searchErr, err, overLimitCanceled)
+		tr.LogFields(otlog.Object("searchErr", searchErr),  otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
 		if searchErr != nil && err == nil && !overLimitCanceled {
 			err = searchErr
 			tr.LazyPrintf("cancel indexed search due to error: %v", err)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -364,7 +364,7 @@ func fileMatchURI(name api.RepoName, ref, path string) string {
 	return b.String()
 }
 
-func kFromNumRepos(numRepos int, query *search.PatternInfo) int {
+func zoektResultCountFactor(numRepos int, query *search.PatternInfo) int {
 	// If we're only searching a small number of repositories, return more comprehensive results. This is
 	// arbitrary.
 	k := 1
@@ -388,7 +388,7 @@ func kFromNumRepos(numRepos int, query *search.PatternInfo) int {
 	return k
 }
 
-func zoektSearchOpts(numRepos, k int, query *search.PatternInfo) zoekt.SearchOptions {
+func zoektSearchOpts(k int, query *search.PatternInfo) zoekt.SearchOptions {
 	searchOpts := zoekt.SearchOptions{
 		MaxWallTime:            1500 * time.Millisecond,
 		ShardMaxMatchCount:     100 * k,
@@ -495,7 +495,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 		return nil, false, nil, nil
 	}
 
-	k := kFromNumRepos(len(repos), query)
+	k := zoektResultCountFactor(len(repos), query)
 	maxLineMatches := 25 + k
 	maxLineFragmentMatches := 3 + k
 	if len(resp.Files) > int(query.FileMatchLimit) {
@@ -850,8 +850,8 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		// TODO limitHit, handleRepoSearchResult
 		defer wg.Done()
 		query := args.Pattern
-		k := kFromNumRepos(len(zoektRepos), query)
-		opts := zoektSearchOpts(len(zoektRepos), k, query)
+		k := zoektResultCountFactor(len(zoektRepos), query)
+		opts := zoektSearchOpts(k, query)
 		matches, limitHit, reposLimitHit, searchErr := zoektSearchHEAD(ctx, query, zoektRepos, args.UseFullDeadline, Search().Index.Client, opts)
 		mu.Lock()
 		defer mu.Unlock()

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -322,11 +322,13 @@ func (e *searcherError) Error() string {
 
 type deadlineExceededError struct {}
 
-func (e *deadlineExceededError) Error() string {
+func (e deadlineExceededError) Error() string {
 	return "no results found by deadline in index search"
 }
+func (e deadlineExceededError) Timeout() bool   { return true }
+func (e deadlineExceededError) Temporary() bool { return true }
 
-var DeadlineExceededError = &deadlineExceededError{}
+var DeadlineExceededError = deadlineExceededError{}
 
 var mockSearchFilesInRepo func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error)
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -320,16 +320,6 @@ func (e *searcherError) Error() string {
 	return e.Message
 }
 
-type deadlineExceededError struct {}
-
-func (e deadlineExceededError) Error() string {
-	return "no results found by deadline in index search"
-}
-func (e deadlineExceededError) Timeout() bool   { return true }
-func (e deadlineExceededError) Temporary() bool { return true }
-
-var DeadlineExceededError = deadlineExceededError{}
-
 var mockSearchFilesInRepo func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error)
 
 func searchFilesInRepo(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error) {
@@ -482,7 +472,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 	resp, err := searcher.Search(ctx, finalQuery, &searchOpts)
 	tr.LazyPrintf("resp.FileCount: %v, resp.MatchCount: %v, resp.Wait: %v, MaxWallTime: %v", resp.FileCount, resp.MatchCount, resp.Wait, searchOpts.MaxWallTime)
 	if resp.FileCount == 0 && resp.MatchCount == 0 && time.Now().Sub(t0) >= searchOpts.MaxWallTime {
-		return nil, false, nil, DeadlineExceededError
+		return nil, false, nil, errors.New("no results found by deadline in index search")
 	}
 	if err != nil {
 		return nil, false, nil, err

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -470,7 +470,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 
 	t0 := time.Now()
 	resp, err := searcher.Search(ctx, finalQuery, &searchOpts)
-	tr.LazyPrintf("resp.FileCount: %v, resp.MatchCount: %v, resp.Wait: %v, MaxWallTime: %v", resp.FileCount, resp.MatchCount, resp.Wait, searchOpts.MaxWallTime)
+	tr.LogFields(otlog.Int("resp.FileCount", resp.FileCount), otlog.Int("resp.MatchCount", resp.MatchCount), otlog.Object("searchOpts.MaxWallTime", searchOpts.MaxWallTime))
 	if resp.FileCount == 0 && resp.MatchCount == 0 && time.Since(t0) >= searchOpts.MaxWallTime {
 		return nil, false, nil, errors.New("no results found by deadline in index search")
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -372,7 +372,58 @@ func fileMatchURI(name api.RepoName, ref, path string) string {
 	return b.String()
 }
 
-func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*search.RepositoryRevisions, useFullDeadline bool) (fm []*fileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
+func kFromNumRepos(numRepos int, query *search.PatternInfo) int {
+	// If we're only searching a small number of repositories, return more comprehensive results. This is
+	// arbitrary.
+	k := 1
+	switch {
+	case numRepos <= 500:
+		k = 2
+	case numRepos <= 100:
+		k = 3
+	case numRepos <= 50:
+		k = 5
+	case numRepos <= 25:
+		k = 8
+	case numRepos <= 10:
+		k = 10
+	case numRepos <= 5:
+		k = 100
+	}
+	if query.FileMatchLimit > defaultMaxSearchResults {
+		k = int(float64(k) * 3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
+	}
+	return k
+}
+
+func zoektSearchOpts(numRepos, k int, query *search.PatternInfo) zoekt.SearchOptions {
+	searchOpts := zoekt.SearchOptions{
+		MaxWallTime:            1500 * time.Millisecond,
+		ShardMaxMatchCount:     100 * k,
+		TotalMaxMatchCount:     100 * k,
+		ShardMaxImportantMatch: 15 * k,
+		TotalMaxImportantMatch: 25 * k,
+		MaxDocDisplayCount:     2 * defaultMaxSearchResults,
+	}
+
+	// We want zoekt to return more than FileMatchLimit results since we use
+	// the extra results to populate reposLimitHit. Additionally the defaults
+	// are very low, so we always want to return at least 2000.
+	if query.FileMatchLimit > defaultMaxSearchResults {
+		searchOpts.MaxDocDisplayCount = 2 * int(query.FileMatchLimit)
+	}
+	if searchOpts.MaxDocDisplayCount < 2000 {
+		searchOpts.MaxDocDisplayCount = 2000
+	}
+
+	if userProbablyWantsToWaitLonger := query.FileMatchLimit > defaultMaxSearchResults; userProbablyWantsToWaitLonger {
+		searchOpts.MaxWallTime *= time.Duration(3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
+	}
+
+	return searchOpts
+}
+
+func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*search.RepositoryRevisions, useFullDeadline bool, searcher zoekt.Searcher, searchOpts zoekt.SearchOptions) (fm []*fileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
 	if len(repos) == 0 {
 		return nil, false, nil, nil
 	}
@@ -400,50 +451,6 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 		tr.Finish()
 	}()
 
-	// If we're only searching a small number of repositories, return more comprehensive results. This is
-	// arbitrary.
-	k := 1
-	switch {
-	case len(repos) <= 500:
-		k = 2
-	case len(repos) <= 100:
-		k = 3
-	case len(repos) <= 50:
-		k = 5
-	case len(repos) <= 25:
-		k = 8
-	case len(repos) <= 10:
-		k = 10
-	case len(repos) <= 5:
-		k = 100
-	}
-	if query.FileMatchLimit > defaultMaxSearchResults {
-		k = int(float64(k) * 3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
-	}
-
-	searchOpts := zoekt.SearchOptions{
-		MaxWallTime:            1500 * time.Millisecond,
-		ShardMaxMatchCount:     100 * k,
-		TotalMaxMatchCount:     100 * k,
-		ShardMaxImportantMatch: 15 * k,
-		TotalMaxImportantMatch: 25 * k,
-		MaxDocDisplayCount:     2 * defaultMaxSearchResults,
-	}
-
-	// We want zoekt to return more than FileMatchLimit results since we use
-	// the extra results to populate reposLimitHit. Additionally the defaults
-	// are very low, so we always want to return at least 2000.
-	if query.FileMatchLimit > defaultMaxSearchResults {
-		searchOpts.MaxDocDisplayCount = 2 * int(query.FileMatchLimit)
-	}
-	if searchOpts.MaxDocDisplayCount < 2000 {
-		searchOpts.MaxDocDisplayCount = 2000
-	}
-
-	if userProbablyWantsToWaitLonger := query.FileMatchLimit > defaultMaxSearchResults; userProbablyWantsToWaitLonger {
-		searchOpts.MaxWallTime *= time.Duration(3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
-	}
-
 	if useFullDeadline {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
 		deadline, _ := ctx.Deadline()
@@ -470,7 +477,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 	tr.LogFields(otlog.String("maxWallTime", searchOpts.MaxWallTime.String()))
 
 	t0 := time.Now()
-	resp, err := Search().Index.Client.Search(ctx, finalQuery, &searchOpts)
+	resp, err := searcher.Search(ctx, finalQuery, &searchOpts)
 	tr.LazyPrintf("resp.FileCount: %v, resp.MatchCount: %v, resp.Wait: %v, MaxWallTime: %v", resp.FileCount, resp.MatchCount, resp.Wait, searchOpts.MaxWallTime)
 	if resp.FileCount == 0 && resp.MatchCount == 0 && time.Now().Sub(t0) >= searchOpts.MaxWallTime {
 		return nil, false, nil, DeadlineExceededError
@@ -496,6 +503,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 		return nil, false, nil, nil
 	}
 
+	k := kFromNumRepos(len(repos), query)
 	maxLineMatches := 25 + k
 	maxLineFragmentMatches := 3 + k
 	if len(resp.Files) > int(query.FileMatchLimit) {
@@ -754,6 +762,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 	}
 
 	var (
+		// TODO: convert wg to an errgroup
 		wg                sync.WaitGroup
 		mu                sync.Mutex
 		unflattened       [][]*fileMatchResolver
@@ -848,7 +857,10 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 	go func() {
 		// TODO limitHit, handleRepoSearchResult
 		defer wg.Done()
-		matches, limitHit, reposLimitHit, searchErr := zoektSearchHEAD(ctx, args.Pattern, zoektRepos, args.UseFullDeadline)
+		query := args.Pattern
+		k := kFromNumRepos(len(zoektRepos), query)
+		opts := zoektSearchOpts(len(zoektRepos), k, query)
+		matches, limitHit, reposLimitHit, searchErr := zoektSearchHEAD(ctx, query, zoektRepos, args.UseFullDeadline, Search().Index.Client, opts)
 		mu.Lock()
 		defer mu.Unlock()
 		if ctx.Err() == nil {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -872,7 +872,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		if limitHit {
 			common.limitHit = true
 		}
-		tr.LogFields(otlog.Object("searchErr", searchErr),  otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
+		tr.LogFields(otlog.Object("searchErr", searchErr), otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
 		if searchErr != nil && err == nil && !overLimitCanceled {
 			err = searchErr
 			tr.LazyPrintf("cancel indexed search due to error: %v", err)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -471,7 +471,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 	t0 := time.Now()
 	resp, err := searcher.Search(ctx, finalQuery, &searchOpts)
 	tr.LazyPrintf("resp.FileCount: %v, resp.MatchCount: %v, resp.Wait: %v, MaxWallTime: %v", resp.FileCount, resp.MatchCount, resp.Wait, searchOpts.MaxWallTime)
-	if resp.FileCount == 0 && resp.MatchCount == 0 && time.Now().Sub(t0) >= searchOpts.MaxWallTime {
+	if resp.FileCount == 0 && resp.MatchCount == 0 && time.Since(t0) >= searchOpts.MaxWallTime {
 		return nil, false, nil, errors.New("no results found by deadline in index search")
 	}
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -239,7 +239,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		useFullDeadline bool
 		searcher        zoekt.Searcher
 		opts            zoekt.SearchOptions
-		since			func(time.Time) time.Duration
+		since           func(time.Time) time.Duration
 	}
 	tests := []struct {
 		name              string
@@ -260,7 +260,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 				useFullDeadline: false,
 				searcher:        &fakeSearcher{result: &zoekt.SearchResult{}},
 				opts:            zoekt.SearchOptions{MaxWallTime: time.Second},
-				since:			 func(time.Time) time.Duration { return time.Second - time.Millisecond },
+				since:           func(time.Time) time.Duration { return time.Second - time.Millisecond },
 			},
 			wantFm:            nil,
 			wantLimitHit:      false,
@@ -278,7 +278,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 				useFullDeadline: false,
 				searcher:        &fakeSearcher{result: &zoekt.SearchResult{}},
 				opts:            zoekt.SearchOptions{MaxWallTime: time.Second},
-				since:			 func(time.Time) time.Duration { return time.Second },
+				since:           func(time.Time) time.Duration { return time.Second },
 			},
 			wantFm:            nil,
 			wantLimitHit:      false,

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -232,7 +232,7 @@ func (ss *sleepySearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoek
 	return &zoekt.SearchResult{}, nil
 }
 
-var linuxMinimumNap = 10*time.Millisecond
+var linuxMinimumNap = 10 * time.Millisecond
 
 func Test_zoektSearchHEAD(t *testing.T) {
 	type args struct {
@@ -241,7 +241,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		repos           []*search.RepositoryRevisions
 		useFullDeadline bool
 		searcher        zoekt.Searcher
-		opts			zoekt.SearchOptions
+		opts            zoekt.SearchOptions
 	}
 	tests := []struct {
 		name              string
@@ -249,31 +249,31 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		wantFm            []*fileMatchResolver
 		wantLimitHit      bool
 		wantReposLimitHit map[string]struct{}
-		wantErr           error
+		wantErr           bool
 	}{
 		{
-			name:"taking too long returns deadline exceeded error",
+			name: "taking too long returns deadline exceeded error",
 			args: args{
-				ctx: context.Background(),
+				ctx:   context.Background(),
 				query: &search.PatternInfo{PathPatternsAreRegExps: true},
 				repos: []*search.RepositoryRevisions{
 					{Repo: &types.Repo{}},
 				},
 				useFullDeadline: false,
-				searcher: &sleepySearcher{nap: linuxMinimumNap},
-				opts: zoekt.SearchOptions{MaxWallTime: linuxMinimumNap/2},
+				searcher:        &sleepySearcher{nap: linuxMinimumNap},
+				opts:            zoekt.SearchOptions{MaxWallTime: linuxMinimumNap / 2},
 			},
-			wantFm: nil,
-			wantLimitHit: false,
+			wantFm:            nil,
+			wantLimitHit:      false,
 			wantReposLimitHit: nil,
-			wantErr: DeadlineExceededError,
+			wantErr:           true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotFm, gotLimitHit, gotReposLimitHit, err := zoektSearchHEAD(tt.args.ctx, tt.args.query, tt.args.repos, tt.args.useFullDeadline, tt.args.searcher, tt.args.opts)
-			if err != tt.wantErr {
-				t.Errorf("zoektSearchHEAD() error = %v, want %v", err, tt.wantErr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(gotFm, tt.wantFm) {


### PR DESCRIPTION
This is progress on #3294.

Test plan: Unit test

Before:
![Screen Shot 2019-04-10 at 10 09 43 PM](https://user-images.githubusercontent.com/15530/56013731-0eda6b80-5ca7-11e9-9e93-43aef62067d6.png)

After:
<img width="675" alt="Screen Shot 2019-04-11 at 10 15 04 PM" src="https://user-images.githubusercontent.com/15530/56013788-595be800-5ca7-11e9-8e3e-d6e7e1d08a20.png">
