### PR TITLE
Code nav: single-click jump-to-definition

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -314,6 +314,7 @@ export function initCodeIntelligence({
             ),
             getHover: ({ line, character, part, ...rest }) => getHover({ ...rest, position: { line, character } }),
             getActions: context => getHoverActions({ extensionsController, platformContext }, context),
+            pinningEnabled: true,
         }
     )
 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
   "dependencies": {
     "@sentry/browser": "^4.6.6",
     "@slimsag/react-shortcuts": "^1.2.1",
-    "@sourcegraph/codeintellify": "^6.0.6",
+    "@sourcegraph/codeintellify": "^6.1.0",
     "@sourcegraph/comlink": "^3.1.1-fork.3",
     "@sourcegraph/extension-api-types": "link:packages/@sourcegraph/extension-api-types",
     "@sourcegraph/react-loading-spinner": "0.0.7",

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -152,10 +152,10 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             share()
         )
 
-        const singleClickJ2D = Boolean(
+        const singleClickGoToDefinition = Boolean(
             this.props.settingsCascade.final &&
                 !isErrorLike(this.props.settingsCascade.final) &&
-                this.props.settingsCascade.final.singleClickJ2D === true
+                this.props.settingsCascade.final.singleClickGoToDefinition === true
         )
 
         const hoverifier = createHoverifier<
@@ -174,7 +174,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             ),
             getHover: position => getHover(this.getLSPTextDocumentPositionParams(position), this.props),
             getActions: context => getHoverActions(this.props, context),
-            pinningEnabled: !singleClickJ2D,
+            pinningEnabled: !singleClickGoToDefinition,
         })
         this.subscriptions.add(hoverifier)
 
@@ -204,25 +204,25 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                 dom: domFunctions,
             })
         )
-        const j2d = (ev: MouseEvent) => {
-            const j2daction =
+        const goToDefinition = (ev: MouseEvent) => {
+            const goToDefinitionAction =
                 this.state.actionsOrError instanceof Array &&
-                this.state.actionsOrError.find(a => a.action.id === 'goToDefinition.preloaded')
-            if (j2daction) {
-                this.props.history.push(j2daction.action.commandArguments![0])
+                this.state.actionsOrError.find(action => action.action.id === 'goToDefinition.preloaded')
+            if (goToDefinitionAction) {
+                this.props.history.push(goToDefinitionAction.action.commandArguments![0])
                 ev.stopPropagation()
             }
         }
         this.subscriptions.add(
             hoverifier.hoverStateUpdates.subscribe(update => {
-                if (singleClickJ2D && this.state.hoveredTokenElement !== update.hoveredTokenElement) {
+                if (singleClickGoToDefinition && this.state.hoveredTokenElement !== update.hoveredTokenElement) {
                     if (this.state.hoveredTokenElement) {
                         this.state.hoveredTokenElement.style.cursor = 'auto'
-                        this.state.hoveredTokenElement.removeEventListener('click', j2d)
+                        this.state.hoveredTokenElement.removeEventListener('click', goToDefinition)
                     }
                     if (update.hoveredTokenElement) {
                         update.hoveredTokenElement.style.cursor = 'pointer'
-                        update.hoveredTokenElement.addEventListener('click', j2d)
+                        update.hoveredTokenElement.addEventListener('click', goToDefinition)
                     }
                 }
                 this.setState(update)

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -205,7 +205,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                 this.state.actionsOrError instanceof Array &&
                 this.state.actionsOrError.find(a => a.action.id === 'goToDefinition.preloaded')
             if (j2daction) {
-                window.location = j2daction.action.commandArguments![0]
+                this.props.history.push(j2daction.action.commandArguments![0])
                 ev.stopPropagation()
             }
         }

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -4,7 +4,7 @@ import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
 import * as H from 'history'
 import { isEqual, pick } from 'lodash'
 import * as React from 'react'
-import { combineLatest, EMPTY, fromEvent, merge, Observable, Subject, Subscription } from 'rxjs'
+import { combineLatest, fromEvent, merge, Observable, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, share, switchMap, withLatestFrom } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../shared/src/actions/ActionItem'
 import { decorationStyleForTheme } from '../../../../shared/src/api/client/services/decoration'
@@ -152,7 +152,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             share()
         )
 
-        const pinningEnabled = false
+        const singleClickJ2D = Boolean(this.props.settingsCascade.final && !isErrorLike(this.props.settingsCascade.final) && this.props.settingsCascade.final.singleClickJ2D === true)
 
         const hoverifier = createHoverifier<
             RepoSpec & RevSpec & FileSpec & ResolvedRevSpec,
@@ -170,7 +170,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             ),
             getHover: position => getHover(this.getLSPTextDocumentPositionParams(position), this.props),
             getActions: context => getHoverActions(this.props, context),
-            pinningEnabled,
+            pinningEnabled: !singleClickJ2D,
         })
         this.subscriptions.add(hoverifier)
 
@@ -205,16 +205,13 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                 this.state.actionsOrError instanceof Array &&
                 this.state.actionsOrError.find(a => a.action.id === 'goToDefinition.preloaded')
             if (j2daction) {
-                console.log('navigating to', j2daction.action.commandArguments![0])
                 window.location = j2daction.action.commandArguments![0]
                 ev.stopPropagation()
-            } else {
-                console.log('not navigating =(')
             }
         }
         this.subscriptions.add(
             hoverifier.hoverStateUpdates.subscribe(update => {
-                if (this.state.token !== update.token) {
+                if (singleClickJ2D && this.state.token !== update.token) {
                     if (this.state.token) {
                         this.state.token.style.cursor = 'auto'
                         this.state.token.removeEventListener('click', j2d)

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -213,17 +213,20 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                 ev.stopPropagation()
             }
         }
+
+        let hoveredTokenElement: HTMLElement | undefined
         this.subscriptions.add(
             hoverifier.hoverStateUpdates.subscribe(update => {
-                if (singleClickGoToDefinition && this.state.hoveredTokenElement !== update.hoveredTokenElement) {
-                    if (this.state.hoveredTokenElement) {
-                        this.state.hoveredTokenElement.style.cursor = 'auto'
-                        this.state.hoveredTokenElement.removeEventListener('click', goToDefinition)
+                if (singleClickGoToDefinition && hoveredTokenElement !== update.hoveredTokenElement) {
+                    if (hoveredTokenElement) {
+                        hoveredTokenElement.style.cursor = 'auto'
+                        hoveredTokenElement.removeEventListener('click', goToDefinition)
                     }
                     if (update.hoveredTokenElement) {
                         update.hoveredTokenElement.style.cursor = 'pointer'
                         update.hoveredTokenElement.addEventListener('click', goToDefinition)
                     }
+                    hoveredTokenElement = update.hoveredTokenElement
                 }
                 this.setState(update)
             })

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -152,7 +152,11 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             share()
         )
 
-        const singleClickJ2D = Boolean(this.props.settingsCascade.final && !isErrorLike(this.props.settingsCascade.final) && this.props.settingsCascade.final.singleClickJ2D === true)
+        const singleClickJ2D = Boolean(
+            this.props.settingsCascade.final &&
+                !isErrorLike(this.props.settingsCascade.final) &&
+                this.props.settingsCascade.final.singleClickJ2D === true
+        )
 
         const hoverifier = createHoverifier<
             RepoSpec & RevSpec & FileSpec & ResolvedRevSpec,
@@ -211,14 +215,14 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         }
         this.subscriptions.add(
             hoverifier.hoverStateUpdates.subscribe(update => {
-                if (singleClickJ2D && this.state.token !== update.token) {
-                    if (this.state.token) {
-                        this.state.token.style.cursor = 'auto'
-                        this.state.token.removeEventListener('click', j2d)
+                if (singleClickJ2D && this.state.hoveredTokenElement !== update.hoveredTokenElement) {
+                    if (this.state.hoveredTokenElement) {
+                        this.state.hoveredTokenElement.style.cursor = 'auto'
+                        this.state.hoveredTokenElement.removeEventListener('click', j2d)
                     }
-                    if (update.token) {
-                        update.token.style.cursor = 'pointer'
-                        update.token.addEventListener('click', j2d)
+                    if (update.hoveredTokenElement) {
+                        update.hoveredTokenElement.style.cursor = 'pointer'
+                        update.hoveredTokenElement.addEventListener('click', j2d)
                     }
                 }
                 this.setState(update)

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -117,6 +117,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
             ),
             getHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
             getActions: context => getHoverActions(this.props, context),
+            pinningEnabled: false,
         })
         this.subscriptions.add(this.hoverifier)
         this.state = this.hoverifier.hoverState

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -117,7 +117,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
             ),
             getHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
             getActions: context => getHoverActions(this.props, context),
-            pinningEnabled: false,
+            pinningEnabled: true,
         })
         this.subscriptions.add(this.hoverifier)
         this.state = this.hoverifier.hoverState

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -115,7 +115,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
             ),
             getHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
             getActions: context => getHoverActions(this.props, context),
-            pinningEnabled: false,
+            pinningEnabled: true,
         })
         this.subscriptions.add(this.hoverifier)
         this.state = this.hoverifier.hoverState

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -115,6 +115,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
             ),
             getHover: hoveredToken => getHover(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
             getActions: context => getHoverActions(this.props, context),
+            pinningEnabled: false,
         })
         this.subscriptions.add(this.hoverifier)
         this.state = this.hoverifier.hoverState

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,10 +1475,10 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@sourcegraph/codeintellify@^6.0.6":
-  version "6.0.6"
-  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.0.6.tgz#83853d825ca7b7c6a0c9e31a74e54aabb8f9bb22"
-  integrity sha512-n572z17urfMFblwLaEhYGKiSLiBiqgPq4JyRusUvn3T1xkQEEC/UaOyiDnzHukfUBckGKHGNbhA6xUckE5n8Cg==
+"@sourcegraph/codeintellify@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.1.0.tgz#cf7b555c817e06d7c6be5137a79152c89b4d209c"
+  integrity sha512-5EbbZMpiNnxGWE4vLnYzstpxjNkCLArICjFbITeFEmnGRBZMllyHouqGkchl1GFk9zD+53ppUra+5c2VMGmVAQ==
   dependencies:
     "@sourcegraph/event-positions" "^1.0.2"
     "@sourcegraph/extension-api-types" "^2.0.0"


### PR DESCRIPTION
This lets you jump to definition by clicking on the token:

![2019-04-16 14 57 36](https://user-images.githubusercontent.com/1387653/56247089-9124b000-6058-11e9-8e92-0174ed5ccee8.gif)

You can still select text even though the cursor is the hand icon 👆

This is a prototype and the plan is to merge it behind a feature flag to get a feel for the UX.

**Motivation**

This is similar to how [Bazel](https://source.bazel.build/bazel/+/master:src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java;l=921;drc=d888e4d44fe1eb04a7122ebb206b2255e6862f1a;bpv=;bpt=1) and [Haskell Code Explorer](https://haskell-code-explorer.mfix.io/package/stm-2.4.5.0/show/Control/Concurrent/STM/TQueue.hs#L108) work and was [requested by a user](https://sourcegraph.slack.com/archives/C0W2E592M/p1552492262046200).

**Feature flag**

Global/org/user settings:

```
  "singleClickGoToDefinition": true,
```

TODO

- [ ] Merge https://github.com/sourcegraph/codeintellify/pull/106 (depends on a new API)
- [x] Figure out how to avoid needing to assign to `window.location` (currently causes a full page load when jumping to a different file)
- [x] Put this behind a feature flag

See proposal doc https://sourcegraph.slack.com/archives/CHXHX7XAS/p1555110738009200