### PR TITLE
repo-updater: Instructions on splitting large GitHub repositoryQuerys

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -509,7 +509,7 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 						// return 1000 results. We specially handle this case
 						// to ensure the admin gets a detailed error
 						// message. https://github.com/sourcegraph/sourcegraph/issues/2562
-						ch <- batch{err: errors.Wrapf(err, `repositoryQuery %q would return %d results. GitHub's Search API only returns up to 1000 results. Please adjust your repository query into multiple queries such that each returns less than 1000 results. For example: {"repositoryQuery": %s}`, repositoryQuery, reposPage.TotalCount, exampleRepositoryQuerySplit(repositoryQuery))}
+						ch <- batch{err: errors.Errorf(`repositoryQuery %q would return %d results. GitHub's Search API only returns up to 1000 results. Please adjust your repository query into multiple queries such that each returns less than 1000 results. For example: {"repositoryQuery": %s}`, repositoryQuery, reposPage.TotalCount, exampleRepositoryQuerySplit(repositoryQuery))}
 						break
 					}
 

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -491,7 +491,6 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 			default:
 				// Run the query as a GitHub advanced repository search
 				// (https://github.com/search/advanced).
-				totalRepos := 0
 				hasNextPage := true
 				for page := 1; hasNextPage; page++ {
 					if err := ctx.Err(); err != nil {
@@ -501,15 +500,16 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 
 					reposPage, err := c.searchClient.ListRepositoriesForSearch(ctx, repositoryQuery, page)
 					if err != nil {
-						if totalRepos >= 1000 {
-							// GitHub's advanced repository search will only
-							// return 1000 results. We specially handle this
-							// case to ensure the admin gets a detailed error
-							// message. https://github.com/sourcegraph/sourcegraph/issues/2562
-							ch <- batch{err: errors.Wrapf(err, "repositoryQuery %q would return more than 1000 results. GitHub's Search API only returns up to 1000 results. Please adjust your repository query into multiple queries such that each returns less than 1000 results. For example: repositoryQuery: %s", repositoryQuery, exampleRepositoryQuerySplit(repositoryQuery))}
-							break
-						}
 						ch <- batch{err: errors.Wrapf(err, "failed to list GitHub repositories for search: page=%q, searchString=%q,", page, repositoryQuery)}
+						break
+					}
+
+					if reposPage.TotalCount > 1000 {
+						// GitHub's advanced repository search will only
+						// return 1000 results. We specially handle this case
+						// to ensure the admin gets a detailed error
+						// message. https://github.com/sourcegraph/sourcegraph/issues/2562
+						ch <- batch{err: errors.Wrapf(err, `repositoryQuery %q would return %d results. GitHub's Search API only returns up to 1000 results. Please adjust your repository query into multiple queries such that each returns less than 1000 results. For example: {"repositoryQuery": %s}`, repositoryQuery, reposPage.TotalCount, exampleRepositoryQuerySplit(repositoryQuery))}
 						break
 					}
 
@@ -519,7 +519,6 @@ func (c *githubConnection) listAllRepositories(ctx context.Context) ([]*github.R
 					rateLimitRemaining, rateLimitReset, _ := c.searchClient.RateLimit.Get()
 					log15.Debug("github sync: ListRepositoriesForSearch", "searchString", repositoryQuery, "repos", len(repos), "rateLimitRemaining", rateLimitRemaining, "rateLimitReset", rateLimitReset)
 
-					totalRepos += len(repos)
 					ch <- batch{repos: repos}
 
 					if hasNextPage {

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -82,3 +82,12 @@ func TestGetGitHubConnection(t *testing.T) {
 		})
 	})
 }
+
+func TestExampleRepositoryQuerySplit(t *testing.T) {
+	q := "org:sourcegraph"
+	want := `["org:sourcegraph created:>=2019","org:sourcegraph created:2018","org:sourcegraph created:2016..2017","org:sourcegraph created:<2016"]`
+	have := exampleRepositoryQuerySplit(q)
+	if want != have {
+		t.Errorf("unexpected example query for %s:\nwant: %s\nhave: %s", q, want, have)
+	}
+}

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -22,7 +22,7 @@ To set this up, add GitHub as an external service to Sourcegraph:
 There are three fields for configuring which repositories are mirrored/synchronized:
 
 - [`repos`](github.md#configuration)<br>A list of repositories in `owner/name` format.
-- [`repositoryQuery`](github.md#configuration)<br>A list of strings with three pre-defined options (`public`, `affiliated`, `none`), and/or a [GitHub advanced search query](https://github.com/search/advanced).
+- [`repositoryQuery`](github.md#configuration)<br>A list of strings with three pre-defined options (`public`, `affiliated`, `none`), and/or a [GitHub advanced search query](https://github.com/search/advanced). Note: GitHub advanced search queries must return [less than 1000 results](#repositoryquery-returns-first-1000-results-only).
 - [`exclude`](github.md#configuration)<br>A list of repositories to exclude which takes precedence over the `repos`, and `repositoryQuery` fields.
 
 ## GitHub API token and access
@@ -51,3 +51,23 @@ To configure GitHub as an authentication provider (which will enable sign-in via
 GitHub external service connections support the following configuration options, which are specified in the JSON editor in the site admin external services area.
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/github.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/github) to see rendered content.</div>
+
+## Troubleshooting
+
+### RepositoryQuery returns first 1000 results only
+
+GitHub's [Search API](https://developer.github.com/v3/search/) only returns the first 1000 results. Therefore a `repositoryQuery` needs to return a 1000 results or less otherwise Sourcegraph will not synchronize some repositories. To workaround this limitation you can split your query into multiple queries, each returning less than a 1000 results. For example if your query is `org:Microsoft fork:no` you can adjust your query to:
+
+```jsonx
+{
+  // ...
+  "repositoryQuery": [
+    "org:Microsoft fork:no created:>=2019",
+    "org:Microsoft fork:no created:2018",
+    "org:Microsoft fork:no created:2016..2017",
+    "org:Microsoft fork:no created:<2016"
+  ]
+}
+```
+
+If splitting by creation date does not work, try another field. See [GitHub advanced search query](https://github.com/search/advanced) for other fields you can try.

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -22,7 +22,7 @@ To set this up, add GitHub as an external service to Sourcegraph:
 There are three fields for configuring which repositories are mirrored/synchronized:
 
 - [`repos`](github.md#configuration)<br>A list of repositories in `owner/name` format.
-- [`repositoryQuery`](github.md#configuration)<br>A list of strings with three pre-defined options (`public`, `affiliated`, `none`), and/or a [GitHub advanced search query](https://github.com/search/advanced). Note: GitHub advanced search queries must return [less than 1000 results](#repositoryquery-returns-first-1000-results-only).
+- [`repositoryQuery`](github.md#configuration)<br>A list of strings with three pre-defined options (`public`, `affiliated`, `none`), and/or a [GitHub advanced search query](https://github.com/search/advanced). Note: There is an existing limitation that requires GitHub advanced search queries to return [less than 1000 results](#repositoryquery-returns-first-1000-results-only). See [this issue](https://github.com/sourcegraph/sourcegraph/issues/2562) for ongoing work to address this limitation.
 - [`exclude`](github.md#configuration)<br>A list of repositories to exclude which takes precedence over the `repos`, and `repositoryQuery` fields.
 
 ## GitHub API token and access
@@ -71,3 +71,5 @@ GitHub's [Search API](https://developer.github.com/v3/search/) only returns the 
 ```
 
 If splitting by creation date does not work, try another field. See [GitHub advanced search query](https://github.com/search/advanced) for other fields you can try.
+
+See [Handle GitHub repositoryQuery that has more than 1000 results](https://github.com/sourcegraph/sourcegraph/issues/2562) for ongoing work to address this limitation.

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -360,6 +360,7 @@ type restSearchResponse struct {
 
 // RepositoryListPage is a page of repositories returned from the GitHub Search API.
 type RepositoryListPage struct {
+	TotalCount  int
 	Repos       []*Repository
 	HasNextPage bool
 }
@@ -383,8 +384,10 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 		repos = append(repos, convertRestRepo(restRepo))
 	}
 	c.addRepositoriesToCache("", repos)
+
 	return RepositoryListPage{
+		TotalCount:  response.TotalCount,
 		Repos:       repos,
-		HasNextPage: len(repos) > 0,
+		HasNextPage: page*100 < response.TotalCount,
 	}, nil
 }

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -358,7 +358,13 @@ type restSearchResponse struct {
 	Items             []restRepository `json:"items"`
 }
 
-func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
+// RepositoryListPage is a page of repositories returned from the GitHub Search API.
+type RepositoryListPage struct {
+	Repos       []*Repository
+	HasNextPage bool
+}
+
+func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString string, page int) (RepositoryListPage, error) {
 	urlValues := url.Values{
 		"q":        []string{searchString},
 		"page":     []string{strconv.Itoa(page)},
@@ -367,15 +373,18 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 	path := "search/repositories?" + urlValues.Encode()
 	var response restSearchResponse
 	if err := c.requestGet(ctx, "", path, &response); err != nil {
-		return nil, false, 1, err
+		return RepositoryListPage{}, err
 	}
 	if response.IncompleteResults {
-		return nil, false, 1, errors.Errorf("github repository search returned incomplete results: query=%q page=%d total=%d", searchString, page, response.TotalCount)
+		return RepositoryListPage{}, errors.Errorf("github repository search returned incomplete results: query=%q page=%d total=%d", searchString, page, response.TotalCount)
 	}
-	repos = make([]*Repository, 0, len(response.Items))
+	repos := make([]*Repository, 0, len(response.Items))
 	for _, restRepo := range response.Items {
 		repos = append(repos, convertRestRepo(restRepo))
 	}
 	c.addRepositoriesToCache("", repos)
-	return repos, len(repos) > 0, 1, nil
+	return RepositoryListPage{
+		Repos:       repos,
+		HasNextPage: len(repos) > 0,
+	}, nil
 }

--- a/pkg/extsvc/github/repos_test.go
+++ b/pkg/extsvc/github/repos_test.go
@@ -286,14 +286,12 @@ func TestClient_ListRepositoriesForSearch(t *testing.T) {
 		},
 	}
 
-	repos, _, _, err :=
-		c.ListRepositoriesForSearch(context.Background(), "org:sourcegraph", 1)
-
+	reposPage, err := c.ListRepositoriesForSearch(context.Background(), "org:sourcegraph", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !repoListsAreEqual(repos, wantRepos) {
-		t.Errorf("got repositories:\n%s\nwant:\n%s", stringForRepoList(repos), stringForRepoList(wantRepos))
+	if !repoListsAreEqual(reposPage.Repos, wantRepos) {
+		t.Errorf("got repositories:\n%s\nwant:\n%s", stringForRepoList(reposPage.Repos), stringForRepoList(wantRepos))
 	}
 }
 
@@ -327,8 +325,7 @@ func TestClient_ListRepositoriesForSearch_incomplete(t *testing.T) {
 	// repositories to be returned, otherwise it will delete the missing
 	// repositories.
 	want := `github repository search returned incomplete results: query="org:sourcegraph" page=1 total=2`
-	_, _, _, err :=
-		c.ListRepositoriesForSearch(context.Background(), "org:sourcegraph", 1)
+	_, err := c.ListRepositoriesForSearch(context.Background(), "org:sourcegraph", 1)
 
 	if have := fmt.Sprint(err); want != have {
 		t.Errorf("\nhave: %s\nwant: %s", have, want)


### PR DESCRIPTION
Implementing automatic splitting of repository queries is tricky due to there
being no solution that works for all repository queries. Instead, we provide a
very detailed error message to admins. This will show up on the external
services UI when an admin attempts to create/update an external service that
returns too many results.

Test plan: Created a GitHub external service with the repositoryQuery `org:Microsoft`. Observed error message.

![image](https://user-images.githubusercontent.com/187831/56133957-dc25c100-5f8d-11e9-8952-2b3daabde5c9.png)

Part of #2562
Part of #2025