### PR TITLE
docs: edit this page button and page nav now on mobile devices and other fixes

### DIFF
--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -525,9 +525,6 @@
     padding-bottom: 0.3em;
     font-size: 2em;
     border-bottom: 1px solid #eaecef;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .markdown-body h2 {

--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -2,21 +2,17 @@
 .virtual-br::before {
     content: '\A';
 }
-
 .pre-wrap {
     white-space: pre-wrap;
 }
-
 .text-center {
     text-align: center;
 }
-
 .truncate {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
-
 .markdown-body {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
@@ -28,34 +24,32 @@
     tab-size: 2;
     width: 100%;
 }
-
+a:active,
+a:hover {
+    outline-width: 0;
+    box-shadow: none;
+}
 .markdown-body .pl-c {
     color: #6a737d;
 }
-
 .markdown-body .pl-c1,
 .markdown-body .pl-s .pl-v {
     color: #005cc5;
 }
-
 .markdown-body .pl-e,
 .markdown-body .pl-en {
     color: #6f42c1;
 }
-
 .markdown-body .pl-smi,
 .markdown-body .pl-s .pl-s1 {
     color: #24292e;
 }
-
 .markdown-body .pl-ent {
     color: #22863a;
 }
-
 .markdown-body .pl-k {
     color: #d73a49;
 }
-
 .markdown-body .pl-s,
 .markdown-body .pl-pds,
 .markdown-body .pl-s .pl-pse .pl-s1,
@@ -65,167 +59,129 @@
 .markdown-body .pl-sr .pl-sra {
     color: #032f62;
 }
-
 .markdown-body .pl-v,
 .markdown-body .pl-smw {
     color: #e36209;
 }
-
 .markdown-body .pl-bu {
     color: #b31d28;
 }
-
 .markdown-body .pl-ii {
     color: #fafbfc;
     background-color: #b31d28;
 }
-
 .markdown-body .pl-c2 {
     color: #fafbfc;
     background-color: #d73a49;
 }
-
 .markdown-body .pl-c2::before {
     content: '^M';
 }
-
 .markdown-body .pl-sr .pl-cce {
     font-weight: bold;
     color: #22863a;
 }
-
 .markdown-body .pl-ml {
     color: #735c0f;
 }
-
 .markdown-body .pl-mh,
 .markdown-body .pl-mh .pl-en,
 .markdown-body .pl-ms {
     font-weight: bold;
     color: #005cc5;
 }
-
 .markdown-body .pl-mi {
     font-style: italic;
     color: #24292e;
 }
-
 .markdown-body .pl-mb {
     font-weight: bold;
     color: #24292e;
 }
-
 .markdown-body .pl-md {
     color: #b31d28;
     background-color: #ffeef0;
 }
-
 .markdown-body .pl-mi1 {
     color: #22863a;
     background-color: #f0fff4;
 }
-
 .markdown-body .pl-mc {
     color: #e36209;
     background-color: #ffebda;
 }
-
 .markdown-body .pl-mi2 {
     color: #f6f8fa;
     background-color: #005cc5;
 }
-
 .markdown-body .pl-mdr {
     font-weight: bold;
     color: #6f42c1;
 }
-
 .markdown-body .pl-ba {
     color: #586069;
 }
-
 .markdown-body .pl-sg {
     color: #959da5;
 }
-
 .markdown-body .pl-corl {
     text-decoration: underline;
     color: #032f62;
 }
-
 .markdown-body .octicon {
     display: inline-block;
     vertical-align: text-top;
     fill: currentColor;
 }
-
 .markdown-body a {
     background-color: transparent;
 }
-
-.markdown-body a:active,
-.markdown-body a:hover {
-    outline-width: 0;
-}
-
 .markdown-body strong {
     font-weight: inherit;
 }
-
 .markdown-body strong {
     font-weight: bolder;
 }
-
 .markdown-body h1 {
     font-size: 2em;
     margin: 0.67em 0;
 }
-
 .markdown-body img {
     border-style: none;
 }
-
 .markdown-body code,
 .markdown-body kbd,
 .markdown-body pre {
     font-family: monospace, monospace;
     font-size: 1em;
 }
-
 .markdown-body hr {
     box-sizing: content-box;
     height: 0;
     overflow: visible;
 }
-
 .markdown-body input {
     font: inherit;
     margin: 0;
 }
-
 .markdown-body input {
     overflow: visible;
 }
-
 .markdown-body [type='checkbox'] {
     box-sizing: border-box;
     padding: 0;
 }
-
 .markdown-body * {
     box-sizing: border-box;
 }
-
 .markdown-body input {
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
 }
-
 .markdown-body strong {
     font-weight: 600;
 }
-
 .markdown-body hr {
     height: 0;
     margin: 15px 0;
@@ -234,18 +190,15 @@
     border: 0;
     border-bottom: 1px solid #dfe2e5;
 }
-
 .markdown-body hr::before {
     display: table;
     content: '';
 }
-
 .markdown-body hr::after {
     display: table;
     clear: both;
     content: '';
 }
-
 .markdown-body table {
     word-wrap: break-word;
     table-layout: fixed;
@@ -253,12 +206,10 @@
     border-spacing: 0;
     border-collapse: collapse;
 }
-
 .markdown-body td,
 .markdown-body th {
     padding: 0;
 }
-
 .markdown-body h1,
 .markdown-body h2,
 .markdown-body h3,
@@ -268,69 +219,56 @@
     margin-top: 0;
     margin-bottom: 0;
 }
-
 .markdown-body h1 {
     font-size: 32px;
     font-weight: 600;
 }
-
 .markdown-body h2 {
     font-size: 24px;
     font-weight: 600;
 }
-
 .markdown-body h3 {
     font-size: 20px;
     font-weight: 600;
 }
-
 .markdown-body h4 {
     font-size: 16px;
     font-weight: 600;
 }
-
 .markdown-body h5 {
     font-size: 14px;
     font-weight: 600;
 }
-
 .markdown-body h6 {
     font-size: 12px;
     font-weight: 600;
 }
-
 .markdown-body p {
     margin-top: 0;
     margin-bottom: 10px;
 }
-
 .markdown-body blockquote {
     margin: 0;
 }
-
 .markdown-body ul,
 .markdown-body ol {
     padding-left: 0;
     margin-top: 0;
     margin-bottom: 0;
 }
-
 .markdown-body ol ol,
 .markdown-body ul ol {
     list-style-type: lower-roman;
 }
-
 .markdown-body ul ul ol,
 .markdown-body ul ol ol,
 .markdown-body ol ul ol,
 .markdown-body ol ol ol {
     list-style-type: lower-alpha;
 }
-
 .markdown-body dd {
     margin-left: 0;
 }
-
 .markdown-body code {
     font-family: 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
     font-size: 12px;
@@ -344,68 +282,53 @@
     font-family: 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
     font-size: 12px;
 }
-
 .markdown-body .octicon {
     vertical-align: text-bottom;
 }
-
 .markdown-body .pl-0 {
     padding-left: 0 !important;
 }
-
 .markdown-body .pl-1 {
     padding-left: 4px !important;
 }
-
 .markdown-body .pl-2 {
     padding-left: 8px !important;
 }
-
 .markdown-body .pl-3 {
     padding-left: 16px !important;
 }
-
 .markdown-body .pl-4 {
     padding-left: 24px !important;
 }
-
 .markdown-body .pl-5 {
     padding-left: 32px !important;
 }
-
 .markdown-body .pl-6 {
     padding-left: 40px !important;
 }
-
 .markdown-body::before {
     display: table;
     content: '';
 }
-
 .markdown-body::after {
     display: table;
     clear: both;
     content: '';
 }
-
 .markdown-body > *:first-child {
     margin-top: 0 !important;
 }
-
 .markdown-body > *:last-child {
     margin-bottom: 0 !important;
 }
-
 .markdown-body a:not([href]) {
     color: inherit;
     text-decoration: none;
 }
-
 .markdown-body .anchor {
     position: relative;
     opacity: 0;
 }
-
 .markdown-body .anchor::before {
     content: '#';
     position: absolute;
@@ -423,11 +346,9 @@
         top: -26px;
     }
 }
-
 .markdown-body .anchor:focus {
     outline: none;
 }
-
 .markdown-body p,
 .markdown-body blockquote,
 .markdown-body ul,
@@ -438,7 +359,6 @@
     margin-top: 0;
     margin-bottom: 16px;
 }
-
 .markdown-body hr {
     height: 0.25em;
     padding: 0;
@@ -446,21 +366,17 @@
     background-color: #e1e4e8;
     border: 0;
 }
-
 .markdown-body blockquote {
     padding: 0 1em;
     color: #6a737d;
     border-left: 0.25em solid #dfe2e5;
 }
-
 .markdown-body blockquote > :first-child {
     margin-top: 0;
 }
-
 .markdown-body blockquote > :last-child {
     margin-bottom: 0;
 }
-
 .markdown-body aside {
     padding: 0.65em 0.9em 0.55em;
     margin-bottom: 1em;
@@ -484,7 +400,6 @@
     background-color: #fcf8e3;
     color: #70572b;
 }
-
 .markdown-body kbd {
     display: inline-block;
     padding: 3px 5px;
@@ -498,7 +413,6 @@
     border-radius: 3px;
     box-shadow: inset 0 -1px 0 #959da5;
 }
-
 .markdown-body h1,
 .markdown-body h2,
 .markdown-body h3,
@@ -510,7 +424,6 @@
     font-weight: 500;
     line-height: 1.25;
 }
-
 .markdown-body h1:hover .anchor,
 .markdown-body h2:hover .anchor,
 .markdown-body h3:hover .anchor,
@@ -520,41 +433,33 @@
     text-decoration: none;
     opacity: 1;
 }
-
 .markdown-body h1 {
     padding-bottom: 0.3em;
     font-size: 2em;
     border-bottom: 1px solid #eaecef;
 }
-
 .markdown-body h2 {
     padding-bottom: 0.3em;
     font-size: 1.5em;
     border-bottom: 1px solid #eaecef;
 }
-
 .markdown-body h3 {
     font-size: 1.25em;
 }
-
 .markdown-body h4 {
     font-size: 1em;
 }
-
 .markdown-body h5 {
     font-size: 0.875em;
 }
-
 .markdown-body h6 {
     font-size: 0.85em;
     color: #6a737d;
 }
-
 .markdown-body ul,
 .markdown-body ol {
     padding-left: 2em;
 }
-
 .markdown-body ul ul,
 .markdown-body ul ol,
 .markdown-body ol ol,
@@ -562,23 +467,18 @@
     margin-top: 0;
     margin-bottom: 0;
 }
-
 .markdown-body li {
     word-wrap: break-all;
 }
-
 .markdown-body li > p {
     margin-top: 16px;
 }
-
 .markdown-body li + li {
     margin-top: 0.25em;
 }
-
 .markdown-body dl {
     padding: 0;
 }
-
 .markdown-body dl dt {
     padding: 0;
     margin-top: 16px;
@@ -586,51 +486,40 @@
     font-style: italic;
     font-weight: 600;
 }
-
 .markdown-body dl dd {
     padding: 0 16px;
     margin-bottom: 16px;
 }
-
 .markdown-body table {
     display: block;
     width: 100%;
     overflow: auto;
 }
-
 .markdown-body table th {
     font-weight: 600;
 }
-
 .markdown-body table th,
 .markdown-body table td {
     padding: 6px 13px;
     border: 1px solid #dfe2e5;
 }
-
 .markdown-body table tr {
     background-color: #fff;
     border-top: 1px solid #c6cbd1;
 }
-
 .markdown-body table tr:nth-child(2n) {
     background-color: #f6f8fa;
 }
-
 .markdown-body img {
     max-width: 100%;
-    box-sizing: content-box;
     background-color: #fff;
 }
-
 .markdown-body img[align='right'] {
     padding-left: 20px;
 }
-
 .markdown-body img[align='left'] {
     padding-right: 20px;
 }
-
 .markdown-body code {
     padding: 0.2em 0.4em;
     margin: 0;
@@ -638,15 +527,12 @@
     background-color: rgba(27, 31, 35, 0.05);
     border-radius: 3px;
 }
-
 .markdown-body pre {
     word-wrap: normal;
 }
-
 .markdown-body .pre-wrap pre {
     white-space: pre-wrap !important;
 }
-
 .markdown-body pre > code {
     padding: 0;
     margin: 0;
@@ -656,16 +542,13 @@
     background: transparent;
     border: 0;
 }
-
 .markdown-body .highlight {
     margin-bottom: 16px;
 }
-
 .markdown-body .highlight pre {
     margin-bottom: 0;
     word-break: normal;
 }
-
 .markdown-body .highlight pre,
 .markdown-body pre {
     padding: 16px;
@@ -675,7 +558,6 @@
     background-color: #e4e9f1 !important;
     border-radius: 3px;
 }
-
 .markdown-body pre code {
     display: inline;
     max-width: auto;
@@ -687,7 +569,6 @@
     background-color: transparent;
     border: 0;
 }
-
 .markdown-body kbd {
     display: inline-block;
     padding: 3px 5px;
@@ -701,11 +582,9 @@
     border-radius: 3px;
     box-shadow: inset 0 -1px 0 #c6cbd1;
 }
-
 .markdown-body hr {
     border-bottom-color: #eee;
 }
-
 /*
 
 Visibility classes:

--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -1,18 +1,3 @@
-/* Prevent header from covering hash tag links */
-/* This prevents the header from being covered by the nav bar when loading hash links */
-h1::before,
-h2::before,
-h3::before,
-h4::before,
-h5::before {
-    display: block;
-    content: ' ';
-    margin-top: -90px;
-    height: 90px;
-    visibility: hidden;
-    pointer-events: none;
-}
-
 /* Line break that is only visible, but not copy-pasted. Used for terminal commands. */
 .virtual-br::before {
     content: '\A';
@@ -24,6 +9,12 @@ h5::before {
 
 .text-center {
     text-align: center;
+}
+
+.truncate {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .markdown-body {
@@ -534,6 +525,9 @@ h5::before {
     padding-bottom: 0.3em;
     font-size: 2em;
     border-bottom: 1px solid #eaecef;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .markdown-body h2 {

--- a/doc/_resources/assets/docs.js
+++ b/doc/_resources/assets/docs.js
@@ -89,6 +89,9 @@ window.sgdocs = (() => {
     document.querySelectorAll('button.content-nav-button').forEach(el => {
       el.addEventListener('click', e => e.srcElement.closest('.content-nav-section').classList.toggle('expanded'))
     })
+
+    // TODO(ryan): Link titles should be auto-generated
+    document.querySelectorAll('.content-nav a').forEach(el => (el.title = el.text.trim()))
   }
 
   function breadcrumbsInit() {

--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -765,16 +765,13 @@ li.content-nav-no-hover:hover {
         position: relative;
         top: 135px;
         border-bottom: 1px solid #eaeaea;
-        padding: 1rem;
+        padding: 1rem 1rem 135px;
     }
     #home .page-nav {
         top: 135px;
     }
-    .docs-content-section {
-        top: 135px;
-        /* padding: 8rem 1rem 2rem; */
-    }
 }
+
 /* Footer */
 /* Code pulled from about.sourcegraph.com footer */
 /* This sound not be modified */
@@ -1006,7 +1003,7 @@ li.content-nav-no-hover:hover {
 }
 /* Mobile devices with notch support. This must use a px value to compare sizes */
 @supports (padding: max(0px)) {
-    .footer__block {.
+    .footer__block {
         padding-left: max(0px, env(safe-area-inset-left));
         padding-right: max(0px, env(safe-area-inset-right));
     }

--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -626,10 +626,12 @@ li.content-nav-no-hover:hover {
 .page-nav > ul li::before {
     content: '\203A\00a0';
 }
+/* Docs Content layout */
 .docs-content {
+    position: relative;
+    width: 100%;
     min-height: 100vh;
 }
-
 .docs-content-section {
     padding: 0 1rem 2rem;
 }
@@ -1004,7 +1006,7 @@ li.content-nav-no-hover:hover {
 }
 /* Mobile devices with notch support. This must use a px value to compare sizes */
 @supports (padding: max(0px)) {
-    .footer__block {
+    .footer__block {.
         padding-left: max(0px, env(safe-area-inset-left));
         padding-right: max(0px, env(safe-area-inset-right));
     }

--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -18,7 +18,6 @@ body {
     margin: auto;
     max-width: 980px;
 }
-
 /* Create non-flexbox grid system for docs */
 .column {
     box-sizing: border-box;
@@ -174,7 +173,6 @@ body {
         width: 8.33333%;
     }
 }
-
 .flex-container {
     display: flex;
     display: flex;
@@ -183,7 +181,6 @@ body {
     justify-content: between;
     height: 100%;
 }
-
 /* Global Nav Layout */
 
 .global-navbar {
@@ -214,7 +211,6 @@ body {
         padding-right: max(1rem, env(safe-area-inset-right));
     }
 }
-
 .nav-header {
     padding-top: 0.4rem;
     padding-bottom: 0.4rem;
@@ -271,7 +267,6 @@ body {
     float: left;
     list-style: none;
 }
-
 .nav-state,
 .mobile-nav-button {
     display: none;
@@ -303,7 +298,6 @@ body {
 a:active .current-branch {
     border: 1.5px solid #ffffff;
 }
-
 /* Nav iOS */
 
 @media screen and (max-width: 1020px) {
@@ -323,6 +317,10 @@ a:active .current-branch {
         background-repeat: no-repeat;
         background-position: center;
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%23babcbe' d='M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z' /%3E%3C/svg%3E");
+    }
+    input[type='checkbox'].nav-state:hover,
+    .mobile-nav-button:hover {
+        cursor: pointer;
     }
     /* devices with notch support */
     @supports (right: max(1rem)) {
@@ -430,15 +428,10 @@ a:active .current-branch {
         margin-right: 0;
     }
 }
-
-/* Wrapper for nav components */
-
 .nav-sticky-wrapper {
     height: 100%;
     position: absolute;
 }
-
-/* Content (Left Hand) Nav */
 .content-nav {
     position: -webkit-sticky;
     position: sticky;
@@ -453,7 +446,6 @@ a:active .current-branch {
     padding-top: 4px;
     overflow-scrolling: touch;
 }
-
 .content-nav-section {
     list-style: none;
     padding-left: 0;
@@ -464,11 +456,16 @@ a:active .current-branch {
 .content-nav-section li {
     list-style: none;
 }
+.content-nav-section .close--icon + li {
+    padding-right: 17px;
+}
 .content-nav-section li a {
     transition: all 200ms ease;
     color: #405377;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
-
 .content-nav-section li a:hover {
     text-decoration: none;
     color: #242e42;
@@ -480,9 +477,6 @@ a:active .current-branch {
 }
 .content-nav > ul:first-of-type {
     border-top: none;
-}
-.content-nav > ul:nth-of-type(2) {
-    /* border-top: none; */
 }
 .content-nav > ul ul {
     padding-left: 0;
@@ -496,8 +490,6 @@ a.content-nav-section-header {
     font-size: 15px;
     font-weight: 500;
     color: #242e42 !important;
-}
-.content-nav-section-header:first-of-type {
 }
 .content-nav-section-group {
     line-height: normal;
@@ -599,43 +591,24 @@ li.content-nav-no-hover:hover {
     right: 0;
     position: absolute;
 }
-
 /* Page (Right Hand) Nav */
-
 .page-nav {
-    position: -webkit-sticky;
-    position: sticky;
-    top: 45px;
-    padding-left: 14px;
-    padding-right: 8px;
+    position: fixed;
+    right: 0;
+    top: 135px;
     padding-bottom: 2rem;
 }
+/* Because there is no breadcrumb trail */
 #home .page-nav {
-    top: 16px;
+    top: 106px;
 }
 .page-nav-title {
-    width: 100%;
-    display: block;
     border-bottom: 1px solid #eaeaea;
 }
-.nav-edit-button {
-    display: inline-block;
-}
-.nav-edit-button svg {
-    display: inline-block;
-    margin-bottom: 6px;
-}
-
-.page-nav-wrapper {
+.content-nav-wrapper {
     border-right: 1px solid #eaecee;
     padding-left: env(safe-area-inset-left);
 }
-
-.page-nav {
-    font-size: 90%;
-    line-height: 24px;
-}
-
 /* These ul styles are copied to https://github.com/sourcegraph/sourcegraph DocSitePage.scss. They should be kept in sync. */
 .page-nav > ul {
     padding-left: var(--spacing);
@@ -647,13 +620,12 @@ li.content-nav-no-hover:hover {
     list-style: none;
     line-height: normal;
     padding-left: 10px;
-    text-indent: -13px;
+    text-indent: -11px;
     padding-top: 8px;
 }
 .page-nav > ul li::before {
     content: '\203A\00a0';
 }
-
 /* Docs Content layout */
 .docs-content {
     width: 100%;
@@ -674,10 +646,8 @@ li.content-nav-no-hover:hover {
     }
 }
 .docs-content-section {
-    padding: 0 1rem;
-    padding-bottom: 2rem;
+    padding: 0 1rem 2rem;
 }
-
 /* Docs breadcrumbs */
 .breadcrumbs {
     margin-top: 84px;
@@ -688,20 +658,17 @@ li.content-nav-no-hover:hover {
     color: inherit;
     opacity: 0.8;
 }
-
 .content-nav-mobile-checkbox,
 .content-nav-mobile-button {
     display: none;
 }
-
 @media screen and (max-width: 768px) {
-    .page-nav-wrapper {
+    .content-nav-wrapper {
         border: none;
     }
     /* Give space at bottom of div for breadcrumbs */
     .docs-content-section .markdown-body {
-        padding-bottom: 1rem;
-        padding-top: 9rem;
+        padding: 1rem 0;
     }
     .mobile-search {
         margin: 1rem 0 0;
@@ -723,7 +690,6 @@ li.content-nav-no-hover:hover {
         border: 1px solid #eaeaea;
         box-shadow: 0 0 12px 4px rgba(0, 0, 0, 0.1);
     }
-
     .breadcrumb-links {
         margin-left: 42px;
         display: block;
@@ -757,7 +723,7 @@ li.content-nav-no-hover:hover {
         width: 46px;
         height: 100%;
     }
-    .page-nav-wrapper {
+    .content-nav-wrapper {
         display: none;
     }
     .content-nav {
@@ -777,7 +743,7 @@ li.content-nav-no-hover:hover {
     .content-nav.mobile-show > ul:last-of-type {
         margin-bottom: 5rem;
     }
-    .page-nav-wrapper {
+    .content-nav-wrapper {
         z-index: 99;
         display: block;
         /**
@@ -797,7 +763,7 @@ li.content-nav-no-hover:hover {
         left: 1rem;
         right: 1rem;
     }
-    .page-nav-wrapper.mobile-show .content-nav {
+    .content-nav-wrapper.mobile-show .content-nav {
         padding-left: 20px;
         padding-right: 20px;
     }
@@ -808,8 +774,20 @@ li.content-nav-no-hover:hover {
     .content-nav-section:nth-of-type(2) {
         border-top: 1px solid #eaeaea !important;
     }
+    .page-nav {
+        position: relative;
+        top: 135px;
+        border-bottom: 1px solid #eaeaea;
+        padding: 1rem;
+    }
+    #home .page-nav {
+        top: 135px;
+    }
+    .docs-content-section {
+        top: 135px;
+        /* padding: 8rem 1rem 2rem; */
+    }
 }
-
 /* Footer */
 /* Code pulled from about.sourcegraph.com footer */
 /* This sound not be modified */
@@ -823,62 +801,50 @@ li.content-nav-no-hover:hover {
     flex: 1 0 auto;
     max-width: 1140px;
 }
-
 .footer__block {
     background: #151c28;
     color: #7a8fb8;
     padding: 4rem 0 1rem 0;
     overflow: hidden;
 }
-
 .footer__block .small__contact {
     padding-top: 1.5rem;
     margin-bottom: -2rem;
 }
-
 @media screen and (min-width: 768px) {
     .footer__block .small__contact {
         display: none;
     }
 }
-
 .footer__block .logo__section a {
     color: #afbcd4;
 }
-
 .footer__block .logo__section .footer__logo {
     padding: 0 0 1.25rem 0;
     margin: 0 0 0 -8px;
 }
-
 @media screen and (max-width: 768px) {
     .footer__block .logo__section {
         padding-bottom: 0.2rem;
         margin-top: -2.5rem;
     }
-
     .footer__block .logo__section .footer__contact {
         display: none;
     }
 }
-
 .footer__block .footer__extend {
     transition: all 0.3s ease-in-out;
 }
-
 .footer__block .footer__extend * {
     transition: all 0.3s ease-in-out;
 }
-
 .footer__block .footer__extend h3 {
     cursor: pointer;
 }
-
 .footer__block .footer__extend ul {
     overflow: hidden;
     padding-left: 0;
 }
-
 @media screen and (max-width: 768px) {
     .footer__block .footer__extend ul li {
         transition: all 0.3s ease-in-out;
@@ -887,24 +853,20 @@ li.content-nav-no-hover:hover {
         overflow: hidden;
     }
 }
-
 @media screen and (min-width: 768px) {
     .footer__block .footer__extend input,
     .footer__block .footer__extend .close--icon {
         display: none;
     }
 }
-
 @media screen and (max-width: 768px) {
     .footer__block .footer__extend {
         padding-top: 6px;
         border-top: solid 1px #7a8fb8;
     }
-
     .footer__block .footer__extend:last-of-type {
         border-bottom: solid 1px #7a8fb8;
     }
-
     .footer__block .footer__extend.community .close--icon,
     .footer__block .footer__extend.company .close--icon,
     .footer__block .footer__extend.features .close--icon,
@@ -918,7 +880,6 @@ li.content-nav-no-hover:hover {
         transform: rotate(-45deg);
         transform: rotate(-45deg);
     }
-
     .footer__block .footer__extend.community .close--icon svg,
     .footer__block .footer__extend.company .close--icon svg,
     .footer__block .footer__extend.features .close--icon svg,
@@ -926,21 +887,18 @@ li.content-nav-no-hover:hover {
         height: 18px;
         width: 18px;
     }
-
     .footer__block .footer__extend.community .close--icon svg path,
     .footer__block .footer__extend.company .close--icon svg path,
     .footer__block .footer__extend.features .close--icon svg path,
     .footer__block .footer__extend.resources .close--icon svg path {
         fill: #7a8fb8;
     }
-
     .footer__block .footer__extend.community li:last-child,
     .footer__block .footer__extend.company li:last-child,
     .footer__block .footer__extend.features li:last-child,
     .footer__block .footer__extend.resources li:last-child {
         padding-bottom: 0.5rem;
     }
-
     .footer__block .footer__extend.community input,
     .footer__block .footer__extend.company input,
     .footer__block .footer__extend.features input,
@@ -953,7 +911,6 @@ li.content-nav-no-hover:hover {
         cursor: pointer;
         z-index: 9999;
     }
-
     .footer__block .footer__extend.community input + ul,
     .footer__block .footer__extend.company input + ul,
     .footer__block .footer__extend.features input + ul,
@@ -962,7 +919,6 @@ li.content-nav-no-hover:hover {
         height: 0px;
         padding: 0;
     }
-
     .footer__block .footer__extend.community input:checked + ul,
     .footer__block .footer__extend.company input:checked + ul,
     .footer__block .footer__extend.features input:checked + ul,
@@ -970,7 +926,6 @@ li.content-nav-no-hover:hover {
         display: block;
         height: auto;
     }
-
     .footer__block .footer__extend.community input:checked + ul li,
     .footer__block .footer__extend.company input:checked + ul li,
     .footer__block .footer__extend.features input:checked + ul li,
@@ -979,7 +934,6 @@ li.content-nav-no-hover:hover {
         display: block;
         top: 0px;
     }
-
     .footer__block .footer__extend.community input:checked ~ .close--icon,
     .footer__block .footer__extend.company input:checked ~ .close--icon,
     .footer__block .footer__extend.features input:checked ~ .close--icon,
@@ -988,98 +942,78 @@ li.content-nav-no-hover:hover {
         transform: rotate(0deg);
     }
 }
-
 .footer__block .social__column .icon {
     margin-left: 1rem;
 }
-
 .footer__block .social__column .icon svg path {
     fill: #566e9f;
 }
-
 .footer__block .social__column .icon:hover svg path {
     fill: #0e121b;
 }
-
 .footer__block .social__column img,
 .footer__block .social__column .btn {
     margin-bottom: 1rem;
 }
-
 .footer__block .social__column .copyright {
     color: #566e9f;
 }
-
 .footer__block h3 {
     text-transform: uppercase;
     font-weight: 600;
     font-size: 1rem;
     letter-spacing: 0.1rem;
 }
-
 .footer__block ul {
     color: #afbcd4;
     margin: 0;
     list-style: none;
 }
-
 .footer__block ul li {
     margin-bottom: 0.5rem;
 }
-
 .footer__block ul li a {
     color: #afbcd4;
 }
-
 .footer__block ul li a:hover {
     color: #f2f4f8;
     text-decoration: underline;
 }
-
 .footer__block .copyright__container {
     margin: 3rem 0 0 0;
     padding-top: 1rem;
     border-top: 2px solid #405377;
 }
-
 .footer__block .copyright__container .copyright {
     float: left;
 }
-
 @media screen and (max-width: 768px) {
     .footer__block .copyright__container .copyright {
         float: none;
     }
 }
-
 .footer__block .copyright__container .terms {
     float: right;
 }
-
 .footer__block .copyright__container .terms a {
     margin-left: 2rem;
 }
-
 @media screen and (max-width: 768px) {
     .footer__block .copyright__container .terms {
         float: none;
     }
-
     .footer__block .copyright__container .terms a:first-of-type {
         margin-left: 0rem;
     }
 }
-
 .align-footer {
     align-content: flex-end !important;
 }
-
 @media screen and (max-width: 992px) {
     .align-footer {
         padding-top: 2rem;
     }
 }
-
 .align-footer * {
     align-self: center;
 }
@@ -1090,7 +1024,6 @@ li.content-nav-no-hover:hover {
         padding-right: max(0px, env(safe-area-inset-right));
     }
 }
-
 /* Helpers */
 /* Display helpers that should be loaded last */
 @media screen and (max-width: 768px) {

--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -626,25 +626,10 @@ li.content-nav-no-hover:hover {
 .page-nav > ul li::before {
     content: '\203A\00a0';
 }
-/* Docs Content layout */
 .docs-content {
-    width: 100%;
-    /*
-		Set min height of content to viewport height minus the footer.
-		This prevents small pages from having footer above bottom of page.
-	 */
-    min-height: calc(100vh - 340px);
-    position: relative;
+    min-height: 100vh;
 }
-@media screen and (max-width: 1020px) {
-    .docs-content {
-        /*
-			Set min height of content to viewport height on mobile
-			This prevents small pages from having footer above bottom of page.
-		 */
-        min-height: 100vh;
-    }
-}
+
 .docs-content-section {
     padding: 0 1rem 2rem;
 }

--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -54,27 +54,27 @@
             </div>
         </div>
         <div class="docs-content">
-            <div class="nav-sticky-wrapper page-nav-wrapper column large-2 medium-3 mobile-show">
-                <!-- Mobile breadcrumb nav -->
+            <div class="nav-sticky-wrapper content-nav-wrapper column large-2 medium-3 mobile-show">
                 <nav id="breadcrumbs-mobile" class="breadcrumbs large-hidden medium-hidden">
                     <input type="button" class="content-nav-mobile-state large-hidden medium-hidden" />
                     <span class="content-nav-mobile-button"></span>
                     <span class="breadcrumb-links">
-                        {{with .Content}}
+                    {{with .Content}}
                         {{if eq (len .Breadcrumbs ) 0}}<a href="#">Home</a>{{end}}
-                        {{range .Breadcrumbs}}
-                        <a href="{{.URL}}" {{if .IsActive}} class="active" {{end}}>{{.Label}}</a>
-                        {{if not .IsActive}}/{{end}}
-                        {{end}} &nbsp;
-                        {{else}}
-                            {{if .ContentVersionNotFoundError}}
+                            {{range .Breadcrumbs}}
+                                <a href="{{.URL}}" {{if .IsActive}} class="active" {{end}}>{{.Label}}</a>
+                                {{if not .IsActive}}/{{end}}
+                                {{end}}
+                                &nbsp;
+                            {{else}}
+                        {{if .ContentVersionNotFoundError}}
                             Version not found
-                            {{else if .ContentPageNotFoundError}}
-                                Page not found
-                                {{else}}
-                                    Error
-                                    {{end}}
-                                    {{end}}
+                        {{else if .ContentPageNotFoundError}}
+                            Page not found
+                        {{else}}
+                            Error
+                        {{end}}
+                    {{end}}
                     </span>
                 </nav>
                 <div id="content-nav" class="content-nav">
@@ -85,7 +85,6 @@
                     <ul class="content-nav-section expandable">
                         <li><a class="content-nav-section-header" href="/">Home</a></li>
                     </ul>
-                    <!-- NAV START -->
                     <ul class="content-nav-section expandable" data-nav-section="user">
                         <button class="content-nav-button"></button>
                         <div class="close--icon">
@@ -302,10 +301,6 @@
                             </ul>
                         </li>
                     </ul>
-
-
-
-
                     <ul class="content-nav-section expandable" data-nav-section="dev">
                         <button class="content-nav-button"></button>
                         <div class="close--icon">
@@ -375,11 +370,14 @@
                             </ul>
                         </li>
                     </ul>
-                    <!-- NAV END -->
-
                 </div>
             </div>
-            <section class="column large-7 large-push-2 medium-9 medium-push-3 small-12 docs-content-section">
+            {{with .Content}}
+            <div class="page-nav column large-3 medium-3 small-12">
+                {{template "index" .}}
+            </div>
+            {{end}}
+            <section class="column large-7 large-push-2 medium-6 medium-push-3 small-12 docs-content-section">
                 {{/* Create breadcrumb nav*/}}
                 {{with .Content}}
 
@@ -417,15 +415,8 @@
                 </div>
                 {{end}}
             </section>
-            {{with .Content}}
-            <div class="nav-sticky-wrapper column large-3 medium-hidden small-hidden">
-                <div class="page-nav">
-                    {{template "index" .}}
-                </div>
-            </div>
-            {{end}}
         </div>
-        {{/* Sourcegraph.com Footer - Do not modify */}}
+        {{/* Keep up-to-date with Sourcegraph.com */}}
         <div class="footer-container column large-12">
             <div class="footer__block">
                 <footer>
@@ -533,24 +524,26 @@
         <h3 class="page-nav-title">On this page:</h3>
         <ul>{{template "doc_nav" .}}</ul>
     {{end}}
-    <a class="nav-edit-button" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">
-        Edit this page on GitHub
-        <svg class="icon-inline small" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V12H19V19Z"></path>
-        </svg>
-    </a>
+    <a class="nav-edit-button btn btn-secondary" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">Edit this page on GitHub</a>
 {{end}}
 
-{{/* Define Page Nav Template*/}}
-    {{define "doc_nav"}}
-        {{range .}}
+{{define "doc_nav"}}
+    {{range .}}
+        <li>
+            <a href="{{.URL}}">{{.Title}}</a>
+        </li>
+    {{end}}
+{{end}}
+
+{{define "doc_nav_nested"}}
+    {{range .}}
         <li>
             <a href="{{.URL}}">{{.Title}}</a>
             {{with .Children}}
-            <ul>
-                {{template "doc_nav" .}}
-            </ul>
+                <ul>
+                    {{template "doc_nav" .}}
+                </ul>
+            {{end}}
         </li>
-        {{end}}
     {{end}}
 {{end}}


### PR DESCRIPTION
  - Content nav top level link text is now truncated instead of displaying under `+` icon
  - "Edit this page on GitHub" and page outline is now visible on tablet and mobile devices
  - Previously, page nav links were nested. Now, it's only the top level (h2) headings.
  - Edit "Edit this page on GitHub" anchor is now styled like a button
  - Hamburger menu has pointer cursor on hover

![ScreenFlow](https://user-images.githubusercontent.com/133014/56625795-cfd7de80-65f3-11e9-8fe0-5c15d9c69fe3.gif)

Fixes #3562, and #3575

Preview latest commits at http://newdocs.sgdev.org:5080