### PR TITLE
repo-updater: Do not specify a default username and dbname

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -171,7 +171,6 @@ func doPostgresDSN(currentUser string, getenv func(string) string) string {
 	dsn := &url.URL{
 		Scheme:   "postgres",
 		Host:     "127.0.0.1:5432",
-		Path:     "/sourcegraph",
 		RawQuery: "sslmode=disable",
 	}
 

--- a/cmd/frontend/internal/cli/config_test.go
+++ b/cmd/frontend/internal/cli/config_test.go
@@ -10,7 +10,7 @@ func TestPostgresDSN(t *testing.T) {
 	}{{
 		name: "default",
 		env:  map[string]string{},
-		dsn:  "postgres://testuser@127.0.0.1:5432/sourcegraph?sslmode=disable",
+		dsn:  "postgres://testuser@127.0.0.1:5432?sslmode=disable",
 	}, {
 		name: "deploy-sourcegraph",
 		env: map[string]string{


### PR DESCRIPTION
Rather rely on the logic psql does when connecting to it. This is what
Sourcegraph did in 3.2 and before. During 3.2 we hardcoded sourcegraph as a
default, which required us in devenvs to specify PGDATABASE. Note: For
deploy-sourcegraph and server PGDATABASE was always specified.

Test plan: go test works without specifying PG* vars.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3409
