### PR TITLE
quick configure buttons for management console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The new `bitbucketserver.repos` setting in [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) allows you to select specific repositories to be synced.
 - The new required `bitbucketserver.repositoryQuery` setting in [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) allows you to use Bitbucket API repository search queries to select repos to be synced. Existing configurations will be migrate to have it set to `["?visibility=public", "?visibility=private"]` which is equivalent to the previous implicit behaviour that this setting supersedes.
 - "Quick configure" buttons for common actions have been added to the config editor for all external services.
+- "Quick configure" buttons for common actions have been added to the critical site config editor in the management console.
 - Site-admins now receive an alert every day for the seven days before their license key expires.
 - The user menu (in global nav) now lists the user's organizations.
 - All users on an instance now see a non-dismissable alert when when there's no license key in use and the limit of free user accounts is exceeded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The new `bitbucketserver.repos` setting in [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) allows you to select specific repositories to be synced.
 - The new required `bitbucketserver.repositoryQuery` setting in [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) allows you to use Bitbucket API repository search queries to select repos to be synced. Existing configurations will be migrate to have it set to `["?visibility=public", "?visibility=private"]` which is equivalent to the previous implicit behaviour that this setting supersedes.
 - "Quick configure" buttons for common actions have been added to the config editor for all external services.
-- "Quick configure" buttons for common actions have been added to the critical site config editor in the management console.
+- "Quick configure" buttons for common actions have been added to the management console.
 - Site-admins now receive an alert every day for the seven days before their license key expires.
 - The user menu (in global nav) now lists the user's organizations.
 - All users on an instance now see a non-dismissable alert when when there's no license key in use and the limit of free user accounts is exceeded.

--- a/cmd/management-console/web/src/CriticalConfigEditor.scss
+++ b/cmd/management-console/web/src/CriticalConfigEditor.scss
@@ -1,7 +1,6 @@
 .critical-config-editor {
     &__monaco-reserved-space {
-        width: 45rem;
-        height: 32rem;
+        height: 50rem;
         padding-top: 1rem;
         padding-bottom: 1rem;
         margin-bottom: 0.75rem;

--- a/cmd/management-console/web/src/CriticalConfigEditor.scss
+++ b/cmd/management-console/web/src/CriticalConfigEditor.scss
@@ -20,9 +20,7 @@
             color: red;
         }
     }
-}
 
-.critical-config-page {
     &__action-groups {
         margin-bottom: 0.75rem;
     }

--- a/cmd/management-console/web/src/CriticalConfigEditor.scss
+++ b/cmd/management-console/web/src/CriticalConfigEditor.scss
@@ -22,3 +22,23 @@
         }
     }
 }
+
+.critical-config-page {
+    &__action-groups {
+        margin-bottom: 0.75rem;
+    }
+
+    &__action-group-header {
+        font-weight: bold;
+    }
+
+    &__actions {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    &__action {
+        margin: 0.25rem 0.5rem 0.25rem 0;
+        flex: 0 auto;
+    }
+}

--- a/cmd/management-console/web/src/CriticalConfigEditor.scss
+++ b/cmd/management-console/web/src/CriticalConfigEditor.scss
@@ -1,6 +1,12 @@
 .critical-config-editor {
+    width: 50rem;
+    margin-bottom: 10rem;
+
     &__monaco-reserved-space {
-        height: 50rem;
+        height: 35rem;
+        overflow: hidden;
+        resize: both;
+
         padding-top: 1rem;
         padding-bottom: 1rem;
         margin-bottom: 0.75rem;

--- a/cmd/management-console/web/src/CriticalConfigEditor.tsx
+++ b/cmd/management-console/web/src/CriticalConfigEditor.tsx
@@ -172,7 +172,7 @@ const quickConfigureActions = [
       // Create a SAML app in OneLogin:
       // 1. Go to https://mycompany.onelogin.com/apps/find (replace "mycompany" with your
       //    company's OneLogin ID).
-      // 2. Select "SAML Test Connector (SP)" and create the app.
+      // 2. Select "SAML Test Connector (SP)" and click "Save".
       // 3. Under the "Configuration" tab, set the following properties:
       //    Audience:  ${externalURL}/.auth/saml/metadata
       //    Recipient: ${externalURL}/.auth/saml/acs

--- a/cmd/management-console/web/src/CriticalConfigEditor.tsx
+++ b/cmd/management-console/web/src/CriticalConfigEditor.tsx
@@ -153,29 +153,23 @@ const quickConfigureActions = [
         id: 'useOneLoginSAML',
         label: 'Add OneLogin SAML',
         run: config => {
-            let externalURL
-            let externalURLRegexp
-            try {
-                externalURL = jsonc.parse(config).externalURL
-                externalURLRegexp = externalURL.replace(/\//g, '\\/')
-            } catch {
-                /* not necessarily an error, config might be empty */
-            }
-            if (!externalURL) {
-                externalURL = '<externalURL>'
-                externalURLRegexp = '<externalURL regex>'
-            }
+            const { externalURL, externalURLRegexp } = getExternalURLPlaceholders(config)
             const value = {
-                COMMENT_1: true,
                 type: 'saml',
                 displayName: 'OneLogin',
+                COMMENT_1: true,
                 COMMENT_2: true,
                 identityProviderMetadataURL: '<identity provider metadata URL>',
             }
             const comments = {
-                COMMENT_1: `// Before proceeding, ensure you've set externalURL to the appropriate value.
+                COMMENT_1: `
+      // OneLogin SAML instructions
+      // ==========================
       //
-      // To enable OneLogin SAML sign-in, you'll first need to create a SAML app in OneLogin:
+      // Before proceeding, ensure you've set externalURL to the appropriate value.
+      // (The instructions below use the current value of externalURL.)
+      //
+      // Create a SAML app in OneLogin:
       // 1. Go to https://mycompany.onelogin.com/apps/find (replace "mycompany" with your
       //    company's OneLogin ID).
       // 2. Select "SAML Test Connector (SP)" and create the app.
@@ -188,16 +182,63 @@ const quickConfigureActions = [
       //    Email (NameID): Email
       //    DisplayName:    First Name         Include in SAML Assertion: ✓
       //    login:          AD user name       Include in SAML Assertion: ✓
-      // 5. Save the app in OneLogin and then fill in the fields below:
-`,
+      // 5. Save the app in OneLogin and fill in the fields below:`,
                 COMMENT_2: `
       // This URL describes OneLogin to Sourcegraph. Find it in the OneLogin app config GUI
       // under the "SSO" tab, under "Issuer URL".
-      // It should look something like "https://mycompany.onelogin.com/saml/metadata/000000"
-      // or "https://app.onelogin.com/saml/metadata/000000".`,
+      // It should look something like "https://mycompany.onelogin.com/saml/metadata/123456"
+      // or "https://app.onelogin.com/saml/metadata/123456".`,
             }
             const edits = [editWithComments(config, ['auth.providers', -1], value, comments)]
-            return { edits, selectText: '<identity provider metadata URL>' }
+            return { edits, selectText: 'OneLogin SAML instructions' }
+        },
+    },
+    {
+        id: 'useOktaSAML',
+        label: 'Add Okta SAML',
+        run: config => {
+            const { externalURL, externalURLRegexp } = getExternalURLPlaceholders(config)
+            const value = {
+                type: 'saml',
+                displayName: 'Okta',
+                COMMENT_1: true,
+                COMMENT_2: true,
+                identityProviderMetadataURL: '<identity provider metadata URL>',
+            }
+            const comments = {
+                COMMENT_1: `
+      // Okta SAML instructions
+      // ======================
+      //
+      // Before proceeding, ensure you've set externalURL to the appropriate value.
+      // (The instructions below use the current value of externalURL.)
+      //
+      // Create a SAML app in Okta:
+      // 1. Go to the Okta admin "Add Application" page, classic UI (looks like
+      //    https://my-org.okta.com/admin/apps/add-app or https://dev-12345.oktapreview.com/admin/apps/add-app).
+      // 2. Click "Create New App", select "SAML 2.0", and "Create".
+      // 3. Give the app the name "Sourcegraph", click "Next".
+      // 4. Set the following SAML settings:
+      //    Single Sign On URL: ${externalURL}/.auth/saml/acs
+      //      Use this for Recipient URL and Destination URL: ✓
+      //    Audience URI (SP Entity ID) / Audience Restriction: ${externalURL}/.auth/saml/metadata
+      //    Attribute statements:
+      //      Email: user.email
+      //      Login: user.login
+      //      DisplayName: \${user.firstName} \${user.lastName}
+      //    Click "Next".
+      // 5. Select "I'm an Okta customer adding an internal app" and click "Finish".
+      // 6. Go to the "Assignments" tab, click the "Assign" dropdown > "Assign to Groups"
+      //    > Everyone ("Assign" button).
+      // 7. Fill in the fields below:`,
+                COMMENT_2: `
+      // This URL describes Okta to Sourcegraph. Go to the "Sign On" tab and copy
+      // the hyperlink "Identity Provider metadata is available if this application
+      // supports dynamic configuration." The value looks like
+      // "https://my-org.okta.com/app/abcdefghijk012345678/sso/saml/metadata" or "https://dev-123435.oktapreview.com/app/abcdefghijk012345678/sso/saml/metadata".`,
+            }
+            const edits = [editWithComments(config, ['auth.providers', -1], value, comments)]
+            return { edits, selectText: 'Okta SAML instructions' }
         },
     },
     {
@@ -517,4 +558,20 @@ function editWithComments(
         edit.content = edit.content.replace(`"${commentKey}": true`, comments[commentKey])
     }
     return edit
+}
+
+function getExternalURLPlaceholders(config: string): { externalURL: string; externalURLRegexp: string } {
+    let externalURL
+    let externalURLRegexp
+    try {
+        externalURL = jsonc.parse(config).externalURL
+        externalURLRegexp = externalURL.replace(/\//g, '\\/')
+    } catch {
+        /* not necessarily an error, config might be empty */
+    }
+    if (!externalURL) {
+        externalURL = '<externalURL>'
+        externalURLRegexp = '<externalURL regex>'
+    }
+    return { externalURL, externalURLRegexp }
 }

--- a/cmd/management-console/web/src/CriticalConfigEditor.tsx
+++ b/cmd/management-console/web/src/CriticalConfigEditor.tsx
@@ -350,21 +350,19 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
             <div className="critical-config-editor">
                 {actions && (
                     <div className="critical-config-editor__action-groups">
-                        <div className="critical-config-editor__action-groups">
-                            <div className="critical-config-editor__action-group-header">Quick configure:</div>
-                            <div className="critical-config-editor__actions">
-                                {actions.map(({ id, label }) => (
-                                    <button
-                                        key={id}
-                                        className="btn btn-secondary btn-sm critical-config-editor__action"
-                                        // tslint:disable-next-line:jsx-no-lambda
-                                        onClick={() => this.runAction(id, this.configEditor)}
-                                        type="button"
-                                    >
-                                        {label}
-                                    </button>
-                                ))}
-                            </div>
+                        <div className="critical-config-editor__action-group-header">Quick configure:</div>
+                        <div className="critical-config-editor__actions">
+                            {actions.map(({ id, label }) => (
+                                <button
+                                    key={id}
+                                    className="btn btn-secondary btn-sm critical-config-editor__action"
+                                    // tslint:disable-next-line:jsx-no-lambda
+                                    onClick={() => this.runAction(id, this.configEditor)}
+                                    type="button"
+                                >
+                                    {label}
+                                </button>
+                            ))}
                         </div>
                     </div>
                 )}

--- a/cmd/management-console/web/src/CriticalConfigEditor.tsx
+++ b/cmd/management-console/web/src/CriticalConfigEditor.tsx
@@ -66,6 +66,9 @@ interface State {
     /** Whether or not the loader can be shown yet, iff criticalConfig === null */
     canShowLoader: boolean
 
+    /** Whether or not the Monaco editor has loaded */
+    hasLoadedEditor: boolean
+
     /** Whether or not to show a "Saving..." indicator */
     showSaving: boolean
 
@@ -286,6 +289,7 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
         showSaving: false,
         showSaved: false,
         showSavingError: null,
+        hasLoadedEditor: false,
     }
 
     private configEditor?: _monaco.editor.ICodeEditor
@@ -333,8 +337,6 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
         if (editor) {
             const action = editor.getAction(id)
             action.run().then(() => void 0, (err: any) => console.error(err))
-        } else {
-            alert('Wait for editor to load before running action.')
         }
     }
 
@@ -348,7 +350,7 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
         const actions = quickConfigureActions
         return (
             <div className="critical-config-editor">
-                {actions && (
+                {actions && this.state.hasLoadedEditor && (
                     <div className="critical-config-editor__action-groups">
                         <div className="critical-config-editor__action-group-header">Quick configure:</div>
                         <div className="critical-config-editor__actions">
@@ -406,7 +408,6 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
      */
     private editorWillMount = (editor: _monaco.editor.IStandaloneCodeEditor, model: _monaco.editor.IModel) => {
         this.configEditor = editor
-
         if (CriticalConfigEditor.isStandaloneCodeEditor(editor)) {
             for (const { id, label, run } of quickConfigureActions) {
                 editor.addAction({
@@ -443,6 +444,7 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
                 })
             }
         }
+        this.setState({ hasLoadedEditor: true })
     }
 
     private onDidContentChange = (content: string) => this.setState({ content })

--- a/cmd/management-console/web/src/CriticalConfigEditor.tsx
+++ b/cmd/management-console/web/src/CriticalConfigEditor.tsx
@@ -9,7 +9,6 @@ import { ajax } from 'rxjs/ajax'
 import { catchError, delay, distinctUntilChanged, mapTo, startWith, takeUntil } from 'rxjs/operators'
 import './CriticalConfigEditor.scss'
 import { MonacoEditor } from './MonacoEditor'
-import { json } from 'body-parser'
 
 const DEBUG_LOADING_STATE_DELAY = 0 // ms
 
@@ -419,7 +418,6 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
                     label,
                     id,
                     run: editor => {
-                        // copy-pasta
                         editor.focus()
                         editor.pushUndoStop()
                         const { edits, selectText } = run(editor.getValue())
@@ -527,6 +525,10 @@ function toMonacoEdits(
     }))
 }
 
+/**
+ * Returns the (line, column) position into the text (@param text) at the given
+ * byte offset (@param offset).
+ */
 function getPositionAt(text: string, offset: number): _monaco.IPosition {
     const lines = text.split('\n')
     let pos = 0

--- a/cmd/management-console/web/src/CriticalConfigEditor.tsx
+++ b/cmd/management-console/web/src/CriticalConfigEditor.tsx
@@ -347,16 +347,16 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
     public render(): JSX.Element | null {
         const actions = quickConfigureActions
         return (
-            <div>
+            <div className="critical-config-editor">
                 {actions && (
-                    <div className="critical-config-page__action-groups">
-                        <div className="critical-config-page__action-groups">
-                            <div className="critical-config-page__action-group-header">Quick configure:</div>
-                            <div className="critical-config-page__actions">
+                    <div className="critical-config-editor__action-groups">
+                        <div className="critical-config-editor__action-groups">
+                            <div className="critical-config-editor__action-group-header">Quick configure:</div>
+                            <div className="critical-config-editor__actions">
                                 {actions.map(({ id, label }) => (
                                     <button
                                         key={id}
-                                        className="btn btn-secondary btn-sm critical-config-page__action"
+                                        className="btn btn-secondary btn-sm critical-config-editor__action"
                                         // tslint:disable-next-line:jsx-no-lambda
                                         onClick={() => this.runAction(id, this.configEditor)}
                                         type="button"
@@ -368,39 +368,36 @@ export class CriticalConfigEditor extends React.PureComponent<Props, State> {
                         </div>
                     </div>
                 )}
-                <div className="critical-config-editor">
-                    <div
-                        className={`critical-config-editor__monaco-reserved-space${
-                            this.state.criticalConfig ? ' critical-config-editor__monaco-reserved-space--monaco' : ''
-                        }`}
-                    >
-                        {!this.state.criticalConfig && this.state.canShowLoader && <div>Loading...</div>}
 
-                        {this.state.criticalConfig && (
-                            <MonacoEditor
-                                content={this.state.criticalConfig.Contents}
-                                language="json"
-                                onDidContentChange={this.onDidContentChange}
-                                onDidSave={this.onDidSave}
-                                editorWillMount={this.editorWillMount}
-                            />
-                        )}
-                    </div>
-                    <button onClick={this.onDidSave}>Save changes</button>
-                    {this.state.showSaving && (
-                        <span className="critical-config-editor__status-indicator">Saving...</span>
-                    )}
-                    {this.state.showSaved && (
-                        <span className="critical-config-editor__status-indicator critical-config-editor__status-indicator--success">
-                            Saved!
-                        </span>
-                    )}
-                    {this.state.showSavingError && (
-                        <span className="critical-config-editor__status-indicator critical-config-editor__status-indicator--error">
-                            {this.state.showSavingError}
-                        </span>
+                <div
+                    className={`critical-config-editor__monaco-reserved-space${
+                        this.state.criticalConfig ? ' critical-config-editor__monaco-reserved-space--monaco' : ''
+                    }`}
+                >
+                    {!this.state.criticalConfig && this.state.canShowLoader && <div>Loading...</div>}
+
+                    {this.state.criticalConfig && (
+                        <MonacoEditor
+                            content={this.state.criticalConfig.Contents}
+                            language="json"
+                            onDidContentChange={this.onDidContentChange}
+                            onDidSave={this.onDidSave}
+                            editorWillMount={this.editorWillMount}
+                        />
                     )}
                 </div>
+                <button onClick={this.onDidSave}>Save changes</button>
+                {this.state.showSaving && <span className="critical-config-editor__status-indicator">Saving...</span>}
+                {this.state.showSaved && (
+                    <span className="critical-config-editor__status-indicator critical-config-editor__status-indicator--success">
+                        Saved!
+                    </span>
+                )}
+                {this.state.showSavingError && (
+                    <span className="critical-config-editor__status-indicator critical-config-editor__status-indicator--error">
+                        {this.state.showSavingError}
+                    </span>
+                )}
             </div>
         )
     }

--- a/cmd/management-console/web/src/MonacoEditor.tsx
+++ b/cmd/management-console/web/src/MonacoEditor.tsx
@@ -1,4 +1,5 @@
 // Regular imports
+import * as _monaco from 'monaco-editor'
 import * as React from 'react'
 import { Subject, Subscription } from 'rxjs'
 import { distinctUntilChanged, map, startWith } from 'rxjs/operators'
@@ -65,6 +66,9 @@ interface Props {
      * Called when the user presses the key binding for "save" (Ctrl+S/Cmd+S).
      */
     onDidSave: () => void
+
+    /** Called when the editor will mount. */
+    editorWillMount: (editor: monaco.editor.IStandaloneCodeEditor, model: monaco.editor.IModel) => void
 }
 
 export class MonacoEditor extends React.Component<Props, {}> {
@@ -113,7 +117,7 @@ export class MonacoEditor extends React.Component<Props, {}> {
         })
 
         // Create the actual Monaco editor.
-        monaco.editor.create(this.ref, {
+        const editor = monaco.editor.create(this.ref, {
             lineNumbers: 'on',
             automaticLayout: true,
             minimap: { enabled: false },
@@ -132,6 +136,8 @@ export class MonacoEditor extends React.Component<Props, {}> {
             theme: 'vs-dark',
             model,
         })
+
+        this.props.editorWillMount(editor, model)
 
         // Register theme for the editor.
         monaco.editor.defineTheme('sourcegraph-dark', {
@@ -184,7 +190,11 @@ export class MonacoEditor extends React.Component<Props, {}> {
     }
 
     public render(): JSX.Element | null {
-        return <div className="monaco-editor-container" ref={ref => (this.ref = ref)} />
+        return <div className="monaco-editor-container" ref={this.setRef} />
+    }
+
+    private setRef = (e: HTMLElement | null): void => {
+        this.ref = e
     }
 }
 

--- a/enterprise/cmd/frontend/auth/saml/config.go
+++ b/enterprise/cmd/frontend/auth/saml/config.go
@@ -50,13 +50,13 @@ func handleGetProvider(ctx context.Context, w http.ResponseWriter, pcID string) 
 
 	p = getProvider(pcID)
 	if p == nil {
-		log15.Error("No SAML auth provider found with ID.", "id", pcID)
+		log15.Error("No SAML auth provider found with ID", "id", pcID)
 		http.Error(w, "Misconfigured SAML auth provider.", http.StatusInternalServerError)
 		return nil, true
 	}
 	if err := p.Refresh(ctx); err != nil {
-		log15.Error("Error refreshing SAML auth provider.", "id", p.ConfigID(), "error", err)
-		http.Error(w, "Unexpected error refreshing SAML authentication provider.", http.StatusInternalServerError)
+		log15.Error("Error getting SAML auth provider", "id", p.ConfigID(), "error", err)
+		http.Error(w, "Unexpected error getting SAML authentication provider. This may indicate that the SAML IdP does not exist. Ask a site admin to check the server \"frontend\" logs for \"Error getting SAML auth provider\".", http.StatusInternalServerError)
 		return nil, true
 	}
 	return p, false

--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -208,7 +208,8 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
     public static isStandaloneCodeEditor(
         editor: monaco.editor.ICodeEditor
     ): editor is monaco.editor.IStandaloneCodeEditor {
-        return editor.getEditorType() === monaco.editor.EditorType.ICodeEditor
+        const editorAny = editor as any
+        return editor.getEditorType() === monaco.editor.EditorType.ICodeEditor && editorAny.addAction
     }
 
     public static addEditorAction(


### PR DESCRIPTION
Add "Quick configure" buttons to quickly configure auth, licenses, and external URL in critical site config:

![image](https://user-images.githubusercontent.com/1646931/56071805-a5f60080-5d45-11e9-9a8f-7d275d29c75a.png)

Fixes https://github.com/sourcegraph/sourcegraph/issues/3218

- [ ] Code review: @slimsag 
- [ ] Design/product review: @francisschmaltz @sqs 