### PR TITLE
repo-updater: Implement GitoliteSource

### DIFF
--- a/cmd/gitserver/server/list-gitolite.go
+++ b/cmd/gitserver/server/list-gitolite.go
@@ -5,24 +5,17 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitolite"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func (s *Server) handleListGitolite(w http.ResponseWriter, r *http.Request) {
 	defaultGitolite.listRepos(r.Context(), r.URL.Query().Get("gitolite"), w)
 }
 
-var defaultGitolite = gitoliteFetcher{client: gitoliteClient{}, config: config{}}
+var defaultGitolite = gitoliteFetcher{client: gitoliteClient{}}
 
 type gitoliteFetcher struct {
 	client iGitoliteClient
-	config iConfig
-}
-
-type iConfig interface {
-	Gitolite(ctx context.Context) ([]*schema.GitoliteConnection, error)
 }
 
 type iGitoliteClient interface {
@@ -32,36 +25,22 @@ type iGitoliteClient interface {
 // listRepos iterates through all Gitolite configs and, for each, lists the repos for the Gitolite
 // host.
 func (g gitoliteFetcher) listRepos(ctx context.Context, gitoliteHost string, w http.ResponseWriter) {
-	repos := make([]*gitolite.Repo, 0)
+	var (
+		repos = []*gitolite.Repo{}
+		err   error
+	)
 
-	config, err := g.config.Gitolite(ctx)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	for _, gconf := range config {
-		if gconf.Host != gitoliteHost {
-			continue
-		}
-		rp, err := g.client.ListRepos(ctx, gconf.Host)
-		if err != nil {
+	if gitoliteHost != "" {
+		if repos, err = g.client.ListRepos(ctx, gitoliteHost); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		repos = append(repos, rp...)
 	}
 
-	if err := json.NewEncoder(w).Encode(repos); err != nil {
+	if err = json.NewEncoder(w).Encode(repos); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-}
-
-type config struct{}
-
-func (c config) Gitolite(ctx context.Context) ([]*schema.GitoliteConnection, error) {
-	return conf.GitoliteConfigs(ctx)
 }
 
 type gitoliteClient struct{}

--- a/cmd/gitserver/server/list-gitolite.go
+++ b/cmd/gitserver/server/list-gitolite.go
@@ -22,8 +22,7 @@ type iGitoliteClient interface {
 	ListRepos(ctx context.Context, host string) ([]*gitolite.Repo, error)
 }
 
-// listRepos iterates through all Gitolite configs and, for each, lists the repos for the Gitolite
-// host.
+// listRepos lists the repos of a Gitolite server reachable at the address in gitoliteHost
 func (g gitoliteFetcher) listRepos(ctx context.Context, gitoliteHost string, w http.ResponseWriter) {
 	var (
 		repos = []*gitolite.Repo{}

--- a/cmd/gitserver/server/list-gitolite_test.go
+++ b/cmd/gitserver/server/list-gitolite_test.go
@@ -45,11 +45,6 @@ func Test_Gitolite_listRepos(t *testing.T) {
 						return test.listRepos[host], nil
 					},
 				},
-				config: stubConfig{
-					Gitolite_: func(ctx context.Context) ([]*schema.GitoliteConnection, error) {
-						return test.configs, nil
-					},
-				},
 			}
 			w := httptest.NewRecorder()
 			g.listRepos(context.Background(), test.gitoliteHost, w)
@@ -66,14 +61,6 @@ func Test_Gitolite_listRepos(t *testing.T) {
 			}
 		})
 	}
-}
-
-type stubConfig struct {
-	Gitolite_ func(ctx context.Context) ([]*schema.GitoliteConnection, error)
-}
-
-func (c stubConfig) Gitolite(ctx context.Context) ([]*schema.GitoliteConnection, error) {
-	return c.Gitolite_(ctx)
 }
 
 type stubGitoliteClient struct {

--- a/cmd/gitserver/server/list_test.go
+++ b/cmd/gitserver/server/list_test.go
@@ -1,19 +1,12 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
 func TestServer_handleList(t *testing.T) {
-	api.MockExternalServiceConfigs = func(kind string, result interface{}) error {
-		return json.Unmarshal([]byte("[]"), result)
-	}
-	defer func() { api.MockExternalServiceConfigs = nil }()
 	s := &Server{ReposDir: "/testroot"}
 	h := s.Handler()
 	_, ok := s.locker.TryAcquire("a", "test status")

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -32,9 +32,12 @@ func TestIntegration(t *testing.T) {
 		Isolation: sql.LevelSerializable,
 	})
 
+	lg := log15.New()
+	lg.SetHandler(log15.DiscardHandler())
+
 	store := repos.NewObservedStore(
 		dbstore,
-		log15.Root(),
+		lg,
 		repos.NewStoreMetrics(),
 		trace.Tracer{Tracer: opentracing.GlobalTracer()},
 	)

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -180,6 +180,12 @@ func TestSources_ListRepos(t *testing.T) {
 				}),
 			},
 			{
+				Kind: "GITOLITE",
+				Config: marshalJSON(t, &schema.GitoliteConnection{
+					Host: "ssh://git@127.0.0.1:2222",
+				}),
+			},
+			{
 				Kind: "OTHER",
 				Config: marshalJSON(t, &schema.OtherExternalServiceConnection{
 					Url: "https://github.com",
@@ -507,6 +513,7 @@ func newClientFactory(t testing.TB, name string) (httpcli.Factory, func(testing.
 	rec := newRecorder(t, cassete, *update)
 	mw := httpcli.NewMiddleware(
 		githubProxyRedirectMiddleware,
+		gitserverRedirectMiddleware,
 	)
 	return httpcli.NewFactory(mw, newRecorderOpt(t, rec)),
 		func(t testing.TB) { save(t, rec) }
@@ -517,6 +524,17 @@ func githubProxyRedirectMiddleware(cli httpcli.Doer) httpcli.Doer {
 		if req.URL.Hostname() == "github-proxy" {
 			req.URL.Host = "api.github.com"
 			req.URL.Scheme = "https"
+		}
+		return cli.Do(req)
+	})
+}
+
+func gitserverRedirectMiddleware(cli httpcli.Doer) httpcli.Doer {
+	return httpcli.DoerFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Hostname() == "gitserver" {
+			// Start local git server first
+			req.URL.Host = "127.0.0.1:3178"
+			req.URL.Scheme = "http"
 		}
 		return cli.Do(req)
 	})

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -476,7 +476,10 @@ func TestSources_ListRepos(t *testing.T) {
 			cf, save := newClientFactory(t, tc.name)
 			defer save(t)
 
-			obs := ObservedSource(log15.Root(), NewSourceMetrics())
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			obs := ObservedSource(lg, NewSourceMetrics())
 			srcs, err := NewSourcer(cf, obs)(tc.svcs...)
 			if err != nil {
 				t.Fatal(err)

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -23,6 +23,9 @@ import (
 func TestFakeStore(t *testing.T) {
 	t.Parallel()
 
+	lg := log15.New()
+	lg.SetHandler(log15.DiscardHandler())
+
 	for _, tc := range []struct {
 		name string
 		test func(repos.Store) func(*testing.T)
@@ -34,7 +37,7 @@ func TestFakeStore(t *testing.T) {
 	} {
 		t.Run(tc.name, tc.test(repos.NewObservedStore(
 			new(repos.FakeStore),
-			log15.Root(),
+			lg,
 			repos.NewStoreMetrics(),
 			trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		)))

--- a/cmd/repo-updater/repos/testdata/sources/yielded-repos-are-always-enabled.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/yielded-repos-are-always-enabled.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/repos?%3Fvisibility=public&limit=100
+    url: http://127.0.0.1:7990/rest/api/1.0/repos?%3Fvisibility=private&limit=100
     method: GET
   response:
     body: '{"size":3,"limit":100,"isLastPage":true,"values":[{"slug":"bar","id":2,"name":"bar","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"ORG","id":1,"name":"Org","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/ORG"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/org/bar.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/org/bar.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/ORG/repos/bar/browse"}]}},{"slug":"baz","id":3,"name":"baz","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"ORG","id":1,"name":"Org","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/ORG"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/org/baz.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/org/baz.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/ORG/repos/baz/browse"}]}},{"slug":"foo","id":1,"name":"foo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"ORG","id":1,"name":"Org","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/ORG"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/org/foo.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/org/foo.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/ORG/repos/foo/browse"}]}}],"start":0}'
@@ -18,19 +18,19 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 01 Apr 2019 15:50:33 GMT
+      - Thu, 18 Apr 2019 14:33:18 GMT
       Pragma:
       - no-cache
       Set-Cookie:
-      - BITBUCKETSESSIONID=C8BA2E65C4F4BBF27CA0134F062EB799; Path=/; HttpOnly
+      - BITBUCKETSESSIONID=90E888EC48474D47CD31C791CD5E637B; Path=/; HttpOnly
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@OEF9HRx950x3022x0'
+      - '@WENS5Ax873x86x0'
       X-Asen:
       - SEN-L13362690
       X-Asessionid:
-      - 1to689y
+      - jta69f
       X-Auserid:
       - "1"
       X-Ausername:
@@ -46,7 +46,7 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/repos?%3Fvisibility=private&limit=100
+    url: http://127.0.0.1:7990/rest/api/1.0/repos?%3Fvisibility=public&limit=100
     method: GET
   response:
     body: '{"size":3,"limit":100,"isLastPage":true,"values":[{"slug":"bar","id":2,"name":"bar","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"ORG","id":1,"name":"Org","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/ORG"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/org/bar.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/org/bar.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/ORG/repos/bar/browse"}]}},{"slug":"baz","id":3,"name":"baz","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"ORG","id":1,"name":"Org","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/ORG"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/org/baz.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/org/baz.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/ORG/repos/baz/browse"}]}},{"slug":"foo","id":1,"name":"foo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"ORG","id":1,"name":"Org","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/ORG"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/org/foo.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/org/foo.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/ORG/repos/foo/browse"}]}}],"start":0}'
@@ -57,19 +57,19 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 01 Apr 2019 15:50:33 GMT
+      - Thu, 18 Apr 2019 14:33:18 GMT
       Pragma:
       - no-cache
       Set-Cookie:
-      - BITBUCKETSESSIONID=93032ECBF85AC2DA795DF90EA449EAE2; Path=/; HttpOnly
+      - BITBUCKETSESSIONID=E7DB9857673A9C6CE6C077CC0C2A9210; Path=/; HttpOnly
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@OEF9HRx950x3021x0'
+      - '@WENS5Ax873x85x0'
       X-Asen:
       - SEN-L13362690
       X-Asessionid:
-      - 1xhrefw
+      - akdntp
       X-Auserid:
       - "1"
       X-Ausername:
@@ -77,6 +77,25 @@ interactions:
       X-Content-Type-Options:
       - nosniff
     status: '200 '
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: http://127.0.0.1:3178/list-gitolite?gitolite=ssh%3A%2F%2Fgit%40127.0.0.1%3A2222
+    method: GET
+  response:
+    body: |
+      [{"Name":"bar","URL":"ssh://git@127.0.0.1:2222:bar"},{"Name":"baz","URL":"ssh://git@127.0.0.1:2222:baz"},{"Name":"foo","URL":"ssh://git@127.0.0.1:2222:foo"},{"Name":"gitolite-admin","URL":"ssh://git@127.0.0.1:2222:gitolite-admin"},{"Name":"testing","URL":"ssh://git@127.0.0.1:2222:testing"}]
+    headers:
+      Content-Length:
+      - "292"
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 18 Apr 2019 14:33:18 GMT
+    status: 200 OK
     code: 200
     duration: ""
 - request:
@@ -91,7 +110,7 @@ interactions:
     method: GET
   response:
     body: '{"id":41288708,"node_id":"MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==","name":"sourcegraph","full_name":"sourcegraph/sourcegraph","private":false,"owner":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/sourcegraph/sourcegraph","description":"Code
-      search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2019-04-01T14:29:05Z","pushed_at":"2019-04-01T15:40:21Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":293685,"stargazers_count":1886,"watchers_count":1886,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":124,"mirror_url":null,"archived":false,"open_issues_count":700,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"forks":124,"open_issues":700,"watchers":1886,"default_branch":"master","organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":124,"subscribers_count":39}'
+      search and navigation tool (self-hosted)","fork":false,"url":"https://api.github.com/repos/sourcegraph/sourcegraph","forks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/forks","keys_url":"https://api.github.com/repos/sourcegraph/sourcegraph/keys{/key_id}","collaborators_url":"https://api.github.com/repos/sourcegraph/sourcegraph/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/sourcegraph/sourcegraph/teams","hooks_url":"https://api.github.com/repos/sourcegraph/sourcegraph/hooks","issue_events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/events{/number}","events_url":"https://api.github.com/repos/sourcegraph/sourcegraph/events","assignees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/assignees{/user}","branches_url":"https://api.github.com/repos/sourcegraph/sourcegraph/branches{/branch}","tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/tags","blobs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/refs{/sha}","trees_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/trees{/sha}","statuses_url":"https://api.github.com/repos/sourcegraph/sourcegraph/statuses/{sha}","languages_url":"https://api.github.com/repos/sourcegraph/sourcegraph/languages","stargazers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/stargazers","contributors_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contributors","subscribers_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscribers","subscription_url":"https://api.github.com/repos/sourcegraph/sourcegraph/subscription","commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/commits{/sha}","git_commits_url":"https://api.github.com/repos/sourcegraph/sourcegraph/git/commits{/sha}","comments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/comments{/number}","issue_comment_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues/comments{/number}","contents_url":"https://api.github.com/repos/sourcegraph/sourcegraph/contents/{+path}","compare_url":"https://api.github.com/repos/sourcegraph/sourcegraph/compare/{base}...{head}","merges_url":"https://api.github.com/repos/sourcegraph/sourcegraph/merges","archive_url":"https://api.github.com/repos/sourcegraph/sourcegraph/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/sourcegraph/sourcegraph/downloads","issues_url":"https://api.github.com/repos/sourcegraph/sourcegraph/issues{/number}","pulls_url":"https://api.github.com/repos/sourcegraph/sourcegraph/pulls{/number}","milestones_url":"https://api.github.com/repos/sourcegraph/sourcegraph/milestones{/number}","notifications_url":"https://api.github.com/repos/sourcegraph/sourcegraph/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/sourcegraph/sourcegraph/labels{/name}","releases_url":"https://api.github.com/repos/sourcegraph/sourcegraph/releases{/id}","deployments_url":"https://api.github.com/repos/sourcegraph/sourcegraph/deployments","created_at":"2015-08-24T07:27:28Z","updated_at":"2019-04-18T14:19:58Z","pushed_at":"2019-04-18T14:18:00Z","git_url":"git://github.com/sourcegraph/sourcegraph.git","ssh_url":"git@github.com:sourcegraph/sourcegraph.git","clone_url":"https://github.com/sourcegraph/sourcegraph.git","svn_url":"https://github.com/sourcegraph/sourcegraph","homepage":"https://sourcegraph.com","size":296089,"stargazers_count":2013,"watchers_count":2013,"language":"HTML","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":131,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":751,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"forks":131,"open_issues":751,"watchers":2013,"default_branch":"master","organization":{"login":"sourcegraph","id":3979584,"node_id":"MDEyOk9yZ2FuaXphdGlvbjM5Nzk1ODQ=","avatar_url":"https://avatars0.githubusercontent.com/u/3979584?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph","html_url":"https://github.com/sourcegraph","followers_url":"https://api.github.com/users/sourcegraph/followers","following_url":"https://api.github.com/users/sourcegraph/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph/orgs","repos_url":"https://api.github.com/users/sourcegraph/repos","events_url":"https://api.github.com/users/sourcegraph/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph/received_events","type":"Organization","site_admin":false},"network_count":131,"subscribers_count":41}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -106,11 +125,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 01 Apr 2019 15:50:33 GMT
+      - Thu, 18 Apr 2019 14:33:19 GMT
       Etag:
-      - W/"2e3105d0380293b0ead26d11b9701af2"
+      - W/"da032a5ad2d0bd9b912df85f4bc6ebe3"
       Last-Modified:
-      - Mon, 01 Apr 2019 14:29:05 GMT
+      - Thu, 18 Apr 2019 14:19:58 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -128,7 +147,7 @@ interactions:
       X-Github-Media-Type:
       - github.v3; param=jean-grey-preview; format=json
       X-Github-Request-Id:
-      - BAAC:20EE:51F87F:D549E9:5CA23349
+      - 49E9:4FA6:126C649:285C3DC:5CB88AAE
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -147,8 +166,8 @@ interactions:
   response:
     body: '{"total_count":1,"incomplete_results":false,"items":[{"id":153657245,"node_id":"MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU=","name":"patrol","full_name":"tsenart/patrol","private":false,"owner":{"login":"tsenart","id":67471,"node_id":"MDQ6VXNlcjY3NDcx","avatar_url":"https://avatars2.githubusercontent.com/u/67471?v=4","gravatar_id":"","url":"https://api.github.com/users/tsenart","html_url":"https://github.com/tsenart","followers_url":"https://api.github.com/users/tsenart/followers","following_url":"https://api.github.com/users/tsenart/following{/other_user}","gists_url":"https://api.github.com/users/tsenart/gists{/gist_id}","starred_url":"https://api.github.com/users/tsenart/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/tsenart/subscriptions","organizations_url":"https://api.github.com/users/tsenart/orgs","repos_url":"https://api.github.com/users/tsenart/repos","events_url":"https://api.github.com/users/tsenart/events{/privacy}","received_events_url":"https://api.github.com/users/tsenart/received_events","type":"User","site_admin":false},"html_url":"https://github.com/tsenart/patrol","description":"Patrol
       is an operator friendly distributed rate limiting HTTP API with strong eventually
-      consistent CvRDT based replication.","fork":false,"url":"https://api.github.com/repos/tsenart/patrol","forks_url":"https://api.github.com/repos/tsenart/patrol/forks","keys_url":"https://api.github.com/repos/tsenart/patrol/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/patrol/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/patrol/teams","hooks_url":"https://api.github.com/repos/tsenart/patrol/hooks","issue_events_url":"https://api.github.com/repos/tsenart/patrol/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/patrol/events","assignees_url":"https://api.github.com/repos/tsenart/patrol/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/patrol/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/patrol/tags","blobs_url":"https://api.github.com/repos/tsenart/patrol/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/patrol/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/patrol/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/patrol/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/patrol/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/patrol/languages","stargazers_url":"https://api.github.com/repos/tsenart/patrol/stargazers","contributors_url":"https://api.github.com/repos/tsenart/patrol/contributors","subscribers_url":"https://api.github.com/repos/tsenart/patrol/subscribers","subscription_url":"https://api.github.com/repos/tsenart/patrol/subscription","commits_url":"https://api.github.com/repos/tsenart/patrol/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/patrol/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/patrol/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/patrol/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/patrol/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/patrol/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/patrol/merges","archive_url":"https://api.github.com/repos/tsenart/patrol/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/patrol/downloads","issues_url":"https://api.github.com/repos/tsenart/patrol/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/patrol/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/patrol/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/patrol/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/patrol/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/patrol/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/patrol/deployments","created_at":"2018-10-18T16:50:37Z","updated_at":"2019-03-04T11:30:11Z","pushed_at":"2018-11-13T14:57:15Z","git_url":"git://github.com/tsenart/patrol.git","ssh_url":"git@github.com:tsenart/patrol.git","clone_url":"https://github.com/tsenart/patrol.git","svn_url":"https://github.com/tsenart/patrol","homepage":"","size":95,"stargazers_count":20,"watchers_count":20,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"open_issues_count":1,"license":{"key":"mit","name":"MIT
-      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"forks":2,"open_issues":1,"watchers":20,"default_branch":"master","score":46.163803}]}'
+      consistent CvRDT based replication.","fork":false,"url":"https://api.github.com/repos/tsenart/patrol","forks_url":"https://api.github.com/repos/tsenart/patrol/forks","keys_url":"https://api.github.com/repos/tsenart/patrol/keys{/key_id}","collaborators_url":"https://api.github.com/repos/tsenart/patrol/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/tsenart/patrol/teams","hooks_url":"https://api.github.com/repos/tsenart/patrol/hooks","issue_events_url":"https://api.github.com/repos/tsenart/patrol/issues/events{/number}","events_url":"https://api.github.com/repos/tsenart/patrol/events","assignees_url":"https://api.github.com/repos/tsenart/patrol/assignees{/user}","branches_url":"https://api.github.com/repos/tsenart/patrol/branches{/branch}","tags_url":"https://api.github.com/repos/tsenart/patrol/tags","blobs_url":"https://api.github.com/repos/tsenart/patrol/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/tsenart/patrol/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/tsenart/patrol/git/refs{/sha}","trees_url":"https://api.github.com/repos/tsenart/patrol/git/trees{/sha}","statuses_url":"https://api.github.com/repos/tsenart/patrol/statuses/{sha}","languages_url":"https://api.github.com/repos/tsenart/patrol/languages","stargazers_url":"https://api.github.com/repos/tsenart/patrol/stargazers","contributors_url":"https://api.github.com/repos/tsenart/patrol/contributors","subscribers_url":"https://api.github.com/repos/tsenart/patrol/subscribers","subscription_url":"https://api.github.com/repos/tsenart/patrol/subscription","commits_url":"https://api.github.com/repos/tsenart/patrol/commits{/sha}","git_commits_url":"https://api.github.com/repos/tsenart/patrol/git/commits{/sha}","comments_url":"https://api.github.com/repos/tsenart/patrol/comments{/number}","issue_comment_url":"https://api.github.com/repos/tsenart/patrol/issues/comments{/number}","contents_url":"https://api.github.com/repos/tsenart/patrol/contents/{+path}","compare_url":"https://api.github.com/repos/tsenart/patrol/compare/{base}...{head}","merges_url":"https://api.github.com/repos/tsenart/patrol/merges","archive_url":"https://api.github.com/repos/tsenart/patrol/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/tsenart/patrol/downloads","issues_url":"https://api.github.com/repos/tsenart/patrol/issues{/number}","pulls_url":"https://api.github.com/repos/tsenart/patrol/pulls{/number}","milestones_url":"https://api.github.com/repos/tsenart/patrol/milestones{/number}","notifications_url":"https://api.github.com/repos/tsenart/patrol/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/tsenart/patrol/labels{/name}","releases_url":"https://api.github.com/repos/tsenart/patrol/releases{/id}","deployments_url":"https://api.github.com/repos/tsenart/patrol/deployments","created_at":"2018-10-18T16:50:37Z","updated_at":"2019-03-04T11:30:11Z","pushed_at":"2018-11-13T14:57:15Z","git_url":"git://github.com/tsenart/patrol.git","ssh_url":"git@github.com:tsenart/patrol.git","clone_url":"https://github.com/tsenart/patrol.git","svn_url":"https://github.com/tsenart/patrol","homepage":"","size":95,"stargazers_count":20,"watchers_count":20,"language":"Go","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":{"key":"mit","name":"MIT
+      License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"forks":2,"open_issues":1,"watchers":20,"default_branch":"master","score":46.125343}]}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -163,7 +182,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 01 Apr 2019 15:50:33 GMT
+      - Thu, 18 Apr 2019 14:33:19 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -179,7 +198,7 @@ interactions:
       X-Github-Media-Type:
       - github.v3; param=jean-grey-preview; format=json
       X-Github-Request-Id:
-      - EADB:6EE0:1429C2C:289F326:5CA23349
+      - 6916:73E2:1172BA0:25C093A:5CB88AAE
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -204,13 +223,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 01 Apr 2019 15:50:33 GMT
+      - Thu, 18 Apr 2019 14:33:20 GMT
       Etag:
       - W/"2e213a0bf612bec448cc4972d255ca73"
       Link:
       - <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
         rel="first", <https://gitlab.com/api/v4/projects?membership=false&order_by=last_activity_at&owned=false&page=1&per_page=100&repository_checksum_failed=false&search=gokulkarthick&simple=false&sort=desc&starred=false&statistics=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
         rel="last"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
@@ -230,66 +251,13 @@ interactions:
       X-Prev-Page:
       - ""
       X-Request-Id:
-      - 81UnmREOur2
+      - Tcn2jHy34m6
       X-Runtime:
-      - "0.132361"
+      - "0.144321"
       X-Total:
       - "1"
       X-Total-Pages:
       - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/vnd.github.jean-grey-preview+json
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.github.com/search/repositories?page=2&per_page=100&q=user%3Atsenart+in%3Aname+patrol
-    method: GET
-  response:
-    body: '{"total_count":1,"incomplete_results":false,"items":[]}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - no-cache
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 01 Apr 2019 15:50:33 GMT
-      Link:
-      - <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
-        rel="prev", <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
-        rel="last", <https://api.github.com/search/repositories?page=1&per_page=100&q=user%3Atsenart+in%3Aname+patrol>;
-        rel="first"
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json
-      X-Github-Request-Id:
-      - EADB:6EE0:1429C52:289F354:5CA23349
-      X-Xss-Protection:
-      - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""

--- a/pkg/vcs/git/main_test.go
+++ b/pkg/vcs/git/main_test.go
@@ -24,9 +24,9 @@ func TestMain(m *testing.M) {
 	srv := &http.Server{Handler: (&server.Server{}).Handler()}
 	go srv.Serve(l)
 
-	gitserver.DefaultClient = &gitserver.Client{Addrs: func(ctx context.Context) []string {
+	gitserver.DefaultClient.Addrs = func(ctx context.Context) []string {
 		return []string{l.Addr().String()}
-	}}
+	}
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
This change set implements the `GitoliteSource`, the first step in #3464.

@beyang: Regarding the change in ffb804d, it's meant to aid testing. I was trying to think of any security reason why we had that check but couldn't come up with anything. Can you verify this please?

Part of #3467 