### PR TITLE
Move zip retrieval retries into pkg/store

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -196,7 +196,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		return path, zf, err
 	}
 
-	zf, err := store.GetZipFileWithRetry(getZf)
+	_, zf, err := store.GetZipFileWithRetry(getZf)
 	if err != nil {
 		return nil, false, false, err
 	}

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -196,7 +196,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		return path, zf, err
 	}
 
-	zf, err := getZipFileWithRetry(getZf)
+	zf, err := store.GetZipFileWithRetry(getZf)
 	if err != nil {
 		return nil, false, false, err
 	}

--- a/pkg/store/retry.go
+++ b/pkg/store/retry.go
@@ -1,15 +1,13 @@
-package search
+package store
 
 import (
 	"os"
 	"strings"
-
-	"github.com/sourcegraph/sourcegraph/pkg/store"
 )
 
-// getZipFileWithRetry retries getting a zip file if the zip is for some reason
+// GetZipFileWithRetry retries getting a zip file if the zip is for some reason
 // invalid.
-func getZipFileWithRetry(get func() (string, *store.ZipFile, error)) (zf *store.ZipFile, err error) {
+func GetZipFileWithRetry(get func() (string, *ZipFile, error)) (zf *ZipFile, err error) {
 	var path string
 	tries := 0
 	for zf == nil {

--- a/pkg/store/retry.go
+++ b/pkg/store/retry.go
@@ -7,7 +7,7 @@ import (
 
 // GetZipFileWithRetry retries getting a zip file if the zip is for some reason
 // invalid.
-func GetZipFileWithRetry(get func() (string, *ZipFile, error)) (zf *ZipFile, err error) {
+func GetZipFileWithRetry(get func() (string, *ZipFile, error)) (validPath string, zf *ZipFile, err error) {
 	var path string
 	tries := 0
 	for zf == nil {
@@ -16,16 +16,16 @@ func GetZipFileWithRetry(get func() (string, *ZipFile, error)) (zf *ZipFile, err
 			if tries < 2 && strings.Contains(err.Error(), "not a valid zip file") {
 				err = os.Remove(path)
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				tries++
 				if tries == 2 {
-					return nil, err
+					return "", nil, err
 				}
 				continue
 			}
-			return nil, err
+			return "", nil, err
 		}
 	}
-	return zf, nil
+	return path, zf, nil
 }

--- a/pkg/store/retry_test.go
+++ b/pkg/store/retry_test.go
@@ -1,4 +1,4 @@
-package search
+package store
 
 import (
 	"io/ioutil"
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/pkg/store"
 )
 
 func TestGetZipFileWithRetry(t *testing.T) {
@@ -49,7 +48,7 @@ func TestGetZipFileWithRetry(t *testing.T) {
 			}()
 
 			tries := 0
-			get := func() (string, *store.ZipFile, error) {
+			get := func() (string, *ZipFile, error) {
 				var err error
 				tmp, err = ioutil.TempFile("", "")
 				if err != nil {
@@ -57,15 +56,15 @@ func TestGetZipFileWithRetry(t *testing.T) {
 				}
 
 				err = test.errs[tries]
-				var zf *store.ZipFile
+				var zf *ZipFile
 				if err == nil {
-					zf = &store.ZipFile{}
+					zf = &ZipFile{}
 				}
 				tries++
 				return tmp.Name(), zf, err
 			}
 
-			zf, err := getZipFileWithRetry(get)
+			zf, err := GetZipFileWithRetry(get)
 			if test.succeeds && err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/store/retry_test.go
+++ b/pkg/store/retry_test.go
@@ -64,7 +64,7 @@ func TestGetZipFileWithRetry(t *testing.T) {
 				return tmp.Name(), zf, err
 			}
 
-			zf, err := GetZipFileWithRetry(get)
+			_, zf, err := GetZipFileWithRetry(get)
 			if test.succeeds && err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
Going to need this recent retry logic for replacer too...

Test plan: None, moving a reusable component to package.
