### PR TITLE
httpcli: TestNewCertPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Fixed an issue where the http.Client.Transport would not be initialized when using custom Certificate Authority or self signed certificate.
+- Fixed a bug that prevented external service configurations specifying client certificates from working (#3523)
 
 ## 3.3.0
 


### PR DESCRIPTION
This commit is a follow up to #3524 to cover `TestNewCertPool` with unit
tests.
