### PR TITLE
make /subscriptions/new not 404

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -66,6 +66,7 @@ const (
 	routeExplore        = "explore"
 	routeWelcome        = "welcome"
 	routeSnippets       = "snippets"
+	routeSubscriptions  = "subscriptions"
 
 	// Legacy redirects
 	routeLegacyLogin                   = "login"
@@ -140,6 +141,7 @@ func newRouter() *mux.Router {
 	r.PathPrefix("/help").Methods("GET").Name(routeHelp)
 	r.PathPrefix("/explore").Methods("GET").Name(routeExplore)
 	r.PathPrefix("/snippets").Methods("GET").Name(routeSnippets)
+	r.PathPrefix("/subscriptions").Methods("GET").Name(routeSubscriptions)
 
 	// Legacy redirects
 	r.Path("/login").Methods("GET").Name(routeLegacyLogin)
@@ -216,6 +218,7 @@ func initRouter() {
 	router.Get(routeExplore).Handler(handler(serveBasicPageString("Explore - Sourcegraph")))
 	router.Get(routeHelp).HandlerFunc(serveHelp)
 	router.Get(routeSnippets).Handler(handler(serveBasicPageString("Snippets - Sourcegraph")))
+	router.Get(routeSubscriptions).Handler(handler(serveBasicPageString("Subscriptions - Sourcegraph")))
 
 	router.Get(routeUserSettings).Handler(handler(serveBasicPageString("User settings - Sourcegraph")))
 	router.Get(routeUserRedirect).Handler(handler(serveBasicPageString("User - Sourcegraph")))


### PR DESCRIPTION
The new URL https://sourcegraph.com/subscriptions/new for unauthed users to price out a plan was merged in #3397, but I forgot to add a Go route entry for it. This meant that it would 404 and the tab title would briefly read "Not found". These are minor issues that this commit fixes.

(The URL used to be https://sourcegraph.com/user/subscriptions/new, which was already handled by the existing Go user route.)


