### PR TITLE
fix completion widget position in scrolled textarea

### DIFF
--- a/shared/src/components/completion/CompletionWidget.tsx
+++ b/shared/src/components/completion/CompletionWidget.tsx
@@ -217,7 +217,13 @@ export class CompletionWidget extends React.Component<Props, State> {
             return null
         }
 
-        const caretCoordinates = getCaretCoordinates(this.props.textArea, this.props.textArea.selectionStart)
+        const caretCoordinates = getCaretCoordinates(this.props.textArea, this.props.textArea.selectionStart, {
+            debug: true,
+        })
+
+        // Support textareas that scroll vertically. Fixes
+        // https://github.com/sourcegraph/sourcegraph/issues/3424.
+        caretCoordinates.top -= this.props.textArea.scrollTop
 
         return (
             <div className={`completion-widget ${this.props.widgetContainerClassName || ''}`}>


### PR DESCRIPTION
Despite https://github.com/component/textarea-caret-position/blob/master/README.md claiming it supports scrolled textareas ("no problem getting the correct position when the input text is scrolled (i.e. the first visible character is no longer the first in the text)"), it was not working. If the textarea was scrolled down, the completion widget would be displayed well below the cursor (by the amount that the textarea was scrolled down).

fix #3424

![scrolleddown](https://user-images.githubusercontent.com/1976/56178921-d2fe1980-5fb8-11e9-95c6-3e5f4d28206a.png)
