### PR TITLE
Enable indexing by default for new deployments

### DIFF
--- a/pkg/conf/computed_test.go
+++ b/pkg/conf/computed_test.go
@@ -1,6 +1,9 @@
 package conf
 
 import (
+	"fmt"
+	"github.com/sourcegraph/sourcegraph/pkg/conf/confdefaults"
+	"github.com/sourcegraph/sourcegraph/pkg/conf/conftypes"
 	"os"
 	"strings"
 	"testing"
@@ -55,6 +58,27 @@ func TestSearchIndexEnabled(t *testing.T) {
 			got := SearchIndexEnabled()
 			if got != test.want {
 				t.Fatalf("SearchIndexEnabled() = %v, want %v", got, test.want)
+			}
+		})
+	}
+
+	defaults := map[string]conftypes.RawUnified{
+		"Cluster": confdefaults.Cluster,
+		"Default": confdefaults.Default,
+		"DevAndTesting": confdefaults.DevAndTesting,
+		"DockerContainer": confdefaults.DockerContainer,
+	}
+	for dStr, d := range defaults {
+		test := fmt.Sprintf("for %s defaults", dStr)
+		t.Run(test, func(t *testing.T) {
+			cfg, err := ParseConfig(d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			Mock(cfg)
+			defer Mock(nil)
+			if !SearchIndexEnabled() {
+				t.Errorf("search indexing should be enabled by default for Docker deployments")
 			}
 		})
 	}

--- a/pkg/conf/computed_test.go
+++ b/pkg/conf/computed_test.go
@@ -2,11 +2,12 @@ package conf
 
 import (
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/pkg/conf/confdefaults"
-	"github.com/sourcegraph/sourcegraph/pkg/conf/conftypes"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/pkg/conf/confdefaults"
+	"github.com/sourcegraph/sourcegraph/pkg/conf/conftypes"
 
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -63,9 +64,9 @@ func TestSearchIndexEnabled(t *testing.T) {
 	}
 
 	defaults := map[string]conftypes.RawUnified{
-		"Cluster": confdefaults.Cluster,
-		"Default": confdefaults.Default,
-		"DevAndTesting": confdefaults.DevAndTesting,
+		"Cluster":         confdefaults.Cluster,
+		"Default":         confdefaults.Default,
+		"DevAndTesting":   confdefaults.DevAndTesting,
 		"DockerContainer": confdefaults.DockerContainer,
 	}
 	for dStr, d := range defaults {

--- a/pkg/conf/confdefaults/confdefaults.go
+++ b/pkg/conf/confdefaults/confdefaults.go
@@ -29,7 +29,9 @@ var DevAndTesting = conftypes.RawUnified{
 		}
 	],
 }`,
-	Site: `{}`,
+	Site: `{
+    "search.index.enabled": true,
+}`,
 }
 
 // DockerContainer is the default configuration applied to Docker
@@ -44,7 +46,8 @@ var DockerContainer = conftypes.RawUnified{
 	]
 }`,
 	Site: `{
-	"disablePublicRepoRedirects": true
+	"disablePublicRepoRedirects": true,
+    "search.index.enabled": true,
 }`,
 }
 
@@ -69,7 +72,9 @@ var Cluster = conftypes.RawUnified{
 		}
 	]
 }`,
-	Site: `{}`,
+	Site: `{
+    "search.index.enabled": true,
+}`,
 }
 
 // Default is the default for *this* deployment type. It is populated by

--- a/pkg/conf/confdefaults/confdefaults.go
+++ b/pkg/conf/confdefaults/confdefaults.go
@@ -30,7 +30,7 @@ var DevAndTesting = conftypes.RawUnified{
 	],
 }`,
 	Site: `{
-    "search.index.enabled": true,
+	"search.index.enabled": true,
 }`,
 }
 
@@ -47,7 +47,7 @@ var DockerContainer = conftypes.RawUnified{
 }`,
 	Site: `{
 	"disablePublicRepoRedirects": true,
-    "search.index.enabled": true,
+	"search.index.enabled": true,
 }`,
 }
 
@@ -73,7 +73,7 @@ var Cluster = conftypes.RawUnified{
 	]
 }`,
 	Site: `{
-    "search.index.enabled": true,
+	"search.index.enabled": true,
 }`,
 }
 


### PR DESCRIPTION
Fixes #2176.

Cluster and dev deployments were already getting indexing enabled by default. This change enables it by default for Docker deployments.

Test plan: I added a unit test.