### PR TITLE
WIP: MessagePortLike

### DIFF
--- a/client/browser/src/extension/scripts/background.tsx
+++ b/client/browser/src/extension/scripts/background.tsx
@@ -2,12 +2,13 @@
 // prettier-ignore
 import '../../config/polyfill'
 
-import { Endpoint } from '@sourcegraph/comlink'
 import { without } from 'lodash'
 import { fromEventPattern, noop, Observable } from 'rxjs'
 import { bufferCount, filter, groupBy, map, mergeMap } from 'rxjs/operators'
 import DPT from 'webext-domain-permission-toggle'
 import { createExtensionHostWorker } from '../../../../../shared/src/api/extension/worker'
+import { EndpointLike } from '../../../../../shared/src/platform/context'
+import { MessagePortLike } from '../../../../../shared/src/util/messagePort'
 import * as browserAction from '../../browser/browserAction'
 import * as omnibox from '../../browser/omnibox'
 import * as permissions from '../../browser/permissions'
@@ -438,7 +439,7 @@ endpointPairs.subscribe(({ proxy, expose }) => {
     const { worker, clientEndpoints } = createExtensionHostWorker({ wrapEndpoints: true })
     const connectPortAndEndpoint = (
         port: chrome.runtime.Port,
-        endpoint: Endpoint & Pick<MessagePort, 'start'>
+        endpoint: EndpointLike & Pick<MessagePortLike, 'start'>
     ): void => {
         endpoint.start()
         port.onMessage.addListener(message => {

--- a/shared/src/api/extension/main.worker.ts
+++ b/shared/src/api/extension/main.worker.ts
@@ -4,12 +4,13 @@ import * as MessageChannelAdapter from '@sourcegraph/comlink/messagechanneladapt
 import { fromEvent } from 'rxjs'
 import { take } from 'rxjs/operators'
 import { EndpointPair, isEndpointPair } from '../../platform/context'
+import { MessagePortLike } from '../../util/messagePort'
 import { startExtensionHost } from './extensionHost'
 
 export interface InitMessage {
     endpoints: {
-        proxy: MessagePort
-        expose: MessagePort
+        proxy: MessagePortLike
+        expose: MessagePortLike
     }
     /**
      * Whether the endpoints should be wrapped with a comlink {@link MessageChannelAdapter}.
@@ -22,7 +23,7 @@ export interface InitMessage {
 
 const isInitMessage = (value: any): value is InitMessage => value.endpoints && isEndpointPair(value.endpoints)
 
-const wrapMessagePort = (port: MessagePort) =>
+const wrapMessagePort = (port: MessagePortLike) =>
     MessageChannelAdapter.wrap({
         send: data => port.postMessage(data),
         addEventListener: (event, listener) => port.addEventListener(event, listener),

--- a/shared/src/platform/context.ts
+++ b/shared/src/platform/context.ts
@@ -4,14 +4,31 @@ import { SettingsEdit } from '../api/client/services/settings'
 import { GraphQLResult } from '../graphql/graphql'
 import * as GQL from '../graphql/schema'
 import { Settings, SettingsCascadeOrError } from '../settings/settings'
+import { MessageEventLike, MessagePortLike } from '../util/messagePort'
 import { FileSpec, PositionSpec, RepoSpec, RevSpec, ViewStateSpec } from '../util/url'
+
+/**
+ * Compatible with {@link module:@sourcegraph/comlink.Endpoint} but synthesizable.
+ */
+export interface EndpointLike extends Pick<Endpoint, 'postMessage'> {
+    addEventListener(
+        type: 'message',
+        listener: (ev: MessageEventLike) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void
+    removeEventListener(
+        type: 'message',
+        listener: (ev: MessageEventLike) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void
+}
 
 export interface EndpointPair {
     /** The endpoint to proxy the API of the other thread from */
-    proxy: Endpoint & Pick<MessagePort, 'start'>
+    proxy: EndpointLike & Pick<MessagePortLike, 'start'>
 
     /** The endpoint to expose the API of this thread to */
-    expose: Endpoint & Pick<MessagePort, 'start'>
+    expose: EndpointLike & Pick<MessagePortLike, 'start'>
 }
 export const isEndpointPair = (val: any): val is EndpointPair =>
     typeof val === 'object' && val !== null && isEndpoint(val.proxy) && isEndpoint(val.expose)

--- a/shared/src/util/messagePort.ts
+++ b/shared/src/util/messagePort.ts
@@ -1,0 +1,20 @@
+/**
+ * Compatible with {@link MessageEvent} but synthesizable.
+ */
+export interface MessageEventLike extends Pick<MessageEvent, 'data'> {}
+
+/**
+ * Compatible with {@link MessagePort} but synthesizable.
+ */
+export interface MessagePortLike extends Pick<MessagePort, 'postMessage' | 'start'> {
+    addEventListener<E extends MessageEventLike>(
+        type: 'message',
+        listener: (ev: E) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void
+    removeEventListener<E extends MessageEventLike>(
+        type: 'message',
+        listener: (ev: E) => any,
+        options?: boolean | EventListenerOptions
+    ): void
+}


### PR DESCRIPTION
Attempts to address https://github.com/sourcegraph/sourcegraph/pull/3434#discussion_r275951925

Unfortunately, our code is too intertwined with comlink's API (not in a bad way, just in a way that makes it harder to use a synthesizable type). So I am going to see if we can make comlink's API use MessageEventLike instead of introducing it in our code.


