### PR TITLE
docs: Expand on GitHub exclude and repos fields.

### DIFF
--- a/doc/integration/github.md
+++ b/doc/integration/github.md
@@ -4,14 +4,14 @@ You can use Sourcegraph with [GitHub.com](https://github.com) and [GitHub Enterp
 
 Feature | Supported?
 ------- | ----------
-[Repository syncing](../admin/external_service/github.md#repository-syncing) | ✅
+[Repository syncing](../admin/external_service/github.md#selecting-repositories-for-code-search) | ✅
 [Repository permissions](../admin/external_service/github.md#repository-permissions) | ✅
 [User authentication](../admin/external_service/github.md#user-authentication) | ✅
 [Browser extension](#browser-extension) | ✅
 
 ## Repository syncing
 
-Site admins can [add GitHub repositories to Sourcegraph](../admin/external_service/github.md#repository-syncing).
+Site admins can [add GitHub repositories to Sourcegraph](../admin/external_service/github.md#selecting-repositories-for-code-search).
 
 ## Repository permissions
 

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -38,7 +38,8 @@
     "repos": {
       "description": "An array of repository \"owner/name\" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+$" }
+      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+$" },
+      "examples": [["owner/name"], ["kubernetes/kubernetes", "golang/go", "facebook/react"]]
     },
     "exclude": {
       "description": "A list of repositories to never mirror from this GitHub instance. Takes precedence over \"repos\" and \"repositoryQuery\" configuration.",
@@ -56,12 +57,16 @@
             "pattern": "^[\\w-]+/[\\w.-]+$"
           },
           "id": {
-            "description": "The ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring.",
+            "description": "The node ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring. Use this to exclude the repository, even if renamed. Note: This is the GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",
             "type": "string",
             "minLength": 1
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "owner/name" }, { "id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==" }],
+        [{ "name": "vuejs/vue" }, { "name": "php/php-src" }]
+      ]
     },
     "repositoryQuery": {
       "description": "An array of strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph. The valid values are:\n\n- `public` mirrors all public repositories for GitHub Enterprise and is the equivalent of `none` for GitHub\n\n- `affiliated` mirrors all repositories affiliated with the configured token's user:\n\t- Private repositories with read access\n\t- Public repositories owned by the user or their orgs\n\t- Public repositories with write access\n\n- `none` mirrors no repositories (except those specified in the `repos` configuration property or added manually)\n\n- All other values are executed as a GitHub advanced repository search as described at https://github.com/search/advanced. Example: to sync all repositories from the \"sourcegraph\" organization including forks the query would be \"org:sourcegraph fork:true\".\n\nIf multiple values are provided, their results are unioned.\n\nIf you need to narrow the set of mirrored repositories further (and don't want to enumerate it with a list or query set as above), create a new bot/machine user on GitHub or GitHub Enterprise that is only affiliated with the desired repositories.",

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -42,7 +42,7 @@
       "examples": [["owner/name"], ["kubernetes/kubernetes", "golang/go", "facebook/react"]]
     },
     "exclude": {
-      "description": "A list of repositories to never mirror from this GitHub instance. Takes precedence over \"repos\" and \"repositoryQuery\" configuration.",
+      "description": "A list of repositories to never mirror from this GitHub instance. Takes precedence over \"repos\" and \"repositoryQuery\" configuration.\n\nSupports excluding by name ({\"name\": \"owner/name\"}) or by ID ({\"id\": \"MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==\"}).\n\nNote: ID is the GitHub GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",
       "type": "array",
       "minItems": 1,
       "items": {

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -47,7 +47,7 @@ const GitHubSchemaJSON = `{
       "examples": [["owner/name"], ["kubernetes/kubernetes", "golang/go", "facebook/react"]]
     },
     "exclude": {
-      "description": "A list of repositories to never mirror from this GitHub instance. Takes precedence over \"repos\" and \"repositoryQuery\" configuration.",
+      "description": "A list of repositories to never mirror from this GitHub instance. Takes precedence over \"repos\" and \"repositoryQuery\" configuration.\n\nSupports excluding by name ({\"name\": \"owner/name\"}) or by ID ({\"id\": \"MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==\"}).\n\nNote: ID is the GitHub GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",
       "type": "array",
       "minItems": 1,
       "items": {

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -43,7 +43,8 @@ const GitHubSchemaJSON = `{
     "repos": {
       "description": "An array of repository \"owner/name\" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+$" }
+      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+$" },
+      "examples": [["owner/name"], ["kubernetes/kubernetes", "golang/go", "facebook/react"]]
     },
     "exclude": {
       "description": "A list of repositories to never mirror from this GitHub instance. Takes precedence over \"repos\" and \"repositoryQuery\" configuration.",
@@ -61,12 +62,16 @@ const GitHubSchemaJSON = `{
             "pattern": "^[\\w-]+/[\\w.-]+$"
           },
           "id": {
-            "description": "The ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring.",
+            "description": "The node ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring. Use this to exclude the repository, even if renamed. Note: This is the GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",
             "type": "string",
             "minLength": 1
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "owner/name" }, { "id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==" }],
+        [{ "name": "vuejs/vue" }, { "name": "php/php-src" }]
+      ]
     },
     "repositoryQuery": {
       "description": "An array of strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph. The valid values are:\n\n- ` + "`" + `public` + "`" + ` mirrors all public repositories for GitHub Enterprise and is the equivalent of ` + "`" + `none` + "`" + ` for GitHub\n\n- ` + "`" + `affiliated` + "`" + ` mirrors all repositories affiliated with the configured token's user:\n\t- Private repositories with read access\n\t- Public repositories owned by the user or their orgs\n\t- Public repositories with write access\n\n- ` + "`" + `none` + "`" + ` mirrors no repositories (except those specified in the ` + "`" + `repos` + "`" + ` configuration property or added manually)\n\n- All other values are executed as a GitHub advanced repository search as described at https://github.com/search/advanced. Example: to sync all repositories from the \"sourcegraph\" organization including forks the query would be \"org:sourcegraph fork:true\".\n\nIf multiple values are provided, their results are unioned.\n\nIf you need to narrow the set of mirrored repositories further (and don't want to enumerate it with a list or query set as above), create a new bot/machine user on GitHub or GitHub Enterprise that is only affiliated with the desired repositories.",


### PR DESCRIPTION
The documentation for the GitHub external service is a bit sparse for exclude
since it doesn't explain what you can put in the exclude field. By including
examples (and expanding on the description) in the schema it becomes better
documented both in our docs and in the editor.

![image](https://user-images.githubusercontent.com/187831/56199089-81976e00-603c-11e9-9c8b-cdd20302c701.png)

![image](https://user-images.githubusercontent.com/187831/56199703-b35d0480-603d-11e9-957e-8ee021ae629c.png)

Test plan: Loaded the docs site in dev and took the above screenshots

Part of #2025