### PR TITLE
update sourcegraph/zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20190116094554-8aa57bd35909
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20190116094554-c742ce874aa3
 	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20180929065141-c790ffc3c46a
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -607,8 +607,8 @@ github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614 h1:MrlKMpoGse4bC
 github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/sourcegraph/zoekt v0.0.0-20190116094554-8aa57bd35909 h1:Kvw5NnG2luRcCU9TRdb0WILvqp09kHrzyRhtIOQ6hEg=
-github.com/sourcegraph/zoekt v0.0.0-20190116094554-8aa57bd35909/go.mod h1:WvXuHA1Bqi7FB9mKYXuvR2Tj27E6EsP/kZydqx7Vzts=
+github.com/sourcegraph/zoekt v0.0.0-20190116094554-c742ce874aa3 h1:vAUL5cXaRT43gdK4LStxgvS5gfVJSrEDgQ+VbrxgmzU=
+github.com/sourcegraph/zoekt v0.0.0-20190116094554-c742ce874aa3/go.mod h1:WvXuHA1Bqi7FB9mKYXuvR2Tj27E6EsP/kZydqx7Vzts=
 github.com/spf13/afero v1.1.0 h1:bopulORc2JeYaxfHLvJa5NzxviA9PoWhpiiJkru7Ji4=
 github.com/spf13/afero v1.1.0/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.2.0 h1:HHl1DSRbEQN2i8tJmtS6ViPyHx35+p51amrdsiTCrkg=


### PR DESCRIPTION
Pulls in changes from sourcegraph/zoekt. The changes add an option for allowing a list of files to be indexed regardless of their size and ensures the index for a repository gets updated when the whitelist changes. Officially closes #1624.