### PR TITLE
pkg/ratelimit: Support Retry-After abuse headers

### DIFF
--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -186,7 +186,7 @@ var gitLabRepositorySyncWorker = &worker{
 		for _, c := range gitlabConnections {
 			go func(c *gitlabConnection) {
 				for {
-					if rateLimitRemaining, rateLimitReset, ok := c.client.RateLimit.Get(); ok && rateLimitRemaining < 50 {
+					if rateLimitRemaining, rateLimitReset, _, ok := c.client.RateLimit.Get(); ok && rateLimitRemaining < 50 {
 						wait := rateLimitReset + 10*time.Second
 						log15.Warn("GitLab API rate limit is almost exhausted. Waiting until rate limit is reset.", "wait", rateLimitReset, "rateLimitRemaining", rateLimitRemaining)
 						time.Sleep(wait)


### PR DESCRIPTION
This commit adds support for `Retry-After` abuse headers to the
`ratelimit.Monitor` type we use in both GitHub and GitLab API clients
and repo-updater Sources.

Part of #3582
