### PR TITLE
repo-updater: Return all ExternalServices

### DIFF
--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -436,8 +436,11 @@ var migrateOnce sync.Once
 // This migration can be deleted as soon as (whichever happens first):
 //   - All customers have updated to 3.0 or newer.
 //   - 3 months after 3.0 is released.
-func (c *ExternalServicesStore) migrateJsonConfigToExternalServices(ctx context.Context) {
+func (c *ExternalServicesStore) migrateJsonConfigToExternalServices() {
 	migrateOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
 		// Run in a transaction because we are racing with other frontend replicas.
 		err := dbutil.Transaction(ctx, dbconn.Global, func(tx *sql.Tx) error {
 			now := time.Now()
@@ -540,7 +543,7 @@ func (c *ExternalServicesStore) migrateJsonConfigToExternalServices(ctx context.
 }
 
 func (c *ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, limitOffset *LimitOffset) ([]*types.ExternalService, error) {
-	c.migrateJsonConfigToExternalServices(ctx)
+	c.migrateJsonConfigToExternalServices()
 	q := sqlf.Sprintf(`
 		SELECT id, kind, display_name, config, created_at, updated_at
 		FROM external_services

--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -52,7 +52,7 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 
 		var sourced Repos
 		{
-			ctx, cancel := context.WithTimeout(ctx, time.Minute)
+			ctx, cancel := context.WithTimeout(ctx, sourceTimeout)
 			sourced, err = srcs.ListRepos(ctx)
 			cancel()
 		}

--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -52,7 +52,7 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 
 		var sourced Repos
 		{
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, time.Minute)
 			sourced, err = srcs.ListRepos(ctx)
 			cancel()
 		}

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -81,10 +81,12 @@ func NewSource(svc *ExternalService, cf httpcli.Factory) (Source, error) {
 }
 
 func includesGitHubDotComSource(srcs []Source) bool {
-	for _, src := range srcs {
-		if gs, ok := src.(*GithubSource); !ok {
+	for _, svc := range Sources(srcs).ExternalServices() {
+		if !strings.EqualFold(svc.Kind, "GITHUB") {
 			continue
-		} else if u, err := url.Parse(gs.conn.config.Url); err != nil {
+		} else if cfg, err := svc.Configuration(); err != nil {
+			continue
+		} else if u, err := url.Parse(cfg.(*schema.GitHubConnection).Url); err != nil {
 			continue
 		} else if strings.HasSuffix(u.Hostname(), "github.com") {
 			return true

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -94,6 +95,9 @@ func includesGitHubDotComSource(srcs []Source) bool {
 	}
 	return false
 }
+
+// sourceTimeout is the default timeout to use on Source.ListRepos
+const sourceTimeout = 10 * time.Minute
 
 // A Source yields repositories to be stored and analysed by Sourcegraph.
 // Successive calls to its ListRepos method may yield different results.

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -233,7 +233,7 @@ func (s *Syncer) sourced(ctx context.Context, kinds ...string) ([]*Repo, error) 
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, sourceTimeout)
 	defer cancel()
 
 	return srcs.ListRepos(ctx)

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -46,6 +46,11 @@ func (s FakeSource) ListRepos(context.Context) ([]*Repo, error) {
 	return repos, s.err
 }
 
+// ExternalServices returns a singleton slice containing the external service.
+func (s FakeSource) ExternalServices() ExternalServices {
+	return ExternalServices{s.svc}
+}
+
 // FakeStore is a fake implementation of Store to be used in tests.
 type FakeStore struct {
 	ListExternalServicesError   error // error to be returned in ListExternalServices


### PR DESCRIPTION
Our enabled migration relies on all external services being returned. However,
it had two flaws:

- It did type assertions against concrete types. We now wrap our concrete
  source types in an observable layer, causing the assertions to fail.
- It only handled GitHub

After this commit the enabled migration should run against all sources we
support as well as succeed outside of unit tests.

Test plan: Tested via launch.sh from a DB snapshot of a 3.2 release.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3450