### PR TITLE
Don't show the permissions alert on `newtab` or `extensions`

### DIFF
--- a/client/browser/src/libs/options/Menu.test.tsx
+++ b/client/browser/src/libs/options/Menu.test.tsx
@@ -37,6 +37,28 @@ describe('ServerURLForm', () => {
         ).toMatchSnapshot()
     })
 
+    test("doesn't render the permissions alert on newtab", () => {
+        expect(
+            renderer.create(
+                <OptionsMenu
+                    {...stubs}
+                    currentTabStatus={{ host: 'extensions', protocol: 'http', hasPermissions: false }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    test("doesn't render the permissions alert on extensions", () => {
+        expect(
+            renderer.create(
+                <OptionsMenu
+                    {...stubs}
+                    currentTabStatus={{ host: 'newtab', protocol: 'http', hasPermissions: false }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
     test('fires requestPermissions', () => {
         const requestPermissions = sinon.spy()
         const { container } = render(

--- a/client/browser/src/libs/options/Menu.tsx
+++ b/client/browser/src/libs/options/Menu.tsx
@@ -39,6 +39,11 @@ const buildRequestPermissionsHandler = (
     requestPermissions(`${protocol}//${host}`)
 }
 
+/**
+ * A list of hosts where we should *not* show the permissions notification.
+ */
+const PERMISSIONS_HOST_BLACKLIST = ['extensions', 'newtab']
+
 export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
     sourcegraphURL,
     onURLChange,
@@ -62,21 +67,24 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
             requestPermissions={requestPermissions}
             className="options-menu__section"
         />
-        {status === 'connected' && currentTabStatus && !currentTabStatus.hasPermissions && (
-            <div className="options-menu__section">
-                <div className="alert alert-danger">
-                    Sourcegraph is not enabled on <strong>{currentTabStatus.host}</strong>.{' '}
-                    <a
-                        href=""
-                        onClick={buildRequestPermissionsHandler(currentTabStatus, requestPermissions)}
-                        className="request-permissions__test"
-                    >
-                        Grant permissions
-                    </a>{' '}
-                    to enable Sourcegraph.
+        {status === 'connected' &&
+            currentTabStatus &&
+            !currentTabStatus.hasPermissions &&
+            !PERMISSIONS_HOST_BLACKLIST.includes(currentTabStatus.host) && (
+                <div className="options-menu__section">
+                    <div className="alert alert-danger">
+                        Sourcegraph is not enabled on <strong>{currentTabStatus.host}</strong>.{' '}
+                        <a
+                            href=""
+                            onClick={buildRequestPermissionsHandler(currentTabStatus, requestPermissions)}
+                            className="request-permissions__test"
+                        >
+                            Grant permissions
+                        </a>{' '}
+                        to enable Sourcegraph.
+                    </div>
                 </div>
-            </div>
-        )}
+            )}
         {isSettingsOpen && featureFlags && (
             <div className="options-menu__section">
                 <label>Configuration</label>

--- a/client/browser/src/libs/options/__snapshots__/Menu.test.tsx.snap
+++ b/client/browser/src/libs/options/__snapshots__/Menu.test.tsx.snap
@@ -1,5 +1,153 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ServerURLForm doesn't render the permissions alert on extensions 1`] = `
+<div
+  className="options-menu options-menu--full"
+>
+  <div
+    className="options-header options-menu__section"
+  >
+    <img
+      className="options-header__logo"
+      src="/img/sourcegraph-logo.svg"
+    />
+    <div
+      className="options-header__right"
+    >
+      <span>
+        v
+        0.0.0
+      </span>
+      <button
+        className="options-header__settings btn btn-icon"
+        onClick={[Function]}
+      >
+        <svg
+          className="mdi-icon icon-inline"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19.43,12.97L21.54,14.63C21.73,14.78 21.78,15.05 21.66,15.27L19.66,18.73C19.54,18.95 19.27,19.03 19.05,18.95L16.56,17.94C16.04,18.34 15.5,18.67 14.87,18.93L14.5,21.58C14.46,21.82 14.25,22 14,22H10C9.75,22 9.54,21.82 9.5,21.58L9.13,18.93C8.5,18.68 7.96,18.34 7.44,17.94L4.95,18.95C4.73,19.03 4.46,18.95 4.34,18.73L2.34,15.27C2.21,15.05 2.27,14.78 2.46,14.63L4.57,12.97L4.5,12L4.57,11L2.46,9.37C2.27,9.22 2.21,8.95 2.34,8.73L4.34,5.27C4.46,5.05 4.73,4.96 4.95,5.05L7.44,6.05C7.96,5.66 8.5,5.32 9.13,5.07L9.5,2.42C9.54,2.18 9.75,2 10,2H14C14.25,2 14.46,2.18 14.5,2.42L14.87,5.07C15.5,5.32 16.04,5.66 16.56,6.05L19.05,5.05C19.27,4.96 19.54,5.05 19.66,5.27L21.66,8.73C21.78,8.95 21.73,9.22 21.54,9.37L19.43,11L19.5,12L19.43,12.97M6.5,12C6.5,12.58 6.59,13.13 6.75,13.66L4.68,15.36L5.43,16.66L7.95,15.72C8.69,16.53 9.68,17.12 10.8,17.37L11.24,20H12.74L13.18,17.37C14.3,17.13 15.3,16.54 16.05,15.73L18.56,16.67L19.31,15.37L17.24,13.67C17.41,13.14 17.5,12.58 17.5,12C17.5,11.43 17.41,10.87 17.25,10.35L19.31,8.66L18.56,7.36L16.06,8.29C15.31,7.47 14.31,6.88 13.19,6.63L12.75,4H11.25L10.81,6.63C9.69,6.88 8.69,7.47 7.94,8.29L5.44,7.35L4.69,8.65L6.75,10.35C6.59,10.87 6.5,11.43 6.5,12M12,8.5C13.93,8.5 15.5,10.07 15.5,12C15.5,13.93 13.93,15.5 12,15.5C10.07,15.5 8.5,13.93 8.5,12C8.5,10.07 10.07,8.5 12,8.5M12,10.5C11.17,10.5 10.5,11.17 10.5,12C10.5,12.83 11.17,13.5 12,13.5C12.83,13.5 13.5,12.83 13.5,12C13.5,11.17 12.83,10.5 12,10.5Z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <form
+    className="server-url-form options-menu__section"
+    onSubmit={[Function]}
+  >
+    <label
+      className="server-url-form__label"
+    >
+      Sourcegraph URL
+    </label>
+    <div
+      className="server-url-form__input-container"
+    >
+      <div
+        className="server-url-form__input-container__status"
+      >
+        <span
+          className="server-url-form__input-container__status__indicator server-url-form__input-container__status__indicator--success"
+        />
+        <span
+          className="server-url-form__input-container__status__text"
+        >
+          Connected
+        </span>
+      </div>
+      <input
+        autoCapitalize="off"
+        autoCorrect="off"
+        className="server-url-form__input-container__input"
+        onChange={[Function]}
+        spellCheck={false}
+        type="text"
+        value="https://sourcegraph.com"
+      />
+    </div>
+  </form>
+</div>
+`;
+
+exports[`ServerURLForm doesn't render the permissions alert on newtab 1`] = `
+<div
+  className="options-menu options-menu--full"
+>
+  <div
+    className="options-header options-menu__section"
+  >
+    <img
+      className="options-header__logo"
+      src="/img/sourcegraph-logo.svg"
+    />
+    <div
+      className="options-header__right"
+    >
+      <span>
+        v
+        0.0.0
+      </span>
+      <button
+        className="options-header__settings btn btn-icon"
+        onClick={[Function]}
+      >
+        <svg
+          className="mdi-icon icon-inline"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19.43,12.97L21.54,14.63C21.73,14.78 21.78,15.05 21.66,15.27L19.66,18.73C19.54,18.95 19.27,19.03 19.05,18.95L16.56,17.94C16.04,18.34 15.5,18.67 14.87,18.93L14.5,21.58C14.46,21.82 14.25,22 14,22H10C9.75,22 9.54,21.82 9.5,21.58L9.13,18.93C8.5,18.68 7.96,18.34 7.44,17.94L4.95,18.95C4.73,19.03 4.46,18.95 4.34,18.73L2.34,15.27C2.21,15.05 2.27,14.78 2.46,14.63L4.57,12.97L4.5,12L4.57,11L2.46,9.37C2.27,9.22 2.21,8.95 2.34,8.73L4.34,5.27C4.46,5.05 4.73,4.96 4.95,5.05L7.44,6.05C7.96,5.66 8.5,5.32 9.13,5.07L9.5,2.42C9.54,2.18 9.75,2 10,2H14C14.25,2 14.46,2.18 14.5,2.42L14.87,5.07C15.5,5.32 16.04,5.66 16.56,6.05L19.05,5.05C19.27,4.96 19.54,5.05 19.66,5.27L21.66,8.73C21.78,8.95 21.73,9.22 21.54,9.37L19.43,11L19.5,12L19.43,12.97M6.5,12C6.5,12.58 6.59,13.13 6.75,13.66L4.68,15.36L5.43,16.66L7.95,15.72C8.69,16.53 9.68,17.12 10.8,17.37L11.24,20H12.74L13.18,17.37C14.3,17.13 15.3,16.54 16.05,15.73L18.56,16.67L19.31,15.37L17.24,13.67C17.41,13.14 17.5,12.58 17.5,12C17.5,11.43 17.41,10.87 17.25,10.35L19.31,8.66L18.56,7.36L16.06,8.29C15.31,7.47 14.31,6.88 13.19,6.63L12.75,4H11.25L10.81,6.63C9.69,6.88 8.69,7.47 7.94,8.29L5.44,7.35L4.69,8.65L6.75,10.35C6.59,10.87 6.5,11.43 6.5,12M12,8.5C13.93,8.5 15.5,10.07 15.5,12C15.5,13.93 13.93,15.5 12,15.5C10.07,15.5 8.5,13.93 8.5,12C8.5,10.07 10.07,8.5 12,8.5M12,10.5C11.17,10.5 10.5,11.17 10.5,12C10.5,12.83 11.17,13.5 12,13.5C12.83,13.5 13.5,12.83 13.5,12C13.5,11.17 12.83,10.5 12,10.5Z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <form
+    className="server-url-form options-menu__section"
+    onSubmit={[Function]}
+  >
+    <label
+      className="server-url-form__label"
+    >
+      Sourcegraph URL
+    </label>
+    <div
+      className="server-url-form__input-container"
+    >
+      <div
+        className="server-url-form__input-container__status"
+      >
+        <span
+          className="server-url-form__input-container__status__indicator server-url-form__input-container__status__indicator--success"
+        />
+        <span
+          className="server-url-form__input-container__status__text"
+        >
+          Connected
+        </span>
+      </div>
+      <input
+        autoCapitalize="off"
+        autoCorrect="off"
+        className="server-url-form__input-container__input"
+        onChange={[Function]}
+        spellCheck={false}
+        type="text"
+        value="https://sourcegraph.com"
+      />
+    </div>
+  </form>
+</div>
+`;
+
 exports[`ServerURLForm renders a default state 1`] = `
 <div
   className="options-menu options-menu--full"


### PR DESCRIPTION
Avoids the following silliness:

![image](https://user-images.githubusercontent.com/1741180/56140425-2e211380-5f9b-11e9-9b6f-ea47ebd36d1c.png)

#### Test Plan

##### Browsers

- [x] Chrome
- [x] Firefox
