### PR TITLE
fix notification styles on code hosts

### DIFF
--- a/shared/src/notifications/NotificationItem.scss
+++ b/shared/src/notifications/NotificationItem.scss
@@ -1,19 +1,24 @@
 .sourcegraph-notification-item {
     display: block;
     transition: all 300ms ease-in;
+    padding: 0;
 
     &__progressbar {
         height: 0.25rem;
         transition: width 0.6s ease;
     }
 
-    &__title {
-        font-weight: bold;
-
-        > p {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            white-space: nowrap;
+    &__body-container {
+        display: flex;
+        align-items: start;
+    }
+    &__body {
+        flex: 1;
+        padding: 0.5rem;
+        overflow: hidden;
+        pre,
+        code {
+            overflow-x: auto;
         }
     }
 
@@ -24,7 +29,7 @@
 
     &__close {
         cursor: pointer;
-        flex: 0;
+        flex: 0 0;
         font-size: 1.25rem;
         line-height: 1.25rem;
         background-color: transparent;
@@ -32,6 +37,7 @@
         outline: 0 !important;
         color: inherit;
         opacity: 0.7;
+        padding: 0.5rem;
 
         &:hover,
         &:focus {

--- a/shared/src/notifications/NotificationItem.tsx
+++ b/shared/src/notifications/NotificationItem.tsx
@@ -71,11 +71,10 @@ export class NotificationItem extends React.PureComponent<Props, State> {
         const bootstrapClass = getBootstrapClass(this.props.notification.type)
         return (
             <div
-                className={`sourcegraph-notification-item alert alert-${bootstrapClass} p-0 ${this.props.className ||
-                    ''}`}
+                className={`sourcegraph-notification-item alert alert-${bootstrapClass} ${this.props.className || ''}`}
             >
-                <div className="w-100 d-flex align-items-start">
-                    <div className="p-2 flex-grow-1 mw-100">
+                <div className="sourcegraph-notification-item__body-container">
+                    <div className="sourcegraph-notification-item__body">
                         <div
                             className="sourcegraph-notification-item__title"
                             dangerouslySetInnerHTML={{ __html: renderMarkdown(this.props.notification.message || '') }}
@@ -92,7 +91,7 @@ export class NotificationItem extends React.PureComponent<Props, State> {
                     {(!this.props.notification.progress || !this.state.progress) && (
                         <button
                             type="button"
-                            className="sourcegraph-notification-item__close close p-2 flex-grow-0 flex-shrink-0"
+                            className="sourcegraph-notification-item__close close"
                             onClick={this.onDismiss}
                             aria-label="Close"
                         >


### PR DESCRIPTION
This moves the CSS from using Bootstrap's builtin classes (which may or may not exist on the code host, or may differ from Bootstrap) to our own CSS. The ideal solution may be to use each code host's own CSS (as we do for CommandList and others), but this is a much quicker fix that is almost as good.

fix #3326