### PR TITLE
doc: Update Bitbucket Server admin and schema docs

### DIFF
--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -14,21 +14,22 @@ To set this up, add Bitbucket Server as an external service to Sourcegraph:
 
 ## Repository syncing
 
+There are four fields for configuring which repositories are mirrored/synchronized:
+
+- [`repos`](bitbucket_server.md#configuration)<br>A list of repositories in `projectKey/repositorySlug` format.
+- [`repositoryQuery`](bitbucket_server.md#configuration)<br>A list of strings with one pre-defined option (`none`), and/or a [Bitbucket Server Repo Search Request Query Parameters](https://docs.atlassian.com/bitbucket-server/rest/6.1.2/bitbucket-rest.html#idp355).
+- [`exclude`](bitbucket_server.md#configuration)<br>A list of repositories to exclude which takes precedence over the `repos`, and `repositoryQuery` fields.
+- ['excludePersonalRepositories'](bitbucket_server.md#configuration)<br>With this enabled, Sourcegraph will exclude any personal repositories from being imported, even if it has access to them.
+
 ### Authentication for older Bitbucket Server versions
 
 Bitbucket Server versions older than v5.5 require specifying a less secure username and password combination, as those versions of Bitbucket Server do not support [personal access tokens](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).
 
-### Excluding personal repositories
-
-Sourcegraph will be able to view and clone the repositories that the account you provide has access to. For example, if you provide a personal access token or username/password of an administrator Bitbucket Server account, Sourcegraph will be able to view and clone all repositories -- even personal ones.
-
-We recommend that you create a new Bitbucket user account specifically for Sourcegraph (e.g. a "Sourcegraph Bot" account) and only give that account access to the repositories you wish to be viewable on Sourcegraph.
-
-If you don't wish to create a separate Bitbucket user account just for Sourcegraph, you can specify `"excludePersonalRepositories": true` in the configuration. With this enabled, Sourcegraph will exclude any personal repositories from being imported, even if it has access to them.
-
 ### HTTPS cloning
 
-Sourcegraph by default clones repositories from your Bitbucket Server via HTTP(S), using the access token or account credentials you provide in the configuration. SSH cloning is not used, so you don't need to configure SSH cloning.
+Sourcegraph by default clones repositories from your Bitbucket Server via HTTP(S), using the access token or account credentials you provide in the configuration. The [`username`](bitbucket_server.md#configuration) field is always used when cloning, so is required.
+
+SSH cloning is not used, so you don't need to configure SSH cloning.
 
 ## Configuration
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -14,7 +14,7 @@ To set this up, add Bitbucket Server as an external service to Sourcegraph:
 
 ## Repository syncing
 
-There are four fields for configuring which repositories are mirrored/synchronized:
+There are four fields for configuring which repositories are mirrored:
 
 - [`repos`](bitbucket_server.md#configuration)<br>A list of repositories in `projectKey/repositorySlug` format.
 - [`repositoryQuery`](bitbucket_server.md#configuration)<br>A list of strings with one pre-defined option (`none`), and/or a [Bitbucket Server Repo Search Request Query Parameters](https://docs.atlassian.com/bitbucket-server/rest/6.1.2/bitbucket-rest.html#idp355).

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -33,12 +33,12 @@
       "examples": ["https://bitbucket.example.com"]
     },
     "token": {
-      "description": "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
+      "description": "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
       "type": "string",
       "minLength": 1
     },
     "username": {
-      "description": "The username to use when authenticating to the Bitbucket Server instance. Also set the corresponding \"password\" field.\n\nFor Bitbucket Server instances that support personal access tokens (Bitbucket Server version 5.5 and newer), it is recommended to provide a token instead (in the \"token\" field).",
+      "description": "The username to use when authenticating to the Bitbucket Server instance. Also set the corresponding \"token\" or \"password\" field.",
       "type": "string"
     },
     "password": {
@@ -77,19 +77,21 @@
         "minLength": 1
       },
       "default": ["none"],
-      "minItems": 1
+      "minItems": 1,
+      "examples": [["?name=my-repo&projectname=PROJECT&visibility=private"]]
     },
     "repos": {
-      "description": "An array of repository \"projectKey/repositorySlug\" strings specifying  repositories to mirror on Sourcegraph.",
+      "description": "An array of repository \"projectKey/repositorySlug\" strings specifying repositories to mirror on Sourcegraph.",
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "string",
         "pattern": "^[\\w-]+/[\\w.-]+$"
-      }
+      },
+      "examples": [["myproject/myrepo", "myproject/myotherrepo"]]
     },
     "exclude": {
-      "description": "A list of repositories to never mirror from this Bitbucket Server instance. Takes precedence over \"repos\" and \"repositoryQuery\".",
+      "description": "A list of repositories to never mirror from this Bitbucket Server instance. Takes precedence over \"repos\" and \"repositoryQuery\".\n\nSupports excluding by name ({\"name\": \"projectKey/repositorySlug\"}) or by ID ({\"id\": 42}).",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -108,7 +110,11 @@
             "type": "integer"
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "myproject/myrepo" }, { "id": 42 }],
+        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }]
+      ]
     },
     "initialRepositoryEnablement": {
       "description": "Defines whether repositories from this Bitbucket Server instance should be enabled and cloned when they are first seen by Sourcegraph. If false, the site admin must explicitly enable Bitbucket Server repositories (in the site admin area) to clone them and make them searchable on Sourcegraph. If true, they will be enabled and cloned immediately (subject to rate limiting by Bitbucket Server); site admins can still disable them explicitly, and they'll remain disabled.",

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -38,12 +38,12 @@ const BitbucketServerSchemaJSON = `{
       "examples": ["https://bitbucket.example.com"]
     },
     "token": {
-      "description": "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
+      "description": "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
       "type": "string",
       "minLength": 1
     },
     "username": {
-      "description": "The username to use when authenticating to the Bitbucket Server instance. Also set the corresponding \"password\" field.\n\nFor Bitbucket Server instances that support personal access tokens (Bitbucket Server version 5.5 and newer), it is recommended to provide a token instead (in the \"token\" field).",
+      "description": "The username to use when authenticating to the Bitbucket Server instance. Also set the corresponding \"token\" or \"password\" field.",
       "type": "string"
     },
     "password": {
@@ -82,19 +82,21 @@ const BitbucketServerSchemaJSON = `{
         "minLength": 1
       },
       "default": ["none"],
-      "minItems": 1
+      "minItems": 1,
+      "examples": [["?name=my-repo&projectname=PROJECT&visibility=private"]]
     },
     "repos": {
-      "description": "An array of repository \"projectKey/repositorySlug\" strings specifying  repositories to mirror on Sourcegraph.",
+      "description": "An array of repository \"projectKey/repositorySlug\" strings specifying repositories to mirror on Sourcegraph.",
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "string",
         "pattern": "^[\\w-]+/[\\w.-]+$"
-      }
+      },
+      "examples": [["myproject/myrepo", "myproject/myotherrepo"]]
     },
     "exclude": {
-      "description": "A list of repositories to never mirror from this Bitbucket Server instance. Takes precedence over \"repos\" and \"repositoryQuery\".",
+      "description": "A list of repositories to never mirror from this Bitbucket Server instance. Takes precedence over \"repos\" and \"repositoryQuery\".\n\nSupports excluding by name ({\"name\": \"projectKey/repositorySlug\"}) or by ID ({\"id\": 42}).",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -113,7 +115,11 @@ const BitbucketServerSchemaJSON = `{
             "type": "integer"
           }
         }
-      }
+      },
+      "examples": [
+        [{ "name": "myproject/myrepo" }, { "id": 42 }],
+        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }]
+      ]
     },
     "initialRepositoryEnablement": {
       "description": "Defines whether repositories from this Bitbucket Server instance should be enabled and cloned when they are first seen by Sourcegraph. If false, the site admin must explicitly enable Bitbucket Server repositories (in the site admin area) to clone them and make them searchable on Sourcegraph. If true, they will be enabled and cloned immediately (subject to rate limiting by Bitbucket Server); site admins can still disable them explicitly, and they'll remain disabled.",


### PR DESCRIPTION
Document new `repositoryQuery`, `repos` and `exclude` settings.
Document new required `username` field. Follows same pattern used by GitHub
for 3.3 documentation.

Test plan: Loaded docs locally. See screenshots below

![image](https://user-images.githubusercontent.com/187831/56218341-17df8a00-6065-11e9-8e26-dcc9791c2066.png)

![image](https://user-images.githubusercontent.com/187831/56218355-20d05b80-6065-11e9-8c7c-f46532c52521.png)

![image](https://user-images.githubusercontent.com/187831/56218374-2cbc1d80-6065-11e9-855e-519ba5a50964.png)

![image](https://user-images.githubusercontent.com/187831/56218400-334a9500-6065-11e9-8111-019b7697242a.png)

Part of #2025