### PR TITLE
handle invalid request error

### DIFF
--- a/pkg/highlight/highlight.go
+++ b/pkg/highlight/highlight.go
@@ -82,7 +82,7 @@ func Code(ctx context.Context, content []byte, filepath string, disableTimeout b
 		table, err2 := generatePlainTable(code)
 		return table, true, err2
 	} else if err != nil {
-		if err == gosyntect.ErrInvalidRequest {
+		if err == gosyntect.ErrRequestTooLarge {
 			// Failed to highlight code, e.g. for a text file. We still need to
 			// generate the table.
 			table, err2 := generatePlainTable(code)

--- a/pkg/highlight/highlight.go
+++ b/pkg/highlight/highlight.go
@@ -82,8 +82,7 @@ func Code(ctx context.Context, content []byte, filepath string, disableTimeout b
 		table, err2 := generatePlainTable(code)
 		return table, true, err2
 	} else if err != nil {
-		postTooLarge := strings.HasSuffix(err.Error(), "EOF")
-		if postTooLarge {
+		if err == gosyntect.ErrInvalidRequest {
 			// Failed to highlight code, e.g. for a text file. We still need to
 			// generate the table.
 			table, err2 := generatePlainTable(code)


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/gosyntect/pull/2.

Closes https://github.com/sourcegraph/sourcegraph/issues/3421 by generating a plain html table with no highlighting if we get an invalid request error from gosyntect.