### PR TITLE
make browser extension code view resolution generic

### DIFF
--- a/client/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/client/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -2,7 +2,9 @@ import { AdjustmentDirection, DOMFunctions, PositionAdjuster } from '@sourcegrap
 import { of } from 'rxjs'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
 import { querySelectorOrSelf } from '../../shared/util/dom'
-import { CodeViewSpecResolver, CodeViewSpecWithOutSelector, MountGetter } from '../code_intelligence'
+import { MountGetter } from '../code_intelligence'
+import { CodeViewSpecResolver } from '../code_intelligence/code_views'
+import { ViewResolver } from '../code_intelligence/views'
 import { getContext } from './context'
 import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import {
@@ -77,7 +79,7 @@ const toolbarButtonProps = {
 /**
  * A code view spec for single file code view in the "source" view (not diff).
  */
-const singleFileSourceCodeView: CodeViewSpecWithOutSelector = {
+const singleFileSourceCodeView: CodeViewSpecResolver = {
     getToolbarMount,
     dom: singleFileDOMFunctions,
     resolveFileInfo: resolveFileInfoForSingleFileSourceView,
@@ -95,7 +97,7 @@ const baseDiffCodeView = {
 /**
  * A code view spec for a single file "diff to previous" view
  */
-const singleFileDiffCodeView: CodeViewSpecWithOutSelector = {
+const singleFileDiffCodeView: CodeViewSpecResolver = {
     ...baseDiffCodeView,
     resolveFileInfo: resolveSingleFileDiffFileInfo,
 }
@@ -103,7 +105,7 @@ const singleFileDiffCodeView: CodeViewSpecWithOutSelector = {
 /**
  * A code view spec for pull requests
  */
-const pullRequestDiffCodeView: CodeViewSpecWithOutSelector = {
+const pullRequestDiffCodeView: CodeViewSpecResolver = {
     ...baseDiffCodeView,
     resolveFileInfo: resolvePullRequestFileInfo,
 }
@@ -111,7 +113,7 @@ const pullRequestDiffCodeView: CodeViewSpecWithOutSelector = {
 /**
  * A code view spec for compare pages
  */
-const compareDiffCodeView: CodeViewSpecWithOutSelector = {
+const compareDiffCodeView: CodeViewSpecResolver = {
     ...baseDiffCodeView,
     resolveFileInfo: resolveCompareFileInfo,
 }
@@ -119,14 +121,14 @@ const compareDiffCodeView: CodeViewSpecWithOutSelector = {
 /**
  * A code view spec for commit pages
  */
-const commitDiffCodeView: CodeViewSpecWithOutSelector = {
+const commitDiffCodeView: CodeViewSpecResolver = {
     ...baseDiffCodeView,
     resolveFileInfo: resolveCommitViewFileInfo,
 }
 
-const codeViewSpecResolver: CodeViewSpecResolver = {
+const codeViewSpecResolver: ViewResolver<CodeViewSpecResolver> = {
     selector: '.file-content',
-    resolveCodeViewSpec: codeView => {
+    resolveView: codeView => {
         const contentView = codeView.querySelector('.content-view')
         if (!contentView) {
             return null

--- a/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
+++ b/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
@@ -1,7 +1,8 @@
 import assert from 'assert'
 import { readFile } from 'mz/fs'
 import { SetIntersection } from 'utility-types'
-import { CodeHost, CodeViewSpec, MountGetter } from './code_intelligence'
+import { CodeHost, MountGetter } from './code_intelligence'
+import { CodeViewSpec } from './code_views'
 
 const mountGetterKeys = ['getCommandPaletteMount', 'getViewContextOnSourcegraphMount'] as const
 type MountGetterKey = (typeof mountGetterKeys)[number]

--- a/client/browser/src/libs/code_intelligence/code_views.test.ts
+++ b/client/browser/src/libs/code_intelligence/code_views.test.ts
@@ -2,8 +2,8 @@ import { of, Subject } from 'rxjs'
 import { toArray } from 'rxjs/operators'
 import * as sinon from 'sinon'
 import { MutationRecordLike } from '../../shared/util/dom'
-import { CodeViewSpecWithOutSelector, FileInfo } from './code_intelligence'
-import { trackCodeViews } from './code_views'
+import { FileInfo } from './code_intelligence'
+import { CodeViewSpecResolver, trackCodeViews } from './code_views'
 
 describe('code_views', () => {
     beforeEach(() => {
@@ -15,7 +15,7 @@ describe('code_views', () => {
             filePath: '/bar.ts',
             commitID: '1',
         }
-        const codeViewSpec: CodeViewSpecWithOutSelector = {
+        const codeViewSpec: CodeViewSpecResolver = {
             dom: {
                 getCodeElementFromTarget: () => null,
                 getCodeElementFromLineNumber: () => null,
@@ -43,7 +43,7 @@ describe('code_views', () => {
             element.className = 'test-code-view'
             document.body.append(element)
             const selector = '.test-code-view'
-            const codeViewSpecResolver = { selector, resolveCodeViewSpec: sinon.spy(() => codeViewSpec) }
+            const codeViewSpecResolver = { selector, resolveView: sinon.spy(() => codeViewSpec) }
             const detected = await of([{ addedNodes: [document.body], removedNodes: [] }])
                 .pipe(
                     trackCodeViews({ codeViewSpecResolver }),
@@ -51,8 +51,8 @@ describe('code_views', () => {
                 )
                 .toPromise()
             expect(detected).toEqual([{ ...codeViewSpec, element, type: 'added' }])
-            sinon.assert.calledOnce(codeViewSpecResolver.resolveCodeViewSpec)
-            sinon.assert.calledWith(codeViewSpecResolver.resolveCodeViewSpec, element)
+            sinon.assert.calledOnce(codeViewSpecResolver.resolveView)
+            sinon.assert.calledWith(codeViewSpecResolver.resolveView, element)
         })
         it('should detect an added code view if it is the added element itself', async () => {
             const element = document.createElement('div')

--- a/client/browser/src/libs/code_intelligence/views.ts
+++ b/client/browser/src/libs/code_intelligence/views.ts
@@ -26,7 +26,7 @@ interface AddedViewEvent {
     type: 'added'
 }
 
-interface RemovedView {
+interface RemovedViewEvent {
     type: 'removed'
 
     /** The HTML element that was removed. */
@@ -38,7 +38,7 @@ interface RemovedView {
  *
  * @template V The type of view, such as a code view.
  */
-export type ViewEvent<V> = (AddedViewEvent & V) | RemovedView
+export type ViewEvent<V> = (AddedViewEvent & V) | RemovedViewEvent
 
 /**
  * Find all the views (e.g., code views) on a page using view resolvers (defined in

--- a/client/browser/src/libs/code_intelligence/views.ts
+++ b/client/browser/src/libs/code_intelligence/views.ts
@@ -1,0 +1,102 @@
+import { from, merge, Observable } from 'rxjs'
+import { concatAll, filter, map, mergeMap } from 'rxjs/operators'
+import { isDefined, isInstanceOf } from '../../../../../shared/src/util/types'
+import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
+
+/**
+ * Finds and resolves elements matched by a MutationObserver to views.
+ *
+ * @template V The type of view, such as a code view.
+ */
+export interface ViewResolver<V> {
+    /**
+     * The element selector (used with {@link Window#querySelectorAll}) that matches candidate
+     * elements to be passed to {@link ViewResolver#resolveView}.
+     */
+    selector: string
+
+    /**
+     * Resolve an element matched by {@link ViewResolver#selector} to a view, or `null` if it's not
+     * a a valid view upon further examination.
+     */
+    resolveView: (element: HTMLElement) => V | null
+}
+
+interface AddedViewEvent {
+    type: 'added'
+}
+
+interface RemovedView {
+    type: 'removed'
+
+    /** The HTML element that was removed. */
+    element: HTMLElement
+}
+
+/**
+ * An addition or removal of a view observed by a {@link MutationObserver}.
+ *
+ * @template V The type of view, such as a code view.
+ */
+export type ViewEvent<V> = (AddedViewEvent & V) | RemovedView
+
+/**
+ * Find all the views (e.g., code views) on a page using view resolvers (defined in
+ * {@link CodeHost}).
+ *
+ * Emits every view that gets added or removed.
+ *
+ * At any given time, there can be any number of views on a page.
+ *
+ * @template V The type of view, such as a code view.
+ */
+export function trackViews<V>(
+    viewResolvers: ViewResolver<V>[]
+): (mutations: Observable<MutationRecordLike[]>) => Observable<ViewEvent<V>> {
+    return mutations =>
+        mutations.pipe(
+            concatAll(),
+            mergeMap(mutation =>
+                merge(
+                    // Find all new code views within the added nodes
+                    // (MutationObservers don't emit all descendant nodes of an addded node recursively)
+                    from(mutation.addedNodes).pipe(
+                        filter(isInstanceOf(HTMLElement)),
+                        mergeMap(addedElement =>
+                            from(viewResolvers).pipe(
+                                mergeMap(spec =>
+                                    [...(querySelectorAllOrSelf(addedElement, spec.selector) as Iterable<HTMLElement>)]
+                                        .map(element => {
+                                            const view = spec.resolveView(element)
+                                            return (
+                                                view && {
+                                                    ...view,
+                                                    type: 'added' as const,
+                                                }
+                                            )
+                                        })
+                                        .filter(isDefined)
+                                )
+                            )
+                        )
+                    ),
+                    // For removed nodes, find the removed elements, but don't resolve the kind (it's not relevant)
+                    from(mutation.removedNodes).pipe(
+                        filter(isInstanceOf(HTMLElement)),
+                        mergeMap(removedElement =>
+                            from(viewResolvers).pipe(
+                                mergeMap(
+                                    ({ selector }) =>
+                                        querySelectorAllOrSelf(removedElement, selector) as Iterable<HTMLElement>
+                                ),
+                                map(element => ({
+                                    element,
+                                    type: 'removed' as const,
+                                }))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+}

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -12,7 +12,9 @@ import {
 import { fetchBlobContentLines } from '../../shared/repo/backend'
 import { querySelectorOrSelf } from '../../shared/util/dom'
 import { toAbsoluteBlobURL } from '../../shared/util/url'
-import { CodeViewSpec, CodeViewSpecResolver, CodeViewSpecWithOutSelector, MountGetter } from '../code_intelligence'
+import { MountGetter } from '../code_intelligence'
+import { CodeViewSpec, CodeViewSpecResolver } from '../code_intelligence/code_views'
+import { ViewResolver } from '../code_intelligence/views'
 import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { getCommandPaletteMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './file_info'
@@ -62,7 +64,7 @@ const toolbarButtonProps = {
     className: 'btn btn-sm tooltipped tooltipped-s',
 }
 
-const diffCodeView: CodeViewSpecWithOutSelector = {
+const diffCodeView: CodeViewSpecResolver = {
     dom: diffDomFunctions,
     getToolbarMount: createCodeViewToolbarMount,
     resolveFileInfo: resolveDiffFileInfo,
@@ -70,12 +72,12 @@ const diffCodeView: CodeViewSpecWithOutSelector = {
     isDiff: true,
 }
 
-const diffConversationCodeView: CodeViewSpecWithOutSelector = {
+const diffConversationCodeView: CodeViewSpecResolver = {
     ...diffCodeView,
     getToolbarMount: undefined,
 }
 
-const singleFileCodeView: CodeViewSpecWithOutSelector = {
+const singleFileCodeView: CodeViewSpecResolver = {
     dom: singleFileDOMFunctions,
     getToolbarMount: createCodeViewToolbarMount,
     resolveFileInfo,
@@ -177,9 +179,9 @@ export const fileLineContainerCodeView = {
     isDiff: false,
 }
 
-const codeViewSpecResolver: CodeViewSpecResolver = {
+const codeViewSpecResolver: ViewResolver<CodeViewSpecResolver> = {
     selector: '.file',
-    resolveCodeViewSpec: (elem: HTMLElement): CodeViewSpecWithOutSelector | null => {
+    resolveView: (elem: HTMLElement): CodeViewSpecResolver | null => {
         if (elem.querySelector('article.markdown-body')) {
             // This code view is rendered markdown, we shouldn't add code intelligence
             return null

--- a/client/browser/src/libs/gitlab/code_intelligence.ts
+++ b/client/browser/src/libs/gitlab/code_intelligence.ts
@@ -1,4 +1,6 @@
-import { CodeHost, CodeViewSpecResolver, CodeViewSpecWithOutSelector } from '../code_intelligence'
+import { CodeHost } from '../code_intelligence'
+import { CodeViewSpecResolver } from '../code_intelligence/code_views'
+import { ViewResolver } from '../code_intelligence/views'
 import { diffDOMFunctions, singleFileDOMFunctions } from './dom_functions'
 import { getCommandPaletteMount } from './extensions'
 import { resolveCommitFileInfo, resolveDiffFileInfo, resolveFileInfo } from './file_info'
@@ -42,7 +44,7 @@ export const getToolbarMount = (codeView: HTMLElement): HTMLElement => {
     return mount
 }
 
-const singleFileCodeView: CodeViewSpecWithOutSelector = {
+const singleFileCodeView: CodeViewSpecResolver = {
     dom: singleFileDOMFunctions,
     isDiff: false,
     getToolbarMount,
@@ -50,7 +52,7 @@ const singleFileCodeView: CodeViewSpecWithOutSelector = {
     toolbarButtonProps,
 }
 
-const mergeRequestCodeView: CodeViewSpecWithOutSelector = {
+const mergeRequestCodeView: CodeViewSpecResolver = {
     dom: diffDOMFunctions,
     isDiff: true,
     getToolbarMount,
@@ -58,7 +60,7 @@ const mergeRequestCodeView: CodeViewSpecWithOutSelector = {
     toolbarButtonProps,
 }
 
-const commitCodeView: CodeViewSpecWithOutSelector = {
+const commitCodeView: CodeViewSpecResolver = {
     dom: diffDOMFunctions,
     isDiff: true,
     getToolbarMount,
@@ -66,7 +68,7 @@ const commitCodeView: CodeViewSpecWithOutSelector = {
     toolbarButtonProps,
 }
 
-const resolveCodeViewSpec = (codeView: HTMLElement): CodeViewSpecWithOutSelector => {
+const resolveView = (codeView: HTMLElement): CodeViewSpecResolver => {
     const { pageKind } = getPageInfo()
 
     if (pageKind === GitLabPageKind.File) {
@@ -80,9 +82,9 @@ const resolveCodeViewSpec = (codeView: HTMLElement): CodeViewSpecWithOutSelector
     return commitCodeView
 }
 
-const codeViewSpecResolver: CodeViewSpecResolver = {
+const codeViewSpecResolver: ViewResolver<CodeViewSpecResolver> = {
     selector: '.file-holder',
-    resolveCodeViewSpec,
+    resolveView,
 }
 
 export const gitlabCodeHost: CodeHost = {

--- a/client/browser/src/libs/phabricator/code_intelligence.ts
+++ b/client/browser/src/libs/phabricator/code_intelligence.ts
@@ -5,7 +5,9 @@ import { map } from 'rxjs/operators'
 import { convertSpacesToTabs, spacesToTabsAdjustment } from '.'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../../shared/src/util/url'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
-import { CodeHost, CodeViewSpec, CodeViewSpecResolver, CodeViewSpecWithOutSelector } from '../code_intelligence'
+import { CodeHost } from '../code_intelligence'
+import { CodeViewSpec, CodeViewSpecResolver } from '../code_intelligence/code_views'
+import { ViewResolver } from '../code_intelligence/views'
 import { diffDomFunctions, diffusionDOMFns } from './dom_functions'
 import { resolveDiffFileInfo, resolveDiffusionFileInfo, resolveRevisionFileInfo } from './file_info'
 
@@ -78,7 +80,7 @@ const adjustPosition: PositionAdjuster<RepoSpec & RevSpec & FileSpec & ResolvedR
 const toolbarButtonProps = {
     className: 'button grey button-grey has-icon has-text phui-button-default msl',
 }
-const commitCodeView: CodeViewSpecWithOutSelector = {
+const commitCodeView: CodeViewSpecResolver = {
     dom: diffDomFunctions,
     resolveFileInfo: resolveRevisionFileInfo,
     adjustPosition,
@@ -124,9 +126,9 @@ export const diffCodeView = {
     isDiff: true,
 }
 
-const codeViewSpecResolver: CodeViewSpecResolver = {
+const codeViewSpecResolver: ViewResolver<CodeViewSpecResolver> = {
     selector: '.differential-changeset',
-    resolveCodeViewSpec: (codeView: HTMLElement): CodeViewSpecWithOutSelector => {
+    resolveView: (codeView: HTMLElement): CodeViewSpecResolver => {
         if (window.location.pathname.match(/^\/r/)) {
             return commitCodeView
         }


### PR DESCRIPTION
This refactor reduces code duplication when we add more kinds of views (such as content views for link previews and text fields for completion in GitHub issue textareas).

Suggested by @felixfbecker at https://github.com/sourcegraph/sourcegraph/pull/3316#discussion_r273464610.