### PR TITLE
remove symbol resolver from file match and suggestions

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -620,8 +620,11 @@ func (r *searchSuggestionResolver) ToGitTree() (*gitTreeEntryResolver, bool) {
 }
 
 func (r *searchSuggestionResolver) ToSymbol() (*symbolResolver, bool) {
-	res, ok := r.result.(*symbolResolver)
-	return res, ok
+	s, ok := r.result.(*searchSymbolResult)
+	if !ok {
+		return nil, false
+	}
+	return toSymbolResolver(s.symbol, s.baseURI, s.lang, s.commit), true
 }
 
 // newSearchResultResolver returns a new searchResultResolver wrapping the
@@ -637,7 +640,7 @@ func newSearchResultResolver(result interface{}, score int) *searchSuggestionRes
 	case *gitTreeEntryResolver:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.path), label: r.path}
 
-	case *symbolResolver:
+	case *searchSymbolResult:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.symbol.Name + " " + r.symbol.Parent), label: r.symbol.Name + " " + r.symbol.Parent}
 
 	default:

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -130,7 +130,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 				case lsp.SKClass:
 					score += 3
 				}
-				if len(sr.symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.uri.String()), strings.ToLower(sr.symbol.Name)) {
+				if len(sr.symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.uri().String()), strings.ToLower(sr.symbol.Name)) {
 					score++
 				}
 				results = append(results, newSearchResultResolver(sr, score))
@@ -244,8 +244,8 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			// (that do specify a commit ID), because their key k (i.e., k in seen[k]) will not
 			// equal.
 			k.file = s.path
-		case *symbolResolver:
-			k.repoName = s.location.resource.commit.repo.repo.Name
+		case *searchSymbolResult:
+			k.repoName = s.commit.repo.repo.Name
 			k.symbol = s.symbol.Name + s.symbol.Parent
 		default:
 			panic(fmt.Sprintf("unhandled: %#v", s))

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -26,10 +26,7 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-// searchSymbolResult is a type that holds the data needed to create a symbol
-// resolver. Each field is a parameter for toSymbolResolver. This type is used
-// to prevent search code from being tangled up with other parts of the
-// graphql.
+// searchSymbolResult is a result from symbol search.
 type searchSymbolResult struct {
 	symbol  protocol.Symbol
 	baseURI *gituri.URI

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -13,11 +13,11 @@ import (
 func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	symbol := protocol.Symbol{
 		Name:    "test",
-		Path:    "test/path",
+		Path:    "foo/bar",
 		Line:    0,
 		Pattern: "",
 	}
-	baseURI, _ := gituri.Parse("https://github.com/foo/bar?v#f/d")
+	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
 	commit := &gitCommitResolver{
 		repo:   &repositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
@@ -30,8 +30,8 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 		rev  string
 		want string
 	}{
-		{"", "git://repo#f/d"},
-		{"test", "git://repo?test#f/d"},
+		{"", "git://repo#foo/bar"},
+		{"test", "git://repo?test#foo/bar"},
 	}
 
 	for _, test := range tests {

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -1,0 +1,43 @@
+package graphqlbackend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/gituri"
+	"github.com/sourcegraph/sourcegraph/pkg/symbols/protocol"
+	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
+)
+
+func TestMakeFileMatchURIFromSymbol(t *testing.T) {
+	symbol := protocol.Symbol{
+		Name:    "test",
+		Path:    "test/path",
+		Line:    0,
+		Pattern: "",
+	}
+	baseURI, _ := gituri.Parse("https://github.com/foo/bar?v#f/d")
+	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
+	commit := &gitCommitResolver{
+		repo:   &repositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
+		oid:    "c1",
+		author: *toSignatureResolver(&gitSignatureWithDate),
+	}
+	sr := &searchSymbolResult{symbol, baseURI, "go", commit}
+
+	tests := []struct {
+		rev  string
+		want string
+	}{
+		{"", "git://repo#f/d"},
+		{"test", "git://repo?test#f/d"},
+	}
+
+	for _, test := range tests {
+		got := makeFileMatchURIFromSymbol(sr, test.rev)
+		if got != test.want {
+			t.Errorf("rev(%v) got %v want %v", test.rev, got, test.want)
+		}
+	}
+}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -57,7 +57,7 @@ type fileMatchResolver struct {
 	JPath        string       `json:"Path"`
 	JLineMatches []*lineMatch `json:"LineMatches"`
 	JLimitHit    bool         `json:"LimitHit"`
-	symbols      []*symbolResolver
+	symbols      []*searchSymbolResult
 	uri          string
 	repo         *types.Repo
 	commitID     api.CommitID // or empty for default branch
@@ -95,7 +95,11 @@ func (fm *fileMatchResolver) Resource() string {
 }
 
 func (fm *fileMatchResolver) Symbols() []*symbolResolver {
-	return fm.symbols
+	symbols := make([]*symbolResolver, len(fm.symbols))
+	for i, s := range fm.symbols {
+		symbols[i] = toSymbolResolver(s.symbol, s.baseURI, s.lang, s.commit)
+	}
+	return symbols
 }
 
 func (fm *fileMatchResolver) LineMatches() []*lineMatch {


### PR DESCRIPTION
This PR decouples the `symbolResolver` type from search code. It does so by creating a `searchSymbolResult` that contains the data needed for `toSymbolResolver` and only uses `toSymbolResolver` when leaving the search portion of the graphqlbackend.

Helps with https://github.com/sourcegraph/sourcegraph/issues/3566.

Test plan: rely on existing tests and added one test
