### PR TITLE
saved queries guidance

### DIFF
--- a/cmd/frontend/graphqlbackend/saved_queries.go
+++ b/cmd/frontend/graphqlbackend/saved_queries.go
@@ -170,12 +170,14 @@ func (r *settingsMutation) CreateSavedQuery(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	// Read new configuration and inform the query-runner.
-	var config api.PartialConfigSavedQueries
-	if err := r.subject.readSettings(ctx, &config); err != nil {
-		return nil, err
-	}
-	go queryrunnerapi.Client.SavedQueryWasCreatedOrUpdated(context.Background(), r.subject.toSubject(), config, args.DisableSubscriptionNotifications)
+	/*
+		// Read new configuration and inform the query-runner.
+		var config api.PartialConfigSavedQueries
+		if err := r.subject.readSettings(ctx, &config); err != nil {
+			return nil, err
+		}
+		go queryrunnerapi.Client.SavedQueryWasCreatedOrUpdated(context.Background(), r.subject.toSubject(), config, args.DisableSubscriptionNotifications)
+	*/
 
 	return &savedQueryResolver{
 		subject:     r.subject,
@@ -256,7 +258,7 @@ func (r *settingsMutation) UpdateSavedQuery(ctx context.Context, args *struct {
 	if err := r.subject.readSettings(ctx, &config); err != nil {
 		return nil, err
 	}
-	go queryrunnerapi.Client.SavedQueryWasCreatedOrUpdated(context.Background(), spec.Subject, config, false)
+	//go queryrunnerapi.Client.SavedQueryWasCreatedOrUpdated(context.Background(), spec.Subject, config, false)
 	return toSavedQueryResolver(index, r.subject, config.SavedQueries[index]), nil
 }
 
@@ -287,7 +289,7 @@ func (r *settingsMutation) DeleteSavedQuery(ctx context.Context, args *struct {
 	if err != nil {
 		return nil, err
 	}
-	go queryrunnerapi.Client.SavedQueryWasDeleted(context.Background(), spec, args.DisableSubscriptionNotifications)
+	//go queryrunnerapi.Client.SavedQueryWasDeleted(context.Background(), spec, args.DisableSubscriptionNotifications)
 	return &EmptyResponse{}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
-	"github.com/sourcegraph/sourcegraph/cmd/query-runner/queryrunnerapi"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
@@ -64,38 +63,40 @@ func settingsCreateIfUpToDate(ctx context.Context, subject *settingsSubject, las
 		return nil, err
 	}
 
-	// Read new saved queries.
-	var newSavedQueries api.PartialConfigSavedQueries
-	if err := subject.readSettings(ctx, &newSavedQueries); err != nil {
-		return nil, err
-	}
+	/*
+		// Read new saved queries.
+		var newSavedQueries api.PartialConfigSavedQueries
+		if err := subject.readSettings(ctx, &newSavedQueries); err != nil {
+			return nil, err
+		}
 
-	// Notify query-runner of any changes.
-	createdOrUpdated := false
-	for i, newQuery := range newSavedQueries.SavedQueries {
-		if i >= len(oldSavedQueries.SavedQueries) {
-			// Created
-			createdOrUpdated = true
-			break
+		// Notify query-runner of any changes.
+		createdOrUpdated := false
+		for i, newQuery := range newSavedQueries.SavedQueries {
+			if i >= len(oldSavedQueries.SavedQueries) {
+				// Created
+				createdOrUpdated = true
+				break
+			}
+			if !newQuery.Equals(oldSavedQueries.SavedQueries[i]) {
+				// Updated or list was re-ordered.
+				createdOrUpdated = true
+				break
+			}
 		}
-		if !newQuery.Equals(oldSavedQueries.SavedQueries[i]) {
-			// Updated or list was re-ordered.
-			createdOrUpdated = true
-			break
+		if createdOrUpdated {
+			go queryrunnerapi.Client.SavedQueryWasCreatedOrUpdated(context.Background(), subject.toSubject(), newSavedQueries, false)
 		}
-	}
-	if createdOrUpdated {
-		go queryrunnerapi.Client.SavedQueryWasCreatedOrUpdated(context.Background(), subject.toSubject(), newSavedQueries, false)
-	}
-	for i, deletedQuery := range oldSavedQueries.SavedQueries {
-		if i <= len(newSavedQueries.SavedQueries) {
-			// Not deleted.
-			continue
+		for i, deletedQuery := range oldSavedQueries.SavedQueries {
+			if i <= len(newSavedQueries.SavedQueries) {
+				// Not deleted.
+				continue
+			}
+			// Deleted
+			spec := api.SavedQueryIDSpec{Subject: subject.toSubject(), Key: deletedQuery.Key}
+			go queryrunnerapi.Client.SavedQueryWasDeleted(context.Background(), spec, false)
 		}
-		// Deleted
-		spec := api.SavedQueryIDSpec{Subject: subject.toSubject(), Key: deletedQuery.Key}
-		go queryrunnerapi.Client.SavedQueryWasDeleted(context.Background(), spec, false)
-	}
+	*/
 
 	return latestSettings, nil
 }

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -213,6 +213,12 @@ func serveReposListEnabled(w http.ResponseWriter, r *http.Request) error {
 }
 
 func serveSavedQueriesListAll(w http.ResponseWriter, r *http.Request) error {
+	// TODO: This needs to be updated to return the list of all search queries in your new
+	// saved_searches (rename saved_queries -> query_runner_state). Currently, this is
+	// listing ALL user/org settings from the DB, parsing them, and grabbing the `search.savedQueries`
+	// field out to return the final list. You should just make a `db.SavedSearches.ListAll` call
+	// or such here.
+
 	// List settings for all users, orgs, etc.
 	settings, err := db.Settings.ListAll(r.Context())
 	if err != nil {
@@ -228,7 +234,19 @@ func serveSavedQueriesListAll(w http.ResponseWriter, r *http.Request) error {
 		for _, query := range config.SavedQueries {
 			spec := api.SavedQueryIDSpec{Subject: settings.Subject, Key: query.Key}
 			queries = append(queries, api.SavedQuerySpecAndConfig{
-				Spec:   spec,
+				// Contains the config subject (user ID or org ID) AND unique key (same `"key": "nRyyMK"` as below)
+				Spec: spec,
+
+				// This is like:
+				/*
+					{
+					"key": "nRyyMK",
+					"description": "test",
+					"query": "repo:^github\\.com/sourcegraph/sourcegraph$ wow",
+					"notify": true,
+					"notifySlack": "",
+					}
+				*/
 				Config: query,
 			})
 		}

--- a/cmd/query-runner/all_saved_queries.go
+++ b/cmd/query-runner/all_saved_queries.go
@@ -77,6 +77,7 @@ func (sq *allSavedQueriesCached) fetchInitialListFromFrontend() {
 	}
 }
 
+/*
 func serveSavedQueryWasCreatedOrUpdated(w http.ResponseWriter, r *http.Request) {
 	allSavedQueries.mu.Lock()
 	defer allSavedQueries.mu.Unlock()
@@ -153,7 +154,9 @@ func serveSavedQueryWasDeleted(w http.ResponseWriter, r *http.Request) {
 	}
 	log15.Info("saved query deleted", "total_saved_queries", len(allSavedQueries.allSavedQueries))
 }
+*/
 
+// TODO: this needs to be called
 func notifySavedQueryWasCreatedOrUpdated(oldValue, newValue api.SavedQuerySpecAndConfig) error {
 	ctx := context.Background()
 

--- a/cmd/query-runner/all_saved_queries.go
+++ b/cmd/query-runner/all_saved_queries.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
+/*
 var allSavedQueries = &allSavedQueriesCached{}
 
 // allSavedQueriesCached allows us to get a list of all the saved queries
@@ -76,6 +77,7 @@ func (sq *allSavedQueriesCached) fetchInitialListFromFrontend() {
 		return
 	}
 }
+*/
 
 /*
 func serveSavedQueryWasCreatedOrUpdated(w http.ResponseWriter, r *http.Request) {
@@ -155,6 +157,28 @@ func serveSavedQueryWasDeleted(w http.ResponseWriter, r *http.Request) {
 	log15.Info("saved query deleted", "total_saved_queries", len(allSavedQueries.allSavedQueries))
 }
 */
+
+// TODO: this is pseudo-code, implement me
+func sendNotificationsForCreatedOrUpdatedOrDeleted(oldList, newList map[string]api.SavedQuerySpecAndConfig) {
+	for diff(oldList, newList) {
+		if deleted {
+			// Notify users of saved query deletions.
+			go func() {
+				if err := notifySavedQueryWasCreatedOrUpdated(query, api.SavedQuerySpecAndConfig{}); err != nil {
+					log15.Error("Failed to handle created/updated saved search.", "query", query, "error", err)
+				}
+			}()
+		}
+		if created || updated {
+			// Notify users of saved query creation and updates.
+			go func() {
+				if err := notifySavedQueryWasCreatedOrUpdated(oldValue, newValue); err != nil {
+					log15.Error("Failed to handle created/updated saved search.", "query", query, "error", err)
+				}
+			}()
+		}
+	}
+}
 
 // TODO: this needs to be called
 func notifySavedQueryWasCreatedOrUpdated(oldValue, newValue api.SavedQuerySpecAndConfig) error {

--- a/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
+++ b/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
@@ -36,15 +36,16 @@ type ErrorResponse struct {
 }
 
 const (
-	PathSavedQueryWasCreatedOrUpdated = "/saved-query-was-created-or-updated"
-	PathSavedQueryWasDeleted          = "/saved-query-was-deleted"
-	PathTestNotification              = "/test-notification"
+	//PathSavedQueryWasCreatedOrUpdated = "/saved-query-was-created-or-updated"
+	//PathSavedQueryWasDeleted          = "/saved-query-was-deleted"
+	PathTestNotification = "/test-notification"
 )
 
 type client struct {
 	client *http.Client
 }
 
+/*
 type SavedQueryWasCreatedOrUpdatedArgs struct {
 	SubjectAndConfig                 *SubjectAndConfig
 	DisableSubscriptionNotifications bool
@@ -75,6 +76,7 @@ func (c *client) SavedQueryWasDeleted(ctx context.Context, spec api.SavedQueryID
 		DisableSubscriptionNotifications: disableSubscriptionNotifications,
 	})
 }
+*/
 
 type TestNotificationArgs struct {
 	Spec api.SavedQueryIDSpec

--- a/pkg/api/internal_client.go
+++ b/pkg/api/internal_client.go
@@ -71,7 +71,11 @@ func (c *internalClient) WaitForFrontend(ctx context.Context) error {
 }
 
 type SavedQueryIDSpec struct {
-	// TODO: farhan: change this to be a user ID or org ID
+	// TODO: farhan: create one of these using the user ID or org ID:
+	//
+	// userSubject := &SettingsSubject{Org: nil, User: userID}
+	// orgSubject := &SettingsSubject{Org: orgID, User: nil}
+	//
 	Subject SettingsSubject
 
 	// TODO: farhan: this should be DB primary key integer

--- a/pkg/api/internal_client.go
+++ b/pkg/api/internal_client.go
@@ -71,14 +71,19 @@ func (c *internalClient) WaitForFrontend(ctx context.Context) error {
 }
 
 type SavedQueryIDSpec struct {
+	// TODO: farhan: change this to be a user ID or org ID
 	Subject SettingsSubject
-	Key     string
+
+	// TODO: farhan: this should be DB primary key integer
+	Key string
 }
 
 // ConfigSavedQuery is the JSON shape of a saved query entry in the JSON configuration
 // (i.e., an entry in the {"search.savedQueries": [...]} array).
 type ConfigSavedQuery struct {
-	Key         string `json:"key,omitempty"`
+	// TODO: farhan: this should be DB primary key integer
+	Key string `json:"key,omitempty"`
+
 	Description string `json:"description"`
 	Query       string `json:"query"`
 	Notify      bool   `json:"notify,omitempty"`
@@ -105,6 +110,9 @@ type SavedQuerySpecAndConfig struct {
 
 // SavedQueriesListAll lists all saved queries, from every user, org, etc.
 func (c *internalClient) SavedQueriesListAll(ctx context.Context) (map[SavedQueryIDSpec]ConfigSavedQuery, error) {
+	// @farhan Client side here: the return type will need to be updated both here and
+	// on the server side (`serveSavedQueriesListAll` func).
+	//
 	var result []SavedQuerySpecAndConfig
 	err := c.postInternal(ctx, "saved-queries/list-all", nil, &result)
 	if err != nil {


### PR DESCRIPTION
Changes to make:

1. query-runner would pull list of saved searches from frontend on startup, but it was too expensive so AFTER doing that once on startup we would have the frontend notify the query-runner of updates (added, removed, changed saved searches) via `queryrunnerapi.Client.*`.
    - After this change, since we are storing saved searches in the DB directly and we don't have to parse all user/org settings from the DB -- it is cheap to get the full list (just `select * from` DB). So the query-runner should now just ask the frontend for the full list each time it loops (see query-runner/main.go).
2. When the query-runner sends out notifications for added/removed/changed queries (e.g. "you have been subscribed to recieve notifications about query <foobar>" or "the query <foobar> has been deleted from your organization"), this was previously handled by those endpoints in the query-runner that were called by the frontend via `queryrunnerapi.Client.*`. We cannot use those query-runner endpoints now because we removed them (see #1 above) (which is simpler), but due to this we need to re-implement this notification logic by simply diffing the last list we got from the frontend AND the new list we got to determine which saved searches were added/removed/modified. Implement this logic here: https://github.com/sourcegraph/sourcegraph/commit/715173a6def8da843e6160efcd10afe3a20bc91d#diff-2d6316986810e5853865d0366967952bR161
3. When the query-runner used to recieve the full list of saved searches, it was essentially a mirror of what was in the user settings. You will need to update this endpoint to pull information from the DB instead of pulling all user+org configurations from the DB and getting info from there. See how to implement this in https://github.com/sourcegraph/sourcegraph/commit/0336be151c79e7a20d56c273c078ef38fa1eca1d and https://github.com/sourcegraph/sourcegraph/commit/b9e06da77923e74d91ef7ecff0bd6a9383dd60cc
4. Finally, there is unused code we can remove see https://github.com/sourcegraph/sourcegraph/commit/99f4e31e35f8efbeecc81ee5e83292f7a50467e6 for that.

If you get this PR to compile + be based on your DB changes, everything should work :)