### PR TITLE
test removal of content views and text fields in browser extension

### DIFF
--- a/client/browser/src/libs/code_intelligence/content_views.test.ts
+++ b/client/browser/src/libs/code_intelligence/content_views.test.ts
@@ -1,9 +1,10 @@
 import { uniqueId } from 'lodash'
-import { of, Subject, Subscription } from 'rxjs'
+import { concat, Observable, of, Subject, Subscription } from 'rxjs'
 import { first } from 'rxjs/operators'
 import { MarkupKind } from 'sourcegraph'
 import { LinkPreviewMerged } from '../../../../../shared/src/api/client/services/linkPreview'
 import { createBarrier } from '../../../../../shared/src/api/integration-test/testHelpers'
+import { MutationRecordLike } from '../../shared/util/dom'
 import { handleContentViews } from './content_views'
 
 describe('content_views', () => {
@@ -26,14 +27,18 @@ describe('content_views', () => {
             return el
         }
 
-        test('detects and annotates content views', async () => {
+        test('detects addition, mutation, and removal of content views (and annotates them)', async () => {
             const element = createTestElement()
             element.id = 'content-view'
             element.innerHTML = '0 <a href=#foo>foo</a> 1 <a href=#bar>bar</a> 2 <a href=#qux>qux</a> 3'
+
             const wait = new Subject<void>()
+            const unsubscribed = new Subject<void>()
+            const mutations = new Subject<MutationRecordLike[]>()
+
             subscriptions.add(
                 handleContentViews(
-                    of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    mutations,
                     {
                         extensionsController: {
                             services: {
@@ -43,20 +48,24 @@ describe('content_views', () => {
                                         if (url.includes('bar')) {
                                             return of(null)
                                         }
-                                        return of<LinkPreviewMerged>({
-                                            content: [
-                                                {
-                                                    kind: 'markdown' as MarkupKind.Markdown,
-                                                    value: `**${url.slice(url.lastIndexOf('#') + 1)}** x`,
-                                                },
-                                            ],
-                                            hover: [
-                                                {
-                                                    kind: 'plaintext' as MarkupKind.PlainText,
-                                                    value: url.slice(url.lastIndexOf('#') + 1),
-                                                },
-                                            ],
-                                        })
+                                        return concat(
+                                            of<LinkPreviewMerged>({
+                                                content: [
+                                                    {
+                                                        kind: 'markdown' as MarkupKind.Markdown,
+                                                        value: `**${url.slice(url.lastIndexOf('#') + 1)}** x`,
+                                                    },
+                                                ],
+                                                hover: [
+                                                    {
+                                                        kind: 'plaintext' as MarkupKind.PlainText,
+                                                        value: url.slice(url.lastIndexOf('#') + 1),
+                                                    },
+                                                ],
+                                            }),
+                                            // Support checking that the provider's observable was unsubscribed.
+                                            new Observable<LinkPreviewMerged>(() => () => unsubscribed.next())
+                                        )
                                     },
                                 },
                             },
@@ -69,6 +78,9 @@ describe('content_views', () => {
                     }
                 )
             )
+
+            // Add content view.
+            mutations.next([{ addedNodes: [document.body], removedNodes: [] }])
             await wait.pipe(first()).toPromise()
             expect(element.classList.contains('sg-mounted')).toBe(true)
             expect(element.innerHTML).toBe(
@@ -77,11 +89,15 @@ describe('content_views', () => {
 
             // Mutate content view.
             element.innerHTML = '4 <a href=#zip>zip</a> 5'
-            await wait.pipe(first()).toPromise()
+            await Promise.all([unsubscribed.pipe(first()).toPromise(), wait.pipe(first()).toPromise()])
             expect(element.classList.contains('sg-mounted')).toBe(true)
             expect(element.innerHTML).toBe(
                 '4 <a href="#zip" data-tooltip="zip">zip</a><span class="sg-link-preview-content" data-tooltip="zip"><strong>zip</strong> x</span> 5'
             )
+
+            // Remove content view.
+            mutations.next([{ addedNodes: [], removedNodes: [element] }])
+            await unsubscribed.pipe(first()).toPromise()
         })
 
         test('handles multiple emissions', async () => {

--- a/client/browser/src/libs/code_intelligence/content_views.ts
+++ b/client/browser/src/libs/code_intelligence/content_views.ts
@@ -92,6 +92,7 @@ export function handleContentViews(
                     let contentViewState = contentViewStates.get(contentViewEvent.element)
                     if (!contentViewState) {
                         contentViewState = { subscriptions: new Subscription() }
+                        contentViewStates.set(contentViewEvent.element, contentViewState)
                     }
 
                     // Add link preview content.

--- a/client/browser/src/libs/code_intelligence/text_fields.test.tsx
+++ b/client/browser/src/libs/code_intelligence/text_fields.test.tsx
@@ -6,12 +6,13 @@ jest.mock('react-dom', () => ({
 }))
 
 import { uniqueId } from 'lodash'
-import { from, NEVER, of, Subscription } from 'rxjs'
-import { skip, take } from 'rxjs/operators'
+import { from, NEVER, Subject, Subscription } from 'rxjs'
+import { first, skip, take } from 'rxjs/operators'
 import { Services } from '../../../../../shared/src/api/client/services'
 import { CodeEditor } from '../../../../../shared/src/api/client/services/editorService'
 import { integrationTestContext } from '../../../../../shared/src/api/integration-test/testHelpers'
 import { Controller } from '../../../../../shared/src/extensions/controller'
+import { MutationRecordLike } from '../../shared/util/dom'
 import { handleTextFields } from './text_fields'
 
 jest.mock('uuid', () => ({
@@ -46,15 +47,18 @@ describe('text_fields', () => {
             return el
         }
 
-        test('detects text fields based on selectors', async () => {
+        test('detects addition and removal of text fields', async () => {
             const { services } = await integrationTestContext(undefined, { roots: [], editors: [] })
             const textFieldElement = createTestElement()
             textFieldElement.id = 'text-field'
             textFieldElement.value = 'abc'
             textFieldElement.setSelectionRange(2, 3)
+
+            const mutations = new Subject<MutationRecordLike[]>()
+
             subscriptions.add(
                 handleTextFields(
-                    of([{ addedNodes: [document.body], removedNodes: [] }]),
+                    mutations,
                     { extensionsController: createMockController(services) },
                     {
                         textFieldResolvers: [
@@ -63,6 +67,9 @@ describe('text_fields', () => {
                     }
                 )
             )
+
+            // Add text field.
+            mutations.next([{ addedNodes: [document.body], removedNodes: [] }])
             const editors = await from(services.editor.editors)
                 .pipe(
                     skip(2),
@@ -92,6 +99,18 @@ describe('text_fields', () => {
                 },
             ] as CodeEditor[])
             expect(textFieldElement.classList.contains('sg-mounted')).toBe(true)
+
+            // Remove text field.
+            textFieldElement.remove()
+            mutations.next([{ addedNodes: [], removedNodes: [textFieldElement] }])
+            expect(
+                await from(services.editor.editors)
+                    .pipe(
+                        skip(1),
+                        first()
+                    )
+                    .toPromise()
+            ).toEqual([])
         })
     })
 })


### PR DESCRIPTION
Also fixes a bug where link preview provider observables were not unsubscribed when they were no longer needed, which consumed needless resources (though is not the cause of any known issues and probably was not noticeable).

Addresses https://github.com/sourcegraph/sourcegraph/pull/3392/files#r275946039