### PR TITLE
use tslint rules for React hooks linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.15.0",
     "tslint-language-service": "^0.9.9",
+    "tslint-react-hooks": "^2.1.0",
     "typedoc": "^0.14.0",
     "typescript": "3.5.0-dev.20190406",
     "utc-version": "^1.1.0",

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@sourcegraph/tslint-config"],
+  "extends": ["@sourcegraph/tslint-config", "tslint-react-hooks"],
   "linterOptions": { "exclude": ["node_modules/**"] },
   "rules": {
     "await-promise": false,
@@ -21,6 +21,7 @@
         "^select$",
         "Use the Select component in src/components/Select.tsx instead of the native HTML select element for proper cross-browser styling"
       ]
-    ]
+    ],
+    "react-hooks-nesting": "error"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,7 +1506,8 @@
   integrity sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.0.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -13686,7 +13687,8 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "23.0.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -14648,6 +14650,11 @@ tslint-language-service@^0.9.9:
   integrity sha1-9UbcOEg5eeb7PPpZWErYUls61No=
   dependencies:
     mock-require "^2.0.2"
+
+tslint-react-hooks@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/tslint-react-hooks/-/tslint-react-hooks-2.1.0.tgz#cc9841da0cef20d3527c8d16412f029c33767898"
+  integrity sha512-ccjyguEHGEU5rXikLDaQ6kT1AVo3C0HV8gi2MIJc7SbYAXjbzJkpbs4IXulgfqdEY1T6RnNSuGhyXg+2jTm5Bg==
 
 tslint-react@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Uses https://github.com/Gelio/tslint-react-hooks for linting React hooks code to find common mistakes, as recommended by https://reactjs.org/docs/hooks-rules.html.

Addresses https://github.com/sourcegraph/sourcegraph/pull/3392#discussion_r275895266.

Note: We plan to switch from TSLint to ESLint soon (https://github.com/sourcegraph/sourcegraph/issues/2461). In that case, we will use the more standard ESLint rules for React hooks instead.

Confirmed working; if I add a `useEffect` in an if-statement, it reports:

```
/home/sqs/src/github.com/sourcegraph/sourcegraph/shared/src/components/linkPreviews/WithLinkPreviews.tsx:27:9
ERROR: 27:9     react-hooks-nesting               A hook cannot appear inside an if statement
```