### PR TITLE
doc: Update Gitlab admin and schema docs

### DIFF
--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -19,7 +19,11 @@ To set this up, add GitLab as an external service to Sourcegraph:
 
 ## Repository syncing
 
-By default, Sourcegraph adds every GitLab project where the token's user is a member. If you wish to limit the set of repositories that is indexed by Sourcegraph, the recommended way is to create a Sourcegraph "bot" user, which is just a normal user account with the desired access scope. For instance, if you wanted to add all internal GitLab projects to Sourcegraph, you could create a user "sourcegraph-bot" and give it no explicit access to any GitLab repositories.
+There are three fields for configuring which projects are mirrored/synchronized:
+
+- [`projects`](gitlab.md#configuration)<br>A list of projects in `{"name": "group/name"}` or `{"id": id}` format.
+- [`projectQuery`](gitlab.md#configuration)<br>A list of strings with one pre-defined option (`none`), and/or an URL path and query that targets a GitLab API endpoint returing a list of projects.
+- [`exclude`](gitlab.md#configuration)<br>A list of projects to exclude which takes precedence over the `projects`, and `projectQuery` fields. It has the same format as `projects`.
 
 ### Troubleshooting
 

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -36,7 +36,7 @@
       "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
     "projects": {
-      "description": "A list of projects to mirror from this GitLab instance.",
+      "description": "A list of projects to mirror from this GitLab instance. Supports including by name ({\"name\": \"group/name\"}) or by ID ({\"id\": 42}).",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -46,7 +46,7 @@
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {
           "name": {
-            "description": "The name of a GitLab project (\"owner/name\") to mirror.",
+            "description": "The name of a GitLab project (\"group/name\") to mirror.",
             "type": "string",
             "pattern": "^[\\w-]+/[\\w.-]+$"
           },
@@ -55,10 +55,14 @@
             "type": "integer"
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "group/name" }, { "id": 42 }],
+        [{ "name": "gnachman/iterm2" }, { "name": "gitlab-org/gitlab-ce" }]
+      ]
     },
     "exclude": {
-      "description": "A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration.",
+      "description": "A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration. Supports excluding by name ({\"name\": \"group/name\"}) or by ID ({\"id\": 42}).",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -68,7 +72,7 @@
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {
           "name": {
-            "description": "The name of a GitLab project (\"owner/name\") to exclude from mirroring.",
+            "description": "The name of a GitLab project (\"group/name\") to exclude from mirroring.",
             "type": "string",
             "pattern": "^[\\w-]+/[\\w.-]+$"
           },
@@ -77,7 +81,11 @@
             "type": "integer"
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "group/name" }, { "id": 42 }],
+        [{ "name": "gitlab-org/gitlab-ee" }, { "name": "gitlab-com/www-gitlab-com" }]
+      ]
     },
     "projectQuery": {
       "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL path and query that targets a GitLab API endpoint returning a list of projects. If the string only contains a query, then \"projects\" is used as the path. Examples: \"?membership=true&search=foo\", \"groups/mygroup/projects\".\n\nThe special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. Here are a few endpoints that return a list of projects: https://docs.gitlab.com/ee/api/projects.html#list-all-projects, https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects, https://docs.gitlab.com/ee/api/search.html#scope-projects.",
@@ -87,7 +95,8 @@
         "type": "string",
         "minLength": 1
       },
-      "minItems": 1
+      "minItems": 1,
+      "examples": [["?membership=true&search=foo", "groups/mygroup/projects"]]
     },
     "repositoryPathPattern": {
       "description": "The pattern used to generate a the corresponding Sourcegraph repository name for a GitLab project. In the pattern, the variable \"{host}\" is replaced with the GitLab URL's host (such as gitlab.example.com), and \"{pathWithNamespace}\" is replaced with the GitLab project's \"namespace/path\" (such as \"myteam/myproject\").\n\nFor example, if your GitLab is https://gitlab.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{pathWithNamespace}\" would mean that a GitLab project at https://gitlab.example.com/myteam/myproject is available on Sourcegraph at https://src.example.com/gitlab.example.com/myteam/myproject.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -41,7 +41,7 @@ const GitLabSchemaJSON = `{
       "examples": ["-----BEGIN CERTIFICATE-----\n..."]
     },
     "projects": {
-      "description": "A list of projects to mirror from this GitLab instance.",
+      "description": "A list of projects to mirror from this GitLab instance. Supports including by name ({\"name\": \"group/name\"}) or by ID ({\"id\": 42}).",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -51,7 +51,7 @@ const GitLabSchemaJSON = `{
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {
           "name": {
-            "description": "The name of a GitLab project (\"owner/name\") to mirror.",
+            "description": "The name of a GitLab project (\"group/name\") to mirror.",
             "type": "string",
             "pattern": "^[\\w-]+/[\\w.-]+$"
           },
@@ -60,10 +60,14 @@ const GitLabSchemaJSON = `{
             "type": "integer"
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "group/name" }, { "id": 42 }],
+        [{ "name": "gnachman/iterm2" }, { "name": "gitlab-org/gitlab-ce" }]
+      ]
     },
     "exclude": {
-      "description": "A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration.",
+      "description": "A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration. Supports excluding by name ({\"name\": \"group/name\"}) or by ID ({\"id\": 42}).",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -73,7 +77,7 @@ const GitLabSchemaJSON = `{
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {
           "name": {
-            "description": "The name of a GitLab project (\"owner/name\") to exclude from mirroring.",
+            "description": "The name of a GitLab project (\"group/name\") to exclude from mirroring.",
             "type": "string",
             "pattern": "^[\\w-]+/[\\w.-]+$"
           },
@@ -82,7 +86,11 @@ const GitLabSchemaJSON = `{
             "type": "integer"
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "group/name" }, { "id": 42 }],
+        [{ "name": "gitlab-org/gitlab-ee" }, { "name": "gitlab-com/www-gitlab-com" }]
+      ]
     },
     "projectQuery": {
       "description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL path and query that targets a GitLab API endpoint returning a list of projects. If the string only contains a query, then \"projects\" is used as the path. Examples: \"?membership=true&search=foo\", \"groups/mygroup/projects\".\n\nThe special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. Here are a few endpoints that return a list of projects: https://docs.gitlab.com/ee/api/projects.html#list-all-projects, https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects, https://docs.gitlab.com/ee/api/search.html#scope-projects.",
@@ -92,7 +100,8 @@ const GitLabSchemaJSON = `{
         "type": "string",
         "minLength": 1
       },
-      "minItems": 1
+      "minItems": 1,
+      "examples": [["?membership=true&search=foo", "groups/mygroup/projects"]]
     },
     "repositoryPathPattern": {
       "description": "The pattern used to generate a the corresponding Sourcegraph repository name for a GitLab project. In the pattern, the variable \"{host}\" is replaced with the GitLab URL's host (such as gitlab.example.com), and \"{pathWithNamespace}\" is replaced with the GitLab project's \"namespace/path\" (such as \"myteam/myproject\").\n\nFor example, if your GitLab is https://gitlab.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{pathWithNamespace}\" would mean that a GitLab project at https://gitlab.example.com/myteam/myproject is available on Sourcegraph at https://src.example.com/gitlab.example.com/myteam/myproject.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",


### PR DESCRIPTION
Followed the same pattern used by GitHub for 3.3 release.

Test plan: Visited docs page. See screenshots.

![image](https://user-images.githubusercontent.com/187831/56216771-56277a00-6062-11e9-996b-eb48839f2019.png)

![image](https://user-images.githubusercontent.com/187831/56216794-60497880-6062-11e9-9c98-09da07cf9212.png)

![image](https://user-images.githubusercontent.com/187831/56216869-84a55500-6062-11e9-9fae-f7dad5350f92.png)

Fixes https://github.com/sourcegraph/sourcegraph/issues/3042
Part of #2025