### PR TITLE
show user's orgs in user menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The new required `bitbucketserver.repositoryQuery` setting in [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) allows you to use Bitbucket API repository search queries to select repos to be synced. Existing configurations will be migrate to have it set to `["?visibility=public", "?visibility=private"]` which is equivalent to the previous implicit behaviour that this setting supersedes.
 - "Quick configure" buttons for common actions have been added to the config editor for all external services.
 - Site-admins now receive an alert every day for the seven days before their license key expires.
+- The user menu (in global nav) now lists the user's organizations.
 
 ### Changed
 

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -35,6 +35,9 @@ export function refreshAuthenticatedUser(): Observable<never> {
                     nodes {
                         id
                         name
+                        displayName
+                        url
+                        settingsURL
                     }
                 }
                 session {

--- a/web/src/nav/UserNavItem.test.tsx
+++ b/web/src/nav/UserNavItem.test.tsx
@@ -12,7 +12,14 @@ describe('UserNavItem', () => {
     afterAll(() => setLinkComponent(null as any)) // reset global env for other tests
 
     // tslint:disable-next-line:no-object-literal-type-assertion
-    const USER = { username: 'u', url: '/u', settingsURL: '/u/settings' } as GQL.IUser
+    const ORG_CONNECTION = {
+        __typename: 'OrgConnection',
+        nodes: [{ id: '1', displayName: 'd', settingsURL: 'u' }, { id: '2', name: 'n', settingsURL: 'u' }] as unknown,
+        totalCount: 2,
+    } as GQL.IOrgConnection
+    // tslint:disable-next-line: no-object-literal-type-assertion
+    const USER = { username: 'u', url: '/u', settingsURL: '/u/settings', organizations: ORG_CONNECTION } as GQL.IUser
+
     const history = H.createMemoryHistory({ keyLength: 0 })
 
     test('simple', () => {

--- a/web/src/nav/UserNavItem.tsx
+++ b/web/src/nav/UserNavItem.tsx
@@ -66,23 +66,6 @@ export class UserNavItem extends React.PureComponent<Props, State> {
                     <Link to="/search/searches" className="dropdown-item">
                         Saved searches
                     </Link>
-                    {this.props.showDotComMarketing ? (
-                        <a href="https://docs.sourcegraph.com" target="_blank" className="dropdown-item">
-                            Help
-                        </a>
-                    ) : (
-                        <Link to="/help" className="dropdown-item">
-                            Help
-                        </Link>
-                    )}
-                    {this.props.authenticatedUser.siteAdmin && (
-                        <>
-                            <DropdownItem divider={true} />
-                            <Link to="/site-admin" className="dropdown-item">
-                                Site admin
-                            </Link>
-                        </>
-                    )}
                     <DropdownItem divider={true} />
                     <div className="px-2 py-1">
                         <div className="d-flex align-items-center">
@@ -113,13 +96,36 @@ export class UserNavItem extends React.PureComponent<Props, State> {
                             </div>
                         )}
                     </div>
-                    {this.props.authenticatedUser.session && this.props.authenticatedUser.session.canSignOut && (
+                    {this.props.authenticatedUser.organizations.nodes.length > 0 && (
                         <>
                             <DropdownItem divider={true} />
-                            <a href="/-/sign-out" className="dropdown-item">
-                                Sign out
-                            </a>
+                            <DropdownItem header={true}>Organizations</DropdownItem>
+                            {this.props.authenticatedUser.organizations.nodes.map(org => (
+                                <Link key={org.id} to={org.settingsURL || org.url} className="dropdown-item">
+                                    {org.displayName || org.name}
+                                </Link>
+                            ))}
                         </>
+                    )}
+                    <DropdownItem divider={true} />
+                    {this.props.authenticatedUser.siteAdmin && (
+                        <Link to="/site-admin" className="dropdown-item">
+                            Site admin
+                        </Link>
+                    )}
+                    {this.props.showDotComMarketing ? (
+                        <a href="https://docs.sourcegraph.com" target="_blank" className="dropdown-item">
+                            Help
+                        </a>
+                    ) : (
+                        <Link to="/help" className="dropdown-item">
+                            Help
+                        </Link>
+                    )}
+                    {this.props.authenticatedUser.session && this.props.authenticatedUser.session.canSignOut && (
+                        <a href="/-/sign-out" className="dropdown-item">
+                            Sign out
+                        </a>
                     )}
                     {this.props.showDotComMarketing && (
                         <>

--- a/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
@@ -66,13 +66,6 @@ exports[`UserNavItem simple 1`] = `
     >
       Saved searches
     </a>
-    <a
-      className="dropdown-item"
-      href="https://docs.sourcegraph.com"
-      target="_blank"
-    >
-      Help
-    </a>
     <div
       className="dropdown-divider"
       onClick={[Function]}
@@ -112,6 +105,44 @@ exports[`UserNavItem simple 1`] = `
         </select>
       </div>
     </div>
+    <div
+      className="dropdown-divider"
+      onClick={[Function]}
+      tabIndex="-1"
+    />
+    <h6
+      className="dropdown-header"
+      onClick={[Function]}
+      tabIndex="-1"
+    >
+      Organizations
+    </h6>
+    <a
+      className="dropdown-item"
+      href="/u"
+      onClick={[Function]}
+    >
+      d
+    </a>
+    <a
+      className="dropdown-item"
+      href="/u"
+      onClick={[Function]}
+    >
+      n
+    </a>
+    <div
+      className="dropdown-divider"
+      onClick={[Function]}
+      tabIndex="-1"
+    />
+    <a
+      className="dropdown-item"
+      href="https://docs.sourcegraph.com"
+      target="_blank"
+    >
+      Help
+    </a>
     <div
       className="dropdown-divider"
       onClick={[Function]}


### PR DESCRIPTION
This makes it easier to go to the orgs you're in (the primary reason for which is to view or change org settings).

![image](https://user-images.githubusercontent.com/1976/56091130-9bc82500-5e5f-11e9-9651-5942455fc6a5.png)
