### PR TITLE
repo-updater: Adjust sleep rate limit heuristic for GitHub Search API

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -356,13 +356,18 @@ func newGitHubConnection(config *schema.GitHubConnection, cf httpcli.Factory) (*
 		}
 	}
 
+	// We need to adjust rate limit heuristics for search since it is 30r/min
+	// vs the normal 5000r/hour.
+	searchClient := github.NewClient(apiURL, config.Token, cli)
+	searchClient.RateLimit.NoWaitMinimum = 8
+
 	return &githubConnection{
 		config:           config,
 		exclude:          exclude,
 		baseURL:          baseURL,
 		githubDotCom:     githubDotCom,
 		client:           github.NewClient(apiURL, config.Token, cli),
-		searchClient:     github.NewClient(apiURL, config.Token, cli),
+		searchClient:     searchClient,
 		originalHostname: originalHostname,
 	}, nil
 }

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -356,18 +356,13 @@ func newGitHubConnection(config *schema.GitHubConnection, cf httpcli.Factory) (*
 		}
 	}
 
-	// We need to adjust rate limit heuristics for search since it is 30r/min
-	// vs the normal 5000r/hour.
-	searchClient := github.NewClient(apiURL, config.Token, cli)
-	searchClient.RateLimit.NoWaitMinimum = 8
-
 	return &githubConnection{
 		config:           config,
 		exclude:          exclude,
 		baseURL:          baseURL,
 		githubDotCom:     githubDotCom,
 		client:           github.NewClient(apiURL, config.Token, cli),
-		searchClient:     searchClient,
+		searchClient:     github.NewClient(apiURL, config.Token, cli),
 		originalHostname: originalHostname,
 	}, nil
 }

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -245,7 +245,7 @@ func (s *Syncer) sourced(ctx context.Context, kinds ...string) ([]*Repo, error) 
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	return srcs.ListRepos(ctx)

--- a/pkg/ratelimit/rate_limit.go
+++ b/pkg/ratelimit/rate_limit.go
@@ -14,6 +14,16 @@ import (
 type Monitor struct {
 	HeaderPrefix string // "X-" (GitHub) or "" (GitLab)
 
+	// NoWaitMinimum determines if RecommendedWaitForBackgroundOp returns a
+	// zero duration. Psuedocode
+	//
+	//   limit > NoWaitMinimum:     0
+	//   limit > NoWaitMinimum / 2: 250ms
+	//   default:                   time.Until(reset) / remaining
+	//
+	// Defaults to 500 (suitable for GitHub's 5000 hour limit)
+	NoWaitMinimum int
+
 	mu        sync.Mutex
 	known     bool
 	limit     int       // last RateLimit-Limit HTTP response header value
@@ -73,10 +83,15 @@ func (c *Monitor) RecommendedWaitForBackgroundOp(cost int) time.Duration {
 	if n < 1 {
 		return timeRemaining
 	}
-	if n > 500 {
+
+	noWait := float64(c.NoWaitMinimum)
+	if noWait == 0 {
+		noWait = 500
+	}
+	if n > noWait {
 		return 0
 	}
-	if n > 250 {
+	if n > noWait/2 {
 		return 200 * time.Millisecond
 	}
 	// N is limitRemaining / cost. timeRemaining / N is thus

--- a/pkg/ratelimit/rate_limit.go
+++ b/pkg/ratelimit/rate_limit.go
@@ -31,6 +31,12 @@ func (c *Monitor) Get() (remaining int, reset time.Duration, known bool) {
 	return c.remaining, time.Until(c.reset), true
 }
 
+// TODO(keegancsmith) Update RecommendedWaitForBackgroundOp to work with other
+// rate limits. Such as:
+//
+// - GitHub search 30req/m
+// - GitLab.com 600 req/h
+
 // RecommendedWaitForBackgroundOp returns the recommended wait time before performing a periodic
 // background operation with the given rate limit cost. It takes the rate limit information from the last API
 // request into account.

--- a/pkg/ratelimit/rate_limit.go
+++ b/pkg/ratelimit/rate_limit.go
@@ -14,16 +14,6 @@ import (
 type Monitor struct {
 	HeaderPrefix string // "X-" (GitHub) or "" (GitLab)
 
-	// NoWaitMinimum determines if RecommendedWaitForBackgroundOp returns a
-	// zero duration. Psuedocode
-	//
-	//   limit > NoWaitMinimum:     0
-	//   limit > NoWaitMinimum / 2: 250ms
-	//   default:                   time.Until(reset) / remaining
-	//
-	// Defaults to 500 (suitable for GitHub's 5000 hour limit)
-	NoWaitMinimum int
-
 	mu        sync.Mutex
 	known     bool
 	limit     int       // last RateLimit-Limit HTTP response header value
@@ -83,15 +73,10 @@ func (c *Monitor) RecommendedWaitForBackgroundOp(cost int) time.Duration {
 	if n < 1 {
 		return timeRemaining
 	}
-
-	noWait := float64(c.NoWaitMinimum)
-	if noWait == 0 {
-		noWait = 500
-	}
-	if n > noWait {
+	if n > 500 {
 		return 0
 	}
-	if n > noWait/2 {
+	if n > 250 {
 		return 200 * time.Millisecond
 	}
 	// N is limitRemaining / cost. timeRemaining / N is thus


### PR DESCRIPTION
GitHub source which relied on repositoryQuery would be very slow, normally
leading to a timeout. This was due to the very low rate limits and the "sleep"
heuristic being based on the normal GitHub rate limit. Essentially the sleep
operation would always be 10s. Instead we only rely on the heuristic if there
is less than 5 requests left.