### PR TITLE
repo-updater: Enable new repository syncer by default

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -29,7 +29,7 @@ import (
 const port = "3182"
 
 func main() {
-	syncerEnabled, _ := strconv.ParseBool(env.Get("SRC_SYNCER_ENABLED", "false", "Use the new repo metadata syncer."))
+	syncerEnabled, _ := strconv.ParseBool(env.Get("SRC_SYNCER_ENABLED", "true", "Use the new repo metadata syncer."))
 
 	ctx := context.Background()
 	env.Lock()


### PR DESCRIPTION
The only environment we don't want to be running the feature flag yet is
Sourcegraph.com. I have just confirmed that it has
`SRC_SYNCER_ENABLED: false` on the repo-updater pod in production.

We are deferring the work to special case Sourcegraph.com until early in the
next milestone so that we can focus on more pressing issues before branch cut
tomorrow.