### PR TITLE
remove unused pkg/conf/server.Server.Edit() method

### DIFF
--- a/pkg/conf/server.go
+++ b/pkg/conf/server.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/jsonx"
 	"github.com/sourcegraph/sourcegraph/pkg/conf/conftypes"
 )
 
@@ -77,56 +76,6 @@ func (s *Server) Write(ctx context.Context, input conftypes.RawUnified) error {
 	s.fileWrite <- doneReading
 	<-doneReading
 
-	return nil
-}
-
-// Edits describes some JSON edits to apply to site or critical configuration.
-type Edits struct {
-	Site, Critical []jsonx.Edit
-}
-
-// Edit invokes the provided function to compute edits to the site
-// configuration. It then applies and writes them.
-//
-// The computation function is provided the current configuration, which should
-// NEVER be modified in any way. Always copy values.
-//
-// TODO(slimsag): Currently, edits may only be applied via the frontend. It may
-// make sense to allow non-frontend services to apply edits as well. To do this
-// we would need to pipe writes through the frontend's internal httpapi.
-func (s *Server) Edit(ctx context.Context, computeEdits func(current *Unified, raw conftypes.RawUnified) (Edits, error)) error {
-	// TODO@ggilmore: There is a race condition here (also present in the existing library).
-	// Current and raw could be inconsistent. Another thing to offload to configStore?
-	// Snapshot method?
-	current := s.store.LastValid()
-	raw := s.store.Raw()
-
-	// Compute edits.
-	edits, err := computeEdits(current, raw)
-	if err != nil {
-		return errors.Wrap(err, "computeEdits")
-	}
-
-	// Apply edits and write out new configuration.
-	newCritical, err := jsonx.ApplyEdits(raw.Critical, edits.Critical...)
-	if err != nil {
-		return errors.Wrap(err, "jsonx.ApplyEdits Critical")
-	}
-	newSite, err := jsonx.ApplyEdits(raw.Site, edits.Site...)
-	if err != nil {
-		return errors.Wrap(err, "jsonx.ApplyEdits Site")
-	}
-
-	// TODO@ggilmore: Another race condition (also present in the existing library). Locks
-	// aren't held between applying the edits and writing the config file,
-	// so the newConfig could be outdated.
-	err = s.Write(ctx, conftypes.RawUnified{
-		Site:     newSite,
-		Critical: newCritical,
-	})
-	if err != nil {
-		return errors.Wrap(err, "conf.Write")
-	}
 	return nil
 }
 


### PR DESCRIPTION

Test plan: The existing tests are enough since this is just removing some code.