### PR TITLE
repo-updater: BitbucketServerUsernameMigration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Removes corrupted archives in the searcher cache and tries to populate the cache again instead of returning an error.
-- The required `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration), if unset or empty, is automatically set to the user part of the `url` (if defined).
+- The required `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration), if unset or empty, is automatically migrated to match the user part of the `url` (if defined).
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Removes corrupted archives in the searcher cache and tries to populate the cache again instead of returning an error.
 - The required `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration), if unset or empty, is automatically migrated to match the user part of the `url` (if defined).
-- The required `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration), if unset or empty, is automatically set to the user part of the `url` (if defined).
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Removes corrupted archives in the searcher cache and tries to populate the cache again instead of returning an error.
+- The required `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration), if unset or empty, is automatically set to the user part of the `url` (if defined).
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Removes corrupted archives in the searcher cache and tries to populate the cache again instead of returning an error.
 - The required `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration), if unset or empty, is automatically migrated to match the user part of the `url` (if defined).
+- The required `bitbucketserver.username` field of a [Bitbucket Server external service configuration](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration), if unset or empty, is automatically set to the user part of the `url` (if defined).
 
 ## 3.3.1
 

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -96,6 +96,7 @@ func main() {
 	migrations := []repos.Migration{
 		repos.GithubSetDefaultRepositoryQueryMigration(clock),
 		repos.GitLabSetDefaultProjectQueryMigration(clock),
+		repos.BitbucketServerUsernameMigration(clock), // Needs to run before EnabledStateDeprecationMigration
 		repos.BitbucketServerSetDefaultRepositoryQueryMigration(clock),
 	}
 

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -54,8 +54,12 @@ func TestIntegration(t *testing.T) {
 		{"Syncer/Sync", testSyncerSync(store)},
 		{"Migrations/GithubSetDefaultRepositoryQuery",
 			testGithubSetDefaultRepositoryQueryMigration(store)},
-		{"Migrations/GitLabSetDefaultProjectQueryMigration",
+		{"Migrations/GitLabSetDefaultProjectQuery",
 			testGitLabSetDefaultProjectQueryMigration(store)},
+		{"Migrations/BitbucketServerSetDefaultRepositoryQuery",
+			testBitbucketServerSetDefaultRepositoryQueryMigration(store)},
+		{"Migrations/BitbucketServerUsername",
+			testBitbucketServerUsernameMigration(store)},
 		{"Migrations/EnabledStateDeprecationMigration",
 			testEnabledStateDeprecationMigration(store)},
 	} {

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -689,6 +689,134 @@ func testBitbucketServerSetDefaultRepositoryQueryMigration(store repos.Store) fu
 	}
 }
 
+func TestBitbucketServerUsernameMigration(t *testing.T) {
+	t.Parallel()
+	testBitbucketServerUsernameMigration(new(repos.FakeStore))(t)
+}
+
+func testBitbucketServerUsernameMigration(store repos.Store) func(*testing.T) {
+	bitbucketsrv := repos.ExternalService{
+		Kind:        "BITBUCKETSERVER",
+		DisplayName: "BitbucketServer - Test",
+		Config: formatJSON(`
+			{
+				// Some comment
+				"url": "https://admin@bitbucketserver.mycorp.com",
+				"token": "secret"
+			}
+		`),
+	}
+
+	bitbucketsrvNoUsername := repos.ExternalService{
+		Kind:        "BITBUCKETSERVER",
+		DisplayName: "BitbucketServer - Test",
+		Config: formatJSON(`
+			{
+				// Some comment
+				"url": "https://bitbucketserver.mycorp.com",
+				"token": "secret"
+			}
+		`),
+	}
+
+	bitbucketsrvWithUsername := repos.ExternalService{
+		Kind:        "BITBUCKETSERVER",
+		DisplayName: "BitbucketServer - Test",
+		Config: formatJSON(`
+			{
+				// Some comment
+				"url": "https://bitbucketserver.mycorp.com",
+				"username": "admin",
+				"token": "secret",
+			}
+		`),
+	}
+
+	gitlab := repos.ExternalService{
+		Kind:        "GITLAB",
+		DisplayName: "Gitlab - Test",
+		Config:      formatJSON(`{"url": "https://gitlab.com"}`),
+	}
+
+	clock := repos.NewFakeClock(time.Now(), 0)
+
+	return func(t *testing.T) {
+		t.Helper()
+
+		for _, tc := range []struct {
+			name   string
+			stored repos.ExternalServices
+			assert repos.ExternalServicesAssertion
+			err    string
+		}{
+			{
+				name:   "no external services",
+				stored: repos.ExternalServices{},
+				assert: repos.Assert.ExternalServicesEqual(),
+				err:    "<nil>",
+			},
+			{
+				name:   "non-bitbucketserver services are left unchanged",
+				stored: repos.ExternalServices{&gitlab},
+				assert: repos.Assert.ExternalServicesEqual(&gitlab),
+				err:    "<nil>",
+			},
+			{
+				name:   "bitbucketserver services with username set are left unchanged",
+				stored: repos.ExternalServices{&bitbucketsrvWithUsername},
+				assert: repos.Assert.ExternalServicesEqual(&bitbucketsrvWithUsername),
+				err:    "<nil>",
+			},
+			{
+				name:   "bitbucketserver services without username in url are left unchanged",
+				stored: repos.ExternalServices{&bitbucketsrvNoUsername},
+				assert: repos.Assert.ExternalServicesEqual(&bitbucketsrvNoUsername),
+				err:    "<nil>",
+			},
+			{
+				name:   "bitbucketserver services without username are migrated",
+				stored: repos.ExternalServices{&bitbucketsrv},
+				assert: repos.Assert.ExternalServicesEqual(
+					bitbucketsrv.With(
+						repos.Opt.ExternalServiceModifiedAt(clock.Time(0)),
+						func(e *repos.ExternalService) {
+							var err error
+							e.Config, err = jsonc.Edit(e.Config, "admin", "username")
+							if err != nil {
+								panic(err)
+							}
+						},
+					),
+				),
+				err: "<nil>",
+			},
+		} {
+			tc := tc
+			ctx := context.Background()
+
+			t.Run(tc.name, transact(ctx, store, func(t testing.TB, tx repos.Store) {
+				if err := tx.UpsertExternalServices(ctx, tc.stored.Clone()...); err != nil {
+					t.Fatalf("failed to prepare store: %v", err)
+				}
+
+				err := repos.BitbucketServerUsernameMigration(clock.Now).Run(ctx, tx)
+				if have, want := fmt.Sprint(err), tc.err; have != want {
+					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
+				}
+
+				es, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if tc.assert != nil {
+					tc.assert(t, es)
+				}
+			}))
+		}
+
+	}
+}
 func formatJSON(s string) string {
 	formatted, err := jsonc.Format(s, true, 2)
 	if err != nil {


### PR DESCRIPTION
This commit implements a best effort migration that extracts the
username from the `url` field of Bitbucket Server external service
configurations and sets in the `username` field if missing or empty.

The `username` field became required in #3299 because it was always
actually required for things to fuction properly.

If there are configs without the `username` field set not the `user`
part of the `url` set, the admins will need to intervene to fix their
configs manually.

Fixes #3592
