### PR TITLE
Init transport if nil when registering custom certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue where the http.Client.Transport would not be initialized when using custom Certificate Authority or self signed certificate.
+
 ## 3.3.0
 
 ### Added

--- a/pkg/httpcli/client.go
+++ b/pkg/httpcli/client.go
@@ -115,6 +115,10 @@ func ContextErrorMiddleware(cli Doer) Doer {
 // transport.
 func NewCertPoolOpt(pool *x509.CertPool) Opt {
 	return func(cli *http.Client) error {
+		if cli.Transport == nil {
+			cli.Transport = http.DefaultTransport
+		}
+
 		tr, ok := cli.Transport.(*http.Transport)
 		if !ok {
 			return errors.New("httpcli.NewCertPoolOpt: http.Client.Transport is not an *http.Transport")


### PR DESCRIPTION
Commit ae5c19aaf3e6edb46f7845ce093c47010d93c043 introduced parametized
http client, the order used in httpcli.NewFactory makes NewCertPoolOpt
called first, but its http.Client.Transport is not initialized yet.

This commit initialized http.Client.Transport to http.DefaultTransport
like in NewCachedTransportOpt and TracedTransportOpt.

Fixes #3523

Test plan: Add an external service with a custom Certificate Authority or self signed certificate.
