### PR TITLE
fix: add updated ping docs

### DIFF
--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -15,3 +15,4 @@ Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and
 - Total count of existing user accounts
 - Aggregate counts of current daily, weekly, and monthly users
 - Aggregate counts of current users using code host integrations
+- Aggregate counts of current users by product feature (site management, code search and navigation, code review, saved searches, diff searches)

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -57,6 +57,10 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                     <li>Total count of existing user accounts</li>
                     <li>Aggregate counts of current daily, weekly, and monthly users</li>
                     <li>Aggregate counts of current users using code host integrations</li>
+                    <li>
+                        Aggregate counts of current users by product feature (site management, code search and
+                        navigation, code review, saved searches, diff searches)
+                    </li>
                 </ul>
                 {!pingsEnabled ? (
                     <p>Pings are disabled.</p>


### PR DESCRIPTION
This should have gone into 3.3, but since one of these two parts (docs.sourcegraph.com) will get updated, it's not the end of the world if it doesn't make it in.

@slimsag I'll check in with you if I have trouble cherry picking this in!