### PR TITLE
improve performance of browser ext completion

### DIFF
--- a/client/browser/src/libs/code_intelligence/text_fields.tsx
+++ b/client/browser/src/libs/code_intelligence/text_fields.tsx
@@ -105,15 +105,19 @@ function synchronizeTextField(
 
     // Keep the text field in sync with the editor and model.
     subscriptions.add(
-        fromEvent(element, 'input').subscribe(() => {
-            EditorTextFieldUtils.updateModelFromElement(modelService, modelUri, element)
-            EditorTextFieldUtils.updateEditorSelectionFromElement(editorService, editor, element)
-        })
+        fromEvent(element, 'input')
+            .pipe(observeOn(animationFrameScheduler))
+            .subscribe(() => {
+                EditorTextFieldUtils.updateModelFromElement(modelService, modelUri, element)
+                EditorTextFieldUtils.updateEditorSelectionFromElement(editorService, editor, element)
+            })
     )
     subscriptions.add(
-        fromEvent(element, 'keydown').subscribe(() => {
-            EditorTextFieldUtils.updateEditorSelectionFromElement(editorService, editor, element)
-        })
+        fromEvent(element, 'keydown')
+            .pipe(observeOn(animationFrameScheduler))
+            .subscribe(() => {
+                EditorTextFieldUtils.updateEditorSelectionFromElement(editorService, editor, element)
+            })
     )
     subscriptions.add(
         EditorTextFieldUtils.updateElementOnEditorOrModelChanges(

--- a/shared/src/util/rxjs/throttleTimeWindow.test.ts
+++ b/shared/src/util/rxjs/throttleTimeWindow.test.ts
@@ -1,0 +1,164 @@
+import { of } from 'rxjs'
+import { mergeMap } from 'rxjs/operators'
+import { TestScheduler } from 'rxjs/testing'
+import { throttleTimeWindow } from './throttleTimeWindow'
+
+const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
+
+describe('throttleTimeWindow', () => {
+    test('emit the first value (immediately) and last value (at the end) in each time window', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-a-x-y----b---x-cx---|')
+            const subs = '^--------------------!'
+            const expected = '-a----y---b----xc----(x|)'
+
+            const result = e1.pipe(throttleTimeWindow(5, 1))
+
+            expectObservable(result).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('emit the first 2 values (immediately) and last value (at the end) in each time window', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-a-x-y----b---x-cx---|')
+            const subs = '^--------------------!'
+            const expected = '-a-x--y---b---x-cx---|'
+
+            const result = e1.pipe(throttleTimeWindow(5, 2))
+
+            expectObservable(result).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('emit the first 3 values (immediately) and last value (at the end) in each time window', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-a-x-y----bxy-z-cx---|')
+            const subs = '^--------------------!'
+            const expected = '-a-x-y----bxy--zcx---|'
+
+            const result = e1.pipe(throttleTimeWindow(5, 3))
+
+            expectObservable(result).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('simply mirror the source if values are not emitted often enough', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-a--------b-----c----|')
+            const subs = '^--------------------!'
+            const expected = '-a--------b-----c----|'
+            expectObservable(e1.pipe(throttleTimeWindow(5, 2))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('handle a busy producer emitting a regular repeating sequence', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('abcdefabcdefabcdefabcdefa|')
+            const subs = '^------------------------!'
+            const expected = 'ab---fab---fab---fab---fa|'
+
+            expectObservable(e1.pipe(throttleTimeWindow(5, 2))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('complete when source does not emit', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-----|')
+            const subs = '^----!'
+            const expected = '-----|'
+
+            expectObservable(e1.pipe(throttleTimeWindow(5, 2))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('raise error when source does not emit and raises error', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-----#')
+            const subs = '^----!'
+            const expected = '-----#'
+
+            expectObservable(e1.pipe(throttleTimeWindow(1, 2))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('handle an empty source', () => {
+        scheduler().run(({ cold, expectObservable, expectSubscriptions }) => {
+            const e1 = cold('|')
+            const subs = '(^!)'
+            const expected = '|'
+
+            expectObservable(e1.pipe(throttleTimeWindow(3, 2))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('handle a never source', () => {
+        scheduler().run(({ cold, expectObservable, expectSubscriptions }) => {
+            const e1 = cold('-')
+            const subs = '^'
+            const expected = '-'
+
+            expectObservable(e1.pipe(throttleTimeWindow(3, 2))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('handle a throw source', () => {
+        scheduler().run(({ cold, expectObservable, expectSubscriptions }) => {
+            const e1 = cold('#')
+            const subs = '(^!)'
+            const expected = '#'
+
+            expectObservable(e1.pipe(throttleTimeWindow(3, 2))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('throttle and does not complete when source does not completes', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-a--(bc)-------d----------------')
+            const unsub = '-------------------------------!'
+            const subs = '^------------------------------!'
+            const expected = '-a----c--------d----------------'
+
+            expectObservable(e1.pipe(throttleTimeWindow(5)), unsub).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('not break unsubscription chains when result is unsubscribed explicitly', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-a--(bc)-------d----------------')
+            const subs = '^------------------------------!'
+            const expected = '-a----c--------d----------------'
+            const unsub = '-------------------------------!'
+
+            const result = e1.pipe(
+                mergeMap((x: string) => of(x)),
+                throttleTimeWindow(5),
+                mergeMap((x: string) => of(x))
+            )
+
+            expectObservable(result, unsub).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+
+    test('throttle values until source raises error', () => {
+        scheduler().run(({ hot, expectObservable, expectSubscriptions }) => {
+            const e1 = hot('-a--(bc)-------d---------------#')
+            const subs = '^------------------------------!'
+            const expected = '-a----c--------d---------------#'
+
+            expectObservable(e1.pipe(throttleTimeWindow(5))).toBe(expected)
+            expectSubscriptions(e1.subscriptions).toBe(subs)
+        })
+    })
+})

--- a/shared/src/util/rxjs/throttleTimeWindow.ts
+++ b/shared/src/util/rxjs/throttleTimeWindow.ts
@@ -1,0 +1,127 @@
+import {
+    asyncScheduler,
+    MonoTypeOperatorFunction,
+    Observable,
+    Operator,
+    SchedulerLike,
+    Subscriber,
+    Subscription,
+    TeardownLogic,
+} from 'rxjs'
+
+// tslint:disable no-use-before-declare
+
+/**
+ * Emits `valuesPerWindow` values from the source Observable, then ignores subsequent source values
+ * for `windowDuration` milliseconds, then repeats this process.
+ *
+ * It is useful for throttling user input when the user wants immediate responses for the first
+ * several inputs, but if there is a repeated input (such as a depressed key that repeats), it is
+ * acceptable to ignore intermediate inputs.
+ *
+ * @see {@link throttleTime}
+ *
+ * @param windowDuration Time to wait before emitting another value after emitting the last value
+ * allowed by `valuesPerWindow`, measured in milliseconds or the time unit determined internally by
+ * the optional `scheduler`.
+ * @param valuesPerWindow The number of values to allow per time window.
+ * @param The {@link SchedulerLike} to use for managing the timers that handle the throttling.
+ * @return An Observable that performs the throttle operation to limit the rate of emissions from
+ * the source.
+ */
+export function throttleTimeWindow<T>(
+    windowDuration: number,
+    valuesPerWindow = 1,
+    scheduler: SchedulerLike = asyncScheduler
+): MonoTypeOperatorFunction<T> {
+    return (source: Observable<T>) =>
+        source.lift(new ThrottleTimeWindowOperator(windowDuration, valuesPerWindow, scheduler))
+}
+
+class ThrottleTimeWindowOperator<T> implements Operator<T, T> {
+    constructor(private windowDuration: number, private valuesPerWindow: number, private scheduler: SchedulerLike) {}
+
+    public call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+        return source.subscribe(
+            new ThrottleTimeWindowSubscriber(subscriber, this.windowDuration, this.valuesPerWindow, this.scheduler)
+        )
+    }
+}
+
+class ThrottleTimeWindowSubscriber<T> extends Subscriber<T> {
+    private throttled: Subscription | undefined
+    private _hasTrailingValue = false
+    private _trailingValue: T | undefined
+    private intervalEnds: number | undefined
+    private valuesInCurrentWindow = 0
+
+    constructor(
+        destination: Subscriber<T>,
+        private windowDuration: number,
+        private valuesPerWindow: number,
+        private scheduler: SchedulerLike
+    ) {
+        super(destination)
+    }
+
+    protected _next(value: T): void {
+        if (this.throttled) {
+            this._trailingValue = value
+            this._hasTrailingValue = true
+        } else {
+            if (
+                this.valuesInCurrentWindow === 0 ||
+                (this.intervalEnds !== undefined && this.scheduler.now() > this.intervalEnds)
+            ) {
+                this.intervalEnds = this.scheduler.now() + this.windowDuration
+            }
+            this.valuesInCurrentWindow++
+            if (this.valuesInCurrentWindow === this.valuesPerWindow) {
+                this.throttled = this.scheduler.schedule<DispatchArg<T>>(
+                    dispatchNext,
+                    this.intervalEnds! - this.scheduler.now(),
+                    {
+                        subscriber: this,
+                    }
+                )
+                this.add(this.throttled)
+            }
+            this.destination.next!(value)
+        }
+    }
+
+    protected _complete(): void {
+        if (this._hasTrailingValue) {
+            this.destination.next!(this._trailingValue)
+            this.destination.complete!()
+        } else {
+            this.destination.complete!()
+        }
+    }
+
+    public clearThrottle(): void {
+        const throttled = this.throttled
+        if (throttled) {
+            if (this._hasTrailingValue) {
+                this.destination.next!(this._trailingValue)
+                this._trailingValue = undefined
+                this._hasTrailingValue = false
+            }
+            throttled.unsubscribe()
+            this.remove(throttled)
+            this.throttled = undefined
+        }
+        this.valuesInCurrentWindow = 0
+        this.intervalEnds = undefined
+    }
+}
+
+interface DispatchArg<T> {
+    subscriber: ThrottleTimeWindowSubscriber<T>
+}
+
+function dispatchNext<T>(arg: DispatchArg<T> | undefined): void {
+    if (arg) {
+        arg.subscriber.clearThrottle()
+    }
+}


### PR DESCRIPTION
- create less garbage in chromePortListener
- defer UI updates until the animation frame
- better throttling of EditorCompletionWidget calls to the providers in response to textarea changes

Partially addresses https://github.com/sourcegraph/sourcegraph/issues/3433.

These signiicantly improve the perf problem to the point where it feels as smooth as native GitHub to me.