### PR TITLE
support theming of completion menu

### DIFF
--- a/web/src/components/completion/CompletionWidgetDropdown.scss
+++ b/web/src/components/completion/CompletionWidgetDropdown.scss
@@ -1,10 +1,12 @@
 .completion-widget-dropdown {
     cursor: pointer;
-    border: 1px solid #dfe2e5;
+    border: 1px solid var(--border-color);
     box-shadow: 0 0 5px rgba(27, 31, 35, 0.1);
 
     &__item {
-        border-bottom: 1px solid #dfe2e5;
+        border-bottom: 1px solid var(--border-color);
+        background-color: $color-bg-2;
+        color: $color-text-2;
         &--selected {
             color: #ffffff !important;
         }
@@ -14,5 +16,14 @@
         border-bottom: 0;
         border-bottom-right-radius: 3px;
         border-bottom-left-radius: 3px;
+    }
+}
+
+.theme-light {
+    .completion-widget-dropdown {
+        &__item {
+            color: $color-light-text-1;
+            background-color: #ffffff;
+        }
     }
 }

--- a/web/src/components/completion/styles.ts
+++ b/web/src/components/completion/styles.ts
@@ -1,9 +1,9 @@
 import { CompletionWidgetClassProps } from '../../../../shared/src/components/completion/CompletionWidget'
 
-const listItemClassName = 'completion-widget-dropdown__item d-flex align-items-center p-2 text-dark'
+const listItemClassName = 'completion-widget-dropdown__item d-flex align-items-center p-2'
 
 export const COMPLETION_WIDGET_CLASS_PROPS: CompletionWidgetClassProps = {
-    listClassName: 'completion-widget-dropdown d-block list-unstyled rounded p-0 m-0 mt-3 bg-white',
+    listClassName: 'completion-widget-dropdown d-block list-unstyled rounded p-0 m-0 mt-3',
     listItemClassName,
     selectedListItemClassName: 'completion-widget-dropdown__item--selected bg-primary',
     loadingClassName: listItemClassName,


### PR DESCRIPTION
Previously, on Sourcegraph (in code discussions textareas), it showed using a light theme even when you were using a dark theme for the rest of Sourcegraph.

Reported by @slimsag at https://app.hubspot.com/contacts/2762526/company/409527326 

![themed-autocomplete](https://user-images.githubusercontent.com/1976/56177357-32f1c180-5fb3-11e9-9197-d34d600ddebb.png)
