### PR TITLE
repo-updater: Idiomatic go error messages for GitHub source

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -422,7 +422,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 			switch repositoryQuery {
 			case "public":
 				if c.githubDotCom {
-					ch <- batch{err: errors.New(`ignoring unsupported configuration "public" for "repositoryQuery" for github.com`)}
+					ch <- batch{err: errors.New(`unsupported configuration "public" for "repositoryQuery" for github.com`)}
 					return
 				}
 				var sinceRepoID int64
@@ -434,13 +434,13 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 
 					repos, err := c.client.ListPublicRepositories(ctx, sinceRepoID)
 					if err != nil {
-						ch <- batch{err: errors.Wrapf(err, "Error listing public repositories: sinceRepoID=%d", sinceRepoID)}
+						ch <- batch{err: errors.Wrapf(err, "failed to list public repositories: sinceRepoID=%d", sinceRepoID)}
 						return
 					}
 					if len(repos) == 0 {
 						return
 					}
-					log15.Debug("github sync public", "repos", len(repos), "err", err)
+					log15.Debug("github sync public", "repos", len(repos), "error", err)
 					for _, r := range repos {
 						if sinceRepoID < r.DatabaseID {
 							sinceRepoID = r.DatabaseID
@@ -461,7 +461,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 					var err error
 					repos, hasNextPage, rateLimitCost, err = c.client.ListUserRepositories(ctx, page)
 					if err != nil {
-						ch <- batch{err: errors.Wrapf(err, "Error listing affiliated GitHub repositories page %d", page)}
+						ch <- batch{err: errors.Wrapf(err, "failed to list affiliated GitHub repositories page %d", page)}
 						break
 					}
 					rateLimitRemaining, rateLimitReset, _ := c.client.RateLimit.Get()
@@ -501,7 +501,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 					var err error
 					repos, hasNextPage, rateLimitCost, err = c.searchClient.ListRepositoriesForSearch(ctx, repositoryQuery, page)
 					if err != nil {
-						ch <- batch{err: errors.Wrapf(err, "Error listing GitHub repositories for search: page=%q, searchString=%q,", page, repositoryQuery)}
+						ch <- batch{err: errors.Wrapf(err, "failed to list GitHub repositories for search: page=%q, searchString=%q,", page, repositoryQuery)}
 						break
 					}
 					rateLimitRemaining, rateLimitReset, _ := c.searchClient.RateLimit.Get()

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -370,7 +370,7 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 		return nil, false, 1, err
 	}
 	if response.IncompleteResults {
-		return nil, false, 1, errors.Errorf("github repository search returned incomplete results: query=%q page=%d total=%d", searchString, page, response.TotalCount)
+		return nil, false, 1, errors.Errorf("github repository search returned incomplete results. This is an ephemeral error: query=%q page=%d total=%d", searchString, page, response.TotalCount)
 	}
 	repos = make([]*Repository, 0, len(response.Items))
 	for _, restRepo := range response.Items {

--- a/pkg/extsvc/github/repos_test.go
+++ b/pkg/extsvc/github/repos_test.go
@@ -326,7 +326,7 @@ func TestClient_ListRepositoriesForSearch_incomplete(t *testing.T) {
 	// If we have incomplete results we want to fail. Our syncer requires all
 	// repositories to be returned, otherwise it will delete the missing
 	// repositories.
-	want := `github repository search returned incomplete results: query="org:sourcegraph" page=1 total=2`
+	want := `github repository search returned incomplete results. This is an ephemeral error: query="org:sourcegraph" page=1 total=2`
 	_, _, _, err :=
 		c.ListRepositoriesForSearch(context.Background(), "org:sourcegraph", 1)
 


### PR DESCRIPTION
Also updated the incomplete results error message to make it clear to the user
that it is an ephemeral error.
