### PR TITLE
fix bug where panel views w/o location provider were not shown

### DIFF
--- a/shared/src/api/integration-test/views.test.ts
+++ b/shared/src/api/integration-test/views.test.ts
@@ -1,0 +1,65 @@
+import { NEVER } from 'rxjs'
+import { first } from 'rxjs/operators'
+import { assertToJSON } from '../extension/types/testHelpers'
+import { ContributableViewContainer } from '../protocol'
+import { collectSubscribableValues, integrationTestContext } from './testHelpers'
+
+describe('Views (integration)', () => {
+    describe('app.createPanelView', () => {
+        test('no component', async () => {
+            const { extensionAPI, services } = await integrationTestContext()
+            const panelView = extensionAPI.app.createPanelView('p')
+            panelView.title = 't'
+            panelView.content = 'c'
+            panelView.priority = 3
+            await extensionAPI.internal.sync()
+
+            const values = collectSubscribableValues(
+                services.views.getViews(ContributableViewContainer.Panel).pipe(first())
+            )
+            assertToJSON(values, [
+                [
+                    {
+                        id: 'p',
+                        title: 't',
+                        content: 'c',
+                        priority: 3,
+                        container: ContributableViewContainer.Panel,
+                    },
+                ],
+            ])
+        })
+
+        test('with component (location provider)', async () => {
+            const { extensionAPI, services } = await integrationTestContext()
+
+            const LOCATION_PROVIDER_ID = 'x'
+            extensionAPI.languages.registerLocationProvider(LOCATION_PROVIDER_ID, ['*'], {
+                provideLocations: () => NEVER,
+            })
+
+            const panelView = extensionAPI.app.createPanelView('p')
+            panelView.title = 't'
+            panelView.content = 'c'
+            panelView.priority = 3
+            panelView.component = { locationProvider: LOCATION_PROVIDER_ID }
+            await extensionAPI.internal.sync()
+
+            const values = collectSubscribableValues(
+                services.views.getViews(ContributableViewContainer.Panel).pipe(first())
+            )
+            assertToJSON(values.map(v => v.map(v => ({ ...v, locationProvider: 'value not checked' }))), [
+                [
+                    {
+                        id: 'p',
+                        title: 't',
+                        content: 'c',
+                        priority: 3,
+                        container: ContributableViewContainer.Panel,
+                        locationProvider: 'value not checked',
+                    },
+                ],
+            ])
+        })
+    })
+})


### PR DESCRIPTION
A panel view created with `sourcegraph.app.createPanelView` can contain Markdown content and (optionally) show a location provider. This is how custom location providers, such as implementations, work. There was a bug where only panels with location providers (which is the most common kind) were shown.

One example of an extension that creates a panel without a component is https://sourcegraph.com/extensions/sqs/word-count.