### PR TITLE
retry when we have a corrupt archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Removes corrupted archives in the searcher cache and tries to populate the cache again instead of returning an error.
+
 ## 3.3.1
 
 ### Fixed

--- a/cmd/searcher/search/retry.go
+++ b/cmd/searcher/search/retry.go
@@ -1,0 +1,31 @@
+package search
+
+import (
+	"os"
+	"strings"
+)
+
+// getZipFileWithRetry retries getting a zip file if the zip is for some reason
+// invalid.
+func getZipFileWithRetry(get func() (string, *zipFile, error)) (zf *zipFile, err error) {
+	var path string
+	tries := 0
+	for zf == nil {
+		path, zf, err = get()
+		if err != nil {
+			if tries < 2 && strings.Contains(err.Error(), "not a valid zip file") {
+				err = os.Remove(path)
+				if err != nil {
+					return nil, err
+				}
+				tries++
+				if tries == 2 {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+	}
+	return zf, nil
+}

--- a/cmd/searcher/search/retry_test.go
+++ b/cmd/searcher/search/retry_test.go
@@ -1,0 +1,76 @@
+package search
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestGetZipFileWithRetry(t *testing.T) {
+	tests := []struct {
+		name     string
+		errs     []error
+		succeeds bool
+	}{
+		{
+			name:     "success first try",
+			errs:     []error{nil},
+			succeeds: true,
+		},
+		{
+			name:     "success second try",
+			errs:     []error{errors.New("not a valid zip file"), nil},
+			succeeds: true,
+		},
+		{
+			name:     "error that doesn't get a retry",
+			errs:     []error{errors.New("blah")},
+			succeeds: false,
+		},
+		{
+			name:     "fails twice",
+			errs:     []error{errors.New("not a valid zip file"), errors.New("not a valid zip file")},
+			succeeds: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var tmp *os.File
+			defer func() {
+				if tmp == nil {
+					return
+				}
+
+				tmp.Close()
+			}()
+
+			tries := 0
+			get := func() (string, *zipFile, error) {
+				var err error
+				tmp, err = ioutil.TempFile("", "")
+				if err != nil {
+					t.Fatalf("TempFile(%v)", err)
+				}
+
+				err = test.errs[tries]
+				var zf *zipFile
+				if err == nil {
+					zf = &zipFile{}
+				}
+				tries++
+				return tmp.Name(), zf, err
+			}
+
+			zf, err := getZipFileWithRetry(get)
+			if test.succeeds && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if test.succeeds && zf == nil {
+				t.Error("expected a zip file; got nil")
+			}
+		})
+	}
+}

--- a/dev/corrupt-archives/main.go
+++ b/dev/corrupt-archives/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func corruptArchives(dir string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	archives := []os.FileInfo{}
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".zip") {
+			archives = append(archives, f)
+		}
+	}
+
+	for _, f := range archives {
+		if err := corruptArchive(filepath.Join(dir, f.Name()), f.Size()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func corruptArchive(path string, size int64) error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open err: %v", err)
+	}
+	defer file.Close()
+
+	err = file.Truncate(size / 2)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write([]byte(strings.Repeat("corrupt", 100)))
+
+	return err
+}
+
+func main() {
+	if err := corruptArchives(os.Args[len(os.Args)-1]); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR handles corrupted searcher archives by removing the bad zip and retrying. It's unclear why archives would ever be corrupt in the first place so this is only a partial solution. Closes https://github.com/sourcegraph/sourcegraph/issues/1759.

Test plan: Added a test for retry logic.

To manually test:
1. Run a local sourcegraph with `dev/launch.sh` and add some repositories
2. Ensure there are searcher archives by running a search like `index:no test`.
3. Run `go run ./dev/corrupt-archives/main.go /tmp/searcher-archives` to corrupt the archives
4. Execute the search again. You should see search results appear as expected
