### PR TITLE
enable R, Perl, and Kotlin by default

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -20,6 +20,9 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/csharp":     true,
 	"sourcegraph/shell":      true,
 	"sourcegraph/scala":      true,
+	"sourcegraph/kotlin":     true,
+	"sourcegraph/r":          true,
+	"sourcegraph/perl":       true,
 }
 
 const singletonDefaultSettingsGQLID = "DefaultSettings"


### PR DESCRIPTION
Some users of these languages have been unaware that Sourcegraph has support for these languages (or unaware how to enable it). The overall fix is #995, but enabling these by default helps in the short term.