### PR TITLE
repo-updater: Don't record Phabricator body and form

### DIFF
--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -615,6 +615,14 @@ func newRecorder(t testing.TB, file string, record bool) *recorder.Recorder {
 		} {
 			i.Response.Headers.Del(name)
 		}
+
+		// Phabricator requests include a token in the form and body.
+		ua := i.Request.Headers.Get("User-Agent")
+		if strings.Contains(strings.ToLower(ua), "phabricator") {
+			i.Request.Body = ""
+			i.Request.Form = nil
+		}
+
 		return nil
 	})
 

--- a/cmd/repo-updater/repos/testdata/sources/phabricator.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/phabricator.yaml
@@ -2,15 +2,13 @@
 version: 1
 interactions:
 - request:
-    body: output=json&params=%7B%7D
-    form:
-      output:
-      - json
-      params:
-      - '{}'
+    body: ""
+    form: {}
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
+      User-Agent:
+      - sourcegraph/phabricator-client
     url: https://secure.phabricator.com/api/conduit.getcapabilities
     method: POST
   response:
@@ -28,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Apr 2019 14:16:06 GMT
+      - Wed, 24 Apr 2019 15:07:50 GMT
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       Referrer-Policy:
@@ -47,15 +45,13 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: output=json&params=%7B%22__conduit__%22%3A%7B%22token%22%3A%22api-w3ztmvqblkspxmanu4urlwz3d5sd%22%7D%2C%22limit%22%3A100%2C%22order%22%3A%22oldest%22%2C%22attachments%22%3A%7B%22uris%22%3Atrue%7D%7D
-    form:
-      output:
-      - json
-      params:
-      - '{"__conduit__":{"token":"api-w3ztmvqblkspxmanu4urlwz3d5sd"},"limit":100,"order":"oldest","attachments":{"uris":true}}'
+    body: ""
+    form: {}
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
+      User-Agent:
+      - sourcegraph/phabricator-client
     url: https://secure.phabricator.com/api/diffusion.repository.search
     method: POST
   response:
@@ -76,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Apr 2019 14:16:06 GMT
+      - Wed, 24 Apr 2019 15:07:50 GMT
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       Referrer-Policy:

--- a/pkg/extsvc/phabricator/client.go
+++ b/pkg/extsvc/phabricator/client.go
@@ -27,7 +27,7 @@ type Client struct {
 func NewClient(ctx context.Context, url, token string, cli httpcli.Doer) (*Client, error) {
 	conn, err := gonduit.DialContext(ctx, url, &core.ClientOptions{
 		APIToken: token,
-		Client:   cli,
+		Client:   httpcli.HeadersMiddleware("User-Agent", "sourcegraph/phabricator-client")(cli),
 	})
 
 	if err != nil {

--- a/pkg/httpcli/client.go
+++ b/pkg/httpcli/client.go
@@ -89,6 +89,22 @@ func NewFactory(stack Middleware, common ...Opt) Factory {
 // Common Middleware
 //
 
+// HeadersMiddleware returns a middleware that wraps a Doer
+// and sets the given headers.
+func HeadersMiddleware(headers ...string) Middleware {
+	if len(headers)%2 != 0 {
+		panic("missing header values")
+	}
+	return func(cli Doer) Doer {
+		return DoerFunc(func(req *http.Request) (*http.Response, error) {
+			for i := 0; i < len(headers); i += 2 {
+				req.Header.Add(headers[i], headers[i+1])
+			}
+			return cli.Do(req)
+		})
+	}
+}
+
 // ContextErrorMiddleware wraps a Doer with context.Context error
 // handling.  It checks if the request context is done, and if so,
 // returns its error. Otherwise it returns the error from the inner


### PR DESCRIPTION
This commit excludes Phabricator requests body and form from VCR
recordings in the source tests. This slipped through before. The token
that was checked-in has been revoked. There's no risk since it had
access to only public data in https://secure.phabricator.com/

Part of #3490