### PR TITLE
support TARGETS=chrome or TARGETS=firefox for faster bext builds

### DIFF
--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -70,6 +70,8 @@ For each browser run:
 yarn run dev
 ```
 
+To only build for a single browser (which makes builds faster in local development), set the env var `TARGETS=chrome` or `TARGETS=firefox`.
+
 Now, follow the steps below for the browser you intend to work with.
 
 ### Chrome

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -103,6 +103,12 @@ function buildForBrowser(browser: Browser): (env: BuildEnv) => () => void {
         writeSchema(env, browser, buildDir)
 
         return () => {
+            // Allow only building for specific browser targets. Useful in local dev for faster
+            // builds.
+            if (process.env.TARGETS && !process.env.TARGETS.includes(browser)) {
+                return
+            }
+
             signale.await(`Building the ${title} ${env} bundle`)
 
             copyDist(buildDir)


### PR DESCRIPTION
When developing for just a single browser (eg Chrome), this makes rebuilds of the bext slightly faster.