### PR TITLE
Build phabricator assets in frontend pre-build.sh

### DIFF
--- a/client/browser/gulpfile.ts
+++ b/client/browser/gulpfile.ts
@@ -19,13 +19,14 @@ export function watch(): ChildProcess {
 }
 
 const PHABRICATOR_EXTENSION_FILES = path.join(__dirname, './build/phabricator/dist/**')
+const PHABRICATOR_ASSETS_DIRECTORY = path.join(__dirname, '../../ui/assets/extension')
 
 /**
  * Copies the phabricator extension over to the ui/assets folder so they can be served by the webapp. The package
  * is published from ./client/browser.
  */
 export function phabricator(): NodeJS.ReadWriteStream {
-    return gulp.src(PHABRICATOR_EXTENSION_FILES).pipe(gulp.dest('../../ui/assets/extension'))
+    return gulp.src(PHABRICATOR_EXTENSION_FILES).pipe(gulp.dest(PHABRICATOR_ASSETS_DIRECTORY))
 }
 
 export const watchPhabricator = gulp.series(phabricator, async function watchPhabricator(): Promise<void> {

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -5,7 +5,8 @@ cd $(dirname "${BASH_SOURCE[0]}")/../..
 
 pushd ..
 yarn --frozen-lockfile --network-timeout 60000
-(cd web && NODE_ENV=production yarn -s run build --color)
+(pushd client/browser && TARGETS=phabricator yarn build && popd)
+(pushd web && NODE_ENV=production yarn -s run build --color && popd)
 popd
 
 dev/generate.sh


### PR DESCRIPTION
It appears that we have been building the frontend for a *long* time without including the Phabricator assets, because even though we tried to copy them, the Phabricator assets weren't actually built.