### PR TITLE
No default project query

### DIFF
--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -197,7 +197,6 @@ export const GITHUB_EXTERNAL_SERVICE: ExternalServiceKindMetadata = {
   // An array of strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.
   // See the repositoryQuery documentation at https://docs.sourcegraph.com/admin/external_service/github#configuration for details.
   "repositoryQuery": [
-      "none"
   ]
 }`,
 }
@@ -281,7 +280,6 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
   // Here's the official Bitbucket Server documentation about which query string parameters are valid:
   // https://docs.atlassian.com/bitbucket-server/rest/6.1.2/bitbucket-rest.html#idp355
   "repositoryQuery": [
-      "none"
   ]
 }`,
         editorActions: [
@@ -362,7 +360,6 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
   // An array of strings specifying GitLab project search queries to mirror on Sourcegraph.
   // See the projectQuery documentation at https://docs.sourcegraph.com/admin/external_service/gitlab#configuration for details.
   "projectQuery": [
-      "none"
   ]
 }`,
         editorActions: [


### PR DESCRIPTION
Why do we have a default project query? I just setup a new instance and forgot to configure this and no repos showed up. In the expected case a user needs to configure repositoryQuery, so I propose removing the "none" default so that it isn't possible to create a new external service without configuring repositoryQuery.