### PR TITLE
Handle changed GitHub DOM

### DIFF
--- a/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
+++ b/client/browser/src/libs/code_intelligence/code_intelligence_test_utils.ts
@@ -135,27 +135,33 @@ export function testDOMFunctions(
         })
         describe('getCodeElementFromLineNumber()', () => {
             for (const { getElement, diffPart, lineNumber } of codeElements) {
-                test(`diffPart: ${diffPart}`, () => {
-                    const codeView = getCodeView()
-                    const element = getElement()
-                    expect(domFunctions.getCodeElementFromLineNumber(codeView, lineNumber, diffPart)).toBe(element)
+                describe(`diffPart: ${diffPart}`, () => {
+                    it('should return the right element', () => {
+                        const codeView = getCodeView()
+                        const element = getElement()
+                        expect(domFunctions.getCodeElementFromLineNumber(codeView, lineNumber, diffPart)).toBe(element)
+                    })
                 })
             }
         })
         describe('getLineNumberFromCodeElement()', () => {
             for (const { getElement, diffPart, lineNumber } of codeElements) {
-                test(`diffPart: ${diffPart}`, () => {
-                    const element = getElement()
-                    expect(domFunctions.getLineNumberFromCodeElement(element)).toBe(lineNumber)
+                describe(`diffPart: ${diffPart}`, () => {
+                    it('should return a number', () => {
+                        const element = getElement()
+                        expect(domFunctions.getLineNumberFromCodeElement(element)).toBe(lineNumber)
+                    })
                 })
             }
         })
         if (domFunctions.getDiffCodePart) {
             describe('getDiffCodePart()', () => {
                 for (const { getElement, diffPart } of codeElements) {
-                    test(`diffPart: ${diffPart}`, () => {
-                        const element = getElement()
-                        expect(domFunctions.getDiffCodePart!(element)).toBe(diffPart)
+                    describe(`diffPart: ${diffPart}`, () => {
+                        it('should return the right diff part for an element', () => {
+                            const element = getElement()
+                            expect(domFunctions.getDiffCodePart!(element)).toBe(diffPart)
+                        })
                     })
                 }
             })
@@ -163,9 +169,13 @@ export function testDOMFunctions(
         if (domFunctions.isFirstCharacterDiffIndicator) {
             describe('isFirstCharacterDiffIndicator()', () => {
                 for (const { getElement, diffPart } of codeElements) {
-                    test(`diffPart: ${diffPart}`, () => {
-                        const element = getElement()
-                        expect(domFunctions.isFirstCharacterDiffIndicator!(element)).toBe(firstCharacterIsDiffIndicator)
+                    describe(`diffPart: ${diffPart}`, () => {
+                        it('should return correctly whether the first character is a diff indicator', () => {
+                            const element = getElement()
+                            expect(domFunctions.isFirstCharacterDiffIndicator!(element)).toBe(
+                                firstCharacterIsDiffIndicator
+                            )
+                        })
                     })
                 }
             })

--- a/client/browser/src/libs/github/__fixtures__/ghe-2.14.11/blob/refined-github/code-view.html
+++ b/client/browser/src/libs/github/__fixtures__/ghe-2.14.11/blob/refined-github/code-view.html
@@ -1,259 +1,515 @@
 <div class="file">
     <div class="file-header">
-  <div class="file-actions">
+        <div class="file-actions">
+            <div class="BtnGroup">
+                <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/beyang/mux/raw/master/bench_test.go">Raw</a>
+                <a
+                    class="btn btn-sm js-update-url-with-hash BtnGroup-item"
+                    data-hotkey="b"
+                    href="/beyang/mux/blame/master/bench_test.go"
+                    >Blame</a
+                >
+                <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/beyang/mux/commits/master/bench_test.go"
+                    >History</a
+                >
+            </div>
 
-    <div class="BtnGroup">
-      <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/beyang/mux/raw/master/bench_test.go">Raw</a>
-        <a class="btn btn-sm js-update-url-with-hash BtnGroup-item" data-hotkey="b" href="/beyang/mux/blame/master/bench_test.go">Blame</a>
-      <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/beyang/mux/commits/master/bench_test.go">History</a>
+            <a
+                class="btn-octicon tooltipped tooltipped-nw"
+                href="https://desktop.github.com"
+                aria-label="Open this file in GitHub Desktop"
+                data-ga-click="Repository, open with desktop, type:mac"
+            >
+                <svg
+                    class="octicon octicon-device-desktop"
+                    viewBox="0 0 16 16"
+                    version="1.1"
+                    width="16"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
+                    ></path>
+                </svg>
+            </a>
+
+            <!-- '"` --><!-- </textarea></xmp> -->
+            <form
+                class="inline-form js-update-url-with-hash"
+                action="/beyang/mux/edit/master/bench_test.go"
+                accept-charset="UTF-8"
+                method="post"
+            >
+                <input name="utf8" type="hidden" value="✓" /><input
+                    type="hidden"
+                    name="authenticity_token"
+                    value="y0JZdkjDeGuuQuVZA0Nu9OGAPtmGLAwqqPQ7RrItPtBh6VjIef0aKiSnO5aYYEToVt5JSEF9Vsu2J5jGuUNJ3w=="
+                />
+                <button
+                    class="btn-octicon tooltipped tooltipped-nw"
+                    type="submit"
+                    aria-label="Edit this file"
+                    data-hotkey="e"
+                    data-disable-with=""
+                >
+                    <svg
+                        class="octicon octicon-pencil"
+                        viewBox="0 0 14 16"
+                        version="1.1"
+                        width="14"
+                        height="16"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
+                        ></path>
+                    </svg>
+                </button>
+            </form>
+            <!-- '"` --><!-- </textarea></xmp> -->
+            <form
+                class="inline-form"
+                action="/beyang/mux/delete/master/bench_test.go"
+                accept-charset="UTF-8"
+                method="post"
+            >
+                <input name="utf8" type="hidden" value="✓" /><input
+                    type="hidden"
+                    name="authenticity_token"
+                    value="HVBVvrnUcdDNodjRZ48UP2aw19IVI0NrXE4zOe342iJhG0T/8Uy5iMCEVgJEOoc5z2CqddYjILfbRuZkvvIREA=="
+                />
+                <button
+                    class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw"
+                    type="submit"
+                    aria-label="Delete this file"
+                    data-disable-with=""
+                >
+                    <svg
+                        class="octicon octicon-trashcan"
+                        viewBox="0 0 12 16"
+                        version="1.1"
+                        width="12"
+                        height="16"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                        ></path>
+                    </svg>
+                </button>
+            </form>
+        </div>
+
+        <div class="file-info">
+            50 lines (41 sloc)
+            <span class="file-info-divider"></span>
+            1.37 KB
+        </div>
     </div>
 
-        <a class="btn-octicon tooltipped tooltipped-nw" href="https://desktop.github.com" aria-label="Open this file in GitHub Desktop" data-ga-click="Repository, open with desktop, type:mac">
-            <svg class="octicon octicon-device-desktop" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"></path></svg>
-        </a>
+    <div itemprop="text" class="blob-wrapper data type-go">
+        <table class="highlight tab-size js-file-line-container" data-tab-size="8">
+            <tbody>
+                <tr>
+                    <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
+                    <td id="LC1" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-c"
+                            ><span class="pl-c">//</span> Copyright 2012 The Gorilla Authors. All rights reserved.</span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
+                    <td id="LC2" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-c"
+                            ><span class="pl-c">//</span> Use of this source code is governed by a BSD-style</span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
+                    <td id="LC3" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-c"
+                            ><span class="pl-c">//</span> license that can be found in the LICENSE file.</span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
+                    <td id="LC4" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L5" class="blob-num js-line-number" data-line-number="5"></td>
+                    <td id="LC5" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">package</span> mux
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L6" class="blob-num js-line-number" data-line-number="6"></td>
+                    <td id="LC6" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L7" class="blob-num js-line-number" data-line-number="7"></td>
+                    <td id="LC7" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> (</td>
+                </tr>
+                <tr>
+                    <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
+                    <td id="LC8" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-s"><span class="pl-pds">"</span>net/http<span class="pl-pds">"</span></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
+                    <td id="LC9" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-s"
+                            ><span class="pl-pds">"</span>net/http/httptest<span class="pl-pds">"</span></span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
+                    <td id="LC10" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-s"><span class="pl-pds">"</span>testing<span class="pl-pds">"</span></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
+                    <td id="LC11" class="blob-code blob-code-inner js-file-line">)</td>
+                </tr>
+                <tr>
+                    <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
+                    <td id="LC12" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
+                    <td id="LC13" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">func</span> <span class="pl-en">BenchmarkMux</span>(<span class="pl-v"
+                            >b</span
+                        >
+                        *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
+                    <td id="LC14" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">router</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">new</span>(Router)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
+                    <td id="LC15" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">handler</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span
+                            class="pl-smi"
+                            >Request</span
+                        >) {}
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
+                    <td id="LC16" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>/v1/{v1}<span class="pl-pds">"</span></span
+                        >, handler)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
+                    <td id="LC17" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
+                    <td id="LC18" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">request</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >,
+                        <span class="pl-s"><span class="pl-pds">"</span>/v1/anything<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
+                    <td id="LC19" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
+                    <td id="LC20" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, request)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
+                    <td id="LC21" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
+                    <td id="LC22" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
+                    <td id="LC23" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
+                    <td id="LC24" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">func</span> <span class="pl-en">BenchmarkMuxAlternativeInRegexp</span>(<span
+                            class="pl-v"
+                            >b</span
+                        >
+                        *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
+                    <td id="LC25" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">router</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">new</span>(Router)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
+                    <td id="LC26" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">handler</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span
+                            class="pl-smi"
+                            >Request</span
+                        >) {}
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
+                    <td id="LC27" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>/v1/{v1:(?:a|b)}<span class="pl-pds">"</span></span
+                        >, handler)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
+                    <td id="LC28" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
+                    <td id="LC29" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">requestA</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >, <span class="pl-s"><span class="pl-pds">"</span>/v1/a<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
+                    <td id="LC30" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">requestB</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >, <span class="pl-s"><span class="pl-pds">"</span>/v1/b<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
+                    <td id="LC31" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
+                    <td id="LC32" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestA)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
+                    <td id="LC33" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestB)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
+                    <td id="LC34" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
+                    <td id="LC35" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
+                    <td id="LC36" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
+                    <td id="LC37" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">func</span> <span class="pl-en">BenchmarkManyPathVariables</span>(<span
+                            class="pl-v"
+                            >b</span
+                        >
+                        *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
+                    <td id="LC38" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">router</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">new</span>(Router)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
+                    <td id="LC39" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">handler</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span
+                            class="pl-smi"
+                            >Request</span
+                        >) {}
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
+                    <td id="LC40" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>/v1/{v1}/{v2}/{v3}/{v4}/{v5}<span class="pl-pds"
+                                >"</span
+                            ></span
+                        >, handler)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
+                    <td id="LC41" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
+                    <td id="LC42" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">matchingRequest</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >,
+                        <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4/5<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
+                    <td id="LC43" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">notMatchingRequest</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >,
+                        <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
+                    <td id="LC44" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">recorder</span> <span class="pl-k">:=</span> httptest.<span class="pl-c1"
+                            >NewRecorder</span
+                        >()
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
+                    <td id="LC45" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
+                    <td id="LC46" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, matchingRequest)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L47" class="blob-num js-line-number" data-line-number="47"></td>
+                    <td id="LC47" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(recorder, notMatchingRequest)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L48" class="blob-num js-line-number" data-line-number="48"></td>
+                    <td id="LC48" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L49" class="blob-num js-line-number" data-line-number="49"></td>
+                    <td id="LC49" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+            </tbody>
+        </table>
 
-          <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-update-url-with-hash" action="/beyang/mux/edit/master/bench_test.go" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="y0JZdkjDeGuuQuVZA0Nu9OGAPtmGLAwqqPQ7RrItPtBh6VjIef0aKiSnO5aYYEToVt5JSEF9Vsu2J5jGuUNJ3w==">
-            <button class="btn-octicon tooltipped tooltipped-nw" type="submit" aria-label="Edit this file" data-hotkey="e" data-disable-with="">
-              <svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"></path></svg>
+        <div
+            class="BlobToolbar position-absolute js-file-line-actions dropdown js-menu-container js-select-menu d-none"
+            aria-hidden="true"
+        >
+            <button
+                class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1 dropdown-toggle js-menu-target"
+                type="button"
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Inline file action toolbar"
+                aria-controls="inline-file-actions"
+            >
+                <svg
+                    class="octicon octicon-kebab-horizontal"
+                    viewBox="0 0 13 16"
+                    version="1.1"
+                    width="13"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                    ></path>
+                </svg>
             </button>
-</form>
-        <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form" action="/beyang/mux/delete/master/bench_test.go" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="HVBVvrnUcdDNodjRZ48UP2aw19IVI0NrXE4zOe342iJhG0T/8Uy5iMCEVgJEOoc5z2CqddYjILfbRuZkvvIREA==">
-          <button class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw" type="submit" aria-label="Delete this file" data-disable-with="">
-            <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"></path></svg>
-          </button>
-</form>  </div>
-
-  <div class="file-info">
-      50 lines (41 sloc)
-      <span class="file-info-divider"></span>
-    1.37 KB
-  </div>
-</div>
-
-    
-
-  <div itemprop="text" class="blob-wrapper data type-go">
-      <table class="highlight tab-size js-file-line-container" data-tab-size="8">
-      <tbody><tr>
-        <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
-        <td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> Copyright 2012 The Gorilla Authors. All rights reserved.</span></td>
-      </tr>
-      <tr>
-        <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
-        <td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> Use of this source code is governed by a BSD-style</span></td>
-      </tr>
-      <tr>
-        <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
-        <td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> license that can be found in the LICENSE file.</span></td>
-      </tr>
-      <tr>
-        <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
-        <td id="LC4" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L5" class="blob-num js-line-number" data-line-number="5"></td>
-        <td id="LC5" class="blob-code blob-code-inner js-file-line"><span class="pl-k">package</span> mux</td>
-      </tr>
-      <tr>
-        <td id="L6" class="blob-num js-line-number" data-line-number="6"></td>
-        <td id="LC6" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L7" class="blob-num js-line-number" data-line-number="7"></td>
-        <td id="LC7" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> (</td>
-      </tr>
-      <tr>
-        <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
-        <td id="LC8" class="blob-code blob-code-inner js-file-line">	<span class="pl-s"><span class="pl-pds">"</span>net/http<span class="pl-pds">"</span></span></td>
-      </tr>
-      <tr>
-        <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
-        <td id="LC9" class="blob-code blob-code-inner js-file-line">	<span class="pl-s"><span class="pl-pds">"</span>net/http/httptest<span class="pl-pds">"</span></span></td>
-      </tr>
-      <tr>
-        <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
-        <td id="LC10" class="blob-code blob-code-inner js-file-line">	<span class="pl-s"><span class="pl-pds">"</span>testing<span class="pl-pds">"</span></span></td>
-      </tr>
-      <tr>
-        <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
-        <td id="LC11" class="blob-code blob-code-inner js-file-line">)</td>
-      </tr>
-      <tr>
-        <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
-        <td id="LC12" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
-        <td id="LC13" class="blob-code blob-code-inner js-file-line"><span class="pl-k">func</span> <span class="pl-en">BenchmarkMux</span>(<span class="pl-v">b</span> *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {</td>
-      </tr>
-      <tr>
-        <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
-        <td id="LC14" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">router</span> <span class="pl-k">:=</span> <span class="pl-c1">new</span>(Router)</td>
-      </tr>
-      <tr>
-        <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
-        <td id="LC15" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">handler</span> <span class="pl-k">:=</span> <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span class="pl-smi">Request</span>) {}</td>
-      </tr>
-      <tr>
-        <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
-        <td id="LC16" class="blob-code blob-code-inner js-file-line">	router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"><span class="pl-pds">"</span>/v1/{v1}<span class="pl-pds">"</span></span>, handler)</td>
-      </tr>
-      <tr>
-        <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
-        <td id="LC17" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
-        <td id="LC18" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">request</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/anything<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
-        <td id="LC19" class="blob-code blob-code-inner js-file-line">	<span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span> <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {</td>
-      </tr>
-      <tr>
-        <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
-        <td id="LC20" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, request)</td>
-      </tr>
-      <tr>
-        <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
-        <td id="LC21" class="blob-code blob-code-inner js-file-line">	}</td>
-      </tr>
-      <tr>
-        <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
-        <td id="LC22" class="blob-code blob-code-inner js-file-line">}</td>
-      </tr>
-      <tr>
-        <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
-        <td id="LC23" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
-        <td id="LC24" class="blob-code blob-code-inner js-file-line"><span class="pl-k">func</span> <span class="pl-en">BenchmarkMuxAlternativeInRegexp</span>(<span class="pl-v">b</span> *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {</td>
-      </tr>
-      <tr>
-        <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
-        <td id="LC25" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">router</span> <span class="pl-k">:=</span> <span class="pl-c1">new</span>(Router)</td>
-      </tr>
-      <tr>
-        <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
-        <td id="LC26" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">handler</span> <span class="pl-k">:=</span> <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span class="pl-smi">Request</span>) {}</td>
-      </tr>
-      <tr>
-        <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
-        <td id="LC27" class="blob-code blob-code-inner js-file-line">	router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"><span class="pl-pds">"</span>/v1/{v1:(?:a|b)}<span class="pl-pds">"</span></span>, handler)</td>
-      </tr>
-      <tr>
-        <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
-        <td id="LC28" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
-        <td id="LC29" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">requestA</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/a<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
-        <td id="LC30" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">requestB</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/b<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
-        <td id="LC31" class="blob-code blob-code-inner js-file-line">	<span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span> <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {</td>
-      </tr>
-      <tr>
-        <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
-        <td id="LC32" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestA)</td>
-      </tr>
-      <tr>
-        <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
-        <td id="LC33" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestB)</td>
-      </tr>
-      <tr>
-        <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
-        <td id="LC34" class="blob-code blob-code-inner js-file-line">	}</td>
-      </tr>
-      <tr>
-        <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
-        <td id="LC35" class="blob-code blob-code-inner js-file-line">}</td>
-      </tr>
-      <tr>
-        <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
-        <td id="LC36" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
-        <td id="LC37" class="blob-code blob-code-inner js-file-line"><span class="pl-k">func</span> <span class="pl-en">BenchmarkManyPathVariables</span>(<span class="pl-v">b</span> *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {</td>
-      </tr>
-      <tr>
-        <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
-        <td id="LC38" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">router</span> <span class="pl-k">:=</span> <span class="pl-c1">new</span>(Router)</td>
-      </tr>
-      <tr>
-        <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
-        <td id="LC39" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">handler</span> <span class="pl-k">:=</span> <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span class="pl-smi">Request</span>) {}</td>
-      </tr>
-      <tr>
-        <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
-        <td id="LC40" class="blob-code blob-code-inner js-file-line">	router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"><span class="pl-pds">"</span>/v1/{v1}/{v2}/{v3}/{v4}/{v5}<span class="pl-pds">"</span></span>, handler)</td>
-      </tr>
-      <tr>
-        <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
-        <td id="LC41" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
-        <td id="LC42" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">matchingRequest</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4/5<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
-        <td id="LC43" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">notMatchingRequest</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
-        <td id="LC44" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">recorder</span> <span class="pl-k">:=</span> httptest.<span class="pl-c1">NewRecorder</span>()</td>
-      </tr>
-      <tr>
-        <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
-        <td id="LC45" class="blob-code blob-code-inner js-file-line">	<span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span> <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {</td>
-      </tr>
-      <tr>
-        <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
-        <td id="LC46" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, matchingRequest)</td>
-      </tr>
-      <tr>
-        <td id="L47" class="blob-num js-line-number" data-line-number="47"></td>
-        <td id="LC47" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(recorder, notMatchingRequest)</td>
-      </tr>
-      <tr>
-        <td id="L48" class="blob-num js-line-number" data-line-number="48"></td>
-        <td id="LC48" class="blob-code blob-code-inner js-file-line">	}</td>
-      </tr>
-      <tr>
-        <td id="L49" class="blob-num js-line-number" data-line-number="49"></td>
-        <td id="LC49" class="blob-code blob-code-inner js-file-line">}</td>
-      </tr>
-</tbody></table>
-
-  <div class="BlobToolbar position-absolute js-file-line-actions dropdown js-menu-container js-select-menu d-none" aria-hidden="true">
-    <button class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1 dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Inline file action toolbar" aria-controls="inline-file-actions">
-      <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-    </button>
-    <div class="dropdown-menu-content js-menu-content" id="inline-file-actions">
-      <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2">
-        <li><clipboard-copy class="dropdown-item" id="js-copy-lines" style="cursor:pointer;" data-original-text="Copy lines" tabindex="0" role="button">Copy lines</clipboard-copy></li>
-        <li><clipboard-copy class="dropdown-item" id="js-copy-permalink" style="cursor:pointer;" data-original-text="Copy permalink" tabindex="0" role="button">Copy permalink</clipboard-copy></li>
-        <li><a class="dropdown-item js-update-url-with-hash" id="js-view-git-blame" href="/beyang/mux/blame/058953caa945faa213f42789c5921a53f9135a5e/bench_test.go">View git blame</a></li>
-          <li><a class="dropdown-item" id="js-new-issue" href="/beyang/mux/issues/new">Open new issue</a></li>
-      </ul>
+            <div class="dropdown-menu-content js-menu-content" id="inline-file-actions">
+                <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2">
+                    <li>
+                        <clipboard-copy
+                            class="dropdown-item"
+                            id="js-copy-lines"
+                            style="cursor:pointer;"
+                            data-original-text="Copy lines"
+                            tabindex="0"
+                            role="button"
+                            >Copy lines</clipboard-copy
+                        >
+                    </li>
+                    <li>
+                        <clipboard-copy
+                            class="dropdown-item"
+                            id="js-copy-permalink"
+                            style="cursor:pointer;"
+                            data-original-text="Copy permalink"
+                            tabindex="0"
+                            role="button"
+                            >Copy permalink</clipboard-copy
+                        >
+                    </li>
+                    <li>
+                        <a
+                            class="dropdown-item js-update-url-with-hash"
+                            id="js-view-git-blame"
+                            href="/beyang/mux/blame/058953caa945faa213f42789c5921a53f9135a5e/bench_test.go"
+                            >View git blame</a
+                        >
+                    </li>
+                    <li><a class="dropdown-item" id="js-new-issue" href="/beyang/mux/issues/new">Open new issue</a></li>
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
-
-  </div>
-
-  </div>
+</div>

--- a/client/browser/src/libs/github/__fixtures__/ghe-2.14.11/blob/vanilla/code-view.html
+++ b/client/browser/src/libs/github/__fixtures__/ghe-2.14.11/blob/vanilla/code-view.html
@@ -1,259 +1,515 @@
 <div class="file">
     <div class="file-header">
-  <div class="file-actions">
+        <div class="file-actions">
+            <div class="BtnGroup">
+                <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/beyang/mux/raw/master/bench_test.go">Raw</a>
+                <a
+                    class="btn btn-sm js-update-url-with-hash BtnGroup-item"
+                    data-hotkey="b"
+                    href="/beyang/mux/blame/master/bench_test.go"
+                    >Blame</a
+                >
+                <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/beyang/mux/commits/master/bench_test.go"
+                    >History</a
+                >
+            </div>
 
-    <div class="BtnGroup">
-      <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/beyang/mux/raw/master/bench_test.go">Raw</a>
-        <a class="btn btn-sm js-update-url-with-hash BtnGroup-item" data-hotkey="b" href="/beyang/mux/blame/master/bench_test.go">Blame</a>
-      <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/beyang/mux/commits/master/bench_test.go">History</a>
+            <a
+                class="btn-octicon tooltipped tooltipped-nw"
+                href="https://desktop.github.com"
+                aria-label="Open this file in GitHub Desktop"
+                data-ga-click="Repository, open with desktop, type:mac"
+            >
+                <svg
+                    class="octicon octicon-device-desktop"
+                    viewBox="0 0 16 16"
+                    version="1.1"
+                    width="16"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
+                    ></path>
+                </svg>
+            </a>
+
+            <!-- '"` --><!-- </textarea></xmp> -->
+            <form
+                class="inline-form js-update-url-with-hash"
+                action="/beyang/mux/edit/master/bench_test.go"
+                accept-charset="UTF-8"
+                method="post"
+            >
+                <input name="utf8" type="hidden" value="✓" /><input
+                    type="hidden"
+                    name="authenticity_token"
+                    value="zhdlJEcKVLK4lerq+K4EdLAD6ez54Kh7jdG9vnpxh1JkvGSadjQ28zJwNCVjjS5oB12efT6x8pqTAh4+cR/wXQ=="
+                />
+                <button
+                    class="btn-octicon tooltipped tooltipped-nw"
+                    type="submit"
+                    aria-label="Edit this file"
+                    data-hotkey="e"
+                    data-disable-with=""
+                >
+                    <svg
+                        class="octicon octicon-pencil"
+                        viewBox="0 0 14 16"
+                        version="1.1"
+                        width="14"
+                        height="16"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
+                        ></path>
+                    </svg>
+                </button>
+            </form>
+            <!-- '"` --><!-- </textarea></xmp> -->
+            <form
+                class="inline-form"
+                action="/beyang/mux/delete/master/bench_test.go"
+                accept-charset="UTF-8"
+                method="post"
+            >
+                <input name="utf8" type="hidden" value="✓" /><input
+                    type="hidden"
+                    name="authenticity_token"
+                    value="NafwwuWTrDicmvVSaldfM5aV+CQvZNGqmJiYO0vE7n1J7OGDrQtkYJG/e4FJ4sw1P0WFg+xksnYfkE1mGM4lTw=="
+                />
+                <button
+                    class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw"
+                    type="submit"
+                    aria-label="Delete this file"
+                    data-disable-with=""
+                >
+                    <svg
+                        class="octicon octicon-trashcan"
+                        viewBox="0 0 12 16"
+                        version="1.1"
+                        width="12"
+                        height="16"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                        ></path>
+                    </svg>
+                </button>
+            </form>
+        </div>
+
+        <div class="file-info">
+            50 lines (41 sloc)
+            <span class="file-info-divider"></span>
+            1.37 KB
+        </div>
     </div>
 
-        <a class="btn-octicon tooltipped tooltipped-nw" href="https://desktop.github.com" aria-label="Open this file in GitHub Desktop" data-ga-click="Repository, open with desktop, type:mac">
-            <svg class="octicon octicon-device-desktop" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"></path></svg>
-        </a>
+    <div itemprop="text" class="blob-wrapper data type-go">
+        <table class="highlight tab-size js-file-line-container" data-tab-size="8">
+            <tbody>
+                <tr>
+                    <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
+                    <td id="LC1" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-c"
+                            ><span class="pl-c">//</span> Copyright 2012 The Gorilla Authors. All rights reserved.</span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
+                    <td id="LC2" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-c"
+                            ><span class="pl-c">//</span> Use of this source code is governed by a BSD-style</span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
+                    <td id="LC3" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-c"
+                            ><span class="pl-c">//</span> license that can be found in the LICENSE file.</span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
+                    <td id="LC4" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L5" class="blob-num js-line-number" data-line-number="5"></td>
+                    <td id="LC5" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">package</span> mux
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L6" class="blob-num js-line-number" data-line-number="6"></td>
+                    <td id="LC6" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L7" class="blob-num js-line-number" data-line-number="7"></td>
+                    <td id="LC7" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> (</td>
+                </tr>
+                <tr>
+                    <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
+                    <td id="LC8" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-s"><span class="pl-pds">"</span>net/http<span class="pl-pds">"</span></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
+                    <td id="LC9" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-s"
+                            ><span class="pl-pds">"</span>net/http/httptest<span class="pl-pds">"</span></span
+                        >
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
+                    <td id="LC10" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-s"><span class="pl-pds">"</span>testing<span class="pl-pds">"</span></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
+                    <td id="LC11" class="blob-code blob-code-inner js-file-line">)</td>
+                </tr>
+                <tr>
+                    <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
+                    <td id="LC12" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
+                    <td id="LC13" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">func</span> <span class="pl-en">BenchmarkMux</span>(<span class="pl-v"
+                            >b</span
+                        >
+                        *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
+                    <td id="LC14" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">router</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">new</span>(Router)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
+                    <td id="LC15" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">handler</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span
+                            class="pl-smi"
+                            >Request</span
+                        >) {}
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
+                    <td id="LC16" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>/v1/{v1}<span class="pl-pds">"</span></span
+                        >, handler)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
+                    <td id="LC17" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
+                    <td id="LC18" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">request</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >,
+                        <span class="pl-s"><span class="pl-pds">"</span>/v1/anything<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
+                    <td id="LC19" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
+                    <td id="LC20" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, request)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
+                    <td id="LC21" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
+                    <td id="LC22" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
+                    <td id="LC23" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
+                    <td id="LC24" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">func</span> <span class="pl-en">BenchmarkMuxAlternativeInRegexp</span>(<span
+                            class="pl-v"
+                            >b</span
+                        >
+                        *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
+                    <td id="LC25" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">router</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">new</span>(Router)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
+                    <td id="LC26" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">handler</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span
+                            class="pl-smi"
+                            >Request</span
+                        >) {}
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
+                    <td id="LC27" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>/v1/{v1:(?:a|b)}<span class="pl-pds">"</span></span
+                        >, handler)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
+                    <td id="LC28" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
+                    <td id="LC29" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">requestA</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >, <span class="pl-s"><span class="pl-pds">"</span>/v1/a<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
+                    <td id="LC30" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">requestB</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >, <span class="pl-s"><span class="pl-pds">"</span>/v1/b<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
+                    <td id="LC31" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
+                    <td id="LC32" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestA)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
+                    <td id="LC33" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestB)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
+                    <td id="LC34" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
+                    <td id="LC35" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
+                    <td id="LC36" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
+                    <td id="LC37" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">func</span> <span class="pl-en">BenchmarkManyPathVariables</span>(<span
+                            class="pl-v"
+                            >b</span
+                        >
+                        *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
+                    <td id="LC38" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">router</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">new</span>(Router)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
+                    <td id="LC39" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">handler</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span
+                            class="pl-smi"
+                            >Request</span
+                        >) {}
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
+                    <td id="LC40" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>/v1/{v1}/{v2}/{v3}/{v4}/{v5}<span class="pl-pds"
+                                >"</span
+                            ></span
+                        >, handler)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
+                    <td id="LC41" class="blob-code blob-code-inner js-file-line"></td>
+                </tr>
+                <tr>
+                    <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
+                    <td id="LC42" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">matchingRequest</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >,
+                        <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4/5<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
+                    <td id="LC43" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">notMatchingRequest</span>, <span class="pl-smi">_</span>
+                        <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"
+                            ><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span
+                        >,
+                        <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4<span class="pl-pds">"</span></span
+                        >, <span class="pl-c1">nil</span>)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
+                    <td id="LC44" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-smi">recorder</span> <span class="pl-k">:=</span> httptest.<span class="pl-c1"
+                            >NewRecorder</span
+                        >()
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
+                    <td id="LC45" class="blob-code blob-code-inner js-file-line">
+                        <span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span>
+                        <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
+                    <td id="LC46" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, matchingRequest)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L47" class="blob-num js-line-number" data-line-number="47"></td>
+                    <td id="LC47" class="blob-code blob-code-inner js-file-line">
+                        router.<span class="pl-c1">ServeHTTP</span>(recorder, notMatchingRequest)
+                    </td>
+                </tr>
+                <tr>
+                    <td id="L48" class="blob-num js-line-number" data-line-number="48"></td>
+                    <td id="LC48" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+                <tr>
+                    <td id="L49" class="blob-num js-line-number" data-line-number="49"></td>
+                    <td id="LC49" class="blob-code blob-code-inner js-file-line">}</td>
+                </tr>
+            </tbody>
+        </table>
 
-          <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form js-update-url-with-hash" action="/beyang/mux/edit/master/bench_test.go" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="zhdlJEcKVLK4lerq+K4EdLAD6ez54Kh7jdG9vnpxh1JkvGSadjQ28zJwNCVjjS5oB12efT6x8pqTAh4+cR/wXQ==">
-            <button class="btn-octicon tooltipped tooltipped-nw" type="submit" aria-label="Edit this file" data-hotkey="e" data-disable-with="">
-              <svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"></path></svg>
+        <div
+            class="BlobToolbar position-absolute js-file-line-actions dropdown js-menu-container js-select-menu d-none"
+            aria-hidden="true"
+        >
+            <button
+                class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1 dropdown-toggle js-menu-target"
+                type="button"
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Inline file action toolbar"
+                aria-controls="inline-file-actions"
+            >
+                <svg
+                    class="octicon octicon-kebab-horizontal"
+                    viewBox="0 0 13 16"
+                    version="1.1"
+                    width="13"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                    ></path>
+                </svg>
             </button>
-</form>
-        <!-- '"` --><!-- </textarea></xmp> --><form class="inline-form" action="/beyang/mux/delete/master/bench_test.go" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="NafwwuWTrDicmvVSaldfM5aV+CQvZNGqmJiYO0vE7n1J7OGDrQtkYJG/e4FJ4sw1P0WFg+xksnYfkE1mGM4lTw==">
-          <button class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw" type="submit" aria-label="Delete this file" data-disable-with="">
-            <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"></path></svg>
-          </button>
-</form>  </div>
-
-  <div class="file-info">
-      50 lines (41 sloc)
-      <span class="file-info-divider"></span>
-    1.37 KB
-  </div>
-</div>
-
-
-
-  <div itemprop="text" class="blob-wrapper data type-go">
-      <table class="highlight tab-size js-file-line-container" data-tab-size="8">
-      <tbody><tr>
-        <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
-        <td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> Copyright 2012 The Gorilla Authors. All rights reserved.</span></td>
-      </tr>
-      <tr>
-        <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
-        <td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> Use of this source code is governed by a BSD-style</span></td>
-      </tr>
-      <tr>
-        <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
-        <td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> license that can be found in the LICENSE file.</span></td>
-      </tr>
-      <tr>
-        <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
-        <td id="LC4" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L5" class="blob-num js-line-number" data-line-number="5"></td>
-        <td id="LC5" class="blob-code blob-code-inner js-file-line"><span class="pl-k">package</span> mux</td>
-      </tr>
-      <tr>
-        <td id="L6" class="blob-num js-line-number" data-line-number="6"></td>
-        <td id="LC6" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L7" class="blob-num js-line-number" data-line-number="7"></td>
-        <td id="LC7" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> (</td>
-      </tr>
-      <tr>
-        <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
-        <td id="LC8" class="blob-code blob-code-inner js-file-line">	<span class="pl-s"><span class="pl-pds">"</span>net/http<span class="pl-pds">"</span></span></td>
-      </tr>
-      <tr>
-        <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
-        <td id="LC9" class="blob-code blob-code-inner js-file-line">	<span class="pl-s"><span class="pl-pds">"</span>net/http/httptest<span class="pl-pds">"</span></span></td>
-      </tr>
-      <tr>
-        <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
-        <td id="LC10" class="blob-code blob-code-inner js-file-line">	<span class="pl-s"><span class="pl-pds">"</span>testing<span class="pl-pds">"</span></span></td>
-      </tr>
-      <tr>
-        <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
-        <td id="LC11" class="blob-code blob-code-inner js-file-line">)</td>
-      </tr>
-      <tr>
-        <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
-        <td id="LC12" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
-        <td id="LC13" class="blob-code blob-code-inner js-file-line"><span class="pl-k">func</span> <span class="pl-en">BenchmarkMux</span>(<span class="pl-v">b</span> *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {</td>
-      </tr>
-      <tr>
-        <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
-        <td id="LC14" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">router</span> <span class="pl-k">:=</span> <span class="pl-c1">new</span>(Router)</td>
-      </tr>
-      <tr>
-        <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
-        <td id="LC15" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">handler</span> <span class="pl-k">:=</span> <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span class="pl-smi">Request</span>) {}</td>
-      </tr>
-      <tr>
-        <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
-        <td id="LC16" class="blob-code blob-code-inner js-file-line">	router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"><span class="pl-pds">"</span>/v1/{v1}<span class="pl-pds">"</span></span>, handler)</td>
-      </tr>
-      <tr>
-        <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
-        <td id="LC17" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
-        <td id="LC18" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">request</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/anything<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
-        <td id="LC19" class="blob-code blob-code-inner js-file-line">	<span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span> <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {</td>
-      </tr>
-      <tr>
-        <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
-        <td id="LC20" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, request)</td>
-      </tr>
-      <tr>
-        <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
-        <td id="LC21" class="blob-code blob-code-inner js-file-line">	}</td>
-      </tr>
-      <tr>
-        <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
-        <td id="LC22" class="blob-code blob-code-inner js-file-line">}</td>
-      </tr>
-      <tr>
-        <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
-        <td id="LC23" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
-        <td id="LC24" class="blob-code blob-code-inner js-file-line"><span class="pl-k">func</span> <span class="pl-en">BenchmarkMuxAlternativeInRegexp</span>(<span class="pl-v">b</span> *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {</td>
-      </tr>
-      <tr>
-        <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
-        <td id="LC25" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">router</span> <span class="pl-k">:=</span> <span class="pl-c1">new</span>(Router)</td>
-      </tr>
-      <tr>
-        <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
-        <td id="LC26" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">handler</span> <span class="pl-k">:=</span> <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span class="pl-smi">Request</span>) {}</td>
-      </tr>
-      <tr>
-        <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
-        <td id="LC27" class="blob-code blob-code-inner js-file-line">	router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"><span class="pl-pds">"</span>/v1/{v1:(?:a|b)}<span class="pl-pds">"</span></span>, handler)</td>
-      </tr>
-      <tr>
-        <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
-        <td id="LC28" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
-        <td id="LC29" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">requestA</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/a<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
-        <td id="LC30" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">requestB</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/b<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
-        <td id="LC31" class="blob-code blob-code-inner js-file-line">	<span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span> <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {</td>
-      </tr>
-      <tr>
-        <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
-        <td id="LC32" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestA)</td>
-      </tr>
-      <tr>
-        <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
-        <td id="LC33" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, requestB)</td>
-      </tr>
-      <tr>
-        <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
-        <td id="LC34" class="blob-code blob-code-inner js-file-line">	}</td>
-      </tr>
-      <tr>
-        <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
-        <td id="LC35" class="blob-code blob-code-inner js-file-line">}</td>
-      </tr>
-      <tr>
-        <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
-        <td id="LC36" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
-        <td id="LC37" class="blob-code blob-code-inner js-file-line"><span class="pl-k">func</span> <span class="pl-en">BenchmarkManyPathVariables</span>(<span class="pl-v">b</span> *<span class="pl-v">testing</span>.<span class="pl-v">B</span>) {</td>
-      </tr>
-      <tr>
-        <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
-        <td id="LC38" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">router</span> <span class="pl-k">:=</span> <span class="pl-c1">new</span>(Router)</td>
-      </tr>
-      <tr>
-        <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
-        <td id="LC39" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">handler</span> <span class="pl-k">:=</span> <span class="pl-c1">func</span>(w http.<span class="pl-smi">ResponseWriter</span>, r *http.<span class="pl-smi">Request</span>) {}</td>
-      </tr>
-      <tr>
-        <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
-        <td id="LC40" class="blob-code blob-code-inner js-file-line">	router.<span class="pl-c1">HandleFunc</span>(<span class="pl-s"><span class="pl-pds">"</span>/v1/{v1}/{v2}/{v3}/{v4}/{v5}<span class="pl-pds">"</span></span>, handler)</td>
-      </tr>
-      <tr>
-        <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
-        <td id="LC41" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
-        <td id="LC42" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">matchingRequest</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4/5<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
-        <td id="LC43" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">notMatchingRequest</span>, <span class="pl-smi">_</span> <span class="pl-k">:=</span> http.<span class="pl-c1">NewRequest</span>(<span class="pl-s"><span class="pl-pds">"</span>GET<span class="pl-pds">"</span></span>, <span class="pl-s"><span class="pl-pds">"</span>/v1/1/2/3/4<span class="pl-pds">"</span></span>, <span class="pl-c1">nil</span>)</td>
-      </tr>
-      <tr>
-        <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
-        <td id="LC44" class="blob-code blob-code-inner js-file-line">	<span class="pl-smi">recorder</span> <span class="pl-k">:=</span> httptest.<span class="pl-c1">NewRecorder</span>()</td>
-      </tr>
-      <tr>
-        <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
-        <td id="LC45" class="blob-code blob-code-inner js-file-line">	<span class="pl-k">for</span> <span class="pl-smi">i</span> <span class="pl-k">:=</span> <span class="pl-c1">0</span>; i &lt; b.<span class="pl-smi">N</span>; i++ {</td>
-      </tr>
-      <tr>
-        <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
-        <td id="LC46" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(<span class="pl-c1">nil</span>, matchingRequest)</td>
-      </tr>
-      <tr>
-        <td id="L47" class="blob-num js-line-number" data-line-number="47"></td>
-        <td id="LC47" class="blob-code blob-code-inner js-file-line">		router.<span class="pl-c1">ServeHTTP</span>(recorder, notMatchingRequest)</td>
-      </tr>
-      <tr>
-        <td id="L48" class="blob-num js-line-number" data-line-number="48"></td>
-        <td id="LC48" class="blob-code blob-code-inner js-file-line">	}</td>
-      </tr>
-      <tr>
-        <td id="L49" class="blob-num js-line-number" data-line-number="49"></td>
-        <td id="LC49" class="blob-code blob-code-inner js-file-line">}</td>
-      </tr>
-</tbody></table>
-
-  <div class="BlobToolbar position-absolute js-file-line-actions dropdown js-menu-container js-select-menu d-none" aria-hidden="true">
-    <button class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1 dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Inline file action toolbar" aria-controls="inline-file-actions">
-      <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"></path></svg>
-    </button>
-    <div class="dropdown-menu-content js-menu-content" id="inline-file-actions">
-      <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2">
-        <li><clipboard-copy class="dropdown-item" id="js-copy-lines" style="cursor:pointer;" data-original-text="Copy lines" tabindex="0" role="button">Copy lines</clipboard-copy></li>
-        <li><clipboard-copy class="dropdown-item" id="js-copy-permalink" style="cursor:pointer;" data-original-text="Copy permalink" tabindex="0" role="button">Copy permalink</clipboard-copy></li>
-        <li><a class="dropdown-item js-update-url-with-hash" id="js-view-git-blame" href="/beyang/mux/blame/058953caa945faa213f42789c5921a53f9135a5e/bench_test.go">View git blame</a></li>
-          <li><a class="dropdown-item" id="js-new-issue" href="/beyang/mux/issues/new">Open new issue</a></li>
-      </ul>
+            <div class="dropdown-menu-content js-menu-content" id="inline-file-actions">
+                <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2">
+                    <li>
+                        <clipboard-copy
+                            class="dropdown-item"
+                            id="js-copy-lines"
+                            style="cursor:pointer;"
+                            data-original-text="Copy lines"
+                            tabindex="0"
+                            role="button"
+                            >Copy lines</clipboard-copy
+                        >
+                    </li>
+                    <li>
+                        <clipboard-copy
+                            class="dropdown-item"
+                            id="js-copy-permalink"
+                            style="cursor:pointer;"
+                            data-original-text="Copy permalink"
+                            tabindex="0"
+                            role="button"
+                            >Copy permalink</clipboard-copy
+                        >
+                    </li>
+                    <li>
+                        <a
+                            class="dropdown-item js-update-url-with-hash"
+                            id="js-view-git-blame"
+                            href="/beyang/mux/blame/058953caa945faa213f42789c5921a53f9135a5e/bench_test.go"
+                            >View git blame</a
+                        >
+                    </li>
+                    <li><a class="dropdown-item" id="js-new-issue" href="/beyang/mux/issues/new">Open new issue</a></li>
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
-
-  </div>
-
-  </div>
+</div>

--- a/client/browser/src/libs/github/__fixtures__/github.com/blob/refined-github/code-view.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/blob/refined-github/code-view.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts -->
 <div class="Box mt-3 position-relative">
     <div class="Box-header py-2 d-flex flex-column flex-shrink-0 flex-md-row flex-md-items-center">
         <div class="text-mono f6 flex-auto pr-3 flex-order-2 flex-md-order-1 mt-2 mt-md-0">
@@ -18,29 +19,29 @@
                 <a
                     id="raw-url"
                     class="btn btn-sm BtnGroup-item"
-                    href="/sourcegraph/sourcegraph/raw/master/shared/src/api/extension/types/url.ts"
+                    href="/sourcegraph/sourcegraph/raw/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                     >Raw</a
                 >
                 <a
                     class="btn btn-sm js-update-url-with-hash BtnGroup-item"
                     data-hotkey="b"
-                    href="https://github.com/sourcegraph/sourcegraph/blame/master/shared/src/api/extension/types/url.ts"
+                    href="https://github.com/sourcegraph/sourcegraph/blame/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                     >Blame</a
                 >
                 <a
                     rel="nofollow"
                     class="btn btn-sm BtnGroup-item"
-                    href="/sourcegraph/sourcegraph/commits/master/shared/src/api/extension/types/url.ts"
+                    href="/sourcegraph/sourcegraph/commits/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                     >History</a
                 >
             </div>
 
             <div>
-                <a
-                    class="btn-octicon tooltipped tooltipped-nw"
-                    href="github-mac://openRepo/https://github.com/sourcegraph/sourcegraph?branch=master&amp;filepath=shared%2Fsrc%2Fapi%2Fextension%2Ftypes%2Furl.ts"
-                    aria-label="Open this file in GitHub Desktop"
-                    data-ga-click="Repository, open with desktop, type:mac"
+                <button
+                    class="btn-octicon disabled tooltipped tooltipped-nw"
+                    type="button"
+                    disabled=""
+                    aria-label="You must be on a branch to open this file in GitHub Desktop"
                 >
                     <svg
                         class="octicon octicon-device-desktop"
@@ -55,75 +56,46 @@
                             d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
                         ></path>
                     </svg>
-                </a>
+                </button>
 
-                <!-- '"` --><!-- </textarea></xmp> -->
-                <form
-                    class="inline-form js-update-url-with-hash"
-                    action="https://github.com/sourcegraph/sourcegraph/edit/master/shared/src/api/extension/types/url.ts"
-                    accept-charset="UTF-8"
-                    method="post"
+                <button
+                    type="button"
+                    class="btn-octicon disabled tooltipped tooltipped-nw"
+                    aria-label="You must be on a branch to make or propose changes to this file"
                 >
-                    <input name="utf8" type="hidden" value="✓" /><input
-                        type="hidden"
-                        name="authenticity_token"
-                        value="fs15kXkOR4KPjZ1G+I9fDUrFuvoR6hmAPIVYDFVFSAMVT3uCCcAmWNqQccG2kT1L2mPWjD9+PKaMy8lbHD8tSg=="
-                    />
-                    <button
-                        class="btn-octicon tooltipped tooltipped-nw"
-                        type="submit"
-                        aria-label="Edit this file"
-                        data-hotkey="e"
-                        data-disable-with=""
+                    <svg
+                        class="octicon octicon-pencil"
+                        viewBox="0 0 14 16"
+                        version="1.1"
+                        width="14"
+                        height="16"
+                        aria-hidden="true"
                     >
-                        <svg
-                            class="octicon octicon-pencil"
-                            viewBox="0 0 14 16"
-                            version="1.1"
-                            width="14"
-                            height="16"
-                            aria-hidden="true"
-                        >
-                            <path
-                                fill-rule="evenodd"
-                                d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                            ></path>
-                        </svg>
-                    </button>
-                </form>
-                <!-- '"` --><!-- </textarea></xmp> -->
-                <form
-                    class="inline-form"
-                    action="/sourcegraph/sourcegraph/delete/master/shared/src/api/extension/types/url.ts"
-                    accept-charset="UTF-8"
-                    method="post"
+                        <path
+                            fill-rule="evenodd"
+                            d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
+                        ></path>
+                    </svg>
+                </button>
+                <button
+                    type="button"
+                    class="btn-octicon btn-octicon-danger disabled tooltipped tooltipped-nw"
+                    aria-label="You must be on a branch to make or propose changes to this file"
                 >
-                    <input name="utf8" type="hidden" value="✓" /><input
-                        type="hidden"
-                        name="authenticity_token"
-                        value="DHGtjEpz3eDWjWCFdQCAp55iAqv6JWRhBP7VV05nwzy4N4vUO0kLQOTHLgrD4kx0FiBAETN7qSaEJ96C441ieg=="
-                    />
-                    <button
-                        class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw"
-                        type="submit"
-                        aria-label="Delete this file"
-                        data-disable-with=""
+                    <svg
+                        class="octicon octicon-trashcan"
+                        viewBox="0 0 12 16"
+                        version="1.1"
+                        width="12"
+                        height="16"
+                        aria-hidden="true"
                     >
-                        <svg
-                            class="octicon octicon-trashcan"
-                            viewBox="0 0 12 16"
-                            version="1.1"
-                            width="12"
-                            height="16"
-                            aria-hidden="true"
-                        >
-                            <path
-                                fill-rule="evenodd"
-                                d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                            ></path>
-                        </svg>
-                    </button>
-                </form>
+                        <path
+                            fill-rule="evenodd"
+                            d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                        ></path>
+                    </svg>
+                </button>
             </div>
         </div>
     </div>
@@ -212,7 +184,7 @@
                             class="dropdown-item js-update-url-with-hash"
                             id="js-view-git-blame"
                             role="menuitem"
-                            href="https://github.com/sourcegraph/sourcegraph/blame/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+                            href="https://github.com/sourcegraph/sourcegraph/blame/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                             >View git blame</a
                         >
                     </li>

--- a/client/browser/src/libs/github/__fixtures__/github.com/blob/refined-github/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/blob/refined-github/page.html
@@ -1,1157 +1,2949 @@
-
-
-
-
-
-
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-  <link rel="dns-prefetch" href="https://github.githubassets.com">
-  <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
-  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
-
-
-
-  <link crossorigin="anonymous" media="all" integrity="sha512-OBabailf0Gja8rWVZO1xyYAw//CQdLOJF4riG050gTxsVqVD7az4Sq56hPWfv3AoaxuEhYXgQlGQcNxzZzDyVA==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-d69542a4a3958db914b3bec3f757de26.css" />
-  
-    <link crossorigin="anonymous" media="all" integrity="sha512-NuTIwC5UFn67DeQnzZUYtnS1vm5tRZ4BtBic9TpGK+RnuP+MH/OqIVS+Dr7rpnOwnSmxezyl1L50kLWW3sSNGQ==" rel="stylesheet" href="https://github.githubassets.com/assets/github-a7545a042547353ea45ba3211e585d1c.css" />
-    
-    
-    
-    
-
-  <meta name="viewport" content="width=device-width">
-  
-  <title>sourcegraph/url.ts at master · sourcegraph/sourcegraph</title>
-    <meta name="description" content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub.">
-    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
-  <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
-  <meta property="fb:app_id" content="1401488693436528">
-
-    <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" /><meta name="twitter:site" content="@github" /><meta name="twitter:card" content="summary" /><meta name="twitter:title" content="sourcegraph/sourcegraph" /><meta name="twitter:description" content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub." />
-    <meta property="og:image" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="sourcegraph/sourcegraph" /><meta property="og:url" content="https://github.com/sourcegraph/sourcegraph" /><meta property="og:description" content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub." />
-
-  <link rel="assets" href="https://github.githubassets.com/">
-  <link rel="web-socket" href="wss://live.github.com/_sockets/VjI6MzgyNzA5NjM2OmExNDNjNGQyNjgwNzFiZWFhNjJmMTJlODAwNTAzMTIzODAwMzcwNmQ1YWUzYTJmOTdhMTg2YzA2NWFjNmQzZDE=--05c5525d52ec5bb5453b3274698d1133c97d549b">
-  <meta name="pjax-timeout" content="1000">
-  <link rel="sudo-modal" href="/sessions/sudo_modal">
-  <meta name="request-id" content="CC49:15DA0:2DE33C:4412C4:5CB99055" data-pjax-transient>
-
-
-  
-
-  <meta name="selected-link" value="repo_source" data-pjax-transient>
-
-      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-
-  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="CC49:15DA0:2DE33C:4412C4:5CB99055" /><meta name="octolytics-dimension-region_edge" content="ams" /><meta name="octolytics-dimension-region_render" content="iad" /><meta name="octolytics-actor-id" content="1741180" /><meta name="octolytics-actor-login" content="lguychard" /><meta name="octolytics-actor-hash" content="1b59c154e057c2d407257621fb6e4b8828b3625d9c8781f14d6c02dffd7a4100" />
-<meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-pjax-transient="true" />
-
-
-
-    <meta name="google-analytics" content="UA-3769691-2">
-
-  <meta class="js-ga-set" name="userId" content="d006a5262acdf70eda7670879e8c073e">
-
-<meta class="js-ga-set" name="dimension1" content="Logged In">
-
-
-
-  
-
-      <meta name="hostname" content="github.com">
-    <meta name="user-login" content="lguychard">
-
-      <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="MmE4Mjk3YTUwZjdkNGMwYzU4NGE0NjJlM2VmODEzODQ2Zjc2YzQ0MjBjZWRhY2Y0NGVkZGUwNTkzMDM3ZDlhNnx7InJlbW90ZV9hZGRyZXNzIjoiOTIuMTM5LjkwLjIzMCIsInJlcXVlc3RfaWQiOiJDQzQ5OjE1REEwOjJERTMzQzo0NDEyQzQ6NUNCOTkwNTUiLCJ0aW1lc3RhbXAiOjE1NTU2NjQ5ODIsImhvc3QiOiJnaXRodWIuY29tIn0=">
-
-    <meta name="enabled-features" content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_ENTERPRISE_CONTACTS,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES">
-
-  <meta name="html-safe-nonce" content="f2aa177d3304d4abd9f30ff5c7aa38ba935da1e9">
-
-  <meta http-equiv="x-pjax-version" content="7f7ec9b1425b9f5a1e241ce3969f9adb">
-  
-
-      <link href="https://github.com/sourcegraph/sourcegraph/commits/master.atom" rel="alternate" title="Recent Commits to sourcegraph:master" type="application/atom+xml">
-
-  <meta name="go-import" content="github.com/sourcegraph/sourcegraph git https://github.com/sourcegraph/sourcegraph.git">
-
-  <meta name="octolytics-dimension-user_id" content="3979584" /><meta name="octolytics-dimension-user_login" content="sourcegraph" /><meta name="octolytics-dimension-repository_id" content="41288708" /><meta name="octolytics-dimension-repository_nwo" content="sourcegraph/sourcegraph" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="41288708" /><meta name="octolytics-dimension-repository_network_root_nwo" content="sourcegraph/sourcegraph" /><meta name="octolytics-dimension-repository_explore_github_marketplace_ci_cta_shown" content="false" />
-
-
-    <link rel="canonical" href="https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts" data-pjax-transient>
-
-
-  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
-
-  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
-
-  <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000">
-  <link rel="icon" type="image/x-icon" class="js-site-favicon" href="https://github.githubassets.com/favicon.ico">
-
-<meta name="theme-color" content="#1e2327">
-
-
-  <meta name="u2f-enabled" content="true">
-
-
-  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
-
-  </head>
-
-  <body class="logged-in env-production emoji-size-boost page-responsive min-width-0 page-blob">
-    
-
-  <div class="position-relative js-header-wrapper ">
-    <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
-    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
-
-    
-    
-    
-
-
-          <header class="Header js-details-container Details flex-wrap flex-lg-nowrap p-responsive" role="banner">
-
-    <div class="Header-item d-none d-lg-flex">
-      <a class="Header-link" href="https://github.com/" data-hotkey="g d" aria-label="Homepage" data-ga-click="Header, go to dashboard, icon:logo">
-  <svg class="octicon octicon-mark-github v-align-middle" height="32" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-</a>
-
-    </div>
-
-    <div class="Header-item d-lg-none">
-      <button class="Header-link btn-link mt-1 js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
-        <svg height="24" class="octicon octicon-three-bars" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M11.41 9H.59C0 9 0 8.59 0 8c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zm0-4H.59C0 5 0 4.59 0 4c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM.59 11H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1H.59C0 13 0 12.59 0 12c0-.59 0-1 .59-1z"/></svg>
-      </button>
-    </div>
-
-    <div class="Header-item Header-item--full flex-column flex-lg-row width-full flex-order-2 flex-lg-order-none mr-0 mr-lg-3 mt-3 mt-lg-0 Details-content--hidden">
-        <div class="header-search flex-self-stretch flex-lg-self-auto mr-0 mr-lg-3 mb-3 mb-lg-0 scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="combobox"
-  aria-owns="jump-to-results"
-  aria-label="Search or jump to"
-  aria-haspopup="listbox"
-  aria-expanded="false"
->
-  <div class="position-relative">
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-scope-type="Repository" data-scope-id="41288708" data-scoped-search-url="/sourcegraph/sourcegraph/search" data-unscoped-search-url="/search" action="/sourcegraph/sourcegraph/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
-      <label class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container">
-        <input type="text"
-          class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
-          data-hotkey="s,/"
-          name="q"
-          value=""
-          placeholder="Search or jump to…"
-          data-unscoped-placeholder="Search or jump to…"
-          data-scoped-placeholder="Search or jump to…"
-          autocapitalize="off"
-          aria-autocomplete="list"
-          aria-controls="jump-to-results"
-          aria-label="Search or jump to…"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=eGcLPXmiK5wftGa/cgJ3mCEupGdrFEe1TQoCVjQfV0F+FM7w1GIN43ZJkSiF4Wbr+uaS+CsSE7cCBYWbdylT2w=="
-          spellcheck="false"
-          autocomplete="off"
-          >
-          <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://github.githubassets.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
-
-            <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              
-<ul class="d-none js-jump-to-suggestions-template-container">
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-</ul>
-
-<ul class="d-none js-jump-to-no-results-template-container">
-  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
-    <span class="text-gray">No suggested jump to results</span>
-  </li>
-</ul>
-
-<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-
-    <li class="d-flex flex-justify-center flex-items-center p-0 f5 js-jump-to-suggestion">
-      <img src="https://github.githubassets.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-    </li>
-</ul>
-
-            </div>
-      </label>
-</form>  </div>
-</div>
-
-
-      <nav class="d-flex flex-column flex-lg-row flex-self-stretch flex-lg-self-auto" aria-label="Global">
-    <a class="Header-link d-block d-lg-none py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-ga-click="Header, click, Nav menu - item:dashboard:user" aria-label="Dashboard" href="/dashboard">
-      Dashboard
-</a>
-  <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-hotkey="g p" data-ga-click="Header, click, Nav menu - item:pulls context:user" aria-label="Pull requests you created" data-selected-links="/pulls /pulls/assigned /pulls/mentioned /pulls" href="/pulls">
-    Pull requests
-</a>
-  <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-hotkey="g i" data-ga-click="Header, click, Nav menu - item:issues context:user" aria-label="Issues you created" data-selected-links="/issues /issues/assigned /issues/mentioned /issues" href="/issues">
-    Issues
-</a>
-    <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-ga-click="Header, click, Nav menu - item:marketplace context:user" data-octo-click="marketplace_click" data-octo-dimensions="location:nav_bar" data-selected-links=" /marketplace" href="/marketplace">
-      Marketplace
-</a>      
-
-  <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
-    Explore
-</a>
-    <a class="Header-link d-block d-lg-none mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" aria-label="View profile and more" aria-expanded="false" aria-haspopup="false" href="https://github.com/lguychard">
-      <img class="avatar" src="https://avatars3.githubusercontent.com/u/1741180?s=40&amp;v=4" width="20" height="20" alt="@lguychard" />
-      lguychard
-</a>
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/logout" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="8u4WP8d/U5ObaK6XOvidpDGusYzRx21fmo0U6ZRqGutK8A4Df5GHP5GZpU9H1J96h5d0Nnxy4jeKiPYdinOj1A==" />
-      <button type="submit" class="Header-link mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15 d-lg-none btn-link d-block width-full text-left" data-ga-click="Header, sign out, icon:logout" style="padding-left: 2px;">
-        <svg class="octicon octicon-sign-out v-align-middle" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 9V7H8V5h4V3l4 3-4 3zm-2 3H6V3L2 1h8v3h1V1c0-.55-.45-1-1-1H1C.45 0 0 .45 0 1v11.38c0 .39.22.73.55.91L6 16.01V13h4c.55 0 1-.45 1-1V8h-1v4z"/></svg>
-        Sign out
-      </button>
-</form></nav>
-
-    </div>
-
-    <div class="Header-item Header-item--full flex-justify-center d-lg-none position-relative">
-      <div class="css-truncate css-truncate-target width-fit position-absolute left-0 right-0 text-center">
-              <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-    <a class="Header-link" href="/sourcegraph">sourcegraph</a>
-    /
-    <a class="Header-link" href="/sourcegraph/sourcegraph">sourcegraph</a>
-
-</div>
-    </div>
-
-    <div class="Header-item position-relative d-none d-lg-flex">
-      
-
-    </div>
-
-    <div class="Header-item mr-0 mr-lg-3 flex-order-1 flex-lg-order-none">
-      
-    <a aria-label="You have unread notifications" class="Header-link notification-indicator tooltipped tooltipped-s my-2 my-lg-0 js-socket-channel js-notification-indicator" data-hotkey="g n" data-ga-click="Header, go to notifications, icon:unread" data-channel="notification-changed:1741180" href="/notifications">
-        <span class="mail-status unread"></span>
-        <svg class="octicon octicon-bell" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 12v1H0v-1l.73-.58c.77-.77.81-2.55 1.19-4.42C2.69 3.23 6 2 6 2c0-.55.45-1 1-1s1 .45 1 1c0 0 3.39 1.23 4.16 5 .38 1.88.42 3.66 1.19 4.42l.66.58H14zm-7 4c1.11 0 2-.89 2-2H5c0 1.11.89 2 2 2z"/></svg>
-</a>
-    </div>
-
-
-    <div class="Header-item position-relative d-none d-lg-flex">
-      <details class="details-overlay details-reset">
-  <summary class="Header-link"
-      aria-label="Create new…"
-      data-ga-click="Header, create new, icon:add">
-    <svg class="octicon octicon-plus" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 9H7v5H5V9H0V7h5V2h2v5h5v2z"/></svg> <span class="dropdown-caret"></span>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw">
-    
-<a role="menuitem" class="dropdown-item" href="/new" data-ga-click="Header, create new repository">
-  New repository
-</a>
-
-  <a role="menuitem" class="dropdown-item" href="/new/import" data-ga-click="Header, import a repository">
-    Import repository
-  </a>
-
-<a role="menuitem" class="dropdown-item" href="https://gist.github.com/" data-ga-click="Header, create new gist">
-  New gist
-</a>
-
-  <a role="menuitem" class="dropdown-item" href="/organizations/new" data-ga-click="Header, create new organization">
-    New organization
-  </a>
-
-
-  <div role="none" class="dropdown-divider"></div>
-  <div class="dropdown-header">
-    <span title="sourcegraph/sourcegraph">This repository</span>
-  </div>
-    <a role="menuitem" class="dropdown-item" href="/sourcegraph/sourcegraph/issues/new/choose" data-ga-click="Header, create new issue" data-skip-pjax>
-      New issue
-    </a>
-
-
-  </details-menu>
-</details>
-
-    </div>
-
-    <div class="Header-item position-relative mr-0 d-none d-lg-flex">
-      
-<details class="details-overlay details-reset">
-  <summary class="Header-link"
-    aria-label="View profile and more"
-    data-ga-click="Header, show menu, icon:avatar">
-    <img alt="@lguychard" class="avatar" src="https://avatars3.githubusercontent.com/u/1741180?s=40&amp;v=4" height="20" width="20">
-    <span class="dropdown-caret"></span>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px">
-    <div class="header-nav-current-user css-truncate"><a role="menuitem" class="no-underline user-profile-link px-3 pt-2 pb-2 mb-n2 mt-n1 d-block" href="/lguychard" data-ga-click="Header, go to profile, text:Signed in as">Signed in as <strong class="css-truncate-target">lguychard</strong></a></div>
-    <div role="none" class="dropdown-divider"></div>
-
-      <div class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1" data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1">
-        
-<div class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 border" data-team-hovercards-enabled>
-  <details class="js-user-status-details details-reset details-overlay details-overlay-dark">
-    <summary class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray " aria-haspopup="dialog" role="menuitem" data-hydro-click="{&quot;event_type&quot;:&quot;user_profile.click&quot;,&quot;payload&quot;:{&quot;profile_user_id&quot;:3979584,&quot;target&quot;:&quot;EDIT_USER_STATUS&quot;,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CC49:15DA0:2DE33C:4412C4:5CB99055&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;}}" data-hydro-click-hmac="19383d62758ac01ba7e2ab199ff4fec0a445e163b13e31c9b76fe10bd5092c6e">
-      <div class="f6 d-inline-block v-align-middle user-status-emoji-only-header circle pr-2 lh-condensed user-status-header " style="max-width: 29px">
-        <div class="user-status-emoji-container flex-shrink-0 mr-1 mt-1 lh-condensed-ultra v-align-bottom" style="">
-          <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"/></svg>
-        </div>
-      </div>
-      <div class="
-        d-inline-block v-align-middle
-        
-        
-         css-truncate css-truncate-target 
-         user-status-message-wrapper f6"
-        style="line-height: 20px;">
-        <div class="d-inline-block text-gray-dark v-align-text-top">
-            <span class="text-gray ml-2">Set status</span>
-        </div>
-      </div>
-</summary>    <details-dialog class="details-dialog rounded-1 anim-fade-in fast Box Box--overlay" role="dialog" tabindex="-1">
-      <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="position-relative flex-auto js-user-status-form" action="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="vLnR9bg1DRzPyCslwuVnWHuvW2EqZlwQs1/Y6p5kP3reztBPu+P7elgCfxc26z64Iv/iDuq3qbLMbjjVdyOM5w==" />
-        <div class="Box-header bg-gray border-bottom p-3">
-          <button class="Box-btn-octicon js-toggle-user-status-edit btn-octicon float-right" type="reset" aria-label="Close dialog" data-close-dialog>
-            <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-          </button>
-          <h3 class="Box-title f5 text-bold text-gray-dark">Edit status</h3>
-        </div>
-        <input type="hidden" name="emoji" class="js-user-status-emoji-field" value="">
-        <input type="hidden" name="organization_id" class="js-user-status-org-id-field" value="">
-        <div class="px-3 py-2 text-gray-dark">
-          <div class="js-characters-remaining-container js-suggester-container position-relative mt-2">
-            <div class="input-group d-table form-group my-0 js-user-status-form-group">
-              <span class="input-group-button d-table-cell v-align-middle" style="width: 1%">
-                <button type="button" aria-label="Choose an emoji" class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0">
-                  <span class="js-user-status-original-emoji" hidden></span>
-                  <span class="js-user-status-custom-emoji"></span>
-                  <span class="js-user-status-no-emoji-icon" >
-                    <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"/></svg>
-                  </span>
-                </button>
-              </span>
-              <input type="text" autocomplete="off" data-maxlength="80" class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field" placeholder="What's happening?" name="message" value="" aria-label="What is your current status?">
-              <div class="error">Could not update your status, please try again.</div>
-            </div>
-            <div class="suggester-container">
-              <div class="suggester js-suggester js-navigation-container" data-url="/autocomplete/user-suggestions" data-no-org-url="/autocomplete/user-suggestions" data-org-url="/suggestions" hidden>
-              </div>
-            </div>
-            <div style="margin-left: 53px" class="my-1 text-small label-characters-remaining js-characters-remaining" data-suffix="remaining" hidden>
-              80 remaining
-            </div>
-          </div>
-          <include-fragment class="js-user-status-emoji-picker" data-url="/users/status/emoji"></include-fragment>
-          <div class="overflow-auto ml-n3 mr-n3 px-3" style="max-height: 33vh">
-            <div class="user-status-suggestions js-user-status-suggestions collapsed overflow-hidden">
-              <h4 class="f6 text-normal my-3">Suggestions:</h4>
-              <div class="mx-3 mt-2 clearfix">
-                  <div class="float-left col-6">
-                      <button type="button" value=":palm_tree:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="palm_tree" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png">🌴</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          On vacation
-                        </div>
-                      </button>
-                      <button type="button" value=":face_with_thermometer:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="face_with_thermometer" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f912.png">🤒</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          Out sick
-                        </div>
-                      </button>
-                  </div>
-                  <div class="float-left col-6">
-                      <button type="button" value=":house:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="house" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3e0.png">🏠</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          Working from home
-                        </div>
-                      </button>
-                      <button type="button" value=":dart:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="dart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3af.png">🎯</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          Focusing
-                        </div>
-                      </button>
-                  </div>
-              </div>
-            </div>
-            <div class="user-status-limited-availability-container">
-              <div class="form-checkbox my-0">
-                <input type="checkbox" name="limited_availability" value="1" class="js-user-status-limited-availability-checkbox" data-default-message="I may be slow to respond." aria-describedby="limited-availability-help-text-truncate-true" id="limited-availability-truncate-true">
-                <label class="d-block f5 text-gray-dark mb-1" for="limited-availability-truncate-true">
-                  Busy
-                </label>
-                <p class="note" id="limited-availability-help-text-truncate-true">
-                  When others mention you, assign you, or request your review,
-                  GitHub will let them know that you have limited availability.
-                </p>
-              </div>
-            </div>
-          </div>
-            
-
-<div class="d-inline-block f5 border-top mr-2 pt-3 pb-2" >
-  <div class="d-inline-block mr-1">
-    Clear status
-  </div>
-
-  <details class="js-user-status-expire-drop-down f6 dropdown details-reset details-overlay d-inline-block mr-2">
-    <summary class="f5 btn-link link-gray-dark border px-2 py-1 rounded-1" aria-haspopup="true">
-      <div class="js-user-status-expiration-interval-selected d-inline-block v-align-baseline">
-        Never
-      </div>
-      <div class="dropdown-caret"></div>
-    </summary>
-
-    <ul class="dropdown-menu dropdown-menu-se pl-0 overflow-auto" style="width: 220px; max-height: 15.5em">
-      <li>
-        <button type="button" class="btn-link dropdown-item js-user-status-expire-button ws-normal" title="Never">
-          <span class="d-inline-block text-bold mb-1">Never</span>
-          <div class="f6 lh-condensed">Keep this status until you clear your status or edit your status.</div>
-        </button>
-      </li>
-      <li class="dropdown-divider" role="none"></li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="in 30 minutes" value="2019-04-19T11:39:42+02:00">
-            in 30 minutes
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="in 1 hour" value="2019-04-19T12:09:42+02:00">
-            in 1 hour
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="in 4 hours" value="2019-04-19T15:09:42+02:00">
-            in 4 hours
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="today" value="2019-04-19T23:59:59+02:00">
-            today
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="this week" value="2019-04-21T23:59:59+02:00">
-            this week
-          </button>
-        </li>
-    </ul>
-  </details>
-  <input class="js-user-status-expiration-date-input" type="hidden" name="expires_at" value="">
-</div>
-
-          <include-fragment class="js-user-status-org-picker" data-url="/users/status/organizations"></include-fragment>
-        </div>
-        <div class="d-flex flex-items-center flex-justify-between p-3 border-top">
-          <button type="submit" disabled class="width-full btn btn-primary mr-2 js-user-status-submit">
-            Set status
-          </button>
-          <button type="button" disabled class="width-full js-clear-user-status-button btn ml-2 ">
-            Clear status
-          </button>
-        </div>
-</form>    </details-dialog>
-  </details>
-</div>
-
-      </div>
-      <div role="none" class="dropdown-divider"></div>
-
-
-    <a role="menuitem" class="dropdown-item" href="/lguychard" data-ga-click="Header, go to profile, text:your profile">Your profile</a>
-    <a role="menuitem" class="dropdown-item" href="/lguychard?tab=repositories" data-ga-click="Header, go to repositories, text:your repositories">Your repositories</a>
-
-    <a role="menuitem" class="dropdown-item" href="/lguychard?tab=projects" data-ga-click="Header, go to projects, text:your projects">Your projects</a>
-
-    <a role="menuitem" class="dropdown-item" href="/lguychard?tab=stars" data-ga-click="Header, go to starred repos, text:your stars">Your stars</a>
-      <a role="menuitem" class="dropdown-item" href="https://gist.github.com/" data-ga-click="Header, your gists, text:your gists">Your gists</a>
-
-    <div role="none" class="dropdown-divider"></div>
-    <a role="menuitem" class="dropdown-item" href="https://help.github.com" data-ga-click="Header, go to help, text:help">Help</a>
-    <a role="menuitem" class="dropdown-item" href="/settings/profile" data-ga-click="Header, go to settings, icon:settings">Settings</a>
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="logout-form" action="/logout" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="WRPwB7vcXJfIm+kFv3wArfoKATstLiyoc/sbbVKUKZvhDeg7AzKIO8Jq4t3CUAJzTDPEgYCbo8Bj/vmZTI2QpA==" />
-      
-      <button type="submit" class="dropdown-item dropdown-signout" data-ga-click="Header, sign out, icon:logout" role="menuitem">
-        Sign out
-      </button>
-</form>  </details-menu>
-</details>
-
-    </div>
-
-  </header>
-
-      
-
-  </div>
-
-  <div id="start-of-content" class="show-on-focus"></div>
-
-
-    <div id="js-flash-container">
-
-</div>
-
-
-
-  <div class="application-main " data-commit-hovercards-enabled>
-        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
-    <main  >
-      
-
-
-  
-
-
-
-  
-
-
-
-
-  <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav pt-0 pt-lg-4 ">
-    <div class="repohead-details-container clearfix container-lg p-responsive d-none d-lg-block">
-
-      <ul class="pagehead-actions">
-
-
-
-  <li>
-    
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form data-remote="true" class="clearfix js-social-form js-social-container" action="/notifications/subscribe" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="DXH/sJ71iicov5NtFWaqZXsmNTLWLPCnPAuZsRW0g+0pVNfqCi6L0N3kHqDRmXRjvEyCZiAD8XqqPegNSVjHfw==" />      <input type="hidden" name="repository_id" value="41288708">
-
-      <details class="details-reset details-overlay select-menu float-left">
-        <summary class="select-menu-button float-left btn btn-sm btn-with-count" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;WATCH_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CC49:15DA0:2DE33C:4412C4:5CB99055&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="54d38cd2ce17d52f61a9bbe5a38079655c57843ab9c43f287b5b9b645db6af16" data-ga-click="Repository, click Watch settings, action:blob#show">            <span data-menu-button>
-                <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                Unwatch
-            </span>
-</summary>        <details-menu
-          class="select-menu-modal position-absolute mt-5"
-          style="z-index: 99; ">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Notifications</span>
-          </div>
-          <div class="select-menu-list">
-            <button type="submit" name="do" value="included" class="select-menu-item width-full" aria-checked="false" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Not watching</span>
-                <span class="description">Be notified only when participating or @mentioned.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                  Watch
-                </span>
-              </div>
-            </button>
-
-            <button type="submit" name="do" value="release_only" class="select-menu-item width-full" aria-checked="false" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Releases only</span>
-                <span class="description">Be notified of new releases, and when participating or @mentioned.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                  Unwatch releases
-                </span>
-              </div>
-            </button>
-
-            <button type="submit" name="do" value="subscribed" class="select-menu-item width-full" aria-checked="true" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Watching</span>
-                <span class="description">Be notified of all conversations.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                  Unwatch
-                </span>
-              </div>
-            </button>
-
-            <button type="submit" name="do" value="ignore" class="select-menu-item width-full" aria-checked="false" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Ignoring</span>
-                <span class="description">Never be notified.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-mute v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 2.81v10.38c0 .67-.81 1-1.28.53L3 10H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h2l3.72-3.72C7.19 1.81 8 2.14 8 2.81zm7.53 3.22l-1.06-1.06-1.97 1.97-1.97-1.97-1.06 1.06L11.44 8 9.47 9.97l1.06 1.06 1.97-1.97 1.97 1.97 1.06-1.06L13.56 8l1.97-1.97z"/></svg>
-                  Stop ignoring
-                </span>
-              </div>
-            </button>
-
-          </div>
-        </details-menu>
-      </details>
-        <a class="social-count js-social-count"
-          href="/sourcegraph/sourcegraph/watchers"
-          aria-label="41 users are watching this repository">
-          41
-        </a>
-</form>
-  </li>
-
-  <li>
-      <div class="js-toggler-container js-social-container starring-container on">
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="starred js-social-form" action="/sourcegraph/sourcegraph/unstar" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="sDhvlZbYMcySWqIE9YpILnbQfSr9z0O46c9TtqzaxMWSsZwyKjd4qZ/o5vgwCCC06DdC+K0dwz5qjM9y5leDMg==" />
-      <input type="hidden" name="context" value="repository"></input>
-      <button type="submit" class="btn btn-sm btn-with-count js-toggler-target" aria-label="Unstar this repository" title="Unstar sourcegraph/sourcegraph" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;UNSTAR_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CC49:15DA0:2DE33C:4412C4:5CB99055&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="772c8b4d669e1248852eedf55a62e336afee61daf7239642572834dc987e7413" data-ga-click="Repository, click unstar button, action:blob#show; text:Unstar">        <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
-        Unstar
-</button>        <a class="social-count js-social-count" href="/sourcegraph/sourcegraph/stargazers"
-           aria-label="2017 users starred this repository">
-          2,017
-        </a>
-</form>
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="unstarred js-social-form" action="/sourcegraph/sourcegraph/star" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="kO3yf60P5PbzCs9gu0euqFHfrB/Dg1sMkP2x9mpRi2bsLL4+iEeNXsp+L71JN5XE26hA64T3Bx7831YRboHJRw==" />
-      <input type="hidden" name="context" value="repository"></input>
-      <button type="submit" class="btn btn-sm btn-with-count js-toggler-target" aria-label="Unstar this repository" title="Star sourcegraph/sourcegraph" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;STAR_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CC49:15DA0:2DE33C:4412C4:5CB99055&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="8e61fdf88941c8200741ff7b13b8e923b28403c51927a1e4e855d41d9d1be664" data-ga-click="Repository, click star button, action:blob#show; text:Star">        <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
-        Star
-</button>        <a class="social-count js-social-count" href="/sourcegraph/sourcegraph/stargazers"
-           aria-label="2017 users starred this repository">
-          2,017
-        </a>
-</form>  </div>
-
-  </li>
-
-  <li>
-          <details class="details-reset details-overlay details-overlay-dark d-inline-block float-left">
-            <summary class="btn btn-sm btn-with-count" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;FORK_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CC49:15DA0:2DE33C:4412C4:5CB99055&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="7844f5c02421de017ffab3a10f869b524a923effd0905b789371b99faef34a80" data-ga-click="Repository, show fork modal, action:blob#show; text:Fork" title="Fork your own copy of sourcegraph/sourcegraph to your account">              <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-              Fork
-</summary>            <details-dialog
-              class="anim-fade-in fast Box Box--overlay d-flex flex-column"
-              src="/sourcegraph/sourcegraph/fork?fragment=1"
-              preload>
-              <div class="Box-header">
-                <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog>
-                  <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-                </button>
-                <h3 class="Box-title">Fork sourcegraph</h3>
-              </div>
-              <div class="overflow-auto text-center">
-                <include-fragment>
-                  <div class="octocat-spinner my-3" aria-label="Loading..."></div>
-                  <p class="f5 text-gray">If this dialog fails to load, you can visit <a href="/sourcegraph/sourcegraph/fork">the fork page</a> directly.</p>
-                </include-fragment>
-              </div>
-            </details-dialog>
-          </details>
-
-    <a href="/sourcegraph/sourcegraph/network/members" class="social-count"
-       aria-label="134 users forked this repository">
-      134
-    </a>
-  </li>
-</ul>
-
-      <h1 class="public ">
-  <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/sourcegraph/hovercard" href="/sourcegraph">sourcegraph</a></span><!--
---><span class="path-divider">/</span><!--
---><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/sourcegraph/sourcegraph">sourcegraph</a></strong>
-  
-
-</h1>
-
-    </div>
-    
-<nav class="reponav js-repo-nav js-sidenav-container-pjax container-lg p-responsive d-none d-lg-block"
-     itemscope
-     itemtype="http://schema.org/BreadcrumbList"
-    aria-label="Repository"
-     data-pjax="#js-repo-pjax-container">
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph" href="/sourcegraph/sourcegraph">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
-      <span itemprop="name">Code</span>
-      <meta itemprop="position" content="1">
-</a>  </span>
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues" href="/sourcegraph/sourcegraph/issues">
-        <svg class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
-        <span itemprop="name">Issues</span>
-        <span class="Counter">676</span>
-        <meta itemprop="position" content="2">
-</a>    </span>
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls" href="/sourcegraph/sourcegraph/pulls">
-      <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-      <span itemprop="name">Pull requests</span>
-      <span class="Counter">82</span>
-      <meta itemprop="position" content="3">
-</a>  </span>
-
-
-    <a data-hotkey="g w" data-skip-pjax="true" class="js-selected-navigation-item reponav-item" data-selected-links="repo_actions /sourcegraph/sourcegraph/actions" href="/sourcegraph/sourcegraph/actions">
-      <svg class="octicon octicon-play" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 8A7 7 0 1 1 0 8a7 7 0 0 1 14 0zm-8.223 3.482l4.599-3.066a.5.5 0 0 0 0-.832L5.777 4.518A.5.5 0 0 0 5 4.934v6.132a.5.5 0 0 0 .777.416z"/></svg>
-      Actions
-</a>
-    <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects" href="/sourcegraph/sourcegraph/projects">
-      <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      Projects
-      <span class="Counter" >0</span>
-</a>
-
-
-    <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse people alerts /sourcegraph/sourcegraph/pulse" href="/sourcegraph/sourcegraph/pulse">
-      <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
-      Insights
-</a>
-    <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_settings repo_branch_settings hooks integration_installations repo_keys_settings issue_template_editor /sourcegraph/sourcegraph/settings" href="/sourcegraph/sourcegraph/settings">
-      <svg class="octicon octicon-gear" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"/></svg>
-      Settings
-</a>
-</nav>
-
-  <div class="reponav-wrapper reponav-small d-lg-none">
-  <nav class="reponav js-reponav text-center no-wrap"
-       itemscope
-       itemtype="http://schema.org/BreadcrumbList">
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a class="js-selected-navigation-item selected reponav-item" itemprop="url" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph" href="/sourcegraph/sourcegraph">
-        <span itemprop="name">Code</span>
-        <meta itemprop="position" content="1">
-</a>    </span>
-
-      <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-        <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues" href="/sourcegraph/sourcegraph/issues">
-          <span itemprop="name">Issues</span>
-          <span class="Counter">676</span>
-          <meta itemprop="position" content="2">
-</a>      </span>
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls" href="/sourcegraph/sourcegraph/pulls">
-        <span itemprop="name">Pull requests</span>
-        <span class="Counter">82</span>
-        <meta itemprop="position" content="3">
-</a>    </span>
-
-      <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-        <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects" href="/sourcegraph/sourcegraph/projects">
-          <span itemprop="name">Projects</span>
-          <span class="Counter">0</span>
-          <meta itemprop="position" content="4">
-</a>      </span>
-
-
-      <a class="js-selected-navigation-item reponav-item" data-selected-links="pulse /sourcegraph/sourcegraph/pulse" href="/sourcegraph/sourcegraph/pulse">
-        Pulse
-</a>
-      <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-        <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="community /sourcegraph/sourcegraph/community" href="/sourcegraph/sourcegraph/community">
-          Community
-</a>      </span>
-
-  </nav>
-</div>
-
-
-  </div>
-<div class="container-lg new-discussion-timeline experiment-repo-nav  p-responsive">
-  <div class="repository-content ">
-
-    
-    
-
-
-
-  
-    <a class="d-none js-permalink-shortcut" data-hotkey="y" href="/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts">Permalink</a>
-
-    <!-- blob contrib key: blob_contributors:v21:03189a821be92bf7a66681c501b9ac8e -->
-
-    
-
-    <div class="d-flex flex-items-start mb-3 flex-column flex-md-row">
-      <span class="d-flex flex-justify-between width-full width-md-auto">
-        
-<details class="details-reset details-overlay select-menu branch-select-menu ">
-  <summary class="btn btn-sm select-menu-button css-truncate"
-           data-hotkey="w"
-           
-           title="Switch branches or tags">
-    <i>Branch:</i>
-    <span class="css-truncate-target">master</span>
-  </summary>
-
-  <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/ref-list/master/shared/src/api/extension/types/url.ts?source_action=show&amp;source_controller=blob" preload>
-    <include-fragment class="select-menu-loading-overlay anim-pulse">
-      <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
-    </include-fragment>
-  </details-menu>
-</details>
-
-        <div class="BtnGroup flex-shrink-0 d-md-none">
-          <a href="/sourcegraph/sourcegraph/find/master"
-                class="js-pjax-capture-input btn btn-sm BtnGroup-item"
-                data-pjax
-                data-hotkey="t">
-            Find file
-          </a>
-          <clipboard-copy value="shared/src/api/extension/types/url.ts" class="btn btn-sm BtnGroup-item">
-            Copy path
-          </clipboard-copy>
-        </div>
-      </span>
-      <h2 id="blob-path" class="breadcrumb flex-auto min-width-0 text-normal flex-md-self-center ml-md-2 mr-md-3 my-2 my-md-0">
-        <span class="js-repo-root text-bold"><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph"><span>sourcegraph</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared"><span>shared</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src"><span>src</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src/api"><span>api</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src/api/extension"><span>extension</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types"><span>types</span></a></span><span class="separator">/</span><strong class="final-path">url.ts</strong>
-      </h2>
-
-      <div class="BtnGroup flex-shrink-0 d-none d-md-inline-block">
-        <a href="/sourcegraph/sourcegraph/find/master"
-              class="js-pjax-capture-input btn btn-sm BtnGroup-item"
-              data-pjax
-              data-hotkey="t">
-          Find file
-        </a>
-        <clipboard-copy value="shared/src/api/extension/types/url.ts" class="btn btn-sm BtnGroup-item">
-          Copy path
-        </clipboard-copy>
-      </div>
-    </div>
-
-
-
-    
-  <div class="Box Box--condensed d-flex flex-column flex-shrink-0">
-      <div class="Box-body d-flex flex-justify-between bg-blue-light flex-column flex-md-row flex-items-start flex-md-items-center">
-        <span class="pr-md-4 f6">
-          <a rel="contributor" data-skip-pjax="true" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=10532611" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/felixfbecker"><img class="avatar" src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4" width="20" height="20" alt="@felixfbecker" /></a>
-          <a class="text-bold link-gray-dark lh-default v-align-middle" rel="contributor" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=10532611" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/felixfbecker">felixfbecker</a>
-            <span class="lh-default v-align-middle">
-              <a data-pjax="true" title="Replace sourcegraph.URI with WHATWG URL (#2430)" class="link-gray" href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37">Replace sourcegraph.URI with WHATWG URL (</a><a class="issue-link js-issue-link" data-error-text="Failed to load issue title" data-id="414041237" data-permission-text="Issue title is private" data-url="https://github.com/sourcegraph/sourcegraph/issues/2430" data-hovercard-type="pull_request" data-hovercard-url="/sourcegraph/sourcegraph/pull/2430/hovercard" href="https://github.com/sourcegraph/sourcegraph/pull/2430">#2430</a><a data-pjax="true" title="Replace sourcegraph.URI with WHATWG URL (#2430)" class="link-gray" href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37">)</a>
-            </span>
-        </span>
-        <span class="d-inline-block flex-shrink-0 v-align-bottom f6 mt-2 mt-md-0">
-          <a class="pr-2 text-mono link-gray" href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37" data-pjax>cd3ccd9</a>
-          <relative-time datetime="2019-02-25T11:27:16Z">Feb 25, 2019</relative-time>
-        </span>
-      </div>
-
-    <div class="Box-body d-flex flex-items-center flex-auto f6 border-bottom-0 flex-wrap" >
-      <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark float-left mr-2" id="blob_contributors_box">
-        <summary class="btn-link" aria-haspopup="dialog">
-          <span><strong>1</strong> contributor</span>
-        </summary>
-        <details-dialog
-          class="Box Box--overlay d-flex flex-column anim-fade-in fast"
-          aria-label="Users who have contributed to this file"
-          >
-          <div class="Box-header">
-            <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog>
-              <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-            </button>
-            <h3 class="Box-title">
-              Users who have contributed to this file
-            </h3>
-          </div>
-              <ul class="list-style-none overflow-auto">
-    <li class="Box-row">
-      <a class="link-gray-dark no-underline" href="/felixfbecker">
-        <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4" width="20" height="20" />
-        felixfbecker
-</a>    </li>
-</ul>
-
-        </details-dialog>
-      </details>
-    </div>
-  </div>
-
-
-
-
-
-    <div class="Box mt-3 position-relative">
-      
-<div class="Box-header py-2 d-flex flex-column flex-shrink-0 flex-md-row flex-md-items-center">
-
-  <div class="text-mono f6 flex-auto pr-3 flex-order-2 flex-md-order-1 mt-2 mt-md-0">
-      3 lines (2 sloc)
-      <span class="file-info-divider"></span>
-    138 Bytes
-  </div>
-
-  <div class="d-flex py-1 py-md-0 flex-auto flex-order-1 flex-md-order-2 flex-sm-grow-0 flex-justify-between">
-
-    <div class="BtnGroup">
-      <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/sourcegraph/sourcegraph/raw/master/shared/src/api/extension/types/url.ts">Raw</a>
-        <a class="btn btn-sm js-update-url-with-hash BtnGroup-item" data-hotkey="b" href="/sourcegraph/sourcegraph/blame/master/shared/src/api/extension/types/url.ts">Blame</a>
-      <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/sourcegraph/sourcegraph/commits/master/shared/src/api/extension/types/url.ts">History</a>
-    </div>
-
-
-    <div>
-            <a class="btn-octicon tooltipped tooltipped-nw"
-               href="github-mac://openRepo/https://github.com/sourcegraph/sourcegraph?branch=master&amp;filepath=shared%2Fsrc%2Fapi%2Fextension%2Ftypes%2Furl.ts"
-               aria-label="Open this file in GitHub Desktop"
-               data-ga-click="Repository, open with desktop, type:mac">
-                <svg class="octicon octicon-device-desktop" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"/></svg>
-            </a>
-
-            <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="inline-form js-update-url-with-hash" action="/sourcegraph/sourcegraph/edit/master/shared/src/api/extension/types/url.ts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="fs15kXkOR4KPjZ1G+I9fDUrFuvoR6hmAPIVYDFVFSAMVT3uCCcAmWNqQccG2kT1L2mPWjD9+PKaMy8lbHD8tSg==" />
-              <button class="btn-octicon tooltipped tooltipped-nw" type="submit"
-                aria-label="Edit this file" data-hotkey="e" data-disable-with>
-                <svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg>
-              </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="inline-form" action="/sourcegraph/sourcegraph/delete/master/shared/src/api/extension/types/url.ts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="DHGtjEpz3eDWjWCFdQCAp55iAqv6JWRhBP7VV05nwzy4N4vUO0kLQOTHLgrD4kx0FiBAETN7qSaEJ96C441ieg==" />
-            <button class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw" type="submit"
-              aria-label="Delete this file" data-disable-with>
-              <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>
-            </button>
-</form>    </div>
-  </div>
-</div>
-
-      
-
-  <div itemprop="text" class="Box-body p-0 blob-wrapper data type-typescript ">
-      
-<table class="highlight tab-size js-file-line-container" data-tab-size="4">
-      <tr>
-        <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
-        <td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-k"><span class="pl-k">export</span></span> <span class="pl-k"><span class="pl-k">const</span></span> isURL <span class="pl-k">=</span> (<span class="pl-v">value</span><span class="pl-k">:</span> <span class="pl-c1">any</span>)<span class="pl-k">:</span> <span class="pl-en">value</span> <span class="pl-k">is</span> <span class="pl-en">URL</span> <span class="pl-k">=&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
-        <td id="LC2" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">!!</span><span class="pl-smi">value</span> <span class="pl-k">&amp;&amp;</span> <span class="pl-k">typeof</span> <span class="pl-smi">value</span>.<span class="pl-smi">toString</span> <span class="pl-k">===</span> <span class="pl-s"><span class="pl-pds">&#39;</span>function<span class="pl-pds">&#39;</span></span> <span class="pl-k">&amp;&amp;</span> <span class="pl-smi">value</span>.<span class="pl-c1">href</span> <span class="pl-k">===</span> <span class="pl-smi">value</span>.<span class="pl-c1">toString</span>()</td>
-      </tr>
-</table>
-
-  <details class="details-reset details-overlay BlobToolbar position-absolute js-file-line-actions dropdown d-none" aria-hidden="true">
-    <summary class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1" aria-label="Inline file action toolbar">
-      <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
-    </summary>
-    <details-menu>
-      <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2" style="width:185px">
-        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-lines" style="cursor:pointer;" data-original-text="Copy lines">Copy lines</clipboard-copy></li>
-        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-permalink" style="cursor:pointer;" data-original-text="Copy permalink">Copy permalink</clipboard-copy></li>
-        <li><a class="dropdown-item js-update-url-with-hash" id="js-view-git-blame" role="menuitem" href="/sourcegraph/sourcegraph/blame/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts">View git blame</a></li>
-          <li><a class="dropdown-item" id="js-new-issue" role="menuitem" href="/sourcegraph/sourcegraph/issues/new/choose">Reference in new issue</a></li>
-      </ul>
-    </details-menu>
-  </details>
-
-  </div>
-
-    </div>
-
-  
-
-  <details class="details-reset details-overlay details-overlay-dark">
-    <summary data-hotkey="l" aria-label="Jump to line"></summary>
-    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast linejump" aria-label="Jump to line">
-      <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-jump-to-line-form Box-body d-flex" action="" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
-        <input class="form-control flex-auto mr-3 linejump-input js-jump-to-line-field" type="text" placeholder="Jump to line&hellip;" aria-label="Jump to line" autofocus>
-        <button type="submit" class="btn" data-close-dialog>Go</button>
-</form>    </details-dialog>
-  </details>
-
-
-
-  </div>
-  <div class="modal-backdrop js-touch-events"></div>
-</div>
-
-    </main>
-  </div>
-  
-
-  </div>
-
-        
-<div class="footer container-lg width-full p-responsive" role="contentinfo">
-  <div class="position-relative d-flex flex-row-reverse flex-lg-row flex-wrap flex-lg-nowrap flex-justify-center flex-lg-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
-    <ul class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-start mb-2 mb-lg-0">
-      <li class="mr-3">&copy; 2019 <span title="0.63696s from unicorn-54fd48477f-wtdkz">GitHub</span>, Inc.</li>
-        <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to security, text:security" href="https://github.com/security">Security</a></li>
-        <li class="mr-3"><a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
-        <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
-    </ul>
-
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon mx-lg-4" href="https://github.com">
-      <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-</a>
-   <ul class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-end mb-2 mb-lg-0">
-        <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
-        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
-      <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
-      <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-        <li class="mr-3"><a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
-        <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
-
-    </ul>
-  </div>
-  <div class="d-flex flex-justify-center pb-6">
-    <span class="f6 text-gray-light"></span>
-  </div>
-</div>
-
-
-
-  <div id="ajax-error-message" class="ajax-error-message flash flash-error">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
-    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
-      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-    </button>
-    You can’t perform that action at this time.
-  </div>
-
-
-    
-    <script crossorigin="anonymous" integrity="sha512-eYWkirt5BXd8Z6IvLT/AkE0jvsyFHbTICcEN1Aczj9caa8b+20ToUYPgohknnTlFrLElgEN0HX9Oh8XHbTFNBw==" type="application/javascript" src="https://github.githubassets.com/assets/frameworks-4199e113.js"></script>
-    
-    <script crossorigin="anonymous" async="async" integrity="sha512-v7DMdD9nOupolgEznyVt6jkYstlmhvl+WlRiHpi6EdRe8FYBp4yK+yEKrghaofifa3x8sXCtV4yy04U0d6fdFg==" type="application/javascript" src="https://github.githubassets.com/assets/github-bootstrap-80470f8d.js"></script>
-    
-    
-    
-  <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden
+<!-- https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts -->
+<html lang="en" class="refined-github">
+    <head>
+        <meta charset="utf-8" />
+        <link rel="dns-prefetch" href="https://github.githubassets.com" />
+        <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com" />
+        <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/" />
+
+        <link
+            crossorigin="anonymous"
+            media="all"
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
+            rel="stylesheet"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
+        />
+
+        <link
+            crossorigin="anonymous"
+            media="all"
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
+            rel="stylesheet"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
+        />
+
+        <meta name="viewport" content="width=device-width" />
+
+        <title>sourcegraph/url.ts at eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9 · sourcegraph/sourcegraph</title>
+        <meta
+            name="description"
+            content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub."
+        />
+        <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub" />
+        <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
+        <meta property="fb:app_id" content="1401488693436528" />
+
+        <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="sourcegraph/sourcegraph" />
+        <meta
+            name="twitter:description"
+            content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub."
+        />
+        <meta property="og:image" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" />
+        <meta property="og:site_name" content="GitHub" />
+        <meta property="og:type" content="object" />
+        <meta property="og:title" content="sourcegraph/sourcegraph" />
+        <meta property="og:url" content="https://github.com/sourcegraph/sourcegraph" />
+        <meta
+            property="og:description"
+            content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub."
+        />
+
+        <link rel="assets" href="https://github.githubassets.com/" />
+        <link
+            rel="web-socket"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmVjMzQyY2RkODE0NDA5ZDg4YjAzYjNmNDBhYzM5NGU4MWNlYzFlYjI0NTcwOTRiOTgyMzI3MjJhMTUwZTNhOGI=--356d5c30991bb6aa3f2db5df5b0dd3f5781d5435"
+        />
+        <meta name="pjax-timeout" content="1000" />
+        <link rel="sudo-modal" href="/sessions/sudo_modal" />
+        <meta name="request-id" content="C74C:2DB09:228E08F:3404402:5CC236C1" data-pjax-transient="" />
+
+        <meta name="selected-link" value="repo_source" data-pjax-transient="" />
+
+        <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU" />
+        <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA" />
+        <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc" />
+
+        <meta name="octolytics-host" content="collector.githubapp.com" />
+        <meta name="octolytics-app-id" content="github" />
+        <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
+        <meta name="octolytics-dimension-request_id" content="C74C:2DB09:228E08F:3404402:5CC236C1" />
+        <meta name="octolytics-dimension-region_edge" content="ams" />
+        <meta name="octolytics-dimension-region_render" content="iad" />
+        <meta name="octolytics-actor-id" content="10532611" />
+        <meta name="octolytics-actor-login" content="felixfbecker" />
+        <meta name="octolytics-actor-hash" content="a0bf5739a312c3a4d600b1ddd462e3b3ac0c4c28370673f3b7aacd82b09f1fac" />
+        <meta name="analytics-location" content="/<user-name>/<repo-name>/blob/show" data-pjax-transient="true" />
+
+        <meta class="js-ga-set" name="userId" content="1b23c6f4348a524a9d5b520c80e3ee17" />
+
+        <meta class="js-ga-set" name="dimension1" content="Logged In" />
+
+        <meta name="hostname" content="github.com" />
+        <meta name="user-login" content="felixfbecker" />
+
+        <meta name="expected-hostname" content="github.com" />
+        <meta
+            name="js-proxy-site-detection-payload"
+            content="YTRkNTcwMDBlMDZhYzM2MGI4MjA2ZjI1YTVlYjE1NjdjNDBhYzA2MWUyMWI5MGZhNzkyMDAxZmNkZDMxYmQwZXx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkM3NEM6MkRCMDk6MjI4RTA4RjozNDA0NDAyOjVDQzIzNkMxIiwidGltZXN0YW1wIjoxNTU2MjMxOTAwLCJob3N0IjoiZ2l0aHViLmNvbSJ9"
+        />
+
+        <meta
+            name="enabled-features"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+        />
+
+        <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
+
+        <meta http-equiv="x-pjax-version" content="ae4ac585f9fbd8269d0af4700dd2453b" />
+
+        <link
+            href="https://github.com/sourcegraph/sourcegraph/commits/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9.atom"
+            rel="alternate"
+            title="Recent Commits to sourcegraph:eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9"
+            type="application/atom+xml"
+        />
+
+        <meta
+            name="go-import"
+            content="github.com/sourcegraph/sourcegraph git https://github.com/sourcegraph/sourcegraph.git"
+        />
+
+        <meta name="octolytics-dimension-user_id" content="3979584" />
+        <meta name="octolytics-dimension-user_login" content="sourcegraph" />
+        <meta name="octolytics-dimension-repository_id" content="41288708" />
+        <meta name="octolytics-dimension-repository_nwo" content="sourcegraph/sourcegraph" />
+        <meta name="octolytics-dimension-repository_public" content="true" />
+        <meta name="octolytics-dimension-repository_is_fork" content="false" />
+        <meta name="octolytics-dimension-repository_network_root_id" content="41288708" />
+        <meta name="octolytics-dimension-repository_network_root_nwo" content="sourcegraph/sourcegraph" />
+        <meta name="octolytics-dimension-repository_explore_github_marketplace_ci_cta_shown" content="false" />
+
+        <link
+            rel="canonical"
+            href="https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
+            data-pjax-transient=""
+        />
+
+        <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats" />
+
+        <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors" />
+
+        <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000" />
+        <link
+            rel="icon"
+            type="image/x-icon"
+            class="js-site-favicon"
+            href="https://github.githubassets.com/favicon.ico"
+        />
+
+        <meta name="theme-color" content="#1e2327" />
+
+        <meta name="u2f-enabled" content="true" />
+
+        <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
+    </head>
+
+    <body
+        class="logged-in env-production emoji-size-boost page-responsive min-width-0 page-blob rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count rgh-recently-pushed-branches"
     >
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
-    <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
-    <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
-  </div>
-  <template id="site-details-dialog">
-  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
-    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
-    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
-      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-      </button>
-      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
-    </details-dialog>
-  </details>
-</template>
+        <div class="position-relative js-header-wrapper ">
+            <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content"
+                >Skip to content</a
+            >
+            <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
 
-  <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
-  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">
-  </div>
-</div>
+            <header class="Header js-details-container Details flex-wrap flex-lg-nowrap p-responsive" role="banner">
+                <div class="Header-item d-none d-lg-flex">
+                    <a
+                        class="Header-link"
+                        href="https://github.com/"
+                        data-hotkey="g d"
+                        aria-label="Homepage"
+                        data-ga-click="Header, go to dashboard, icon:logo"
+                    >
+                        <svg
+                            class="octicon octicon-mark-github v-align-middle"
+                            height="32"
+                            viewBox="0 0 16 16"
+                            version="1.1"
+                            width="32"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+                            ></path>
+                        </svg>
+                    </a>
+                </div>
 
-  <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
+                <div class="Header-item d-lg-none">
+                    <button
+                        class="Header-link btn-link js-details-target"
+                        type="button"
+                        aria-label="Toggle navigation"
+                        aria-expanded="false"
+                    >
+                        <svg
+                            height="24"
+                            class="octicon octicon-three-bars"
+                            viewBox="0 0 12 16"
+                            version="1.1"
+                            width="18"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M11.41 9H.59C0 9 0 8.59 0 8c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zm0-4H.59C0 5 0 4.59 0 4c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM.59 11H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1H.59C0 13 0 12.59 0 12c0-.59 0-1 .59-1z"
+                            ></path>
+                        </svg>
+                    </button>
+                </div>
 
-  </body>
+                <div
+                    class="Header-item Header-item--full flex-column flex-lg-row width-full flex-order-2 flex-lg-order-none mr-0 mr-lg-3 mt-3 mt-lg-0 Details-content--hidden"
+                >
+                    <div
+                        class="header-search flex-self-stretch flex-lg-self-auto mr-0 mr-lg-3 mb-3 mb-lg-0 scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+                        role="combobox"
+                        aria-owns="jump-to-results"
+                        aria-label="Search or jump to"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                    >
+                        <div class="position-relative">
+                            <!-- '"` --><!-- </textarea></xmp> -->
+                            <form
+                                class="js-site-search-form"
+                                role="search"
+                                aria-label="Site"
+                                data-scope-type="Repository"
+                                data-scope-id="41288708"
+                                data-scoped-search-url="/sourcegraph/sourcegraph/search"
+                                data-unscoped-search-url="/search"
+                                action="/sourcegraph/sourcegraph/search"
+                                accept-charset="UTF-8"
+                                method="get"
+                            >
+                                <input name="utf8" type="hidden" value="✓" />
+                                <label
+                                    class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container"
+                                >
+                                    <input
+                                        type="text"
+                                        class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
+                                        data-hotkey="s,/"
+                                        name="q"
+                                        value=""
+                                        placeholder="Search or jump to…"
+                                        data-unscoped-placeholder="Search or jump to…"
+                                        data-scoped-placeholder="Search or jump to…"
+                                        autocapitalize="off"
+                                        aria-autocomplete="list"
+                                        aria-controls="jump-to-results"
+                                        aria-label="Search or jump to…"
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=8IGl9Hjpd1z8z+5QoHn23iTinXdqDSEoOmjJzckDeT2ppjQDXFnm1BjWMzurkI4Fg+ajUnyFyYuVneecxDUcMA=="
+                                        spellcheck="false"
+                                        autocomplete="off"
+                                    />
+                                    <input type="hidden" class="js-site-search-type-field" name="type" />
+                                    <img
+                                        src="https://github.githubassets.com/images/search-key-slash.svg"
+                                        alt=""
+                                        class="mr-2 header-search-key-slash"
+                                    />
+
+                                    <div
+                                        class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container"
+                                    >
+                                        <ul class="d-none js-jump-to-suggestions-template-container">
+                                            <li
+                                                class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion"
+                                                role="option"
+                                            >
+                                                <a
+                                                    tabindex="-1"
+                                                    class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2"
+                                                    href=""
+                                                >
+                                                    <div
+                                                        class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none"
+                                                    >
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none"
+                                                            title="Repository"
+                                                            aria-label="Repository"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none"
+                                                            title="Project"
+                                                            aria-label="Project"
+                                                            viewBox="0 0 15 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none"
+                                                            title="Search"
+                                                            aria-label="Search"
+                                                            viewBox="0 0 16 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"
+                                                            ></path>
+                                                        </svg>
+                                                    </div>
+
+                                                    <img
+                                                        class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none"
+                                                        alt=""
+                                                        aria-label="Team"
+                                                        src=""
+                                                        width="28"
+                                                        height="28"
+                                                    />
+
+                                                    <div
+                                                        class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target"
+                                                    ></div>
+
+                                                    <div
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search"
+                                                    >
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-default d-none"
+                                                            aria-label="in this repository"
+                                                        >
+                                                            In this repository
+                                                        </span>
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-global d-none"
+                                                            aria-label="in all of GitHub"
+                                                        >
+                                                            All GitHub
+                                                        </span>
+                                                        <span
+                                                            aria-hidden="true"
+                                                            class="d-inline-block ml-1 v-align-middle"
+                                                            >↵</span
+                                                        >
+                                                    </div>
+
+                                                    <div
+                                                        aria-hidden="true"
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump"
+                                                    >
+                                                        Jump to
+                                                        <span class="d-inline-block ml-1 v-align-middle">↵</span>
+                                                    </div>
+                                                </a>
+                                            </li>
+                                        </ul>
+
+                                        <ul class="d-none js-jump-to-no-results-template-container">
+                                            <li
+                                                class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2"
+                                            >
+                                                <span class="text-gray">No suggested jump to results</span>
+                                            </li>
+                                        </ul>
+
+                                        <ul
+                                            id="jump-to-results"
+                                            role="listbox"
+                                            class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container"
+                                        >
+                                            <li
+                                                class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none"
+                                                role="option"
+                                            >
+                                                <a
+                                                    tabindex="-1"
+                                                    class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2"
+                                                    href=""
+                                                >
+                                                    <div
+                                                        class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none"
+                                                    >
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none"
+                                                            title="Repository"
+                                                            aria-label="Repository"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none"
+                                                            title="Project"
+                                                            aria-label="Project"
+                                                            viewBox="0 0 15 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none"
+                                                            title="Search"
+                                                            aria-label="Search"
+                                                            viewBox="0 0 16 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"
+                                                            ></path>
+                                                        </svg>
+                                                    </div>
+
+                                                    <img
+                                                        class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none"
+                                                        alt=""
+                                                        aria-label="Team"
+                                                        src=""
+                                                        width="28"
+                                                        height="28"
+                                                    />
+
+                                                    <div
+                                                        class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target"
+                                                    ></div>
+
+                                                    <div
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search"
+                                                    >
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-default d-none"
+                                                            aria-label="in this repository"
+                                                        >
+                                                            In this repository
+                                                        </span>
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-global d-none"
+                                                            aria-label="in all of GitHub"
+                                                        >
+                                                            All GitHub
+                                                        </span>
+                                                        <span
+                                                            aria-hidden="true"
+                                                            class="d-inline-block ml-1 v-align-middle"
+                                                            >↵</span
+                                                        >
+                                                    </div>
+
+                                                    <div
+                                                        aria-hidden="true"
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump"
+                                                    >
+                                                        Jump to
+                                                        <span class="d-inline-block ml-1 v-align-middle">↵</span>
+                                                    </div>
+                                                </a>
+                                            </li>
+
+                                            <li
+                                                class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none"
+                                                role="option"
+                                            >
+                                                <a
+                                                    tabindex="-1"
+                                                    class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2"
+                                                    href=""
+                                                >
+                                                    <div
+                                                        class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none"
+                                                    >
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none"
+                                                            title="Repository"
+                                                            aria-label="Repository"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none"
+                                                            title="Project"
+                                                            aria-label="Project"
+                                                            viewBox="0 0 15 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none"
+                                                            title="Search"
+                                                            aria-label="Search"
+                                                            viewBox="0 0 16 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"
+                                                            ></path>
+                                                        </svg>
+                                                    </div>
+
+                                                    <img
+                                                        class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none"
+                                                        alt=""
+                                                        aria-label="Team"
+                                                        src=""
+                                                        width="28"
+                                                        height="28"
+                                                    />
+
+                                                    <div
+                                                        class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target"
+                                                    ></div>
+
+                                                    <div
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search"
+                                                    >
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-default d-none"
+                                                            aria-label="in this repository"
+                                                        >
+                                                            In this repository
+                                                        </span>
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-global d-none"
+                                                            aria-label="in all of GitHub"
+                                                        >
+                                                            All GitHub
+                                                        </span>
+                                                        <span
+                                                            aria-hidden="true"
+                                                            class="d-inline-block ml-1 v-align-middle"
+                                                            >↵</span
+                                                        >
+                                                    </div>
+
+                                                    <div
+                                                        aria-hidden="true"
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump"
+                                                    >
+                                                        Jump to
+                                                        <span class="d-inline-block ml-1 v-align-middle">↵</span>
+                                                    </div>
+                                                </a>
+                                            </li>
+
+                                            <li
+                                                class="d-flex flex-justify-center flex-items-center p-0 f5 js-jump-to-suggestion"
+                                            >
+                                                <img
+                                                    src="https://github.githubassets.com/images/spinners/octocat-spinner-128.gif"
+                                                    alt="Octocat Spinner Icon"
+                                                    class="m-2"
+                                                    width="28"
+                                                />
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </label>
+                            </form>
+                        </div>
+                    </div>
+
+                    <nav class="d-flex flex-column flex-lg-row flex-self-stretch flex-lg-self-auto" aria-label="Global">
+                        <a
+                            class="Header-link d-block d-lg-none py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-ga-click="Header, click, Nav menu - item:dashboard:user"
+                            aria-label="Dashboard"
+                            href="/dashboard"
+                        >
+                            Dashboard
+                        </a>
+                        <a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-hotkey="g p"
+                            data-ga-click="Header, click, Nav menu - item:pulls context:user"
+                            aria-label="Pull requests you created"
+                            data-selected-links="/pulls /pulls/assigned /pulls/mentioned /pulls"
+                            href="https://github.com/pulls?q=is%3Apr+is%3Aopen+author%3Afelixfbecker+archived%3Afalse+sort%3Aupdated-desc"
+                        >
+                            Pull requests
+                        </a>
+                        <a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-hotkey="g i"
+                            data-ga-click="Header, click, Nav menu - item:issues context:user"
+                            aria-label="Issues you created"
+                            data-selected-links="/issues /issues/assigned /issues/mentioned /issues"
+                            href="https://github.com/issues?q=is%3Aissue+is%3Aopen+author%3Afelixfbecker+archived%3Afalse+sort%3Aupdated-desc"
+                        >
+                            Issues
+                        </a>
+                        <a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-ga-click="Header, click, Nav menu - item:marketplace context:user"
+                            data-octo-click="marketplace_click"
+                            data-octo-dimensions="location:nav_bar"
+                            data-selected-links=" /marketplace"
+                            href="/marketplace"
+                        >
+                            Marketplace
+                        </a>
+
+                        <a
+                            href="/trending"
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-hotkey="g t"
+                            >Trending</a
+                        ><a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-ga-click="Header, click, Nav menu - item:explore"
+                            data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore"
+                            href="/explore"
+                        >
+                            Explore
+                        </a>
+                        <a
+                            class="Header-link d-block d-lg-none mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            aria-label="View profile and more"
+                            aria-expanded="false"
+                            aria-haspopup="false"
+                            href="https://github.com/felixfbecker"
+                        >
+                            <img
+                                class="avatar"
+                                src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4"
+                                width="20"
+                                height="20"
+                                alt="@felixfbecker"
+                            />
+                            felixfbecker
+                        </a>
+                        <!-- '"` --><!-- </textarea></xmp> -->
+                        <form action="/logout" accept-charset="UTF-8" method="post">
+                            <input name="utf8" type="hidden" value="✓" /><input
+                                type="hidden"
+                                name="authenticity_token"
+                                value="EdsRvAy5ex733vRKDxuRKzFS7+XYuB0ikQCmJ+IJYMoWF3KEpScosqfN5cSvb/nTXs4dvnrZ+Ns0DY3bPx5elg=="
+                            />
+                            <button
+                                type="submit"
+                                class="Header-link mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15 d-lg-none btn-link d-block width-full text-left"
+                                data-ga-click="Header, sign out, icon:logout"
+                                style="padding-left: 2px;"
+                            >
+                                <svg
+                                    class="octicon octicon-sign-out v-align-middle"
+                                    viewBox="0 0 16 16"
+                                    version="1.1"
+                                    width="16"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M12 9V7H8V5h4V3l4 3-4 3zm-2 3H6V3L2 1h8v3h1V1c0-.55-.45-1-1-1H1C.45 0 0 .45 0 1v11.38c0 .39.22.73.55.91L6 16.01V13h4c.55 0 1-.45 1-1V8h-1v4z"
+                                    ></path>
+                                </svg>
+                                Sign out
+                            </button>
+                        </form>
+                    </nav>
+                </div>
+                <div
+                    class="js-socket-channel js-updatable-content"
+                    data-channel="repo:41288708:post-receive:10532611"
+                    data-url="/sourcegraph/sourcegraph/show_partial?partial=tree%2Frecently_touched_branches_list"
+                ></div>
+
+                <div class="Header-item Header-item--full flex-justify-center d-lg-none position-relative">
+                    <div
+                        class="css-truncate css-truncate-target width-fit position-absolute left-0 right-0 text-center"
+                    >
+                        <svg
+                            class="octicon octicon-repo"
+                            viewBox="0 0 12 16"
+                            version="1.1"
+                            width="12"
+                            height="16"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                            ></path>
+                        </svg>
+                        <a class="Header-link" href="/sourcegraph">sourcegraph</a>
+                        /
+                        <a class="Header-link" href="/sourcegraph/sourcegraph">sourcegraph</a>
+                    </div>
+                </div>
+
+                <div class="Header-item position-relative d-none d-lg-flex"></div>
+
+                <div class="Header-item mr-0 mr-lg-3 flex-order-1 flex-lg-order-none"></div>
+
+                <div class="Header-item position-relative d-none d-lg-flex">
+                    <details class="details-overlay details-reset">
+                        <summary
+                            class="Header-link"
+                            aria-label="Create new…"
+                            data-ga-click="Header, create new, icon:add"
+                            aria-haspopup="menu"
+                        >
+                            <svg
+                                class="octicon octicon-plus"
+                                viewBox="0 0 12 16"
+                                version="1.1"
+                                width="12"
+                                height="16"
+                                aria-hidden="true"
+                            >
+                                <path fill-rule="evenodd" d="M12 9H7v5H5V9H0V7h5V2h2v5h5v2z"></path>
+                            </svg>
+                            <span class="dropdown-caret"></span>
+                        </summary>
+                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/new"
+                                data-ga-click="Header, create new repository"
+                            >
+                                New repository
+                            </a>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/new/import"
+                                data-ga-click="Header, import a repository"
+                            >
+                                Import repository
+                            </a>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="https://gist.github.com/"
+                                data-ga-click="Header, create new gist"
+                            >
+                                New gist
+                            </a>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/organizations/new"
+                                data-ga-click="Header, create new organization"
+                            >
+                                New organization
+                            </a>
+
+                            <div role="none" class="dropdown-divider"></div>
+                            <div class="dropdown-header">
+                                <span title="sourcegraph/sourcegraph">This repository</span>
+                            </div>
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/sourcegraph/sourcegraph/issues/new/choose"
+                                data-ga-click="Header, create new issue"
+                                data-skip-pjax=""
+                            >
+                                New issue
+                            </a>
+
+                            <a class="dropdown-item" href="/sourcegraph/sourcegraph/projects/new"
+                                >New project</a
+                            ></details-menu
+                        >
+                    </details>
+                </div>
+
+                <div class="Header-item position-relative mr-0 d-none d-lg-flex">
+                    <details class="details-overlay details-reset">
+                        <summary
+                            class="Header-link"
+                            aria-label="View profile and more"
+                            data-ga-click="Header, show menu, icon:avatar"
+                            aria-haspopup="menu"
+                        >
+                            <img
+                                alt="@felixfbecker"
+                                class="avatar"
+                                src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4"
+                                height="20"
+                                width="20"
+                            />
+                            <span class="dropdown-caret"></span>
+                        </summary>
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
+                            <div class="header-nav-current-user css-truncate">
+                                <a
+                                    role="menuitem"
+                                    class="no-underline user-profile-link px-3 pt-2 pb-2 mb-n2 mt-n1 d-block"
+                                    href="/felixfbecker"
+                                    data-ga-click="Header, go to profile, text:Signed in as"
+                                    >Signed in as <strong class="css-truncate-target">felixfbecker</strong></a
+                                >
+                            </div>
+                            <div role="none" class="dropdown-divider"></div>
+
+                            <div
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
+                                data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
+                            >
+                                <div
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
+                                    data-team-hovercards-enabled=""
+                                >
+                                    <details
+                                        class="js-user-status-details details-reset details-overlay details-overlay-dark"
+                                    >
+                                        <summary
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
+                                            aria-haspopup="dialog"
+                                            role="menuitem"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"C74C:2DB09:228E08F:3404402:5CC236C1","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts","referrer":null}}'
+                                            data-hydro-click-hmac="87775fff48eebb6a363e78638208d57261ac040436ab3561526f10e8fd221719"
+                                        >
+                                            <div
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
+                                            >
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            title=":palm_tree:"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
+                                            >
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
+                                            </div>
+                                        </summary>
+                                        <details-dialog
+                                            class="details-dialog rounded-1 anim-fade-in fast Box Box--overlay"
+                                            role="dialog"
+                                            tabindex="-1"
+                                        >
+                                            <!-- '"` --><!-- </textarea></xmp> -->
+                                            <form
+                                                class="position-relative flex-auto js-user-status-form"
+                                                action="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
+                                                accept-charset="UTF-8"
+                                                method="post"
+                                            >
+                                                <input name="utf8" type="hidden" value="✓" /><input
+                                                    type="hidden"
+                                                    name="_method"
+                                                    value="put"
+                                                /><input
+                                                    type="hidden"
+                                                    name="authenticity_token"
+                                                    value="e8dacf9dz3uECr2yv6+n6EwfGtIMOeQ2A4WY4OacnbCNqfWqvtwGpwFcG/a04OzrUnrb0CIVSMeVyFwPUXo+TA=="
+                                                />
+                                                <div class="Box-header bg-gray border-bottom p-3">
+                                                    <button
+                                                        class="Box-btn-octicon js-toggle-user-status-edit btn-octicon float-right"
+                                                        type="reset"
+                                                        aria-label="Close dialog"
+                                                        data-close-dialog=""
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-x"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                                                            ></path>
+                                                        </svg>
+                                                    </button>
+                                                    <h3 class="Box-title f5 text-bold text-gray-dark">Edit status</h3>
+                                                </div>
+                                                <input
+                                                    type="hidden"
+                                                    name="emoji"
+                                                    class="js-user-status-emoji-field"
+                                                    value=":palm_tree:"
+                                                />
+                                                <input
+                                                    type="hidden"
+                                                    name="organization_id"
+                                                    class="js-user-status-org-id-field"
+                                                    value=""
+                                                />
+                                                <div class="px-3 py-2 text-gray-dark">
+                                                    <div
+                                                        class="js-characters-remaining-container js-suggester-container position-relative mt-2"
+                                                    >
+                                                        <div
+                                                            class="input-group d-table form-group my-0 js-user-status-form-group"
+                                                        >
+                                                            <span
+                                                                class="input-group-button d-table-cell v-align-middle"
+                                                                style="width: 1%"
+                                                            >
+                                                                <button
+                                                                    type="button"
+                                                                    aria-label="Choose an emoji"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
+                                                                >
+                                                                    <span
+                                                                        class="js-user-status-original-emoji"
+                                                                        hidden=""
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
+                                                                        <svg
+                                                                            class="octicon octicon-smiley"
+                                                                            viewBox="0 0 16 16"
+                                                                            version="1.1"
+                                                                            width="16"
+                                                                            height="16"
+                                                                            aria-hidden="true"
+                                                                        >
+                                                                            <path
+                                                                                fill-rule="evenodd"
+                                                                                d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
+                                                                            ></path>
+                                                                        </svg>
+                                                                    </span>
+                                                                </button>
+                                                            </span>
+                                                            <input
+                                                                type="text"
+                                                                autocomplete="off"
+                                                                data-maxlength="80"
+                                                                class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
+                                                                placeholder="What's happening?"
+                                                                name="message"
+                                                                value="On vacation"
+                                                                aria-label="What is your current status?"
+                                                            />
+                                                            <div class="error">
+                                                                Could not update your status, please try again.
+                                                            </div>
+                                                        </div>
+                                                        <div class="suggester-container">
+                                                            <div
+                                                                class="suggester js-suggester js-navigation-container"
+                                                                data-url="/autocomplete/user-suggestions"
+                                                                data-no-org-url="/autocomplete/user-suggestions"
+                                                                data-org-url="/suggestions"
+                                                                hidden=""
+                                                            ></div>
+                                                        </div>
+                                                        <div
+                                                            style="margin-left: 53px"
+                                                            class="my-1 text-small label-characters-remaining js-characters-remaining"
+                                                            data-suffix="remaining"
+                                                            hidden=""
+                                                        >
+                                                            80 remaining
+                                                        </div>
+                                                    </div>
+                                                    <include-fragment
+                                                        class="js-user-status-emoji-picker"
+                                                        data-url="/users/status/emoji"
+                                                    ></include-fragment>
+                                                    <div
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
+                                                        style="max-height: 33vh"
+                                                    >
+                                                        <div
+                                                            class="user-status-suggestions js-user-status-suggestions collapsed overflow-hidden"
+                                                        >
+                                                            <h4 class="f6 text-normal my-3">Suggestions:</h4>
+                                                            <div class="mx-3 mt-2 clearfix">
+                                                                <div class="float-left col-6">
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":palm_tree:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            On vacation
+                                                                        </div>
+                                                                    </button>
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":face_with_thermometer:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="face_with_thermometer"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f912.png"
+                                                                                title=":face_with_thermometer:"
+                                                                                >🤒</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            Out sick
+                                                                        </div>
+                                                                    </button>
+                                                                </div>
+                                                                <div class="float-left col-6">
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":house:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="house"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3e0.png"
+                                                                                title=":house:"
+                                                                                >🏠</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            Working from home
+                                                                        </div>
+                                                                    </button>
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":dart:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="dart"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3af.png"
+                                                                                title=":dart:"
+                                                                                >🎯</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            Focusing
+                                                                        </div>
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="user-status-limited-availability-container">
+                                                            <div class="form-checkbox my-0">
+                                                                <input
+                                                                    type="checkbox"
+                                                                    name="limited_availability"
+                                                                    value="1"
+                                                                    class="js-user-status-limited-availability-checkbox"
+                                                                    data-default-message="I may be slow to respond."
+                                                                    aria-describedby="limited-availability-help-text-truncate-true"
+                                                                    id="limited-availability-truncate-true"
+                                                                    checked=""
+                                                                />
+                                                                <label
+                                                                    class="d-block f5 text-gray-dark mb-1"
+                                                                    for="limited-availability-truncate-true"
+                                                                >
+                                                                    Busy
+                                                                </label>
+                                                                <p
+                                                                    class="note"
+                                                                    id="limited-availability-help-text-truncate-true"
+                                                                >
+                                                                    When others mention you, assign you, or request your
+                                                                    review, GitHub will let them know that you have
+                                                                    limited availability.
+                                                                </p>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
+                                                        <div class="d-inline-block mr-1">
+                                                            Clear status
+                                                        </div>
+
+                                                        <details
+                                                            class="js-user-status-expire-drop-down f6 dropdown details-reset details-overlay d-inline-block mr-2"
+                                                        >
+                                                            <summary
+                                                                class="f5 btn-link link-gray-dark border px-2 py-1 rounded-1"
+                                                                aria-haspopup="true"
+                                                            >
+                                                                <div
+                                                                    class="js-user-status-expiration-interval-selected d-inline-block v-align-baseline"
+                                                                >
+                                                                    Never
+                                                                </div>
+                                                                <div class="dropdown-caret"></div>
+                                                            </summary>
+
+                                                            <ul
+                                                                class="dropdown-menu dropdown-menu-se pl-0 overflow-auto"
+                                                                style="width: 220px; max-height: 15.5em"
+                                                            >
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item js-user-status-expire-button ws-normal"
+                                                                        title="Never"
+                                                                    >
+                                                                        <span class="d-inline-block text-bold mb-1"
+                                                                            >Never</span
+                                                                        >
+                                                                        <div class="f6 lh-condensed">
+                                                                            Keep this status until you clear your status
+                                                                            or edit your status.
+                                                                        </div>
+                                                                    </button>
+                                                                </li>
+                                                                <li class="dropdown-divider" role="none"></li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="in 30 minutes"
+                                                                        value="2019-04-26T01:08:20+02:00"
+                                                                    >
+                                                                        in 30 minutes
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="in 1 hour"
+                                                                        value="2019-04-26T01:38:20+02:00"
+                                                                    >
+                                                                        in 1 hour
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="in 4 hours"
+                                                                        value="2019-04-26T04:38:20+02:00"
+                                                                    >
+                                                                        in 4 hours
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="today"
+                                                                        value="2019-04-26T23:59:59+02:00"
+                                                                    >
+                                                                        today
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="this week"
+                                                                        value="2019-04-28T23:59:59+02:00"
+                                                                    >
+                                                                        this week
+                                                                    </button>
+                                                                </li>
+                                                            </ul>
+                                                        </details>
+                                                        <input
+                                                            class="js-user-status-expiration-date-input"
+                                                            type="hidden"
+                                                            name="expires_at"
+                                                            value=""
+                                                        />
+                                                    </div>
+
+                                                    <include-fragment
+                                                        class="js-user-status-org-picker"
+                                                        data-url="/users/status/organizations"
+                                                    ></include-fragment>
+                                                </div>
+                                                <div
+                                                    class="d-flex flex-items-center flex-justify-between p-3 border-top"
+                                                >
+                                                    <button
+                                                        type="submit"
+                                                        class="width-full btn btn-primary mr-2 js-user-status-submit"
+                                                    >
+                                                        Set status
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
+                                                    >
+                                                        Clear status
+                                                    </button>
+                                                </div>
+                                            </form>
+                                        </details-dialog>
+                                    </details>
+                                </div>
+                            </div>
+                            <div role="none" class="dropdown-divider"></div>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker"
+                                data-ga-click="Header, go to profile, text:your profile"
+                                >Your profile</a
+                            >
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker?tab=repositories"
+                                data-ga-click="Header, go to repositories, text:your repositories"
+                                >Your repositories</a
+                            >
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker?tab=projects"
+                                data-ga-click="Header, go to projects, text:your projects"
+                                >Your projects</a
+                            >
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker?tab=stars"
+                                data-ga-click="Header, go to starred repos, text:your stars"
+                                >Your stars</a
+                            >
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="https://gist.github.com/"
+                                data-ga-click="Header, your gists, text:your gists"
+                                >Your gists</a
+                            >
+
+                            <div role="none" class="dropdown-divider"></div>
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="https://help.github.com"
+                                data-ga-click="Header, go to help, text:help"
+                                >Help</a
+                            >
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/settings/profile"
+                                data-ga-click="Header, go to settings, icon:settings"
+                                >Settings</a
+                            >
+                            <!-- '"` --><!-- </textarea></xmp> -->
+                            <form class="logout-form" action="/logout" accept-charset="UTF-8" method="post">
+                                <input name="utf8" type="hidden" value="✓" /><input
+                                    type="hidden"
+                                    name="authenticity_token"
+                                    value="cz0Nk7GWPzWpNSeqyNE+tsJoTcf0ahNZ3jAeQvNT2kV08W6rGAhsmfkmNiRopVZOrfS/nFYL9qB7PTW+LkTkGQ=="
+                                />
+
+                                <button
+                                    type="submit"
+                                    class="dropdown-item dropdown-signout"
+                                    data-ga-click="Header, sign out, icon:logout"
+                                    role="menuitem"
+                                >
+                                    Sign out
+                                </button>
+                            </form>
+                        </details-menu>
+                    </details>
+                </div>
+            </header>
+        </div>
+
+        <div id="start-of-content" class="show-on-focus"></div>
+
+        <div id="js-flash-container"></div>
+
+        <div class="application-main " data-commit-hovercards-enabled="">
+            <div itemscope="" itemtype="http://schema.org/SoftwareSourceCode" class="">
+                <main>
+                    <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav pt-0 pt-lg-4 ">
+                        <div class="repohead-details-container clearfix container-lg p-responsive d-none d-lg-block">
+                            <ul class="pagehead-actions">
+                                <li>
+                                    <!-- '"` --><!-- </textarea></xmp> -->
+                                    <form
+                                        data-remote="true"
+                                        class="clearfix js-social-form js-social-container"
+                                        action="/notifications/subscribe"
+                                        accept-charset="UTF-8"
+                                        method="post"
+                                    >
+                                        <input name="utf8" type="hidden" value="✓" /><input
+                                            type="hidden"
+                                            name="authenticity_token"
+                                            value="LBYeRe+InmTMtJ0fCsQ0PFXszwXwP8bYTytnZ5eFx/C0Y0M3ddOWgfv5LvhY35Pn8kibmLSBTT2flKGB+MF5Gg=="
+                                        />
+                                        <input type="hidden" name="repository_id" value="41288708" />
+
+                                        <details class="details-reset details-overlay select-menu float-left">
+                                            <summary
+                                                class="select-menu-button float-left btn btn-sm btn-with-count"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C74C:2DB09:228E08F:3404402:5CC236C1","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="09cea1b1e1e24c00301110700f66b907d61de215014f1a3096b7ddac3f342c86"
+                                                data-ga-click="Repository, click Watch settings, action:blob#show"
+                                                aria-haspopup="menu"
+                                            >
+                                                <span data-menu-button="">
+                                                    <svg
+                                                        class="octicon octicon-eye v-align-text-bottom"
+                                                        viewBox="0 0 16 16"
+                                                        version="1.1"
+                                                        width="16"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                        ></path>
+                                                    </svg>
+                                                    Watch
+                                                </span>
+                                            </summary>
+                                            <details-menu
+                                                class="select-menu-modal position-absolute mt-5"
+                                                style="z-index: 99;"
+                                                role="menu"
+                                            >
+                                                <div class="select-menu-header">
+                                                    <span class="select-menu-title">Notifications</span>
+                                                </div>
+                                                <div class="select-menu-list">
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="included"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="true"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Not watching</span>
+                                                            <span class="description"
+                                                                >Be notified only when participating or
+                                                                @mentioned.</span
+                                                            >
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-eye v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Watch
+                                                            </span>
+                                                        </div>
+                                                    </button>
+
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="release_only"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="false"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Releases only</span>
+                                                            <span class="description"
+                                                                >Be notified of new releases, and when participating or
+                                                                @mentioned.</span
+                                                            >
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-eye v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Unwatch releases
+                                                            </span>
+                                                        </div>
+                                                    </button>
+
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="subscribed"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="false"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Watching</span>
+                                                            <span class="description"
+                                                                >Be notified of all conversations.</span
+                                                            >
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-eye v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Unwatch
+                                                            </span>
+                                                        </div>
+                                                    </button>
+
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="ignore"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="false"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Ignoring</span>
+                                                            <span class="description">Never be notified.</span>
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-mute v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8 2.81v10.38c0 .67-.81 1-1.28.53L3 10H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h2l3.72-3.72C7.19 1.81 8 2.14 8 2.81zm7.53 3.22l-1.06-1.06-1.97 1.97-1.97-1.97-1.06 1.06L11.44 8 9.47 9.97l1.06 1.06 1.97-1.97 1.97 1.97 1.06-1.06L13.56 8l1.97-1.97z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Stop ignoring
+                                                            </span>
+                                                        </div>
+                                                    </button>
+                                                </div>
+                                            </details-menu>
+                                        </details>
+                                        <a
+                                            class="social-count js-social-count"
+                                            href="/sourcegraph/sourcegraph/watchers"
+                                            aria-label="42 users are watching this repository"
+                                        >
+                                            42
+                                        </a>
+                                    </form>
+                                </li>
+
+                                <li>
+                                    <div class="js-toggler-container js-social-container starring-container on">
+                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                        <form
+                                            class="starred js-social-form"
+                                            action="/sourcegraph/sourcegraph/unstar"
+                                            accept-charset="UTF-8"
+                                            method="post"
+                                        >
+                                            <input name="utf8" type="hidden" value="✓" /><input
+                                                type="hidden"
+                                                name="authenticity_token"
+                                                value="8Q1kZxQkUJHrCF7bDk6PQmfMzfN9fOdQr3/8khd4IBR9rwvHCBrnoUbhxQn3cEzs82LCHSTU+UT+hzQfvrUnWg=="
+                                            />
+                                            <input type="hidden" name="context" value="repository" />
+                                            <button
+                                                type="submit"
+                                                class="btn btn-sm btn-with-count js-toggler-target"
+                                                aria-label="Unstar this repository"
+                                                title="Unstar sourcegraph/sourcegraph"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C74C:2DB09:228E08F:3404402:5CC236C1","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="8577faa52e59b1c9a1198b3ef2274044a9ac823bcdbe7e95de34e1011febafd6"
+                                                data-ga-click="Repository, click unstar button, action:blob#show; text:Unstar"
+                                                data-hotkey="g s"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-star v-align-text-bottom"
+                                                    viewBox="0 0 14 16"
+                                                    version="1.1"
+                                                    width="14"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"
+                                                    ></path>
+                                                </svg>
+                                                Unstar
+                                            </button>
+                                            <a
+                                                class="social-count js-social-count"
+                                                href="/sourcegraph/sourcegraph/stargazers"
+                                                aria-label="2048 users starred this repository"
+                                            >
+                                                2,048
+                                            </a>
+                                        </form>
+                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                        <form
+                                            class="unstarred js-social-form"
+                                            action="/sourcegraph/sourcegraph/star"
+                                            accept-charset="UTF-8"
+                                            method="post"
+                                        >
+                                            <input name="utf8" type="hidden" value="✓" /><input
+                                                type="hidden"
+                                                name="authenticity_token"
+                                                value="RePWMbMQ1ZxGf841bdO7M1HmLROLZ5Bvc+w0FEvIETT82BZAOnVh1XddYiyIcbzuFHeuefYAKJcGNn4PWdgrpg=="
+                                            />
+                                            <input type="hidden" name="context" value="repository" />
+                                            <button
+                                                type="submit"
+                                                class="btn btn-sm btn-with-count js-toggler-target"
+                                                aria-label="Unstar this repository"
+                                                title="Star sourcegraph/sourcegraph"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C74C:2DB09:228E08F:3404402:5CC236C1","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="789119a6dc8c18bf694ee8e5ec3bd0003e9dc1f3b3629b7a328aa4c7346968f8"
+                                                data-ga-click="Repository, click star button, action:blob#show; text:Star"
+                                                data-hotkey="g s"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-star v-align-text-bottom"
+                                                    viewBox="0 0 14 16"
+                                                    version="1.1"
+                                                    width="14"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"
+                                                    ></path>
+                                                </svg>
+                                                Star
+                                            </button>
+                                            <a
+                                                class="social-count js-social-count"
+                                                href="/sourcegraph/sourcegraph/stargazers"
+                                                aria-label="2048 users starred this repository"
+                                            >
+                                                2,048
+                                            </a>
+                                        </form>
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <details
+                                        class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
+                                    >
+                                        <summary
+                                            class="btn btn-sm btn-with-count"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C74C:2DB09:228E08F:3404402:5CC236C1","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="29ffa49cd93060b0c613b8a61b2cbb0d7f24b4e94b3b4b8703af80e142252837"
+                                            data-ga-click="Repository, show fork modal, action:blob#show; text:Fork"
+                                            title="Fork your own copy of sourcegraph/sourcegraph to your account"
+                                            aria-haspopup="dialog"
+                                        >
+                                            <svg
+                                                class="octicon octicon-repo-forked v-align-text-bottom"
+                                                viewBox="0 0 10 16"
+                                                version="1.1"
+                                                width="10"
+                                                height="16"
+                                                aria-hidden="true"
+                                            >
+                                                <path
+                                                    fill-rule="evenodd"
+                                                    d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                ></path>
+                                            </svg>
+                                            Fork
+                                        </summary>
+                                        <details-dialog
+                                            class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
+                                            role="dialog"
+                                        >
+                                            <div class="Box-header">
+                                                <button
+                                                    class="Box-btn-octicon btn-octicon float-right"
+                                                    type="button"
+                                                    aria-label="Close dialog"
+                                                    data-close-dialog=""
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-x"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                                                        ></path>
+                                                    </svg>
+                                                </button>
+                                                <h3 class="Box-title">Fork sourcegraph</h3>
+                                            </div>
+                                            <div class="overflow-auto text-center">
+                                                <include-fragment>
+                                                    <div class="octocat-spinner my-3" aria-label="Loading..."></div>
+                                                    <p class="f5 text-gray">
+                                                        If this dialog fails to load, you can visit
+                                                        <a href="/sourcegraph/sourcegraph/fork">the fork page</a>
+                                                        directly.
+                                                    </p>
+                                                </include-fragment>
+                                            </div>
+                                        </details-dialog>
+                                    </details>
+
+                                    <a
+                                        href="/sourcegraph/sourcegraph/network/members"
+                                        class="social-count"
+                                        aria-label="138 users forked this repository"
+                                    >
+                                        138
+                                    </a>
+                                </li>
+                            </ul>
+
+                            <h1 class="public ">
+                                <svg
+                                    class="octicon octicon-repo"
+                                    viewBox="0 0 12 16"
+                                    version="1.1"
+                                    width="12"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                    ></path>
+                                </svg>
+                                <span class="author" itemprop="author"
+                                    ><a
+                                        class="url fn"
+                                        rel="author"
+                                        data-hovercard-type="organization"
+                                        data-hovercard-url="/orgs/sourcegraph/hovercard"
+                                        href="/sourcegraph"
+                                        >sourcegraph</a
+                                    ></span
+                                ><!--
+--><span class="path-divider">/</span
+                                ><!--
+--><strong itemprop="name"
+                                    ><a data-pjax="#js-repo-pjax-container" href="/sourcegraph/sourcegraph"
+                                        >sourcegraph</a
+                                    ></strong
+                                >
+
+                                <details
+                                    class="commit-build-statuses details-overlay details-reset js-dropdown-details rgh-ci-link"
+                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6ZWFhMGZlNWQxMGRmYjBkOTlmNWRlNjQwZmNjN2RhYzI4ZjcxNWJjOQ==/statuses/combined_branch_status"
+                                >
+                                    <summary class="bg-pending">
+                                        <svg
+                                            class="octicon octicon-primitive-dot v-align-middle"
+                                            aria-label="0 / 1 checks OK"
+                                            viewBox="0 0 8 16"
+                                            version="1.1"
+                                            width="8"
+                                            height="16"
+                                            role="img"
+                                        >
+                                            <path
+                                                fill-rule="evenodd"
+                                                d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"
+                                            ></path>
+                                        </svg>
+                                    </summary>
+                                    <div class="dropdown-menu dropdown-menu-e overflow-hidden">
+                                        <include-fragment class="m-4 d-flex flex-column flex-items-center">
+                                            <div class="anim-pulse">
+                                                <svg
+                                                    height="32"
+                                                    class="octicon octicon-octoface"
+                                                    viewBox="0 0 16 16"
+                                                    version="1.1"
+                                                    width="32"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"
+                                                    ></path>
+                                                </svg>
+                                            </div>
+                                            <div class="text-gray no-wrap">Loading status checks…</div>
+                                        </include-fragment>
+                                    </div>
+                                </details>
+                            </h1>
+                        </div>
+
+                        <nav
+                            class="reponav js-repo-nav js-sidenav-container-pjax container-lg p-responsive d-none d-lg-block"
+                            itemscope=""
+                            itemtype="http://schema.org/BreadcrumbList"
+                            aria-label="Repository"
+                            data-pjax="#js-repo-pjax-container"
+                        >
+                            <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                <a
+                                    class="js-selected-navigation-item selected reponav-item"
+                                    itemprop="url"
+                                    data-hotkey="g c"
+                                    aria-current="page"
+                                    data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph"
+                                    href="/sourcegraph/sourcegraph"
+                                >
+                                    <svg
+                                        class="octicon octicon-code"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                        ></path>
+                                    </svg>
+                                    <span itemprop="name">Code</span>
+                                    <meta itemprop="position" content="1" />
+                                </a>
+                            </span>
+
+                            <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                <a
+                                    itemprop="url"
+                                    data-hotkey="g i"
+                                    class="js-selected-navigation-item reponav-item"
+                                    data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues"
+                                    href="https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc"
+                                >
+                                    <svg
+                                        class="octicon octicon-issue-opened"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+                                        ></path>
+                                    </svg>
+                                    <span itemprop="name">Issues</span>
+                                    <span class="Counter">696</span>
+                                    <meta itemprop="position" content="2" />
+                                </a>
+                            </span>
+
+                            <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                <a
+                                    data-hotkey="g p"
+                                    itemprop="url"
+                                    class="js-selected-navigation-item reponav-item"
+                                    data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls"
+                                    href="https://github.com/sourcegraph/sourcegraph/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc"
+                                >
+                                    <svg
+                                        class="octicon octicon-git-pull-request"
+                                        viewBox="0 0 12 16"
+                                        version="1.1"
+                                        width="12"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                        ></path>
+                                    </svg>
+                                    <span itemprop="name">Pull requests</span>
+                                    <span class="Counter">83</span>
+                                    <meta itemprop="position" content="3" />
+                                </a>
+                            </span>
+
+                            <a
+                                data-hotkey="g w"
+                                data-skip-pjax="true"
+                                class="js-selected-navigation-item reponav-item"
+                                data-selected-links="repo_actions /sourcegraph/sourcegraph/actions"
+                                href="/sourcegraph/sourcegraph/actions"
+                            >
+                                <svg
+                                    class="octicon octicon-play"
+                                    viewBox="0 0 14 16"
+                                    version="1.1"
+                                    width="14"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M14 8A7 7 0 1 1 0 8a7 7 0 0 1 14 0zm-8.223 3.482l4.599-3.066a.5.5 0 0 0 0-.832L5.777 4.518A.5.5 0 0 0 5 4.934v6.132a.5.5 0 0 0 .777.416z"
+                                    ></path>
+                                </svg>
+                                Actions
+                            </a>
+                            <a
+                                data-hotkey="g b"
+                                class="js-selected-navigation-item reponav-item"
+                                data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects"
+                                href="/sourcegraph/sourcegraph/projects"
+                            >
+                                <svg
+                                    class="octicon octicon-project"
+                                    viewBox="0 0 15 16"
+                                    version="1.1"
+                                    width="15"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                    ></path>
+                                </svg>
+                                Projects
+                                <span class="Counter">0</span>
+                            </a>
+
+                            <a href="/sourcegraph/sourcegraph/releases" class="reponav-item" data-hotkey="g r"
+                                ><svg aria-hidden="true" class="octicon octicon-tag" width="14" height="16">
+                                    <path
+                                        d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"
+                                    ></path></svg
+                                ><span> Releases </span></a
+                            >
+                            <div class="reponav-dropdown js-menu-container">
+                                <button
+                                    type="button"
+                                    class="btn-link reponav-item js-menu-target"
+                                    aria-expanded="false"
+                                    aria-haspopup="true"
+                                >
+                                    More <span class="dropdown-caret"></span>
+                                </button>
+                                <div class="dropdown-menu-content js-menu-content">
+                                    <div class="dropdown-menu dropdown-menu-se">
+                                        <a
+                                            href="/sourcegraph/sourcegraph/compare"
+                                            class="rgh-reponav-more dropdown-item"
+                                            data-skip-pjax=""
+                                            ><svg
+                                                aria-hidden="true"
+                                                class="octicon octicon-diff"
+                                                width="15"
+                                                height="16"
+                                                viewBox="0 0 13 16"
+                                            >
+                                                <path
+                                                    d="M6 7h2v1H6v2H5V8H3V7h2V5h1zm-3 6h5v-1H3zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm1-2H3v1h5l4 4v8h1V4.5z"
+                                                    fill-rule="evenodd"
+                                                ></path>
+                                            </svg>
+                                            Compare</a
+                                        ><a
+                                            href="/sourcegraph/sourcegraph/network/dependencies"
+                                            class="rgh-reponav-more dropdown-item rgh-dependency-graph"
+                                            data-skip-pjax=""
+                                            ><svg
+                                                aria-hidden="true"
+                                                class="octicon octicon-package"
+                                                width="16"
+                                                height="16"
+                                            >
+                                                <path
+                                                    fill-rule="evenodd"
+                                                    d="M1 4.27v7.47c0 .45.3.84.75.97l6.5 1.73c.16.05.34.05.5 0l6.5-1.73c.45-.13.75-.52.75-.97V4.27c0-.45-.3-.84-.75-.97l-6.5-1.74a1.4 1.4 0 0 0-.5 0L1.75 3.3c-.45.13-.75.52-.75.97zm7 9.09l-6-1.59V5l6 1.61v6.75zM2 4l2.5-.67L11 5.06l-2.5.67L2 4zm13 7.77l-6 1.59V6.61l2-.55V8.5l2-.53V5.53L15 5v6.77zm-2-7.24L6.5 2.8l2-.53L15 4l-2 .53z"
+                                                ></path>
+                                            </svg>
+                                            Dependencies</a
+                                        ><a
+                                            href="/sourcegraph/sourcegraph/pulse"
+                                            class="rgh-reponav-more dropdown-item"
+                                            data-skip-pjax=""
+                                            ><svg
+                                                aria-hidden="true"
+                                                class="octicon octicon-graph"
+                                                width="16"
+                                                height="16"
+                                            >
+                                                <path
+                                                    fill-rule="evenodd"
+                                                    d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"
+                                                ></path>
+                                            </svg>
+                                            Insights</a
+                                        ><a
+                                            href="/sourcegraph/sourcegraph/commits"
+                                            class="rgh-reponav-more dropdown-item"
+                                            data-skip-pjax=""
+                                            ><svg
+                                                aria-hidden="true"
+                                                class="octicon octicon-history"
+                                                width="14"
+                                                height="16"
+                                            >
+                                                <path
+                                                    d="M8 13H6V6h5v2H8v5zM7 1C4.81 1 2.87 2.02 1.59 3.59L0 2v4h4L2.5 4.5C3.55 3.17 5.17 2.3 7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-.34.03-.67.09-1H.08C.03 7.33 0 7.66 0 8c0 3.86 3.14 7 7 7s7-3.14 7-7-3.14-7-7-7z"
+                                                ></path>
+                                            </svg>
+                                            Commits</a
+                                        ><a
+                                            href="/sourcegraph/sourcegraph/branches"
+                                            class="rgh-reponav-more dropdown-item"
+                                            data-skip-pjax=""
+                                            ><svg
+                                                aria-hidden="true"
+                                                class="octicon octicon-git-branch"
+                                                height="16"
+                                                width="10"
+                                            >
+                                                <path
+                                                    fill-rule="evenodd"
+                                                    d="M10 5c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v.3c-.02.52-.23.98-.63 1.38-.4.4-.86.61-1.38.63-.83.02-1.48.16-2 .45V4.72a1.993 1.993 0 0 0-1-3.72C.88 1 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2 1.11 0 2-.89 2-2 0-.53-.2-1-.53-1.36.09-.06.48-.41.59-.47.25-.11.56-.17.94-.17 1.05-.05 1.95-.45 2.75-1.25S8.95 7.77 9 6.73h-.02C9.59 6.37 10 5.73 10 5zM2 1.8c.66 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2C1.35 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2zm0 12.41c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm6-8c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                ></path>
+                                            </svg>
+                                            Branches</a
+                                        >
+                                    </div>
+                                </div>
+                            </div>
+                            <a
+                                class="js-selected-navigation-item reponav-item"
+                                data-selected-links="repo_settings repo_branch_settings hooks integration_installations repo_keys_settings issue_template_editor /sourcegraph/sourcegraph/settings"
+                                href="/sourcegraph/sourcegraph/settings"
+                            >
+                                <svg
+                                    class="octicon octicon-gear"
+                                    viewBox="0 0 14 16"
+                                    version="1.1"
+                                    width="14"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"
+                                    ></path>
+                                </svg>
+                                Settings
+                            </a>
+                        </nav>
+
+                        <div class="reponav-wrapper reponav-small d-lg-none">
+                            <nav
+                                class="reponav js-reponav text-center no-wrap"
+                                itemscope=""
+                                itemtype="http://schema.org/BreadcrumbList"
+                            >
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        class="js-selected-navigation-item selected reponav-item"
+                                        itemprop="url"
+                                        aria-current="page"
+                                        data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph"
+                                        href="/sourcegraph/sourcegraph"
+                                    >
+                                        <span itemprop="name">Code</span>
+                                        <meta itemprop="position" content="1" />
+                                    </a>
+                                </span>
+
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues"
+                                        href="https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc"
+                                    >
+                                        <span itemprop="name">Issues</span>
+                                        <span class="Counter">696</span>
+                                        <meta itemprop="position" content="2" />
+                                    </a>
+                                </span>
+
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls"
+                                        href="https://github.com/sourcegraph/sourcegraph/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc"
+                                    >
+                                        <span itemprop="name">Pull requests</span>
+                                        <span class="Counter">83</span>
+                                        <meta itemprop="position" content="3" />
+                                    </a>
+                                </span>
+
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects"
+                                        href="/sourcegraph/sourcegraph/projects"
+                                    >
+                                        <span itemprop="name">Projects</span>
+                                        <span class="Counter">0</span>
+                                        <meta itemprop="position" content="5" />
+                                    </a>
+                                </span>
+
+                                <a
+                                    class="js-selected-navigation-item reponav-item"
+                                    data-selected-links="pulse /sourcegraph/sourcegraph/pulse"
+                                    href="/sourcegraph/sourcegraph/pulse"
+                                >
+                                    Pulse
+                                </a>
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="community /sourcegraph/sourcegraph/community"
+                                        href="/sourcegraph/sourcegraph/community"
+                                    >
+                                        Community
+                                    </a>
+                                </span>
+                            </nav>
+                        </div>
+                    </div>
+                    <div class="container-lg new-discussion-timeline experiment-repo-nav  p-responsive">
+                        <div class="repository-content ">
+                            <a
+                                class="d-none js-permalink-shortcut"
+                                data-hotkey="y"
+                                href="/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
+                                >Permalink</a
+                            >
+
+                            <!-- blob contrib key: blob_contributors:v21:4eb85bdcf32e37c190c6c4b3782513c9 -->
+
+                            <div class="d-flex flex-items-start mb-3 flex-column flex-md-row">
+                                <span class="d-flex flex-justify-between width-full width-md-auto">
+                                    <details class="details-reset details-overlay select-menu branch-select-menu ">
+                                        <summary
+                                            class="btn btn-sm select-menu-button css-truncate"
+                                            data-hotkey="w"
+                                            title="Switch branches or tags"
+                                            aria-haspopup="menu"
+                                        >
+                                            <i>Tree:</i>
+                                            <span class="css-truncate-target">eaa0fe5d10</span>
+                                        </summary>
+
+                                        <details-menu
+                                            class="select-menu-modal position-absolute"
+                                            style="z-index: 99;"
+                                            src="/sourcegraph/sourcegraph/ref-list/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts?source_action=show&amp;source_controller=blob"
+                                            preload=""
+                                            role="menu"
+                                        >
+                                            <include-fragment class="select-menu-loading-overlay anim-pulse">
+                                                <svg
+                                                    height="32"
+                                                    class="octicon octicon-octoface"
+                                                    viewBox="0 0 16 16"
+                                                    version="1.1"
+                                                    width="32"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"
+                                                    ></path>
+                                                </svg>
+                                            </include-fragment>
+                                        </details-menu>
+                                    </details>
+
+                                    <div class="BtnGroup flex-shrink-0 d-md-none">
+                                        <a
+                                            href="/sourcegraph/sourcegraph/find/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9"
+                                            class="js-pjax-capture-input btn btn-sm BtnGroup-item"
+                                            data-pjax=""
+                                            data-hotkey="t"
+                                        >
+                                            Find file
+                                        </a>
+                                        <clipboard-copy
+                                            value="shared/src/api/extension/types/url.ts"
+                                            class="btn btn-sm BtnGroup-item"
+                                            tabindex="0"
+                                            role="button"
+                                        >
+                                            Copy path
+                                        </clipboard-copy>
+                                    </div>
+                                </span>
+                                <h2
+                                    id="blob-path"
+                                    class="breadcrumb flex-auto min-width-0 text-normal flex-md-self-center ml-md-2 mr-md-3 my-2 my-md-0"
+                                >
+                                    <span class="js-repo-root text-bold"
+                                        ><span class="js-path-segment"
+                                            ><a
+                                                data-pjax="true"
+                                                rel="nofollow"
+                                                href="/sourcegraph/sourcegraph/tree/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9"
+                                                ><span>sourcegraph</span></a
+                                            ></span
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared"
+                                            ><span>shared</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src"
+                                            ><span>src</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api"
+                                            ><span>api</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension"
+                                            ><span>extension</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types"
+                                            ><span>types</span></a
+                                        ></span
+                                    ><span class="separator">/</span><strong class="final-path">url.ts</strong>
+                                </h2>
+
+                                <div class="BtnGroup flex-shrink-0 d-none d-md-inline-block">
+                                    <a
+                                        href="/sourcegraph/sourcegraph/find/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9"
+                                        class="js-pjax-capture-input btn btn-sm BtnGroup-item"
+                                        data-pjax=""
+                                        data-hotkey="t"
+                                    >
+                                        Find file
+                                    </a>
+                                    <clipboard-copy
+                                        value="shared/src/api/extension/types/url.ts"
+                                        class="btn btn-sm BtnGroup-item"
+                                        tabindex="0"
+                                        role="button"
+                                    >
+                                        Copy path
+                                    </clipboard-copy>
+                                </div>
+                            </div>
+
+                            <div class="Box Box--condensed d-flex flex-column flex-shrink-0">
+                                <div
+                                    class="Box-body d-flex flex-justify-between bg-blue-light flex-column flex-md-row flex-items-start flex-md-items-center"
+                                >
+                                    <span class="pr-md-4 f6">
+                                        <a
+                                            rel="contributor"
+                                            data-skip-pjax="true"
+                                            data-hovercard-type="user"
+                                            data-hovercard-url="/hovercards?user_id=10532611"
+                                            data-octo-click="hovercard-link-click"
+                                            data-octo-dimensions="link_type:self"
+                                            href="/felixfbecker"
+                                            ><img
+                                                class="avatar"
+                                                src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4"
+                                                width="20"
+                                                height="20"
+                                                alt="@felixfbecker"
+                                        /></a>
+                                        <a
+                                            class="text-bold link-gray-dark lh-default v-align-middle"
+                                            rel="contributor"
+                                            data-hovercard-type="user"
+                                            data-hovercard-url="/hovercards?user_id=10532611"
+                                            data-octo-click="hovercard-link-click"
+                                            data-octo-dimensions="link_type:self"
+                                            href="/felixfbecker"
+                                            >felixfbecker</a
+                                        >
+                                        <span class="lh-default v-align-middle">
+                                            <a
+                                                data-pjax="true"
+                                                title="Replace sourcegraph.URI with WHATWG URL (#2430)"
+                                                class="link-gray"
+                                                href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37"
+                                                >Replace sourcegraph.URI with WHATWG URL (</a
+                                            ><a
+                                                class="issue-link js-issue-link"
+                                                data-error-text="Failed to load issue title"
+                                                data-id="414041237"
+                                                data-permission-text="Issue title is private"
+                                                data-url="https://github.com/sourcegraph/sourcegraph/issues/2430"
+                                                data-hovercard-type="pull_request"
+                                                data-hovercard-url="/sourcegraph/sourcegraph/pull/2430/hovercard"
+                                                href="https://github.com/sourcegraph/sourcegraph/pull/2430"
+                                                >#2430</a
+                                            ><a
+                                                data-pjax="true"
+                                                title="Replace sourcegraph.URI with WHATWG URL (#2430)"
+                                                class="link-gray"
+                                                href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37"
+                                                >)</a
+                                            >
+                                        </span>
+                                    </span>
+                                    <span class="d-inline-block flex-shrink-0 v-align-bottom f6 mt-2 mt-md-0">
+                                        <a
+                                            class="pr-2 text-mono link-gray"
+                                            href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37"
+                                            data-pjax=""
+                                            >cd3ccd9</a
+                                        >
+                                        <relative-time datetime="2019-02-25T11:27:16Z" title="25 Feb 2019, 12:27 CET"
+                                            >on 25 Feb</relative-time
+                                        >
+                                    </span>
+                                </div>
+
+                                <div class="Box-body d-flex flex-items-center flex-auto f6 border-bottom-0 flex-wrap">
+                                    <details
+                                        class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark float-left mr-2"
+                                        id="blob_contributors_box"
+                                    >
+                                        <summary class="btn-link" aria-haspopup="dialog">
+                                            <span><strong>1</strong> contributor</span>
+                                        </summary>
+                                        <details-dialog
+                                            class="Box Box--overlay d-flex flex-column anim-fade-in fast"
+                                            aria-label="Users who have contributed to this file"
+                                            src="/sourcegraph/sourcegraph/contributors/master/shared/src/api/extension/types/url.ts/list"
+                                            preload=""
+                                            role="dialog"
+                                        >
+                                            <div class="Box-header">
+                                                <button
+                                                    class="Box-btn-octicon btn-octicon float-right"
+                                                    type="button"
+                                                    aria-label="Close dialog"
+                                                    data-close-dialog=""
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-x"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                                                        ></path>
+                                                    </svg>
+                                                </button>
+                                                <h3 class="Box-title">
+                                                    Users who have contributed to this file
+                                                </h3>
+                                            </div>
+                                            <include-fragment
+                                                class="octocat-spinner my-3"
+                                                aria-label="Loading..."
+                                            ></include-fragment>
+                                        </details-dialog>
+                                    </details>
+                                </div>
+                            </div>
+
+                            <div class="Box mt-3 position-relative">
+                                <div
+                                    class="Box-header py-2 d-flex flex-column flex-shrink-0 flex-md-row flex-md-items-center"
+                                >
+                                    <div class="text-mono f6 flex-auto pr-3 flex-order-2 flex-md-order-1 mt-2 mt-md-0">
+                                        3 lines (2 sloc)
+                                        <span class="file-info-divider"></span>
+                                        138 Bytes
+                                    </div>
+
+                                    <div
+                                        class="d-flex py-1 py-md-0 flex-auto flex-order-1 flex-md-order-2 flex-sm-grow-0 flex-justify-between"
+                                    >
+                                        <div class="BtnGroup">
+                                            <button
+                                                class="btn btn-sm copy-btn tooltipped tooltipped-n BtnGroup-item"
+                                                aria-label="Copy file to clipboard"
+                                                type="button"
+                                            >
+                                                Copy
+                                            </button>
+                                            <a
+                                                id="raw-url"
+                                                class="btn btn-sm BtnGroup-item"
+                                                href="/sourcegraph/sourcegraph/raw/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
+                                                >Raw</a
+                                            >
+                                            <a
+                                                class="btn btn-sm js-update-url-with-hash BtnGroup-item"
+                                                data-hotkey="b"
+                                                href="https://github.com/sourcegraph/sourcegraph/blame/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
+                                                >Blame</a
+                                            >
+                                            <a
+                                                rel="nofollow"
+                                                class="btn btn-sm BtnGroup-item"
+                                                href="/sourcegraph/sourcegraph/commits/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
+                                                >History</a
+                                            >
+                                        </div>
+
+                                        <div>
+                                            <button
+                                                class="btn-octicon disabled tooltipped tooltipped-nw"
+                                                type="button"
+                                                disabled=""
+                                                aria-label="You must be on a branch to open this file in GitHub Desktop"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-device-desktop"
+                                                    viewBox="0 0 16 16"
+                                                    version="1.1"
+                                                    width="16"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
+                                                    ></path>
+                                                </svg>
+                                            </button>
+
+                                            <button
+                                                type="button"
+                                                class="btn-octicon disabled tooltipped tooltipped-nw"
+                                                aria-label="You must be on a branch to make or propose changes to this file"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-pencil"
+                                                    viewBox="0 0 14 16"
+                                                    version="1.1"
+                                                    width="14"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
+                                                    ></path>
+                                                </svg>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                class="btn-octicon btn-octicon-danger disabled tooltipped tooltipped-nw"
+                                                aria-label="You must be on a branch to make or propose changes to this file"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-trashcan"
+                                                    viewBox="0 0 12 16"
+                                                    version="1.1"
+                                                    width="12"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                                                    ></path>
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div
+                                    itemprop="text"
+                                    class="Box-body p-0 blob-wrapper data type-typescript rgh-linkified-code"
+                                >
+                                    <table
+                                        class="highlight tab-size js-file-line-container rgh-copy-file"
+                                        data-tab-size="4"
+                                    >
+                                        <tbody>
+                                            <tr>
+                                                <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
+                                                <td id="LC1" class="blob-code blob-code-inner js-file-line">
+                                                    <span class="pl-k"><span class="pl-k">export</span></span>
+                                                    <span class="pl-k"><span class="pl-k">const</span></span> isURL
+                                                    <span class="pl-k">=</span> (<span class="pl-v">value</span
+                                                    ><span class="pl-k">:</span> <span class="pl-c1">any</span>)<span
+                                                        class="pl-k"
+                                                        >:</span
+                                                    >
+                                                    <span class="pl-en">value</span> <span class="pl-k">is</span>
+                                                    <span class="pl-en">URL</span> <span class="pl-k">=&gt;</span>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
+                                                <td id="LC2" class="blob-code blob-code-inner js-file-line">
+                                                    <span class="pl-k">!!</span><span class="pl-smi">value</span>
+                                                    <span class="pl-k">&amp;&amp;</span>
+                                                    <span class="pl-k">typeof</span>
+                                                    <span class="pl-smi">value</span>.<span class="pl-smi"
+                                                        >toString</span
+                                                    >
+                                                    <span class="pl-k">===</span>
+                                                    <span class="pl-s"
+                                                        ><span class="pl-pds">'</span>function<span class="pl-pds"
+                                                            >'</span
+                                                        ></span
+                                                    >
+                                                    <span class="pl-k">&amp;&amp;</span>
+                                                    <span class="pl-smi">value</span>.<span class="pl-c1">href</span>
+                                                    <span class="pl-k">===</span>
+                                                    <span class="pl-smi">value</span>.<span class="pl-c1">toString</span
+                                                    >()
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+
+                                    <details
+                                        class="details-reset details-overlay BlobToolbar position-absolute js-file-line-actions dropdown d-none"
+                                        aria-hidden="true"
+                                    >
+                                        <summary
+                                            class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1"
+                                            aria-label="Inline file action toolbar"
+                                            aria-haspopup="menu"
+                                        >
+                                            <svg
+                                                class="octicon octicon-kebab-horizontal"
+                                                viewBox="0 0 13 16"
+                                                version="1.1"
+                                                width="13"
+                                                height="16"
+                                                aria-hidden="true"
+                                            >
+                                                <path
+                                                    fill-rule="evenodd"
+                                                    d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                                                ></path>
+                                            </svg>
+                                        </summary>
+                                        <details-menu role="menu">
+                                            <ul
+                                                class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2"
+                                                style="width:185px"
+                                            >
+                                                <li>
+                                                    <clipboard-copy
+                                                        role="menuitem"
+                                                        class="dropdown-item"
+                                                        id="js-copy-lines"
+                                                        style="cursor:pointer;"
+                                                        data-original-text="Copy lines"
+                                                        tabindex="0"
+                                                        >Copy lines</clipboard-copy
+                                                    >
+                                                </li>
+                                                <li>
+                                                    <clipboard-copy
+                                                        role="menuitem"
+                                                        class="dropdown-item"
+                                                        id="js-copy-permalink"
+                                                        style="cursor:pointer;"
+                                                        data-original-text="Copy permalink"
+                                                        tabindex="0"
+                                                        >Copy permalink</clipboard-copy
+                                                    >
+                                                </li>
+                                                <li>
+                                                    <a
+                                                        class="dropdown-item js-update-url-with-hash"
+                                                        id="js-view-git-blame"
+                                                        role="menuitem"
+                                                        href="https://github.com/sourcegraph/sourcegraph/blame/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
+                                                        >View git blame</a
+                                                    >
+                                                </li>
+                                                <li>
+                                                    <a
+                                                        class="dropdown-item"
+                                                        id="js-new-issue"
+                                                        role="menuitem"
+                                                        href="/sourcegraph/sourcegraph/issues/new/choose"
+                                                        >Reference in new issue</a
+                                                    >
+                                                </li>
+                                            </ul>
+                                        </details-menu>
+                                    </details>
+                                </div>
+                            </div>
+
+                            <details class="details-reset details-overlay details-overlay-dark">
+                                <summary data-hotkey="l" aria-label="Jump to line" aria-haspopup="dialog"></summary>
+                                <details-dialog
+                                    class="Box Box--overlay d-flex flex-column anim-fade-in fast linejump"
+                                    aria-label="Jump to line"
+                                    role="dialog"
+                                >
+                                    <!-- '"` --><!-- </textarea></xmp> -->
+                                    <form
+                                        class="js-jump-to-line-form Box-body d-flex"
+                                        action=""
+                                        accept-charset="UTF-8"
+                                        method="get"
+                                    >
+                                        <input name="utf8" type="hidden" value="✓" />
+                                        <input
+                                            class="form-control flex-auto mr-3 linejump-input js-jump-to-line-field"
+                                            type="text"
+                                            placeholder="Jump to line…"
+                                            aria-label="Jump to line"
+                                            autofocus=""
+                                        />
+                                        <button type="submit" class="btn" data-close-dialog="">Go</button>
+                                    </form>
+                                </details-dialog>
+                            </details>
+                        </div>
+                        <div class="modal-backdrop js-touch-events"></div>
+                    </div>
+                </main>
+            </div>
+        </div>
+
+        <div class="footer container-lg width-full p-responsive" role="contentinfo">
+            <div
+                class="position-relative d-flex flex-row-reverse flex-lg-row flex-wrap flex-lg-nowrap flex-justify-center flex-lg-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light "
+            >
+                <ul
+                    class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-start mb-2 mb-lg-0"
+                >
+                    <li class="mr-3">
+                        © 2019 <span title="0.26174s from unicorn-5675df497d-fj8v5">GitHub</span>, Inc.
+                    </li>
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
+                            >Terms</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy"
+                            >Privacy</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to security, text:security" href="https://github.com/security"
+                            >Security</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a>
+                    </li>
+                    <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
+                </ul>
+
+                <a aria-label="Homepage" title="GitHub" class="footer-octicon mx-lg-4" href="https://github.com">
+                    <svg
+                        height="24"
+                        class="octicon octicon-mark-github"
+                        viewBox="0 0 16 16"
+                        version="1.1"
+                        width="24"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+                        ></path>
+                    </svg>
+                </a>
+                <ul
+                    class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-end mb-2 mb-lg-0"
+                >
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact"
+                            >Contact GitHub</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing"
+                            >Pricing</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a>
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://training.github.com" data-ga-click="Footer, go to training, text:training"
+                            >Training</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a>
+                    </li>
+                    <li>
+                        <a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="d-flex flex-justify-center pb-6">
+                <span class="f6 text-gray-light"></span>
+            </div>
+        </div>
+
+        <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+            <svg
+                class="octicon octicon-alert"
+                viewBox="0 0 16 16"
+                version="1.1"
+                width="16"
+                height="16"
+                aria-hidden="true"
+            >
+                <path
+                    fill-rule="evenodd"
+                    d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+                ></path>
+            </svg>
+            <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+                <svg
+                    class="octicon octicon-x"
+                    viewBox="0 0 12 16"
+                    version="1.1"
+                    width="12"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                    ></path>
+                </svg>
+            </button>
+            You can’t perform that action at this time.
+        </div>
+
+        <script
+            crossorigin="anonymous"
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
+            type="application/javascript"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
+        ></script>
+
+        <script
+            crossorigin="anonymous"
+            async="async"
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
+            type="application/javascript"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
+        ></script>
+
+        <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">
+            <svg
+                class="octicon octicon-alert"
+                viewBox="0 0 16 16"
+                version="1.1"
+                width="16"
+                height="16"
+                aria-hidden="true"
+            >
+                <path
+                    fill-rule="evenodd"
+                    d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+                ></path>
+            </svg>
+            <span class="signed-in-tab-flash"
+                >You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span
+            >
+            <span class="signed-out-tab-flash"
+                >You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span
+            >
+        </div>
+        <template id="site-details-dialog">
+            <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open="">
+                <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+                <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+                    <button
+                        class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0"
+                        type="button"
+                        aria-label="Close dialog"
+                        data-close-dialog=""
+                    >
+                        <svg
+                            class="octicon octicon-x"
+                            viewBox="0 0 12 16"
+                            version="1.1"
+                            width="12"
+                            height="16"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                            ></path>
+                        </svg>
+                    </button>
+                    <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+                </details-dialog>
+            </details>
+        </template>
+
+        <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
+            <div
+                class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large"
+                style="width:360px;"
+            ></div>
+        </div>
+
+        <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
+    </body>
 </html>
-

--- a/client/browser/src/libs/github/__fixtures__/github.com/blob/vanilla/code-view.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/blob/vanilla/code-view.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/blob/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts -->
 <div class="Box mt-3 position-relative">
     <div class="Box-header py-2 d-flex flex-column flex-shrink-0 flex-md-row flex-md-items-center">
         <div class="text-mono f6 flex-auto pr-3 flex-order-2 flex-md-order-1 mt-2 mt-md-0">
@@ -11,29 +12,29 @@
                 <a
                     id="raw-url"
                     class="btn btn-sm BtnGroup-item"
-                    href="/sourcegraph/sourcegraph/raw/master/shared/src/api/extension/types/url.ts"
+                    href="/sourcegraph/sourcegraph/raw/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                     >Raw</a
                 >
                 <a
                     class="btn btn-sm js-update-url-with-hash BtnGroup-item"
                     data-hotkey="b"
-                    href="https://github.com/sourcegraph/sourcegraph/blame/master/shared/src/api/extension/types/url.ts"
+                    href="https://github.com/sourcegraph/sourcegraph/blame/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                     >Blame</a
                 >
                 <a
                     rel="nofollow"
                     class="btn btn-sm BtnGroup-item"
-                    href="/sourcegraph/sourcegraph/commits/master/shared/src/api/extension/types/url.ts"
+                    href="/sourcegraph/sourcegraph/commits/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                     >History</a
                 >
             </div>
 
             <div>
-                <a
-                    class="btn-octicon tooltipped tooltipped-nw"
-                    href="github-mac://openRepo/https://github.com/sourcegraph/sourcegraph?branch=master&amp;filepath=shared%2Fsrc%2Fapi%2Fextension%2Ftypes%2Furl.ts"
-                    aria-label="Open this file in GitHub Desktop"
-                    data-ga-click="Repository, open with desktop, type:mac"
+                <button
+                    class="btn-octicon disabled tooltipped tooltipped-nw"
+                    type="button"
+                    disabled=""
+                    aria-label="You must be on a branch to open this file in GitHub Desktop"
                 >
                     <svg
                         class="octicon octicon-device-desktop"
@@ -48,75 +49,46 @@
                             d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
                         ></path>
                     </svg>
-                </a>
+                </button>
 
-                <!-- '"` --><!-- </textarea></xmp> -->
-                <form
-                    class="inline-form js-update-url-with-hash"
-                    action="https://github.com/sourcegraph/sourcegraph/edit/master/shared/src/api/extension/types/url.ts"
-                    accept-charset="UTF-8"
-                    method="post"
+                <button
+                    type="button"
+                    class="btn-octicon disabled tooltipped tooltipped-nw"
+                    aria-label="You must be on a branch to make or propose changes to this file"
                 >
-                    <input name="utf8" type="hidden" value="✓" /><input
-                        type="hidden"
-                        name="authenticity_token"
-                        value="okXRqogBr0n57KEMkTkU83xroOwpME/U11qw84q63hrJx9O5+M/Ok6zxTYvfJ3a17M3MmgekavJnFCGkw8C7Uw=="
-                    />
-                    <button
-                        class="btn-octicon tooltipped tooltipped-nw"
-                        type="submit"
-                        aria-label="Edit this file"
-                        data-hotkey="e"
-                        data-disable-with=""
+                    <svg
+                        class="octicon octicon-pencil"
+                        viewBox="0 0 14 16"
+                        version="1.1"
+                        width="14"
+                        height="16"
+                        aria-hidden="true"
                     >
-                        <svg
-                            class="octicon octicon-pencil"
-                            viewBox="0 0 14 16"
-                            version="1.1"
-                            width="14"
-                            height="16"
-                            aria-hidden="true"
-                        >
-                            <path
-                                fill-rule="evenodd"
-                                d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                            ></path>
-                        </svg>
-                    </button>
-                </form>
-                <!-- '"` --><!-- </textarea></xmp> -->
-                <form
-                    class="inline-form"
-                    action="/sourcegraph/sourcegraph/delete/master/shared/src/api/extension/types/url.ts"
-                    accept-charset="UTF-8"
-                    method="post"
+                        <path
+                            fill-rule="evenodd"
+                            d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
+                        ></path>
+                    </svg>
+                </button>
+                <button
+                    type="button"
+                    class="btn-octicon btn-octicon-danger disabled tooltipped tooltipped-nw"
+                    aria-label="You must be on a branch to make or propose changes to this file"
                 >
-                    <input name="utf8" type="hidden" value="✓" /><input
-                        type="hidden"
-                        name="authenticity_token"
-                        value="VQ69l1tmlxRMvKSed+eBcBNiDKa6RRioYQB/DgLptgLhSJvPKlxBtH726hHBBU2jmyBOHHMb1e/h2XTbrwMXRA=="
-                    />
-                    <button
-                        class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw"
-                        type="submit"
-                        aria-label="Delete this file"
-                        data-disable-with=""
+                    <svg
+                        class="octicon octicon-trashcan"
+                        viewBox="0 0 12 16"
+                        version="1.1"
+                        width="12"
+                        height="16"
+                        aria-hidden="true"
                     >
-                        <svg
-                            class="octicon octicon-trashcan"
-                            viewBox="0 0 12 16"
-                            version="1.1"
-                            width="12"
-                            height="16"
-                            aria-hidden="true"
-                        >
-                            <path
-                                fill-rule="evenodd"
-                                d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                            ></path>
-                        </svg>
-                    </button>
-                </form>
+                        <path
+                            fill-rule="evenodd"
+                            d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                        ></path>
+                    </svg>
+                </button>
             </div>
         </div>
     </div>
@@ -205,7 +177,7 @@
                             class="dropdown-item js-update-url-with-hash"
                             id="js-view-git-blame"
                             role="menuitem"
-                            href="https://github.com/sourcegraph/sourcegraph/blame/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+                            href="https://github.com/sourcegraph/sourcegraph/blame/eaa0fe5d10dfb0d99f5de640fcc7dac28f715bc9/shared/src/api/extension/types/url.ts"
                             >View git blame</a
                         >
                     </li>

--- a/client/browser/src/libs/github/__fixtures__/github.com/blob/vanilla/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/blob/vanilla/page.html
@@ -1,1121 +1,2787 @@
-
-
-
-
-
-
-<!DOCTYPE html>
+<!-- https://github.com/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts -->
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-  <link rel="dns-prefetch" href="https://github.githubassets.com">
-  <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
-  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
-
-
-
-  <link crossorigin="anonymous" media="all" integrity="sha512-OBabailf0Gja8rWVZO1xyYAw//CQdLOJF4riG050gTxsVqVD7az4Sq56hPWfv3AoaxuEhYXgQlGQcNxzZzDyVA==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-d69542a4a3958db914b3bec3f757de26.css" />
-  
-    <link crossorigin="anonymous" media="all" integrity="sha512-NuTIwC5UFn67DeQnzZUYtnS1vm5tRZ4BtBic9TpGK+RnuP+MH/OqIVS+Dr7rpnOwnSmxezyl1L50kLWW3sSNGQ==" rel="stylesheet" href="https://github.githubassets.com/assets/github-a7545a042547353ea45ba3211e585d1c.css" />
-    
-    
-    
-    
-
-  <meta name="viewport" content="width=device-width">
-  
-  <title>sourcegraph/url.ts at master · sourcegraph/sourcegraph</title>
-    <meta name="description" content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub.">
-    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
-  <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
-  <meta property="fb:app_id" content="1401488693436528">
-
-    <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" /><meta name="twitter:site" content="@github" /><meta name="twitter:card" content="summary" /><meta name="twitter:title" content="sourcegraph/sourcegraph" /><meta name="twitter:description" content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub." />
-    <meta property="og:image" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="sourcegraph/sourcegraph" /><meta property="og:url" content="https://github.com/sourcegraph/sourcegraph" /><meta property="og:description" content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub." />
-
-  <link rel="assets" href="https://github.githubassets.com/">
-  <link rel="web-socket" href="wss://live.github.com/_sockets/VjI6MzgyNzA5NjM2OmFiNTg5NWMyOGEwYmY1NzdjMDQyNjI5M2Y5MjlkNDdlZjhkODAxZWUxNTBjYmEwODg2NDM0NDE4ZjgyYmNhNTY=--a41bd7f54a7583e634e20708dd597e466ffdb573">
-  <meta name="pjax-timeout" content="1000">
-  <link rel="sudo-modal" href="/sessions/sudo_modal">
-  <meta name="request-id" content="CB1C:1FB94:B973DC:1156FE9:5CB98FCB" data-pjax-transient>
-
-
-  
-
-  <meta name="selected-link" value="repo_source" data-pjax-transient>
-
-      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-
-  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="CB1C:1FB94:B973DC:1156FE9:5CB98FCB" /><meta name="octolytics-dimension-region_edge" content="ams" /><meta name="octolytics-dimension-region_render" content="iad" /><meta name="octolytics-actor-id" content="1741180" /><meta name="octolytics-actor-login" content="lguychard" /><meta name="octolytics-actor-hash" content="1b59c154e057c2d407257621fb6e4b8828b3625d9c8781f14d6c02dffd7a4100" />
-<meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-pjax-transient="true" />
-
-
-
-    <meta name="google-analytics" content="UA-3769691-2">
-
-  <meta class="js-ga-set" name="userId" content="d006a5262acdf70eda7670879e8c073e">
-
-<meta class="js-ga-set" name="dimension1" content="Logged In">
-
-
-
-  
-
-      <meta name="hostname" content="github.com">
-    <meta name="user-login" content="lguychard">
-
-      <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="MjJkZTIwZWY3NDY4MGUxZjhhZjdhMmEyODgzMmFiZjEwMDliM2FiMjg3OTZjYjhiZTAwOTM0NDM0MDMxMjg4N3x7InJlbW90ZV9hZGRyZXNzIjoiOTIuMTM5LjkwLjIzMCIsInJlcXVlc3RfaWQiOiJDQjFDOjFGQjk0OkI5NzNEQzoxMTU2RkU5OjVDQjk4RkNCIiwidGltZXN0YW1wIjoxNTU1NjY0ODQzLCJob3N0IjoiZ2l0aHViLmNvbSJ9">
-
-    <meta name="enabled-features" content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_ENTERPRISE_CONTACTS,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES">
-
-  <meta name="html-safe-nonce" content="f2aa177d3304d4abd9f30ff5c7aa38ba935da1e9">
-
-  <meta http-equiv="x-pjax-version" content="7f7ec9b1425b9f5a1e241ce3969f9adb">
-  
-
-      <link href="https://github.com/sourcegraph/sourcegraph/commits/master.atom" rel="alternate" title="Recent Commits to sourcegraph:master" type="application/atom+xml">
-
-  <meta name="go-import" content="github.com/sourcegraph/sourcegraph git https://github.com/sourcegraph/sourcegraph.git">
-
-  <meta name="octolytics-dimension-user_id" content="3979584" /><meta name="octolytics-dimension-user_login" content="sourcegraph" /><meta name="octolytics-dimension-repository_id" content="41288708" /><meta name="octolytics-dimension-repository_nwo" content="sourcegraph/sourcegraph" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="41288708" /><meta name="octolytics-dimension-repository_network_root_nwo" content="sourcegraph/sourcegraph" /><meta name="octolytics-dimension-repository_explore_github_marketplace_ci_cta_shown" content="false" />
-
-
-    <link rel="canonical" href="https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts" data-pjax-transient>
-
-
-  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
-
-  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
-
-  <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000">
-  <link rel="icon" type="image/x-icon" class="js-site-favicon" href="https://github.githubassets.com/favicon.ico">
-
-<meta name="theme-color" content="#1e2327">
-
-
-  <meta name="u2f-enabled" content="true">
-
-
-  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
-
-  </head>
-
-  <body class="logged-in env-production emoji-size-boost page-responsive min-width-0 page-blob">
-    
-
-  <div class="position-relative js-header-wrapper ">
-    <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
-    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
-
-    
-    
-    
-
-
-          <header class="Header js-details-container Details flex-wrap flex-lg-nowrap p-responsive" role="banner">
-
-    <div class="Header-item d-none d-lg-flex">
-      <a class="Header-link" href="https://github.com/" data-hotkey="g d" aria-label="Homepage" data-ga-click="Header, go to dashboard, icon:logo">
-  <svg class="octicon octicon-mark-github v-align-middle" height="32" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-</a>
-
-    </div>
-
-    <div class="Header-item d-lg-none">
-      <button class="Header-link btn-link mt-1 js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
-        <svg height="24" class="octicon octicon-three-bars" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M11.41 9H.59C0 9 0 8.59 0 8c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zm0-4H.59C0 5 0 4.59 0 4c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM.59 11H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1H.59C0 13 0 12.59 0 12c0-.59 0-1 .59-1z"/></svg>
-      </button>
-    </div>
-
-    <div class="Header-item Header-item--full flex-column flex-lg-row width-full flex-order-2 flex-lg-order-none mr-0 mr-lg-3 mt-3 mt-lg-0 Details-content--hidden">
-        <div class="header-search flex-self-stretch flex-lg-self-auto mr-0 mr-lg-3 mb-3 mb-lg-0 scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="combobox"
-  aria-owns="jump-to-results"
-  aria-label="Search or jump to"
-  aria-haspopup="listbox"
-  aria-expanded="false"
->
-  <div class="position-relative">
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-scope-type="Repository" data-scope-id="41288708" data-scoped-search-url="/sourcegraph/sourcegraph/search" data-unscoped-search-url="/search" action="/sourcegraph/sourcegraph/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
-      <label class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container">
-        <input type="text"
-          class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
-          data-hotkey="s,/"
-          name="q"
-          value=""
-          placeholder="Search or jump to…"
-          data-unscoped-placeholder="Search or jump to…"
-          data-scoped-placeholder="Search or jump to…"
-          autocapitalize="off"
-          aria-autocomplete="list"
-          aria-controls="jump-to-results"
-          aria-label="Search or jump to…"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=gY8z2VJYFJRNUaRXZ5Or5fXYKmxETDjsjq/m2+jW4eaH/PYU/5gy6ySsU8CQcLqWLhAc8wRKbO7BoGEWq+DlfA=="
-          spellcheck="false"
-          autocomplete="off"
-          >
-          <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://github.githubassets.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
-
-            <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              
-<ul class="d-none js-jump-to-suggestions-template-container">
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-</ul>
-
-<ul class="d-none js-jump-to-no-results-template-container">
-  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
-    <span class="text-gray">No suggested jump to results</span>
-  </li>
-</ul>
-
-<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-
-    <li class="d-flex flex-justify-center flex-items-center p-0 f5 js-jump-to-suggestion">
-      <img src="https://github.githubassets.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-    </li>
-</ul>
-
-            </div>
-      </label>
-</form>  </div>
-</div>
-
-
-      <nav class="d-flex flex-column flex-lg-row flex-self-stretch flex-lg-self-auto" aria-label="Global">
-    <a class="Header-link d-block d-lg-none py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-ga-click="Header, click, Nav menu - item:dashboard:user" aria-label="Dashboard" href="/dashboard">
-      Dashboard
-</a>
-  <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-hotkey="g p" data-ga-click="Header, click, Nav menu - item:pulls context:user" aria-label="Pull requests you created" data-selected-links="/pulls /pulls/assigned /pulls/mentioned /pulls" href="/pulls">
-    Pull requests
-</a>
-  <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-hotkey="g i" data-ga-click="Header, click, Nav menu - item:issues context:user" aria-label="Issues you created" data-selected-links="/issues /issues/assigned /issues/mentioned /issues" href="/issues">
-    Issues
-</a>
-    <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-ga-click="Header, click, Nav menu - item:marketplace context:user" data-octo-click="marketplace_click" data-octo-dimensions="location:nav_bar" data-selected-links=" /marketplace" href="/marketplace">
-      Marketplace
-</a>      
-
-  <a class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
-    Explore
-</a>
-    <a class="Header-link d-block d-lg-none mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15" aria-label="View profile and more" aria-expanded="false" aria-haspopup="false" href="https://github.com/lguychard">
-      <img class="avatar" src="https://avatars3.githubusercontent.com/u/1741180?s=40&amp;v=4" width="20" height="20" alt="@lguychard" />
-      lguychard
-</a>
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/logout" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="8Bup+8V2ku0ALtgZESB5owFkDKuXF1jTA8V3py9um4BIBbHHfZhGQQrf08FsDHt9t13JETqi17sTwJVTMXcivw==" />
-      <button type="submit" class="Header-link mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15 d-lg-none btn-link d-block width-full text-left" data-ga-click="Header, sign out, icon:logout" style="padding-left: 2px;">
-        <svg class="octicon octicon-sign-out v-align-middle" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 9V7H8V5h4V3l4 3-4 3zm-2 3H6V3L2 1h8v3h1V1c0-.55-.45-1-1-1H1C.45 0 0 .45 0 1v11.38c0 .39.22.73.55.91L6 16.01V13h4c.55 0 1-.45 1-1V8h-1v4z"/></svg>
-        Sign out
-      </button>
-</form></nav>
-
-    </div>
-
-    <div class="Header-item Header-item--full flex-justify-center d-lg-none position-relative">
-      <div class="css-truncate css-truncate-target width-fit position-absolute left-0 right-0 text-center">
-              <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-    <a class="Header-link" href="/sourcegraph">sourcegraph</a>
-    /
-    <a class="Header-link" href="/sourcegraph/sourcegraph">sourcegraph</a>
-
-</div>
-    </div>
-
-    <div class="Header-item position-relative d-none d-lg-flex">
-      
-
-    </div>
-
-    <div class="Header-item mr-0 mr-lg-3 flex-order-1 flex-lg-order-none">
-      
-    <a aria-label="You have unread notifications" class="Header-link notification-indicator tooltipped tooltipped-s my-2 my-lg-0 js-socket-channel js-notification-indicator" data-hotkey="g n" data-ga-click="Header, go to notifications, icon:unread" data-channel="notification-changed:1741180" href="/notifications">
-        <span class="mail-status unread"></span>
-        <svg class="octicon octicon-bell" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 12v1H0v-1l.73-.58c.77-.77.81-2.55 1.19-4.42C2.69 3.23 6 2 6 2c0-.55.45-1 1-1s1 .45 1 1c0 0 3.39 1.23 4.16 5 .38 1.88.42 3.66 1.19 4.42l.66.58H14zm-7 4c1.11 0 2-.89 2-2H5c0 1.11.89 2 2 2z"/></svg>
-</a>
-    </div>
-
-
-    <div class="Header-item position-relative d-none d-lg-flex">
-      <details class="details-overlay details-reset">
-  <summary class="Header-link"
-      aria-label="Create new…"
-      data-ga-click="Header, create new, icon:add">
-    <svg class="octicon octicon-plus" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 9H7v5H5V9H0V7h5V2h2v5h5v2z"/></svg> <span class="dropdown-caret"></span>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw">
-    
-<a role="menuitem" class="dropdown-item" href="/new" data-ga-click="Header, create new repository">
-  New repository
-</a>
-
-  <a role="menuitem" class="dropdown-item" href="/new/import" data-ga-click="Header, import a repository">
-    Import repository
-  </a>
-
-<a role="menuitem" class="dropdown-item" href="https://gist.github.com/" data-ga-click="Header, create new gist">
-  New gist
-</a>
-
-  <a role="menuitem" class="dropdown-item" href="/organizations/new" data-ga-click="Header, create new organization">
-    New organization
-  </a>
-
-
-  <div role="none" class="dropdown-divider"></div>
-  <div class="dropdown-header">
-    <span title="sourcegraph/sourcegraph">This repository</span>
-  </div>
-    <a role="menuitem" class="dropdown-item" href="/sourcegraph/sourcegraph/issues/new/choose" data-ga-click="Header, create new issue" data-skip-pjax>
-      New issue
-    </a>
-
-
-  </details-menu>
-</details>
-
-    </div>
-
-    <div class="Header-item position-relative mr-0 d-none d-lg-flex">
-      
-<details class="details-overlay details-reset">
-  <summary class="Header-link"
-    aria-label="View profile and more"
-    data-ga-click="Header, show menu, icon:avatar">
-    <img alt="@lguychard" class="avatar" src="https://avatars3.githubusercontent.com/u/1741180?s=40&amp;v=4" height="20" width="20">
-    <span class="dropdown-caret"></span>
-  </summary>
-  <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px">
-    <div class="header-nav-current-user css-truncate"><a role="menuitem" class="no-underline user-profile-link px-3 pt-2 pb-2 mb-n2 mt-n1 d-block" href="/lguychard" data-ga-click="Header, go to profile, text:Signed in as">Signed in as <strong class="css-truncate-target">lguychard</strong></a></div>
-    <div role="none" class="dropdown-divider"></div>
-
-      <div class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1" data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1">
-        
-<div class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 border" data-team-hovercards-enabled>
-  <details class="js-user-status-details details-reset details-overlay details-overlay-dark">
-    <summary class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray " aria-haspopup="dialog" role="menuitem" data-hydro-click="{&quot;event_type&quot;:&quot;user_profile.click&quot;,&quot;payload&quot;:{&quot;profile_user_id&quot;:3979584,&quot;target&quot;:&quot;EDIT_USER_STATUS&quot;,&quot;user_id&quot;:1741180,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CB1C:1FB94:B973DC:1156FE9:5CB98FCB&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;}}" data-hydro-click-hmac="03b7db45be7db4c7de16b1ec4703ea6ccd7e7397528c8e4ebb3634ac64bd8811">
-      <div class="f6 d-inline-block v-align-middle user-status-emoji-only-header circle pr-2 lh-condensed user-status-header " style="max-width: 29px">
-        <div class="user-status-emoji-container flex-shrink-0 mr-1 mt-1 lh-condensed-ultra v-align-bottom" style="">
-          <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"/></svg>
-        </div>
-      </div>
-      <div class="
-        d-inline-block v-align-middle
-        
-        
-         css-truncate css-truncate-target 
+    <head>
+        <meta charset="utf-8" />
+        <link rel="dns-prefetch" href="https://github.githubassets.com" />
+        <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com" />
+        <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com" />
+        <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/" />
+
+        <link
+            crossorigin="anonymous"
+            media="all"
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
+            rel="stylesheet"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
+        />
+
+        <link
+            crossorigin="anonymous"
+            media="all"
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
+            rel="stylesheet"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
+        />
+
+        <meta name="viewport" content="width=device-width" />
+
+        <title>sourcegraph/url.ts at 45705b3b0407ff44ff7db8660370d2a7bba79db2 · sourcegraph/sourcegraph</title>
+        <meta
+            name="description"
+            content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub."
+        />
+        <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub" />
+        <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
+        <meta property="fb:app_id" content="1401488693436528" />
+
+        <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="sourcegraph/sourcegraph" />
+        <meta
+            name="twitter:description"
+            content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub."
+        />
+        <meta property="og:image" content="https://avatars2.githubusercontent.com/u/3979584?s=400&amp;v=4" />
+        <meta property="og:site_name" content="GitHub" />
+        <meta property="og:type" content="object" />
+        <meta property="og:title" content="sourcegraph/sourcegraph" />
+        <meta property="og:url" content="https://github.com/sourcegraph/sourcegraph" />
+        <meta
+            property="og:description"
+            content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub."
+        />
+
+        <link rel="assets" href="https://github.githubassets.com/" />
+        <link
+            rel="web-socket"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmUzMGJlNDgwOGQwNmI1YzUxYzRmZmRjYTZmZGVmNmFjOWI5NTY2OGY4NWMwZTI4YjM4ZmYwNjMyNWQwN2E4YzI=--3eb07e9a53b6f13046bf63c38693bcd01d8cfab5"
+        />
+        <meta name="pjax-timeout" content="1000" />
+        <link rel="sudo-modal" href="/sessions/sudo_modal" />
+        <meta name="request-id" content="C645:38C3E:C7C775:12D76DE:5CC23683" data-pjax-transient="" />
+
+        <meta name="selected-link" value="repo_source" data-pjax-transient="" />
+
+        <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU" />
+        <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA" />
+        <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc" />
+
+        <meta name="octolytics-host" content="collector.githubapp.com" />
+        <meta name="octolytics-app-id" content="github" />
+        <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
+        <meta name="octolytics-dimension-request_id" content="C645:38C3E:C7C775:12D76DE:5CC23683" />
+        <meta name="octolytics-dimension-region_edge" content="ams" />
+        <meta name="octolytics-dimension-region_render" content="iad" />
+        <meta name="octolytics-actor-id" content="10532611" />
+        <meta name="octolytics-actor-login" content="felixfbecker" />
+        <meta name="octolytics-actor-hash" content="a0bf5739a312c3a4d600b1ddd462e3b3ac0c4c28370673f3b7aacd82b09f1fac" />
+        <meta name="analytics-location" content="/<user-name>/<repo-name>/blob/show" data-pjax-transient="true" />
+
+        <meta class="js-ga-set" name="userId" content="1b23c6f4348a524a9d5b520c80e3ee17" />
+
+        <meta class="js-ga-set" name="dimension1" content="Logged In" />
+
+        <meta name="hostname" content="github.com" />
+        <meta name="user-login" content="felixfbecker" />
+
+        <meta name="expected-hostname" content="github.com" />
+        <meta
+            name="js-proxy-site-detection-payload"
+            content="N2JjZjM5OGIwMzQ0NWUyOWU5ODM0ODkxNWM0NzI4ODZmM2IyZmFmZjIyY2Q5NjU5ZjVlZjNlZmVkNWE1OGYzMHx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkM2NDU6MzhDM0U6QzdDNzc1OjEyRDc2REU6NUNDMjM2ODMiLCJ0aW1lc3RhbXAiOjE1NTYyMzE4MTEsImhvc3QiOiJnaXRodWIuY29tIn0="
+        />
+
+        <meta
+            name="enabled-features"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+        />
+
+        <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
+
+        <meta http-equiv="x-pjax-version" content="ae4ac585f9fbd8269d0af4700dd2453b" />
+
+        <link
+            href="https://github.com/sourcegraph/sourcegraph/commits/45705b3b0407ff44ff7db8660370d2a7bba79db2.atom"
+            rel="alternate"
+            title="Recent Commits to sourcegraph:45705b3b0407ff44ff7db8660370d2a7bba79db2"
+            type="application/atom+xml"
+        />
+
+        <meta
+            name="go-import"
+            content="github.com/sourcegraph/sourcegraph git https://github.com/sourcegraph/sourcegraph.git"
+        />
+
+        <meta name="octolytics-dimension-user_id" content="3979584" />
+        <meta name="octolytics-dimension-user_login" content="sourcegraph" />
+        <meta name="octolytics-dimension-repository_id" content="41288708" />
+        <meta name="octolytics-dimension-repository_nwo" content="sourcegraph/sourcegraph" />
+        <meta name="octolytics-dimension-repository_public" content="true" />
+        <meta name="octolytics-dimension-repository_is_fork" content="false" />
+        <meta name="octolytics-dimension-repository_network_root_id" content="41288708" />
+        <meta name="octolytics-dimension-repository_network_root_nwo" content="sourcegraph/sourcegraph" />
+        <meta name="octolytics-dimension-repository_explore_github_marketplace_ci_cta_shown" content="false" />
+
+        <link
+            rel="canonical"
+            href="https://github.com/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+            data-pjax-transient=""
+        />
+
+        <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats" />
+
+        <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors" />
+
+        <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000" />
+        <link
+            rel="icon"
+            type="image/x-icon"
+            class="js-site-favicon"
+            href="https://github.githubassets.com/favicon.ico"
+        />
+
+        <meta name="theme-color" content="#1e2327" />
+
+        <meta name="u2f-enabled" content="true" />
+
+        <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
+    </head>
+
+    <body class="logged-in env-production emoji-size-boost page-responsive min-width-0 page-blob">
+        <div class="position-relative js-header-wrapper ">
+            <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content"
+                >Skip to content</a
+            >
+            <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
+
+            <header class="Header js-details-container Details flex-wrap flex-lg-nowrap p-responsive" role="banner">
+                <div class="Header-item d-none d-lg-flex">
+                    <a
+                        class="Header-link"
+                        href="https://github.com/"
+                        data-hotkey="g d"
+                        aria-label="Homepage"
+                        data-ga-click="Header, go to dashboard, icon:logo"
+                    >
+                        <svg
+                            class="octicon octicon-mark-github v-align-middle"
+                            height="32"
+                            viewBox="0 0 16 16"
+                            version="1.1"
+                            width="32"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+                            ></path>
+                        </svg>
+                    </a>
+                </div>
+
+                <div class="Header-item d-lg-none">
+                    <button
+                        class="Header-link btn-link js-details-target"
+                        type="button"
+                        aria-label="Toggle navigation"
+                        aria-expanded="false"
+                    >
+                        <svg
+                            height="24"
+                            class="octicon octicon-three-bars"
+                            viewBox="0 0 12 16"
+                            version="1.1"
+                            width="18"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M11.41 9H.59C0 9 0 8.59 0 8c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zm0-4H.59C0 5 0 4.59 0 4c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM.59 11H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1H.59C0 13 0 12.59 0 12c0-.59 0-1 .59-1z"
+                            ></path>
+                        </svg>
+                    </button>
+                </div>
+
+                <div
+                    class="Header-item Header-item--full flex-column flex-lg-row width-full flex-order-2 flex-lg-order-none mr-0 mr-lg-3 mt-3 mt-lg-0 Details-content--hidden"
+                >
+                    <div
+                        class="header-search flex-self-stretch flex-lg-self-auto mr-0 mr-lg-3 mb-3 mb-lg-0 scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+                        role="combobox"
+                        aria-owns="jump-to-results"
+                        aria-label="Search or jump to"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                    >
+                        <div class="position-relative">
+                            <!-- '"` --><!-- </textarea></xmp> -->
+                            <form
+                                class="js-site-search-form"
+                                role="search"
+                                aria-label="Site"
+                                data-scope-type="Repository"
+                                data-scope-id="41288708"
+                                data-scoped-search-url="/sourcegraph/sourcegraph/search"
+                                data-unscoped-search-url="/search"
+                                action="/sourcegraph/sourcegraph/search"
+                                accept-charset="UTF-8"
+                                method="get"
+                            >
+                                <input name="utf8" type="hidden" value="✓" />
+                                <label
+                                    class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container"
+                                >
+                                    <input
+                                        type="text"
+                                        class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
+                                        data-hotkey="s,/"
+                                        name="q"
+                                        value=""
+                                        placeholder="Search or jump to…"
+                                        data-unscoped-placeholder="Search or jump to…"
+                                        data-scoped-placeholder="Search or jump to…"
+                                        autocapitalize="off"
+                                        aria-autocomplete="list"
+                                        aria-controls="jump-to-results"
+                                        aria-label="Search or jump to…"
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=DBwDLcj4fK3L/gFEXY4+Egm1WFOgl1Gph/PiB9clTZNVO5La7EjtJS/n3C9WZ0bJrrFmdrYfuQooBsxW2hMong=="
+                                        spellcheck="false"
+                                        autocomplete="off"
+                                    />
+                                    <input type="hidden" class="js-site-search-type-field" name="type" />
+                                    <img
+                                        src="https://github.githubassets.com/images/search-key-slash.svg"
+                                        alt=""
+                                        class="mr-2 header-search-key-slash"
+                                    />
+
+                                    <div
+                                        class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container"
+                                    >
+                                        <ul class="d-none js-jump-to-suggestions-template-container">
+                                            <li
+                                                class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion"
+                                                role="option"
+                                            >
+                                                <a
+                                                    tabindex="-1"
+                                                    class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2"
+                                                    href=""
+                                                >
+                                                    <div
+                                                        class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none"
+                                                    >
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none"
+                                                            title="Repository"
+                                                            aria-label="Repository"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none"
+                                                            title="Project"
+                                                            aria-label="Project"
+                                                            viewBox="0 0 15 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none"
+                                                            title="Search"
+                                                            aria-label="Search"
+                                                            viewBox="0 0 16 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"
+                                                            ></path>
+                                                        </svg>
+                                                    </div>
+
+                                                    <img
+                                                        class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none"
+                                                        alt=""
+                                                        aria-label="Team"
+                                                        src=""
+                                                        width="28"
+                                                        height="28"
+                                                    />
+
+                                                    <div
+                                                        class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target"
+                                                    ></div>
+
+                                                    <div
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search"
+                                                    >
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-default d-none"
+                                                            aria-label="in this repository"
+                                                        >
+                                                            In this repository
+                                                        </span>
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-global d-none"
+                                                            aria-label="in all of GitHub"
+                                                        >
+                                                            All GitHub
+                                                        </span>
+                                                        <span
+                                                            aria-hidden="true"
+                                                            class="d-inline-block ml-1 v-align-middle"
+                                                            >↵</span
+                                                        >
+                                                    </div>
+
+                                                    <div
+                                                        aria-hidden="true"
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump"
+                                                    >
+                                                        Jump to
+                                                        <span class="d-inline-block ml-1 v-align-middle">↵</span>
+                                                    </div>
+                                                </a>
+                                            </li>
+                                        </ul>
+
+                                        <ul class="d-none js-jump-to-no-results-template-container">
+                                            <li
+                                                class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2"
+                                            >
+                                                <span class="text-gray">No suggested jump to results</span>
+                                            </li>
+                                        </ul>
+
+                                        <ul
+                                            id="jump-to-results"
+                                            role="listbox"
+                                            class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container"
+                                        >
+                                            <li
+                                                class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none"
+                                                role="option"
+                                            >
+                                                <a
+                                                    tabindex="-1"
+                                                    class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2"
+                                                    href=""
+                                                >
+                                                    <div
+                                                        class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none"
+                                                    >
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none"
+                                                            title="Repository"
+                                                            aria-label="Repository"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none"
+                                                            title="Project"
+                                                            aria-label="Project"
+                                                            viewBox="0 0 15 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none"
+                                                            title="Search"
+                                                            aria-label="Search"
+                                                            viewBox="0 0 16 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"
+                                                            ></path>
+                                                        </svg>
+                                                    </div>
+
+                                                    <img
+                                                        class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none"
+                                                        alt=""
+                                                        aria-label="Team"
+                                                        src=""
+                                                        width="28"
+                                                        height="28"
+                                                    />
+
+                                                    <div
+                                                        class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target"
+                                                    ></div>
+
+                                                    <div
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search"
+                                                    >
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-default d-none"
+                                                            aria-label="in this repository"
+                                                        >
+                                                            In this repository
+                                                        </span>
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-global d-none"
+                                                            aria-label="in all of GitHub"
+                                                        >
+                                                            All GitHub
+                                                        </span>
+                                                        <span
+                                                            aria-hidden="true"
+                                                            class="d-inline-block ml-1 v-align-middle"
+                                                            >↵</span
+                                                        >
+                                                    </div>
+
+                                                    <div
+                                                        aria-hidden="true"
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump"
+                                                    >
+                                                        Jump to
+                                                        <span class="d-inline-block ml-1 v-align-middle">↵</span>
+                                                    </div>
+                                                </a>
+                                            </li>
+
+                                            <li
+                                                class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none"
+                                                role="option"
+                                            >
+                                                <a
+                                                    tabindex="-1"
+                                                    class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2"
+                                                    href=""
+                                                >
+                                                    <div
+                                                        class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none"
+                                                    >
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none"
+                                                            title="Repository"
+                                                            aria-label="Repository"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none"
+                                                            title="Project"
+                                                            aria-label="Project"
+                                                            viewBox="0 0 15 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                                            ></path>
+                                                        </svg>
+                                                        <svg
+                                                            height="16"
+                                                            width="16"
+                                                            class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none"
+                                                            title="Search"
+                                                            aria-label="Search"
+                                                            viewBox="0 0 16 16"
+                                                            version="1.1"
+                                                            role="img"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"
+                                                            ></path>
+                                                        </svg>
+                                                    </div>
+
+                                                    <img
+                                                        class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none"
+                                                        alt=""
+                                                        aria-label="Team"
+                                                        src=""
+                                                        width="28"
+                                                        height="28"
+                                                    />
+
+                                                    <div
+                                                        class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target"
+                                                    ></div>
+
+                                                    <div
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search"
+                                                    >
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-default d-none"
+                                                            aria-label="in this repository"
+                                                        >
+                                                            In this repository
+                                                        </span>
+                                                        <span
+                                                            class="js-jump-to-badge-search-text-global d-none"
+                                                            aria-label="in all of GitHub"
+                                                        >
+                                                            All GitHub
+                                                        </span>
+                                                        <span
+                                                            aria-hidden="true"
+                                                            class="d-inline-block ml-1 v-align-middle"
+                                                            >↵</span
+                                                        >
+                                                    </div>
+
+                                                    <div
+                                                        aria-hidden="true"
+                                                        class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump"
+                                                    >
+                                                        Jump to
+                                                        <span class="d-inline-block ml-1 v-align-middle">↵</span>
+                                                    </div>
+                                                </a>
+                                            </li>
+
+                                            <li
+                                                class="d-flex flex-justify-center flex-items-center p-0 f5 js-jump-to-suggestion"
+                                            >
+                                                <img
+                                                    src="https://github.githubassets.com/images/spinners/octocat-spinner-128.gif"
+                                                    alt="Octocat Spinner Icon"
+                                                    class="m-2"
+                                                    width="28"
+                                                />
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </label>
+                            </form>
+                        </div>
+                    </div>
+
+                    <nav class="d-flex flex-column flex-lg-row flex-self-stretch flex-lg-self-auto" aria-label="Global">
+                        <a
+                            class="Header-link d-block d-lg-none py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-ga-click="Header, click, Nav menu - item:dashboard:user"
+                            aria-label="Dashboard"
+                            href="/dashboard"
+                        >
+                            Dashboard
+                        </a>
+                        <a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-hotkey="g p"
+                            data-ga-click="Header, click, Nav menu - item:pulls context:user"
+                            aria-label="Pull requests you created"
+                            data-selected-links="/pulls /pulls/assigned /pulls/mentioned /pulls"
+                            href="/pulls"
+                        >
+                            Pull requests
+                        </a>
+                        <a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-hotkey="g i"
+                            data-ga-click="Header, click, Nav menu - item:issues context:user"
+                            aria-label="Issues you created"
+                            data-selected-links="/issues /issues/assigned /issues/mentioned /issues"
+                            href="/issues"
+                        >
+                            Issues
+                        </a>
+                        <a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-ga-click="Header, click, Nav menu - item:marketplace context:user"
+                            data-octo-click="marketplace_click"
+                            data-octo-dimensions="location:nav_bar"
+                            data-selected-links=" /marketplace"
+                            href="/marketplace"
+                        >
+                            Marketplace
+                        </a>
+
+                        <a
+                            class="js-selected-navigation-item Header-link  mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            data-ga-click="Header, click, Nav menu - item:explore"
+                            data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore"
+                            href="/explore"
+                        >
+                            Explore
+                        </a>
+                        <a
+                            class="Header-link d-block d-lg-none mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15"
+                            aria-label="View profile and more"
+                            aria-expanded="false"
+                            aria-haspopup="false"
+                            href="https://github.com/felixfbecker"
+                        >
+                            <img
+                                class="avatar"
+                                src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4"
+                                width="20"
+                                height="20"
+                                alt="@felixfbecker"
+                            />
+                            felixfbecker
+                        </a>
+                        <!-- '"` --><!-- </textarea></xmp> -->
+                        <form action="/logout" accept-charset="UTF-8" method="post">
+                            <input name="utf8" type="hidden" value="✓" /><input
+                                type="hidden"
+                                name="authenticity_token"
+                                value="1BYsr+YFP+YYQJD4RvTJzLi8ahV3x04PzEMDubBvkvXT2k+XT5tsSkhTgXbmgKE01yCYTtWmq/ZpTihFbXisqQ=="
+                            />
+                            <button
+                                type="submit"
+                                class="Header-link mr-0 mr-lg-3 py-2 py-lg-0 border-top border-lg-top-0 border-white-fade-15 d-lg-none btn-link d-block width-full text-left"
+                                data-ga-click="Header, sign out, icon:logout"
+                                style="padding-left: 2px;"
+                            >
+                                <svg
+                                    class="octicon octicon-sign-out v-align-middle"
+                                    viewBox="0 0 16 16"
+                                    version="1.1"
+                                    width="16"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M12 9V7H8V5h4V3l4 3-4 3zm-2 3H6V3L2 1h8v3h1V1c0-.55-.45-1-1-1H1C.45 0 0 .45 0 1v11.38c0 .39.22.73.55.91L6 16.01V13h4c.55 0 1-.45 1-1V8h-1v4z"
+                                    ></path>
+                                </svg>
+                                Sign out
+                            </button>
+                        </form>
+                    </nav>
+                </div>
+
+                <div class="Header-item Header-item--full flex-justify-center d-lg-none position-relative">
+                    <div
+                        class="css-truncate css-truncate-target width-fit position-absolute left-0 right-0 text-center"
+                    >
+                        <svg
+                            class="octicon octicon-repo"
+                            viewBox="0 0 12 16"
+                            version="1.1"
+                            width="12"
+                            height="16"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                            ></path>
+                        </svg>
+                        <a class="Header-link" href="/sourcegraph">sourcegraph</a>
+                        /
+                        <a class="Header-link" href="/sourcegraph/sourcegraph">sourcegraph</a>
+                    </div>
+                </div>
+
+                <div class="Header-item position-relative d-none d-lg-flex"></div>
+
+                <div class="Header-item mr-0 mr-lg-3 flex-order-1 flex-lg-order-none"></div>
+
+                <div class="Header-item position-relative d-none d-lg-flex">
+                    <details class="details-overlay details-reset">
+                        <summary
+                            class="Header-link"
+                            aria-label="Create new…"
+                            data-ga-click="Header, create new, icon:add"
+                            aria-haspopup="menu"
+                        >
+                            <svg
+                                class="octicon octicon-plus"
+                                viewBox="0 0 12 16"
+                                version="1.1"
+                                width="12"
+                                height="16"
+                                aria-hidden="true"
+                            >
+                                <path fill-rule="evenodd" d="M12 9H7v5H5V9H0V7h5V2h2v5h5v2z"></path>
+                            </svg>
+                            <span class="dropdown-caret"></span>
+                        </summary>
+                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/new"
+                                data-ga-click="Header, create new repository"
+                            >
+                                New repository
+                            </a>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/new/import"
+                                data-ga-click="Header, import a repository"
+                            >
+                                Import repository
+                            </a>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="https://gist.github.com/"
+                                data-ga-click="Header, create new gist"
+                            >
+                                New gist
+                            </a>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/organizations/new"
+                                data-ga-click="Header, create new organization"
+                            >
+                                New organization
+                            </a>
+
+                            <div role="none" class="dropdown-divider"></div>
+                            <div class="dropdown-header">
+                                <span title="sourcegraph/sourcegraph">This repository</span>
+                            </div>
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/sourcegraph/sourcegraph/issues/new/choose"
+                                data-ga-click="Header, create new issue"
+                                data-skip-pjax=""
+                            >
+                                New issue
+                            </a>
+                        </details-menu>
+                    </details>
+                </div>
+
+                <div class="Header-item position-relative mr-0 d-none d-lg-flex">
+                    <details class="details-overlay details-reset">
+                        <summary
+                            class="Header-link"
+                            aria-label="View profile and more"
+                            data-ga-click="Header, show menu, icon:avatar"
+                            aria-haspopup="menu"
+                        >
+                            <img
+                                alt="@felixfbecker"
+                                class="avatar"
+                                src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4"
+                                height="20"
+                                width="20"
+                            />
+                            <span class="dropdown-caret"></span>
+                        </summary>
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
+                            <div class="header-nav-current-user css-truncate">
+                                <a
+                                    role="menuitem"
+                                    class="no-underline user-profile-link px-3 pt-2 pb-2 mb-n2 mt-n1 d-block"
+                                    href="/felixfbecker"
+                                    data-ga-click="Header, go to profile, text:Signed in as"
+                                    >Signed in as <strong class="css-truncate-target">felixfbecker</strong></a
+                                >
+                            </div>
+                            <div role="none" class="dropdown-divider"></div>
+
+                            <div
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
+                                data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
+                            >
+                                <div
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
+                                    data-team-hovercards-enabled=""
+                                >
+                                    <details
+                                        class="js-user-status-details details-reset details-overlay details-overlay-dark"
+                                    >
+                                        <summary
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
+                                            aria-haspopup="dialog"
+                                            role="menuitem"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"C645:38C3E:C7C775:12D76DE:5CC23683","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts","referrer":null}}'
+                                            data-hydro-click-hmac="fcf0d73794c621120701f0954392ea1895252802047e7de2303d9039555d2f01"
+                                        >
+                                            <div
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
+                                            >
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div
+                                                class="
+
+
+
+         css-truncate css-truncate-target
          user-status-message-wrapper f6"
-        style="line-height: 20px;">
-        <div class="d-inline-block text-gray-dark v-align-text-top">
-            <span class="text-gray ml-2">Set status</span>
+                                                style="line-height: 20px;"
+                                            >
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
+                                            </div>
+                                        </summary>
+                                        <details-dialog
+                                            class="details-dialog rounded-1 anim-fade-in fast Box Box--overlay"
+                                            role="dialog"
+                                            tabindex="-1"
+                                        >
+                                            <!-- '"` --><!-- </textarea></xmp> -->
+                                            <form
+                                                class="position-relative flex-auto js-user-status-form"
+                                                action="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
+                                                accept-charset="UTF-8"
+                                                method="post"
+                                            >
+                                                <input name="utf8" type="hidden" value="✓" /><input
+                                                    type="hidden"
+                                                    name="_method"
+                                                    value="put"
+                                                /><input
+                                                    type="hidden"
+                                                    name="authenticity_token"
+                                                    value="Gh+aFQ8BZwNPcL7DoaiaOqUZfgSbuqyy7JF8b+1MhzbscTXOToCu38omGIeq59E5u3y/BrWWAEN63LiAWqokyg=="
+                                                />
+                                                <div class="Box-header bg-gray border-bottom p-3">
+                                                    <button
+                                                        class="Box-btn-octicon js-toggle-user-status-edit btn-octicon float-right"
+                                                        type="reset"
+                                                        aria-label="Close dialog"
+                                                        data-close-dialog=""
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-x"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                                                            ></path>
+                                                        </svg>
+                                                    </button>
+                                                    <h3 class="Box-title f5 text-bold text-gray-dark">Edit status</h3>
+                                                </div>
+                                                <input
+                                                    type="hidden"
+                                                    name="emoji"
+                                                    class="js-user-status-emoji-field"
+                                                    value=":palm_tree:"
+                                                />
+                                                <input
+                                                    type="hidden"
+                                                    name="organization_id"
+                                                    class="js-user-status-org-id-field"
+                                                    value=""
+                                                />
+                                                <div class="px-3 py-2 text-gray-dark">
+                                                    <div
+                                                        class="js-characters-remaining-container js-suggester-container position-relative mt-2"
+                                                    >
+                                                        <div
+                                                            class="input-group d-table form-group my-0 js-user-status-form-group"
+                                                        >
+                                                            <span
+                                                                class="input-group-button d-table-cell v-align-middle"
+                                                                style="width: 1%"
+                                                            >
+                                                                <button
+                                                                    type="button"
+                                                                    aria-label="Choose an emoji"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
+                                                                >
+                                                                    <span
+                                                                        class="js-user-status-original-emoji"
+                                                                        hidden=""
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
+                                                                        <svg
+                                                                            class="octicon octicon-smiley"
+                                                                            viewBox="0 0 16 16"
+                                                                            version="1.1"
+                                                                            width="16"
+                                                                            height="16"
+                                                                            aria-hidden="true"
+                                                                        >
+                                                                            <path
+                                                                                fill-rule="evenodd"
+                                                                                d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
+                                                                            ></path>
+                                                                        </svg>
+                                                                    </span>
+                                                                </button>
+                                                            </span>
+                                                            <input
+                                                                type="text"
+                                                                autocomplete="off"
+                                                                data-maxlength="80"
+                                                                class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
+                                                                placeholder="What's happening?"
+                                                                name="message"
+                                                                value="On vacation"
+                                                                aria-label="What is your current status?"
+                                                            />
+                                                            <div class="error">
+                                                                Could not update your status, please try again.
+                                                            </div>
+                                                        </div>
+                                                        <div class="suggester-container">
+                                                            <div
+                                                                class="suggester js-suggester js-navigation-container"
+                                                                data-url="/autocomplete/user-suggestions"
+                                                                data-no-org-url="/autocomplete/user-suggestions"
+                                                                data-org-url="/suggestions"
+                                                                hidden=""
+                                                            ></div>
+                                                        </div>
+                                                        <div
+                                                            style="margin-left: 53px"
+                                                            class="my-1 text-small label-characters-remaining js-characters-remaining"
+                                                            data-suffix="remaining"
+                                                            hidden=""
+                                                        >
+                                                            80 remaining
+                                                        </div>
+                                                    </div>
+                                                    <include-fragment
+                                                        class="js-user-status-emoji-picker"
+                                                        data-url="/users/status/emoji"
+                                                    ></include-fragment>
+                                                    <div
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
+                                                        style="max-height: 33vh"
+                                                    >
+                                                        <div
+                                                            class="user-status-suggestions js-user-status-suggestions collapsed overflow-hidden"
+                                                        >
+                                                            <h4 class="f6 text-normal my-3">Suggestions:</h4>
+                                                            <div class="mx-3 mt-2 clearfix">
+                                                                <div class="float-left col-6">
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":palm_tree:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            On vacation
+                                                                        </div>
+                                                                    </button>
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":face_with_thermometer:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="face_with_thermometer"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f912.png"
+                                                                                >🤒</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            Out sick
+                                                                        </div>
+                                                                    </button>
+                                                                </div>
+                                                                <div class="float-left col-6">
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":house:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="house"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3e0.png"
+                                                                                >🏠</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            Working from home
+                                                                        </div>
+                                                                    </button>
+                                                                    <button
+                                                                        type="button"
+                                                                        value=":dart:"
+                                                                        class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1"
+                                                                    >
+                                                                        <div
+                                                                            class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji"
+                                                                        >
+                                                                            <g-emoji
+                                                                                alias="dart"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3af.png"
+                                                                                >🎯</g-emoji
+                                                                            >
+                                                                        </div>
+                                                                        <div
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
+                                                                            style="border-left: 1px solid transparent"
+                                                                        >
+                                                                            Focusing
+                                                                        </div>
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="user-status-limited-availability-container">
+                                                            <div class="form-checkbox my-0">
+                                                                <input
+                                                                    type="checkbox"
+                                                                    name="limited_availability"
+                                                                    value="1"
+                                                                    class="js-user-status-limited-availability-checkbox"
+                                                                    data-default-message="I may be slow to respond."
+                                                                    aria-describedby="limited-availability-help-text-truncate-true"
+                                                                    id="limited-availability-truncate-true"
+                                                                    checked=""
+                                                                />
+                                                                <label
+                                                                    class="d-block f5 text-gray-dark mb-1"
+                                                                    for="limited-availability-truncate-true"
+                                                                >
+                                                                    Busy
+                                                                </label>
+                                                                <p
+                                                                    class="note"
+                                                                    id="limited-availability-help-text-truncate-true"
+                                                                >
+                                                                    When others mention you, assign you, or request your
+                                                                    review, GitHub will let them know that you have
+                                                                    limited availability.
+                                                                </p>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
+                                                        <div class="d-inline-block mr-1">
+                                                            Clear status
+                                                        </div>
+
+                                                        <details
+                                                            class="js-user-status-expire-drop-down f6 dropdown details-reset details-overlay d-inline-block mr-2"
+                                                        >
+                                                            <summary
+                                                                class="f5 btn-link link-gray-dark border px-2 py-1 rounded-1"
+                                                                aria-haspopup="true"
+                                                            >
+                                                                <div
+                                                                    class="js-user-status-expiration-interval-selected d-inline-block v-align-baseline"
+                                                                >
+                                                                    Never
+                                                                </div>
+                                                                <div class="dropdown-caret"></div>
+                                                            </summary>
+
+                                                            <ul
+                                                                class="dropdown-menu dropdown-menu-se pl-0 overflow-auto"
+                                                                style="width: 220px; max-height: 15.5em"
+                                                            >
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item js-user-status-expire-button ws-normal"
+                                                                        title="Never"
+                                                                    >
+                                                                        <span class="d-inline-block text-bold mb-1"
+                                                                            >Never</span
+                                                                        >
+                                                                        <div class="f6 lh-condensed">
+                                                                            Keep this status until you clear your status
+                                                                            or edit your status.
+                                                                        </div>
+                                                                    </button>
+                                                                </li>
+                                                                <li class="dropdown-divider" role="none"></li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="in 30 minutes"
+                                                                        value="2019-04-26T01:06:52+02:00"
+                                                                    >
+                                                                        in 30 minutes
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="in 1 hour"
+                                                                        value="2019-04-26T01:36:52+02:00"
+                                                                    >
+                                                                        in 1 hour
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="in 4 hours"
+                                                                        value="2019-04-26T04:36:52+02:00"
+                                                                    >
+                                                                        in 4 hours
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="today"
+                                                                        value="2019-04-26T23:59:59+02:00"
+                                                                    >
+                                                                        today
+                                                                    </button>
+                                                                </li>
+                                                                <li>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-link dropdown-item ws-normal js-user-status-expire-button"
+                                                                        title="this week"
+                                                                        value="2019-04-28T23:59:59+02:00"
+                                                                    >
+                                                                        this week
+                                                                    </button>
+                                                                </li>
+                                                            </ul>
+                                                        </details>
+                                                        <input
+                                                            class="js-user-status-expiration-date-input"
+                                                            type="hidden"
+                                                            name="expires_at"
+                                                            value=""
+                                                        />
+                                                    </div>
+
+                                                    <include-fragment
+                                                        class="js-user-status-org-picker"
+                                                        data-url="/users/status/organizations"
+                                                    ></include-fragment>
+                                                </div>
+                                                <div
+                                                    class="d-flex flex-items-center flex-justify-between p-3 border-top"
+                                                >
+                                                    <button
+                                                        type="submit"
+                                                        class="width-full btn btn-primary mr-2 js-user-status-submit"
+                                                    >
+                                                        Set status
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
+                                                    >
+                                                        Clear status
+                                                    </button>
+                                                </div>
+                                            </form>
+                                        </details-dialog>
+                                    </details>
+                                </div>
+                            </div>
+                            <div role="none" class="dropdown-divider"></div>
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker"
+                                data-ga-click="Header, go to profile, text:your profile"
+                                >Your profile</a
+                            >
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker?tab=repositories"
+                                data-ga-click="Header, go to repositories, text:your repositories"
+                                >Your repositories</a
+                            >
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker?tab=projects"
+                                data-ga-click="Header, go to projects, text:your projects"
+                                >Your projects</a
+                            >
+
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/felixfbecker?tab=stars"
+                                data-ga-click="Header, go to starred repos, text:your stars"
+                                >Your stars</a
+                            >
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="https://gist.github.com/"
+                                data-ga-click="Header, your gists, text:your gists"
+                                >Your gists</a
+                            >
+
+                            <div role="none" class="dropdown-divider"></div>
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="https://help.github.com"
+                                data-ga-click="Header, go to help, text:help"
+                                >Help</a
+                            >
+                            <a
+                                role="menuitem"
+                                class="dropdown-item"
+                                href="/settings/profile"
+                                data-ga-click="Header, go to settings, icon:settings"
+                                >Settings</a
+                            >
+                            <!-- '"` --><!-- </textarea></xmp> -->
+                            <form class="logout-form" action="/logout" accept-charset="UTF-8" method="post">
+                                <input name="utf8" type="hidden" value="✓" /><input
+                                    type="hidden"
+                                    name="authenticity_token"
+                                    value="Ue+e8MoQaN7ytifT8QqRz+mZ2HC1R1lFjnSl4z5xq0dWI/3IY447cqKlNl1Rfvk3hgUqKxcmvLwreY4f42aVGw=="
+                                />
+
+                                <button
+                                    type="submit"
+                                    class="dropdown-item dropdown-signout"
+                                    data-ga-click="Header, sign out, icon:logout"
+                                    role="menuitem"
+                                >
+                                    Sign out
+                                </button>
+                            </form>
+                        </details-menu>
+                    </details>
+                </div>
+            </header>
         </div>
-      </div>
-</summary>    <details-dialog class="details-dialog rounded-1 anim-fade-in fast Box Box--overlay" role="dialog" tabindex="-1">
-      <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="position-relative flex-auto js-user-status-form" action="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="wA43qIT09mMO+HwqbznFBa2d5oUXDxm+nW4ZRP4sYFSieTYShyIABZkyKBibN5zl9M1f6tfe7BziX/l7F2vTyQ==" />
-        <div class="Box-header bg-gray border-bottom p-3">
-          <button class="Box-btn-octicon js-toggle-user-status-edit btn-octicon float-right" type="reset" aria-label="Close dialog" data-close-dialog>
-            <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-          </button>
-          <h3 class="Box-title f5 text-bold text-gray-dark">Edit status</h3>
+
+        <div id="start-of-content" class="show-on-focus"></div>
+
+        <div id="js-flash-container"></div>
+
+        <div class="application-main " data-commit-hovercards-enabled="">
+            <div itemscope="" itemtype="http://schema.org/SoftwareSourceCode" class="">
+                <main>
+                    <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav pt-0 pt-lg-4 ">
+                        <div class="repohead-details-container clearfix container-lg p-responsive d-none d-lg-block">
+                            <ul class="pagehead-actions">
+                                <li>
+                                    <!-- '"` --><!-- </textarea></xmp> -->
+                                    <form
+                                        data-remote="true"
+                                        class="clearfix js-social-form js-social-container"
+                                        action="/notifications/subscribe"
+                                        accept-charset="UTF-8"
+                                        method="post"
+                                    >
+                                        <input name="utf8" type="hidden" value="✓" /><input
+                                            type="hidden"
+                                            name="authenticity_token"
+                                            value="S5V5U+1zS5DWAPZiKrgDzm9+zGdrNDxGBNQqQjgtOnnT4CQhdyhDdeFNRYV4o6QVyNqY+i+Kt6PUa+ykV2mEkw=="
+                                        />
+                                        <input type="hidden" name="repository_id" value="41288708" />
+
+                                        <details class="details-reset details-overlay select-menu float-left">
+                                            <summary
+                                                class="select-menu-button float-left btn btn-sm btn-with-count"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C645:38C3E:C7C775:12D76DE:5CC23683","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="24dc54a3311cbba298328de0eba7f2178cda07ebd1f070cec4d5114c0abdca08"
+                                                data-ga-click="Repository, click Watch settings, action:blob#show"
+                                                aria-haspopup="menu"
+                                            >
+                                                <span data-menu-button="">
+                                                    <svg
+                                                        class="octicon octicon-eye v-align-text-bottom"
+                                                        viewBox="0 0 16 16"
+                                                        version="1.1"
+                                                        width="16"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                        ></path>
+                                                    </svg>
+                                                    Watch
+                                                </span>
+                                            </summary>
+                                            <details-menu
+                                                class="select-menu-modal position-absolute mt-5"
+                                                style="z-index: 99;"
+                                                role="menu"
+                                            >
+                                                <div class="select-menu-header">
+                                                    <span class="select-menu-title">Notifications</span>
+                                                </div>
+                                                <div class="select-menu-list">
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="included"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="true"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Not watching</span>
+                                                            <span class="description"
+                                                                >Be notified only when participating or
+                                                                @mentioned.</span
+                                                            >
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-eye v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Watch
+                                                            </span>
+                                                        </div>
+                                                    </button>
+
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="release_only"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="false"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Releases only</span>
+                                                            <span class="description"
+                                                                >Be notified of new releases, and when participating or
+                                                                @mentioned.</span
+                                                            >
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-eye v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Unwatch releases
+                                                            </span>
+                                                        </div>
+                                                    </button>
+
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="subscribed"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="false"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Watching</span>
+                                                            <span class="description"
+                                                                >Be notified of all conversations.</span
+                                                            >
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-eye v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Unwatch
+                                                            </span>
+                                                        </div>
+                                                    </button>
+
+                                                    <button
+                                                        type="submit"
+                                                        name="do"
+                                                        value="ignore"
+                                                        class="select-menu-item width-full"
+                                                        aria-checked="false"
+                                                        role="menuitemradio"
+                                                    >
+                                                        <svg
+                                                            class="octicon octicon-check select-menu-item-icon"
+                                                            viewBox="0 0 12 16"
+                                                            version="1.1"
+                                                            width="12"
+                                                            height="16"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <path
+                                                                fill-rule="evenodd"
+                                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                            ></path>
+                                                        </svg>
+                                                        <div class="select-menu-item-text">
+                                                            <span class="select-menu-item-heading">Ignoring</span>
+                                                            <span class="description">Never be notified.</span>
+                                                            <span
+                                                                class="hidden-select-button-text"
+                                                                data-menu-button-contents=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-mute v-align-text-bottom"
+                                                                    viewBox="0 0 16 16"
+                                                                    version="1.1"
+                                                                    width="16"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M8 2.81v10.38c0 .67-.81 1-1.28.53L3 10H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h2l3.72-3.72C7.19 1.81 8 2.14 8 2.81zm7.53 3.22l-1.06-1.06-1.97 1.97-1.97-1.97-1.06 1.06L11.44 8 9.47 9.97l1.06 1.06 1.97-1.97 1.97 1.97 1.06-1.06L13.56 8l1.97-1.97z"
+                                                                    ></path>
+                                                                </svg>
+                                                                Stop ignoring
+                                                            </span>
+                                                        </div>
+                                                    </button>
+                                                </div>
+                                            </details-menu>
+                                        </details>
+                                        <a
+                                            class="social-count js-social-count"
+                                            href="/sourcegraph/sourcegraph/watchers"
+                                            aria-label="42 users are watching this repository"
+                                        >
+                                            42
+                                        </a>
+                                    </form>
+                                </li>
+
+                                <li>
+                                    <div class="js-toggler-container js-social-container starring-container on">
+                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                        <form
+                                            class="starred js-social-form"
+                                            action="/sourcegraph/sourcegraph/unstar"
+                                            accept-charset="UTF-8"
+                                            method="post"
+                                        >
+                                            <input name="utf8" type="hidden" value="✓" /><input
+                                                type="hidden"
+                                                name="authenticity_token"
+                                                value="szfw3ugl8OWGuPWnXHjcjciL/GNt0HML+cyeB17lCY0/lZ9+9BtH1StRbnWlRh8jXCXzjTR4bR+oNFaK9ygOww=="
+                                            />
+                                            <input type="hidden" name="context" value="repository" />
+                                            <button
+                                                type="submit"
+                                                class="btn btn-sm btn-with-count js-toggler-target"
+                                                aria-label="Unstar this repository"
+                                                title="Unstar sourcegraph/sourcegraph"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C645:38C3E:C7C775:12D76DE:5CC23683","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="a403988e17b0594b7715b9e992152d313d8280088b76f00fb1b93c376c18fdb0"
+                                                data-ga-click="Repository, click unstar button, action:blob#show; text:Unstar"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-star v-align-text-bottom"
+                                                    viewBox="0 0 14 16"
+                                                    version="1.1"
+                                                    width="14"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"
+                                                    ></path>
+                                                </svg>
+                                                Unstar
+                                            </button>
+                                            <a
+                                                class="social-count js-social-count"
+                                                href="/sourcegraph/sourcegraph/stargazers"
+                                                aria-label="2048 users starred this repository"
+                                            >
+                                                2,048
+                                            </a>
+                                        </form>
+                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                        <form
+                                            class="unstarred js-social-form"
+                                            action="/sourcegraph/sourcegraph/star"
+                                            accept-charset="UTF-8"
+                                            method="post"
+                                        >
+                                            <input name="utf8" type="hidden" value="✓" /><input
+                                                type="hidden"
+                                                name="authenticity_token"
+                                                value="KXCNNv2sMPK21jxRPF1F+dYpFu+xq7PuFV4zgePFeaiQS01HdMmEu4f0kEjZ/0Ikk7iVhczMCxZghHma8dVDOg=="
+                                            />
+                                            <input type="hidden" name="context" value="repository" />
+                                            <button
+                                                type="submit"
+                                                class="btn btn-sm btn-with-count js-toggler-target"
+                                                aria-label="Unstar this repository"
+                                                title="Star sourcegraph/sourcegraph"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C645:38C3E:C7C775:12D76DE:5CC23683","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="d301a420c2871eef23d267a81924a8d1e0dde3c5f438b51ef8a1d46bc02b1a57"
+                                                data-ga-click="Repository, click star button, action:blob#show; text:Star"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-star v-align-text-bottom"
+                                                    viewBox="0 0 14 16"
+                                                    version="1.1"
+                                                    width="14"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"
+                                                    ></path>
+                                                </svg>
+                                                Star
+                                            </button>
+                                            <a
+                                                class="social-count js-social-count"
+                                                href="/sourcegraph/sourcegraph/stargazers"
+                                                aria-label="2048 users starred this repository"
+                                            >
+                                                2,048
+                                            </a>
+                                        </form>
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <details
+                                        class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
+                                    >
+                                        <summary
+                                            class="btn btn-sm btn-with-count"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C645:38C3E:C7C775:12D76DE:5CC23683","originating_url":"https://github.com/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="41e801208147a48ebcc47db164f6e8b80893387aedbacf4a65dbc7da4b87cd01"
+                                            data-ga-click="Repository, show fork modal, action:blob#show; text:Fork"
+                                            title="Fork your own copy of sourcegraph/sourcegraph to your account"
+                                            aria-haspopup="dialog"
+                                        >
+                                            <svg
+                                                class="octicon octicon-repo-forked v-align-text-bottom"
+                                                viewBox="0 0 10 16"
+                                                version="1.1"
+                                                width="10"
+                                                height="16"
+                                                aria-hidden="true"
+                                            >
+                                                <path
+                                                    fill-rule="evenodd"
+                                                    d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                ></path>
+                                            </svg>
+                                            Fork
+                                        </summary>
+                                        <details-dialog
+                                            class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
+                                            role="dialog"
+                                        >
+                                            <div class="Box-header">
+                                                <button
+                                                    class="Box-btn-octicon btn-octicon float-right"
+                                                    type="button"
+                                                    aria-label="Close dialog"
+                                                    data-close-dialog=""
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-x"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                                                        ></path>
+                                                    </svg>
+                                                </button>
+                                                <h3 class="Box-title">Fork sourcegraph</h3>
+                                            </div>
+                                            <div class="overflow-auto text-center">
+                                                <include-fragment>
+                                                    <div class="octocat-spinner my-3" aria-label="Loading..."></div>
+                                                    <p class="f5 text-gray">
+                                                        If this dialog fails to load, you can visit
+                                                        <a href="/sourcegraph/sourcegraph/fork">the fork page</a>
+                                                        directly.
+                                                    </p>
+                                                </include-fragment>
+                                            </div>
+                                        </details-dialog>
+                                    </details>
+
+                                    <a
+                                        href="/sourcegraph/sourcegraph/network/members"
+                                        class="social-count"
+                                        aria-label="138 users forked this repository"
+                                    >
+                                        138
+                                    </a>
+                                </li>
+                            </ul>
+
+                            <h1 class="public ">
+                                <svg
+                                    class="octicon octicon-repo"
+                                    viewBox="0 0 12 16"
+                                    version="1.1"
+                                    width="12"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                                    ></path>
+                                </svg>
+                                <span class="author" itemprop="author"
+                                    ><a
+                                        class="url fn"
+                                        rel="author"
+                                        data-hovercard-type="organization"
+                                        data-hovercard-url="/orgs/sourcegraph/hovercard"
+                                        href="/sourcegraph"
+                                        >sourcegraph</a
+                                    ></span
+                                ><!--
+--><span class="path-divider">/</span
+                                ><!--
+--><strong itemprop="name"
+                                    ><a data-pjax="#js-repo-pjax-container" href="/sourcegraph/sourcegraph"
+                                        >sourcegraph</a
+                                    ></strong
+                                >
+                            </h1>
+                        </div>
+
+                        <nav
+                            class="reponav js-repo-nav js-sidenav-container-pjax container-lg p-responsive d-none d-lg-block"
+                            itemscope=""
+                            itemtype="http://schema.org/BreadcrumbList"
+                            aria-label="Repository"
+                            data-pjax="#js-repo-pjax-container"
+                        >
+                            <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                <a
+                                    class="js-selected-navigation-item selected reponav-item"
+                                    itemprop="url"
+                                    data-hotkey="g c"
+                                    aria-current="page"
+                                    data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph"
+                                    href="/sourcegraph/sourcegraph"
+                                >
+                                    <svg
+                                        class="octicon octicon-code"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                        ></path>
+                                    </svg>
+                                    <span itemprop="name">Code</span>
+                                    <meta itemprop="position" content="1" />
+                                </a>
+                            </span>
+
+                            <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                <a
+                                    itemprop="url"
+                                    data-hotkey="g i"
+                                    class="js-selected-navigation-item reponav-item"
+                                    data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues"
+                                    href="/sourcegraph/sourcegraph/issues"
+                                >
+                                    <svg
+                                        class="octicon octicon-issue-opened"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+                                        ></path>
+                                    </svg>
+                                    <span itemprop="name">Issues</span>
+                                    <span class="Counter">696</span>
+                                    <meta itemprop="position" content="2" />
+                                </a>
+                            </span>
+
+                            <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                <a
+                                    data-hotkey="g p"
+                                    itemprop="url"
+                                    class="js-selected-navigation-item reponav-item"
+                                    data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls"
+                                    href="/sourcegraph/sourcegraph/pulls"
+                                >
+                                    <svg
+                                        class="octicon octicon-git-pull-request"
+                                        viewBox="0 0 12 16"
+                                        version="1.1"
+                                        width="12"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                        ></path>
+                                    </svg>
+                                    <span itemprop="name">Pull requests</span>
+                                    <span class="Counter">83</span>
+                                    <meta itemprop="position" content="3" />
+                                </a>
+                            </span>
+
+                            <a
+                                data-hotkey="g w"
+                                data-skip-pjax="true"
+                                class="js-selected-navigation-item reponav-item"
+                                data-selected-links="repo_actions /sourcegraph/sourcegraph/actions"
+                                href="/sourcegraph/sourcegraph/actions"
+                            >
+                                <svg
+                                    class="octicon octicon-play"
+                                    viewBox="0 0 14 16"
+                                    version="1.1"
+                                    width="14"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M14 8A7 7 0 1 1 0 8a7 7 0 0 1 14 0zm-8.223 3.482l4.599-3.066a.5.5 0 0 0 0-.832L5.777 4.518A.5.5 0 0 0 5 4.934v6.132a.5.5 0 0 0 .777.416z"
+                                    ></path>
+                                </svg>
+                                Actions
+                            </a>
+                            <a
+                                data-hotkey="g b"
+                                class="js-selected-navigation-item reponav-item"
+                                data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects"
+                                href="/sourcegraph/sourcegraph/projects"
+                            >
+                                <svg
+                                    class="octicon octicon-project"
+                                    viewBox="0 0 15 16"
+                                    version="1.1"
+                                    width="15"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"
+                                    ></path>
+                                </svg>
+                                Projects
+                                <span class="Counter">0</span>
+                            </a>
+
+                            <a
+                                class="js-selected-navigation-item reponav-item"
+                                data-selected-links="repo_graphs repo_contributors dependency_graph pulse people alerts /sourcegraph/sourcegraph/pulse"
+                                href="/sourcegraph/sourcegraph/pulse"
+                            >
+                                <svg
+                                    class="octicon octicon-graph"
+                                    viewBox="0 0 16 16"
+                                    version="1.1"
+                                    width="16"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"
+                                    ></path>
+                                </svg>
+                                Insights
+                            </a>
+                            <a
+                                class="js-selected-navigation-item reponav-item"
+                                data-selected-links="repo_settings repo_branch_settings hooks integration_installations repo_keys_settings issue_template_editor /sourcegraph/sourcegraph/settings"
+                                href="/sourcegraph/sourcegraph/settings"
+                            >
+                                <svg
+                                    class="octicon octicon-gear"
+                                    viewBox="0 0 14 16"
+                                    version="1.1"
+                                    width="14"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"
+                                    ></path>
+                                </svg>
+                                Settings
+                            </a>
+                        </nav>
+
+                        <div class="reponav-wrapper reponav-small d-lg-none">
+                            <nav
+                                class="reponav js-reponav text-center no-wrap"
+                                itemscope=""
+                                itemtype="http://schema.org/BreadcrumbList"
+                            >
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        class="js-selected-navigation-item selected reponav-item"
+                                        itemprop="url"
+                                        aria-current="page"
+                                        data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph"
+                                        href="/sourcegraph/sourcegraph"
+                                    >
+                                        <span itemprop="name">Code</span>
+                                        <meta itemprop="position" content="1" />
+                                    </a>
+                                </span>
+
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues"
+                                        href="/sourcegraph/sourcegraph/issues"
+                                    >
+                                        <span itemprop="name">Issues</span>
+                                        <span class="Counter">696</span>
+                                        <meta itemprop="position" content="2" />
+                                    </a>
+                                </span>
+
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls"
+                                        href="/sourcegraph/sourcegraph/pulls"
+                                    >
+                                        <span itemprop="name">Pull requests</span>
+                                        <span class="Counter">83</span>
+                                        <meta itemprop="position" content="3" />
+                                    </a>
+                                </span>
+
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects"
+                                        href="/sourcegraph/sourcegraph/projects"
+                                    >
+                                        <span itemprop="name">Projects</span>
+                                        <span class="Counter">0</span>
+                                        <meta itemprop="position" content="5" />
+                                    </a>
+                                </span>
+
+                                <a
+                                    class="js-selected-navigation-item reponav-item"
+                                    data-selected-links="pulse /sourcegraph/sourcegraph/pulse"
+                                    href="/sourcegraph/sourcegraph/pulse"
+                                >
+                                    Pulse
+                                </a>
+                                <span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+                                    <a
+                                        itemprop="url"
+                                        class="js-selected-navigation-item reponav-item"
+                                        data-selected-links="community /sourcegraph/sourcegraph/community"
+                                        href="/sourcegraph/sourcegraph/community"
+                                    >
+                                        Community
+                                    </a>
+                                </span>
+                            </nav>
+                        </div>
+                    </div>
+                    <div class="container-lg new-discussion-timeline experiment-repo-nav  p-responsive">
+                        <div class="repository-content ">
+                            <a
+                                class="d-none js-permalink-shortcut"
+                                data-hotkey="y"
+                                href="/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+                                >Permalink</a
+                            >
+
+                            <!-- blob contrib key: blob_contributors:v21:4eb85bdcf32e37c190c6c4b3782513c9 -->
+
+                            <div class="d-flex flex-items-start mb-3 flex-column flex-md-row">
+                                <span class="d-flex flex-justify-between width-full width-md-auto">
+                                    <details class="details-reset details-overlay select-menu branch-select-menu ">
+                                        <summary
+                                            class="btn btn-sm select-menu-button css-truncate"
+                                            data-hotkey="w"
+                                            title="Switch branches or tags"
+                                            aria-haspopup="menu"
+                                        >
+                                            <i>Tree:</i>
+                                            <span class="css-truncate-target">45705b3b04</span>
+                                        </summary>
+
+                                        <details-menu
+                                            class="select-menu-modal position-absolute"
+                                            style="z-index: 99;"
+                                            src="/sourcegraph/sourcegraph/ref-list/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts?source_action=show&amp;source_controller=blob"
+                                            preload=""
+                                            role="menu"
+                                        >
+                                            <include-fragment class="select-menu-loading-overlay anim-pulse">
+                                                <svg
+                                                    height="32"
+                                                    class="octicon octicon-octoface"
+                                                    viewBox="0 0 16 16"
+                                                    version="1.1"
+                                                    width="32"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"
+                                                    ></path>
+                                                </svg>
+                                            </include-fragment>
+                                        </details-menu>
+                                    </details>
+
+                                    <div class="BtnGroup flex-shrink-0 d-md-none">
+                                        <a
+                                            href="/sourcegraph/sourcegraph/find/45705b3b0407ff44ff7db8660370d2a7bba79db2"
+                                            class="js-pjax-capture-input btn btn-sm BtnGroup-item"
+                                            data-pjax=""
+                                            data-hotkey="t"
+                                        >
+                                            Find file
+                                        </a>
+                                        <clipboard-copy
+                                            value="shared/src/api/extension/types/url.ts"
+                                            class="btn btn-sm BtnGroup-item"
+                                            tabindex="0"
+                                            role="button"
+                                        >
+                                            Copy path
+                                        </clipboard-copy>
+                                    </div>
+                                </span>
+                                <h2
+                                    id="blob-path"
+                                    class="breadcrumb flex-auto min-width-0 text-normal flex-md-self-center ml-md-2 mr-md-3 my-2 my-md-0"
+                                >
+                                    <span class="js-repo-root text-bold"
+                                        ><span class="js-path-segment"
+                                            ><a
+                                                data-pjax="true"
+                                                rel="nofollow"
+                                                href="/sourcegraph/sourcegraph/tree/45705b3b0407ff44ff7db8660370d2a7bba79db2"
+                                                ><span>sourcegraph</span></a
+                                            ></span
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared"
+                                            ><span>shared</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src"
+                                            ><span>src</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api"
+                                            ><span>api</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension"
+                                            ><span>extension</span></a
+                                        ></span
+                                    ><span class="separator">/</span
+                                    ><span class="js-path-segment"
+                                        ><a
+                                            data-pjax="true"
+                                            rel="nofollow"
+                                            href="/sourcegraph/sourcegraph/tree/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types"
+                                            ><span>types</span></a
+                                        ></span
+                                    ><span class="separator">/</span><strong class="final-path">url.ts</strong>
+                                </h2>
+
+                                <div class="BtnGroup flex-shrink-0 d-none d-md-inline-block">
+                                    <a
+                                        href="/sourcegraph/sourcegraph/find/45705b3b0407ff44ff7db8660370d2a7bba79db2"
+                                        class="js-pjax-capture-input btn btn-sm BtnGroup-item"
+                                        data-pjax=""
+                                        data-hotkey="t"
+                                    >
+                                        Find file
+                                    </a>
+                                    <clipboard-copy
+                                        value="shared/src/api/extension/types/url.ts"
+                                        class="btn btn-sm BtnGroup-item"
+                                        tabindex="0"
+                                        role="button"
+                                    >
+                                        Copy path
+                                    </clipboard-copy>
+                                </div>
+                            </div>
+
+                            <div class="Box Box--condensed d-flex flex-column flex-shrink-0">
+                                <div
+                                    class="Box-body d-flex flex-justify-between bg-blue-light flex-column flex-md-row flex-items-start flex-md-items-center"
+                                >
+                                    <span class="pr-md-4 f6">
+                                        <a
+                                            rel="contributor"
+                                            data-skip-pjax="true"
+                                            data-hovercard-type="user"
+                                            data-hovercard-url="/hovercards?user_id=10532611"
+                                            data-octo-click="hovercard-link-click"
+                                            data-octo-dimensions="link_type:self"
+                                            href="/felixfbecker"
+                                            ><img
+                                                class="avatar"
+                                                src="https://avatars3.githubusercontent.com/u/10532611?s=40&amp;v=4"
+                                                width="20"
+                                                height="20"
+                                                alt="@felixfbecker"
+                                        /></a>
+                                        <a
+                                            class="text-bold link-gray-dark lh-default v-align-middle"
+                                            rel="contributor"
+                                            data-hovercard-type="user"
+                                            data-hovercard-url="/hovercards?user_id=10532611"
+                                            data-octo-click="hovercard-link-click"
+                                            data-octo-dimensions="link_type:self"
+                                            href="/felixfbecker"
+                                            >felixfbecker</a
+                                        >
+                                        <span class="lh-default v-align-middle">
+                                            <a
+                                                data-pjax="true"
+                                                title="Replace sourcegraph.URI with WHATWG URL (#2430)"
+                                                class="link-gray"
+                                                href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37"
+                                                >Replace sourcegraph.URI with WHATWG URL (</a
+                                            ><a
+                                                class="issue-link js-issue-link"
+                                                data-error-text="Failed to load issue title"
+                                                data-id="414041237"
+                                                data-permission-text="Issue title is private"
+                                                data-url="https://github.com/sourcegraph/sourcegraph/issues/2430"
+                                                data-hovercard-type="pull_request"
+                                                data-hovercard-url="/sourcegraph/sourcegraph/pull/2430/hovercard"
+                                                href="https://github.com/sourcegraph/sourcegraph/pull/2430"
+                                                >#2430</a
+                                            ><a
+                                                data-pjax="true"
+                                                title="Replace sourcegraph.URI with WHATWG URL (#2430)"
+                                                class="link-gray"
+                                                href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37"
+                                                >)</a
+                                            >
+                                        </span>
+                                    </span>
+                                    <span class="d-inline-block flex-shrink-0 v-align-bottom f6 mt-2 mt-md-0">
+                                        <a
+                                            class="pr-2 text-mono link-gray"
+                                            href="/sourcegraph/sourcegraph/commit/cd3ccd923625c9d3ea5ef439d3218a8bb4c19f37"
+                                            data-pjax=""
+                                            >cd3ccd9</a
+                                        >
+                                        <relative-time datetime="2019-02-25T11:27:16Z" title="25 Feb 2019, 12:27 CET"
+                                            >on 25 Feb</relative-time
+                                        >
+                                    </span>
+                                </div>
+
+                                <div class="Box-body d-flex flex-items-center flex-auto f6 border-bottom-0 flex-wrap">
+                                    <details
+                                        class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark float-left mr-2"
+                                        id="blob_contributors_box"
+                                    >
+                                        <summary class="btn-link" aria-haspopup="dialog">
+                                            <span><strong>1</strong> contributor</span>
+                                        </summary>
+                                        <details-dialog
+                                            class="Box Box--overlay d-flex flex-column anim-fade-in fast"
+                                            aria-label="Users who have contributed to this file"
+                                            src="/sourcegraph/sourcegraph/contributors/master/shared/src/api/extension/types/url.ts/list"
+                                            preload=""
+                                            role="dialog"
+                                        >
+                                            <div class="Box-header">
+                                                <button
+                                                    class="Box-btn-octicon btn-octicon float-right"
+                                                    type="button"
+                                                    aria-label="Close dialog"
+                                                    data-close-dialog=""
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-x"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                                                        ></path>
+                                                    </svg>
+                                                </button>
+                                                <h3 class="Box-title">
+                                                    Users who have contributed to this file
+                                                </h3>
+                                            </div>
+                                            <include-fragment
+                                                class="octocat-spinner my-3"
+                                                aria-label="Loading..."
+                                            ></include-fragment>
+                                        </details-dialog>
+                                    </details>
+                                </div>
+                            </div>
+
+                            <div class="Box mt-3 position-relative">
+                                <div
+                                    class="Box-header py-2 d-flex flex-column flex-shrink-0 flex-md-row flex-md-items-center"
+                                >
+                                    <div class="text-mono f6 flex-auto pr-3 flex-order-2 flex-md-order-1 mt-2 mt-md-0">
+                                        3 lines (2 sloc)
+                                        <span class="file-info-divider"></span>
+                                        138 Bytes
+                                    </div>
+
+                                    <div
+                                        class="d-flex py-1 py-md-0 flex-auto flex-order-1 flex-md-order-2 flex-sm-grow-0 flex-justify-between"
+                                    >
+                                        <div class="BtnGroup">
+                                            <a
+                                                id="raw-url"
+                                                class="btn btn-sm BtnGroup-item"
+                                                href="/sourcegraph/sourcegraph/raw/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+                                                >Raw</a
+                                            >
+                                            <a
+                                                class="btn btn-sm js-update-url-with-hash BtnGroup-item"
+                                                data-hotkey="b"
+                                                href="https://github.com/sourcegraph/sourcegraph/blame/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+                                                >Blame</a
+                                            >
+                                            <a
+                                                rel="nofollow"
+                                                class="btn btn-sm BtnGroup-item"
+                                                href="/sourcegraph/sourcegraph/commits/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+                                                >History</a
+                                            >
+                                        </div>
+
+                                        <div>
+                                            <button
+                                                class="btn-octicon disabled tooltipped tooltipped-nw"
+                                                type="button"
+                                                disabled=""
+                                                aria-label="You must be on a branch to open this file in GitHub Desktop"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-device-desktop"
+                                                    viewBox="0 0 16 16"
+                                                    version="1.1"
+                                                    width="16"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
+                                                    ></path>
+                                                </svg>
+                                            </button>
+
+                                            <button
+                                                type="button"
+                                                class="btn-octicon disabled tooltipped tooltipped-nw"
+                                                aria-label="You must be on a branch to make or propose changes to this file"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-pencil"
+                                                    viewBox="0 0 14 16"
+                                                    version="1.1"
+                                                    width="14"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
+                                                    ></path>
+                                                </svg>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                class="btn-octicon btn-octicon-danger disabled tooltipped tooltipped-nw"
+                                                aria-label="You must be on a branch to make or propose changes to this file"
+                                            >
+                                                <svg
+                                                    class="octicon octicon-trashcan"
+                                                    viewBox="0 0 12 16"
+                                                    version="1.1"
+                                                    width="12"
+                                                    height="16"
+                                                    aria-hidden="true"
+                                                >
+                                                    <path
+                                                        fill-rule="evenodd"
+                                                        d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                                                    ></path>
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div itemprop="text" class="Box-body p-0 blob-wrapper data type-typescript ">
+                                    <table class="highlight tab-size js-file-line-container" data-tab-size="4">
+                                        <tbody>
+                                            <tr>
+                                                <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
+                                                <td id="LC1" class="blob-code blob-code-inner js-file-line">
+                                                    <span class="pl-k"><span class="pl-k">export</span></span>
+                                                    <span class="pl-k"><span class="pl-k">const</span></span> isURL
+                                                    <span class="pl-k">=</span> (<span class="pl-v">value</span
+                                                    ><span class="pl-k">:</span> <span class="pl-c1">any</span>)<span
+                                                        class="pl-k"
+                                                        >:</span
+                                                    >
+                                                    <span class="pl-en">value</span> <span class="pl-k">is</span>
+                                                    <span class="pl-en">URL</span> <span class="pl-k">=&gt;</span>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
+                                                <td id="LC2" class="blob-code blob-code-inner js-file-line">
+                                                    <span class="pl-k">!!</span><span class="pl-smi">value</span>
+                                                    <span class="pl-k">&amp;&amp;</span>
+                                                    <span class="pl-k">typeof</span>
+                                                    <span class="pl-smi">value</span>.<span class="pl-smi"
+                                                        >toString</span
+                                                    >
+                                                    <span class="pl-k">===</span>
+                                                    <span class="pl-s"
+                                                        ><span class="pl-pds">'</span>function<span class="pl-pds"
+                                                            >'</span
+                                                        ></span
+                                                    >
+                                                    <span class="pl-k">&amp;&amp;</span>
+                                                    <span class="pl-smi">value</span>.<span class="pl-c1">href</span>
+                                                    <span class="pl-k">===</span>
+                                                    <span class="pl-smi">value</span>.<span class="pl-c1">toString</span
+                                                    >()
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+
+                                    <details
+                                        class="details-reset details-overlay BlobToolbar position-absolute js-file-line-actions dropdown d-none"
+                                        aria-hidden="true"
+                                    >
+                                        <summary
+                                            class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1"
+                                            aria-label="Inline file action toolbar"
+                                            aria-haspopup="menu"
+                                        >
+                                            <svg
+                                                class="octicon octicon-kebab-horizontal"
+                                                viewBox="0 0 13 16"
+                                                version="1.1"
+                                                width="13"
+                                                height="16"
+                                                aria-hidden="true"
+                                            >
+                                                <path
+                                                    fill-rule="evenodd"
+                                                    d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                                                ></path>
+                                            </svg>
+                                        </summary>
+                                        <details-menu role="menu">
+                                            <ul
+                                                class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2"
+                                                style="width:185px"
+                                            >
+                                                <li>
+                                                    <clipboard-copy
+                                                        role="menuitem"
+                                                        class="dropdown-item"
+                                                        id="js-copy-lines"
+                                                        style="cursor:pointer;"
+                                                        data-original-text="Copy lines"
+                                                        tabindex="0"
+                                                        >Copy lines</clipboard-copy
+                                                    >
+                                                </li>
+                                                <li>
+                                                    <clipboard-copy
+                                                        role="menuitem"
+                                                        class="dropdown-item"
+                                                        id="js-copy-permalink"
+                                                        style="cursor:pointer;"
+                                                        data-original-text="Copy permalink"
+                                                        tabindex="0"
+                                                        >Copy permalink</clipboard-copy
+                                                    >
+                                                </li>
+                                                <li>
+                                                    <a
+                                                        class="dropdown-item js-update-url-with-hash"
+                                                        id="js-view-git-blame"
+                                                        role="menuitem"
+                                                        href="https://github.com/sourcegraph/sourcegraph/blame/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts"
+                                                        >View git blame</a
+                                                    >
+                                                </li>
+                                                <li>
+                                                    <a
+                                                        class="dropdown-item"
+                                                        id="js-new-issue"
+                                                        role="menuitem"
+                                                        href="/sourcegraph/sourcegraph/issues/new/choose"
+                                                        >Reference in new issue</a
+                                                    >
+                                                </li>
+                                            </ul>
+                                        </details-menu>
+                                    </details>
+                                </div>
+                            </div>
+
+                            <details class="details-reset details-overlay details-overlay-dark">
+                                <summary data-hotkey="l" aria-label="Jump to line" aria-haspopup="dialog"></summary>
+                                <details-dialog
+                                    class="Box Box--overlay d-flex flex-column anim-fade-in fast linejump"
+                                    aria-label="Jump to line"
+                                    role="dialog"
+                                >
+                                    <!-- '"` --><!-- </textarea></xmp> -->
+                                    <form
+                                        class="js-jump-to-line-form Box-body d-flex"
+                                        action=""
+                                        accept-charset="UTF-8"
+                                        method="get"
+                                    >
+                                        <input name="utf8" type="hidden" value="✓" />
+                                        <input
+                                            class="form-control flex-auto mr-3 linejump-input js-jump-to-line-field"
+                                            type="text"
+                                            placeholder="Jump to line…"
+                                            aria-label="Jump to line"
+                                            autofocus=""
+                                        />
+                                        <button type="submit" class="btn" data-close-dialog="">Go</button>
+                                    </form>
+                                </details-dialog>
+                            </details>
+                        </div>
+                        <div class="modal-backdrop js-touch-events"></div>
+                    </div>
+                </main>
+            </div>
         </div>
-        <input type="hidden" name="emoji" class="js-user-status-emoji-field" value="">
-        <input type="hidden" name="organization_id" class="js-user-status-org-id-field" value="">
-        <div class="px-3 py-2 text-gray-dark">
-          <div class="js-characters-remaining-container js-suggester-container position-relative mt-2">
-            <div class="input-group d-table form-group my-0 js-user-status-form-group">
-              <span class="input-group-button d-table-cell v-align-middle" style="width: 1%">
-                <button type="button" aria-label="Choose an emoji" class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0">
-                  <span class="js-user-status-original-emoji" hidden></span>
-                  <span class="js-user-status-custom-emoji"></span>
-                  <span class="js-user-status-no-emoji-icon" >
-                    <svg class="octicon octicon-smiley" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"/></svg>
-                  </span>
-                </button>
-              </span>
-              <input type="text" autocomplete="off" data-maxlength="80" class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field" placeholder="What's happening?" name="message" value="" aria-label="What is your current status?">
-              <div class="error">Could not update your status, please try again.</div>
-            </div>
-            <div class="suggester-container">
-              <div class="suggester js-suggester js-navigation-container" data-url="/autocomplete/user-suggestions" data-no-org-url="/autocomplete/user-suggestions" data-org-url="/suggestions" hidden>
-              </div>
-            </div>
-            <div style="margin-left: 53px" class="my-1 text-small label-characters-remaining js-characters-remaining" data-suffix="remaining" hidden>
-              80 remaining
-            </div>
-          </div>
-          <include-fragment class="js-user-status-emoji-picker" data-url="/users/status/emoji"></include-fragment>
-          <div class="overflow-auto ml-n3 mr-n3 px-3" style="max-height: 33vh">
-            <div class="user-status-suggestions js-user-status-suggestions collapsed overflow-hidden">
-              <h4 class="f6 text-normal my-3">Suggestions:</h4>
-              <div class="mx-3 mt-2 clearfix">
-                  <div class="float-left col-6">
-                      <button type="button" value=":palm_tree:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="palm_tree" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png">🌴</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          On vacation
-                        </div>
-                      </button>
-                      <button type="button" value=":face_with_thermometer:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="face_with_thermometer" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f912.png">🤒</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          Out sick
-                        </div>
-                      </button>
-                  </div>
-                  <div class="float-left col-6">
-                      <button type="button" value=":house:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="house" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3e0.png">🏠</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          Working from home
-                        </div>
-                      </button>
-                      <button type="button" value=":dart:" class="d-flex flex-items-baseline flex-items-stretch lh-condensed f6 btn-link link-gray no-underline js-predefined-user-status mb-1">
-                        <div class="emoji-status-width mr-2 v-align-middle js-predefined-user-status-emoji">
-                          <g-emoji alias="dart" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f3af.png">🎯</g-emoji>
-                        </div>
-                        <div class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left" style="border-left: 1px solid transparent">
-                          Focusing
-                        </div>
-                      </button>
-                  </div>
-              </div>
-            </div>
-            <div class="user-status-limited-availability-container">
-              <div class="form-checkbox my-0">
-                <input type="checkbox" name="limited_availability" value="1" class="js-user-status-limited-availability-checkbox" data-default-message="I may be slow to respond." aria-describedby="limited-availability-help-text-truncate-true" id="limited-availability-truncate-true">
-                <label class="d-block f5 text-gray-dark mb-1" for="limited-availability-truncate-true">
-                  Busy
-                </label>
-                <p class="note" id="limited-availability-help-text-truncate-true">
-                  When others mention you, assign you, or request your review,
-                  GitHub will let them know that you have limited availability.
-                </p>
-              </div>
-            </div>
-          </div>
-            
 
-<div class="d-inline-block f5 border-top mr-2 pt-3 pb-2" >
-  <div class="d-inline-block mr-1">
-    Clear status
-  </div>
+        <div class="footer container-lg width-full p-responsive" role="contentinfo">
+            <div
+                class="position-relative d-flex flex-row-reverse flex-lg-row flex-wrap flex-lg-nowrap flex-justify-center flex-lg-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light "
+            >
+                <ul
+                    class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-start mb-2 mb-lg-0"
+                >
+                    <li class="mr-3">
+                        © 2019 <span title="0.34198s from unicorn-5675df497d-w2zc5">GitHub</span>, Inc.
+                    </li>
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
+                            >Terms</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy"
+                            >Privacy</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to security, text:security" href="https://github.com/security"
+                            >Security</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a>
+                    </li>
+                    <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
+                </ul>
 
-  <details class="js-user-status-expire-drop-down f6 dropdown details-reset details-overlay d-inline-block mr-2">
-    <summary class="f5 btn-link link-gray-dark border px-2 py-1 rounded-1" aria-haspopup="true">
-      <div class="js-user-status-expiration-interval-selected d-inline-block v-align-baseline">
-        Never
-      </div>
-      <div class="dropdown-caret"></div>
-    </summary>
-
-    <ul class="dropdown-menu dropdown-menu-se pl-0 overflow-auto" style="width: 220px; max-height: 15.5em">
-      <li>
-        <button type="button" class="btn-link dropdown-item js-user-status-expire-button ws-normal" title="Never">
-          <span class="d-inline-block text-bold mb-1">Never</span>
-          <div class="f6 lh-condensed">Keep this status until you clear your status or edit your status.</div>
-        </button>
-      </li>
-      <li class="dropdown-divider" role="none"></li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="in 30 minutes" value="2019-04-19T11:37:23+02:00">
-            in 30 minutes
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="in 1 hour" value="2019-04-19T12:07:23+02:00">
-            in 1 hour
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="in 4 hours" value="2019-04-19T15:07:23+02:00">
-            in 4 hours
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="today" value="2019-04-19T23:59:59+02:00">
-            today
-          </button>
-        </li>
-        <li>
-          <button type="button" class="btn-link dropdown-item ws-normal js-user-status-expire-button" title="this week" value="2019-04-21T23:59:59+02:00">
-            this week
-          </button>
-        </li>
-    </ul>
-  </details>
-  <input class="js-user-status-expiration-date-input" type="hidden" name="expires_at" value="">
-</div>
-
-          <include-fragment class="js-user-status-org-picker" data-url="/users/status/organizations"></include-fragment>
+                <a aria-label="Homepage" title="GitHub" class="footer-octicon mx-lg-4" href="https://github.com">
+                    <svg
+                        height="24"
+                        class="octicon octicon-mark-github"
+                        viewBox="0 0 16 16"
+                        version="1.1"
+                        width="24"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+                        ></path>
+                    </svg>
+                </a>
+                <ul
+                    class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-end mb-2 mb-lg-0"
+                >
+                    <li class="mr-3">
+                        <a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact"
+                            >Contact GitHub</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing"
+                            >Pricing</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a>
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://training.github.com" data-ga-click="Footer, go to training, text:training"
+                            >Training</a
+                        >
+                    </li>
+                    <li class="mr-3">
+                        <a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a>
+                    </li>
+                    <li>
+                        <a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="d-flex flex-justify-center pb-6">
+                <span class="f6 text-gray-light"></span>
+            </div>
         </div>
-        <div class="d-flex flex-items-center flex-justify-between p-3 border-top">
-          <button type="submit" disabled class="width-full btn btn-primary mr-2 js-user-status-submit">
-            Set status
-          </button>
-          <button type="button" disabled class="width-full js-clear-user-status-button btn ml-2 ">
-            Clear status
-          </button>
+
+        <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+            <svg
+                class="octicon octicon-alert"
+                viewBox="0 0 16 16"
+                version="1.1"
+                width="16"
+                height="16"
+                aria-hidden="true"
+            >
+                <path
+                    fill-rule="evenodd"
+                    d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+                ></path>
+            </svg>
+            <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+                <svg
+                    class="octicon octicon-x"
+                    viewBox="0 0 12 16"
+                    version="1.1"
+                    width="12"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                    ></path>
+                </svg>
+            </button>
+            You can’t perform that action at this time.
         </div>
-</form>    </details-dialog>
-  </details>
-</div>
 
-      </div>
-      <div role="none" class="dropdown-divider"></div>
-
-
-    <a role="menuitem" class="dropdown-item" href="/lguychard" data-ga-click="Header, go to profile, text:your profile">Your profile</a>
-    <a role="menuitem" class="dropdown-item" href="/lguychard?tab=repositories" data-ga-click="Header, go to repositories, text:your repositories">Your repositories</a>
-
-    <a role="menuitem" class="dropdown-item" href="/lguychard?tab=projects" data-ga-click="Header, go to projects, text:your projects">Your projects</a>
-
-    <a role="menuitem" class="dropdown-item" href="/lguychard?tab=stars" data-ga-click="Header, go to starred repos, text:your stars">Your stars</a>
-      <a role="menuitem" class="dropdown-item" href="https://gist.github.com/" data-ga-click="Header, your gists, text:your gists">Your gists</a>
-
-    <div role="none" class="dropdown-divider"></div>
-    <a role="menuitem" class="dropdown-item" href="https://help.github.com" data-ga-click="Header, go to help, text:help">Help</a>
-    <a role="menuitem" class="dropdown-item" href="/settings/profile" data-ga-click="Header, go to settings, icon:settings">Settings</a>
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="logout-form" action="/logout" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="p7FdPsq2/45G4krvvrBVyc/l6/+zDgEEb4XAb+K/ifUfr0UCclgrIkwTQTfDnFcXedwuRR67jmx/gCKb/KYwyg==" />
-      
-      <button type="submit" class="dropdown-item dropdown-signout" data-ga-click="Header, sign out, icon:logout" role="menuitem">
-        Sign out
-      </button>
-</form>  </details-menu>
-</details>
-
-    </div>
-
-  </header>
-
-      
-
-  </div>
-
-  <div id="start-of-content" class="show-on-focus"></div>
-
-
-    <div id="js-flash-container">
-
-</div>
-
-
-
-  <div class="application-main " data-commit-hovercards-enabled>
-        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
-    <main  >
-      
-
-
-  
-
-
-
-  
-
-
-
-
-  <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav pt-0 pt-lg-4 ">
-    <div class="repohead-details-container clearfix container-lg p-responsive d-none d-lg-block">
-
-      <ul class="pagehead-actions">
-
-
-
-  <li>
-    
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form data-remote="true" class="clearfix js-social-form js-social-container" action="/notifications/subscribe" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="EJ9JiwaS0yECeuaxsnXNkdVjwRLH1GB+JyqgN66xtX80umHRkknS1vcha3x2ihOXEgl2RjH7YaOxHNGL8l3x7Q==" />      <input type="hidden" name="repository_id" value="41288708">
-
-      <details class="details-reset details-overlay select-menu float-left">
-        <summary class="select-menu-button float-left btn btn-sm btn-with-count" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;WATCH_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CB1C:1FB94:B973DC:1156FE9:5CB98FCB&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="c10da0c7ac48806b6c52505ebf5d289d23e4b59f56c1643c7057a6480cf96001" data-ga-click="Repository, click Watch settings, action:blob#show">            <span data-menu-button>
-                <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                Unwatch
-            </span>
-</summary>        <details-menu
-          class="select-menu-modal position-absolute mt-5"
-          style="z-index: 99; ">
-          <div class="select-menu-header">
-            <span class="select-menu-title">Notifications</span>
-          </div>
-          <div class="select-menu-list">
-            <button type="submit" name="do" value="included" class="select-menu-item width-full" aria-checked="false" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Not watching</span>
-                <span class="description">Be notified only when participating or @mentioned.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                  Watch
-                </span>
-              </div>
-            </button>
-
-            <button type="submit" name="do" value="release_only" class="select-menu-item width-full" aria-checked="false" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Releases only</span>
-                <span class="description">Be notified of new releases, and when participating or @mentioned.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                  Unwatch releases
-                </span>
-              </div>
-            </button>
-
-            <button type="submit" name="do" value="subscribed" class="select-menu-item width-full" aria-checked="true" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Watching</span>
-                <span class="description">Be notified of all conversations.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-                  Unwatch
-                </span>
-              </div>
-            </button>
-
-            <button type="submit" name="do" value="ignore" class="select-menu-item width-full" aria-checked="false" role="menuitemradio">
-              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
-              <div class="select-menu-item-text">
-                <span class="select-menu-item-heading">Ignoring</span>
-                <span class="description">Never be notified.</span>
-                <span class="hidden-select-button-text" data-menu-button-contents>
-                  <svg class="octicon octicon-mute v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 2.81v10.38c0 .67-.81 1-1.28.53L3 10H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h2l3.72-3.72C7.19 1.81 8 2.14 8 2.81zm7.53 3.22l-1.06-1.06-1.97 1.97-1.97-1.97-1.06 1.06L11.44 8 9.47 9.97l1.06 1.06 1.97-1.97 1.97 1.97 1.06-1.06L13.56 8l1.97-1.97z"/></svg>
-                  Stop ignoring
-                </span>
-              </div>
-            </button>
-
-          </div>
-        </details-menu>
-      </details>
-        <a class="social-count js-social-count"
-          href="/sourcegraph/sourcegraph/watchers"
-          aria-label="41 users are watching this repository">
-          41
-        </a>
-</form>
-  </li>
-
-  <li>
-      <div class="js-toggler-container js-social-container starring-container on">
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="starred js-social-form" action="/sourcegraph/sourcegraph/unstar" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="zJ2aXJJoVy7YAkAxTb8VOha7QcfgiTKKjwCp21U5MzjuFGn7LoceS9WwBM2IPX2giFx+FbBbsgwMQzUfH7R0zw==" />
-      <input type="hidden" name="context" value="repository"></input>
-      <button type="submit" class="btn btn-sm btn-with-count js-toggler-target" aria-label="Unstar this repository" title="Unstar sourcegraph/sourcegraph" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;UNSTAR_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CB1C:1FB94:B973DC:1156FE9:5CB98FCB&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="4f95a1725fc8edf1e3d1e92fae028e543c1ab5c46eccaeaf741e3b7f4a2c530a" data-ga-click="Repository, click unstar button, action:blob#show; text:Unstar">        <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
-        Unstar
-</button>        <a class="social-count js-social-count" href="/sourcegraph/sourcegraph/stargazers"
-           aria-label="2018 users starred this repository">
-          2,018
-        </a>
-</form>
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="unstarred js-social-form" action="/sourcegraph/sourcegraph/star" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="MXZjNOuugaETLUM4dG+9ln5My5BGaMjYrEwT4sWEnJdNty91zuboCSpZo+WGH4b69DsnZAEclMrAbvQFwVTetg==" />
-      <input type="hidden" name="context" value="repository"></input>
-      <button type="submit" class="btn btn-sm btn-with-count js-toggler-target" aria-label="Unstar this repository" title="Star sourcegraph/sourcegraph" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;STAR_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CB1C:1FB94:B973DC:1156FE9:5CB98FCB&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="1d8d4b8c9b9b6939936f6efc9c0bd29fd20e78cdde7ec742fb0ba84c9ca2c05d" data-ga-click="Repository, click star button, action:blob#show; text:Star">        <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
-        Star
-</button>        <a class="social-count js-social-count" href="/sourcegraph/sourcegraph/stargazers"
-           aria-label="2018 users starred this repository">
-          2,018
-        </a>
-</form>  </div>
-
-  </li>
-
-  <li>
-          <details class="details-reset details-overlay details-overlay-dark d-inline-block float-left">
-            <summary class="btn btn-sm btn-with-count" data-hydro-click="{&quot;event_type&quot;:&quot;repository.click&quot;,&quot;payload&quot;:{&quot;target&quot;:&quot;FORK_BUTTON&quot;,&quot;repository_id&quot;:41288708,&quot;client_id&quot;:&quot;1032549827.1548354440&quot;,&quot;originating_request_id&quot;:&quot;CB1C:1FB94:B973DC:1156FE9:5CB98FCB&quot;,&quot;originating_url&quot;:&quot;https://github.com/sourcegraph/sourcegraph/blob/master/shared/src/api/extension/types/url.ts&quot;,&quot;referrer&quot;:&quot;https://github.com/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types&quot;,&quot;user_id&quot;:1741180}}" data-hydro-click-hmac="34ec68a27370717986e3e4531b514b86dcd1571123ddb95b5ff4ac052b7f6001" data-ga-click="Repository, show fork modal, action:blob#show; text:Fork" title="Fork your own copy of sourcegraph/sourcegraph to your account">              <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-              Fork
-</summary>            <details-dialog
-              class="anim-fade-in fast Box Box--overlay d-flex flex-column"
-              src="/sourcegraph/sourcegraph/fork?fragment=1"
-              preload>
-              <div class="Box-header">
-                <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog>
-                  <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-                </button>
-                <h3 class="Box-title">Fork sourcegraph</h3>
-              </div>
-              <div class="overflow-auto text-center">
-                <include-fragment>
-                  <div class="octocat-spinner my-3" aria-label="Loading..."></div>
-                  <p class="f5 text-gray">If this dialog fails to load, you can visit <a href="/sourcegraph/sourcegraph/fork">the fork page</a> directly.</p>
-                </include-fragment>
-              </div>
-            </details-dialog>
-          </details>
-
-    <a href="/sourcegraph/sourcegraph/network/members" class="social-count"
-       aria-label="134 users forked this repository">
-      134
-    </a>
-  </li>
-</ul>
-
-      <h1 class="public ">
-  <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/sourcegraph/hovercard" href="/sourcegraph">sourcegraph</a></span><!--
---><span class="path-divider">/</span><!--
---><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/sourcegraph/sourcegraph">sourcegraph</a></strong>
-  
-
-</h1>
-
-    </div>
-    
-<nav class="reponav js-repo-nav js-sidenav-container-pjax container-lg p-responsive d-none d-lg-block"
-     itemscope
-     itemtype="http://schema.org/BreadcrumbList"
-    aria-label="Repository"
-     data-pjax="#js-repo-pjax-container">
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph" href="/sourcegraph/sourcegraph">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
-      <span itemprop="name">Code</span>
-      <meta itemprop="position" content="1">
-</a>  </span>
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues" href="/sourcegraph/sourcegraph/issues">
-        <svg class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
-        <span itemprop="name">Issues</span>
-        <span class="Counter">676</span>
-        <meta itemprop="position" content="2">
-</a>    </span>
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls" href="/sourcegraph/sourcegraph/pulls">
-      <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-      <span itemprop="name">Pull requests</span>
-      <span class="Counter">82</span>
-      <meta itemprop="position" content="3">
-</a>  </span>
-
-
-    <a data-hotkey="g w" data-skip-pjax="true" class="js-selected-navigation-item reponav-item" data-selected-links="repo_actions /sourcegraph/sourcegraph/actions" href="/sourcegraph/sourcegraph/actions">
-      <svg class="octicon octicon-play" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 8A7 7 0 1 1 0 8a7 7 0 0 1 14 0zm-8.223 3.482l4.599-3.066a.5.5 0 0 0 0-.832L5.777 4.518A.5.5 0 0 0 5 4.934v6.132a.5.5 0 0 0 .777.416z"/></svg>
-      Actions
-</a>
-    <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects" href="/sourcegraph/sourcegraph/projects">
-      <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      Projects
-      <span class="Counter" >0</span>
-</a>
-
-
-    <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse people alerts /sourcegraph/sourcegraph/pulse" href="/sourcegraph/sourcegraph/pulse">
-      <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
-      Insights
-</a>
-    <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_settings repo_branch_settings hooks integration_installations repo_keys_settings issue_template_editor /sourcegraph/sourcegraph/settings" href="/sourcegraph/sourcegraph/settings">
-      <svg class="octicon octicon-gear" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"/></svg>
-      Settings
-</a>
-</nav>
-
-  <div class="reponav-wrapper reponav-small d-lg-none">
-  <nav class="reponav js-reponav text-center no-wrap"
-       itemscope
-       itemtype="http://schema.org/BreadcrumbList">
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a class="js-selected-navigation-item selected reponav-item" itemprop="url" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /sourcegraph/sourcegraph" href="/sourcegraph/sourcegraph">
-        <span itemprop="name">Code</span>
-        <meta itemprop="position" content="1">
-</a>    </span>
-
-      <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-        <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /sourcegraph/sourcegraph/issues" href="/sourcegraph/sourcegraph/issues">
-          <span itemprop="name">Issues</span>
-          <span class="Counter">676</span>
-          <meta itemprop="position" content="2">
-</a>      </span>
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /sourcegraph/sourcegraph/pulls" href="/sourcegraph/sourcegraph/pulls">
-        <span itemprop="name">Pull requests</span>
-        <span class="Counter">82</span>
-        <meta itemprop="position" content="3">
-</a>    </span>
-
-      <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-        <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /sourcegraph/sourcegraph/projects" href="/sourcegraph/sourcegraph/projects">
-          <span itemprop="name">Projects</span>
-          <span class="Counter">0</span>
-          <meta itemprop="position" content="4">
-</a>      </span>
-
-
-      <a class="js-selected-navigation-item reponav-item" data-selected-links="pulse /sourcegraph/sourcegraph/pulse" href="/sourcegraph/sourcegraph/pulse">
-        Pulse
-</a>
-      <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-        <a itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="community /sourcegraph/sourcegraph/community" href="/sourcegraph/sourcegraph/community">
-          Community
-</a>      </span>
-
-  </nav>
-</div>
-
-
-  </div>
-<div class="container-lg new-discussion-timeline experiment-repo-nav  p-responsive">
-  <div class="repository-content ">
-
-    
-    
-
-
-
-  
-    <a class="d-none js-permalink-shortcut" data-hotkey="y" href="/sourcegraph/sourcegraph/blob/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts">Permalink</a>
-
-    <!-- blob contrib key: blob_contributors:v21:03189a821be92bf7a66681c501b9ac8e -->
-
-    
-
-    <div class="d-flex flex-items-start mb-3 flex-column flex-md-row">
-      <span class="d-flex flex-justify-between width-full width-md-auto">
-        
-<details class="details-reset details-overlay select-menu branch-select-menu ">
-  <summary class="btn btn-sm select-menu-button css-truncate"
-           data-hotkey="w"
-           
-           title="Switch branches or tags">
-    <i>Branch:</i>
-    <span class="css-truncate-target">master</span>
-  </summary>
-
-  <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/sourcegraph/sourcegraph/ref-list/master/shared/src/api/extension/types/url.ts?source_action=show&amp;source_controller=blob" preload>
-    <include-fragment class="select-menu-loading-overlay anim-pulse">
-      <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
-    </include-fragment>
-  </details-menu>
-</details>
-
-        <div class="BtnGroup flex-shrink-0 d-md-none">
-          <a href="/sourcegraph/sourcegraph/find/master"
-                class="js-pjax-capture-input btn btn-sm BtnGroup-item"
-                data-pjax
-                data-hotkey="t">
-            Find file
-          </a>
-          <clipboard-copy value="shared/src/api/extension/types/url.ts" class="btn btn-sm BtnGroup-item">
-            Copy path
-          </clipboard-copy>
+        <script
+            crossorigin="anonymous"
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
+            type="application/javascript"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
+        ></script>
+
+        <script
+            crossorigin="anonymous"
+            async="async"
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
+            type="application/javascript"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
+        ></script>
+
+        <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">
+            <svg
+                class="octicon octicon-alert"
+                viewBox="0 0 16 16"
+                version="1.1"
+                width="16"
+                height="16"
+                aria-hidden="true"
+            >
+                <path
+                    fill-rule="evenodd"
+                    d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+                ></path>
+            </svg>
+            <span class="signed-in-tab-flash"
+                >You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span
+            >
+            <span class="signed-out-tab-flash"
+                >You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span
+            >
         </div>
-      </span>
-      <h2 id="blob-path" class="breadcrumb flex-auto min-width-0 text-normal flex-md-self-center ml-md-2 mr-md-3 my-2 my-md-0">
-        <span class="js-repo-root text-bold"><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph"><span>sourcegraph</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared"><span>shared</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src"><span>src</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src/api"><span>api</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src/api/extension"><span>extension</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/sourcegraph/sourcegraph/tree/master/shared/src/api/extension/types"><span>types</span></a></span><span class="separator">/</span><strong class="final-path">url.ts</strong>
-      </h2>
+        <template id="site-details-dialog">
+            <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open="">
+                <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+                <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+                    <button
+                        class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0"
+                        type="button"
+                        aria-label="Close dialog"
+                        data-close-dialog=""
+                    >
+                        <svg
+                            class="octicon octicon-x"
+                            viewBox="0 0 12 16"
+                            version="1.1"
+                            width="12"
+                            height="16"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                            ></path>
+                        </svg>
+                    </button>
+                    <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+                </details-dialog>
+            </details>
+        </template>
 
-      <div class="BtnGroup flex-shrink-0 d-none d-md-inline-block">
-        <a href="/sourcegraph/sourcegraph/find/master"
-              class="js-pjax-capture-input btn btn-sm BtnGroup-item"
-              data-pjax
-              data-hotkey="t">
-          Find file
-        </a>
-        <clipboard-copy value="shared/src/api/extension/types/url.ts" class="btn btn-sm BtnGroup-item">
-          Copy path
-        </clipboard-copy>
-      </div>
-    </div>
+        <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
+            <div
+                class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large"
+                style="width:360px;"
+            ></div>
+        </div>
 
-
-
-    <include-fragment src="/sourcegraph/sourcegraph/contributors/master/shared/src/api/extension/types/url.ts" class="Box Box--condensed commit-loader">
-      <div class="Box-body bg-blue-light f6">
-        Fetching contributors&hellip;
-      </div>
-
-      <div class="Box-body d-flex flex-items-center" >
-          <img alt="" class="loader-loading mr-2" src="https://github.githubassets.com/images/spinners/octocat-spinner-32-EAF2F5.gif" width="16" height="16" />
-        <span class="text-red h6 loader-error">Cannot retrieve contributors at this time</span>
-      </div>
-</include-fragment>
-
-
-
-
-    <div class="Box mt-3 position-relative">
-      
-<div class="Box-header py-2 d-flex flex-column flex-shrink-0 flex-md-row flex-md-items-center">
-
-  <div class="text-mono f6 flex-auto pr-3 flex-order-2 flex-md-order-1 mt-2 mt-md-0">
-      3 lines (2 sloc)
-      <span class="file-info-divider"></span>
-    138 Bytes
-  </div>
-
-  <div class="d-flex py-1 py-md-0 flex-auto flex-order-1 flex-md-order-2 flex-sm-grow-0 flex-justify-between">
-
-    <div class="BtnGroup">
-      <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/sourcegraph/sourcegraph/raw/master/shared/src/api/extension/types/url.ts">Raw</a>
-        <a class="btn btn-sm js-update-url-with-hash BtnGroup-item" data-hotkey="b" href="/sourcegraph/sourcegraph/blame/master/shared/src/api/extension/types/url.ts">Blame</a>
-      <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/sourcegraph/sourcegraph/commits/master/shared/src/api/extension/types/url.ts">History</a>
-    </div>
-
-
-    <div>
-            <a class="btn-octicon tooltipped tooltipped-nw"
-               href="github-mac://openRepo/https://github.com/sourcegraph/sourcegraph?branch=master&amp;filepath=shared%2Fsrc%2Fapi%2Fextension%2Ftypes%2Furl.ts"
-               aria-label="Open this file in GitHub Desktop"
-               data-ga-click="Repository, open with desktop, type:mac">
-                <svg class="octicon octicon-device-desktop" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"/></svg>
-            </a>
-
-            <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="inline-form js-update-url-with-hash" action="/sourcegraph/sourcegraph/edit/master/shared/src/api/extension/types/url.ts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="okXRqogBr0n57KEMkTkU83xroOwpME/U11qw84q63hrJx9O5+M/Ok6zxTYvfJ3a17M3MmgekavJnFCGkw8C7Uw==" />
-              <button class="btn-octicon tooltipped tooltipped-nw" type="submit"
-                aria-label="Edit this file" data-hotkey="e" data-disable-with>
-                <svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg>
-              </button>
-</form>
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="inline-form" action="/sourcegraph/sourcegraph/delete/master/shared/src/api/extension/types/url.ts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="VQ69l1tmlxRMvKSed+eBcBNiDKa6RRioYQB/DgLptgLhSJvPKlxBtH726hHBBU2jmyBOHHMb1e/h2XTbrwMXRA==" />
-            <button class="btn-octicon btn-octicon-danger tooltipped tooltipped-nw" type="submit"
-              aria-label="Delete this file" data-disable-with>
-              <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>
-            </button>
-</form>    </div>
-  </div>
-</div>
-
-      
-
-  <div itemprop="text" class="Box-body p-0 blob-wrapper data type-typescript ">
-      
-<table class="highlight tab-size js-file-line-container" data-tab-size="4">
-      <tr>
-        <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
-        <td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-k"><span class="pl-k">export</span></span> <span class="pl-k"><span class="pl-k">const</span></span> isURL <span class="pl-k">=</span> (<span class="pl-v">value</span><span class="pl-k">:</span> <span class="pl-c1">any</span>)<span class="pl-k">:</span> <span class="pl-en">value</span> <span class="pl-k">is</span> <span class="pl-en">URL</span> <span class="pl-k">=&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
-        <td id="LC2" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">!!</span><span class="pl-smi">value</span> <span class="pl-k">&amp;&amp;</span> <span class="pl-k">typeof</span> <span class="pl-smi">value</span>.<span class="pl-smi">toString</span> <span class="pl-k">===</span> <span class="pl-s"><span class="pl-pds">&#39;</span>function<span class="pl-pds">&#39;</span></span> <span class="pl-k">&amp;&amp;</span> <span class="pl-smi">value</span>.<span class="pl-c1">href</span> <span class="pl-k">===</span> <span class="pl-smi">value</span>.<span class="pl-c1">toString</span>()</td>
-      </tr>
-</table>
-
-  <details class="details-reset details-overlay BlobToolbar position-absolute js-file-line-actions dropdown d-none" aria-hidden="true">
-    <summary class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1" aria-label="Inline file action toolbar">
-      <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
-    </summary>
-    <details-menu>
-      <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2" style="width:185px">
-        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-lines" style="cursor:pointer;" data-original-text="Copy lines">Copy lines</clipboard-copy></li>
-        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-permalink" style="cursor:pointer;" data-original-text="Copy permalink">Copy permalink</clipboard-copy></li>
-        <li><a class="dropdown-item js-update-url-with-hash" id="js-view-git-blame" role="menuitem" href="/sourcegraph/sourcegraph/blame/45705b3b0407ff44ff7db8660370d2a7bba79db2/shared/src/api/extension/types/url.ts">View git blame</a></li>
-          <li><a class="dropdown-item" id="js-new-issue" role="menuitem" href="/sourcegraph/sourcegraph/issues/new/choose">Reference in new issue</a></li>
-      </ul>
-    </details-menu>
-  </details>
-
-  </div>
-
-    </div>
-
-  
-
-  <details class="details-reset details-overlay details-overlay-dark">
-    <summary data-hotkey="l" aria-label="Jump to line"></summary>
-    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast linejump" aria-label="Jump to line">
-      <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-jump-to-line-form Box-body d-flex" action="" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
-        <input class="form-control flex-auto mr-3 linejump-input js-jump-to-line-field" type="text" placeholder="Jump to line&hellip;" aria-label="Jump to line" autofocus>
-        <button type="submit" class="btn" data-close-dialog>Go</button>
-</form>    </details-dialog>
-  </details>
-
-
-
-  </div>
-  <div class="modal-backdrop js-touch-events"></div>
-</div>
-
-    </main>
-  </div>
-  
-
-  </div>
-
-        
-<div class="footer container-lg width-full p-responsive" role="contentinfo">
-  <div class="position-relative d-flex flex-row-reverse flex-lg-row flex-wrap flex-lg-nowrap flex-justify-center flex-lg-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
-    <ul class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-start mb-2 mb-lg-0">
-      <li class="mr-3">&copy; 2019 <span title="0.52366s from unicorn-54fd48477f-nkc8g">GitHub</span>, Inc.</li>
-        <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to security, text:security" href="https://github.com/security">Security</a></li>
-        <li class="mr-3"><a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
-        <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
-    </ul>
-
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon mx-lg-4" href="https://github.com">
-      <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-</a>
-   <ul class="list-style-none d-flex flex-wrap col-12 col-lg-6 flex-justify-center flex-lg-justify-end mb-2 mb-lg-0">
-        <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
-        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
-      <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
-      <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-        <li class="mr-3"><a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
-        <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
-
-    </ul>
-  </div>
-  <div class="d-flex flex-justify-center pb-6">
-    <span class="f6 text-gray-light"></span>
-  </div>
-</div>
-
-
-
-  <div id="ajax-error-message" class="ajax-error-message flash flash-error">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
-    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
-      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-    </button>
-    You can’t perform that action at this time.
-  </div>
-
-
-    
-    <script crossorigin="anonymous" integrity="sha512-eYWkirt5BXd8Z6IvLT/AkE0jvsyFHbTICcEN1Aczj9caa8b+20ToUYPgohknnTlFrLElgEN0HX9Oh8XHbTFNBw==" type="application/javascript" src="https://github.githubassets.com/assets/frameworks-4199e113.js"></script>
-    
-    <script crossorigin="anonymous" async="async" integrity="sha512-v7DMdD9nOupolgEznyVt6jkYstlmhvl+WlRiHpi6EdRe8FYBp4yK+yEKrghaofifa3x8sXCtV4yy04U0d6fdFg==" type="application/javascript" src="https://github.githubassets.com/assets/github-bootstrap-80470f8d.js"></script>
-    
-    
-    
-  <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden
-    >
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
-    <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
-    <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
-  </div>
-  <template id="site-details-dialog">
-  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
-    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
-    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
-      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-      </button>
-      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
-    </details-dialog>
-  </details>
-</template>
-
-  <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
-  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">
-  </div>
-</div>
-
-  <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
-
-  </body>
+        <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
+    </body>
 </html>
-

--- a/client/browser/src/libs/github/__fixtures__/github.com/commit/refined-github/split/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/commit/refined-github/split/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split -->
 <html lang="en" class="refined-github">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -36,6 +37,21 @@
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
+        <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="correct opsgenie command for one-off alerts (#3258) · sourcegraph/sourcegraph@d3d0fe7"
+        />
+        <meta
+            name="twitter:description"
+            content="* correct opsgenie command
+
+* Update doc/dev/incidents.md
+
+Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
+        />
         <meta property="og:image" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
@@ -60,11 +76,11 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmVhMGJjNGZmNDUyOGNhZDVkODI2MWMyNTc3M2QxZDA0YmExZDhjMTkyODNjYTFhZGNhN2ZhZjkyZjFlOTU0OWE=--fd941a268a91029704a1e6b309b0519a752e9cbe"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjQ4NGUzYWUxYzM1OTIzYjYzMGIxYmM5NzAzNWVkNDQ1NThjNzBiNjAzNmUxMzBmNzU1ODkwOWYwMzQwYzhiZWY=--714c11bab5015cfc5cf70c4665cb148b338e305e"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
-        <meta name="request-id" content="FD50:29A2B:1A97DDE:27C95E5:5CA7A86E" data-pjax-transient="" />
+        <meta name="request-id" content="C889:2DB03:C4AB30:1288386:5CC22807" data-pjax-transient="" />
 
         <meta name="selected-link" value="repo_commits" data-pjax-transient="" />
 
@@ -75,7 +91,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="FD50:29A2B:1A97DDE:27C95E5:5CA7A86E" />
+        <meta name="octolytics-dimension-request_id" content="C889:2DB03:C4AB30:1288386:5CC22807" />
         <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
@@ -93,26 +109,26 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="Mzc0MjJmNmY2NWUyYmIzY2NhNWE1ZmZmZmNkNDc0YWQ4NDdjMzBhY2UzY2RhOWNiOWVmMzQ1ZjBkNjUxY2NmNXx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiRkQ1MDoyOUEyQjoxQTk3RERFOjI3Qzk1RTU6NUNBN0E4NkUiLCJ0aW1lc3RhbXAiOjE1NTQ0OTE1MTcsImhvc3QiOiJnaXRodWIuY29tIn0="
+            content="ZGZlNzhhNDYyM2NkNmU5ZDQ0Y2NmNzMyODUxYmRhNDEyNmI1M2RkM2RjOGIyMzFiYzdiZWY3OWQyZTMxODQxMXx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkM4ODk6MkRCMDM6QzRBQjMwOjEyODgzODY6NUNDMjI4MDciLCJ0aW1lc3RhbXAiOjE1NTYyMjgxMzAsImhvc3QiOiJnaXRodWIuY29tIn0="
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
-            href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.diff"
+            href="/sourcegraph/sourcegraph/commit/d3d0fe7.diff"
             rel="alternate"
             type="text/plain+diff"
             data-pjax-transient="true"
         />
         <link
-            href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.patch"
+            href="/sourcegraph/sourcegraph/commit/d3d0fe7.patch"
             rel="alternate"
             type="text/plain+patch"
             data-pjax-transient="true"
@@ -161,7 +177,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
     </head>
 
     <body
-        class="logged-in env-production emoji-size-boost full-width rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count"
+        class="logged-in env-production emoji-size-boost full-width rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count rgh-recently-pushed-branches"
     >
         <div class="position-relative js-header-wrapper ">
             <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content"
@@ -234,7 +250,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=mPQiPZXgbqSDqNoPjpZYHtAlPDPdKZJR5nER1iA9QLTB07PKsVD/LGexB2SFfyDFdyECFsuhevJJhD+HLQsluQ=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=zyahEsUsOXQefJnQjE2CeE+7dy6qz7KbEjueoejoGAeWATDl4Zyo/PplRLuHpPqj6L9JC7xHWji9zrDw5d59Cg=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -624,7 +640,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             Marketplace
                         </a>
 
-                        <a
+                        <a href="/trending" class="js-selected-navigation-item Header-link  mr-3" data-hotkey="g t"
+                            >Trending</a
+                        ><a
                             class="js-selected-navigation-item Header-link  mr-3"
                             data-ga-click="Header, click, Nav menu - item:explore"
                             data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore"
@@ -634,6 +652,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                         </a>
                     </nav>
                 </div>
+                <div
+                    class="js-socket-channel js-updatable-content"
+                    data-channel="repo:41288708:post-receive:10532611"
+                    data-url="/sourcegraph/sourcegraph/show_partial?partial=tree%2Frecently_touched_branches_list"
+                ></div>
+
+                <div class="Header-item position-relative"></div>
 
                 <div class="Header-item"></div>
 
@@ -694,7 +719,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -707,7 +732,11 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             >
                                 New issue
                             </a>
-                        </details-menu>
+
+                            <a class="dropdown-item" href="/sourcegraph/sourcegraph/projects/new"
+                                >New project</a
+                            ></details-menu
+                        >
                     </details>
                 </div>
 
@@ -728,7 +757,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -741,47 +770,54 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"FD50:29A2B:1A97DDE:27C95E5:5CA7A86E","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified"}}'
-                                            data-hydro-click-hmac="6b0cd1b773065968f4ee366c306004d30a7a83ce6a24c810d623e30a9ef34ad4"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"C889:2DB03:C4AB30:1288386:5CC22807","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null}}'
+                                            data-hydro-click-hmac="5bf9be556450877dbd314a676f7062a493102dffdcea92f2d93192f3a890fff0"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            title=":palm_tree:"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -803,7 +839,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="z4fQXaR6S59Q9VdXFwuWT3N0MLmrhnO0kaF3BokYslc56X+G5fuCQ9Wj8RMcRN1MbRHxu4Wq30UH7LPpPv4Rqw=="
+                                                    value="2pJNfm1O6ZAxqCJY+PjSCAbBeRbFprab4U+wKRR82NUs/OKlLM8gTLT+hBzzt5kLGKS4FOuKGmp3AnTGo5p7KQ=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -832,7 +868,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -854,14 +890,36 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -885,8 +943,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -916,7 +973,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -941,7 +998,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -963,7 +1020,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -987,7 +1044,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -1009,7 +1066,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1028,6 +1085,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1047,7 +1105,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1086,13 +1144,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T21:41:57+02:00"
+                                                                        value="2019-04-26T00:05:30+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1102,7 +1160,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:11:57+02:00"
+                                                                        value="2019-04-26T00:35:30+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1112,7 +1170,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:11:57+02:00"
+                                                                        value="2019-04-26T03:35:30+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1122,7 +1180,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-25T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1132,7 +1190,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1157,15 +1215,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1235,7 +1291,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="BA5AZO3bjMgGRPWpnyxhSQhBZkN6lLjBkgmEqHtNYg8DwiNcREXfZFZX5Cc/WAmxZ92UGNj1XTg3BK9UplpcUw=="
+                                    value="VwTKl6FbhTrnS0PKtFodVtqW4NebgvrPe2Us761iJvNQyKmvCMXWlrdYUkQULnWutQoSjDnjHzbeaAcTcHUYrw=="
                                 />
 
                                 <button
@@ -1275,15 +1331,15 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="TCdfNkKI/xozaDIfzRr6mF+/9m4PzDt8dDxb5hB9StrUUgJE2NP3/wQlgfifAV1D+Bui80tysJmkg50Afzn0MA=="
+                                            value="2RKzLoLgMiNM3L0CUbG/IcvqZFxmQTzO+RtbRRy5RwxBZ+5cGLs6xnuRDuUDqhj6bE4wwSL/tysppJ2jc/355g=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FD50:29A2B:1A97DDE:27C95E5:5CA7A86E","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","user_id":10532611}}'
-                                                data-hydro-click-hmac="2d522fa907d0388623bcf209014aa28870685c16d87ecd2833a7f6aa1f2bd722"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C889:2DB03:C4AB30:1288386:5CC22807","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="92cce1b0ff5e742d2af4f2f09c9b037d6d520ed5d377a8561d460320fc441293"
                                                 data-ga-click="Repository, click Watch settings, action:commit#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1306,7 +1362,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1510,9 +1566,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1529,7 +1585,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="DnZ8VtxaRKvJoCxsn6bIolWEtidRGRCoUFpvh75BedqC1BP2wGTzm2RJt75mmAsMwSq5yQixDrwBoqcKF4x+lA=="
+                                                value="9whIff7ttJ9MSp7hzCRYVK968p+HicLJKVKlDwcu4IZ7qifd4tMDr+GjBTM1Gpv6O9T9cd4h3N14qm2CruPnyA=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1537,8 +1593,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FD50:29A2B:1A97DDE:27C95E5:5CA7A86E","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","user_id":10532611}}'
-                                                data-hydro-click-hmac="a9e304f8068ad6e9cae32b4b3ddbf3fb18e1aba5128545bd5bf0fc8748a2f52a"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C889:2DB03:C4AB30:1288386:5CC22807","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="7990a93d692e8019193d0d8a700ea9b3fd389f6751be70529fdb28bc62b5ba51"
                                                 data-ga-click="Repository, click unstar button, action:commit#show; text:Unstar"
                                                 data-hotkey="g s"
                                             >
@@ -1560,9 +1616,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1575,7 +1631,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="t7uUxfRWJPCG7O0yf5x9m10CIQDI4f8VJktBBKrBFHAOgFS0fTOQubfOQSuaPnpGGJOiarWGR+1TkQsfuNEu4g=="
+                                                value="kl2Crv1ydYS/fbIxOJ0Tl/0UhGdNbktfTJaePKEmP4MrZkLfdBfBzY5fHijdPxRKuIUHDTAJ86c5TNQnszYFEQ=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1583,8 +1639,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FD50:29A2B:1A97DDE:27C95E5:5CA7A86E","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","user_id":10532611}}'
-                                                data-hydro-click-hmac="16ac5bb7bec32cd53623ba61ee5791991cb6269fc91d7defc1decc3c92c77fdd"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C889:2DB03:C4AB30:1288386:5CC22807","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="681d1c34ba72a7090f70e847a81d6f4ed9477993dcca0542c427673f80d1a819"
                                                 data-ga-click="Repository, click star button, action:commit#show; text:Star"
                                                 data-hotkey="g s"
                                             >
@@ -1606,9 +1662,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1617,16 +1673,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <li>
                                     <details
                                         class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
-                                        data-deferred-details-content-url="/sourcegraph/sourcegraph/fork?fragment=1"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FD50:29A2B:1A97DDE:27C95E5:5CA7A86E","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","user_id":10532611}}'
-                                            data-hydro-click-hmac="515b8f89a9051996e87667c6acaf5033b2ef659442c2e6015365512c0de194bf"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"C889:2DB03:C4AB30:1288386:5CC22807","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="ca548681756d53d21d1b2a148c30f4c3e9fca0babc7fe1af1cb1b7b01fa1dccc"
                                             data-ga-click="Repository, show fork modal, action:commit#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1646,6 +1699,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1687,9 +1742,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1728,21 +1783,21 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
 
                                 <details
                                     class="commit-build-statuses details-overlay details-reset js-dropdown-details rgh-ci-link"
-                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6MTkzM2Q1NjE5ODQ4YjlmNzEyNWRmYmQ3ZmE3NWYwODJlMjQ4YzJhYQ==/statuses/combined_branch_status"
+                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6YTNlMzMzMGJjYmY2MjQyZWYwNmQyYTMyZGY5NjU4ZWIwZDk0ZTk3ZQ==/statuses/combined_branch_status"
                                 >
-                                    <summary class="text-green">
+                                    <summary class="bg-pending">
                                         <svg
-                                            class="octicon octicon-check v-align-middle"
-                                            aria-label="2 / 2 checks OK"
-                                            viewBox="0 0 12 16"
+                                            class="octicon octicon-primitive-dot v-align-middle"
+                                            aria-label="1 / 2 checks OK"
+                                            viewBox="0 0 8 16"
                                             version="1.1"
-                                            width="12"
+                                            width="8"
                                             height="16"
                                             role="img"
                                         >
                                             <path
                                                 fill-rule="evenodd"
-                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"
                                             ></path>
                                         </svg>
                                     </summary>
@@ -1826,7 +1881,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">695</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1853,7 +1908,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">82</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -2093,6 +2148,42 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             >)
                                         </li>
                                     </ul>
+                                    <svg
+                                        class="octicon octicon-tag"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M7.73 1.73C7.26 1.26 6.62 1 5.96 1H3.5C2.13 1 1 2.13 1 3.5v2.47c0 .66.27 1.3.73 1.77l6.06 6.06c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41L7.73 1.73zM2.38 7.09c-.31-.3-.47-.7-.47-1.13V3.5c0-.88.72-1.59 1.59-1.59h2.47c.42 0 .83.16 1.13.47l6.14 6.13-4.73 4.73-6.13-6.15zM3.01 3h2v2H3V3h.01z"
+                                        ></path>
+                                    </svg>
+                                    <ul class="branches-tag-list js-details-container">
+                                        <li><a href="/sourcegraph/sourcegraph/releases/tag/v3.3.1">v3.3.1</a></li>
+                                        <li class="abbrev-tags">
+                                            <span class="hidden-text-expander"
+                                                ><button
+                                                    type="button"
+                                                    class="ellipsis-expander js-details-target"
+                                                    aria-expanded="false"
+                                                >
+                                                    …
+                                                </button></span
+                                            >
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0">v3.3.0</a>
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.2">v3.3.0-rc.2</a>
+                                        </li>
+                                        <li>
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.1">v3.3.0-rc.1</a>
+                                        </li>
+                                    </ul>
                                 </div>
 
                                 <div class="commit-meta p-2 d-flex flex-wrap">
@@ -2127,7 +2218,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                         committed
                                         <relative-time datetime="2019-04-05T16:55:33Z" title="5 Apr 2019, 18:55 CEST"
-                                            >2 hours ago</relative-time
+                                            >20 days ago</relative-time
                                         >
 
                                         <details
@@ -2201,14 +2292,10 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             ></span
                                         >
                                         <span class="sha-block patch-diff-links"
-                                            ><a
-                                                href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.patch"
-                                                class="sha"
+                                            ><a href="/sourcegraph/sourcegraph/commit/d3d0fe7.patch" class="sha"
                                                 >patch</a
                                             >
-                                            <a
-                                                href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.diff"
-                                                class="sha"
+                                            <a href="/sourcegraph/sourcegraph/commit/d3d0fe7.diff" class="sha"
                                                 >diff</a
                                             ></span
                                         >
@@ -2230,8 +2317,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                 <div
                                                     class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                 >
-                                                    <div class="inline-comment-form-actions"></div>
-
                                                     <div class="inline-comment-form">
                                                         <!-- '"` --><!-- </textarea></xmp> -->
                                                         <form
@@ -2243,7 +2328,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <input name="utf8" type="hidden" value="✓" /><input
                                                                 type="hidden"
                                                                 name="authenticity_token"
-                                                                value="ZUfQuWbuBwN7l19UdiVo+3BFQC30OhQC7oc9UVvfK9/3XmWQWWZVcwDOlbrxUYeMR5/CPwSyQnAL5/9szg4e8Q=="
+                                                                value="MM0a4ZPEu0PlADEKEoryPPdxff12knRUQUbpS0zyko+i1K/IrEzpM55Z++SV/h1LwKv/74YaIiakJit22SOnoQ=="
                                                             />
                                                             <input type="hidden" name="comment_context" value="diff" />
 
@@ -2257,11 +2342,11 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <div
                                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                                data-preview-authenticity-token="jNPwTdAP5Bq1bVSxkxmrunuH2QSI1pYSa8EmyFK8jyxMw601UyPe8YpkQ0Q/2eqpOZTeTzJoopEZ3eNtf/FlAg=="
+                                                                data-preview-authenticity-token="4AQT8Q4n7rBIHUsY9AniP5hmaHPHsUB7Oxsf8TVO7M8gFE6JjQvUW3cUXO1YyaMs2nVvOH0PdPhJB9pUGAMG4Q=="
                                                             >
                                                                 <div class="comment-form-head tabnav ">
                                                                     <markdown-toolbar
-                                                                        for="r312544 new_inline_comment_diff_${anchor}_${position}"
+                                                                        for="r920572 new_inline_comment_diff_${anchor}_${position}"
                                                                         class="toolbar-commenting "
                                                                     >
                                                                         <div class="toolbar-group">
@@ -2603,7 +2688,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                 type="button"
                                                                                 class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                 aria-label="Upload attachments"
-                                                                                hotkey="u"
+                                                                                data-hotkey="u"
                                                                             >
                                                                                 <svg
                                                                                     aria-hidden="true"
@@ -2649,7 +2734,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     class="js-upload-markdown-image is-default"
                                                                     data-upload-repository-id="41288708"
                                                                     data-upload-policy-url="/upload/policies/assets"
-                                                                    data-upload-policy-authenticity-token="zjnAYqlOAZwMZ7G6nU534xGdT+uVphaSrTxCCdmXgwj8L4zz5iP91/lo5Cmpm4Ca3tB7/bEhWuBt9ffGqCv2OA=="
+                                                                    data-upload-policy-authenticity-token="7i6FB5aeoFkFZEROsgWTH5megjfMYXmtiJyUS6dezEbcOMmW2fNcEvBrEd2G0GRmVtO2IejmNd9IVSGE1uK5dg=="
                                                                 >
                                                                     <div
                                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -2665,7 +2750,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                                                         <textarea
                                                                             name="comment[body]"
-                                                                            id="r312544 new_inline_comment_diff_${anchor}_${position}"
+                                                                            id="r920572 new_inline_comment_diff_${anchor}_${position}"
                                                                             placeholder="Leave a comment"
                                                                             aria-label="Comment body"
                                                                             class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -2675,7 +2760,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             required=""
                                                                         ></textarea>
 
-                                                                        <p class="drag-and-drop position-relative">
+                                                                        <p
+                                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                        >
                                                                             <input
                                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                 type="file"
@@ -2811,6 +2898,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                     </span>
                                                                                 </span>
                                                                             </span>
+                                                                            <span
+                                                                                class="tooltipped tooltipped-nw"
+                                                                                aria-label="Styling with Markdown is supported"
+                                                                            >
+                                                                                <a
+                                                                                    class="tabnav-extra position-relative d-inline"
+                                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                                    target="_blank"
+                                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                                    aria-label="Learn about styling with Markdown"
+                                                                                >
+                                                                                    <svg
+                                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                                        viewBox="0 0 16 16"
+                                                                                        version="1.1"
+                                                                                        width="16"
+                                                                                        height="16"
+                                                                                        aria-hidden="true"
+                                                                                    >
+                                                                                        <path
+                                                                                            fill-rule="evenodd"
+                                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                        ></path>
+                                                                                    </svg>
+                                                                                </a>
+                                                                            </span>
                                                                         </p>
                                                                     </div>
                                                                 </file-attachment>
@@ -2845,30 +2958,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             <p>Nothing to preview</p>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-
-                                                                <div class="float-left ">
-                                                                    <a
-                                                                        class="tabnav-extra "
-                                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                                        target="_blank"
-                                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                                    >
-                                                                        <svg
-                                                                            class="octicon octicon-markdown v-align-bottom"
-                                                                            viewBox="0 0 16 16"
-                                                                            version="1.1"
-                                                                            width="16"
-                                                                            height="16"
-                                                                            aria-hidden="true"
-                                                                        >
-                                                                            <path
-                                                                                fill-rule="evenodd"
-                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                            ></path>
-                                                                        </svg>
-                                                                        Styling with Markdown is supported
-                                                                    </a>
                                                                 </div>
 
                                                                 <div
@@ -2933,8 +3022,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                 <div
                                                     class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                 >
-                                                    <div class="inline-comment-form-actions"></div>
-
                                                     <div class="inline-comment-form">
                                                         <!-- '"` --><!-- </textarea></xmp> -->
                                                         <form
@@ -2946,7 +3033,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <input name="utf8" type="hidden" value="✓" /><input
                                                                 type="hidden"
                                                                 name="authenticity_token"
-                                                                value="udf4xMYuBETCTrdzv/TsgI5qWOS2oIxAydRBjJLQTO0rzk3t+aZWNLkXfZ04gAP3ubDa9kYo2jIstIOxBwF5ww=="
+                                                                value="CDYNU2n3oKgW8sQVKrtAMX9DTD9WHWihXS6Xca/fwJOaL7h6Vn/y2G2rDvutz69GSJnOLaaVPtO4TlVMOg71vQ=="
                                                             />
                                                             <input type="hidden" name="comment_context" value="diff" />
 
@@ -2960,11 +3047,11 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <div
                                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                                data-preview-authenticity-token="QQDZpiswIA0ttyWSCHd7KVM6zthajFcQF+NA0yMod1eBEITeqBwa5hK+Mmektzo6ESnJk+AyY5Nl/4V2DmWdeQ=="
+                                                                data-preview-authenticity-token="+kEF08IMccZi+Gjp01XJ7WBc7td1hsGuEFYnL71vry46UVirQSBLLV3xfxx/lYj+Ik/pnM849S1iSuKKkCJFAA=="
                                                             >
                                                                 <div class="comment-form-head tabnav ">
                                                                     <markdown-toolbar
-                                                                        for="r92178 new_inline_comment_diff_${anchor}_${position}"
+                                                                        for="r86221 new_inline_comment_diff_${anchor}_${position}"
                                                                         class="toolbar-commenting "
                                                                     >
                                                                         <div class="toolbar-group">
@@ -3306,7 +3393,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                 type="button"
                                                                                 class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                 aria-label="Upload attachments"
-                                                                                hotkey="u"
+                                                                                data-hotkey="u"
                                                                             >
                                                                                 <svg
                                                                                     aria-hidden="true"
@@ -3352,7 +3439,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     class="js-upload-markdown-image is-default"
                                                                     data-upload-repository-id="41288708"
                                                                     data-upload-policy-url="/upload/policies/assets"
-                                                                    data-upload-policy-authenticity-token="JocfPOiGj1Lv/Ad1xarg8ngZmKg2iuYAO4SWhsBxYXoUkVOtp+tzGRrzUubxfxeLt1SsvhINqnL7TSNJsc0USg=="
+                                                                    data-upload-policy-authenticity-token="xVpCMURzrgb8HPVAGZZghjUeZWzzbv5MLV59mV67pGb3TA6gCx5STQkToNMtQ5f/+lNRetfpsj7tl8hWLwfRVg=="
                                                                 >
                                                                     <div
                                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -3368,7 +3455,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                                                         <textarea
                                                                             name="comment[body]"
-                                                                            id="r92178 new_inline_comment_diff_${anchor}_${position}"
+                                                                            id="r86221 new_inline_comment_diff_${anchor}_${position}"
                                                                             placeholder="Leave a comment"
                                                                             aria-label="Comment body"
                                                                             class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -3378,7 +3465,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             required=""
                                                                         ></textarea>
 
-                                                                        <p class="drag-and-drop position-relative">
+                                                                        <p
+                                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                        >
                                                                             <input
                                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                 type="file"
@@ -3514,6 +3603,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                     </span>
                                                                                 </span>
                                                                             </span>
+                                                                            <span
+                                                                                class="tooltipped tooltipped-nw"
+                                                                                aria-label="Styling with Markdown is supported"
+                                                                            >
+                                                                                <a
+                                                                                    class="tabnav-extra position-relative d-inline"
+                                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                                    target="_blank"
+                                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                                    aria-label="Learn about styling with Markdown"
+                                                                                >
+                                                                                    <svg
+                                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                                        viewBox="0 0 16 16"
+                                                                                        version="1.1"
+                                                                                        width="16"
+                                                                                        height="16"
+                                                                                        aria-hidden="true"
+                                                                                    >
+                                                                                        <path
+                                                                                            fill-rule="evenodd"
+                                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                        ></path>
+                                                                                    </svg>
+                                                                                </a>
+                                                                            </span>
                                                                         </p>
                                                                     </div>
                                                                 </file-attachment>
@@ -3548,30 +3663,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             <p>Nothing to preview</p>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-
-                                                                <div class="float-left ">
-                                                                    <a
-                                                                        class="tabnav-extra "
-                                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                                        target="_blank"
-                                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                                    >
-                                                                        <svg
-                                                                            class="octicon octicon-markdown v-align-bottom"
-                                                                            viewBox="0 0 16 16"
-                                                                            version="1.1"
-                                                                            width="16"
-                                                                            height="16"
-                                                                            aria-hidden="true"
-                                                                        >
-                                                                            <path
-                                                                                fill-rule="evenodd"
-                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                            ></path>
-                                                                        </svg>
-                                                                        Styling with Markdown is supported
-                                                                    </a>
                                                                 </div>
 
                                                                 <div
@@ -3745,94 +3836,162 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             data-file-deleted="false"
                                         >
                                             <div class="file-actions">
-                                                <span class="show-file-notes pt-1">
-                                                    <label>
-                                                        <input
-                                                            type="checkbox"
-                                                            checked="checked"
-                                                            class="js-toggle-file-notes"
-                                                        />
-                                                        Show comments
-                                                    </label>
-                                                </span>
-
-                                                <span class="BtnGroup">
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w source js-source selected"
-                                                            aria-current="true"
-                                                            aria-label="Display the source diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                <div class="mt-1">
+                                                    <span class="BtnGroup mt-n1">
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
                                                         >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w source js-source selected"
+                                                                aria-current="true"
+                                                                aria-label="Display the source diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-code"
+                                                                    viewBox="0 0 14 16"
+                                                                    version="1.1"
+                                                                    width="14"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
+                                                        >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w rendered js-rendered"
+                                                                aria-label="Display the rich diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-file"
+                                                                    viewBox="0 0 12 16"
+                                                                    version="1.1"
+                                                                    width="12"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                    </span>
+
+                                                    <details
+                                                        class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                    >
+                                                        <summary class="btn-link v-align-middle" aria-haspopup="menu">
                                                             <svg
-                                                                class="octicon octicon-code"
-                                                                viewBox="0 0 14 16"
+                                                                class="octicon octicon-kebab-horizontal text-gray"
+                                                                aria-label="Show options"
+                                                                viewBox="0 0 13 16"
                                                                 version="1.1"
-                                                                width="14"
+                                                                width="13"
                                                                 height="16"
-                                                                aria-hidden="true"
+                                                                role="img"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
                                                                 ></path>
                                                             </svg>
-                                                        </button>
-                                                    </form>
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w rendered js-rendered"
-                                                            aria-label="Display the rich diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                        </summary>
+                                                        <details-menu
+                                                            class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                            style="width:185px; z-index:99; right: -4px;"
+                                                            role="menu"
                                                         >
-                                                            <svg
-                                                                class="octicon octicon-file"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
+                                                            <label
+                                                                role="menuitem"
+                                                                class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                tabindex="0"
                                                             >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
-                                                                ></path>
-                                                            </svg>
-                                                        </button>
-                                                    </form>
-                                                </span>
+                                                                <span class="file-notes-check position-absolute ml-n3"
+                                                                    ><svg
+                                                                        class="octicon octicon-check"
+                                                                        viewBox="0 0 12 16"
+                                                                        version="1.1"
+                                                                        width="12"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                        ></path></svg
+                                                                ></span>
+                                                                <input
+                                                                    type="checkbox"
+                                                                    checked="checked"
+                                                                    class="d-none js-toggle-file-notes"
+                                                                />
+                                                                Show comments
+                                                            </label>
 
-                                                <div class="BtnGroup">
-                                                    <a
-                                                        href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
-                                                        class="btn btn-sm BtnGroup-item"
-                                                        rel="nofollow"
-                                                    >
-                                                        View file
-                                                    </a>
+                                                            <div role="none" class="dropdown-divider"></div>
+
+                                                            <a
+                                                                href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                rel="nofollow"
+                                                                role="menuitem"
+                                                                data-ga-click="View file, click, location:files_changed_dropdown"
+                                                            >
+                                                                View file
+                                                            </a>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to make changes."
+                                                            >
+                                                                Edit file
+                                                            </button>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to delete this file."
+                                                            >
+                                                                Delete file
+                                                            </button>
+                                                        </details-menu>
+                                                    </details>
                                                 </div>
-
+                                            </div>
+                                            <div class="file-info">
                                                 <button
                                                     type="button"
-                                                    class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                    class="btn-octicon js-details-target"
                                                     aria-label="Toggle diff contents"
                                                     aria-expanded="true"
+                                                    style="width: 22px;"
                                                 >
                                                     <svg
                                                         class="octicon octicon-chevron-down Details-content--hidden"
@@ -3848,21 +4007,19 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         ></path>
                                                     </svg>
                                                     <svg
-                                                        class="octicon octicon-chevron-up Details-content--shown"
-                                                        viewBox="0 0 10 16"
+                                                        class="octicon octicon-chevron-right Details-content--shown"
+                                                        viewBox="0 0 8 16"
                                                         version="1.1"
-                                                        width="10"
+                                                        width="8"
                                                         height="16"
                                                         aria-hidden="true"
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                            d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                         ></path>
                                                     </svg>
                                                 </button>
-                                            </div>
-                                            <div class="file-info">
                                                 <span
                                                     class="diffstat tooltipped tooltipped-e"
                                                     aria-label="1 addition &amp; 1 deletion"
@@ -3879,6 +4036,41 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     title="doc/dev/incidents.md"
                                                     >doc/dev/incidents.md</a
                                                 >
+
+                                                <clipboard-copy
+                                                    value="doc/dev/incidents.md"
+                                                    aria-label="Copied!"
+                                                    class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                    tabindex="0"
+                                                    role="button"
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                        viewBox="0 0 14 16"
+                                                        version="1.1"
+                                                        width="14"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                        ></path>
+                                                    </svg>
+                                                    <svg
+                                                        class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                        ></path>
+                                                    </svg>
+                                                </clipboard-copy>
                                             </div>
                                         </div>
                                         <div class="js-file-content Details-content--hidden">
@@ -4725,8 +4917,8 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         Lock conversation
                                                     </summary>
                                                     <details-dialog
-                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         aria-label="Lock conversation on this commit"
+                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         role="dialog"
                                                     >
                                                         <div class="Box-header">
@@ -4792,7 +4984,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="vfkmpBlRYZutR6eHDbCOmfkfoc9djE3S2fR7X3J/gh3VWCy8eTuGIajEHOAG1Xnc1rxvQSvboeZeI+zSbDAT8Q=="
+                                                                    value="nsIvnkpGnKtfj0EpddPgsvWF44cvGG+y4MBFogDNv6f2YyWGKix7EVoM+k5+thf32iYtCVlPg4ZnF9IvHoIuSw=="
                                                                 />
                                                                 <button type="submit" class="btn btn-danger btn-block">
                                                                     Lock conversation on this commit
@@ -4848,7 +5040,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="5tCogV1ZTjsO57Qth+OghAuknnrDEIYQ4ls2qgKW9dt0yR2oYtEcS3W+fsMAl0/zPH4caDOY0GIHO/SXl0fA9Q=="
+                                            value="GX7vyPEjQZO0VKez+MLLq/mywa1s6c69hR7sEJxOL8CLZ1rhzqsT488NbV1/tiTczmhDv5xhmM9gfi4tCZ8a7g=="
                                         />
                                         <div class="timeline-comment">
                                             <input
@@ -4860,7 +5052,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             <div
                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                data-preview-authenticity-token="v8qoEvB9+i+CFVD4AYQc3k7LIcg04w+5ys4ritNl9yB/2vVqc1HAxL0cRw2tRF3NDNgmg45dOzq40u4v/igdDg=="
+                                                data-preview-authenticity-token="TAJn7k4l1gqz2lDkHsNMZkYjHR1l3nqbdSWhsi7zsxCMEjqWzQns4YzTRxGyAw11BDAaVt9gThgHOWQXA75ZPg=="
                                             >
                                                 <div class="comment-form-head tabnav ">
                                                     <markdown-toolbar
@@ -5202,7 +5394,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                 type="button"
                                                                 class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                 aria-label="Upload attachments"
-                                                                hotkey="u"
+                                                                data-hotkey="u"
                                                             >
                                                                 <svg
                                                                     aria-hidden="true"
@@ -5248,7 +5440,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     class="js-upload-markdown-image is-default"
                                                     data-upload-repository-id="41288708"
                                                     data-upload-policy-url="/upload/policies/assets"
-                                                    data-upload-policy-authenticity-token="LMSntFGjzRl4rEahibTsFUltxrvAgtj4efHCdwF1RmIe0uslHs4xUo2jEzK9YRtshiDyreQFlIq5OHe4cMkzUg=="
+                                                    data-upload-policy-authenticity-token="jRNe/rwdFGhnUue6A1oweC7azYXwSyos1DmWhFzbBMK/BRJv83DoI5Jdsik3j8cB4Zf5k9TMZl4U8CNLLWdx8g=="
                                                 >
                                                     <div
                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -5274,7 +5466,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             required=""
                                                         ></textarea>
 
-                                                        <p class="drag-and-drop position-relative">
+                                                        <p
+                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                        >
                                                             <input
                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                 type="file"
@@ -5393,6 +5587,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     </span>
                                                                 </span>
                                                             </span>
+                                                            <span
+                                                                class="tooltipped tooltipped-nw"
+                                                                aria-label="Styling with Markdown is supported"
+                                                            >
+                                                                <a
+                                                                    class="tabnav-extra position-relative d-inline"
+                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                    target="_blank"
+                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                    aria-label="Learn about styling with Markdown"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                        viewBox="0 0 16 16"
+                                                                        version="1.1"
+                                                                        width="16"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </a>
+                                                            </span>
                                                         </p>
                                                     </div>
                                                 </file-attachment>
@@ -5415,30 +5635,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <p>Nothing to preview</p>
                                                         </div>
                                                     </div>
-                                                </div>
-
-                                                <div class="float-left ">
-                                                    <a
-                                                        class="tabnav-extra "
-                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                        target="_blank"
-                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                    >
-                                                        <svg
-                                                            class="octicon octicon-markdown v-align-bottom"
-                                                            viewBox="0 0 16 16"
-                                                            version="1.1"
-                                                            width="16"
-                                                            height="16"
-                                                            aria-hidden="true"
-                                                        >
-                                                            <path
-                                                                fill-rule="evenodd"
-                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                            ></path>
-                                                        </svg>
-                                                        Styling with Markdown is supported
-                                                    </a>
                                                 </div>
 
                                                 <div
@@ -5481,7 +5677,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         d="M4.79 6.11c.25-.25.25-.67 0-.92-.32-.33-.48-.76-.48-1.19 0-.43.16-.86.48-1.19.25-.26.25-.67 0-.92a.613.613 0 0 0-.45-.19c-.16 0-.33.06-.45.19-.57.58-.85 1.35-.85 2.11 0 .76.29 1.53.85 2.11.25.25.66.25.9 0zM2.33.52a.651.651 0 0 0-.92 0C.48 1.48.01 2.74.01 3.99c0 1.26.47 2.52 1.4 3.48.25.26.66.26.91 0s.25-.68 0-.94c-.68-.7-1.02-1.62-1.02-2.54 0-.92.34-1.84 1.02-2.54a.66.66 0 0 0 .01-.93zm5.69 5.1A1.62 1.62 0 1 0 6.4 4c-.01.89.72 1.62 1.62 1.62zM14.59.53a.628.628 0 0 0-.91 0c-.25.26-.25.68 0 .94.68.7 1.02 1.62 1.02 2.54 0 .92-.34 1.83-1.02 2.54-.25.26-.25.68 0 .94a.651.651 0 0 0 .92 0c.93-.96 1.4-2.22 1.4-3.48A5.048 5.048 0 0 0 14.59.53zM8.02 6.92c-.41 0-.83-.1-1.2-.3l-3.15 8.37h1.49l.86-1h4l.84 1h1.49L9.21 6.62c-.38.2-.78.3-1.19.3zm-.01.48L9.02 11h-2l.99-3.6zm-1.99 5.59l1-1h2l1 1h-4zm5.19-11.1c-.25.25-.25.67 0 .92.32.33.48.76.48 1.19 0 .43-.16.86-.48 1.19-.25.26-.25.67 0 .92a.63.63 0 0 0 .9 0c.57-.58.85-1.35.85-2.11 0-.76-.28-1.53-.85-2.11a.634.634 0 0 0-.9 0z"
                                     ></path>
                                 </svg>
-
                                 <!-- '"` --><!-- </textarea></xmp> -->
                                 <form
                                     data-replace-remote-form="true"
@@ -5493,7 +5688,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                     <input name="utf8" type="hidden" value="✓" /><input
                                         type="hidden"
                                         name="authenticity_token"
-                                        value="VlxKCrPSXWreCNJrRIYj8H0fQfZ6BZR7Q5JJ5F/dWh2Y9moUpjzvZqU2LezlC0RYXQtPPrfHX2Gyl4HfLJTWOQ=="
+                                        value="gQkwb0lWJ+fmSfcUFkOi+WyfURiE9Fig0b+hKsDyzOxPoxBxXLiV6513CJO3zsVRTItf0Ek2k7ogumkRs7tAyA=="
                                     />
                                     <input type="hidden" name="repository_id" value="41288708" />
                                     <input
@@ -5540,7 +5735,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
             >
                 <ul class="list-style-none d-flex flex-wrap ">
                     <li class="mr-3">
-                        © 2019 <span title="0.29734s from unicorn-854df44466-7pq67">GitHub</span>, Inc.
+                        © 2019 <span title="0.47489s from unicorn-7bd9b5dd4d-skwxk">GitHub</span>, Inc.
                     </li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
@@ -5644,17 +5839,17 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">

--- a/client/browser/src/libs/github/__fixtures__/github.com/commit/refined-github/unified/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/commit/refined-github/unified/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=unified -->
 <html lang="en" class="refined-github">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -36,6 +37,21 @@
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
+        <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="correct opsgenie command for one-off alerts (#3258) · sourcegraph/sourcegraph@d3d0fe7"
+        />
+        <meta
+            name="twitter:description"
+            content="* correct opsgenie command
+
+* Update doc/dev/incidents.md
+
+Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
+        />
         <meta property="og:image" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
@@ -60,11 +76,11 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5Ojg1YmMzNTBiNjBlMDZjOGUzNjU2MGQ2NDUzMTY2NTE2ZDhkODc1MTAwYzFlNGZiNjg3NWM5MzRjMDFmYjk4YjM=--14b795061559443d986b143db1c99806e92fc6f0"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjMwYzIzNTIyMTlkNjRmMzYxYjkxODQ3ZmE4OTQ4MTMwNTUzYjJiNzNmNGUwMDM2NWYxNmQzMTc5YjU5NDZmMGE=--7e7b2e9d8c9c283cef3273818648758be4fc8c92"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
-        <meta name="request-id" content="FCA2:4BCD:191D554:25FCD62:5CA7A84D" data-pjax-transient="" />
+        <meta name="request-id" content="CA50:2AC2F:25EFDEC:39534D5:5CC22867" data-pjax-transient="" />
 
         <meta name="selected-link" value="repo_commits" data-pjax-transient="" />
 
@@ -75,7 +91,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="FCA2:4BCD:191D554:25FCD62:5CA7A84D" />
+        <meta name="octolytics-dimension-request_id" content="CA50:2AC2F:25EFDEC:39534D5:5CC22867" />
         <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
@@ -93,26 +109,26 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="YzAxYTM3YTAwMjQzNjhkMDQxMDdiZWI3NWE3NDkwZWZkOGZiMjg3YjZkZDFiZDY5NzU4NzAwZDk4NjNkZDYzOHx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiRkNBMjo0QkNEOjE5MUQ1NTQ6MjVGQ0Q2Mjo1Q0E3QTg0RCIsInRpbWVzdGFtcCI6MTU1NDQ5MTUwMCwiaG9zdCI6ImdpdGh1Yi5jb20ifQ=="
+            content="MmRiMmQ2MDNiZWFjNTBmZThmYTlhZTM1NmU0NTI0YTJkOGE3Y2RiYjM2ZWU5MjhiY2JmNjkwOTU0MDcwMDc0MXx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkNBNTA6MkFDMkY6MjVFRkRFQzozOTUzNEQ1OjVDQzIyODY3IiwidGltZXN0YW1wIjoxNTU2MjI4MTk5LCJob3N0IjoiZ2l0aHViLmNvbSJ9"
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
-            href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.diff"
+            href="/sourcegraph/sourcegraph/commit/d3d0fe7.diff"
             rel="alternate"
             type="text/plain+diff"
             data-pjax-transient="true"
         />
         <link
-            href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.patch"
+            href="/sourcegraph/sourcegraph/commit/d3d0fe7.patch"
             rel="alternate"
             type="text/plain+patch"
             data-pjax-transient="true"
@@ -161,7 +177,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
     </head>
 
     <body
-        class="logged-in env-production emoji-size-boost rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count"
+        class="logged-in env-production emoji-size-boost rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count rgh-recently-pushed-branches"
     >
         <div class="position-relative js-header-wrapper ">
             <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content"
@@ -234,7 +250,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=utpvhTUPsBFOhTgSESjDiaOx1DxoOiw0Z/LXv60tyEzj/f5yEb8hmaqc5XkawbtSBLXqGX6yxJfIB/nuoButQQ=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=hZsK8+/HQQrQ79jsyWlXXfOdZY+Wq094zZtIGHuF9y7cvJsEy3fQgjT2BYfCgC+GVJlbqoAjp9tibmZJdrOSIw=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -624,7 +640,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             Marketplace
                         </a>
 
-                        <a
+                        <a href="/trending" class="js-selected-navigation-item Header-link  mr-3" data-hotkey="g t"
+                            >Trending</a
+                        ><a
                             class="js-selected-navigation-item Header-link  mr-3"
                             data-ga-click="Header, click, Nav menu - item:explore"
                             data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore"
@@ -634,6 +652,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                         </a>
                     </nav>
                 </div>
+                <div
+                    class="js-socket-channel js-updatable-content"
+                    data-channel="repo:41288708:post-receive:10532611"
+                    data-url="/sourcegraph/sourcegraph/show_partial?partial=tree%2Frecently_touched_branches_list"
+                ></div>
+
+                <div class="Header-item position-relative"></div>
 
                 <div class="Header-item"></div>
 
@@ -694,7 +719,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -707,7 +732,11 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             >
                                 New issue
                             </a>
-                        </details-menu>
+
+                            <a class="dropdown-item" href="/sourcegraph/sourcegraph/projects/new"
+                                >New project</a
+                            ></details-menu
+                        >
                     </details>
                 </div>
 
@@ -728,7 +757,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -741,47 +770,54 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191D554:25FCD62:5CA7A84D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split"}}'
-                                            data-hydro-click-hmac="23b97bdf3069153772c1207458615ecd9b83ddbef4685777edb596f9a2dfb602"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"CA50:2AC2F:25EFDEC:39534D5:5CC22867","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split"}}'
+                                            data-hydro-click-hmac="a2a999aba9c1144926429bd0f28f26d7a0c74a17f60053102edac8a58869263f"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            title=":palm_tree:"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -803,7 +839,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="AIZsKEX/MKYhkn2av6msIjuLT7cSNMeStVwICJEHr2/26MPzBH75eqTE29605uchJe6OtTwYa2MjEcznJuEMkw=="
+                                                    value="wVJsIEEhjj8La6Y/vNFgmOXONcaEjgvkOwg3i6YN44s3PMP7AKBH4449AHu3niub+6v0xKqipxWtRfNkEetAdw=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -832,7 +868,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -854,14 +890,36 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -885,8 +943,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -916,7 +973,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -941,7 +998,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -963,7 +1020,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -987,7 +1044,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -1009,7 +1066,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1028,6 +1085,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1047,7 +1105,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1086,13 +1144,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T21:41:40+02:00"
+                                                                        value="2019-04-26T00:06:39+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1102,7 +1160,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:11:40+02:00"
+                                                                        value="2019-04-26T00:36:39+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1112,7 +1170,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:11:40+02:00"
+                                                                        value="2019-04-26T03:36:39+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1122,7 +1180,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-25T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1132,7 +1190,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1157,15 +1215,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1235,7 +1291,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="0mZ8pH8mCwdgSvg7nwuGLtofWEnfGA2s2eZG/6UIFVDVqh+c1rhYqzBZ6bU/f+7WtYOqEn156FV8620DeB8rDA=="
+                                    value="YLXPK6ZGx0pfJRbtzCrNWALmpNVJLyQKdlkcwk4dUstneawTD9iU5g82B2NsXqWgbXpWjutOwfPTVDc+kwpslw=="
                                 />
 
                                 <button
@@ -1275,15 +1331,15 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="47WFw21jhgMluJZFaPnYiYxa1jNP9RJrYVyN0/dbqsF7wNix9ziO5hL1JaI64n9SK/6CrgtLmY6x40s1mB8UKw=="
+                                            value="N6qkoS940UC57CKGzwTxWtqWE0f6XqVgFSx+AEhZR7Gv3/nTtSPZpY6hkWGdH1aBfTJH2r7gLoXFk7jmJx35Ww=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191D554:25FCD62:5CA7A84D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                                data-hydro-click-hmac="5bac35318d08fc282b56776e6adac77716fb26867ffb56aba602cec84fadd12a"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CA50:2AC2F:25EFDEC:39534D5:5CC22867","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                                data-hydro-click-hmac="93071d555417082f8b8bab6b566a248912a4e89887b5ebe86a40c6157b7cbed7"
                                                 data-ga-click="Repository, click Watch settings, action:commit#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1306,7 +1362,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1510,9 +1566,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1529,7 +1585,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="bIsqdz+E9CIFrcGBb4HnbpYL9qvl4UYbJ8IKV0/o/NzgKUXXI7pDEqhEWlOWvyTAAqX5RbxJWA92OsLa5iX7kg=="
+                                                value="CwDa/gVobX1tknXgH59kBCOQvkdp92QNitfRa2LIMZyHorVeGVbaTcB77jLmoaeqtz6xqTBfehnbLxnmywU20g=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1537,8 +1593,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191D554:25FCD62:5CA7A84D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                                data-hydro-click-hmac="d5fca0cba43d47ffe5aa67f0f434129e310adb1f549d0785fa5386e1f3de115c"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CA50:2AC2F:25EFDEC:39534D5:5CC22867","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                                data-hydro-click-hmac="313057ddae50c3f26d523f68e42a7c8839b37c5888636015682f912e5006ab93"
                                                 data-ga-click="Repository, click unstar button, action:commit#show; text:Unstar"
                                                 data-hotkey="g s"
                                             >
@@ -1560,9 +1616,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1575,7 +1631,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="MMmuheBeIksgN0t2OIIHY1UsAMMzyOZYT2sUjJdX3qWJ8m70aTuWAhEV52/dIAC+EL2DqU6vXqA6sV6XhUfkNw=="
+                                                value="L4TjIwrUvjtebhZxyJV/QG0XVuKjXeLc5v0CCUHAZCyWvyNSg7EKcm9MumgtN3idKIbViN46WiSTJ0gSU9Bevg=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1583,8 +1639,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191D554:25FCD62:5CA7A84D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                                data-hydro-click-hmac="bbf899ec817a58f4866934599bc6ca264191b7c74bd4691d4d54a34ccf629abf"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CA50:2AC2F:25EFDEC:39534D5:5CC22867","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                                data-hydro-click-hmac="9ec711d02c600990d52fc3f7b515ad65eb6ca10a01a0bb5a817be519a4261885"
                                                 data-ga-click="Repository, click star button, action:commit#show; text:Star"
                                                 data-hotkey="g s"
                                             >
@@ -1606,9 +1662,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1617,16 +1673,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <li>
                                     <details
                                         class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
-                                        data-deferred-details-content-url="/sourcegraph/sourcegraph/fork?fragment=1"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191D554:25FCD62:5CA7A84D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                            data-hydro-click-hmac="8d7935cfa3a3c73986e7074ceb046f9d7a20667e40cb58d3856562bdd1422bd3"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CA50:2AC2F:25EFDEC:39534D5:5CC22867","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                            data-hydro-click-hmac="7475ac3e3155b572e3194729eb3df26a36b2982005b25314a99ab505c569b9ae"
                                             data-ga-click="Repository, show fork modal, action:commit#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1646,6 +1699,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1687,9 +1742,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1728,21 +1783,21 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
 
                                 <details
                                     class="commit-build-statuses details-overlay details-reset js-dropdown-details rgh-ci-link"
-                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6MTkzM2Q1NjE5ODQ4YjlmNzEyNWRmYmQ3ZmE3NWYwODJlMjQ4YzJhYQ==/statuses/combined_branch_status"
+                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6YTNlMzMzMGJjYmY2MjQyZWYwNmQyYTMyZGY5NjU4ZWIwZDk0ZTk3ZQ==/statuses/combined_branch_status"
                                 >
-                                    <summary class="text-green">
+                                    <summary class="bg-pending">
                                         <svg
-                                            class="octicon octicon-check v-align-middle"
-                                            aria-label="2 / 2 checks OK"
-                                            viewBox="0 0 12 16"
+                                            class="octicon octicon-primitive-dot v-align-middle"
+                                            aria-label="1 / 2 checks OK"
+                                            viewBox="0 0 8 16"
                                             version="1.1"
-                                            width="12"
+                                            width="8"
                                             height="16"
                                             role="img"
                                         >
                                             <path
                                                 fill-rule="evenodd"
-                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"
                                             ></path>
                                         </svg>
                                     </summary>
@@ -1826,7 +1881,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">695</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1853,7 +1908,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">82</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -2093,6 +2148,42 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             >)
                                         </li>
                                     </ul>
+                                    <svg
+                                        class="octicon octicon-tag"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M7.73 1.73C7.26 1.26 6.62 1 5.96 1H3.5C2.13 1 1 2.13 1 3.5v2.47c0 .66.27 1.3.73 1.77l6.06 6.06c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41L7.73 1.73zM2.38 7.09c-.31-.3-.47-.7-.47-1.13V3.5c0-.88.72-1.59 1.59-1.59h2.47c.42 0 .83.16 1.13.47l6.14 6.13-4.73 4.73-6.13-6.15zM3.01 3h2v2H3V3h.01z"
+                                        ></path>
+                                    </svg>
+                                    <ul class="branches-tag-list js-details-container">
+                                        <li><a href="/sourcegraph/sourcegraph/releases/tag/v3.3.1">v3.3.1</a></li>
+                                        <li class="abbrev-tags">
+                                            <span class="hidden-text-expander"
+                                                ><button
+                                                    type="button"
+                                                    class="ellipsis-expander js-details-target"
+                                                    aria-expanded="false"
+                                                >
+                                                    …
+                                                </button></span
+                                            >
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0">v3.3.0</a>
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.2">v3.3.0-rc.2</a>
+                                        </li>
+                                        <li>
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.1">v3.3.0-rc.1</a>
+                                        </li>
+                                    </ul>
                                 </div>
 
                                 <div class="commit-meta p-2 d-flex flex-wrap">
@@ -2127,7 +2218,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                         committed
                                         <relative-time datetime="2019-04-05T16:55:33Z" title="5 Apr 2019, 18:55 CEST"
-                                            >2 hours ago</relative-time
+                                            >20 days ago</relative-time
                                         >
 
                                         <details
@@ -2201,14 +2292,10 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             ></span
                                         >
                                         <span class="sha-block patch-diff-links"
-                                            ><a
-                                                href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.patch"
-                                                class="sha"
+                                            ><a href="/sourcegraph/sourcegraph/commit/d3d0fe7.patch" class="sha"
                                                 >patch</a
                                             >
-                                            <a
-                                                href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.diff"
-                                                class="sha"
+                                            <a href="/sourcegraph/sourcegraph/commit/d3d0fe7.diff" class="sha"
                                                 >diff</a
                                             ></span
                                         >
@@ -2230,8 +2317,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                 <div
                                                     class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                 >
-                                                    <div class="inline-comment-form-actions"></div>
-
                                                     <div class="inline-comment-form">
                                                         <!-- '"` --><!-- </textarea></xmp> -->
                                                         <form
@@ -2243,7 +2328,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <input name="utf8" type="hidden" value="✓" /><input
                                                                 type="hidden"
                                                                 name="authenticity_token"
-                                                                value="mTHxpQpDko3Ac2UzgjCAYm5TeF7Fg4Fc8tkT57KO4HsLKESMNcvA/bsqr90FRG8VWYn6TDUL1y4XudHaJ1/VVQ=="
+                                                                value="Qqj3mpB8XW6r0bLeQlemVJf4oJkhh+UcPTHrcD8/HOzQsUKzr/QPHtCIeDDFI0kjoCIii9EPs27YUSlNqu4pwg=="
                                                             />
                                                             <input type="hidden" name="comment_context" value="diff" />
 
@@ -2257,11 +2342,11 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <div
                                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                                data-preview-authenticity-token="DXYmCQPoNTSvX67QXI901QP/kT/esgn64wdtXFbGCBvNZntxgMQP35BWuSXwTzXGQeyWdGQMPXmRG6j5e4viNQ=="
+                                                                data-preview-authenticity-token="lDwdopzSqTpUKuGyVTHJTBmh1UNWXHdOFotLYZejmYZULEDaH/6T0Wsj9kf58YhfW7LSCOziQ81kl47Euu5zqA=="
                                                             >
                                                                 <div class="comment-form-head tabnav ">
                                                                     <markdown-toolbar
-                                                                        for="r865759 new_inline_comment_diff_${anchor}_${position}"
+                                                                        for="r651612 new_inline_comment_diff_${anchor}_${position}"
                                                                         class="toolbar-commenting "
                                                                     >
                                                                         <div class="toolbar-group">
@@ -2603,7 +2688,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                 type="button"
                                                                                 class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                 aria-label="Upload attachments"
-                                                                                hotkey="u"
+                                                                                data-hotkey="u"
                                                                             >
                                                                                 <svg
                                                                                     aria-hidden="true"
@@ -2649,7 +2734,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     class="js-upload-markdown-image is-default"
                                                                     data-upload-repository-id="41288708"
                                                                     data-upload-policy-url="/upload/policies/assets"
-                                                                    data-upload-policy-authenticity-token="Z+DtUvwUkc3xhmsuX8qgA1UxA7GsLpvD63P7AgPWGGJV9qHDs3lthgSJPr1rH1d6mnw3p4ip17Eruk7NcmptUg=="
+                                                                    data-upload-policy-authenticity-token="WUwwcuNsVHvdV6u3TFLM1Oxz2olkabcLQJ+t0qXdd+lrWnzjrAGoMChY/iR4hzutIz7un0Du+3mAVhgd1GEC2Q=="
                                                                 >
                                                                     <div
                                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -2665,7 +2750,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                                                         <textarea
                                                                             name="comment[body]"
-                                                                            id="r865759 new_inline_comment_diff_${anchor}_${position}"
+                                                                            id="r651612 new_inline_comment_diff_${anchor}_${position}"
                                                                             placeholder="Leave a comment"
                                                                             aria-label="Comment body"
                                                                             class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -2675,7 +2760,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             required=""
                                                                         ></textarea>
 
-                                                                        <p class="drag-and-drop position-relative">
+                                                                        <p
+                                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                        >
                                                                             <input
                                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                 type="file"
@@ -2811,6 +2898,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                     </span>
                                                                                 </span>
                                                                             </span>
+                                                                            <span
+                                                                                class="tooltipped tooltipped-nw"
+                                                                                aria-label="Styling with Markdown is supported"
+                                                                            >
+                                                                                <a
+                                                                                    class="tabnav-extra position-relative d-inline"
+                                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                                    target="_blank"
+                                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                                    aria-label="Learn about styling with Markdown"
+                                                                                >
+                                                                                    <svg
+                                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                                        viewBox="0 0 16 16"
+                                                                                        version="1.1"
+                                                                                        width="16"
+                                                                                        height="16"
+                                                                                        aria-hidden="true"
+                                                                                    >
+                                                                                        <path
+                                                                                            fill-rule="evenodd"
+                                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                        ></path>
+                                                                                    </svg>
+                                                                                </a>
+                                                                            </span>
                                                                         </p>
                                                                     </div>
                                                                 </file-attachment>
@@ -2845,30 +2958,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             <p>Nothing to preview</p>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-
-                                                                <div class="float-left ">
-                                                                    <a
-                                                                        class="tabnav-extra "
-                                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                                        target="_blank"
-                                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                                    >
-                                                                        <svg
-                                                                            class="octicon octicon-markdown v-align-bottom"
-                                                                            viewBox="0 0 16 16"
-                                                                            version="1.1"
-                                                                            width="16"
-                                                                            height="16"
-                                                                            aria-hidden="true"
-                                                                        >
-                                                                            <path
-                                                                                fill-rule="evenodd"
-                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                            ></path>
-                                                                        </svg>
-                                                                        Styling with Markdown is supported
-                                                                    </a>
                                                                 </div>
 
                                                                 <div
@@ -3042,94 +3131,162 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             data-file-deleted="false"
                                         >
                                             <div class="file-actions">
-                                                <span class="show-file-notes pt-1">
-                                                    <label>
-                                                        <input
-                                                            type="checkbox"
-                                                            checked="checked"
-                                                            class="js-toggle-file-notes"
-                                                        />
-                                                        Show comments
-                                                    </label>
-                                                </span>
-
-                                                <span class="BtnGroup">
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w source js-source selected"
-                                                            aria-current="true"
-                                                            aria-label="Display the source diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                <div class="mt-1">
+                                                    <span class="BtnGroup mt-n1">
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
                                                         >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w source js-source selected"
+                                                                aria-current="true"
+                                                                aria-label="Display the source diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-code"
+                                                                    viewBox="0 0 14 16"
+                                                                    version="1.1"
+                                                                    width="14"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
+                                                        >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w rendered js-rendered"
+                                                                aria-label="Display the rich diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-file"
+                                                                    viewBox="0 0 12 16"
+                                                                    version="1.1"
+                                                                    width="12"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                    </span>
+
+                                                    <details
+                                                        class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                    >
+                                                        <summary class="btn-link v-align-middle" aria-haspopup="menu">
                                                             <svg
-                                                                class="octicon octicon-code"
-                                                                viewBox="0 0 14 16"
+                                                                class="octicon octicon-kebab-horizontal text-gray"
+                                                                aria-label="Show options"
+                                                                viewBox="0 0 13 16"
                                                                 version="1.1"
-                                                                width="14"
+                                                                width="13"
                                                                 height="16"
-                                                                aria-hidden="true"
+                                                                role="img"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
                                                                 ></path>
                                                             </svg>
-                                                        </button>
-                                                    </form>
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w rendered js-rendered"
-                                                            aria-label="Display the rich diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                        </summary>
+                                                        <details-menu
+                                                            class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                            style="width:185px; z-index:99; right: -4px;"
+                                                            role="menu"
                                                         >
-                                                            <svg
-                                                                class="octicon octicon-file"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
+                                                            <label
+                                                                role="menuitem"
+                                                                class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                tabindex="0"
                                                             >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
-                                                                ></path>
-                                                            </svg>
-                                                        </button>
-                                                    </form>
-                                                </span>
+                                                                <span class="file-notes-check position-absolute ml-n3"
+                                                                    ><svg
+                                                                        class="octicon octicon-check"
+                                                                        viewBox="0 0 12 16"
+                                                                        version="1.1"
+                                                                        width="12"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                        ></path></svg
+                                                                ></span>
+                                                                <input
+                                                                    type="checkbox"
+                                                                    checked="checked"
+                                                                    class="d-none js-toggle-file-notes"
+                                                                />
+                                                                Show comments
+                                                            </label>
 
-                                                <div class="BtnGroup">
-                                                    <a
-                                                        href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
-                                                        class="btn btn-sm BtnGroup-item"
-                                                        rel="nofollow"
-                                                    >
-                                                        View file
-                                                    </a>
+                                                            <div role="none" class="dropdown-divider"></div>
+
+                                                            <a
+                                                                href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                rel="nofollow"
+                                                                role="menuitem"
+                                                                data-ga-click="View file, click, location:files_changed_dropdown"
+                                                            >
+                                                                View file
+                                                            </a>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to make changes."
+                                                            >
+                                                                Edit file
+                                                            </button>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to delete this file."
+                                                            >
+                                                                Delete file
+                                                            </button>
+                                                        </details-menu>
+                                                    </details>
                                                 </div>
-
+                                            </div>
+                                            <div class="file-info">
                                                 <button
                                                     type="button"
-                                                    class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                    class="btn-octicon js-details-target"
                                                     aria-label="Toggle diff contents"
                                                     aria-expanded="true"
+                                                    style="width: 22px;"
                                                 >
                                                     <svg
                                                         class="octicon octicon-chevron-down Details-content--hidden"
@@ -3145,21 +3302,19 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         ></path>
                                                     </svg>
                                                     <svg
-                                                        class="octicon octicon-chevron-up Details-content--shown"
-                                                        viewBox="0 0 10 16"
+                                                        class="octicon octicon-chevron-right Details-content--shown"
+                                                        viewBox="0 0 8 16"
                                                         version="1.1"
-                                                        width="10"
+                                                        width="8"
                                                         height="16"
                                                         aria-hidden="true"
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                            d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                         ></path>
                                                     </svg>
                                                 </button>
-                                            </div>
-                                            <div class="file-info">
                                                 <span
                                                     class="diffstat tooltipped tooltipped-e"
                                                     aria-label="1 addition &amp; 1 deletion"
@@ -3176,6 +3331,41 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     title="doc/dev/incidents.md"
                                                     >doc/dev/incidents.md</a
                                                 >
+
+                                                <clipboard-copy
+                                                    value="doc/dev/incidents.md"
+                                                    aria-label="Copied!"
+                                                    class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                    tabindex="0"
+                                                    role="button"
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                        viewBox="0 0 14 16"
+                                                        version="1.1"
+                                                        width="14"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                        ></path>
+                                                    </svg>
+                                                    <svg
+                                                        class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                        ></path>
+                                                    </svg>
+                                                </clipboard-copy>
                                             </div>
                                         </div>
                                         <div class="js-file-content Details-content--hidden">
@@ -3813,8 +4003,8 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         Lock conversation
                                                     </summary>
                                                     <details-dialog
-                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         aria-label="Lock conversation on this commit"
+                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         role="dialog"
                                                     >
                                                         <div class="Box-header">
@@ -3880,7 +4070,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="QU2UW+uAzRCFFLMZ6refdfIoxEX6zUWy4opyIb85biUp7J5Di+oqqoCXCH7h0mgw3YsKy4yaqYZlXeWsoXb/yQ=="
+                                                                    value="sN9qLYdIPBaPlnZQbw4CuYrBWNVPv1mdtOyAIa83DKXYfmA15yLbrIoVzTdka/X8pWKWWznotakzOxessXidSQ=="
                                                                 />
                                                                 <button type="submit" class="btn btn-danger btn-block">
                                                                     Lock conversation on this commit
@@ -3936,7 +4126,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="RRx+D0SOB4nzetZD92PWEW4o/2biY4nDJXtpHCO1fUTXBcsmewZV+YgjHK1wFzlmWfJ9dBLr37HAG6shtmRIag=="
+                                            value="HQ8G2KWplc035lWwaljO1n0g9WJELAtzEkmx8oc/+iCPFrPxmiHHvUy/n17tLCGhSvp3cLSkXQH3KXPPEu7PDg=="
                                         />
                                         <div class="timeline-comment">
                                             <input
@@ -3948,7 +4138,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             <div
                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                data-preview-authenticity-token="GFXKOsdMIszP9xRNirEyOz0tnAXiJFn77c2OTFlVH2HYRZdCRGAYJ/D+A7gmcXMofz6bTliabXif0UvpdBj1Tw=="
+                                                data-preview-authenticity-token="keXwXttv4pUZH2rUsSjwIgNyuSl94XhNtJou74RBcMVR9a0mWEPYfiYWfSEd6LExQWG+YsdfTM7GhutKqQya6w=="
                                             >
                                                 <div class="comment-form-head tabnav ">
                                                     <markdown-toolbar
@@ -4290,7 +4480,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                 type="button"
                                                                 class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                 aria-label="Upload attachments"
-                                                                hotkey="u"
+                                                                data-hotkey="u"
                                                             >
                                                                 <svg
                                                                     aria-hidden="true"
@@ -4336,7 +4526,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     class="js-upload-markdown-image is-default"
                                                     data-upload-repository-id="41288708"
                                                     data-upload-policy-url="/upload/policies/assets"
-                                                    data-upload-policy-authenticity-token="SDUCDSoEs8h4Xl3l2ijYsNojxW1DM0UDlIu50A8qm9t6I06cZWlPg41RCHbu/S/JFW7xe2e0CXFUQgwffpbu6w=="
+                                                    data-upload-policy-authenticity-token="MIrt6s9EwncCpDFCtxzh4g/h7QQ8TRNpP7ftQnbux6ICnKF7gCk+PPerZNGDyRabwKzZEhjKXxv/fliNB1Kykg=="
                                                 >
                                                     <div
                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -4362,7 +4552,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             required=""
                                                         ></textarea>
 
-                                                        <p class="drag-and-drop position-relative">
+                                                        <p
+                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                        >
                                                             <input
                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                 type="file"
@@ -4481,6 +4673,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     </span>
                                                                 </span>
                                                             </span>
+                                                            <span
+                                                                class="tooltipped tooltipped-nw"
+                                                                aria-label="Styling with Markdown is supported"
+                                                            >
+                                                                <a
+                                                                    class="tabnav-extra position-relative d-inline"
+                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                    target="_blank"
+                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                    aria-label="Learn about styling with Markdown"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                        viewBox="0 0 16 16"
+                                                                        version="1.1"
+                                                                        width="16"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </a>
+                                                            </span>
                                                         </p>
                                                     </div>
                                                 </file-attachment>
@@ -4503,30 +4721,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <p>Nothing to preview</p>
                                                         </div>
                                                     </div>
-                                                </div>
-
-                                                <div class="float-left ">
-                                                    <a
-                                                        class="tabnav-extra "
-                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                        target="_blank"
-                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                    >
-                                                        <svg
-                                                            class="octicon octicon-markdown v-align-bottom"
-                                                            viewBox="0 0 16 16"
-                                                            version="1.1"
-                                                            width="16"
-                                                            height="16"
-                                                            aria-hidden="true"
-                                                        >
-                                                            <path
-                                                                fill-rule="evenodd"
-                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                            ></path>
-                                                        </svg>
-                                                        Styling with Markdown is supported
-                                                    </a>
                                                 </div>
 
                                                 <div
@@ -4569,7 +4763,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         d="M4.79 6.11c.25-.25.25-.67 0-.92-.32-.33-.48-.76-.48-1.19 0-.43.16-.86.48-1.19.25-.26.25-.67 0-.92a.613.613 0 0 0-.45-.19c-.16 0-.33.06-.45.19-.57.58-.85 1.35-.85 2.11 0 .76.29 1.53.85 2.11.25.25.66.25.9 0zM2.33.52a.651.651 0 0 0-.92 0C.48 1.48.01 2.74.01 3.99c0 1.26.47 2.52 1.4 3.48.25.26.66.26.91 0s.25-.68 0-.94c-.68-.7-1.02-1.62-1.02-2.54 0-.92.34-1.84 1.02-2.54a.66.66 0 0 0 .01-.93zm5.69 5.1A1.62 1.62 0 1 0 6.4 4c-.01.89.72 1.62 1.62 1.62zM14.59.53a.628.628 0 0 0-.91 0c-.25.26-.25.68 0 .94.68.7 1.02 1.62 1.02 2.54 0 .92-.34 1.83-1.02 2.54-.25.26-.25.68 0 .94a.651.651 0 0 0 .92 0c.93-.96 1.4-2.22 1.4-3.48A5.048 5.048 0 0 0 14.59.53zM8.02 6.92c-.41 0-.83-.1-1.2-.3l-3.15 8.37h1.49l.86-1h4l.84 1h1.49L9.21 6.62c-.38.2-.78.3-1.19.3zm-.01.48L9.02 11h-2l.99-3.6zm-1.99 5.59l1-1h2l1 1h-4zm5.19-11.1c-.25.25-.25.67 0 .92.32.33.48.76.48 1.19 0 .43-.16.86-.48 1.19-.25.26-.25.67 0 .92a.63.63 0 0 0 .9 0c.57-.58.85-1.35.85-2.11 0-.76-.28-1.53-.85-2.11a.634.634 0 0 0-.9 0z"
                                     ></path>
                                 </svg>
-
                                 <!-- '"` --><!-- </textarea></xmp> -->
                                 <form
                                     data-replace-remote-form="true"
@@ -4581,7 +4774,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                     <input name="utf8" type="hidden" value="✓" /><input
                                         type="hidden"
                                         name="authenticity_token"
-                                        value="fMFmPXMBYVi/GNINRDfQIKZL0PC8W6FIQ5XwGimj75Kya0YjZu/TVMQmLYrlureIhl/eOHGZalKykDghWupjtg=="
+                                        value="1OyvObdJoaQ4sengbT1xvPvbBi8Odt1aExM3ZUngduoaRo8noqcTqEOPFmfMsBYU288I58O0FkDiFv9eOqn6zg=="
                                     />
                                     <input type="hidden" name="repository_id" value="41288708" />
                                     <input
@@ -4627,9 +4820,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                 class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light "
             >
                 <ul class="list-style-none d-flex flex-wrap ">
-                    <li class="mr-3">
-                        © 2019 <span title="0.50561s from unicorn-8456ccc87d-tzqns">GitHub</span>, Inc.
-                    </li>
+                    <li class="mr-3">© 2019 <span title="0.44231s from unicorn-65f4b75d5-dkblm">GitHub</span>, Inc.</li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
                             >Terms</a
@@ -4732,17 +4923,17 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">

--- a/client/browser/src/libs/github/__fixtures__/github.com/commit/vanilla/split/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/commit/vanilla/split/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split -->
 <html lang="en">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -36,6 +37,21 @@
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
+        <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="correct opsgenie command for one-off alerts (#3258) · sourcegraph/sourcegraph@d3d0fe7"
+        />
+        <meta
+            name="twitter:description"
+            content="* correct opsgenie command
+
+* Update doc/dev/incidents.md
+
+Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
+        />
         <meta property="og:image" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
@@ -60,11 +76,11 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjM5YzE3ZGVlM2M0Y2JlZmE1YmUwN2M4NGU1YjViNWNmMmJlYjFiNzBlNmY2MTRmOGE5MjI1NzVlZDIzNTMwMWM=--07431d7932942cbddc015f014ae44668223aaa95"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmUyYTZkYzYyMDI1MDZkM2IxN2I5Njg1NWM5M2QyNjkwY2U3YmUzNTRkZTM5Mzg4NjVlMjlhOTI5MjAyNTdhMjE=--fd1b397a641b24ab09c68e3940671ebb6563bf3a"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
-        <meta name="request-id" content="F7DC:4E12:18688FC:25038B6:5CA7A77D" data-pjax-transient="" />
+        <meta name="request-id" content="CC7B:46020:1C164A9:2A43C32:5CC228D0" data-pjax-transient="" />
 
         <meta name="selected-link" value="repo_commits" data-pjax-transient="" />
 
@@ -75,7 +91,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="F7DC:4E12:18688FC:25038B6:5CA7A77D" />
+        <meta name="octolytics-dimension-request_id" content="CC7B:46020:1C164A9:2A43C32:5CC228D0" />
         <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
@@ -93,26 +109,26 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="MmIwY2JmNDgwZWZjMmIyZjVhNmFkZTcxMDdhMGRmYzY5NmYzZjFiOGUwZWJhN2Q2ODhjNTE4YjY3ZmE3NGY0Ynx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiRjdEQzo0RTEyOjE4Njg4RkM6MjUwMzhCNjo1Q0E3QTc3RCIsInRpbWVzdGFtcCI6MTU1NDQ5MTI2OSwiaG9zdCI6ImdpdGh1Yi5jb20ifQ=="
+            content="ZjM4ZWY0OTRkYTJjZTc3NzlkY2IzM2I5MjRhYTZiYTc0Y2FkYzc0YTU1NDRlNGVhZDhiYmFiMzlkYjhkYTg3ZHx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkNDN0I6NDYwMjA6MUMxNjRBOToyQTQzQzMyOjVDQzIyOEQwIiwidGltZXN0YW1wIjoxNTU2MjI4MzA1LCJob3N0IjoiZ2l0aHViLmNvbSJ9"
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
-            href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.diff"
+            href="/sourcegraph/sourcegraph/commit/d3d0fe7.diff"
             rel="alternate"
             type="text/plain+diff"
             data-pjax-transient="true"
         />
         <link
-            href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.patch"
+            href="/sourcegraph/sourcegraph/commit/d3d0fe7.patch"
             rel="alternate"
             type="text/plain+patch"
             data-pjax-transient="true"
@@ -232,7 +248,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=okdG6EG4HLAXVUDnSWuZmxLTMuuRdMJAOPqk8BVvCgv7YNcfZQiNOPNMnYxCguFAtdcMzof8KuOXD4qhGFlvBg=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=bAmkwMdAEM8aghFqUNXQh+6d6qzelJ75nvnfH0gRBmA1LjU34/CBR/6bzAFbPKhcSZnUicgcdloxDPFORSdjbQ=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -633,6 +649,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                     </nav>
                 </div>
 
+                <div class="Header-item position-relative"></div>
+
                 <div class="Header-item"></div>
 
                 <div class="Header-item position-relative">
@@ -692,7 +710,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -726,7 +744,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -739,47 +757,53 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"F7DC:4E12:18688FC:25038B6:5CA7A77D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092"}}'
-                                            data-hydro-click-hmac="da419dcda20e65d6872badd9493e64b3954e6ae954ede1cbbee22d11cfdbf328"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"CC7B:46020:1C164A9:2A43C32:5CC228D0","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null}}'
+                                            data-hydro-click-hmac="635131a789af6f9462315e7c3a7c80b04015ea7f4a562e1bbd935bdaee11eb39"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -801,7 +825,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="bdHoGnnKyzc9H7OuGO4G8fo66J4TE9tYfWZeAptfT4Sbv0fBOEsC67hJFeoToU3y5F8pnD0/d6nrK5rtLLnseA=="
+                                                    value="lhY3q/WbNezHAYKlYcrnBagZEH0u17Hoq3enQsSKyjFgeJhwtBr8MEJXJOFqhawGtnzRfwD7HRk9OmOtc2xpzQ=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -830,7 +854,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -852,14 +876,34 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -883,8 +927,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -914,7 +957,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -938,7 +981,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -959,7 +1002,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -982,7 +1025,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -1003,7 +1046,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1022,6 +1065,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1041,7 +1085,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1080,13 +1124,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T21:37:49+02:00"
+                                                                        value="2019-04-26T00:08:25+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1096,7 +1140,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:07:49+02:00"
+                                                                        value="2019-04-26T00:38:25+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1106,7 +1150,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:07:49+02:00"
+                                                                        value="2019-04-26T03:38:25+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1116,7 +1160,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-25T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1126,7 +1170,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1151,15 +1195,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1229,7 +1271,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="9wQWOSzHYk4iWGqps7rMHG+Z51zIm3fwttDB+9GKsKzwyHUBhVkx4nJLeycTzqTkAAUVB2r6kgkT3eoHDJ2O8A=="
+                                    value="4gKQV5IngOSk2jqMrwEOsgmNTusZ7g9bRaUoHFoh+xrlzvNvO7nTSPTJKwIPdWZKZhG8sLuP6qLgqAPghzbFRg=="
                                 />
 
                                 <button
@@ -1269,15 +1311,15 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="7395+d039her4BvP7++3qSbtCHwgYwHfgNiYxuOVJlx3CiSLR2z+8pytqCi99BBygUlc4WTdijpQZ14gjNGYtg=="
+                                            value="OaC/V0LYoJoe+nzrm0ef84NnP0/M9+Mk/hPbtvZlh3ah1eIl2IOofym3zwzJXDgoJMNr0ohJaMEurB1QmSE5nA=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7DC:4E12:18688FC:25038B6:5CA7A77D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092","user_id":10532611}}'
-                                                data-hydro-click-hmac="c72195b1b571d42560d0fc34ec67c2966efd07992b862f919965bdfb49ed4724"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC7B:46020:1C164A9:2A43C32:5CC228D0","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="636bffb66cafefb355e968fba4b0476598eb01e8114da4bc3cb9e31d4fc11584"
                                                 data-ga-click="Repository, click Watch settings, action:commit#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1300,7 +1342,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1504,9 +1546,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1523,7 +1565,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="eSQPq7J64JFrwFRrKWsF6fYCbhGuipKLm2En6fhAgY/1hmALrkRXocYpz7nQVcZHYqxh//cijJ/Kme9kUY2GwQ=="
+                                                value="xYwNwI5aOpzgRlXw/pG2Vkcj1G4KESFk/ZaqLImzieBJLmJgkmSNrE2vziIHr3X4043bgFO5P3CsbmKhIH6Org=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1531,8 +1573,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7DC:4E12:18688FC:25038B6:5CA7A77D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092","user_id":10532611}}'
-                                                data-hydro-click-hmac="0b0bdf287948b253465f1e479068503327660da4e480179b35f63b8f220ba2d0"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC7B:46020:1C164A9:2A43C32:5CC228D0","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="f9a91bb15660d16addc15ba431c7840bcc7be3ee48647be350592ad6b8894450"
                                                 data-ga-click="Repository, click unstar button, action:commit#show; text:Unstar"
                                             >
                                                 <svg
@@ -1553,9 +1595,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1568,7 +1610,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="+jjUY/1csFy3p211wUxNxRqjY17/R4BFEHKNWpN6yyFDAxQSdDkEFYaFwWwk7koYXzLgNIIgOL1lqMdBgWrxsw=="
+                                                value="eIFJBFuX+o3+yhBsQRm4daQfAKrmnXQjLzf6EqDRksXBuol10vJOxM/ovHWku7+o4Y6DwJv6zNta7bAJssGoVw=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1576,8 +1618,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7DC:4E12:18688FC:25038B6:5CA7A77D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092","user_id":10532611}}'
-                                                data-hydro-click-hmac="4464a84b5faa4a6ebc4624276f356710c3397d304d52dbdd357f21676e07604c"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC7B:46020:1C164A9:2A43C32:5CC228D0","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="f618ebc58016f1ed3d210c8a59ffb14ab6b2923b69351e60ad6acf2d018e4e83"
                                                 data-ga-click="Repository, click star button, action:commit#show; text:Star"
                                             >
                                                 <svg
@@ -1598,9 +1640,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1609,16 +1651,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <li>
                                     <details
                                         class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
-                                        data-deferred-details-content-url="/sourcegraph/sourcegraph/fork?fragment=1"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7DC:4E12:18688FC:25038B6:5CA7A77D","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092","user_id":10532611}}'
-                                            data-hydro-click-hmac="9f97c80ee94b698d730b15798e049d1ad1ba8700e8e14dc17cf65032c7c8e5b7"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC7B:46020:1C164A9:2A43C32:5CC228D0","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="0f3127ce7be92566373d76b5c2bdadf9f142423ccfffac94168ca14e19fb8de3"
                                             data-ga-click="Repository, show fork modal, action:commit#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1638,6 +1677,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1679,9 +1720,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1776,7 +1817,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">695</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1803,7 +1844,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">82</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -1961,6 +2002,42 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             >)
                                         </li>
                                     </ul>
+                                    <svg
+                                        class="octicon octicon-tag"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M7.73 1.73C7.26 1.26 6.62 1 5.96 1H3.5C2.13 1 1 2.13 1 3.5v2.47c0 .66.27 1.3.73 1.77l6.06 6.06c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41L7.73 1.73zM2.38 7.09c-.31-.3-.47-.7-.47-1.13V3.5c0-.88.72-1.59 1.59-1.59h2.47c.42 0 .83.16 1.13.47l6.14 6.13-4.73 4.73-6.13-6.15zM3.01 3h2v2H3V3h.01z"
+                                        ></path>
+                                    </svg>
+                                    <ul class="branches-tag-list js-details-container">
+                                        <li><a href="/sourcegraph/sourcegraph/releases/tag/v3.3.1">v3.3.1</a></li>
+                                        <li class="abbrev-tags">
+                                            <span class="hidden-text-expander"
+                                                ><button
+                                                    type="button"
+                                                    class="ellipsis-expander js-details-target"
+                                                    aria-expanded="false"
+                                                >
+                                                    …
+                                                </button></span
+                                            >
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0">v3.3.0</a>
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.2">v3.3.0-rc.2</a>
+                                        </li>
+                                        <li>
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.1">v3.3.0-rc.1</a>
+                                        </li>
+                                    </ul>
                                 </div>
 
                                 <div class="commit-meta p-2 d-flex flex-wrap">
@@ -1995,7 +2072,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                         committed
                                         <relative-time datetime="2019-04-05T16:55:33Z" title="5 Apr 2019, 18:55 CEST"
-                                            >2 hours ago</relative-time
+                                            >20 days ago</relative-time
                                         >
 
                                         <details
@@ -2086,8 +2163,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                 <div
                                                     class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                 >
-                                                    <div class="inline-comment-form-actions"></div>
-
                                                     <div class="inline-comment-form">
                                                         <!-- '"` --><!-- </textarea></xmp> -->
                                                         <form
@@ -2099,7 +2174,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <input name="utf8" type="hidden" value="✓" /><input
                                                                 type="hidden"
                                                                 name="authenticity_token"
-                                                                value="3KM9z6mOmB37yfIgW8Kpjbj+kjZDtKMNtZskcd0BBC5OuojmlgbKbYCQOM7ctkb6jyQQJLM89X9Q++ZMSNAxAA=="
+                                                                value="e6guGSeAAi8sbnslHyreZJYsajTau6xTAu0JtW5zvP7psZswGAhQX1c3scuYXjETofboJioz+iHnjcuI+6KJ0A=="
                                                             />
                                                             <input type="hidden" name="comment_context" value="diff" />
 
@@ -2113,11 +2188,11 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <div
                                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                                data-preview-authenticity-token="fN/Vr4ll/7yOzWWmPfmM/f4m+kid26zbGW5q79jVNXG8z4jXCknFV7HEclOROc3uvDX9AydlmFhrcq9K9ZjfXw=="
+                                                                data-preview-authenticity-token="O3k8k9gn9bt7vNoIGmjOOd9r/wFiCKlJPsi9y4JDdG/7aWHrWwvPUES1zf22qI8qnXj4Sti2ncpM1Hhurw6eQQ=="
                                                             >
                                                                 <div class="comment-form-head tabnav ">
                                                                     <markdown-toolbar
-                                                                        for="r424667 new_inline_comment_diff_${anchor}_${position}"
+                                                                        for="r721317 new_inline_comment_diff_${anchor}_${position}"
                                                                         class="toolbar-commenting "
                                                                     >
                                                                         <div class="toolbar-group">
@@ -2471,7 +2546,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     class="js-upload-markdown-image is-default"
                                                                     data-upload-repository-id="41288708"
                                                                     data-upload-policy-url="/upload/policies/assets"
-                                                                    data-upload-policy-authenticity-token="6p1y3cbVAxOPxCWKa1HSwOxOD/VAc4jIavH5sxlLnF7Yiz5Mibj/WHrLcBlfhCW5IwM742T0xLqqOEx8aPfpbg=="
+                                                                    data-upload-policy-authenticity-token="aQGfgGNH/ANKnZCghJEaDPi7kPoYVMzjNQI/XMTguS9bF9MRLCoASL+SxTOwRO11N/ak7DzTgJH1y4qTtVzMHw=="
                                                                 >
                                                                     <div
                                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -2487,7 +2562,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                                                         <textarea
                                                                             name="comment[body]"
-                                                                            id="r424667 new_inline_comment_diff_${anchor}_${position}"
+                                                                            id="r721317 new_inline_comment_diff_${anchor}_${position}"
                                                                             placeholder="Leave a comment"
                                                                             aria-label="Comment body"
                                                                             class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -2497,7 +2572,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             required=""
                                                                         ></textarea>
 
-                                                                        <p class="drag-and-drop position-relative">
+                                                                        <p
+                                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                        >
                                                                             <input
                                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                 type="file"
@@ -2633,6 +2710,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                     </span>
                                                                                 </span>
                                                                             </span>
+                                                                            <span
+                                                                                class="tooltipped tooltipped-nw"
+                                                                                aria-label="Styling with Markdown is supported"
+                                                                            >
+                                                                                <a
+                                                                                    class="tabnav-extra position-relative d-inline"
+                                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                                    target="_blank"
+                                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                                    aria-label="Learn about styling with Markdown"
+                                                                                >
+                                                                                    <svg
+                                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                                        viewBox="0 0 16 16"
+                                                                                        version="1.1"
+                                                                                        width="16"
+                                                                                        height="16"
+                                                                                        aria-hidden="true"
+                                                                                    >
+                                                                                        <path
+                                                                                            fill-rule="evenodd"
+                                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                        ></path>
+                                                                                    </svg>
+                                                                                </a>
+                                                                            </span>
                                                                         </p>
                                                                     </div>
                                                                 </file-attachment>
@@ -2667,30 +2770,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             <p>Nothing to preview</p>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-
-                                                                <div class="float-left ">
-                                                                    <a
-                                                                        class="tabnav-extra "
-                                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                                        target="_blank"
-                                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                                    >
-                                                                        <svg
-                                                                            class="octicon octicon-markdown v-align-bottom"
-                                                                            viewBox="0 0 16 16"
-                                                                            version="1.1"
-                                                                            width="16"
-                                                                            height="16"
-                                                                            aria-hidden="true"
-                                                                        >
-                                                                            <path
-                                                                                fill-rule="evenodd"
-                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                            ></path>
-                                                                        </svg>
-                                                                        Styling with Markdown is supported
-                                                                    </a>
                                                                 </div>
 
                                                                 <div
@@ -2755,8 +2834,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                 <div
                                                     class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                 >
-                                                    <div class="inline-comment-form-actions"></div>
-
                                                     <div class="inline-comment-form">
                                                         <!-- '"` --><!-- </textarea></xmp> -->
                                                         <form
@@ -2768,7 +2845,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <input name="utf8" type="hidden" value="✓" /><input
                                                                 type="hidden"
                                                                 name="authenticity_token"
-                                                                value="wBrqAtNMmoBK6qGhmCfNbJAkSYov1FvQDN8vOF4pcqhSA18r7MTI8DGza08fUyIbp/7LmN9cDaLpv+0Fy/hHhg=="
+                                                                value="D9vWTTOvCDL/K4ADfVohqskGRXzjLyuYGQesevAOa8adwmNkDCdaQoRySu36Ls7d/tzHbhOnfer8Z25HZd9e6A=="
                                                             />
                                                             <input type="hidden" name="comment_context" value="diff" />
 
@@ -2782,11 +2859,11 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <div
                                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                                data-preview-authenticity-token="ofP3txHAbcEPQMZVy5B738hi4gl4giTdW8Nzmn2jui5h46rPkuxXKjBJ0aBnUDrMinHlQsI8EF4p37Y/UO5QAA=="
+                                                                data-preview-authenticity-token="XQga1ln4l47sm/ZufwGVTabxU3iSK3niEK3SvOb5nQqdGEeu2tStZdOS4ZvTwdRe5OJUMyiVTWFisRcZy7R3JA=="
                                                             >
                                                                 <div class="comment-form-head tabnav ">
                                                                     <markdown-toolbar
-                                                                        for="r394129 new_inline_comment_diff_${anchor}_${position}"
+                                                                        for="r174174 new_inline_comment_diff_${anchor}_${position}"
                                                                         class="toolbar-commenting "
                                                                     >
                                                                         <div class="toolbar-group">
@@ -3140,7 +3217,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     class="js-upload-markdown-image is-default"
                                                                     data-upload-repository-id="41288708"
                                                                     data-upload-policy-url="/upload/policies/assets"
-                                                                    data-upload-policy-authenticity-token="9M1MsHR1INUvqCpnszodvXKsy1GqrcUPxNA9ZlxCQP/G2wAhOxjcntqnf/SH7+rEveH/R44qiX0EGYipLf41zw=="
+                                                                    data-upload-policy-authenticity-token="XNfO1ne9mm9T8DlOQK+1LK/cdGcQmSsuqMFw5KGZuZ1uwYJHONBmJKb/bN10ekJVYJFAcTQeZ1xoCMUr0CXMrQ=="
                                                                 >
                                                                     <div
                                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -3156,7 +3233,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                                                         <textarea
                                                                             name="comment[body]"
-                                                                            id="r394129 new_inline_comment_diff_${anchor}_${position}"
+                                                                            id="r174174 new_inline_comment_diff_${anchor}_${position}"
                                                                             placeholder="Leave a comment"
                                                                             aria-label="Comment body"
                                                                             class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -3166,7 +3243,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             required=""
                                                                         ></textarea>
 
-                                                                        <p class="drag-and-drop position-relative">
+                                                                        <p
+                                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                        >
                                                                             <input
                                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                 type="file"
@@ -3302,6 +3381,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                     </span>
                                                                                 </span>
                                                                             </span>
+                                                                            <span
+                                                                                class="tooltipped tooltipped-nw"
+                                                                                aria-label="Styling with Markdown is supported"
+                                                                            >
+                                                                                <a
+                                                                                    class="tabnav-extra position-relative d-inline"
+                                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                                    target="_blank"
+                                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                                    aria-label="Learn about styling with Markdown"
+                                                                                >
+                                                                                    <svg
+                                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                                        viewBox="0 0 16 16"
+                                                                                        version="1.1"
+                                                                                        width="16"
+                                                                                        height="16"
+                                                                                        aria-hidden="true"
+                                                                                    >
+                                                                                        <path
+                                                                                            fill-rule="evenodd"
+                                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                        ></path>
+                                                                                    </svg>
+                                                                                </a>
+                                                                            </span>
                                                                         </p>
                                                                     </div>
                                                                 </file-attachment>
@@ -3336,30 +3441,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             <p>Nothing to preview</p>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-
-                                                                <div class="float-left ">
-                                                                    <a
-                                                                        class="tabnav-extra "
-                                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                                        target="_blank"
-                                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                                    >
-                                                                        <svg
-                                                                            class="octicon octicon-markdown v-align-bottom"
-                                                                            viewBox="0 0 16 16"
-                                                                            version="1.1"
-                                                                            width="16"
-                                                                            height="16"
-                                                                            aria-hidden="true"
-                                                                        >
-                                                                            <path
-                                                                                fill-rule="evenodd"
-                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                            ></path>
-                                                                        </svg>
-                                                                        Styling with Markdown is supported
-                                                                    </a>
                                                                 </div>
 
                                                                 <div
@@ -3506,94 +3587,162 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             data-file-deleted="false"
                                         >
                                             <div class="file-actions">
-                                                <span class="show-file-notes pt-1">
-                                                    <label>
-                                                        <input
-                                                            type="checkbox"
-                                                            checked="checked"
-                                                            class="js-toggle-file-notes"
-                                                        />
-                                                        Show comments
-                                                    </label>
-                                                </span>
-
-                                                <span class="BtnGroup">
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w source js-source selected"
-                                                            aria-current="true"
-                                                            aria-label="Display the source diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                <div class="mt-1">
+                                                    <span class="BtnGroup mt-n1">
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
                                                         >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w source js-source selected"
+                                                                aria-current="true"
+                                                                aria-label="Display the source diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-code"
+                                                                    viewBox="0 0 14 16"
+                                                                    version="1.1"
+                                                                    width="14"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
+                                                        >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w rendered js-rendered"
+                                                                aria-label="Display the rich diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-file"
+                                                                    viewBox="0 0 12 16"
+                                                                    version="1.1"
+                                                                    width="12"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                    </span>
+
+                                                    <details
+                                                        class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                    >
+                                                        <summary class="btn-link v-align-middle" aria-haspopup="menu">
                                                             <svg
-                                                                class="octicon octicon-code"
-                                                                viewBox="0 0 14 16"
+                                                                class="octicon octicon-kebab-horizontal text-gray"
+                                                                aria-label="Show options"
+                                                                viewBox="0 0 13 16"
                                                                 version="1.1"
-                                                                width="14"
+                                                                width="13"
                                                                 height="16"
-                                                                aria-hidden="true"
+                                                                role="img"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
                                                                 ></path>
                                                             </svg>
-                                                        </button>
-                                                    </form>
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w rendered js-rendered"
-                                                            aria-label="Display the rich diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                        </summary>
+                                                        <details-menu
+                                                            class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                            style="width:185px; z-index:99; right: -4px;"
+                                                            role="menu"
                                                         >
-                                                            <svg
-                                                                class="octicon octicon-file"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
+                                                            <label
+                                                                role="menuitem"
+                                                                class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                tabindex="0"
                                                             >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
-                                                                ></path>
-                                                            </svg>
-                                                        </button>
-                                                    </form>
-                                                </span>
+                                                                <span class="file-notes-check position-absolute ml-n3"
+                                                                    ><svg
+                                                                        class="octicon octicon-check"
+                                                                        viewBox="0 0 12 16"
+                                                                        version="1.1"
+                                                                        width="12"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                        ></path></svg
+                                                                ></span>
+                                                                <input
+                                                                    type="checkbox"
+                                                                    checked="checked"
+                                                                    class="d-none js-toggle-file-notes"
+                                                                />
+                                                                Show comments
+                                                            </label>
 
-                                                <div class="BtnGroup">
-                                                    <a
-                                                        href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
-                                                        class="btn btn-sm BtnGroup-item"
-                                                        rel="nofollow"
-                                                    >
-                                                        View file
-                                                    </a>
+                                                            <div role="none" class="dropdown-divider"></div>
+
+                                                            <a
+                                                                href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                rel="nofollow"
+                                                                role="menuitem"
+                                                                data-ga-click="View file, click, location:files_changed_dropdown"
+                                                            >
+                                                                View file
+                                                            </a>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to make changes."
+                                                            >
+                                                                Edit file
+                                                            </button>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to delete this file."
+                                                            >
+                                                                Delete file
+                                                            </button>
+                                                        </details-menu>
+                                                    </details>
                                                 </div>
-
+                                            </div>
+                                            <div class="file-info">
                                                 <button
                                                     type="button"
-                                                    class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                    class="btn-octicon js-details-target"
                                                     aria-label="Toggle diff contents"
                                                     aria-expanded="true"
+                                                    style="width: 22px;"
                                                 >
                                                     <svg
                                                         class="octicon octicon-chevron-down Details-content--hidden"
@@ -3609,21 +3758,19 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         ></path>
                                                     </svg>
                                                     <svg
-                                                        class="octicon octicon-chevron-up Details-content--shown"
-                                                        viewBox="0 0 10 16"
+                                                        class="octicon octicon-chevron-right Details-content--shown"
+                                                        viewBox="0 0 8 16"
                                                         version="1.1"
-                                                        width="10"
+                                                        width="8"
                                                         height="16"
                                                         aria-hidden="true"
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                            d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                         ></path>
                                                     </svg>
                                                 </button>
-                                            </div>
-                                            <div class="file-info">
                                                 <span
                                                     class="diffstat tooltipped tooltipped-e"
                                                     aria-label="1 addition &amp; 1 deletion"
@@ -3640,6 +3787,41 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     title="doc/dev/incidents.md"
                                                     >doc/dev/incidents.md</a
                                                 >
+
+                                                <clipboard-copy
+                                                    value="doc/dev/incidents.md"
+                                                    aria-label="Copied!"
+                                                    class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                    tabindex="0"
+                                                    role="button"
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                        viewBox="0 0 14 16"
+                                                        version="1.1"
+                                                        width="14"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                        ></path>
+                                                    </svg>
+                                                    <svg
+                                                        class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                        ></path>
+                                                    </svg>
+                                                </clipboard-copy>
                                             </div>
                                         </div>
                                         <div class="js-file-content Details-content--hidden">
@@ -3967,7 +4149,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                 data-line-number="42"
                                                             ></td>
 
-                                                            <td class="code-review blob-code blob-code-deletion">
+                                                            <td class="code-review blob-code blob-code-deletion ">
                                                                 <button
                                                                     class="btn-link add-line-comment js-add-line-comment js-add-split-line-comment"
                                                                     data-type="deletion"
@@ -4486,8 +4668,8 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         Lock conversation
                                                     </summary>
                                                     <details-dialog
-                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         aria-label="Lock conversation on this commit"
+                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         role="dialog"
                                                     >
                                                         <div class="Box-header">
@@ -4553,7 +4735,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="oGSnylqtI0Ha9a7y12uc5BCoyiprRvBH5aU5/K7abMXIxa3SOsfE+992FZXcDmuhPwsEpB0RHHNicq5xsJX9KQ=="
+                                                                    value="6+YhUloC462z6CVjxP/VBbrePIFpln/fzM2EBeDooO6DRytKOmgEF7ZrngTPmiJAlX3yDx/Bk+tLGhOI/qcxAg=="
                                                                 />
                                                                 <button type="submit" class="btn btn-danger btn-block">
                                                                     Lock conversation on this commit
@@ -4609,7 +4791,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="5DOhF7pneq1S3zvlmLsT0oIcQrPXlRQ6cutNFDxvlhx2KhQ+he8o3SmG8Qsfz/yltcbAoScdQkiXi48pqb6jMg=="
+                                            value="GJfa5R5/zVP5DEq1eF5RmhVXmDAkL+1vj1e6qTiJO2WKjm/MIfefI4JVgFv/Kr7tIo0aItSnux1qN3iUrVgOSw=="
                                         />
                                         <div class="timeline-comment">
                                             <input
@@ -4621,7 +4803,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             <div
                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                data-preview-authenticity-token="JPYskQo8c6UWi6FCLojinUijnqz3ngNzZmCfwKIUjEPk5nHpiRBJTimCtreCSKOOCrCZ500gN/AUfFplj1lmbQ=="
+                                                data-preview-authenticity-token="xznKvANywOHTuL0dP10B2Z2o11z/WJLNSg6jbblzeA4HKZfEgF76CuyxquiTnUDK37vQF0Xmpk44EmbIlD6SIA=="
                                             >
                                                 <div class="comment-form-head tabnav ">
                                                     <markdown-toolbar
@@ -4975,7 +5157,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     class="js-upload-markdown-image is-default"
                                                     data-upload-repository-id="41288708"
                                                     data-upload-policy-url="/upload/policies/assets"
-                                                    data-upload-policy-authenticity-token="6VZFg2/xg5egs3ZYC3QJrUrJDvBC3wmUDxU+jxaC+Q7bQAkSIJx/3FW8I8s/of7UhYQ65mZYRebP3ItAZz6MPg=="
+                                                    data-upload-policy-authenticity-token="BAoVSrKooUAjuWOE6yuAOagb5Msbexl6TGoMsWaf1w82HFnb/cVdC9a2Nhff/ndAZ1bQ3T/8VQiMo7l+FyOiPw=="
                                                 >
                                                     <div
                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -5001,7 +5183,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             required=""
                                                         ></textarea>
 
-                                                        <p class="drag-and-drop position-relative">
+                                                        <p
+                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                        >
                                                             <input
                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                 type="file"
@@ -5120,6 +5304,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     </span>
                                                                 </span>
                                                             </span>
+                                                            <span
+                                                                class="tooltipped tooltipped-nw"
+                                                                aria-label="Styling with Markdown is supported"
+                                                            >
+                                                                <a
+                                                                    class="tabnav-extra position-relative d-inline"
+                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                    target="_blank"
+                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                    aria-label="Learn about styling with Markdown"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                        viewBox="0 0 16 16"
+                                                                        version="1.1"
+                                                                        width="16"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </a>
+                                                            </span>
                                                         </p>
                                                     </div>
                                                 </file-attachment>
@@ -5140,30 +5350,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <p>Nothing to preview</p>
                                                         </div>
                                                     </div>
-                                                </div>
-
-                                                <div class="float-left ">
-                                                    <a
-                                                        class="tabnav-extra "
-                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                        target="_blank"
-                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                    >
-                                                        <svg
-                                                            class="octicon octicon-markdown v-align-bottom"
-                                                            viewBox="0 0 16 16"
-                                                            version="1.1"
-                                                            width="16"
-                                                            height="16"
-                                                            aria-hidden="true"
-                                                        >
-                                                            <path
-                                                                fill-rule="evenodd"
-                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                            ></path>
-                                                        </svg>
-                                                        Styling with Markdown is supported
-                                                    </a>
                                                 </div>
 
                                                 <div
@@ -5206,7 +5392,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         d="M4.79 6.11c.25-.25.25-.67 0-.92-.32-.33-.48-.76-.48-1.19 0-.43.16-.86.48-1.19.25-.26.25-.67 0-.92a.613.613 0 0 0-.45-.19c-.16 0-.33.06-.45.19-.57.58-.85 1.35-.85 2.11 0 .76.29 1.53.85 2.11.25.25.66.25.9 0zM2.33.52a.651.651 0 0 0-.92 0C.48 1.48.01 2.74.01 3.99c0 1.26.47 2.52 1.4 3.48.25.26.66.26.91 0s.25-.68 0-.94c-.68-.7-1.02-1.62-1.02-2.54 0-.92.34-1.84 1.02-2.54a.66.66 0 0 0 .01-.93zm5.69 5.1A1.62 1.62 0 1 0 6.4 4c-.01.89.72 1.62 1.62 1.62zM14.59.53a.628.628 0 0 0-.91 0c-.25.26-.25.68 0 .94.68.7 1.02 1.62 1.02 2.54 0 .92-.34 1.83-1.02 2.54-.25.26-.25.68 0 .94a.651.651 0 0 0 .92 0c.93-.96 1.4-2.22 1.4-3.48A5.048 5.048 0 0 0 14.59.53zM8.02 6.92c-.41 0-.83-.1-1.2-.3l-3.15 8.37h1.49l.86-1h4l.84 1h1.49L9.21 6.62c-.38.2-.78.3-1.19.3zm-.01.48L9.02 11h-2l.99-3.6zm-1.99 5.59l1-1h2l1 1h-4zm5.19-11.1c-.25.25-.25.67 0 .92.32.33.48.76.48 1.19 0 .43-.16.86-.48 1.19-.25.26-.25.67 0 .92a.63.63 0 0 0 .9 0c.57-.58.85-1.35.85-2.11 0-.76-.28-1.53-.85-2.11a.634.634 0 0 0-.9 0z"
                                     ></path>
                                 </svg>
-
                                 <!-- '"` --><!-- </textarea></xmp> -->
                                 <form
                                     data-replace-remote-form="true"
@@ -5218,7 +5403,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                     <input name="utf8" type="hidden" value="✓" /><input
                                         type="hidden"
                                         name="authenticity_token"
-                                        value="S93X4dPBNC+VX+sELCwLAHiT3MCGH2HPCFJMdBagKmaFd/f/xi+GI+5hFIONoWyoWIfSCEvdqtX5V4RPZemmQg=="
+                                        value="O5dQYF2oU7GdTygv/ka2aK+V20ZP1tRX5Ej5HgT3g2/1PXB+SEbhveZx16hfy9HAj4HVjoIUH00VTTEld74PSw=="
                                     />
                                     <input type="hidden" name="repository_id" value="41288708" />
                                     <input
@@ -5263,7 +5448,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
             >
                 <ul class="list-style-none d-flex flex-wrap ">
                     <li class="mr-3">
-                        © 2019 <span title="0.33651s from unicorn-854df44466-bvs66">GitHub</span>, Inc.
+                        © 2019 <span title="0.64367s from unicorn-7bd9b5dd4d-gl74g">GitHub</span>, Inc.
                     </li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
@@ -5367,17 +5552,17 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">

--- a/client/browser/src/libs/github/__fixtures__/github.com/commit/vanilla/unified/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/commit/vanilla/unified/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified -->
 <html lang="en">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -36,6 +37,21 @@
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
+        <meta name="twitter:image:src" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="correct opsgenie command for one-off alerts (#3258) · sourcegraph/sourcegraph@d3d0fe7"
+        />
+        <meta
+            name="twitter:description"
+            content="* correct opsgenie command
+
+* Update doc/dev/incidents.md
+
+Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
+        />
         <meta property="og:image" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
@@ -60,11 +76,11 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjhjMzIzZTE2NDMxZmRiMTI3ZDI2ZDI4N2QwYmY0ZGI2ZGVmZTQ4OTM1NDcxMjczMWFjYTQxOTJhNGZmNjRjNDE=--c7b8a166081d40aad3b3ebd0a848d540a9a5cae8"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjJhMDU2NGM4NjhmN2I4MDFmNmRjNGI3YmNmNWM3MDYyNmQ5NjIwY2I5MTE5M2M4OGE2NmI5NjMyODBhMjExYmE=--87c43ff7db370062f64f2dfd67e316ca6212c98f"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
-        <meta name="request-id" content="FCA2:4BCD:191C280:25FCB3B:5CA7A84B" data-pjax-transient="" />
+        <meta name="request-id" content="CC82:19F10:13B2BC6:1DB4130:5CC228FE" data-pjax-transient="" />
 
         <meta name="selected-link" value="repo_commits" data-pjax-transient="" />
 
@@ -75,7 +91,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="FCA2:4BCD:191C280:25FCB3B:5CA7A84B" />
+        <meta name="octolytics-dimension-request_id" content="CC82:19F10:13B2BC6:1DB4130:5CC228FE" />
         <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
@@ -93,17 +109,17 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="MGEyMzBmYWZiODQxMGQ0MjhkNjU3MzdkZDg5NjYxYmY2ZTc5OTNhMDg2MmRkNjUyNDA1M2Y5MmJlM2VjZTMyZnx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiRkNBMjo0QkNEOjE5MUMyODA6MjVGQ0IzQjo1Q0E3QTg0QiIsInRpbWVzdGFtcCI6MTU1NDQ5MTQ2OCwiaG9zdCI6ImdpdGh1Yi5jb20ifQ=="
+            content="ODI3MmEyNzQ3NGNhZjE0YzBlMTc0YTdhYWQyNjgwYTNlYWQzYzE1Yjg0YzhkN2VhMmFhZjc5NmRkYWQwNmNhN3x7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkNDODI6MTlGMTA6MTNCMkJDNjoxREI0MTMwOjVDQzIyOEZFIiwidGltZXN0YW1wIjoxNTU2MjI4MzUzLCJob3N0IjoiZ2l0aHViLmNvbSJ9"
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
             href="/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.diff"
@@ -232,7 +248,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=evGnFHuy9AaOXo4+/Yh141jjg6JdniBQWoE03EMQ46kj1jbjXwJljmpHU1X2YQ04/+e9h0sWyPP1dBqNTiaGpA=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=vNVNurbGuw9VvpjBNTgKzNUFaJnButMYBqjRQYTcB3Xl8txNknYqh7GnRao+0XIXcgFWvNcyO7upXf8QiepieA=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -633,6 +649,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                     </nav>
                 </div>
 
+                <div class="Header-item position-relative"></div>
+
                 <div class="Header-item"></div>
 
                 <div class="Header-item position-relative">
@@ -692,7 +710,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -726,7 +744,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -739,47 +757,53 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191C280:25FCB3B:5CA7A84B","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split"}}'
-                                            data-hydro-click-hmac="7d037ce8a369900eb11587d750b53c28fa4b25ad8b29fd0e602b26701f828deb"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"CC82:19F10:13B2BC6:1DB4130:5CC228FE","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split"}}'
+                                            data-hydro-click-hmac="578031696eb69e9b9c7a30c3ee2914f041b479f18530df9c242977d5b4764b2d"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -801,7 +825,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="kw9WhT2JWAt0aWQfJwp53uUt24KPPt+2Imr4d0x4Hc9lYflefAiR1/E/wlssRTLd+0gagKESc0e0JzyY+56+Mw=="
+                                                    value="/QfWPD7VO3ev5WDl3l8FReL5qcSiKvtHpZnX99GMFCULaXnnf1TyqyqzxqHVEE5G/JxoxowGV7Yz1BMYZmq32Q=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -830,7 +854,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -852,14 +876,34 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -883,8 +927,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -914,7 +957,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -938,7 +981,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -959,7 +1002,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -982,7 +1025,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -1003,7 +1046,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1022,6 +1065,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1041,7 +1085,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1080,13 +1124,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T21:41:08+02:00"
+                                                                        value="2019-04-26T00:09:13+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1096,7 +1140,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:11:08+02:00"
+                                                                        value="2019-04-26T00:39:13+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1106,7 +1150,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:11:08+02:00"
+                                                                        value="2019-04-26T03:39:13+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1116,7 +1160,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-25T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1126,7 +1170,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1151,15 +1195,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1229,7 +1271,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="fe6T+DsD5/mv9z+TrujevXdWxg9h8hQxYVtTF+0z9ut6IvDAkp20Vf/kLh0OnLZFGMo0VMOT8cjEVnjrMCTItw=="
+                                    value="/Vw7C0KqaJ4z9OlrnDgg4xXruzXaMpRWvjm1AntG3OL6kFgz6zQ7MmPn+OU8TEgbendJbnhTca8bNJ7+plHivg=="
                                 />
 
                                 <button
@@ -1269,15 +1311,15 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="A3k4xZJwIOIiTY9fFwdy6UdR42sZAf8XdKWrIbGwJGKbDGW3CCsoBxUAPLhFHNUy4PW39l2/dPKkGm3H3vSaiA=="
+                                            value="Fs4xzu4YzzlT5RSZ++ps+LPE92Jsne3efeF61s/Q4D6Ou2y8dEPH3GSop36p8csjFGCj/ygjZjutXrwwoJRe1A=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191C280:25FCB3B:5CA7A84B","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                                data-hydro-click-hmac="621e6f3c63085dd061d90ed5c3f1b813c34ac6bd03c04e37745b7e57265d1ebd"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC82:19F10:13B2BC6:1DB4130:5CC228FE","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                                data-hydro-click-hmac="d8db1bbedd62fee0b5f034d31a42fc2d7bf7f2794b330186a25c0cbe5c06eb73"
                                                 data-ga-click="Repository, click Watch settings, action:commit#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1300,7 +1342,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1504,9 +1546,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1523,7 +1565,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="f7WVJoP61XlZVjgSRuKsy6ORuL06VLNuESdZ5LU5XSLzF/qGn8RiSfS/o8C/3G9lNz+3U2P8rXpA35FpHPRabA=="
+                                                value="QP5r/ZS81lpCASE0hDpKCLYhXzV+gENnzpKhCK3Eg7fMXARdiIJhau/ouuZ9BImmIo9Q2ycoXXOfammFBAmE+Q=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1531,8 +1573,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191C280:25FCB3B:5CA7A84B","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                                data-hydro-click-hmac="c93c03bf3324e232a9eb6e98e038a80964ae8fd06550f671dd3933ed27d32d12"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC82:19F10:13B2BC6:1DB4130:5CC228FE","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                                data-hydro-click-hmac="392c6144b4c3c80e07470d8bd30ad503c66f7485d0dee642d052ecb22b1b3956"
                                                 data-ga-click="Repository, click unstar button, action:commit#show; text:Unstar"
                                             >
                                                 <svg
@@ -1553,9 +1595,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1568,7 +1610,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="iNw9Xyk8y/zLofPWZntbvxpCOKzWB1Vbqw8dFgEr0nQx5/0uoFl/tfqDX8+D2VxiX9O7xqtg7aPe1VcNEzvo5g=="
+                                                value="zrVCye8YgRvOO2Lep/ZzDa0Rvl2TN/Gee5FrZK3K2wB3joK4Zn01Uv8ZzsdCVHTQ6IA9N+5QSWYOSyF/v9rhkg=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1576,8 +1618,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191C280:25FCB3B:5CA7A84B","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                                data-hydro-click-hmac="cd33094ae19fd40c106a74f0da74bc7b3fc8446bc9df81424cb32665e75e26b0"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC82:19F10:13B2BC6:1DB4130:5CC228FE","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                                data-hydro-click-hmac="9235070a197c475d5277ac755a694cdf8776de99a3c973965df3703a9be24a4f"
                                                 data-ga-click="Repository, click star button, action:commit#show; text:Star"
                                             >
                                                 <svg
@@ -1598,9 +1640,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1609,16 +1651,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <li>
                                     <details
                                         class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
-                                        data-deferred-details-content-url="/sourcegraph/sourcegraph/fork?fragment=1"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"FCA2:4BCD:191C280:25FCB3B:5CA7A84B","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split","user_id":10532611}}'
-                                            data-hydro-click-hmac="804cf8640cc9e5200d558cb10ecdaa3f1ffbb0576050a9d8103d254f9c9b17a7"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"CC82:19F10:13B2BC6:1DB4130:5CC228FE","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7?diff=split","user_id":10532611}}'
+                                            data-hydro-click-hmac="081c40d2d7645176975d13efe44701dac82b37e72ee0d24d39b42e304b724f25"
                                             data-ga-click="Repository, show fork modal, action:commit#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1638,6 +1677,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1664,14 +1705,162 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 <h3 class="Box-title">Fork sourcegraph</h3>
                                             </div>
                                             <div class="overflow-auto text-center">
-                                                <include-fragment>
-                                                    <div class="octocat-spinner my-3" aria-label="Loading..."></div>
-                                                    <p class="f5 text-gray">
-                                                        If this dialog fails to load, you can visit
-                                                        <a href="/sourcegraph/sourcegraph/fork">the fork page</a>
-                                                        directly.
-                                                    </p>
-                                                </include-fragment>
+                                                <div class="p-4 ">
+                                                    <h3 class="h3 pb-3 text-normal">
+                                                        Where should we fork sourcegraph?
+                                                    </h3>
+
+                                                    <div class="d-flex flex-column flex-items-start">
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="button_to"
+                                                            method="post"
+                                                            action="/sourcegraph/sourcegraph/fork"
+                                                        >
+                                                            <button
+                                                                type="submit"
+                                                                name="organization"
+                                                                value="felixfbecker"
+                                                                tabindex="0"
+                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
+                                                                aria-label="Will be created as felixfbecker/sourcegraph."
+                                                            >
+                                                                <div class="d-flex flex-items-center">
+                                                                    <img
+                                                                        class="avatar avatar-small mr-2"
+                                                                        src="https://avatars0.githubusercontent.com/u/10532611?s=60&amp;v=4"
+                                                                        width="30"
+                                                                        height="30"
+                                                                        alt="@felixfbecker"
+                                                                    />
+                                                                    felixfbecker
+                                                                </div></button
+                                                            ><input
+                                                                type="hidden"
+                                                                name="authenticity_token"
+                                                                value="HPG+DCbelNwahNOSG3RHUIL7wmvk/LkfeNovc7cA51K/GwCoG7mHgx+uRsectuXBdAKH7rTgZKZ0yqKToQEvxg=="
+                                                            />
+                                                        </form>
+
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="button_to"
+                                                            method="get"
+                                                            action="/sourcegraph/sourcegraph"
+                                                        >
+                                                            <button
+                                                                type="submit"
+                                                                name="organization"
+                                                                value="sourcegraph"
+                                                                tabindex="0"
+                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
+                                                                aria-label="You’re already looking at sourcegraph/sourcegraph."
+                                                                disabled="disabled"
+                                                            >
+                                                                <div class="d-flex flex-items-center">
+                                                                    <svg
+                                                                        class="octicon octicon-repo-forked mr-2"
+                                                                        viewBox="0 0 10 16"
+                                                                        version="1.1"
+                                                                        width="10"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                    sourcegraph/sourcegraph
+                                                                </div>
+                                                            </button>
+                                                        </form>
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="button_to"
+                                                            method="post"
+                                                            action="/sourcegraph/sourcegraph/fork"
+                                                        >
+                                                            <button
+                                                                type="submit"
+                                                                name="organization"
+                                                                value="types"
+                                                                tabindex="0"
+                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
+                                                                aria-label="Will be created as types/sourcegraph."
+                                                            >
+                                                                <div class="d-flex flex-items-center">
+                                                                    <img
+                                                                        class="avatar avatar-small mr-2"
+                                                                        src="https://avatars3.githubusercontent.com/u/17114560?s=60&amp;v=4"
+                                                                        width="30"
+                                                                        height="30"
+                                                                        alt="@types"
+                                                                    />
+                                                                    types
+                                                                </div></button
+                                                            ><input
+                                                                type="hidden"
+                                                                name="authenticity_token"
+                                                                value="UF1AsJqIWYRxRk/pPw9/0WD06t7N2BplpPAaHiCsObTzt/4Up+9K23Rs2ry4zd1Alg2vW53Ex9yo4Jf+Nq3xIA=="
+                                                            />
+                                                        </form>
+
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="button_to"
+                                                            method="post"
+                                                            action="/sourcegraph/sourcegraph/fork"
+                                                        >
+                                                            <button
+                                                                type="submit"
+                                                                name="organization"
+                                                                value="typings"
+                                                                tabindex="0"
+                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
+                                                                aria-label="Will be created as typings/sourcegraph."
+                                                            >
+                                                                <div class="d-flex flex-items-center">
+                                                                    <img
+                                                                        class="avatar avatar-small mr-2"
+                                                                        src="https://avatars0.githubusercontent.com/u/15212838?s=60&amp;v=4"
+                                                                        width="30"
+                                                                        height="30"
+                                                                        alt="@typings"
+                                                                    />
+                                                                    typings
+                                                                </div></button
+                                                            ><input
+                                                                type="hidden"
+                                                                name="authenticity_token"
+                                                                value="ZsWJibxkBuEuAREhyrh4XT5+7YW/prwePtThRaCqGT3FLzctgQMVvisrhHRNetrMyIeoAO+6YacyxGyltqvRqQ=="
+                                                            />
+                                                        </form>
+                                                    </div>
+                                                </div>
+
+                                                <div class="p-4 border-top">
+                                                    <h3 class="h3 pb-3 text-normal">
+                                                        Can’t find what you’re looking for?
+                                                    </h3>
+
+                                                    <p>You don’t have permission to fork to these organizations:</p>
+
+                                                    <ul class="list-style-none">
+                                                        <li class="mb-1">
+                                                            <a class="d-block" href="/sabre-io">
+                                                                <img
+                                                                    class="avatar"
+                                                                    src="https://avatars1.githubusercontent.com/u/28524376?s=40&amp;v=4"
+                                                                    width="20"
+                                                                    height="20"
+                                                                    alt="@sabre-io"
+                                                                />
+                                                                sabre-io
+                                                            </a>
+                                                        </li>
+                                                    </ul>
+                                                </div>
                                             </div>
                                         </details-dialog>
                                     </details>
@@ -1679,9 +1868,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1776,7 +1965,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">695</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1803,7 +1992,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">82</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -1961,6 +2150,42 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             >)
                                         </li>
                                     </ul>
+                                    <svg
+                                        class="octicon octicon-tag"
+                                        viewBox="0 0 14 16"
+                                        version="1.1"
+                                        width="14"
+                                        height="16"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fill-rule="evenodd"
+                                            d="M7.73 1.73C7.26 1.26 6.62 1 5.96 1H3.5C2.13 1 1 2.13 1 3.5v2.47c0 .66.27 1.3.73 1.77l6.06 6.06c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41L7.73 1.73zM2.38 7.09c-.31-.3-.47-.7-.47-1.13V3.5c0-.88.72-1.59 1.59-1.59h2.47c.42 0 .83.16 1.13.47l6.14 6.13-4.73 4.73-6.13-6.15zM3.01 3h2v2H3V3h.01z"
+                                        ></path>
+                                    </svg>
+                                    <ul class="branches-tag-list js-details-container">
+                                        <li><a href="/sourcegraph/sourcegraph/releases/tag/v3.3.1">v3.3.1</a></li>
+                                        <li class="abbrev-tags">
+                                            <span class="hidden-text-expander"
+                                                ><button
+                                                    type="button"
+                                                    class="ellipsis-expander js-details-target"
+                                                    aria-expanded="false"
+                                                >
+                                                    …
+                                                </button></span
+                                            >
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0">v3.3.0</a>
+                                        </li>
+                                        <li class="more-commit-details">
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.2">v3.3.0-rc.2</a>
+                                        </li>
+                                        <li>
+                                            <a href="/sourcegraph/sourcegraph/releases/tag/v3.3.0-rc.1">v3.3.0-rc.1</a>
+                                        </li>
+                                    </ul>
                                 </div>
 
                                 <div class="commit-meta p-2 d-flex flex-wrap">
@@ -1995,7 +2220,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                         committed
                                         <relative-time datetime="2019-04-05T16:55:33Z" title="5 Apr 2019, 18:55 CEST"
-                                            >2 hours ago</relative-time
+                                            >20 days ago</relative-time
                                         >
 
                                         <details
@@ -2086,8 +2311,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                 <div
                                                     class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                 >
-                                                    <div class="inline-comment-form-actions"></div>
-
                                                     <div class="inline-comment-form">
                                                         <!-- '"` --><!-- </textarea></xmp> -->
                                                         <form
@@ -2099,7 +2322,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <input name="utf8" type="hidden" value="✓" /><input
                                                                 type="hidden"
                                                                 name="authenticity_token"
-                                                                value="XOBt8uIP68+Utx5fklunfubqTtHJ27HI2WHw9Dn6jDPO+djb3Ye5v+/u1LEVL0gJ0TDMwzlT57o8ATLJrCu5HQ=="
+                                                                value="jgV8XSVPFMfZbD3znNDZQvzX1wcw8kHbSnlzgX4EKm8cHMl0GsdGt6I19x0bpDY1yw1VFcB6F6mvGbG869UfQQ=="
                                                             />
                                                             <input type="hidden" name="comment_context" value="diff" />
 
@@ -2113,11 +2336,11 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <div
                                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                                data-preview-authenticity-token="C/dz4jJqQSSNtoheyHxNi9mg+GuLuS2vLAXcjHookv3L5y6asUZ7z7K/n6tkvAyYm7P/IDEHGSxeGRkpV2V40w=="
+                                                                data-preview-authenticity-token="GSBlXTrIqLdY9qaQho+5lWa9lOhTV7/p5138AftK0EDZMDglueSSXGf/sWUqT/iGJK6To+npi2qVQTmk1gc6bg=="
                                                             >
                                                                 <div class="comment-form-head tabnav ">
                                                                     <markdown-toolbar
-                                                                        for="r572219 new_inline_comment_diff_${anchor}_${position}"
+                                                                        for="r572194 new_inline_comment_diff_${anchor}_${position}"
                                                                         class="toolbar-commenting "
                                                                     >
                                                                         <div class="toolbar-group">
@@ -2471,7 +2694,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     class="js-upload-markdown-image is-default"
                                                                     data-upload-repository-id="41288708"
                                                                     data-upload-policy-url="/upload/policies/assets"
-                                                                    data-upload-policy-authenticity-token="Kbm6MAxVneIuvxMTi/7Yb2CrWjAwfKkduuTHyPn8HzMbr/ahQzhhqduwRoC/Ky8Wr+ZuJhT75W96LXIHiEBqAw=="
+                                                                    data-upload-policy-authenticity-token="j0msjnDl/jxl7WCdHhcqSHBhL8sBCc56hl74iQAU04y9X+AfP4gCd5DiNQ4qwt0xvywb3SWOgghGl01GcaimvA=="
                                                                 >
                                                                     <div
                                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -2487,7 +2710,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
                                                                         <textarea
                                                                             name="comment[body]"
-                                                                            id="r572219 new_inline_comment_diff_${anchor}_${position}"
+                                                                            id="r572194 new_inline_comment_diff_${anchor}_${position}"
                                                                             placeholder="Leave a comment"
                                                                             aria-label="Comment body"
                                                                             class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -2497,7 +2720,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             required=""
                                                                         ></textarea>
 
-                                                                        <p class="drag-and-drop position-relative">
+                                                                        <p
+                                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                        >
                                                                             <input
                                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                 type="file"
@@ -2633,6 +2858,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                                     </span>
                                                                                 </span>
                                                                             </span>
+                                                                            <span
+                                                                                class="tooltipped tooltipped-nw"
+                                                                                aria-label="Styling with Markdown is supported"
+                                                                            >
+                                                                                <a
+                                                                                    class="tabnav-extra position-relative d-inline"
+                                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                                    target="_blank"
+                                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                                    aria-label="Learn about styling with Markdown"
+                                                                                >
+                                                                                    <svg
+                                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                                        viewBox="0 0 16 16"
+                                                                                        version="1.1"
+                                                                                        width="16"
+                                                                                        height="16"
+                                                                                        aria-hidden="true"
+                                                                                    >
+                                                                                        <path
+                                                                                            fill-rule="evenodd"
+                                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                        ></path>
+                                                                                    </svg>
+                                                                                </a>
+                                                                            </span>
                                                                         </p>
                                                                     </div>
                                                                 </file-attachment>
@@ -2667,30 +2918,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                             <p>Nothing to preview</p>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-
-                                                                <div class="float-left ">
-                                                                    <a
-                                                                        class="tabnav-extra "
-                                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                                        target="_blank"
-                                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                                    >
-                                                                        <svg
-                                                                            class="octicon octicon-markdown v-align-bottom"
-                                                                            viewBox="0 0 16 16"
-                                                                            version="1.1"
-                                                                            width="16"
-                                                                            height="16"
-                                                                            aria-hidden="true"
-                                                                        >
-                                                                            <path
-                                                                                fill-rule="evenodd"
-                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                            ></path>
-                                                                        </svg>
-                                                                        Styling with Markdown is supported
-                                                                    </a>
                                                                 </div>
 
                                                                 <div
@@ -2837,94 +3064,162 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             data-file-deleted="false"
                                         >
                                             <div class="file-actions">
-                                                <span class="show-file-notes pt-1">
-                                                    <label>
-                                                        <input
-                                                            type="checkbox"
-                                                            checked="checked"
-                                                            class="js-toggle-file-notes"
-                                                        />
-                                                        Show comments
-                                                    </label>
-                                                </span>
-
-                                                <span class="BtnGroup">
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w source js-source selected"
-                                                            aria-current="true"
-                                                            aria-label="Display the source diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                <div class="mt-1">
+                                                    <span class="BtnGroup mt-n1">
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
                                                         >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w source js-source selected"
+                                                                aria-current="true"
+                                                                aria-label="Display the source diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-code"
+                                                                    viewBox="0 0 14 16"
+                                                                    version="1.1"
+                                                                    width="14"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                        <!-- '"` --><!-- </textarea></xmp> -->
+                                                        <form
+                                                            class="BtnGroup-parent js-prose-diff-toggle-form"
+                                                            action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
+                                                            accept-charset="UTF-8"
+                                                            method="get"
+                                                        >
+                                                            <input name="utf8" type="hidden" value="✓" />
+                                                            <button
+                                                                class="btn btn-sm BtnGroup-item tooltipped tooltipped-w rendered js-rendered"
+                                                                aria-label="Display the rich diff"
+                                                                type="submit"
+                                                                data-disable-with=""
+                                                            >
+                                                                <svg
+                                                                    class="octicon octicon-file"
+                                                                    viewBox="0 0 12 16"
+                                                                    version="1.1"
+                                                                    width="12"
+                                                                    height="16"
+                                                                    aria-hidden="true"
+                                                                >
+                                                                    <path
+                                                                        fill-rule="evenodd"
+                                                                        d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                    </span>
+
+                                                    <details
+                                                        class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                    >
+                                                        <summary class="btn-link v-align-middle" aria-haspopup="menu">
                                                             <svg
-                                                                class="octicon octicon-code"
-                                                                viewBox="0 0 14 16"
+                                                                class="octicon octicon-kebab-horizontal text-gray"
+                                                                aria-label="Show options"
+                                                                viewBox="0 0 13 16"
                                                                 version="1.1"
-                                                                width="14"
+                                                                width="13"
                                                                 height="16"
-                                                                aria-hidden="true"
+                                                                role="img"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                                                                    d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
                                                                 ></path>
                                                             </svg>
-                                                        </button>
-                                                    </form>
-                                                    <!-- '"` --><!-- </textarea></xmp> -->
-                                                    <form
-                                                        class="BtnGroup-parent js-prose-diff-toggle-form"
-                                                        action="/sourcegraph/sourcegraph/diffs/0?commentable=true&amp;commit=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;sha1=08526f7f06b2df657f37f2d823b2bd62abb21230&amp;sha2=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;short_path=087600e"
-                                                        accept-charset="UTF-8"
-                                                        method="get"
-                                                    >
-                                                        <input name="utf8" type="hidden" value="✓" />
-                                                        <button
-                                                            class="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-w rendered js-rendered"
-                                                            aria-label="Display the rich diff"
-                                                            type="submit"
-                                                            data-disable-with=""
+                                                        </summary>
+                                                        <details-menu
+                                                            class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                            style="width:185px; z-index:99; right: -4px;"
+                                                            role="menu"
                                                         >
-                                                            <svg
-                                                                class="octicon octicon-file"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
+                                                            <label
+                                                                role="menuitem"
+                                                                class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                tabindex="0"
                                                             >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"
-                                                                ></path>
-                                                            </svg>
-                                                        </button>
-                                                    </form>
-                                                </span>
+                                                                <span class="file-notes-check position-absolute ml-n3"
+                                                                    ><svg
+                                                                        class="octicon octicon-check"
+                                                                        viewBox="0 0 12 16"
+                                                                        version="1.1"
+                                                                        width="12"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                        ></path></svg
+                                                                ></span>
+                                                                <input
+                                                                    type="checkbox"
+                                                                    checked="checked"
+                                                                    class="d-none js-toggle-file-notes"
+                                                                />
+                                                                Show comments
+                                                            </label>
 
-                                                <div class="BtnGroup">
-                                                    <a
-                                                        href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
-                                                        class="btn btn-sm BtnGroup-item"
-                                                        rel="nofollow"
-                                                    >
-                                                        View file
-                                                    </a>
+                                                            <div role="none" class="dropdown-divider"></div>
+
+                                                            <a
+                                                                href="/sourcegraph/sourcegraph/blob/d3d0fe7fad2c909e3a2e4de2259dc6604983a092/doc/dev/incidents.md"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                rel="nofollow"
+                                                                role="menuitem"
+                                                                data-ga-click="View file, click, location:files_changed_dropdown"
+                                                            >
+                                                                View file
+                                                            </a>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to make changes."
+                                                            >
+                                                                Edit file
+                                                            </button>
+
+                                                            <button
+                                                                type="button"
+                                                                disabled=""
+                                                                role="menuitem"
+                                                                class="pl-5 dropdown-item btn-link"
+                                                                aria-label="You must be signed in and have push access to delete this file."
+                                                            >
+                                                                Delete file
+                                                            </button>
+                                                        </details-menu>
+                                                    </details>
                                                 </div>
-
+                                            </div>
+                                            <div class="file-info">
                                                 <button
                                                     type="button"
-                                                    class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                    class="btn-octicon js-details-target"
                                                     aria-label="Toggle diff contents"
                                                     aria-expanded="true"
+                                                    style="width: 22px;"
                                                 >
                                                     <svg
                                                         class="octicon octicon-chevron-down Details-content--hidden"
@@ -2940,21 +3235,19 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         ></path>
                                                     </svg>
                                                     <svg
-                                                        class="octicon octicon-chevron-up Details-content--shown"
-                                                        viewBox="0 0 10 16"
+                                                        class="octicon octicon-chevron-right Details-content--shown"
+                                                        viewBox="0 0 8 16"
                                                         version="1.1"
-                                                        width="10"
+                                                        width="8"
                                                         height="16"
                                                         aria-hidden="true"
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                            d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                         ></path>
                                                     </svg>
                                                 </button>
-                                            </div>
-                                            <div class="file-info">
                                                 <span
                                                     class="diffstat tooltipped tooltipped-e"
                                                     aria-label="1 addition &amp; 1 deletion"
@@ -2971,6 +3264,41 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     title="doc/dev/incidents.md"
                                                     >doc/dev/incidents.md</a
                                                 >
+
+                                                <clipboard-copy
+                                                    value="doc/dev/incidents.md"
+                                                    aria-label="Copied!"
+                                                    class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                    tabindex="0"
+                                                    role="button"
+                                                >
+                                                    <svg
+                                                        class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                        viewBox="0 0 14 16"
+                                                        version="1.1"
+                                                        width="14"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                        ></path>
+                                                    </svg>
+                                                    <svg
+                                                        class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                        viewBox="0 0 12 16"
+                                                        version="1.1"
+                                                        width="12"
+                                                        height="16"
+                                                        aria-hidden="true"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                        ></path>
+                                                    </svg>
+                                                </clipboard-copy>
                                             </div>
                                         </div>
                                         <div class="js-file-content Details-content--hidden">
@@ -3608,8 +3936,8 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                         Lock conversation
                                                     </summary>
                                                     <details-dialog
-                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         aria-label="Lock conversation on this commit"
+                                                        class="Box Box--overlay d-flex flex-column anim-fade-in fast "
                                                         role="dialog"
                                                     >
                                                         <div class="Box-header">
@@ -3675,7 +4003,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="onZfGvNiuNf1y0ay09ifrb6yzg375eVYbLlTFZ3066zK11UCkwhfbfBI/dXYvWjokREAg42yCWzrbsSYg7t6QA=="
+                                                                    value="zLoMolr4MgvbiMrzDPhVCVXzeOt6PSFn4Bgyw5fc/M6kGwa6OpLVsd4LcZQHnaJMelC2ZQxqzVNnz6VOiZNtIg=="
                                                                 />
                                                                 <button type="submit" class="btn btn-danger btn-block">
                                                                     Lock conversation on this commit
@@ -3731,7 +4059,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="XgpSJDwd/Uvm2jpH4rVbEK5vemG3No7GVMf8KEtoVLLME+cNA5WvO52D8KllwbRnmbX4c0e+2LSxpz4V3rlhnA=="
+                                            value="abKGRO3/JxHjoly4jZ2ZEWAO1qJV9hu0VGBo4i6jeYn7qzNt0nd1YZj7llYK6XZmV9RUsKV+TcaxAKrfu3JMpw=="
                                         />
                                         <div class="timeline-comment">
                                             <input
@@ -3743,7 +4071,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                             <div
                                                 class="js-previewable-comment-form previewable-comment-form write-selected"
                                                 data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=d3d0fe7fad2c909e3a2e4de2259dc6604983a092&amp;subject_type=Commit"
-                                                data-preview-authenticity-token="chSuz9Hu6uGvqCLjH+YOfSI/ViLhdF9T/5bbZpLA2bCyBPO3UsLQCpChNRazJk9uYCxRaVvKa9CNih7Dv40zng=="
+                                                data-preview-authenticity-token="GW3Fm6T0+rmuJJ+gkaRHaLtE0OkWIp3t/tNwZqmHGmTZfZjjJ9jAUpEtiFU9ZAZ7+VfXoqycqW6Mz7XDhMrwSg=="
                                             >
                                                 <div class="comment-form-head tabnav ">
                                                     <markdown-toolbar
@@ -4097,7 +4425,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                     class="js-upload-markdown-image is-default"
                                                     data-upload-repository-id="41288708"
                                                     data-upload-policy-url="/upload/policies/assets"
-                                                    data-upload-policy-authenticity-token="kO2NiAN9BoA+5FJLCz5U++mYdgUTjbUAxH21kGRRUmei+8EZTBD6y8vrB9g/66OCJtVCEzcK+XIEtABfFe0nVw=="
+                                                    data-upload-policy-authenticity-token="K5m/I8vLBkrg/R0lPG6xaRpRE0Rr1B21Q3OzlUYUS/8Zj/OyhKb6ARXySLYIu0YQ1RwnUk9TUceDugZaN6g+zw=="
                                                 >
                                                     <div
                                                         class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -4123,7 +4451,9 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             required=""
                                                         ></textarea>
 
-                                                        <p class="drag-and-drop position-relative">
+                                                        <p
+                                                            class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                        >
                                                             <input
                                                                 accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                 type="file"
@@ -4242,6 +4572,32 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                                     </span>
                                                                 </span>
                                                             </span>
+                                                            <span
+                                                                class="tooltipped tooltipped-nw"
+                                                                aria-label="Styling with Markdown is supported"
+                                                            >
+                                                                <a
+                                                                    class="tabnav-extra position-relative d-inline"
+                                                                    href="https://guides.github.com/features/mastering-markdown/"
+                                                                    target="_blank"
+                                                                    data-ga-click="Markdown Toolbar, click, help"
+                                                                    aria-label="Learn about styling with Markdown"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-markdown v-align-bottom"
+                                                                        viewBox="0 0 16 16"
+                                                                        version="1.1"
+                                                                        width="16"
+                                                                        height="16"
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </a>
+                                                            </span>
                                                         </p>
                                                     </div>
                                                 </file-attachment>
@@ -4262,30 +4618,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                                             <p>Nothing to preview</p>
                                                         </div>
                                                     </div>
-                                                </div>
-
-                                                <div class="float-left ">
-                                                    <a
-                                                        class="tabnav-extra "
-                                                        href="https://guides.github.com/features/mastering-markdown/"
-                                                        target="_blank"
-                                                        data-ga-click="Markdown Toolbar, click, help"
-                                                    >
-                                                        <svg
-                                                            class="octicon octicon-markdown v-align-bottom"
-                                                            viewBox="0 0 16 16"
-                                                            version="1.1"
-                                                            width="16"
-                                                            height="16"
-                                                            aria-hidden="true"
-                                                        >
-                                                            <path
-                                                                fill-rule="evenodd"
-                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                            ></path>
-                                                        </svg>
-                                                        Styling with Markdown is supported
-                                                    </a>
                                                 </div>
 
                                                 <div
@@ -4328,7 +4660,6 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                         d="M4.79 6.11c.25-.25.25-.67 0-.92-.32-.33-.48-.76-.48-1.19 0-.43.16-.86.48-1.19.25-.26.25-.67 0-.92a.613.613 0 0 0-.45-.19c-.16 0-.33.06-.45.19-.57.58-.85 1.35-.85 2.11 0 .76.29 1.53.85 2.11.25.25.66.25.9 0zM2.33.52a.651.651 0 0 0-.92 0C.48 1.48.01 2.74.01 3.99c0 1.26.47 2.52 1.4 3.48.25.26.66.26.91 0s.25-.68 0-.94c-.68-.7-1.02-1.62-1.02-2.54 0-.92.34-1.84 1.02-2.54a.66.66 0 0 0 .01-.93zm5.69 5.1A1.62 1.62 0 1 0 6.4 4c-.01.89.72 1.62 1.62 1.62zM14.59.53a.628.628 0 0 0-.91 0c-.25.26-.25.68 0 .94.68.7 1.02 1.62 1.02 2.54 0 .92-.34 1.83-1.02 2.54-.25.26-.25.68 0 .94a.651.651 0 0 0 .92 0c.93-.96 1.4-2.22 1.4-3.48A5.048 5.048 0 0 0 14.59.53zM8.02 6.92c-.41 0-.83-.1-1.2-.3l-3.15 8.37h1.49l.86-1h4l.84 1h1.49L9.21 6.62c-.38.2-.78.3-1.19.3zm-.01.48L9.02 11h-2l.99-3.6zm-1.99 5.59l1-1h2l1 1h-4zm5.19-11.1c-.25.25-.25.67 0 .92.32.33.48.76.48 1.19 0 .43-.16.86-.48 1.19-.25.26-.25.67 0 .92a.63.63 0 0 0 .9 0c.57-.58.85-1.35.85-2.11 0-.76-.28-1.53-.85-2.11a.634.634 0 0 0-.9 0z"
                                     ></path>
                                 </svg>
-
                                 <!-- '"` --><!-- </textarea></xmp> -->
                                 <form
                                     data-replace-remote-form="true"
@@ -4340,7 +4671,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                                     <input name="utf8" type="hidden" value="✓" /><input
                                         type="hidden"
                                         name="authenticity_token"
-                                        value="gQ592jcaYZ7ZqnNt8F6EO8J6nuk3tAyyUTRpakCYVYdPpF3EIvTTkqKUjOpR0+OT4m6QIfp2x6igMaFRM9HZow=="
+                                        value="1n6qnCYYYWqhieZWKp44YAYu05P24sVnLhmLOEBIuJ0Y1IqCM/bTZtq3GdGLE1/IJjrdWzsgDn3fHEMDMwE0uQ=="
                                     />
                                     <input type="hidden" name="repository_id" value="41288708" />
                                     <input
@@ -4384,7 +4715,7 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
                 class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light "
             >
                 <ul class="list-style-none d-flex flex-wrap ">
-                    <li class="mr-3">© 2019 <span title="1.00155s from unicorn-68f55df84-pds4t">GitHub</span>, Inc.</li>
+                    <li class="mr-3">© 2019 <span title="2.10408s from unicorn-65f4b75d5-v594n">GitHub</span>, Inc.</li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
                             >Terms</a
@@ -4487,17 +4818,17 @@ Co-Authored-By: ijsnow &lt;isaacjsnow@gmail.com&gt;</pre
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">

--- a/client/browser/src/libs/github/__fixtures__/github.com/pull-request/refined-github/split/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/pull-request/refined-github/split/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=split -->
 <html lang="en" class="refined-github">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -35,6 +36,14 @@
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
+        <meta name="twitter:image:src" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="gitserver: Use opentracing for exec endpoint by keegancsmith · Pull Request #3257 · sourcegraph/sourcegraph"
+        />
+        <meta name="twitter:description" content="Part of #3253" />
         <meta property="og:image" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
@@ -48,11 +57,11 @@
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmRhZDU4MDk1ZDZhODkyMDI5YzgxYjRjNzIyZDc2N2Y5OWY3MzAzZDU5OTUwNmZlYWUxYTU1NGQ3OTIyZjM3NzY=--e1ed51ad887f1b129b22e34bd59e58ba6bc3b692"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjI5YzM2ODNkMWMwODY5NjY3NmM4ZmU1YjMwZjdlNmJmNjBkNGFiYWQ0NmU5YjE2ODFhYjNkN2UzNzI1ZDVjZDE=--80b1233b9ad551f0412aef68219b2e4786464f62"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
-        <meta name="request-id" content="DABA:4F10:828F04:E1CFC5:5CA7AE64" data-pjax-transient="" />
+        <meta name="request-id" content="F9A4:2AC2F:25BFD97:390AD43:5CC2248E" data-pjax-transient="" />
 
         <meta name="hovercard-subject-tag" content="pull_request:267881853" data-pjax-transient="" />
 
@@ -65,8 +74,8 @@
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="DABA:4F10:828F04:E1CFC5:5CA7AE64" />
-        <meta name="octolytics-dimension-region_edge" content="iad" />
+        <meta name="octolytics-dimension-request_id" content="F9A4:2AC2F:25BFD97:390AD43:5CC2248E" />
+        <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
         <meta name="octolytics-actor-login" content="felixfbecker" />
@@ -87,17 +96,17 @@
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="ODdiMDczN2RhN2E0YWJhMzBkZGZiMDkyNjEyMDI1MmJmODkyZjRiY2YxNTUxMjI0MThkMzBkM2MwNWQyZDUxZHx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiREFCQTo0RjEwOjgyOEYwNDpFMUNGQzU6NUNBN0FFNjQiLCJ0aW1lc3RhbXAiOjE1NTQ0OTMwNTYsImhvc3QiOiJnaXRodWIuY29tIn0="
+            content="ZDMxMTZhNmU4NWM1ODIxYzNlOWI1ZTY0NzI4NDViNzY1NTRlNmRhMzNiZTEyODg5ZDFjOTM3NWM4Yjc3YzVjN3x7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkY5QTQ6MkFDMkY6MjVCRkQ5NzozOTBBRDQzOjVDQzIyNDhFIiwidGltZXN0YW1wIjoxNTU2MjI3MjE1LCJob3N0IjoiZ2l0aHViLmNvbSJ9"
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
             data-pjax-transient=""
@@ -114,9 +123,9 @@
 
         <meta name="diff-view" content="split" data-pjax-transient="" />
         <link
-            href="https://github.com/sourcegraph/sourcegraph/commits/core/gitserver-tracing.atom"
+            href="https://github.com/sourcegraph/sourcegraph/commits/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd.atom"
             rel="alternate"
-            title="Recent Commits to sourcegraph:core/gitserver-tracing"
+            title="Recent Commits to sourcegraph:a537a324138be6b8a47d544d9ce7ed0cd7bce7dd"
             type="application/atom+xml"
         />
 
@@ -155,7 +164,7 @@
     </head>
 
     <body
-        class="logged-in env-production emoji-size-boost full-width rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count"
+        class="logged-in env-production emoji-size-boost full-width rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count rgh-recently-pushed-branches"
     >
         <div class="position-relative js-header-wrapper ">
             <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content"
@@ -228,7 +237,7 @@
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=69YKyZPCPS+AldYQnlvDfpzIJfnPVexOiSJgxJx2RRqy8Zs+t3Ksp2SMC3uVsrulO8wb3NndBO0m106VkUAgFw=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=SaHmf7PN28ip9WCmmIgxOQ7eipu554L+ZTPZq/ftdzkQhneIl31KQE3svc2TYUniqdq0vq9val3Kxvf6+tsSNA=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -618,7 +627,9 @@
                             Marketplace
                         </a>
 
-                        <a
+                        <a href="/trending" class="js-selected-navigation-item Header-link  mr-3" data-hotkey="g t"
+                            >Trending</a
+                        ><a
                             class="js-selected-navigation-item Header-link  mr-3"
                             data-ga-click="Header, click, Nav menu - item:explore"
                             data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore"
@@ -628,6 +639,13 @@
                         </a>
                     </nav>
                 </div>
+                <div
+                    class="js-socket-channel js-updatable-content"
+                    data-channel="repo:41288708:post-receive:10532611"
+                    data-url="/sourcegraph/sourcegraph/show_partial?partial=tree%2Frecently_touched_branches_list"
+                ></div>
+
+                <div class="Header-item position-relative"></div>
 
                 <div class="Header-item"></div>
 
@@ -688,7 +706,7 @@
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -701,7 +719,11 @@
                             >
                                 New issue
                             </a>
-                        </details-menu>
+
+                            <a class="dropdown-item" href="/sourcegraph/sourcegraph/projects/new"
+                                >New project</a
+                            ></details-menu
+                        >
                     </details>
                 </div>
 
@@ -722,7 +744,7 @@
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -735,47 +757,54 @@
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                            data-hydro-click-hmac="862dfa85cc8b4fca8f0fac23ce120141b859cd9868dec068156f15a91a851b62"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25BFD97:390AD43:5CC2248E","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":null}}'
+                                            data-hydro-click-hmac="e29a1d87d9c76653ddba241c96f62731a986b295f2d6a7fc787f94adbc601424"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            title=":palm_tree:"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -797,7 +826,7 @@
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="WV1PBNoWfiAyskexwyLXYwy72iIowP2mFDdKFzttgO2vM+Dfm5e3/Lfk4fXIbZxgEt4bIAbsUVeCeo74jIsjEQ=="
+                                                    value="RSVzQa5ONXO1tfPfhz6BpVygXcXg2dATcPZFE44WUv+zS9ya78/8rzDjVZuMccqmQsWcx871fOLmu4H8OfDxAw=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -826,7 +855,7 @@
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -848,14 +877,36 @@
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -879,8 +930,7 @@
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -910,7 +960,7 @@
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -935,7 +985,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -957,7 +1007,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -981,7 +1031,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -1003,7 +1053,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1022,6 +1072,7 @@
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1041,7 +1092,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1080,13 +1131,13 @@
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T22:07:37+02:00"
+                                                                        value="2019-04-25T23:50:15+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1096,7 +1147,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:37:37+02:00"
+                                                                        value="2019-04-26T00:20:15+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1106,7 +1157,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:37:37+02:00"
+                                                                        value="2019-04-26T03:20:15+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1116,7 +1167,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-25T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1126,7 +1177,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1151,15 +1202,13 @@
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1229,7 +1278,7 @@
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="LmNwQDmVaNxkF2cPwJs8k7yhAi7g1wcdZjI0UAQ/uKgprxN4kAs7cDQEdoFg71Rr0z3wdUK24uTDPx+s2SiG9A=="
+                                    value="eBhHq8QNfvhHWfis5b08C+Nv8rNYyraaunOrSirxBdx/1CSTbZMtVBdK6SJFyVTzjPMA6PqrU2MffoC29+Y7gA=="
                                 />
 
                                 <button
@@ -1269,15 +1318,15 @@
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="YF7sis8tta5pddzMSfVubrW6UTk3jNKC8j9a9R5KTkv4K7H4VXa9S144bysb7sm1Eh4FpHMyWWcigJwTcQ7woQ=="
+                                            value="Zm/N/nwu+1r2395NBeB6BpjyHrteoIxpb6rHPSpxCoD+GpCM5nXzv8GSbapX+93dP1ZKJhoeB4y/FQHbRTW0ag=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="959780bed7af5d99da88d0e7f0195629fdbecbc5f68c0ff781986325439bd7bf"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25BFD97:390AD43:5CC2248E","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="3948e917d2873c435d03571876fba3ef9a8c867760a2fb18b504f40c70ce886e"
                                                 data-ga-click="Repository, click Watch settings, action:pull_requests#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1300,7 +1349,7 @@
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1504,9 +1553,9 @@
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1523,7 +1572,7 @@
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="4qSw1/s3uMQDuZi18ooCNpbwGOGtT4Yq2t5AksAKiPZuBt935wkP9K5QA2cLtMGYAl4XD/TnmD6LJogfacePuA=="
+                                                value="JQqEplU1dYRTsTQjOw2+LpuyrqHUUcbYT2jvJSy/f4epqOsGSQvCtP5Yr/HCM32ADxyhT4352MwekCeohXJ4yQ=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1531,8 +1580,8 @@
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="74ffc69929cfe3bd16fd4d6bde94f555b3838a10548094e7233feb415f9fc7e3"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25BFD97:390AD43:5CC2248E","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="1f7dca93babd5411c6bffe7a0ede3a588e76993291fc02b4702de57a2deb4c03"
                                                 data-ga-click="Repository, click unstar button, action:pull_requests#show; text:Unstar"
                                                 data-hotkey="g s"
                                             >
@@ -1554,9 +1603,9 @@
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1569,7 +1618,7 @@
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="3IVt3U0rr14M3Ft9z9BwgKf+mbKi7O94lZ7vYyywGl5lvq2sxE4bFz3+92Qqcndd4m8a2N+LV4DgRKV4PqAgzA=="
+                                                value="Xm9SYS0MeEnn415Phwqpc0LZxVlnFB70pRfRySKWvH/nVJIQpGnMANbB8lZiqK6uB0hGMxpzpgzQzZvSMIaG7Q=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1577,8 +1626,8 @@
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="f9e8f5dca4e2ad245c2ec9b4312bb8268e27e9919f121b5f6abf11072787c357"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25BFD97:390AD43:5CC2248E","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="ef4fe97ae8ee7c14ca0f001f95b8346b2f5c912119732a0d23ab32e40d390944"
                                                 data-ga-click="Repository, click star button, action:pull_requests#show; text:Star"
                                                 data-hotkey="g s"
                                             >
@@ -1600,9 +1649,9 @@
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1611,16 +1660,13 @@
                                 <li>
                                     <details
                                         class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
-                                        data-deferred-details-content-url="/sourcegraph/sourcegraph/fork?fragment=1"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                            data-hydro-click-hmac="4a1a74c0b016ebd3c4e180bb5311199cd2c7127eeb228890e2e0dfbd90856cfd"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25BFD97:390AD43:5CC2248E","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="cca6172c2723788468f829c7ede1e7d683da1e65769d676f5e37f1d2f5cf00ef"
                                             data-ga-click="Repository, show fork modal, action:pull_requests#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1640,6 +1686,8 @@
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1681,9 +1729,9 @@
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1722,21 +1770,21 @@
 
                                 <details
                                     class="commit-build-statuses details-overlay details-reset js-dropdown-details rgh-ci-link"
-                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6MTkzM2Q1NjE5ODQ4YjlmNzEyNWRmYmQ3ZmE3NWYwODJlMjQ4YzJhYQ==/statuses/combined_branch_status"
+                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6YTNlMzMzMGJjYmY2MjQyZWYwNmQyYTMyZGY5NjU4ZWIwZDk0ZTk3ZQ==/statuses/combined_branch_status"
                                 >
-                                    <summary class="text-green">
+                                    <summary class="bg-pending">
                                         <svg
-                                            class="octicon octicon-check v-align-middle"
-                                            aria-label="2 / 2 checks OK"
-                                            viewBox="0 0 12 16"
+                                            class="octicon octicon-primitive-dot v-align-middle"
+                                            aria-label="0 / 1 checks OK"
+                                            viewBox="0 0 8 16"
                                             version="1.1"
-                                            width="12"
+                                            width="8"
                                             height="16"
                                             role="img"
                                         >
                                             <path
                                                 fill-rule="evenodd"
-                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"
                                             ></path>
                                         </svg>
                                     </summary>
@@ -1819,7 +1867,7 @@
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">695</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1847,7 +1895,7 @@
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">82</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -2024,13 +2072,7 @@
                     <div class="container new-discussion-timeline experiment-repo-nav  ">
                         <div class="repository-content ">
                             <div
-                                class="js-socket-channel js-updatable-content"
-                                data-channel="repo:41288708:post-receive:10532611"
-                                data-url="/sourcegraph/sourcegraph/show_partial?partial=tree%2Frecently_touched_branches_list"
-                            ></div>
-
-                            <div
-                                class="issues-listing js-review-state-classes  js-suggested-changes-files-tab "
+                                class="position-relative js-review-state-classes  js-suggested-changes-files-tab "
                                 data-pjax=""
                                 data-issue-and-pr-hovercards-enabled=""
                             >
@@ -2043,7 +2085,7 @@
                                         class="gh-header js-details-container Details js-socket-channel js-updatable-content pull request js-pull-header-details"
                                         data-channel="pull_request:267881853"
                                         data-url="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Ftitle&amp;sticky=false"
-                                        data-pull-is-open="true"
+                                        data-pull-is-open="false"
                                         data-gid="MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz"
                                     >
                                         <div class="gh-header-show ">
@@ -2082,7 +2124,7 @@
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="JUNmn+YlfTUUUmUF/IFjVS1H4DIqiUjWRrD3YONgTvikl9zxAAuB7JEviuWY64L5aTwdzZmyR7eaDhXTX86/Pw=="
+                                                    value="xuPLpRd/KPidgLL5gRy3YWGSo0ge0tPwstQjOuzqPZxHN3HL8VHUIRj9XRnldlbNJelet63p3JFuasGJUETMWw=="
                                                 />
                                                 <input
                                                     class="form-control edit-issue-title js-quick-submit"
@@ -2114,10 +2156,10 @@
                                         </div>
                                         <div class="TableObject gh-header-meta">
                                             <div class="TableObject-item">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -2125,31 +2167,28 @@
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
                                             <div class="TableObject-item TableObject-item--primary">
                                                 <a
                                                     class="author link-gray text-bold css-truncate css-truncate-target expandable"
                                                     data-hovercard-type="user"
-                                                    data-hovercard-url="/hovercards?user_id=187831"
+                                                    data-hovercard-url="/hovercards?user_id=1646931"
                                                     data-octo-click="hovercard-link-click"
                                                     data-octo-dimensions="link_type:self"
-                                                    href="/keegancsmith"
-                                                    >keegancsmith</a
+                                                    href="/beyang"
+                                                    >beyang</a
                                                 >
-
-                                                wants to merge
-                                                <span class="js-updating-pull-request-commits-count">1</span>
-                                                commit into
+                                                merged 1 commit into
 
                                                 <a href="/sourcegraph/sourcegraph/tree/master"
                                                     ><span
                                                         title="sourcegraph/sourcegraph:master"
-                                                        class="commit-ref css-truncate user-select-contain expandable base-ref"
+                                                        class="commit-ref css-truncate user-select-contain expandable "
                                                         ><a
                                                             title="sourcegraph/sourcegraph:master"
                                                             class="no-underline"
@@ -2158,51 +2197,6 @@
                                                         ></span
                                                     ></a
                                                 ><span></span>
-
-                                                <div class="commit-ref-dropdown">
-                                                    <details
-                                                        class="details-reset details-overlay select-menu commitish-suggester"
-                                                    >
-                                                        <summary
-                                                            class="btn btn-sm select-menu-button branch"
-                                                            title="Choose a base branch"
-                                                            aria-haspopup="menu"
-                                                        >
-                                                            <i>base:</i>
-                                                            <span
-                                                                class="css-truncate css-truncate-target"
-                                                                title="master"
-                                                                >master</span
-                                                            >
-                                                        </summary>
-                                                        <details-menu
-                                                            class="select-menu-modal position-absolute"
-                                                            style="z-index: 90;"
-                                                            src="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Fdescription_branches_dropdown"
-                                                            preload=""
-                                                            role="menu"
-                                                        >
-                                                            <include-fragment
-                                                                class="select-menu-loading-overlay anim-pulse"
-                                                                aria-label="Loading"
-                                                            >
-                                                                <svg
-                                                                    height="32"
-                                                                    class="octicon octicon-octoface"
-                                                                    viewBox="0 0 16 16"
-                                                                    version="1.1"
-                                                                    width="32"
-                                                                    aria-hidden="true"
-                                                                >
-                                                                    <path
-                                                                        fill-rule="evenodd"
-                                                                        d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"
-                                                                    ></path>
-                                                                </svg>
-                                                            </include-fragment>
-                                                        </details-menu>
-                                                    </details>
-                                                </div>
 
                                                 from
 
@@ -2251,6 +2245,12 @@
                                                                 d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
                                                             ></path></svg></clipboard-copy
                                                 ></span>
+
+                                                <relative-time
+                                                    datetime="2019-04-08T00:40:04Z"
+                                                    title="8 Apr 2019, 02:40 CEST"
+                                                    >18 days ago</relative-time
+                                                >
                                             </div>
                                         </div>
                                     </div>
@@ -2280,7 +2280,7 @@
                                                 Conversation
 
                                                 <span id="conversation_tab_counter" class="Counter">
-                                                    1
+                                                    2
                                                 </span>
                                             </a>
 
@@ -2307,8 +2307,9 @@
                                                 <span
                                                     id="commits_tab_counter"
                                                     class="Counter js-updateable-pull-request-commits-count"
-                                                    >1</span
                                                 >
+                                                    1
+                                                </span>
                                             </a>
 
                                             <a
@@ -2367,10 +2368,10 @@
                                     <div class="pr-toolbar js-sticky js-sticky-offset-scroll" style="position: sticky;">
                                         <div class="diffbar details-collapse js-details-container Details">
                                             <div class="show-if-stuck float-left mr-2 mt-2">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -2378,10 +2379,10 @@
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
 
@@ -2475,7 +2476,7 @@
                                                                                 <relative-time
                                                                                     datetime="2019-04-05T16:05:51Z"
                                                                                     title="5 Apr 2019, 18:05 CEST"
-                                                                                    >4 hours ago</relative-time
+                                                                                    >20 days ago</relative-time
                                                                                 >
                                                                             </span>
                                                                         </div>
@@ -2732,7 +2733,7 @@
                                                                     <button
                                                                         type="button"
                                                                         class="btn btn-outline mt-2 text-bold js-dismiss-batched-suggested-changes-onboarding-notice"
-                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=nEBLwET7mKHJQiMd1j2yEUbUDrKBoJUOEkczAZ/EEdP1tOZoj+Ditw6EVYCugC4dewe5NrE0YcJ0Ue021mkDzQ=="
+                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=NHWcZLos6taRpS3b4Xo/dwFENVurUquNHoRU0P4BrSVdgTHMcTeQwFZjW0aZx6N7PJeC35vGX0F4kornt6y/Ow=="
                                                                     >
                                                                         Got it
                                                                     </button>
@@ -2754,7 +2755,7 @@
                                                                 <input name="utf8" type="hidden" value="✓" /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="nN1059V1WY9nICel3BtUJyWaoY3lvqYlCYiYUI7vetxaV8xETDThyZJxFGjYXYPfggG0NK+82OJtH7ZUtCfbwQ=="
+                                                                    value="n8cBIZxU7z1B96icp7ZYAwU1xi8O0DUTRdK1AFBkfY1ZTbmCBRVXe7Smm1Gj8I/7oq7TlkTSS9QhRZsEaqzckA=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2783,8 +2784,8 @@
                                                                     <button
                                                                         type="submit"
                                                                         class="btn btn-sm btn-primary float-left js-suggestion-batch-submit"
-                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                        data-hydro-click-hmac="30154cf857d3937b834f88fbf4c81f14f9772d815d5e39b601ebf9106f8b8bfd"
+                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25BFD97:390AD43:5CC2248E","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":null}}'
+                                                                        data-hydro-click-hmac="e175c97a33fe981842dfa76b278325c74f6a5d6c210749406859655efcb0d65a"
                                                                         data-ga-click="Markdown Toolbar, click, insert code suggestion"
                                                                         data-disable-invalid="true"
                                                                         data-disable-with="Applying commits..."
@@ -2817,7 +2818,13 @@
                                                 <div class="diffbar-item dropdown js-reviews-container">
                                                     <details class="details-reset details-overlay js-dropdown-details">
                                                         <summary class="btn btn-sm btn-primary js-reviews-toggle">
-                                                            Review changes
+                                                            <span
+                                                                class="js-review-changes"
+                                                                data-pending-message="Finish your review"
+                                                                data-message="Review changes"
+                                                            >
+                                                                Review changes
+                                                            </span>
                                                             <span class="Counter js-pending-review-comment-count">
                                                                 0
                                                             </span>
@@ -2841,7 +2848,7 @@
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="fdJVUZwf5SN69HZegct5IeCDb/UR09HB/q3hjf8bHfjnyW8CYCmm4WkJvZz5l0L7vh9zT0YkYY8nhht7pVmzMQ=="
+                                                                    value="Cht/CLVuDIlQCOTARXxvypoJ+7bk7SpbRT3JkeRHDg6QAEVbSVhPS0P1LwI9IFQQxJXnDLMamhWcFjNnvgWgxw=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2853,7 +2860,7 @@
                                                                 <div
                                                                     class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                     data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                    data-preview-authenticity-token="ILik21I7d1nt9keHqCpdQ6NUskMhCXxupnRtz5Ek87DgqPmj0RdNstL/UHIE6hxQ4Ue1CJu3SO3UaKhqvGkZng=="
+                                                                    data-preview-authenticity-token="5zrEayOcW+PJqKQJFRQz03bE5+vHop9MoXXJzqRYCSEnKpkToLBhCPahs/y51HLANNfgoH0cq8/TaQxriRXjDw=="
                                                                 >
                                                                     <div class="comment-form-head tabnav ">
                                                                         <markdown-toolbar
@@ -3201,7 +3208,7 @@
                                                                                     type="button"
                                                                                     class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                     aria-label="Upload attachments"
-                                                                                    hotkey="u"
+                                                                                    data-hotkey="u"
                                                                                 >
                                                                                     <svg
                                                                                         aria-hidden="true"
@@ -3247,7 +3254,7 @@
                                                                         class="js-upload-markdown-image is-default"
                                                                         data-upload-repository-id="41288708"
                                                                         data-upload-policy-url="/upload/policies/assets"
-                                                                        data-upload-policy-authenticity-token="m40or/6PFDL3gqcxnCZoKyA+Qu/IXyi2X5qLhbwbzCupm2Q+seLoeQKN8qKo859S73N2+ezYZMSfUz5Kzae5Gw=="
+                                                                        data-upload-policy-authenticity-token="cHun9DY89HALsYZbqotFD6S3b3fIl19lel0tSsRrmeFCbetleVEIO/6+08ieXrJ2a/pbYewQExe6lJiFtdfs0Q=="
                                                                     >
                                                                         <div
                                                                             class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -3272,7 +3279,9 @@
                                                                                 data-suggest-mention="/suggestions/pull_request/267881853?repository=sourcegraph&amp;user_id=sourcegraph&amp;mention_suggester=1"
                                                                             ></textarea>
 
-                                                                            <p class="drag-and-drop position-relative">
+                                                                            <p
+                                                                                class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                            >
                                                                                 <input
                                                                                     accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                     type="file"
@@ -3414,6 +3423,32 @@
                                                                                         </span>
                                                                                     </span>
                                                                                 </span>
+                                                                                <span
+                                                                                    class="tooltipped tooltipped-nw"
+                                                                                    aria-label="Styling with Markdown is supported"
+                                                                                >
+                                                                                    <a
+                                                                                        class="tabnav-extra position-relative d-inline"
+                                                                                        href="https://guides.github.com/features/mastering-markdown/"
+                                                                                        target="_blank"
+                                                                                        data-ga-click="Markdown Toolbar, click, help"
+                                                                                        aria-label="Learn about styling with Markdown"
+                                                                                    >
+                                                                                        <svg
+                                                                                            class="octicon octicon-markdown v-align-bottom"
+                                                                                            viewBox="0 0 16 16"
+                                                                                            version="1.1"
+                                                                                            width="16"
+                                                                                            height="16"
+                                                                                            aria-hidden="true"
+                                                                                        >
+                                                                                            <path
+                                                                                                fill-rule="evenodd"
+                                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                            ></path>
+                                                                                        </svg>
+                                                                                    </a>
+                                                                                </span>
                                                                             </p>
                                                                         </div>
                                                                     </file-attachment>
@@ -3455,9 +3490,22 @@
                                                                     ></div>
                                                                 </div>
 
+                                                                <input
+                                                                    type="hidden"
+                                                                    name="pull_request_review[event]"
+                                                                    value="comment"
+                                                                />
+
                                                                 <div
                                                                     class="form-actions p-2 m-0 bg-gray-light border-top"
                                                                 >
+                                                                    <button
+                                                                        type="submit"
+                                                                        class="btn btn-sm btn-primary float-left mr-1"
+                                                                        data-disable-with=""
+                                                                    >
+                                                                        Submit review
+                                                                    </button>
                                                                     <span
                                                                         class="review-title-with-count text-gray-light float-left mt-1 ml-1"
                                                                     >
@@ -3473,29 +3521,6 @@
                                                                             comments
                                                                         </span>
                                                                     </span>
-                                                                    <input
-                                                                        type="hidden"
-                                                                        name="pull_request_review[event]"
-                                                                        value="comment"
-                                                                    /><button
-                                                                        name="pull_request_review[event]"
-                                                                        value="approve"
-                                                                        class="btn btn-sm btn-primary "
-                                                                    >
-                                                                        Approve</button
-                                                                    ><button
-                                                                        name="pull_request_review[event]"
-                                                                        value="reject"
-                                                                        class="btn btn-sm btn-danger "
-                                                                    >
-                                                                        Request changes</button
-                                                                    ><button
-                                                                        name="pull_request_review[event]"
-                                                                        value="comment"
-                                                                        class="btn btn-sm  "
-                                                                    >
-                                                                        Comment
-                                                                    </button>
                                                                 </div>
                                                             </form>
                                                         </div>
@@ -3523,24 +3548,6 @@
                                                         <div
                                                             class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                         >
-                                                            <div class="inline-comment-form-actions">
-                                                                <button
-                                                                    type="button"
-                                                                    class="btn js-toggle-new-thread-form"
-                                                                    data-ga-click="Start a new conversation, click"
-                                                                    data-side=""
-                                                                >
-                                                                    Start a new conversation
-                                                                </button>
-
-                                                                <a
-                                                                    href="/sourcegraph/sourcegraph/pull/3257/files#submit-review"
-                                                                    class="finish-review-label btn ml-1"
-                                                                >
-                                                                    Finish your review
-                                                                </a>
-                                                            </div>
-
                                                             <div class="inline-comment-form">
                                                                 <!-- '"` --><!-- </textarea></xmp> -->
                                                                 <form
@@ -3552,7 +3559,7 @@
                                                                     <input name="utf8" type="hidden" value="✓" /><input
                                                                         type="hidden"
                                                                         name="authenticity_token"
-                                                                        value="l3Cv2hTMLcX89nIyCvVu/UOH+abQZKrYK7nLsDLOsuCCLwivlVqEoO2F5ShZt5uqfvMF1OfR9yI3R9XO4n0wbA=="
+                                                                        value="8sAzOXx0uls7Z2RYtSKarMqlTLWTuCwUqRYqGV7FyULnn5RM/eITPioU80LmYG/799Gwx6QNce616DRnjnZLzg=="
                                                                     />
                                                                     <input
                                                                         type="hidden"
@@ -3589,40 +3596,15 @@
                                                                     <input type="hidden" name="position" value="" />
 
                                                                     <div
-                                                                        class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                                                        class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                         data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                        data-preview-authenticity-token="OUJOe1GYUZPoi2NvoFJEL/oWkFljMuwRlFGajJvmtID5UhMD0rRreNeCdJoMkgU8uAWXEtmM2JLmTV8ptqterg=="
+                                                                        data-preview-authenticity-token="zH2Axo+kpvasIW9NF4JUugyJ2CqwJHVlj74zqKLneugMbd2+DIicHZMoeLi7QhWpTprfYQqaQeb9ovYNj6qQxg=="
                                                                     >
                                                                         <div class="comment-form-head tabnav ">
                                                                             <markdown-toolbar
-                                                                                for="r897916 new_inline_comment_diff_${anchor}_${position}"
+                                                                                for="r926793 new_inline_comment_diff_${anchor}_${position}"
                                                                                 class="toolbar-commenting "
                                                                             >
-                                                                                <div class="toolbar-group">
-                                                                                    <button
-                                                                                        type="button"
-                                                                                        class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item"
-                                                                                        aria-label="Insert a suggestion <cmd-g>"
-                                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"insert_suggestion","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                                        data-hydro-click-hmac="aeb80d70d5c5719acc604fa09fc453bdaa159abbaccc35f7c73cd21cb852e5d5"
-                                                                                        data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                                                        hotkey="g"
-                                                                                    >
-                                                                                        <svg
-                                                                                            class="octicon octicon-diff"
-                                                                                            viewBox="0 0 13 16"
-                                                                                            version="1.1"
-                                                                                            width="13"
-                                                                                            height="16"
-                                                                                            aria-hidden="true"
-                                                                                        >
-                                                                                            <path
-                                                                                                fill-rule="evenodd"
-                                                                                                d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"
-                                                                                            ></path>
-                                                                                        </svg>
-                                                                                    </button>
-                                                                                </div>
                                                                                 <div class="toolbar-group">
                                                                                     <md-header
                                                                                         tabindex="-1"
@@ -3965,7 +3947,7 @@
                                                                                         type="button"
                                                                                         class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                         aria-label="Upload attachments"
-                                                                                        hotkey="u"
+                                                                                        data-hotkey="u"
                                                                                     >
                                                                                         <svg
                                                                                             aria-hidden="true"
@@ -4012,7 +3994,7 @@
                                                                             class="js-upload-markdown-image is-default"
                                                                             data-upload-repository-id="41288708"
                                                                             data-upload-policy-url="/upload/policies/assets"
-                                                                            data-upload-policy-authenticity-token="nMaO5YEA7Vzd1MBnlwVBJdlxPxm2tJPQORAi9UmaDqOu0MJ0zm0RFyjblfSj0LZcFjwLD5Iz36L52Zc6OCZ7kw=="
+                                                                            data-upload-policy-authenticity-token="G9P0il8t69pyEoAqhTuypgZbLfZ8dATvUClNjfLq0VcpxbgbEEAXkYcd1bmx7kXfyRYZ4FjzSJ2Q4PhCg1akZw=="
                                                                         >
                                                                             <div
                                                                                 class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -4028,7 +4010,7 @@
 
                                                                                 <textarea
                                                                                     name="comment[body]"
-                                                                                    id="r897916 new_inline_comment_diff_${anchor}_${position}"
+                                                                                    id="r926793 new_inline_comment_diff_${anchor}_${position}"
                                                                                     placeholder="Leave a comment"
                                                                                     aria-label="Comment body"
                                                                                     class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -4039,7 +4021,7 @@
                                                                                 ></textarea>
 
                                                                                 <p
-                                                                                    class="drag-and-drop position-relative"
+                                                                                    class="drag-and-drop position-relative d-flex flex-justify-between"
                                                                                 >
                                                                                     <input
                                                                                         accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
@@ -4189,6 +4171,32 @@
                                                                                             </span>
                                                                                         </span>
                                                                                     </span>
+                                                                                    <span
+                                                                                        class="tooltipped tooltipped-nw"
+                                                                                        aria-label="Styling with Markdown is supported"
+                                                                                    >
+                                                                                        <a
+                                                                                            class="tabnav-extra position-relative d-inline"
+                                                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                                                            target="_blank"
+                                                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                                                            aria-label="Learn about styling with Markdown"
+                                                                                        >
+                                                                                            <svg
+                                                                                                class="octicon octicon-markdown v-align-bottom"
+                                                                                                viewBox="0 0 16 16"
+                                                                                                version="1.1"
+                                                                                                width="16"
+                                                                                                height="16"
+                                                                                                aria-hidden="true"
+                                                                                            >
+                                                                                                <path
+                                                                                                    fill-rule="evenodd"
+                                                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                                ></path>
+                                                                                            </svg>
+                                                                                        </a>
+                                                                                    </span>
                                                                                 </p>
                                                                             </div>
                                                                         </file-attachment>
@@ -4223,30 +4231,6 @@
                                                                                     <p>Nothing to preview</p>
                                                                                 </div>
                                                                             </div>
-                                                                        </div>
-
-                                                                        <div class="float-left ">
-                                                                            <a
-                                                                                class="tabnav-extra "
-                                                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                                                target="_blank"
-                                                                                data-ga-click="Markdown Toolbar, click, help"
-                                                                            >
-                                                                                <svg
-                                                                                    class="octicon octicon-markdown v-align-bottom"
-                                                                                    viewBox="0 0 16 16"
-                                                                                    version="1.1"
-                                                                                    width="16"
-                                                                                    height="16"
-                                                                                    aria-hidden="true"
-                                                                                >
-                                                                                    <path
-                                                                                        fill-rule="evenodd"
-                                                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                                    ></path>
-                                                                                </svg>
-                                                                                Styling with Markdown is supported
-                                                                            </a>
                                                                         </div>
 
                                                                         <div
@@ -4326,24 +4310,6 @@
                                                         <div
                                                             class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                         >
-                                                            <div class="inline-comment-form-actions">
-                                                                <button
-                                                                    type="button"
-                                                                    class="btn js-toggle-new-thread-form"
-                                                                    data-ga-click="Start a new conversation, click"
-                                                                    data-side=""
-                                                                >
-                                                                    Start a new conversation
-                                                                </button>
-
-                                                                <a
-                                                                    href="/sourcegraph/sourcegraph/pull/3257/files#submit-review"
-                                                                    class="finish-review-label btn ml-1"
-                                                                >
-                                                                    Finish your review
-                                                                </a>
-                                                            </div>
-
                                                             <div class="inline-comment-form">
                                                                 <!-- '"` --><!-- </textarea></xmp> -->
                                                                 <form
@@ -4355,7 +4321,7 @@
                                                                     <input name="utf8" type="hidden" value="✓" /><input
                                                                         type="hidden"
                                                                         name="authenticity_token"
-                                                                        value="xYa7Rh+r60tnUepRacyoDSXSOQ04Go31CIyzlIhR8v3Q2Rwznj1CLnYifUs6jl1aGKbFfw+v0A8Ucq3qWOJwcQ=="
+                                                                        value="epKKIL6PJWcbIO8z1Eu6uIlC3b6xT/1/utpk/ySvPjRvzS1VPxmMAgpTeCmHCU/vtDYhzIb6oIWmJHqB9By8uA=="
                                                                     />
                                                                     <input
                                                                         type="hidden"
@@ -4392,40 +4358,15 @@
                                                                     <input type="hidden" name="position" value="" />
 
                                                                     <div
-                                                                        class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                                                        class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                         data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                        data-preview-authenticity-token="4i6xP52q4p4+UqGvuyklyqUS8UXC3bjDcVwJ6wWykEMiPuxHHobYdQFbtloX6WTZ5wH2DnhjjEADQMxOKP96bQ=="
+                                                                        data-preview-authenticity-token="iJPOnVaqNst5j9MO5mBTosTEG6oP7bgIB72YVJo9vzdIg5Pl1YYMIEaGxPtKoBKxhtcc4bVTjIt1oV3xt3BVGQ=="
                                                                     >
                                                                         <div class="comment-form-head tabnav ">
                                                                             <markdown-toolbar
-                                                                                for="r790463 new_inline_comment_diff_${anchor}_${position}"
+                                                                                for="r133824 new_inline_comment_diff_${anchor}_${position}"
                                                                                 class="toolbar-commenting "
                                                                             >
-                                                                                <div class="toolbar-group">
-                                                                                    <button
-                                                                                        type="button"
-                                                                                        class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item"
-                                                                                        aria-label="Insert a suggestion <cmd-g>"
-                                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"insert_suggestion","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                                        data-hydro-click-hmac="aeb80d70d5c5719acc604fa09fc453bdaa159abbaccc35f7c73cd21cb852e5d5"
-                                                                                        data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                                                        hotkey="g"
-                                                                                    >
-                                                                                        <svg
-                                                                                            class="octicon octicon-diff"
-                                                                                            viewBox="0 0 13 16"
-                                                                                            version="1.1"
-                                                                                            width="13"
-                                                                                            height="16"
-                                                                                            aria-hidden="true"
-                                                                                        >
-                                                                                            <path
-                                                                                                fill-rule="evenodd"
-                                                                                                d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"
-                                                                                            ></path>
-                                                                                        </svg>
-                                                                                    </button>
-                                                                                </div>
                                                                                 <div class="toolbar-group">
                                                                                     <md-header
                                                                                         tabindex="-1"
@@ -4768,7 +4709,7 @@
                                                                                         type="button"
                                                                                         class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                         aria-label="Upload attachments"
-                                                                                        hotkey="u"
+                                                                                        data-hotkey="u"
                                                                                     >
                                                                                         <svg
                                                                                             aria-hidden="true"
@@ -4815,7 +4756,7 @@
                                                                             class="js-upload-markdown-image is-default"
                                                                             data-upload-repository-id="41288708"
                                                                             data-upload-policy-url="/upload/policies/assets"
-                                                                            data-upload-policy-authenticity-token="aiASuJOOU9RsZ9IMdW6HsUt6j1SFljfU0Y2N7je0yFFYNl4p3OOvn5loh59Bu3DIhDe7QqERe6YRRDghRgi9YQ=="
+                                                                            data-upload-policy-authenticity-token="krSBejah2sYEy/otYKrb3w6KHN7J1aco1pYi6tzADnygos3recwmjfHEr75UfyymwccoyO1S61oWX5clrXx7TA=="
                                                                         >
                                                                             <div
                                                                                 class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -4831,7 +4772,7 @@
 
                                                                                 <textarea
                                                                                     name="comment[body]"
-                                                                                    id="r790463 new_inline_comment_diff_${anchor}_${position}"
+                                                                                    id="r133824 new_inline_comment_diff_${anchor}_${position}"
                                                                                     placeholder="Leave a comment"
                                                                                     aria-label="Comment body"
                                                                                     class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -4842,7 +4783,7 @@
                                                                                 ></textarea>
 
                                                                                 <p
-                                                                                    class="drag-and-drop position-relative"
+                                                                                    class="drag-and-drop position-relative d-flex flex-justify-between"
                                                                                 >
                                                                                     <input
                                                                                         accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
@@ -4992,6 +4933,32 @@
                                                                                             </span>
                                                                                         </span>
                                                                                     </span>
+                                                                                    <span
+                                                                                        class="tooltipped tooltipped-nw"
+                                                                                        aria-label="Styling with Markdown is supported"
+                                                                                    >
+                                                                                        <a
+                                                                                            class="tabnav-extra position-relative d-inline"
+                                                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                                                            target="_blank"
+                                                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                                                            aria-label="Learn about styling with Markdown"
+                                                                                        >
+                                                                                            <svg
+                                                                                                class="octicon octicon-markdown v-align-bottom"
+                                                                                                viewBox="0 0 16 16"
+                                                                                                version="1.1"
+                                                                                                width="16"
+                                                                                                height="16"
+                                                                                                aria-hidden="true"
+                                                                                            >
+                                                                                                <path
+                                                                                                    fill-rule="evenodd"
+                                                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                                ></path>
+                                                                                            </svg>
+                                                                                        </a>
+                                                                                    </span>
                                                                                 </p>
                                                                             </div>
                                                                         </file-attachment>
@@ -5026,30 +4993,6 @@
                                                                                     <p>Nothing to preview</p>
                                                                                 </div>
                                                                             </div>
-                                                                        </div>
-
-                                                                        <div class="float-left ">
-                                                                            <a
-                                                                                class="tabnav-extra "
-                                                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                                                target="_blank"
-                                                                                data-ga-click="Markdown Toolbar, click, help"
-                                                                            >
-                                                                                <svg
-                                                                                    class="octicon octicon-markdown v-align-bottom"
-                                                                                    viewBox="0 0 16 16"
-                                                                                    version="1.1"
-                                                                                    width="16"
-                                                                                    height="16"
-                                                                                    aria-hidden="true"
-                                                                                >
-                                                                                    <path
-                                                                                        fill-rule="evenodd"
-                                                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                                    ></path>
-                                                                                </svg>
-                                                                                Styling with Markdown is supported
-                                                                            </a>
                                                                         </div>
 
                                                                         <div
@@ -5130,103 +5073,116 @@
                                                     data-file-deleted="false"
                                                 >
                                                     <div class="file-actions">
-                                                        <span class="show-file-notes pt-1">
-                                                            <label>
-                                                                <input
-                                                                    type="checkbox"
-                                                                    checked="checked"
-                                                                    class="js-toggle-file-notes"
-                                                                />
-                                                                Show comments
-                                                            </label>
-                                                        </span>
+                                                        <div class="mt-1">
+                                                            <details
+                                                                class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                            >
+                                                                <summary
+                                                                    class="btn-link v-align-middle"
+                                                                    aria-haspopup="menu"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-kebab-horizontal text-gray"
+                                                                        aria-label="Show options"
+                                                                        viewBox="0 0 13 16"
+                                                                        version="1.1"
+                                                                        width="13"
+                                                                        height="16"
+                                                                        role="img"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </summary>
+                                                                <details-menu
+                                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                                    style="width:185px; z-index:99; right: -4px;"
+                                                                    role="menu"
+                                                                >
+                                                                    <label
+                                                                        role="menuitem"
+                                                                        class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                        tabindex="0"
+                                                                    >
+                                                                        <span
+                                                                            class="file-notes-check position-absolute ml-n3"
+                                                                            ><svg
+                                                                                class="octicon octicon-check"
+                                                                                viewBox="0 0 12 16"
+                                                                                version="1.1"
+                                                                                width="12"
+                                                                                height="16"
+                                                                                aria-hidden="true"
+                                                                            >
+                                                                                <path
+                                                                                    fill-rule="evenodd"
+                                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                                ></path></svg
+                                                                        ></span>
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            checked="checked"
+                                                                            class="d-none js-toggle-file-notes"
+                                                                        />
+                                                                        Show comments
+                                                                    </label>
 
-                                                        <div class="BtnGroup">
-                                                            <clipboard-copy
-                                                                value="cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                tabindex="0"
-                                                                role="button"
-                                                            >
-                                                                Copy path
-                                                            </clipboard-copy>
-                                                            <a
-                                                                href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                rel="nofollow"
-                                                            >
-                                                                View file
-                                                            </a>
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        rel="nofollow"
+                                                                        role="menuitem"
+                                                                        data-ga-click="View file, click, location:files_changed_dropdown"
+                                                                    >
+                                                                        View file
+                                                                    </a>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to make changes."
+                                                                    >
+                                                                        Edit file
+                                                                    </button>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to delete this file."
+                                                                    >
+                                                                        Delete file
+                                                                    </button>
+
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        role="menuitem"
+                                                                        href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
+                                                                        aria-label="Open this file in GitHub Desktop"
+                                                                        data-ga-click="Repository, open with desktop, type:mac"
+                                                                    >
+                                                                        Open in desktop
+                                                                    </a>
+                                                                </details-menu>
+                                                            </details>
                                                         </div>
-
-                                                        <a
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
-                                                            aria-label="Open this file in GitHub Desktop"
-                                                            data-ga-click="Repository, open with desktop, type:mac"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-device-desktop"
-                                                                viewBox="0 0 16 16"
-                                                                version="1.1"
-                                                                width="16"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/edit/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Change this file using the online editor"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-pencil"
-                                                                viewBox="0 0 14 16"
-                                                                version="1.1"
-                                                                width="14"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/delete/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon btn-octicon-danger tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Delete this file"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-trashcan"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
+                                                    </div>
+                                                    <div class="file-info">
                                                         <button
                                                             type="button"
-                                                            class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                            class="btn-octicon js-details-target"
                                                             aria-label="Toggle diff contents"
                                                             aria-expanded="true"
+                                                            style="width: 22px;"
                                                         >
                                                             <svg
                                                                 class="octicon octicon-chevron-down Details-content--hidden"
@@ -5242,21 +5198,19 @@
                                                                 ></path>
                                                             </svg>
                                                             <svg
-                                                                class="octicon octicon-chevron-up Details-content--shown"
-                                                                viewBox="0 0 10 16"
+                                                                class="octicon octicon-chevron-right Details-content--shown"
+                                                                viewBox="0 0 8 16"
                                                                 version="1.1"
-                                                                width="10"
+                                                                width="8"
                                                                 height="16"
                                                                 aria-hidden="true"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                                    d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                                 ></path>
                                                             </svg>
                                                         </button>
-                                                    </div>
-                                                    <div class="file-info">
                                                         <span
                                                             class="diffstat tooltipped tooltipped-e"
                                                             aria-label="22 additions &amp; 16 deletions"
@@ -5273,6 +5227,41 @@
                                                             title="cmd/gitserver/server/server.go"
                                                             >cmd/gitserver/server/server.go</a
                                                         >
+
+                                                        <clipboard-copy
+                                                            value="cmd/gitserver/server/server.go"
+                                                            aria-label="Copied!"
+                                                            class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                            tabindex="0"
+                                                            role="button"
+                                                        >
+                                                            <svg
+                                                                class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                                viewBox="0 0 14 16"
+                                                                version="1.1"
+                                                                width="14"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                                ></path>
+                                                            </svg>
+                                                            <svg
+                                                                class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                                viewBox="0 0 12 16"
+                                                                version="1.1"
+                                                                width="12"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                ></path>
+                                                            </svg>
+                                                        </clipboard-copy>
                                                     </div>
                                                 </div>
                                                 <div class="js-file-content Details-content--hidden">
@@ -5337,7 +5326,9 @@
                                                                         data-line-number="40"
                                                                     ></td>
 
-                                                                    <td class="code-review blob-code blob-code-context">
+                                                                    <td
+                                                                        class="code-review blob-code blob-code-context "
+                                                                    >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                                                             data-type="deletion"
@@ -11763,7 +11754,9 @@
                 class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light "
             >
                 <ul class="list-style-none d-flex flex-wrap ">
-                    <li class="mr-3">© 2019 <span title="0.53232s from unicorn-fd4b7c6d9-8pdjv">GitHub</span>, Inc.</li>
+                    <li class="mr-3">
+                        © 2019 <span title="0.56478s from unicorn-55c9994df8-xns9s">GitHub</span>, Inc.
+                    </li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
                             >Terms</a
@@ -11866,17 +11859,17 @@
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">

--- a/client/browser/src/libs/github/__fixtures__/github.com/pull-request/refined-github/unified/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/pull-request/refined-github/unified/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified -->
 <html lang="en" class="refined-github">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -35,6 +36,14 @@
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
+        <meta name="twitter:image:src" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="gitserver: Use opentracing for exec endpoint by keegancsmith · Pull Request #3257 · sourcegraph/sourcegraph"
+        />
+        <meta name="twitter:description" content="Part of #3253" />
         <meta property="og:image" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
@@ -48,10 +57,15 @@
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmRhZDU4MDk1ZDZhODkyMDI5YzgxYjRjNzIyZDc2N2Y5OWY3MzAzZDU5OTUwNmZlYWUxYTU1NGQ3OTIyZjM3NzY=--e1ed51ad887f1b129b22e34bd59e58ba6bc3b692"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjRjZDI2NjFlZThlYmQ5ZWQ4ZThlYTQ2ZmVmM2I3MGQxMDk4MWExYTYzOGI5MDQwNWUwY2U5MDFmMTkzMmUzZGE=--67bf8b82e3860594b398ef4668e5de222f530923"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
+        <meta name="request-id" content="F9A4:2AC2F:25C287C:390DA70:5CC224B6" data-pjax-transient="" />
+
+        <meta name="hovercard-subject-tag" content="pull_request:267881853" data-pjax-transient="" />
+
+        <meta name="selected-link" value="repo_pulls" data-pjax-transient="" />
 
         <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU" />
         <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA" />
@@ -60,12 +74,17 @@
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="DABA:4F10:828F04:E1CFC5:5CA7AE64" />
-        <meta name="octolytics-dimension-region_edge" content="iad" />
+        <meta name="octolytics-dimension-request_id" content="F9A4:2AC2F:25C287C:390DA70:5CC224B6" />
+        <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
         <meta name="octolytics-actor-login" content="felixfbecker" />
         <meta name="octolytics-actor-hash" content="a0bf5739a312c3a4d600b1ddd462e3b3ac0c4c28370673f3b7aacd82b09f1fac" />
+        <meta
+            name="analytics-location"
+            content="/<user-name>/<repo-name>/pull_requests/show/files"
+            data-pjax-transient="true"
+        />
 
         <meta class="js-ga-set" name="userId" content="1b23c6f4348a524a9d5b520c80e3ee17" />
 
@@ -77,22 +96,36 @@
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="ODdiMDczN2RhN2E0YWJhMzBkZGZiMDkyNjEyMDI1MmJmODkyZjRiY2YxNTUxMjI0MThkMzBkM2MwNWQyZDUxZHx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiREFCQTo0RjEwOjgyOEYwNDpFMUNGQzU6NUNBN0FFNjQiLCJ0aW1lc3RhbXAiOjE1NTQ0OTMwNTYsImhvc3QiOiJnaXRodWIuY29tIn0="
+            content="OWJjYzFmMjY1ZDRkMDkwYmE3ZGJkZjBlNTgxNTI1NzdmMzc1ODFmZGIyMTk5ZjU3MmE2NjhjNDY0MmFkODFlY3x7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkY5QTQ6MkFDMkY6MjVDMjg3QzozOTBEQTcwOjVDQzIyNEI2IiwidGltZXN0YW1wIjoxNTU2MjI3MjY5LCJob3N0IjoiZ2l0aHViLmNvbSJ9"
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
-            href="https://github.com/sourcegraph/sourcegraph/commits/core/gitserver-tracing.atom"
+            data-pjax-transient=""
             rel="alternate"
-            title="Recent Commits to sourcegraph:core/gitserver-tracing"
+            type="text/x-diff"
+            href="/sourcegraph/sourcegraph/pull/3257.diff"
+        />
+        <link
+            data-pjax-transient=""
+            rel="alternate"
+            type="text/x-patch"
+            href="/sourcegraph/sourcegraph/pull/3257.patch"
+        />
+
+        <meta name="diff-view" content="unified" data-pjax-transient="" />
+        <link
+            href="https://github.com/sourcegraph/sourcegraph/commits/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd.atom"
+            rel="alternate"
+            title="Recent Commits to sourcegraph:a537a324138be6b8a47d544d9ce7ed0cd7bce7dd"
             type="application/atom+xml"
         />
 
@@ -128,47 +161,16 @@
         <meta name="u2f-enabled" content="true" />
 
         <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
-
-        <meta name="selected-link" value="repo_pulls" data-pjax-transient="" />
-        <meta
-            name="analytics-location"
-            content="/<user-name>/<repo-name>/pull_requests/show/files"
-            data-pjax-transient=""
-        />
-        <meta name="request-id" content="DC02:409E2:18EC6FA:25BD2FC:5CA7AE82" data-pjax-transient="" />
-        <meta name="hovercard-subject-tag" content="pull_request:267881853" data-pjax-transient="" />
-        <link
-            data-pjax-transient=""
-            rel="alternate"
-            type="text/x-diff"
-            href="/sourcegraph/sourcegraph/pull/3257.diff"
-        />
-        <link
-            data-pjax-transient=""
-            rel="alternate"
-            type="text/x-patch"
-            href="/sourcegraph/sourcegraph/pull/3257.patch"
-        />
-        <meta name="diff-view" content="unified" data-pjax-transient="" />
-        <link
-            href="https://github.com/sourcegraph/sourcegraph/commits/core/gitserver-tracing.atom"
-            rel="alternate"
-            title="Recent Commits to sourcegraph:core/gitserver-tracing"
-            type="application/atom+xml"
-            data-pjax-transient=""
-        />
     </head>
 
     <body
-        class="logged-in env-production emoji-size-boost rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count intent-mouse"
+        class="logged-in env-production emoji-size-boost rgh-no-navigation-highlight rgh-monospace-textareas rgh-remove-diff-signs rgh-hide-watch-and-fork-count rgh-recently-pushed-branches"
     >
         <div class="position-relative js-header-wrapper ">
             <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content"
                 >Skip to content</a
             >
-            <div id="js-pjax-loader-bar" class="pjax-loader-bar">
-                <div class="progress" style="transition: width 0.4s ease 0s; width: 100%;"></div>
-            </div>
+            <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
 
             <header class="Header" role="banner">
                 <div class="Header-item">
@@ -235,7 +237,7 @@
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=69YKyZPCPS+AldYQnlvDfpzIJfnPVexOiSJgxJx2RRqy8Zs+t3Ksp2SMC3uVsrulO8wb3NndBO0m106VkUAgFw=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=VQLhIGU3Odu+k5hza67D0D8hbcxJS08BvVcaF1jV2P0MJXDXQYeoU1qKRRhgR7sLmCVT6V/Dp6ISojRGVeO98A=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -625,7 +627,9 @@
                             Marketplace
                         </a>
 
-                        <a
+                        <a href="/trending" class="js-selected-navigation-item Header-link  mr-3" data-hotkey="g t"
+                            >Trending</a
+                        ><a
                             class="js-selected-navigation-item Header-link  mr-3"
                             data-ga-click="Header, click, Nav menu - item:explore"
                             data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore"
@@ -635,6 +639,13 @@
                         </a>
                     </nav>
                 </div>
+                <div
+                    class="js-socket-channel js-updatable-content"
+                    data-channel="repo:41288708:post-receive:10532611"
+                    data-url="/sourcegraph/sourcegraph/show_partial?partial=tree%2Frecently_touched_branches_list"
+                ></div>
+
+                <div class="Header-item position-relative"></div>
 
                 <div class="Header-item"></div>
 
@@ -695,7 +706,7 @@
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -708,7 +719,11 @@
                             >
                                 New issue
                             </a>
-                        </details-menu>
+
+                            <a class="dropdown-item" href="/sourcegraph/sourcegraph/projects/new"
+                                >New project</a
+                            ></details-menu
+                        >
                     </details>
                 </div>
 
@@ -729,7 +744,7 @@
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -742,47 +757,54 @@
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:828F04:E1CFC5:5CA7AE64","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                            data-hydro-click-hmac="862dfa85cc8b4fca8f0fac23ce120141b859cd9868dec068156f15a91a851b62"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25C287C:390DA70:5CC224B6","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null}}'
+                                            data-hydro-click-hmac="c0960f03f51519398f6ffbb3fd0b269efc032dfde5e1bda15f1846f1724bb57b"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            title=":palm_tree:"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -804,7 +826,7 @@
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="WV1PBNoWfiAyskexwyLXYwy72iIowP2mFDdKFzttgO2vM+Dfm5e3/Lfk4fXIbZxgEt4bIAbsUVeCeo74jIsjEQ=="
+                                                    value="BTYkg04pplfkU6zxUuqHXfZdcQP9A+8w2AXVdd8hoHfzWItYD6hvi2EFCrVZpcxe6DiwAdMvQ8FOSBGaaMcDiw=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -833,7 +855,7 @@
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -855,14 +877,36 @@
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                title=":palm_tree:"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -886,8 +930,7 @@
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -917,7 +960,7 @@
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -942,7 +985,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -964,7 +1007,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -988,7 +1031,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -1010,7 +1053,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1029,6 +1072,7 @@
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1048,7 +1092,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1087,13 +1131,13 @@
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T22:07:37+02:00"
+                                                                        value="2019-04-25T23:51:09+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1103,7 +1147,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:37:37+02:00"
+                                                                        value="2019-04-26T00:21:09+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1113,7 +1157,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:37:37+02:00"
+                                                                        value="2019-04-26T03:21:09+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1123,7 +1167,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-25T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1133,7 +1177,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1158,15 +1202,13 @@
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1236,7 +1278,7 @@
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="LmNwQDmVaNxkF2cPwJs8k7yhAi7g1wcdZjI0UAQ/uKgprxN4kAs7cDQEdoFg71Rr0z3wdUK24uTDPx+s2SiG9A=="
+                                    value="WCC8WsnWokeyfW+HVQ92LyvBEo7m7mpo05vrvKaasrlf7N9iYEjx6+Jufgn1ex7XRF3g1USPj5F2lsBAe42M5Q=="
                                 />
 
                                 <button
@@ -1276,15 +1318,15 @@
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="ctCIoY0YYDqOBqLWVXYatOAAGLjNGvT0xQ+BfXYrujzqpdXTF0No37lLETEHbb1vR6RMJYmkfxEVsEebGW8E1g=="
+                                            value="jtXLnMXGTISR0AeYL5vNJww8TTw3GDrF/l6CAQy4SpgWoJbuX51EYaadtH99gGr8q5gZoXOmsSAu4UTnY/z0cg=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DC02:409E2:18EC6FA:25BD2FC:5CA7AE82","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified&amp;_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="410201e45cd35bc30bbd0b0136ed5a1caa707b94b42dc1a11e8ea075f888f2ee"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25C287C:390DA70:5CC224B6","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="a1db58c118efa4ed5a2879696cac389013dad99c2368ad1940def76a837a0330"
                                                 data-ga-click="Repository, click Watch settings, action:pull_requests#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1307,7 +1349,7 @@
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1511,9 +1553,9 @@
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1530,7 +1572,7 @@
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="wJtwFy84qhHRdMRltFgtxnKIb+kkvzhc2ZPocAwBpBRMOR+3MwYdIXydX7dNZu5o5iZgB30XJkiIayD9pcyjWg=="
+                                                value="brSx5E+rnEN6EQjmSxW36X2eygyjXfpdQ8fYcx3bMdfiFt5EU5Urc9f4kzSyK3RH6TDF4vr15EkSPxD+tBY2mQ=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1538,8 +1580,8 @@
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DC02:409E2:18EC6FA:25BD2FC:5CA7AE82","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified&amp;_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="b43b3d2ae092fbe037041ba3e4ea3d038a11d7ffef2407e08c6abd669abb647d"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25C287C:390DA70:5CC224B6","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="d61a93703996c6c05fa5ed91e557d4d9f9aeaa4a0536fa88b028e68ae547df9d"
                                                 data-ga-click="Repository, click unstar button, action:pull_requests#show; text:Unstar"
                                                 data-hotkey="g s"
                                             >
@@ -1561,9 +1603,9 @@
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1576,7 +1618,7 @@
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="wCygGzCYatwyoBh3WMCSSsMbjo4gUeqBMmBbdAlxsuB5F2Bquf3elQOCtG69YpWXhooN5F02UnlHuhFvG2GIcg=="
+                                                value="aOz/PXNV3a+fyHEaqv8rucvKDy5qYR81XG/MrbziUG/R1z9M+jBp5q7q3QNPXSxkjluMRBcGp80ptYa2rvJq/Q=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1584,8 +1626,8 @@
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DC02:409E2:18EC6FA:25BD2FC:5CA7AE82","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified&amp;_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="9492f33aa0902da0b259b88dfcae19f014ef600990939d296a60a81be835a241"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25C287C:390DA70:5CC224B6","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="4493a77646720cc5079df3c64e9e0e6de5c1b1a5bdd2045ba8621785a9d20cc7"
                                                 data-ga-click="Repository, click star button, action:pull_requests#show; text:Star"
                                                 data-hotkey="g s"
                                             >
@@ -1607,9 +1649,9 @@
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1618,16 +1660,13 @@
                                 <li>
                                     <details
                                         class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
-                                        data-deferred-details-content-url="/sourcegraph/sourcegraph/fork?fragment=1"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DC02:409E2:18EC6FA:25BD2FC:5CA7AE82","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified&amp;_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                            data-hydro-click-hmac="024e3f829e4d23bcddcc1d7668bb78f9545ed9ae32a4e6ca3359fe92d4614bcb"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25C287C:390DA70:5CC224B6","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="7a4b666bd8d36a158e09c24a15052b04d7b5fa3ca1e8001766c6cbbc883121a1"
                                             data-ga-click="Repository, show fork modal, action:pull_requests#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1647,6 +1686,8 @@
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1688,9 +1729,9 @@
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1729,22 +1770,21 @@
 
                                 <details
                                     class="commit-build-statuses details-overlay details-reset js-dropdown-details rgh-ci-link"
-                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6MTkzM2Q1NjE5ODQ4YjlmNzEyNWRmYmQ3ZmE3NWYwODJlMjQ4YzJhYQ==/statuses/combined_branch_status"
-                                    style="animation: 0s ease 0s 1 normal none running none;"
+                                    data-deferred-details-content-url="/_render_node/MDE3OlN0YXR1c0NoZWNrUm9sbHVwNDEyODg3MDg6YTNlMzMzMGJjYmY2MjQyZWYwNmQyYTMyZGY5NjU4ZWIwZDk0ZTk3ZQ==/statuses/combined_branch_status"
                                 >
-                                    <summary class="text-green">
+                                    <summary class="bg-pending">
                                         <svg
-                                            class="octicon octicon-check v-align-middle"
-                                            aria-label="2 / 2 checks OK"
-                                            viewBox="0 0 12 16"
+                                            class="octicon octicon-primitive-dot v-align-middle"
+                                            aria-label="0 / 1 checks OK"
+                                            viewBox="0 0 8 16"
                                             version="1.1"
-                                            width="12"
+                                            width="8"
                                             height="16"
                                             role="img"
                                         >
                                             <path
                                                 fill-rule="evenodd"
-                                                d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"
                                             ></path>
                                         </svg>
                                     </summary>
@@ -1827,7 +1867,7 @@
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">695</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1855,7 +1895,7 @@
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">82</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -2032,13 +2072,7 @@
                     <div class="container new-discussion-timeline experiment-repo-nav  ">
                         <div class="repository-content ">
                             <div
-                                class="js-socket-channel js-updatable-content"
-                                data-channel="repo:41288708:post-receive:10532611"
-                                data-url="/sourcegraph/sourcegraph/show_partial?partial=tree%2Frecently_touched_branches_list"
-                            ></div>
-
-                            <div
-                                class="issues-listing js-review-state-classes  js-suggested-changes-files-tab "
+                                class="position-relative js-review-state-classes  js-suggested-changes-files-tab "
                                 data-pjax=""
                                 data-issue-and-pr-hovercards-enabled=""
                             >
@@ -2051,7 +2085,7 @@
                                         class="gh-header js-details-container Details js-socket-channel js-updatable-content pull request js-pull-header-details"
                                         data-channel="pull_request:267881853"
                                         data-url="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Ftitle&amp;sticky=false"
-                                        data-pull-is-open="true"
+                                        data-pull-is-open="false"
                                         data-gid="MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz"
                                     >
                                         <div class="gh-header-show ">
@@ -2090,7 +2124,7 @@
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="CAusAHWDTfB9jbD+9K92qditRmkIu43iK49YfgXnn0SJ3xZuk62xKfjwXx6QxZcFnNa7lruAgoP3MbrNuUlugw=="
+                                                    value="5/dECoqPDJ3+zV9GpXZXhEFRyJEmZ0XIyXWN8ezhMuVmI/5kbKHwRHuwsKbBHLYoBSo1bpVcSqkVy29CUE/DIg=="
                                                 />
                                                 <input
                                                     class="form-control edit-issue-title js-quick-submit"
@@ -2122,10 +2156,10 @@
                                         </div>
                                         <div class="TableObject gh-header-meta">
                                             <div class="TableObject-item">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -2133,31 +2167,28 @@
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
                                             <div class="TableObject-item TableObject-item--primary">
                                                 <a
                                                     class="author link-gray text-bold css-truncate css-truncate-target expandable"
                                                     data-hovercard-type="user"
-                                                    data-hovercard-url="/hovercards?user_id=187831"
+                                                    data-hovercard-url="/hovercards?user_id=1646931"
                                                     data-octo-click="hovercard-link-click"
                                                     data-octo-dimensions="link_type:self"
-                                                    href="/keegancsmith"
-                                                    >keegancsmith</a
+                                                    href="/beyang"
+                                                    >beyang</a
                                                 >
-
-                                                wants to merge
-                                                <span class="js-updating-pull-request-commits-count">1</span>
-                                                commit into
+                                                merged 1 commit into
 
                                                 <a href="/sourcegraph/sourcegraph/tree/master"
                                                     ><span
                                                         title="sourcegraph/sourcegraph:master"
-                                                        class="commit-ref css-truncate user-select-contain expandable base-ref"
+                                                        class="commit-ref css-truncate user-select-contain expandable "
                                                         ><a
                                                             title="sourcegraph/sourcegraph:master"
                                                             class="no-underline"
@@ -2166,51 +2197,6 @@
                                                         ></span
                                                     ></a
                                                 ><span></span>
-
-                                                <div class="commit-ref-dropdown">
-                                                    <details
-                                                        class="details-reset details-overlay select-menu commitish-suggester"
-                                                    >
-                                                        <summary
-                                                            class="btn btn-sm select-menu-button branch"
-                                                            title="Choose a base branch"
-                                                            aria-haspopup="menu"
-                                                        >
-                                                            <i>base:</i>
-                                                            <span
-                                                                class="css-truncate css-truncate-target"
-                                                                title="master"
-                                                                >master</span
-                                                            >
-                                                        </summary>
-                                                        <details-menu
-                                                            class="select-menu-modal position-absolute"
-                                                            style="z-index: 90;"
-                                                            src="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Fdescription_branches_dropdown"
-                                                            preload=""
-                                                            role="menu"
-                                                        >
-                                                            <include-fragment
-                                                                class="select-menu-loading-overlay anim-pulse"
-                                                                aria-label="Loading"
-                                                            >
-                                                                <svg
-                                                                    height="32"
-                                                                    class="octicon octicon-octoface"
-                                                                    viewBox="0 0 16 16"
-                                                                    version="1.1"
-                                                                    width="32"
-                                                                    aria-hidden="true"
-                                                                >
-                                                                    <path
-                                                                        fill-rule="evenodd"
-                                                                        d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"
-                                                                    ></path>
-                                                                </svg>
-                                                            </include-fragment>
-                                                        </details-menu>
-                                                    </details>
-                                                </div>
 
                                                 from
 
@@ -2259,6 +2245,12 @@
                                                                 d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
                                                             ></path></svg></clipboard-copy
                                                 ></span>
+
+                                                <relative-time
+                                                    datetime="2019-04-08T00:40:04Z"
+                                                    title="8 Apr 2019, 02:40 CEST"
+                                                    >18 days ago</relative-time
+                                                >
                                             </div>
                                         </div>
                                     </div>
@@ -2288,7 +2280,7 @@
                                                 Conversation
 
                                                 <span id="conversation_tab_counter" class="Counter">
-                                                    1
+                                                    2
                                                 </span>
                                             </a>
 
@@ -2315,8 +2307,9 @@
                                                 <span
                                                     id="commits_tab_counter"
                                                     class="Counter js-updateable-pull-request-commits-count"
-                                                    >1</span
                                                 >
+                                                    1
+                                                </span>
                                             </a>
 
                                             <a
@@ -2375,10 +2368,10 @@
                                     <div class="pr-toolbar js-sticky js-sticky-offset-scroll" style="position: sticky;">
                                         <div class="diffbar details-collapse js-details-container Details">
                                             <div class="show-if-stuck float-left mr-2 mt-2">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -2386,10 +2379,10 @@
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
 
@@ -2483,7 +2476,7 @@
                                                                                 <relative-time
                                                                                     datetime="2019-04-05T16:05:51Z"
                                                                                     title="5 Apr 2019, 18:05 CEST"
-                                                                                    >4 hours ago</relative-time
+                                                                                    >20 days ago</relative-time
                                                                                 >
                                                                             </span>
                                                                         </div>
@@ -2740,7 +2733,7 @@
                                                                     <button
                                                                         type="button"
                                                                         class="btn btn-outline mt-2 text-bold js-dismiss-batched-suggested-changes-onboarding-notice"
-                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=e8dSCjkUTz349sJWpRax8Aw0yjU8TYarz4rfaFSaAlMSM/+i8g81Kz8wtMvdqy38Med9sQzZcmepnAFfHTcQTQ=="
+                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=dH6bo+SRT/zhpHKr3S/DiBfS3JsDv3vZpbHgGyEBPDAdijYLL4o16iZiBDalkl+EKgFrHzMrjxXDpz4saKwuLg=="
                                                                     >
                                                                         Got it
                                                                     </button>
@@ -2762,7 +2755,7 @@
                                                                 <input name="utf8" type="hidden" value="✓" /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="st5iufkd+LyeV9a//KPkO8BmDvnnixfv+i1L6SqH7ex0VNoaYFxA+msG5XL45TPDZ/0bQK2JaSieumXtEE9M8Q=="
+                                                                    value="mMfekM14gV9xtbIXnKakwV1XQxEh54bWe+HG7tNf9l1eTWYzVDk5GYTkgdqY4HM5+sxWqGvl+BEfdujq6ZdXQA=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2791,8 +2784,8 @@
                                                                     <button
                                                                         type="submit"
                                                                         class="btn btn-sm btn-primary float-left js-suggestion-batch-submit"
-                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DC02:409E2:18EC6FA:25BD2FC:5CA7AE82","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified&amp;_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                        data-hydro-click-hmac="b49f8fcfbda5913863878eacad838c7568cf2729d423676eef0d4600f85f85c3"
+                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"F9A4:2AC2F:25C287C:390DA70:5CC224B6","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null}}'
+                                                                        data-hydro-click-hmac="804e7136051a2b856c73087bef53854849d09f44e77df90146f6ac9ca1272f78"
                                                                         data-ga-click="Markdown Toolbar, click, insert code suggestion"
                                                                         data-disable-invalid="true"
                                                                         data-disable-with="Applying commits..."
@@ -2825,7 +2818,13 @@
                                                 <div class="diffbar-item dropdown js-reviews-container">
                                                     <details class="details-reset details-overlay js-dropdown-details">
                                                         <summary class="btn btn-sm btn-primary js-reviews-toggle">
-                                                            Review changes
+                                                            <span
+                                                                class="js-review-changes"
+                                                                data-pending-message="Finish your review"
+                                                                data-message="Review changes"
+                                                            >
+                                                                Review changes
+                                                            </span>
                                                             <span class="Counter js-pending-review-comment-count">
                                                                 0
                                                             </span>
@@ -2849,7 +2848,7 @@
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="HfyfDsdmyZ35ch1AQwtyP1m2z40V9f7ZGbZuT0L0yxCH56VdO1CKX+qP1oI7V0nlByrTN0ICTpfAnZS5GLZl2Q=="
+                                                                    value="QOdpPMHl0lntCxVqZbLaBPrxK6mCkWC0hMVEFTqVOgTa/FNvPdORm/723qgd7uHepG03E9Vm0Ppd7r7jYNeUzQ=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2861,7 +2860,7 @@
                                                                 <div
                                                                     class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                     data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                    data-preview-authenticity-token="pwWNGt61yoIs6WdO6r2YooI/eAGC1IuPfvGRatBjS5FnFdBiXZnwaRPgcLtGfdmxwCx/SjhqvwwM7VTP/S6hvw=="
+                                                                    data-preview-authenticity-token="/g4V5r1ddWi50e23PaJ6gcMash21DWzKWaxGgW4/qZA+HkiePnFPg4bY+kKRYjuSgQm1Vg+zWEkrsIMkQ3JDvg=="
                                                                 >
                                                                     <div class="comment-form-head tabnav ">
                                                                         <markdown-toolbar
@@ -3209,7 +3208,7 @@
                                                                                     type="button"
                                                                                     class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                     aria-label="Upload attachments"
-                                                                                    hotkey="u"
+                                                                                    data-hotkey="u"
                                                                                 >
                                                                                     <svg
                                                                                         aria-hidden="true"
@@ -3255,7 +3254,7 @@
                                                                         class="js-upload-markdown-image is-default"
                                                                         data-upload-repository-id="41288708"
                                                                         data-upload-policy-url="/upload/policies/assets"
-                                                                        data-upload-policy-authenticity-token="ehwUarFZQFv9YLAmBbyDhSbk+PZZHw16nJtPQq8XOehIClj7/jS8EAhv5bUxaXT86anM4H2YQQhcUvqN3qtM2A=="
+                                                                        data-upload-policy-authenticity-token="6u2+NapYrAPeEcuxc8Jy9k8aVN52zk2d+EmIHEyzIkrY+/Kk5TVQSCseniJHF4WPgFdgyFJJAe84gD3TPQ9Xeg=="
                                                                     >
                                                                         <div
                                                                             class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -3280,7 +3279,9 @@
                                                                                 data-suggest-mention="/suggestions/pull_request/267881853?repository=sourcegraph&amp;user_id=sourcegraph&amp;mention_suggester=1"
                                                                             ></textarea>
 
-                                                                            <p class="drag-and-drop position-relative">
+                                                                            <p
+                                                                                class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                            >
                                                                                 <input
                                                                                     accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                     type="file"
@@ -3422,6 +3423,32 @@
                                                                                         </span>
                                                                                     </span>
                                                                                 </span>
+                                                                                <span
+                                                                                    class="tooltipped tooltipped-nw"
+                                                                                    aria-label="Styling with Markdown is supported"
+                                                                                >
+                                                                                    <a
+                                                                                        class="tabnav-extra position-relative d-inline"
+                                                                                        href="https://guides.github.com/features/mastering-markdown/"
+                                                                                        target="_blank"
+                                                                                        data-ga-click="Markdown Toolbar, click, help"
+                                                                                        aria-label="Learn about styling with Markdown"
+                                                                                    >
+                                                                                        <svg
+                                                                                            class="octicon octicon-markdown v-align-bottom"
+                                                                                            viewBox="0 0 16 16"
+                                                                                            version="1.1"
+                                                                                            width="16"
+                                                                                            height="16"
+                                                                                            aria-hidden="true"
+                                                                                        >
+                                                                                            <path
+                                                                                                fill-rule="evenodd"
+                                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                            ></path>
+                                                                                        </svg>
+                                                                                    </a>
+                                                                                </span>
                                                                             </p>
                                                                         </div>
                                                                     </file-attachment>
@@ -3463,9 +3490,22 @@
                                                                     ></div>
                                                                 </div>
 
+                                                                <input
+                                                                    type="hidden"
+                                                                    name="pull_request_review[event]"
+                                                                    value="comment"
+                                                                />
+
                                                                 <div
                                                                     class="form-actions p-2 m-0 bg-gray-light border-top"
                                                                 >
+                                                                    <button
+                                                                        type="submit"
+                                                                        class="btn btn-sm btn-primary float-left mr-1"
+                                                                        data-disable-with=""
+                                                                    >
+                                                                        Submit review
+                                                                    </button>
                                                                     <span
                                                                         class="review-title-with-count text-gray-light float-left mt-1 ml-1"
                                                                     >
@@ -3481,29 +3521,6 @@
                                                                             comments
                                                                         </span>
                                                                     </span>
-                                                                    <input
-                                                                        type="hidden"
-                                                                        name="pull_request_review[event]"
-                                                                        value="comment"
-                                                                    /><button
-                                                                        name="pull_request_review[event]"
-                                                                        value="approve"
-                                                                        class="btn btn-sm btn-primary "
-                                                                    >
-                                                                        Approve</button
-                                                                    ><button
-                                                                        name="pull_request_review[event]"
-                                                                        value="reject"
-                                                                        class="btn btn-sm btn-danger "
-                                                                    >
-                                                                        Request changes</button
-                                                                    ><button
-                                                                        name="pull_request_review[event]"
-                                                                        value="comment"
-                                                                        class="btn btn-sm  "
-                                                                    >
-                                                                        Comment
-                                                                    </button>
                                                                 </div>
                                                             </form>
                                                         </div>
@@ -3531,24 +3548,6 @@
                                                         <div
                                                             class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                         >
-                                                            <div class="inline-comment-form-actions">
-                                                                <button
-                                                                    type="button"
-                                                                    class="btn js-toggle-new-thread-form"
-                                                                    data-ga-click="Start a new conversation, click"
-                                                                    data-side=""
-                                                                >
-                                                                    Start a new conversation
-                                                                </button>
-
-                                                                <a
-                                                                    href="/sourcegraph/sourcegraph/pull/3257/files#submit-review"
-                                                                    class="finish-review-label btn ml-1"
-                                                                >
-                                                                    Finish your review
-                                                                </a>
-                                                            </div>
-
                                                             <div class="inline-comment-form">
                                                                 <!-- '"` --><!-- </textarea></xmp> -->
                                                                 <form
@@ -3560,7 +3559,7 @@
                                                                     <input name="utf8" type="hidden" value="✓" /><input
                                                                         type="hidden"
                                                                         name="authenticity_token"
-                                                                        value="nWplTX/mendSewxlhsbaMrnHeA6MN5h6LtAxCyxTg1OINcI4/nDTEkMIm3/VhC9lhLOEfLuCxYAyLi91/OAB3w=="
+                                                                        value="4/D2SI0DDr+spa33/nWBdAzGfrLAcOq8cHpEXcbH04P2r1E9DJWn2r3WOu2tN3QjMbKCwPfFt0ZshFojFnRRDw=="
                                                                     />
                                                                     <input
                                                                         type="hidden"
@@ -3597,40 +3596,15 @@
                                                                     <input type="hidden" name="position" value="" />
 
                                                                     <div
-                                                                        class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                                                        class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                         data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                        data-preview-authenticity-token="Qs9eeUWOwhwbJ7dKFXrVXvQZ9+ww7bShdnTMwNv+nJKC3wMBxqL49yQuoL+5upRNtgrwp4pTgCIEaAll9rN2vA=="
+                                                                        data-preview-authenticity-token="PoPDN/YrTy8SDZm9iL3h22yUSJX4DugKuq43vS4HPv3+k55PdQd1xC0EjkgkfaDILodP3kKw3InIsvIYA0rU0w=="
                                                                     >
                                                                         <div class="comment-form-head tabnav ">
                                                                             <markdown-toolbar
-                                                                                for="r219673 new_inline_comment_diff_${anchor}_${position}"
+                                                                                for="r686287 new_inline_comment_diff_${anchor}_${position}"
                                                                                 class="toolbar-commenting "
                                                                             >
-                                                                                <div class="toolbar-group">
-                                                                                    <button
-                                                                                        type="button"
-                                                                                        class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item"
-                                                                                        aria-label="Insert a suggestion <cmd-g>"
-                                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"insert_suggestion","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DC02:409E2:18EC6FA:25BD2FC:5CA7AE82","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified&amp;_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                                        data-hydro-click-hmac="61668467dbdef47d55be78d6d9ec771c4e4ab38ed50ad2e4553eb917e6b80fd5"
-                                                                                        data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                                                        hotkey="g"
-                                                                                    >
-                                                                                        <svg
-                                                                                            class="octicon octicon-diff"
-                                                                                            viewBox="0 0 13 16"
-                                                                                            version="1.1"
-                                                                                            width="13"
-                                                                                            height="16"
-                                                                                            aria-hidden="true"
-                                                                                        >
-                                                                                            <path
-                                                                                                fill-rule="evenodd"
-                                                                                                d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"
-                                                                                            ></path>
-                                                                                        </svg>
-                                                                                    </button>
-                                                                                </div>
                                                                                 <div class="toolbar-group">
                                                                                     <md-header
                                                                                         tabindex="-1"
@@ -3973,7 +3947,7 @@
                                                                                         type="button"
                                                                                         class="toolbar-item rgh-upload-btn tooltipped tooltipped-nw"
                                                                                         aria-label="Upload attachments"
-                                                                                        hotkey="u"
+                                                                                        data-hotkey="u"
                                                                                     >
                                                                                         <svg
                                                                                             aria-hidden="true"
@@ -4020,7 +3994,7 @@
                                                                             class="js-upload-markdown-image is-default"
                                                                             data-upload-repository-id="41288708"
                                                                             data-upload-policy-url="/upload/policies/assets"
-                                                                            data-upload-policy-authenticity-token="rTW6LYPTsAwZN4KgjqwRYfkaHd5Tc/2jZjXWTZgEK1yfI/a8zL5MR+w41zO6eeYYNlcpyHf0sdGm/GOC6bhebA=="
+                                                                            data-upload-policy-authenticity-token="s5+61s/mqoufN9s0rJTyLdGja+tKEseG21dvvpxlzuKBifZHgItWwGo4jqeYQQVUHu5f/W6Vi/Qbntpx7dm70g=="
                                                                         >
                                                                             <div
                                                                                 class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -4036,7 +4010,7 @@
 
                                                                                 <textarea
                                                                                     name="comment[body]"
-                                                                                    id="r219673 new_inline_comment_diff_${anchor}_${position}"
+                                                                                    id="r686287 new_inline_comment_diff_${anchor}_${position}"
                                                                                     placeholder="Leave a comment"
                                                                                     aria-label="Comment body"
                                                                                     class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -4047,7 +4021,7 @@
                                                                                 ></textarea>
 
                                                                                 <p
-                                                                                    class="drag-and-drop position-relative"
+                                                                                    class="drag-and-drop position-relative d-flex flex-justify-between"
                                                                                 >
                                                                                     <input
                                                                                         accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
@@ -4197,6 +4171,32 @@
                                                                                             </span>
                                                                                         </span>
                                                                                     </span>
+                                                                                    <span
+                                                                                        class="tooltipped tooltipped-nw"
+                                                                                        aria-label="Styling with Markdown is supported"
+                                                                                    >
+                                                                                        <a
+                                                                                            class="tabnav-extra position-relative d-inline"
+                                                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                                                            target="_blank"
+                                                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                                                            aria-label="Learn about styling with Markdown"
+                                                                                        >
+                                                                                            <svg
+                                                                                                class="octicon octicon-markdown v-align-bottom"
+                                                                                                viewBox="0 0 16 16"
+                                                                                                version="1.1"
+                                                                                                width="16"
+                                                                                                height="16"
+                                                                                                aria-hidden="true"
+                                                                                            >
+                                                                                                <path
+                                                                                                    fill-rule="evenodd"
+                                                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                                ></path>
+                                                                                            </svg>
+                                                                                        </a>
+                                                                                    </span>
                                                                                 </p>
                                                                             </div>
                                                                         </file-attachment>
@@ -4231,30 +4231,6 @@
                                                                                     <p>Nothing to preview</p>
                                                                                 </div>
                                                                             </div>
-                                                                        </div>
-
-                                                                        <div class="float-left ">
-                                                                            <a
-                                                                                class="tabnav-extra "
-                                                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                                                target="_blank"
-                                                                                data-ga-click="Markdown Toolbar, click, help"
-                                                                            >
-                                                                                <svg
-                                                                                    class="octicon octicon-markdown v-align-bottom"
-                                                                                    viewBox="0 0 16 16"
-                                                                                    version="1.1"
-                                                                                    width="16"
-                                                                                    height="16"
-                                                                                    aria-hidden="true"
-                                                                                >
-                                                                                    <path
-                                                                                        fill-rule="evenodd"
-                                                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                                    ></path>
-                                                                                </svg>
-                                                                                Styling with Markdown is supported
-                                                                            </a>
                                                                         </div>
 
                                                                         <div
@@ -4335,103 +4311,116 @@
                                                     data-file-deleted="false"
                                                 >
                                                     <div class="file-actions">
-                                                        <span class="show-file-notes pt-1">
-                                                            <label>
-                                                                <input
-                                                                    type="checkbox"
-                                                                    checked="checked"
-                                                                    class="js-toggle-file-notes"
-                                                                />
-                                                                Show comments
-                                                            </label>
-                                                        </span>
+                                                        <div class="mt-1">
+                                                            <details
+                                                                class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                            >
+                                                                <summary
+                                                                    class="btn-link v-align-middle"
+                                                                    aria-haspopup="menu"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-kebab-horizontal text-gray"
+                                                                        aria-label="Show options"
+                                                                        viewBox="0 0 13 16"
+                                                                        version="1.1"
+                                                                        width="13"
+                                                                        height="16"
+                                                                        role="img"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </summary>
+                                                                <details-menu
+                                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                                    style="width:185px; z-index:99; right: -4px;"
+                                                                    role="menu"
+                                                                >
+                                                                    <label
+                                                                        role="menuitem"
+                                                                        class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                        tabindex="0"
+                                                                    >
+                                                                        <span
+                                                                            class="file-notes-check position-absolute ml-n3"
+                                                                            ><svg
+                                                                                class="octicon octicon-check"
+                                                                                viewBox="0 0 12 16"
+                                                                                version="1.1"
+                                                                                width="12"
+                                                                                height="16"
+                                                                                aria-hidden="true"
+                                                                            >
+                                                                                <path
+                                                                                    fill-rule="evenodd"
+                                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                                ></path></svg
+                                                                        ></span>
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            checked="checked"
+                                                                            class="d-none js-toggle-file-notes"
+                                                                        />
+                                                                        Show comments
+                                                                    </label>
 
-                                                        <div class="BtnGroup">
-                                                            <clipboard-copy
-                                                                value="cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                tabindex="0"
-                                                                role="button"
-                                                            >
-                                                                Copy path
-                                                            </clipboard-copy>
-                                                            <a
-                                                                href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                rel="nofollow"
-                                                            >
-                                                                View file
-                                                            </a>
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        rel="nofollow"
+                                                                        role="menuitem"
+                                                                        data-ga-click="View file, click, location:files_changed_dropdown"
+                                                                    >
+                                                                        View file
+                                                                    </a>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to make changes."
+                                                                    >
+                                                                        Edit file
+                                                                    </button>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to delete this file."
+                                                                    >
+                                                                        Delete file
+                                                                    </button>
+
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        role="menuitem"
+                                                                        href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
+                                                                        aria-label="Open this file in GitHub Desktop"
+                                                                        data-ga-click="Repository, open with desktop, type:mac"
+                                                                    >
+                                                                        Open in desktop
+                                                                    </a>
+                                                                </details-menu>
+                                                            </details>
                                                         </div>
-
-                                                        <a
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
-                                                            aria-label="Open this file in GitHub Desktop"
-                                                            data-ga-click="Repository, open with desktop, type:mac"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-device-desktop"
-                                                                viewBox="0 0 16 16"
-                                                                version="1.1"
-                                                                width="16"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/edit/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Change this file using the online editor"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-pencil"
-                                                                viewBox="0 0 14 16"
-                                                                version="1.1"
-                                                                width="14"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/delete/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon btn-octicon-danger tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Delete this file"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-trashcan"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
+                                                    </div>
+                                                    <div class="file-info">
                                                         <button
                                                             type="button"
-                                                            class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                            class="btn-octicon js-details-target"
                                                             aria-label="Toggle diff contents"
                                                             aria-expanded="true"
+                                                            style="width: 22px;"
                                                         >
                                                             <svg
                                                                 class="octicon octicon-chevron-down Details-content--hidden"
@@ -4447,21 +4436,19 @@
                                                                 ></path>
                                                             </svg>
                                                             <svg
-                                                                class="octicon octicon-chevron-up Details-content--shown"
-                                                                viewBox="0 0 10 16"
+                                                                class="octicon octicon-chevron-right Details-content--shown"
+                                                                viewBox="0 0 8 16"
                                                                 version="1.1"
-                                                                width="10"
+                                                                width="8"
                                                                 height="16"
                                                                 aria-hidden="true"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                                    d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                                 ></path>
                                                             </svg>
                                                         </button>
-                                                    </div>
-                                                    <div class="file-info">
                                                         <span
                                                             class="diffstat tooltipped tooltipped-e"
                                                             aria-label="22 additions &amp; 16 deletions"
@@ -4478,6 +4465,41 @@
                                                             title="cmd/gitserver/server/server.go"
                                                             >cmd/gitserver/server/server.go</a
                                                         >
+
+                                                        <clipboard-copy
+                                                            value="cmd/gitserver/server/server.go"
+                                                            aria-label="Copied!"
+                                                            class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                            tabindex="0"
+                                                            role="button"
+                                                        >
+                                                            <svg
+                                                                class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                                viewBox="0 0 14 16"
+                                                                version="1.1"
+                                                                width="14"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                                ></path>
+                                                            </svg>
+                                                            <svg
+                                                                class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                                viewBox="0 0 12 16"
+                                                                version="1.1"
+                                                                width="12"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                ></path>
+                                                            </svg>
+                                                        </clipboard-copy>
                                                     </div>
                                                 </div>
                                                 <div class="js-file-content Details-content--hidden">
@@ -9313,7 +9335,9 @@
                 class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light "
             >
                 <ul class="list-style-none d-flex flex-wrap ">
-                    <li class="mr-3">© 2019 <span title="0.53232s from unicorn-fd4b7c6d9-8pdjv">GitHub</span>, Inc.</li>
+                    <li class="mr-3">
+                        © 2019 <span title="0.39570s from unicorn-799fc566dd-rq62m">GitHub</span>, Inc.
+                    </li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
                             >Terms</a
@@ -9416,17 +9440,17 @@
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">

--- a/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/split/code-view.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/split/code-view.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/pull/3272/files?diff=split -->
 <div
     id="diff-0"
     class="file js-file js-details-container Details
@@ -21,102 +22,101 @@
         data-file-deleted="false"
     >
         <div class="file-actions">
-            <span class="show-file-notes pt-1">
-                <label>
-                    <input type="checkbox" checked="checked" class="js-toggle-file-notes" />
-                    Show comments
-                </label>
-            </span>
+            <div class="mt-1">
+                <details
+                    class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                >
+                    <summary class="btn-link v-align-middle" aria-haspopup="menu">
+                        <svg
+                            class="octicon octicon-kebab-horizontal text-gray"
+                            aria-label="Show options"
+                            viewBox="0 0 13 16"
+                            version="1.1"
+                            width="13"
+                            height="16"
+                            role="img"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                            ></path>
+                        </svg>
+                    </summary>
+                    <details-menu
+                        class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                        style="width:185px; z-index:99; right: -4px;"
+                        role="menu"
+                    >
+                        <label role="menuitem" class="dropdown-item btn-link text-normal d-block pl-5" tabindex="0">
+                            <span class="file-notes-check position-absolute ml-n3"
+                                ><svg
+                                    class="octicon octicon-check"
+                                    viewBox="0 0 12 16"
+                                    version="1.1"
+                                    width="12"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg
+                            ></span>
+                            <input type="checkbox" checked="checked" class="d-none js-toggle-file-notes" />
+                            Show comments
+                        </label>
 
-            <div class="BtnGroup">
-                <clipboard-copy
-                    value="packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
-                    class="btn btn-sm BtnGroup-item"
-                    tabindex="0"
-                    role="button"
-                >
-                    Copy path
-                </clipboard-copy>
-                <a
-                    href="/sourcegraph/sourcegraph/blob/685a686a933beae5027cfae2121cf0e408a29bd8/packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
-                    class="btn btn-sm BtnGroup-item"
-                    rel="nofollow"
-                    data-ga-click="View file, click, location:files_changed"
-                >
-                    View file
-                </a>
+                        <div role="none" class="dropdown-divider"></div>
+
+                        <a
+                            href="/sourcegraph/sourcegraph/blob/685a686a933beae5027cfae2121cf0e408a29bd8/packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
+                            class="pl-5 dropdown-item btn-link"
+                            rel="nofollow"
+                            role="menuitem"
+                            data-ga-click="View file, click, location:files_changed_dropdown"
+                        >
+                            View file
+                        </a>
+
+                        <button
+                            type="button"
+                            disabled=""
+                            role="menuitem"
+                            class="pl-5 dropdown-item btn-link"
+                            aria-label="You must be signed in and have push access to make changes."
+                        >
+                            Edit file
+                        </button>
+
+                        <button
+                            type="button"
+                            disabled=""
+                            role="menuitem"
+                            class="pl-5 dropdown-item btn-link"
+                            aria-label="You must be signed in and have push access to delete this file."
+                        >
+                            Delete file
+                        </button>
+
+                        <div role="none" class="dropdown-divider"></div>
+
+                        <a
+                            class="pl-5 dropdown-item btn-link"
+                            role="menuitem"
+                            href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=readonly-field&amp;filepath=packages%2Fsourcegraph-extension-api%2Fsrc%2Fsourcegraph.d.ts"
+                            aria-label="Open this file in GitHub Desktop"
+                            data-ga-click="Repository, open with desktop, type:mac"
+                        >
+                            Open in desktop
+                        </a>
+                    </details-menu>
+                </details>
             </div>
-
-            <a
-                class="btn-octicon tooltipped tooltipped-w"
-                href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=readonly-field&amp;filepath=packages%2Fsourcegraph-extension-api%2Fsrc%2Fsourcegraph.d.ts"
-                aria-label="Open this file in GitHub Desktop"
-                data-ga-click="Repository, open with desktop, type:mac"
-            >
-                <svg
-                    class="octicon octicon-device-desktop"
-                    viewBox="0 0 16 16"
-                    version="1.1"
-                    width="16"
-                    height="16"
-                    aria-hidden="true"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
-                    ></path>
-                </svg>
-            </a>
-
-            <a
-                href="/sourcegraph/sourcegraph/edit/readonly-field/packages/sourcegraph-extension-api/src/sourcegraph.d.ts?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3272"
-                class="btn-octicon tooltipped tooltipped-w"
-                rel="nofollow"
-                data-skip-pjax=""
-                aria-label="Change this file using the online editor"
-                data-ga-click="Edit file, click, location:files_changed"
-            >
-                <svg
-                    class="octicon octicon-pencil"
-                    viewBox="0 0 14 16"
-                    version="1.1"
-                    width="14"
-                    height="16"
-                    aria-hidden="true"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                    ></path>
-                </svg>
-            </a>
-            <a
-                href="/sourcegraph/sourcegraph/delete/readonly-field/packages/sourcegraph-extension-api/src/sourcegraph.d.ts?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3272"
-                class="btn-octicon btn-octicon-danger tooltipped tooltipped-w"
-                rel="nofollow"
-                data-skip-pjax=""
-                aria-label="Delete this file"
-                data-ga-click="Delete file, click, location:files_changed"
-            >
-                <svg
-                    class="octicon octicon-trashcan"
-                    viewBox="0 0 12 16"
-                    version="1.1"
-                    width="12"
-                    height="16"
-                    aria-hidden="true"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                    ></path>
-                </svg>
-            </a>
+        </div>
+        <div class="file-info">
             <button
                 type="button"
-                class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                class="btn-octicon js-details-target"
                 aria-label="Toggle diff contents"
                 aria-expanded="true"
+                style="width: 22px;"
             >
                 <svg
                     class="octicon octicon-chevron-down Details-content--hidden"
@@ -129,18 +129,16 @@
                     <path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"></path>
                 </svg>
                 <svg
-                    class="octicon octicon-chevron-up Details-content--shown"
-                    viewBox="0 0 10 16"
+                    class="octicon octicon-chevron-right Details-content--shown"
+                    viewBox="0 0 8 16"
                     version="1.1"
-                    width="10"
+                    width="8"
                     height="16"
                     aria-hidden="true"
                 >
-                    <path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"></path>
+                    <path fill-rule="evenodd" d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"></path>
                 </svg>
             </button>
-        </div>
-        <div class="file-info">
             <span class="diffstat tooltipped tooltipped-e" aria-label="1 addition &amp; 1 deletion"
                 >2 <span class="block-diff-added"></span><span class="block-diff-deleted"></span
                 ><span class="block-diff-neutral"></span><span class="block-diff-neutral"></span
@@ -153,6 +151,38 @@
                 title="packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
                 >packages/sourcegraph-extension-api/src/sourcegraph.d.ts</a
             >
+
+            <clipboard-copy
+                value="packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
+                aria-label="Copied!"
+                class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                tabindex="0"
+                role="button"
+            >
+                <svg
+                    class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                    viewBox="0 0 14 16"
+                    version="1.1"
+                    width="14"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                    ></path>
+                </svg>
+                <svg
+                    class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                    viewBox="0 0 12 16"
+                    version="1.1"
+                    width="12"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path>
+                </svg>
+            </clipboard-copy>
         </div>
     </div>
     <div class="js-file-content Details-content--hidden">
@@ -208,7 +238,7 @@
                             data-line-number="569"
                         ></td>
 
-                        <td class="code-review blob-code blob-code-context">
+                        <td class="code-review blob-code blob-code-context ">
                             <button
                                 class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                 data-type="deletion"
@@ -282,7 +312,7 @@
                             data-line-number="570"
                         ></td>
 
-                        <td class="code-review blob-code blob-code-context">
+                        <td class="code-review blob-code blob-code-context ">
                             <button
                                 class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                 data-type="deletion"
@@ -358,7 +388,7 @@
                             data-line-number="571"
                         ></td>
 
-                        <td class="code-review blob-code blob-code-context">
+                        <td class="code-review blob-code blob-code-context ">
                             <button
                                 class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                 data-type="deletion"
@@ -444,7 +474,7 @@
                             data-line-number="572"
                         ></td>
 
-                        <td class="code-review blob-code blob-code-deletion">
+                        <td class="code-review blob-code blob-code-deletion ">
                             <button
                                 class="btn-link add-line-comment js-add-line-comment js-add-split-line-comment"
                                 data-type="deletion"
@@ -527,7 +557,7 @@
                             data-line-number="573"
                         ></td>
 
-                        <td class="code-review blob-code blob-code-context">
+                        <td class="code-review blob-code blob-code-context ">
                             <button
                                 class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                 data-type="deletion"
@@ -597,7 +627,7 @@
                             data-line-number="574"
                         ></td>
 
-                        <td class="code-review blob-code blob-code-context">
+                        <td class="code-review blob-code blob-code-context ">
                             <button
                                 class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                 data-type="deletion"
@@ -671,7 +701,7 @@
                             data-line-number="575"
                         ></td>
 
-                        <td class="code-review blob-code blob-code-context">
+                        <td class="code-review blob-code blob-code-context ">
                             <button
                                 class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                 data-type="deletion"

--- a/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/split/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/split/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=split -->
 <html lang="en">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -35,6 +36,14 @@
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
+        <meta name="twitter:image:src" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="gitserver: Use opentracing for exec endpoint by keegancsmith · Pull Request #3257 · sourcegraph/sourcegraph"
+        />
+        <meta name="twitter:description" content="Part of #3253" />
         <meta property="og:image" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
@@ -48,11 +57,11 @@
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmEwOTViMWY3NmU4MGZhMGQwMjJmMmFjZDFlMGZiZWM2OTlmZjc4ZDA0MzRlNTQzN2I3ZDJlMDJjMzQ2YmZlZTU=--f7223509cc74cb1e83cef916cea1204100569cb6"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjNmMzMzYThmZDQzNjUyZTFkMTMxZGNhZWY4MTIyOWIyYmY4MjQzZmMwN2UzN2U4NzhkMDZkMGU0NzZmYjk0MGE=--f6f8f6f3a1757b577fab554c571a3aedba7df2aa"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
-        <meta name="request-id" content="DABA:4F10:8283B1:E1BE01:5CA7AE4B" data-pjax-transient="" />
+        <meta name="request-id" content="F7C9:19F16:25CCED1:38FE1CE:5CC2241D" data-pjax-transient="" />
 
         <meta name="hovercard-subject-tag" content="pull_request:267881853" data-pjax-transient="" />
 
@@ -65,8 +74,8 @@
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="DABA:4F10:8283B1:E1BE01:5CA7AE4B" />
-        <meta name="octolytics-dimension-region_edge" content="iad" />
+        <meta name="octolytics-dimension-request_id" content="F7C9:19F16:25CCED1:38FE1CE:5CC2241D" />
+        <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
         <meta name="octolytics-actor-login" content="felixfbecker" />
@@ -87,17 +96,17 @@
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="ZjhhODQ1NTNlOGU3MTRmMjc3Mzg0MjQyMjhhNjBjMDE5YzVmNTM4MTQ0YzkwNzY0NGQ1NjA5MWFkNjhiMmM5M3x7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiREFCQTo0RjEwOjgyODNCMTpFMUJFMDE6NUNBN0FFNEIiLCJ0aW1lc3RhbXAiOjE1NTQ0OTMwMjYsImhvc3QiOiJnaXRodWIuY29tIn0="
+            content="YjQzNGE5Njg4MTM0NWFiMjk0Zjg4MGEyYjk3MmM1Mzk3NjNiMzVlNjRmNTJmMWNiMjUzMzllYTNlYTIyY2Q5Y3x7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkY3Qzk6MTlGMTY6MjVDQ0VEMTozOEZFMUNFOjVDQzIyNDFEIiwidGltZXN0YW1wIjoxNTU2MjI3MTUzLCJob3N0IjoiZ2l0aHViLmNvbSJ9"
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
             data-pjax-transient=""
@@ -114,9 +123,9 @@
 
         <meta name="diff-view" content="split" data-pjax-transient="" />
         <link
-            href="https://github.com/sourcegraph/sourcegraph/commits/core/gitserver-tracing.atom"
+            href="https://github.com/sourcegraph/sourcegraph/commits/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd.atom"
             rel="alternate"
-            title="Recent Commits to sourcegraph:core/gitserver-tracing"
+            title="Recent Commits to sourcegraph:a537a324138be6b8a47d544d9ce7ed0cd7bce7dd"
             type="application/atom+xml"
         />
 
@@ -226,7 +235,7 @@
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=zn/knx2UGd1S45MkxUsFe2P+3z+ZQjV88uY2f0XLIYmXWHVoOSSIVbb6Tk/Oon2gxPrhGo/K3d9dExguSP1EhA=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=wytdWZqRl/iZMmHoY9BMTuy0IB8KZ13JkQ+AmxCD4q6aDMyuviEGcH0rvINoOTSVS7AeOhzvtWo++q7KHbWHow=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -627,6 +636,8 @@
                     </nav>
                 </div>
 
+                <div class="Header-item position-relative"></div>
+
                 <div class="Header-item"></div>
 
                 <div class="Header-item position-relative">
@@ -686,7 +697,7 @@
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -720,7 +731,7 @@
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -733,47 +744,53 @@
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                            data-hydro-click-hmac="1e6459bb4fb0907131bd06d0fd8a741e19bd3e99070561e754a64fdc24c616a0"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"F7C9:19F16:25CCED1:38FE1CE:5CC2241D","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?split","referrer":null}}'
+                                            data-hydro-click-hmac="9d5e8fdbdda161cb1464b4554fe5b97d698075e958a2430a0e02938803b3e423"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -795,7 +812,7 @@
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="xSJEJ9mAgdPJWpAy4G56umit2bjd3QevJJJkTkTm6l8zTOv8mAFID0wMNnbrITG5dsgYuvPxq16y36Ch8wBJow=="
+                                                    value="bfkizwwrQbulU+ry6p16n9UjXYxZsdBAPUxJ4jIBDSybl40UTaqIZyAFTLbh0jGcy0acjnedfLGrAY0Nheeu0A=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -824,7 +841,7 @@
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -846,14 +863,34 @@
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -877,8 +914,7 @@
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -908,7 +944,7 @@
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -932,7 +968,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -953,7 +989,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -976,7 +1012,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -997,7 +1033,7 @@
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1016,6 +1052,7 @@
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1035,7 +1072,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1074,13 +1111,13 @@
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T22:07:06+02:00"
+                                                                        value="2019-04-25T23:49:13+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1090,7 +1127,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:37:06+02:00"
+                                                                        value="2019-04-26T00:19:13+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1100,7 +1137,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:37:06+02:00"
+                                                                        value="2019-04-26T03:19:13+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1110,7 +1147,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-25T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1120,7 +1157,7 @@
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1145,15 +1182,13 @@
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1223,7 +1258,7 @@
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="Lv9x+5FIhLvsWbupgIC2YY3Z2nsc8zEFyw2vDqlqeQApMxLDONbXF7xKqicg9N6Z4kUoIL6S1PxuAITydH1HXA=="
+                                    value="i/79Q1qk6JjsHaMtZ6kgNEKBC2/MrcouF+P6YJ7kfIuMMp578zq7NLwOsqPH3UjMLR35NG7ML9ey7tGcQ/NC1w=="
                                 />
 
                                 <button
@@ -1263,15 +1298,15 @@
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="NyZFq1hTI+JGOaxJJVzQXWWODsMdUy9R23I05W7jRyOvUxjZwggrB3F0H653R3eGwipaXlntpLQLzfIDAaf5yQ=="
+                                            value="tCJ/yjHr+9umANiXLpMjWQfzh7GThf6G+R92Iq8HWbIsVyK4q7DzPpFNa3B8iISCoFfTLNc7dWMpoLDEwEPnWA=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="8b9819ffb98630ef429da8afce107eaebdd51f79d64e00e357652f21f59122cd"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7C9:19F16:25CCED1:38FE1CE:5CC2241D","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="931a7787f9f39f3ad755e87c6aae9f185e9d4edca3453ff3fe1dd11132446613"
                                                 data-ga-click="Repository, click Watch settings, action:pull_requests#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1294,7 +1329,7 @@
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1498,9 +1533,9 @@
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1517,7 +1552,7 @@
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="yFI1kdbPWH5X0sgx0koxVkuTYR6oapNsgCPU/tOVEP1E8FoxyvHvTvo7U+MrdPL43z1u8PHCjXjR2xxzelgXsw=="
+                                                value="j/P9a9Cx6xBCjfAbcUsGByRZix/pKLlylPsgtDayuJ0DUZLLzI9cIO9ka8mIdcWpsPeE8bCAp2bFA+g5n3+/0w=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1525,8 +1560,8 @@
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="af86d6d9baf7a96a600ce55602ac22edca4d9afd2291bc6551d43fb550369aa2"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7C9:19F16:25CCED1:38FE1CE:5CC2241D","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="f7d4209fc7826952a3abb9a473810ae6fbbe6b1b91d3c3c300f70c03ca9ee6df"
                                                 data-ga-click="Repository, click unstar button, action:pull_requests#show; text:Unstar"
                                             >
                                                 <svg
@@ -1547,9 +1582,9 @@
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1562,7 +1597,7 @@
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="63s0kR53mTWrEReciPd8VApOeDOvLJ5jWKLANc6zSYpSQPTglxItfJozu4VtVXuJT9/7WdJLJpsteIou3KNzGA=="
+                                                value="XjziteSNs4vC5aBitdfZpQb7QvImftIEoU2p315zKoLnByLEbegHwvPHDHtQdd54Q2rBmFsZavzUl+PETGMQEA=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1570,8 +1605,8 @@
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                                data-hydro-click-hmac="f5010c4fc9ba66fb70a8c802738b85bbe4c43c7861ae88828a571000e33ee498"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7C9:19F16:25CCED1:38FE1CE:5CC2241D","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?split","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="8e573908fa016e3bf868ffd373a52ecbe4d4d032c1dee69c953f9d778401a023"
                                                 data-ga-click="Repository, click star button, action:pull_requests#show; text:Star"
                                             >
                                                 <svg
@@ -1592,9 +1627,9 @@
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1603,16 +1638,13 @@
                                 <li>
                                     <details
                                         class="details-reset details-overlay details-overlay-dark d-inline-block float-left"
-                                        data-deferred-details-content-url="/sourcegraph/sourcegraph/fork?fragment=1"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files","user_id":10532611}}'
-                                            data-hydro-click-hmac="ec482af0d40971d7ef1f6413ef3fc3840e7a08183bfed8e55519f6e8fac55b03"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"F7C9:19F16:25CCED1:38FE1CE:5CC2241D","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?split","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="87d2ef081b8ddc53fb014349ffb4ae87ffe0b98d3ec61a80b671b173a5ac98b5"
                                             data-ga-click="Repository, show fork modal, action:pull_requests#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1632,6 +1664,8 @@
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1673,9 +1707,9 @@
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1769,7 +1803,7 @@
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">695</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1797,7 +1831,7 @@
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">82</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -1892,7 +1926,7 @@
                     <div class="container new-discussion-timeline experiment-repo-nav  ">
                         <div class="repository-content ">
                             <div
-                                class="issues-listing js-review-state-classes  js-suggested-changes-files-tab "
+                                class="position-relative js-review-state-classes  js-suggested-changes-files-tab "
                                 data-pjax=""
                                 data-issue-and-pr-hovercards-enabled=""
                             >
@@ -1905,7 +1939,7 @@
                                         class="gh-header js-details-container Details js-socket-channel js-updatable-content pull request js-pull-header-details"
                                         data-channel="pull_request:267881853"
                                         data-url="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Ftitle&amp;sticky=false"
-                                        data-pull-is-open="true"
+                                        data-pull-is-open="false"
                                         data-gid="MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz"
                                     >
                                         <div class="gh-header-show ">
@@ -1944,7 +1978,7 @@
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="MugivchvJld7fShHh6jQRvmLHnpW+TB2k+mYQFZwsXuzPJjTLkHajv4Ax6fjwjHqvfDjheXCPxdPV3rz6t5AvA=="
+                                                    value="QZ53XXqWvdIXjhfkwrJNafbRtmKoZl4mm8wbTslqGN7ASs0znLhBC5Lz+ASm2KzFsqpLnRtdUUdHcvn9dcTpGQ=="
                                                 />
                                                 <input
                                                     class="form-control edit-issue-title js-quick-submit"
@@ -1976,10 +2010,10 @@
                                         </div>
                                         <div class="TableObject gh-header-meta">
                                             <div class="TableObject-item">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -1987,30 +2021,27 @@
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
                                             <div class="TableObject-item TableObject-item--primary">
                                                 <a
                                                     class="author link-gray text-bold css-truncate css-truncate-target expandable"
                                                     data-hovercard-type="user"
-                                                    data-hovercard-url="/hovercards?user_id=187831"
+                                                    data-hovercard-url="/hovercards?user_id=1646931"
                                                     data-octo-click="hovercard-link-click"
                                                     data-octo-dimensions="link_type:self"
-                                                    href="/keegancsmith"
-                                                    >keegancsmith</a
+                                                    href="/beyang"
+                                                    >beyang</a
                                                 >
-
-                                                wants to merge
-                                                <span class="js-updating-pull-request-commits-count">1</span>
-                                                commit into
+                                                merged 1 commit into
 
                                                 <span
                                                     title="sourcegraph/sourcegraph:master"
-                                                    class="commit-ref css-truncate user-select-contain expandable base-ref"
+                                                    class="commit-ref css-truncate user-select-contain expandable "
                                                     ><a
                                                         title="sourcegraph/sourcegraph:master"
                                                         class="no-underline"
@@ -2018,51 +2049,6 @@
                                                         ><span class="css-truncate-target">master</span></a
                                                     ></span
                                                 ><span></span>
-
-                                                <div class="commit-ref-dropdown">
-                                                    <details
-                                                        class="details-reset details-overlay select-menu commitish-suggester"
-                                                    >
-                                                        <summary
-                                                            class="btn btn-sm select-menu-button branch"
-                                                            title="Choose a base branch"
-                                                            aria-haspopup="menu"
-                                                        >
-                                                            <i>base:</i>
-                                                            <span
-                                                                class="css-truncate css-truncate-target"
-                                                                title="master"
-                                                                >master</span
-                                                            >
-                                                        </summary>
-                                                        <details-menu
-                                                            class="select-menu-modal position-absolute"
-                                                            style="z-index: 90;"
-                                                            src="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Fdescription_branches_dropdown"
-                                                            preload=""
-                                                            role="menu"
-                                                        >
-                                                            <include-fragment
-                                                                class="select-menu-loading-overlay anim-pulse"
-                                                                aria-label="Loading"
-                                                            >
-                                                                <svg
-                                                                    height="32"
-                                                                    class="octicon octicon-octoface"
-                                                                    viewBox="0 0 16 16"
-                                                                    version="1.1"
-                                                                    width="32"
-                                                                    aria-hidden="true"
-                                                                >
-                                                                    <path
-                                                                        fill-rule="evenodd"
-                                                                        d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"
-                                                                    ></path>
-                                                                </svg>
-                                                            </include-fragment>
-                                                        </details-menu>
-                                                    </details>
-                                                </div>
 
                                                 from
 
@@ -2109,6 +2095,12 @@
                                                                 d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
                                                             ></path></svg></clipboard-copy
                                                 ></span>
+
+                                                <relative-time
+                                                    datetime="2019-04-08T00:40:04Z"
+                                                    title="8 Apr 2019, 02:40 CEST"
+                                                    >18 days ago</relative-time
+                                                >
                                             </div>
                                         </div>
                                     </div>
@@ -2137,7 +2129,7 @@
                                                 Conversation
 
                                                 <span id="conversation_tab_counter" class="Counter">
-                                                    1
+                                                    2
                                                 </span>
                                             </a>
 
@@ -2163,8 +2155,9 @@
                                                 <span
                                                     id="commits_tab_counter"
                                                     class="Counter js-updateable-pull-request-commits-count"
-                                                    >1</span
                                                 >
+                                                    1
+                                                </span>
                                             </a>
 
                                             <a
@@ -2221,10 +2214,10 @@
                                     <div class="pr-toolbar js-sticky js-sticky-offset-scroll" style="position: sticky;">
                                         <div class="diffbar details-collapse js-details-container Details">
                                             <div class="show-if-stuck float-left mr-2 mt-2">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -2232,10 +2225,10 @@
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
 
@@ -2330,7 +2323,7 @@
                                                                                 <relative-time
                                                                                     datetime="2019-04-05T16:05:51Z"
                                                                                     title="5 Apr 2019, 18:05 CEST"
-                                                                                    >4 hours ago</relative-time
+                                                                                    >20 days ago</relative-time
                                                                                 >
                                                                             </span>
                                                                         </div>
@@ -2614,7 +2607,7 @@
                                                                     <button
                                                                         type="button"
                                                                         class="btn btn-outline mt-2 text-bold js-dismiss-batched-suggested-changes-onboarding-notice"
-                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=6WTqbZD7afi/NMeOuy9+fLAiW56FYraLIWHze8bw11mAkEfFW+AT7njysRPDkuJwjfHsGrX2QkdHdy1Mj13FRw=="
+                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=k5y+TwX5Bl7PkDvKAkl89Yi6mp71GChEcEQFNNr8u/X6aBPnzuJ8SAhWTVd69OD5tWktGsWM3IgWUtsDk1Gp6w=="
                                                                     >
                                                                         Got it
                                                                     </button>
@@ -2636,7 +2629,7 @@
                                                                 <input name="utf8" type="hidden" value="✓" /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="Fk8hEUba1IK2CTafrdFAarFrOp3VooyAF6Dn6vF5wM7QxZmy35tsxENYBVKpl5eSFvAvJJ+g8kdzN8nuy7Fh0w=="
+                                                                    value="8XBUSNGGaLm1SE4mEx4xrR5bSqx1t9ihwIWJflvKXkI3+uzrSMfQ/0AZfesXWOZVucBfFT+1pmakEqd6YQL/Xw=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2665,8 +2658,8 @@
                                                                     <button
                                                                         type="submit"
                                                                         class="btn btn-sm btn-primary float-left js-suggestion-batch-submit"
-                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                        data-hydro-click-hmac="d82affd7c0b25cf64b667c1e329ae94380f8c38ad9e29a6da2c09c18922b9b60"
+                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"F7C9:19F16:25CCED1:38FE1CE:5CC2241D","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?split","referrer":null}}'
+                                                                        data-hydro-click-hmac="589c4a672feab737b96c029ed488db7c0aa8de5c5bdf27f0393cc93112d44aa2"
                                                                         data-ga-click="Markdown Toolbar, click, insert code suggestion"
                                                                         data-disable-invalid="true"
                                                                         data-disable-with="Applying commits..."
@@ -2699,7 +2692,13 @@
                                                 <div class="diffbar-item dropdown js-reviews-container">
                                                     <details class="details-reset details-overlay js-dropdown-details">
                                                         <summary class="btn btn-sm btn-primary js-reviews-toggle">
-                                                            Review changes
+                                                            <span
+                                                                class="js-review-changes"
+                                                                data-pending-message="Finish your review"
+                                                                data-message="Review changes"
+                                                            >
+                                                                Review changes
+                                                            </span>
                                                             <span class="Counter js-pending-review-comment-count">
                                                                 0
                                                             </span>
@@ -2722,7 +2721,7 @@
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="CSv0DDx7FyQSdo5TqVd8HDTlQ632NIXf54cFIUKhSCGTMM5fwE1U5gGLRZHRC0fGanlfF6HDNZE+rP/XGOPm6A=="
+                                                                    value="I/yaP5HNey8fbX3OrpCaCxMVNFga6gTVfhRtblYdQOa556Bsbfs47QyQtgzWzKHRTYko4k0dtJunP5eYDF/uLw=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2734,7 +2733,7 @@
                                                                 <div
                                                                     class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                     data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                    data-preview-authenticity-token="KnSKXrOxckW5RV9CozO2F2mbYE4WaqufzdFS9HCDMFPqZNcmMJ1IroZMSLcP8/cEK4hnBazUnxy/zZdRXc7afQ=="
+                                                                    data-preview-authenticity-token="TtNwly0chFMyHyAr3qYyGh+w0k8LPxc8Xt8WNzcER0COwy3vrjC+uA0WN95yZnMJXaPVBLGBI78sw9OSGkmtbg=="
                                                                 >
                                                                     <div class="comment-form-head tabnav ">
                                                                         <markdown-toolbar
@@ -3094,7 +3093,7 @@
                                                                         class="js-upload-markdown-image is-default"
                                                                         data-upload-repository-id="41288708"
                                                                         data-upload-policy-url="/upload/policies/assets"
-                                                                        data-upload-policy-authenticity-token="ydBYIUVOnPHDpgX5amBzWLF4Hgjh4LkHnDwKNBS6VBH7xhSwCiNgujapUGpetYQhfjUqHsVn9XVc9b/7ZQYhIQ=="
+                                                                        data-upload-policy-authenticity-token="MlQY29bqx6tJHFvc4HLj4DKYUjKRQlDrR9Ki6hZkl3QAQlRKmYc74LwTDk/UpxSZ/dVmJLXFHJmHGxclZ9jiRA=="
                                                                     >
                                                                         <div
                                                                             class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -3119,7 +3118,9 @@
                                                                                 data-suggest-mention="/suggestions/pull_request/267881853?repository=sourcegraph&amp;user_id=sourcegraph&amp;mention_suggester=1"
                                                                             ></textarea>
 
-                                                                            <p class="drag-and-drop position-relative">
+                                                                            <p
+                                                                                class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                            >
                                                                                 <input
                                                                                     accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                     type="file"
@@ -3261,6 +3262,32 @@
                                                                                         </span>
                                                                                     </span>
                                                                                 </span>
+                                                                                <span
+                                                                                    class="tooltipped tooltipped-nw"
+                                                                                    aria-label="Styling with Markdown is supported"
+                                                                                >
+                                                                                    <a
+                                                                                        class="tabnav-extra position-relative d-inline"
+                                                                                        href="https://guides.github.com/features/mastering-markdown/"
+                                                                                        target="_blank"
+                                                                                        data-ga-click="Markdown Toolbar, click, help"
+                                                                                        aria-label="Learn about styling with Markdown"
+                                                                                    >
+                                                                                        <svg
+                                                                                            class="octicon octicon-markdown v-align-bottom"
+                                                                                            viewBox="0 0 16 16"
+                                                                                            version="1.1"
+                                                                                            width="16"
+                                                                                            height="16"
+                                                                                            aria-hidden="true"
+                                                                                        >
+                                                                                            <path
+                                                                                                fill-rule="evenodd"
+                                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                            ></path>
+                                                                                        </svg>
+                                                                                    </a>
+                                                                                </span>
                                                                             </p>
                                                                         </div>
                                                                     </file-attachment>
@@ -3302,51 +3329,11 @@
                                                                     ></div>
                                                                 </div>
 
-                                                                <div class="form-checkbox mx-3 mb-2 mt-0">
-                                                                    <label class="d-block">
-                                                                        <input
-                                                                            type="radio"
-                                                                            name="pull_request_review[event]"
-                                                                            value="comment"
-                                                                            checked=""
-                                                                        />
-                                                                        Comment
-                                                                        <p class="text-normal text-gray-light">
-                                                                            Submit general feedback without explicit
-                                                                            approval.
-                                                                        </p>
-                                                                    </label>
-                                                                </div>
-
-                                                                <div class="form-checkbox mx-3 my-2">
-                                                                    <label class="d-block">
-                                                                        <input
-                                                                            type="radio"
-                                                                            name="pull_request_review[event]"
-                                                                            value="approve"
-                                                                        />
-                                                                        Approve
-                                                                        <p class="text-normal text-gray-light">
-                                                                            Submit feedback and approve merging these
-                                                                            changes.
-                                                                        </p>
-                                                                    </label>
-                                                                </div>
-
-                                                                <div class="form-checkbox mx-3 my-2">
-                                                                    <label class="d-block">
-                                                                        <input
-                                                                            type="radio"
-                                                                            name="pull_request_review[event]"
-                                                                            value="reject"
-                                                                        />
-                                                                        Request changes
-                                                                        <p class="text-normal text-gray-light">
-                                                                            Submit feedback that must be addressed
-                                                                            before merging.
-                                                                        </p>
-                                                                    </label>
-                                                                </div>
+                                                                <input
+                                                                    type="hidden"
+                                                                    name="pull_request_review[event]"
+                                                                    value="comment"
+                                                                />
 
                                                                 <div
                                                                     class="form-actions p-2 m-0 bg-gray-light border-top"
@@ -3400,24 +3387,6 @@
                                                         <div
                                                             class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                         >
-                                                            <div class="inline-comment-form-actions">
-                                                                <button
-                                                                    type="button"
-                                                                    class="btn js-toggle-new-thread-form"
-                                                                    data-ga-click="Start a new conversation, click"
-                                                                    data-side=""
-                                                                >
-                                                                    Start a new conversation
-                                                                </button>
-
-                                                                <a
-                                                                    href="/sourcegraph/sourcegraph/pull/3257/files#submit-review"
-                                                                    class="finish-review-label btn ml-1"
-                                                                >
-                                                                    Finish your review
-                                                                </a>
-                                                            </div>
-
                                                             <div class="inline-comment-form">
                                                                 <!-- '"` --><!-- </textarea></xmp> -->
                                                                 <form
@@ -3429,7 +3398,7 @@
                                                                     <input name="utf8" type="hidden" value="✓" /><input
                                                                         type="hidden"
                                                                         name="authenticity_token"
-                                                                        value="JMhuSb19r05sm9byl9eJ6CoxHmzneaTKUskJO5+RKaExl8k8POsGK33oQejElXy/F0XiHtDM+TBONxdFTyKrLQ=="
+                                                                        value="ugbigNIemF0EOR7Ob9IgThXjQFBaPOh8xfkEa6h2KSyvWUX1U4gxOBVKidQ8kNUZKJe8Im2JtYbZBxoVeMWroA=="
                                                                     />
                                                                     <input
                                                                         type="hidden"
@@ -3466,40 +3435,15 @@
                                                                     <input type="hidden" name="position" value="" />
 
                                                                     <div
-                                                                        class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                                                        class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                         data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                        data-preview-authenticity-token="rfGUGzjAvNAWCrDO8w+c2J9Fvnp5o/dSP4zwyFxoUctt4clju+yGOykDpztfz93L3Va5McMdw9FNkDVtcSW75Q=="
+                                                                        data-preview-authenticity-token="LKjXWwOySySH11wdJhVUAMMJo+unkmNNleQiR16Nm3LsuIojgJ5xz7jeS+iK1RUTgRqkoB0sV87n+Ofic8BxXA=="
                                                                     >
                                                                         <div class="comment-form-head tabnav ">
                                                                             <markdown-toolbar
-                                                                                for="r402830 new_inline_comment_diff_${anchor}_${position}"
+                                                                                for="r969851 new_inline_comment_diff_${anchor}_${position}"
                                                                                 class="toolbar-commenting "
                                                                             >
-                                                                                <div class="toolbar-group">
-                                                                                    <button
-                                                                                        type="button"
-                                                                                        class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item"
-                                                                                        aria-label="Insert a suggestion <cmd-g>"
-                                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"insert_suggestion","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                                        data-hydro-click-hmac="4f2e70e51d798ee606c80afd2b5a8814961d61581ba2b3ccd7037f5d48ec42ec"
-                                                                                        data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                                                        hotkey="g"
-                                                                                    >
-                                                                                        <svg
-                                                                                            class="octicon octicon-diff"
-                                                                                            viewBox="0 0 13 16"
-                                                                                            version="1.1"
-                                                                                            width="13"
-                                                                                            height="16"
-                                                                                            aria-hidden="true"
-                                                                                        >
-                                                                                            <path
-                                                                                                fill-rule="evenodd"
-                                                                                                d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"
-                                                                                            ></path>
-                                                                                        </svg>
-                                                                                    </button>
-                                                                                </div>
                                                                                 <div class="toolbar-group">
                                                                                     <md-header
                                                                                         tabindex="-1"
@@ -3855,7 +3799,7 @@
                                                                             class="js-upload-markdown-image is-default"
                                                                             data-upload-repository-id="41288708"
                                                                             data-upload-policy-url="/upload/policies/assets"
-                                                                            data-upload-policy-authenticity-token="PgjonhYUzDpvo8F+feDolVX1/In6aRkK8j+9/drX0VoMHqQPWXkwcZqslO1JNR/smrjIn97uVXgy9ggyq2ukag=="
+                                                                            data-upload-policy-authenticity-token="0IVc7nMDnD8Zl8zCO7pxKtqe8SaMNtXyzIIAcd7CkcrikxB/PG5gdOyYmVEPb4ZTFdPFMKixmYAMS7W+r37k+g=="
                                                                         >
                                                                             <div
                                                                                 class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -3871,7 +3815,7 @@
 
                                                                                 <textarea
                                                                                     name="comment[body]"
-                                                                                    id="r402830 new_inline_comment_diff_${anchor}_${position}"
+                                                                                    id="r969851 new_inline_comment_diff_${anchor}_${position}"
                                                                                     placeholder="Leave a comment"
                                                                                     aria-label="Comment body"
                                                                                     class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -3882,7 +3826,7 @@
                                                                                 ></textarea>
 
                                                                                 <p
-                                                                                    class="drag-and-drop position-relative"
+                                                                                    class="drag-and-drop position-relative d-flex flex-justify-between"
                                                                                 >
                                                                                     <input
                                                                                         accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
@@ -4032,6 +3976,32 @@
                                                                                             </span>
                                                                                         </span>
                                                                                     </span>
+                                                                                    <span
+                                                                                        class="tooltipped tooltipped-nw"
+                                                                                        aria-label="Styling with Markdown is supported"
+                                                                                    >
+                                                                                        <a
+                                                                                            class="tabnav-extra position-relative d-inline"
+                                                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                                                            target="_blank"
+                                                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                                                            aria-label="Learn about styling with Markdown"
+                                                                                        >
+                                                                                            <svg
+                                                                                                class="octicon octicon-markdown v-align-bottom"
+                                                                                                viewBox="0 0 16 16"
+                                                                                                version="1.1"
+                                                                                                width="16"
+                                                                                                height="16"
+                                                                                                aria-hidden="true"
+                                                                                            >
+                                                                                                <path
+                                                                                                    fill-rule="evenodd"
+                                                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                                ></path>
+                                                                                            </svg>
+                                                                                        </a>
+                                                                                    </span>
                                                                                 </p>
                                                                             </div>
                                                                         </file-attachment>
@@ -4066,30 +4036,6 @@
                                                                                     <p>Nothing to preview</p>
                                                                                 </div>
                                                                             </div>
-                                                                        </div>
-
-                                                                        <div class="float-left ">
-                                                                            <a
-                                                                                class="tabnav-extra "
-                                                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                                                target="_blank"
-                                                                                data-ga-click="Markdown Toolbar, click, help"
-                                                                            >
-                                                                                <svg
-                                                                                    class="octicon octicon-markdown v-align-bottom"
-                                                                                    viewBox="0 0 16 16"
-                                                                                    version="1.1"
-                                                                                    width="16"
-                                                                                    height="16"
-                                                                                    aria-hidden="true"
-                                                                                >
-                                                                                    <path
-                                                                                        fill-rule="evenodd"
-                                                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                                    ></path>
-                                                                                </svg>
-                                                                                Styling with Markdown is supported
-                                                                            </a>
                                                                         </div>
 
                                                                         <div
@@ -4169,24 +4115,6 @@
                                                         <div
                                                             class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                         >
-                                                            <div class="inline-comment-form-actions">
-                                                                <button
-                                                                    type="button"
-                                                                    class="btn js-toggle-new-thread-form"
-                                                                    data-ga-click="Start a new conversation, click"
-                                                                    data-side=""
-                                                                >
-                                                                    Start a new conversation
-                                                                </button>
-
-                                                                <a
-                                                                    href="/sourcegraph/sourcegraph/pull/3257/files#submit-review"
-                                                                    class="finish-review-label btn ml-1"
-                                                                >
-                                                                    Finish your review
-                                                                </a>
-                                                            </div>
-
                                                             <div class="inline-comment-form">
                                                                 <!-- '"` --><!-- </textarea></xmp> -->
                                                                 <form
@@ -4198,7 +4126,7 @@
                                                                     <input name="utf8" type="hidden" value="✓" /><input
                                                                         type="hidden"
                                                                         name="authenticity_token"
-                                                                        value="jH0OvMVEt7Ehm2Z2wDiZUM6eQKkrbYIWb2TXbcoe50yZIqnJRNIe1DDo8WyTemwH8+q82xzY3+xzmskTGq1lwA=="
+                                                                        value="eOp6rr3IGkX6CHyTCnOw4IBRQGrI70vCGXZalj4sb6httd3bPF6zIOt764lZMUW3vSW8GP9aFjgFiETo7p/tJA=="
                                                                     />
                                                                     <input
                                                                         type="hidden"
@@ -4235,40 +4163,15 @@
                                                                     <input type="hidden" name="position" value="" />
 
                                                                     <div
-                                                                        class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                                                        class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                         data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                        data-preview-authenticity-token="eqokLziGi++v+dPIst4eKojogyjNlntOwKmfc+nxZ4+6unlXu6qxBJDwxD0eHl85yvuEY3coT82ytVrWxLyNoQ=="
+                                                                        data-preview-authenticity-token="1CRw7rQjCiZon1WvulWeUZ/TEd5LG+R5ygAQ/ktF5TgUNC2WNw8wzVeWQloWld9C3cAWlfGl0Pq4HNVbZggPFg=="
                                                                     >
                                                                         <div class="comment-form-head tabnav ">
                                                                             <markdown-toolbar
-                                                                                for="r62843 new_inline_comment_diff_${anchor}_${position}"
+                                                                                for="r784348 new_inline_comment_diff_${anchor}_${position}"
                                                                                 class="toolbar-commenting "
                                                                             >
-                                                                                <div class="toolbar-group">
-                                                                                    <button
-                                                                                        type="button"
-                                                                                        class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item"
-                                                                                        aria-label="Insert a suggestion <cmd-g>"
-                                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"insert_suggestion","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DABA:4F10:8283B1:E1BE01:5CA7AE4B","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?utf8=%E2%9C%93&amp;diff=split","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257/files"}}'
-                                                                                        data-hydro-click-hmac="4f2e70e51d798ee606c80afd2b5a8814961d61581ba2b3ccd7037f5d48ec42ec"
-                                                                                        data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                                                        hotkey="g"
-                                                                                    >
-                                                                                        <svg
-                                                                                            class="octicon octicon-diff"
-                                                                                            viewBox="0 0 13 16"
-                                                                                            version="1.1"
-                                                                                            width="13"
-                                                                                            height="16"
-                                                                                            aria-hidden="true"
-                                                                                        >
-                                                                                            <path
-                                                                                                fill-rule="evenodd"
-                                                                                                d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"
-                                                                                            ></path>
-                                                                                        </svg>
-                                                                                    </button>
-                                                                                </div>
                                                                                 <div class="toolbar-group">
                                                                                     <md-header
                                                                                         tabindex="-1"
@@ -4624,7 +4527,7 @@
                                                                             class="js-upload-markdown-image is-default"
                                                                             data-upload-repository-id="41288708"
                                                                             data-upload-policy-url="/upload/policies/assets"
-                                                                            data-upload-policy-authenticity-token="/5aquVvBWuYiiXgfGUxKOwfiiu7z5cCvuESbSGO8oZPNgOYoFKymrdeGLYwtmb1CyK+++NdijN14jS6HEgDUow=="
+                                                                            data-upload-policy-authenticity-token="OxP43+4Oj7zlznECGPReeRK9grAt5beLLC2NF8MuEp0JBbROoWNz9xDBJJEsIakA3fC2pgli+/ns5DjYspJnrQ=="
                                                                         >
                                                                             <div
                                                                                 class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -4640,7 +4543,7 @@
 
                                                                                 <textarea
                                                                                     name="comment[body]"
-                                                                                    id="r62843 new_inline_comment_diff_${anchor}_${position}"
+                                                                                    id="r784348 new_inline_comment_diff_${anchor}_${position}"
                                                                                     placeholder="Leave a comment"
                                                                                     aria-label="Comment body"
                                                                                     class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -4651,7 +4554,7 @@
                                                                                 ></textarea>
 
                                                                                 <p
-                                                                                    class="drag-and-drop position-relative"
+                                                                                    class="drag-and-drop position-relative d-flex flex-justify-between"
                                                                                 >
                                                                                     <input
                                                                                         accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
@@ -4801,6 +4704,32 @@
                                                                                             </span>
                                                                                         </span>
                                                                                     </span>
+                                                                                    <span
+                                                                                        class="tooltipped tooltipped-nw"
+                                                                                        aria-label="Styling with Markdown is supported"
+                                                                                    >
+                                                                                        <a
+                                                                                            class="tabnav-extra position-relative d-inline"
+                                                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                                                            target="_blank"
+                                                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                                                            aria-label="Learn about styling with Markdown"
+                                                                                        >
+                                                                                            <svg
+                                                                                                class="octicon octicon-markdown v-align-bottom"
+                                                                                                viewBox="0 0 16 16"
+                                                                                                version="1.1"
+                                                                                                width="16"
+                                                                                                height="16"
+                                                                                                aria-hidden="true"
+                                                                                            >
+                                                                                                <path
+                                                                                                    fill-rule="evenodd"
+                                                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                                ></path>
+                                                                                            </svg>
+                                                                                        </a>
+                                                                                    </span>
                                                                                 </p>
                                                                             </div>
                                                                         </file-attachment>
@@ -4835,30 +4764,6 @@
                                                                                     <p>Nothing to preview</p>
                                                                                 </div>
                                                                             </div>
-                                                                        </div>
-
-                                                                        <div class="float-left ">
-                                                                            <a
-                                                                                class="tabnav-extra "
-                                                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                                                target="_blank"
-                                                                                data-ga-click="Markdown Toolbar, click, help"
-                                                                            >
-                                                                                <svg
-                                                                                    class="octicon octicon-markdown v-align-bottom"
-                                                                                    viewBox="0 0 16 16"
-                                                                                    version="1.1"
-                                                                                    width="16"
-                                                                                    height="16"
-                                                                                    aria-hidden="true"
-                                                                                >
-                                                                                    <path
-                                                                                        fill-rule="evenodd"
-                                                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                                    ></path>
-                                                                                </svg>
-                                                                                Styling with Markdown is supported
-                                                                            </a>
                                                                         </div>
 
                                                                         <div
@@ -4939,103 +4844,116 @@
                                                     data-file-deleted="false"
                                                 >
                                                     <div class="file-actions">
-                                                        <span class="show-file-notes pt-1">
-                                                            <label>
-                                                                <input
-                                                                    type="checkbox"
-                                                                    checked="checked"
-                                                                    class="js-toggle-file-notes"
-                                                                />
-                                                                Show comments
-                                                            </label>
-                                                        </span>
+                                                        <div class="mt-1">
+                                                            <details
+                                                                class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                            >
+                                                                <summary
+                                                                    class="btn-link v-align-middle"
+                                                                    aria-haspopup="menu"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-kebab-horizontal text-gray"
+                                                                        aria-label="Show options"
+                                                                        viewBox="0 0 13 16"
+                                                                        version="1.1"
+                                                                        width="13"
+                                                                        height="16"
+                                                                        role="img"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </summary>
+                                                                <details-menu
+                                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                                    style="width:185px; z-index:99; right: -4px;"
+                                                                    role="menu"
+                                                                >
+                                                                    <label
+                                                                        role="menuitem"
+                                                                        class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                        tabindex="0"
+                                                                    >
+                                                                        <span
+                                                                            class="file-notes-check position-absolute ml-n3"
+                                                                            ><svg
+                                                                                class="octicon octicon-check"
+                                                                                viewBox="0 0 12 16"
+                                                                                version="1.1"
+                                                                                width="12"
+                                                                                height="16"
+                                                                                aria-hidden="true"
+                                                                            >
+                                                                                <path
+                                                                                    fill-rule="evenodd"
+                                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                                ></path></svg
+                                                                        ></span>
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            checked="checked"
+                                                                            class="d-none js-toggle-file-notes"
+                                                                        />
+                                                                        Show comments
+                                                                    </label>
 
-                                                        <div class="BtnGroup">
-                                                            <clipboard-copy
-                                                                value="cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                tabindex="0"
-                                                                role="button"
-                                                            >
-                                                                Copy path
-                                                            </clipboard-copy>
-                                                            <a
-                                                                href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                rel="nofollow"
-                                                            >
-                                                                View file
-                                                            </a>
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        rel="nofollow"
+                                                                        role="menuitem"
+                                                                        data-ga-click="View file, click, location:files_changed_dropdown"
+                                                                    >
+                                                                        View file
+                                                                    </a>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to make changes."
+                                                                    >
+                                                                        Edit file
+                                                                    </button>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to delete this file."
+                                                                    >
+                                                                        Delete file
+                                                                    </button>
+
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        role="menuitem"
+                                                                        href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
+                                                                        aria-label="Open this file in GitHub Desktop"
+                                                                        data-ga-click="Repository, open with desktop, type:mac"
+                                                                    >
+                                                                        Open in desktop
+                                                                    </a>
+                                                                </details-menu>
+                                                            </details>
                                                         </div>
-
-                                                        <a
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
-                                                            aria-label="Open this file in GitHub Desktop"
-                                                            data-ga-click="Repository, open with desktop, type:mac"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-device-desktop"
-                                                                viewBox="0 0 16 16"
-                                                                version="1.1"
-                                                                width="16"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/edit/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Change this file using the online editor"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-pencil"
-                                                                viewBox="0 0 14 16"
-                                                                version="1.1"
-                                                                width="14"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/delete/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon btn-octicon-danger tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Delete this file"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-trashcan"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
+                                                    </div>
+                                                    <div class="file-info">
                                                         <button
                                                             type="button"
-                                                            class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                            class="btn-octicon js-details-target"
                                                             aria-label="Toggle diff contents"
                                                             aria-expanded="true"
+                                                            style="width: 22px;"
                                                         >
                                                             <svg
                                                                 class="octicon octicon-chevron-down Details-content--hidden"
@@ -5051,21 +4969,19 @@
                                                                 ></path>
                                                             </svg>
                                                             <svg
-                                                                class="octicon octicon-chevron-up Details-content--shown"
-                                                                viewBox="0 0 10 16"
+                                                                class="octicon octicon-chevron-right Details-content--shown"
+                                                                viewBox="0 0 8 16"
                                                                 version="1.1"
-                                                                width="10"
+                                                                width="8"
                                                                 height="16"
                                                                 aria-hidden="true"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                                    d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                                 ></path>
                                                             </svg>
                                                         </button>
-                                                    </div>
-                                                    <div class="file-info">
                                                         <span
                                                             class="diffstat tooltipped tooltipped-e"
                                                             aria-label="22 additions &amp; 16 deletions"
@@ -5082,6 +4998,41 @@
                                                             title="cmd/gitserver/server/server.go"
                                                             >cmd/gitserver/server/server.go</a
                                                         >
+
+                                                        <clipboard-copy
+                                                            value="cmd/gitserver/server/server.go"
+                                                            aria-label="Copied!"
+                                                            class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                            tabindex="0"
+                                                            role="button"
+                                                        >
+                                                            <svg
+                                                                class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                                viewBox="0 0 14 16"
+                                                                version="1.1"
+                                                                width="14"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                                ></path>
+                                                            </svg>
+                                                            <svg
+                                                                class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                                viewBox="0 0 12 16"
+                                                                version="1.1"
+                                                                width="12"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                ></path>
+                                                            </svg>
+                                                        </clipboard-copy>
                                                     </div>
                                                 </div>
                                                 <div class="js-file-content Details-content--hidden">
@@ -5146,7 +5097,9 @@
                                                                         data-line-number="40"
                                                                     ></td>
 
-                                                                    <td class="code-review blob-code blob-code-context">
+                                                                    <td
+                                                                        class="code-review blob-code blob-code-context "
+                                                                    >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                                                             data-type="deletion"
@@ -5244,7 +5197,9 @@
                                                                         data-line-number="41"
                                                                     ></td>
 
-                                                                    <td class="code-review blob-code blob-code-context">
+                                                                    <td
+                                                                        class="code-review blob-code blob-code-context "
+                                                                    >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                                                             data-type="deletion"
@@ -6991,7 +6946,9 @@
                                                                         data-line-number="485"
                                                                     ></td>
 
-                                                                    <td class="code-review blob-code blob-code-context">
+                                                                    <td
+                                                                        class="code-review blob-code blob-code-context "
+                                                                    >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                                                             data-type="deletion"
@@ -7087,7 +7044,9 @@
                                                                         data-line-number="486"
                                                                     ></td>
 
-                                                                    <td class="code-review blob-code blob-code-context">
+                                                                    <td
+                                                                        class="code-review blob-code blob-code-context "
+                                                                    >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                                                             data-type="deletion"
@@ -7179,7 +7138,9 @@
                                                                         data-line-number="487"
                                                                     ></td>
 
-                                                                    <td class="code-review blob-code blob-code-context">
+                                                                    <td
+                                                                        class="code-review blob-code blob-code-context "
+                                                                    >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-single-line-comment"
                                                                             data-type="deletion"
@@ -7268,7 +7229,7 @@
                                                                     ></td>
 
                                                                     <td
-                                                                        class="code-review blob-code blob-code-deletion"
+                                                                        class="code-review blob-code blob-code-deletion "
                                                                     >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-split-line-comment"
@@ -7366,7 +7327,7 @@
                                                                     ></td>
 
                                                                     <td
-                                                                        class="code-review blob-code blob-code-deletion"
+                                                                        class="code-review blob-code blob-code-deletion "
                                                                     >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-split-line-comment"
@@ -7467,7 +7428,7 @@
                                                                     ></td>
 
                                                                     <td
-                                                                        class="code-review blob-code blob-code-deletion"
+                                                                        class="code-review blob-code blob-code-deletion "
                                                                     >
                                                                         <button
                                                                             class="btn-link add-line-comment js-add-line-comment js-add-split-line-comment"
@@ -11562,7 +11523,9 @@
                 class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light "
             >
                 <ul class="list-style-none d-flex flex-wrap ">
-                    <li class="mr-3">© 2019 <span title="0.42324s from unicorn-fd4b7c6d9-t5vl9">GitHub</span>, Inc.</li>
+                    <li class="mr-3">
+                        © 2019 <span title="0.70781s from unicorn-55c9994df8-cgsd2">GitHub</span>, Inc.
+                    </li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
                             >Terms</a
@@ -11665,17 +11628,17 @@
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">

--- a/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/unified/code-view.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/unified/code-view.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/pull/3272/files?diff=unified -->
 <div
     id="diff-0"
     class="file js-file js-details-container Details
@@ -21,102 +22,101 @@
         data-file-deleted="false"
     >
         <div class="file-actions">
-            <span class="show-file-notes pt-1">
-                <label>
-                    <input type="checkbox" checked="checked" class="js-toggle-file-notes" />
-                    Show comments
-                </label>
-            </span>
+            <div class="mt-1">
+                <details
+                    class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                >
+                    <summary class="btn-link v-align-middle" aria-haspopup="menu">
+                        <svg
+                            class="octicon octicon-kebab-horizontal text-gray"
+                            aria-label="Show options"
+                            viewBox="0 0 13 16"
+                            version="1.1"
+                            width="13"
+                            height="16"
+                            role="img"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                            ></path>
+                        </svg>
+                    </summary>
+                    <details-menu
+                        class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                        style="width:185px; z-index:99; right: -4px;"
+                        role="menu"
+                    >
+                        <label role="menuitem" class="dropdown-item btn-link text-normal d-block pl-5" tabindex="0">
+                            <span class="file-notes-check position-absolute ml-n3"
+                                ><svg
+                                    class="octicon octicon-check"
+                                    viewBox="0 0 12 16"
+                                    version="1.1"
+                                    width="12"
+                                    height="16"
+                                    aria-hidden="true"
+                                >
+                                    <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg
+                            ></span>
+                            <input type="checkbox" checked="checked" class="d-none js-toggle-file-notes" />
+                            Show comments
+                        </label>
 
-            <div class="BtnGroup">
-                <clipboard-copy
-                    value="packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
-                    class="btn btn-sm BtnGroup-item"
-                    tabindex="0"
-                    role="button"
-                >
-                    Copy path
-                </clipboard-copy>
-                <a
-                    href="/sourcegraph/sourcegraph/blob/685a686a933beae5027cfae2121cf0e408a29bd8/packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
-                    class="btn btn-sm BtnGroup-item"
-                    rel="nofollow"
-                    data-ga-click="View file, click, location:files_changed"
-                >
-                    View file
-                </a>
+                        <div role="none" class="dropdown-divider"></div>
+
+                        <a
+                            href="/sourcegraph/sourcegraph/blob/685a686a933beae5027cfae2121cf0e408a29bd8/packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
+                            class="pl-5 dropdown-item btn-link"
+                            rel="nofollow"
+                            role="menuitem"
+                            data-ga-click="View file, click, location:files_changed_dropdown"
+                        >
+                            View file
+                        </a>
+
+                        <button
+                            type="button"
+                            disabled=""
+                            role="menuitem"
+                            class="pl-5 dropdown-item btn-link"
+                            aria-label="You must be signed in and have push access to make changes."
+                        >
+                            Edit file
+                        </button>
+
+                        <button
+                            type="button"
+                            disabled=""
+                            role="menuitem"
+                            class="pl-5 dropdown-item btn-link"
+                            aria-label="You must be signed in and have push access to delete this file."
+                        >
+                            Delete file
+                        </button>
+
+                        <div role="none" class="dropdown-divider"></div>
+
+                        <a
+                            class="pl-5 dropdown-item btn-link"
+                            role="menuitem"
+                            href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=readonly-field&amp;filepath=packages%2Fsourcegraph-extension-api%2Fsrc%2Fsourcegraph.d.ts"
+                            aria-label="Open this file in GitHub Desktop"
+                            data-ga-click="Repository, open with desktop, type:mac"
+                        >
+                            Open in desktop
+                        </a>
+                    </details-menu>
+                </details>
             </div>
-
-            <a
-                class="btn-octicon tooltipped tooltipped-w"
-                href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=readonly-field&amp;filepath=packages%2Fsourcegraph-extension-api%2Fsrc%2Fsourcegraph.d.ts"
-                aria-label="Open this file in GitHub Desktop"
-                data-ga-click="Repository, open with desktop, type:mac"
-            >
-                <svg
-                    class="octicon octicon-device-desktop"
-                    viewBox="0 0 16 16"
-                    version="1.1"
-                    width="16"
-                    height="16"
-                    aria-hidden="true"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
-                    ></path>
-                </svg>
-            </a>
-
-            <a
-                href="/sourcegraph/sourcegraph/edit/readonly-field/packages/sourcegraph-extension-api/src/sourcegraph.d.ts?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3272"
-                class="btn-octicon tooltipped tooltipped-w"
-                rel="nofollow"
-                data-skip-pjax=""
-                aria-label="Change this file using the online editor"
-                data-ga-click="Edit file, click, location:files_changed"
-            >
-                <svg
-                    class="octicon octicon-pencil"
-                    viewBox="0 0 14 16"
-                    version="1.1"
-                    width="14"
-                    height="16"
-                    aria-hidden="true"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                    ></path>
-                </svg>
-            </a>
-            <a
-                href="/sourcegraph/sourcegraph/delete/readonly-field/packages/sourcegraph-extension-api/src/sourcegraph.d.ts?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3272"
-                class="btn-octicon btn-octicon-danger tooltipped tooltipped-w"
-                rel="nofollow"
-                data-skip-pjax=""
-                aria-label="Delete this file"
-                data-ga-click="Delete file, click, location:files_changed"
-            >
-                <svg
-                    class="octicon octicon-trashcan"
-                    viewBox="0 0 12 16"
-                    version="1.1"
-                    width="12"
-                    height="16"
-                    aria-hidden="true"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                    ></path>
-                </svg>
-            </a>
+        </div>
+        <div class="file-info">
             <button
                 type="button"
-                class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                class="btn-octicon js-details-target"
                 aria-label="Toggle diff contents"
                 aria-expanded="true"
+                style="width: 22px;"
             >
                 <svg
                     class="octicon octicon-chevron-down Details-content--hidden"
@@ -129,18 +129,16 @@
                     <path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"></path>
                 </svg>
                 <svg
-                    class="octicon octicon-chevron-up Details-content--shown"
-                    viewBox="0 0 10 16"
+                    class="octicon octicon-chevron-right Details-content--shown"
+                    viewBox="0 0 8 16"
                     version="1.1"
-                    width="10"
+                    width="8"
                     height="16"
                     aria-hidden="true"
                 >
-                    <path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"></path>
+                    <path fill-rule="evenodd" d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"></path>
                 </svg>
             </button>
-        </div>
-        <div class="file-info">
             <span class="diffstat tooltipped tooltipped-e" aria-label="1 addition &amp; 1 deletion"
                 >2 <span class="block-diff-added"></span><span class="block-diff-deleted"></span
                 ><span class="block-diff-neutral"></span><span class="block-diff-neutral"></span
@@ -153,6 +151,38 @@
                 title="packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
                 >packages/sourcegraph-extension-api/src/sourcegraph.d.ts</a
             >
+
+            <clipboard-copy
+                value="packages/sourcegraph-extension-api/src/sourcegraph.d.ts"
+                aria-label="Copied!"
+                class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                tabindex="0"
+                role="button"
+            >
+                <svg
+                    class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                    viewBox="0 0 14 16"
+                    version="1.1"
+                    width="14"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                    ></path>
+                </svg>
+                <svg
+                    class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                    viewBox="0 0 12 16"
+                    version="1.1"
+                    width="12"
+                    height="16"
+                    aria-hidden="true"
+                >
+                    <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path>
+                </svg>
+            </clipboard-copy>
         </div>
     </div>
     <div class="js-file-content Details-content--hidden">

--- a/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/unified/page.html
+++ b/client/browser/src/libs/github/__fixtures__/github.com/pull-request/vanilla/unified/page.html
@@ -1,3 +1,4 @@
+<!-- https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified -->
 <html lang="en">
     <head>
         <meta charset="utf-8" />
@@ -12,17 +13,17 @@
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-7uoDIEGQ8zTwUS9KjTP+/2I13FQPHvJ9EKoeUThfin5R1+27bcUC08VQzUo4CIjCdhvJM4zxuI+3HcSycAUTCg=="
+            integrity="sha512-iwkZZWcsyMNnn/6c9v2ab3e7h4ZiFTOEZ9R6jj75bN9JzYuYjQ/AC7ufEcfpqd4GcTwcM+p2OhPzRSyeKL7NMQ=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/frameworks-abba74d6e28a6842788159fec056bf26.css"
+            href="https://github.githubassets.com/assets/frameworks-f331a618befc2bf99be870c538f9ac95.css"
         />
 
         <link
             crossorigin="anonymous"
             media="all"
-            integrity="sha512-g+ZfvjjCIOoCpOthSK44Ek7SRyeu17l998KBO0i+H/5VtAZHjfboXtxeVVs07nmao9jod5LTfqCbMS0xgy5xeQ=="
+            integrity="sha512-ldfIeD7fSpzY1dITL/BXG49OHh3m1O1s2j+XoPI9P3Av6p9JemeSfcu3mujtgyLjVfNumtGKMwBk1j7gB+wHGw=="
             rel="stylesheet"
-            href="https://github.githubassets.com/assets/github-da71b9633b0743368ac5d90730dbc826.css"
+            href="https://github.githubassets.com/assets/github-ff83680f35ef916271a72c9b55eda042.css"
         />
 
         <meta name="viewport" content="width=device-width" />
@@ -30,42 +31,41 @@
         <title>
             gitserver: Use opentracing for exec endpoint by keegancsmith · Pull Request #3257 · sourcegraph/sourcegraph
         </title>
-        <meta
-            name="description"
-            content="Code search and navigation tool (self-hosted). Contribute to sourcegraph/sourcegraph development by creating an account on GitHub."
-        />
+        <meta name="description" content="Part of #3253" />
         <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub" />
         <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
         <meta property="fb:app_id" content="1401488693436528" />
 
-        <meta property="og:image" content="https://avatars2.githubusercontent.com/u/11557758?s=200&amp;v=4" />
+        <meta name="twitter:image:src" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
+        <meta name="twitter:site" content="@github" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="gitserver: Use opentracing for exec endpoint by keegancsmith · Pull Request #3257 · sourcegraph/sourcegraph"
+        />
+        <meta name="twitter:description" content="Part of #3253" />
+        <meta property="og:image" content="https://avatars3.githubusercontent.com/u/187831?s=400&amp;v=4" />
         <meta property="og:site_name" content="GitHub" />
         <meta property="og:type" content="object" />
         <meta
             property="og:title"
-            content="correct opsgenie command for one-off alerts (#3258) · sourcegraph/sourcegraph@d3d0fe7"
+            content="gitserver: Use opentracing for exec endpoint by keegancsmith · Pull Request #3257 · sourcegraph/sourcegraph"
         />
-        <meta
-            property="og:url"
-            content="https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
-        />
-        <meta
-            property="og:description"
-            content="* correct opsgenie command
-
-* Update doc/dev/incidents.md
-
-Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
-        />
-        <meta property="og:updated_time" content="1554483333" />
+        <meta property="og:url" content="https://github.com/sourcegraph/sourcegraph/pull/3257" />
+        <meta property="og:description" content="Part of #3253" />
 
         <link rel="assets" href="https://github.githubassets.com/" />
         <link
             rel="web-socket"
-            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OjZkMDA2YWE1YzdkNzIxOTBjZGE4MmE4YzlmYjAxMDYxMmFjNGY1YmQzOTlhYjk1YTk1MTU4YmMxMjFkZDg2YTk=--98912851fd066b0b3bdc1dfdb8d68184f6dafddb"
+            href="wss://live.github.com/_sockets/VjI6MzY2NzY5Nzc5OmFhZmNlNzYzODVkNWQ0OWRiODk4ZGI4NTliNDhlOTM4ZjFkZWQ2M2JlYjhlMTY1OTdmOTg4M2JiZGFiYmRjZjI=--de0e9580a1709a1f372737e915fcc4edf78a4aa3"
         />
         <meta name="pjax-timeout" content="1000" />
         <link rel="sudo-modal" href="/sessions/sudo_modal" />
+        <meta name="request-id" content="D021:2AC2E:22E001B:34B1FC9:5CC238D4" data-pjax-transient="" />
+
+        <meta name="hovercard-subject-tag" content="pull_request:267881853" data-pjax-transient="" />
+
+        <meta name="selected-link" value="repo_pulls" data-pjax-transient="" />
 
         <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU" />
         <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA" />
@@ -74,12 +74,17 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="octolytics-host" content="collector.githubapp.com" />
         <meta name="octolytics-app-id" content="github" />
         <meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" />
-        <meta name="octolytics-dimension-request_id" content="FD50:29A2B:1A99DC4:27CD2A3:5CA7A8AE" />
+        <meta name="octolytics-dimension-request_id" content="D021:2AC2E:22E001B:34B1FC9:5CC238D4" />
         <meta name="octolytics-dimension-region_edge" content="ams" />
         <meta name="octolytics-dimension-region_render" content="iad" />
         <meta name="octolytics-actor-id" content="10532611" />
         <meta name="octolytics-actor-login" content="felixfbecker" />
         <meta name="octolytics-actor-hash" content="a0bf5739a312c3a4d600b1ddd462e3b3ac0c4c28370673f3b7aacd82b09f1fac" />
+        <meta
+            name="analytics-location"
+            content="/<user-name>/<repo-name>/pull_requests/show/files"
+            data-pjax-transient="true"
+        />
 
         <meta class="js-ga-set" name="userId" content="1b23c6f4348a524a9d5b520c80e3ee17" />
 
@@ -91,22 +96,36 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="expected-hostname" content="github.com" />
         <meta
             name="js-proxy-site-detection-payload"
-            content="ZGE3MDMxN2ZjNWRhYjNiZWVhMTUwODliMjA1YTk1MGY4MTBmOGEyOWE2MjllZTM1YzY5OGVjYWU4ODYyYzZlM3x7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIxMS4xMDIiLCJyZXF1ZXN0X2lkIjoiRkQ1MDoyOUEyQjoxQTk5REM0OjI3Q0QyQTM6NUNBN0E4QUUiLCJ0aW1lc3RhbXAiOjE1NTQ0OTE1NjYsImhvc3QiOiJnaXRodWIuY29tIn0="
+            content="YmEzMWI5ZDI5MjlhODRlNjczMmUzYjUxMjRkMGQzNGU2NTU1NGI2MmVmYzFjOTBlMjE1NWQxZGI4MGYwNTc0Nnx7InJlbW90ZV9hZGRyZXNzIjoiODQuMTg2LjIyMy45IiwicmVxdWVzdF9pZCI6IkQwMjE6MkFDMkU6MjJFMDAxQjozNEIxRkM5OjVDQzIzOEQ0IiwidGltZXN0YW1wIjoxNTU2MjMyNDA1LCJob3N0IjoiZ2l0aHViLmNvbSJ9"
         />
 
         <meta
             name="enabled-features"
-            content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_UNVERIFIED_LISTINGS,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
+            content="UNIVERSE_BANNER,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,NOTIFY_ON_BLOCK,RELATED_ISSUES"
         />
 
         <meta name="html-safe-nonce" content="15f33ac754a0534c783366d330e3f83f9af14580" />
 
-        <meta http-equiv="x-pjax-version" content="e6daa074a803c4bbc321ed6691a873eb" />
+        <meta http-equiv="x-pjax-version" content="c6908ba9b37ca407401c94edb70af959" />
 
         <link
-            href="https://github.com/sourcegraph/sourcegraph/commits/d3d0fe7fad2c909e3a2e4de2259dc6604983a092.atom"
+            data-pjax-transient=""
             rel="alternate"
-            title="Recent Commits to sourcegraph:d3d0fe7fad2c909e3a2e4de2259dc6604983a092"
+            type="text/x-diff"
+            href="/sourcegraph/sourcegraph/pull/3257.diff"
+        />
+        <link
+            data-pjax-transient=""
+            rel="alternate"
+            type="text/x-patch"
+            href="/sourcegraph/sourcegraph/pull/3257.patch"
+        />
+
+        <meta name="diff-view" content="unified" data-pjax-transient="" />
+        <link
+            href="https://github.com/sourcegraph/sourcegraph/commits/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd.atom"
+            rel="alternate"
+            title="Recent Commits to sourcegraph:a537a324138be6b8a47d544d9ce7ed0cd7bce7dd"
             type="application/atom+xml"
         />
 
@@ -142,46 +161,14 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
         <meta name="u2f-enabled" content="true" />
 
         <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
-
-        <meta name="selected-link" value="repo_pulls" data-pjax-transient="" />
-        <meta
-            name="analytics-location"
-            content="/<user-name>/<repo-name>/pull_requests/show/files"
-            data-pjax-transient=""
-        />
-        <link rel="prefetch-viewed" data-pjax-transient="" />
-        <meta name="request-id" content="DA99:03EE:861855:EA7DDE:5CA7AE46" data-pjax-transient="" />
-        <meta name="hovercard-subject-tag" content="pull_request:267881853" data-pjax-transient="" />
-        <link
-            data-pjax-transient=""
-            rel="alternate"
-            type="text/x-diff"
-            href="/sourcegraph/sourcegraph/pull/3257.diff"
-        />
-        <link
-            data-pjax-transient=""
-            rel="alternate"
-            type="text/x-patch"
-            href="/sourcegraph/sourcegraph/pull/3257.patch"
-        />
-        <meta name="diff-view" content="unified" data-pjax-transient="" />
-        <link
-            href="https://github.com/sourcegraph/sourcegraph/commits/core/gitserver-tracing.atom"
-            rel="alternate"
-            title="Recent Commits to sourcegraph:core/gitserver-tracing"
-            type="application/atom+xml"
-            data-pjax-transient=""
-        />
     </head>
 
-    <body class="logged-in env-production emoji-size-boost intent-mouse">
+    <body class="logged-in env-production emoji-size-boost ">
         <div class="position-relative js-header-wrapper ">
             <a href="#start-of-content" tabindex="1" class="p-3 bg-blue text-white show-on-focus js-skip-to-content"
                 >Skip to content</a
             >
-            <div id="js-pjax-loader-bar" class="pjax-loader-bar">
-                <div class="progress" style="transition: width 0.4s ease 0s; width: 100%;"></div>
-            </div>
+            <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
 
             <header class="Header" role="banner">
                 <div class="Header-item">
@@ -248,7 +235,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         aria-autocomplete="list"
                                         aria-controls="jump-to-results"
                                         aria-label="Search or jump to…"
-                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=old5t7QrXK9HSEU0Uc5Sp+kEIw+9VrljCvbOTPxpDV77cOhAkJvNJ6NRmF9aJyp8TgAdKqveUcClA+Ad8V9oUw=="
+                                        data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=4+eQAhrWyP+2t934qmBslQyrbHPEXeu4XBM1T8ddRcW6wAH1PmZZd1KuAJOhiRROq69SVtLVAxvz5hseymsgyA=="
                                         spellcheck="false"
                                         autocomplete="off"
                                     />
@@ -649,6 +636,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                     </nav>
                 </div>
 
+                <div class="Header-item position-relative"></div>
+
                 <div class="Header-item"></div>
 
                 <div class="Header-item position-relative">
@@ -708,7 +697,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 New organization
                             </a>
 
-                            <div class="dropdown-divider"></div>
+                            <div role="none" class="dropdown-divider"></div>
                             <div class="dropdown-header">
                                 <span title="sourcegraph/sourcegraph">This repository</span>
                             </div>
@@ -742,7 +731,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             />
                             <span class="dropdown-caret"></span>
                         </summary>
-                        <details-menu class="dropdown-menu dropdown-menu-sw" role="menu">
+                        <details-menu class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px" role="menu">
                             <div class="header-nav-current-user css-truncate">
                                 <a
                                     role="menuitem"
@@ -755,47 +744,53 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                             <div role="none" class="dropdown-divider"></div>
 
                             <div
-                                class="px-3 f6 user-status-container js-user-status-context pb-1"
+                                class="pl-3 pr-5 f6 user-status-container js-user-status-context pb-1"
                                 data-url="/users/status?compact=1&amp;link_mentions=0&amp;truncate=1"
                             >
                                 <div
-                                    class="js-user-status-container user-status-compact"
+                                    class="js-user-status-container  user-status-compact rounded-1 px-2 py-1 mt-2 user-status-container-border-busy"
                                     data-team-hovercards-enabled=""
                                 >
                                     <details
                                         class="js-user-status-details details-reset details-overlay details-overlay-dark"
                                     >
                                         <summary
-                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full"
+                                            class="btn-link no-underline js-toggle-user-status-edit toggle-user-status-edit width-full d-flex link-gray "
                                             aria-haspopup="dialog"
                                             role="menuitem"
-                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"FD50:29A2B:1A99DC4:27CD2A3:5CA7A8AE","originating_url":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=unified","referrer":"https://github.com/sourcegraph/sourcegraph/commit/d3d0fe7fad2c909e3a2e4de2259dc6604983a092?diff=split"}}'
-                                            data-hydro-click-hmac="ebfe01ad18ce34c18116386d07b426f66e0546dfa3c619be6f2dac2101da935d"
+                                            data-hydro-click='{"event_type":"user_profile.click","payload":{"profile_user_id":3979584,"target":"EDIT_USER_STATUS","user_id":10532611,"client_id":"2008835310.1548448452","originating_request_id":"D021:2AC2E:22E001B:34B1FC9:5CC238D4","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null}}'
+                                            data-hydro-click-hmac="4889f3ae2261b136569d3c6caa35796f45c6ac22e62139fbea3703d6c76194a9"
                                         >
                                             <div
-                                                class="f6 d-inline-block v-align-middle  user-status-emoji-only-header pl-0 circle lh-condensed user-status-header "
-                                                style="max-width: 29px"
+                                                class="f6 d-inline-flex  lh-condensed user-status-header user-status-limited-availability"
                                             >
-                                                <div class="user-status-emoji-container flex-shrink-0 mr-1">
-                                                    <svg
-                                                        class="octicon octicon-smiley"
-                                                        viewBox="0 0 16 16"
-                                                        version="1.1"
-                                                        width="16"
-                                                        height="16"
-                                                        aria-hidden="true"
-                                                    >
-                                                        <path
-                                                            fill-rule="evenodd"
-                                                            d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4.81 12.81a6.72 6.72 0 0 1-2.17 1.45c-.83.36-1.72.53-2.64.53-.92 0-1.81-.17-2.64-.53-.81-.34-1.55-.83-2.17-1.45a6.773 6.773 0 0 1-1.45-2.17A6.59 6.59 0 0 1 1.21 8c0-.92.17-1.81.53-2.64.34-.81.83-1.55 1.45-2.17.62-.62 1.36-1.11 2.17-1.45A6.59 6.59 0 0 1 8 1.21c.92 0 1.81.17 2.64.53.81.34 1.55.83 2.17 1.45.62.62 1.11 1.36 1.45 2.17.36.83.53 1.72.53 2.64 0 .92-.17 1.81-.53 2.64-.34.81-.83 1.55-1.45 2.17zM4 6.8v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2H5.2C4.53 8 4 7.47 4 6.8zm5 0v-.59c0-.66.53-1.19 1.2-1.19h.59c.66 0 1.19.53 1.19 1.19v.59c0 .67-.53 1.2-1.19 1.2h-.59C9.53 8 9 7.47 9 6.8zm4 3.2c-.72 1.88-2.91 3-5 3s-4.28-1.13-5-3c-.14-.39.23-1 .66-1h8.59c.41 0 .89.61.75 1z"
-                                                        ></path>
-                                                    </svg>
+                                                <div
+                                                    class="user-status-emoji-container flex-shrink-0 mr-1  "
+                                                    style="margin-top: 2px;"
+                                                >
+                                                    <div>
+                                                        <g-emoji
+                                                            class="g-emoji"
+                                                            alias="palm_tree"
+                                                            fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                            >🌴</g-emoji
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div
-                                                class="d-inline-block v-align-middle user-status-message-wrapper f6 lh-condensed ws-normal pt-1"
+                                                class="
+
+
+
+         css-truncate css-truncate-target
+         user-status-message-wrapper f6"
+                                                style="line-height: 20px;"
                                             >
-                                                <span class="link-gray">Set your status</span>
+                                                <div class="d-inline-block text-gray-dark v-align-text-top">
+                                                    <div class="d-block ws-normal text-gray-dark text-bold f6"></div>
+                                                    <div class="d-inline-block">On vacation</div>
+                                                </div>
                                             </div>
                                         </summary>
                                         <details-dialog
@@ -817,7 +812,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="8m/kl9PpxkjDrABtH+unvlPJhu7VkNhSfW3tlJJmpqQEAUtMkmgPlEb6pikUpOy9TaxH7Pu8dKPrICl7JYAFWA=="
+                                                    value="6MYXl3WC0rKPBXjHHo0FjD+6xp/C9CYDhEdU44XzYA8eqLhMNAMbbgpT3oMVwk6PId8HnezYivISCpAMMhXD8w=="
                                                 />
                                                 <div class="Box-header bg-gray border-bottom p-3">
                                                     <button
@@ -846,7 +841,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     type="hidden"
                                                     name="emoji"
                                                     class="js-user-status-emoji-field"
-                                                    value=""
+                                                    value=":palm_tree:"
                                                 />
                                                 <input
                                                     type="hidden"
@@ -868,14 +863,34 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 <button
                                                                     type="button"
                                                                     aria-label="Choose an emoji"
-                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker bg-white btn-open-emoji-picker"
+                                                                    class="btn-outline btn js-toggle-user-status-emoji-picker btn-open-emoji-picker p-0"
                                                                 >
                                                                     <span
                                                                         class="js-user-status-original-emoji"
                                                                         hidden=""
-                                                                    ></span>
-                                                                    <span class="js-user-status-custom-emoji"></span>
-                                                                    <span class="js-user-status-no-emoji-icon">
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span class="js-user-status-custom-emoji"
+                                                                        ><div>
+                                                                            <g-emoji
+                                                                                class="g-emoji"
+                                                                                alias="palm_tree"
+                                                                                fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f334.png"
+                                                                                >🌴</g-emoji
+                                                                            >
+                                                                        </div></span
+                                                                    >
+                                                                    <span
+                                                                        class="js-user-status-no-emoji-icon"
+                                                                        hidden=""
+                                                                    >
                                                                         <svg
                                                                             class="octicon octicon-smiley"
                                                                             viewBox="0 0 16 16"
@@ -899,8 +914,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 class="js-suggester-field d-table-cell width-full form-control js-user-status-message-field js-characters-remaining-field"
                                                                 placeholder="What's happening?"
                                                                 name="message"
-                                                                required=""
-                                                                value=""
+                                                                value="On vacation"
                                                                 aria-label="What is your current status?"
                                                             />
                                                             <div class="error">
@@ -930,7 +944,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         data-url="/users/status/emoji"
                                                     ></include-fragment>
                                                     <div
-                                                        class="overflow-auto border-bottom ml-n3 mr-n3 px-3"
+                                                        class="overflow-auto ml-n3 mr-n3 px-3"
                                                         style="max-height: 33vh"
                                                     >
                                                         <div
@@ -954,7 +968,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             On vacation
@@ -975,7 +989,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Out sick
@@ -998,7 +1012,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Working from home
@@ -1019,7 +1033,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             >
                                                                         </div>
                                                                         <div
-                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message"
+                                                                            class="d-flex flex-items-center no-underline js-predefined-user-status-message ws-normal text-left"
                                                                             style="border-left: 1px solid transparent"
                                                                         >
                                                                             Focusing
@@ -1038,6 +1052,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     data-default-message="I may be slow to respond."
                                                                     aria-describedby="limited-availability-help-text-truncate-true"
                                                                     id="limited-availability-truncate-true"
+                                                                    checked=""
                                                                 />
                                                                 <label
                                                                     class="d-block f5 text-gray-dark mb-1"
@@ -1057,7 +1072,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         </div>
                                                     </div>
 
-                                                    <div class="d-inline-block f5 mr-2 pt-3 pb-2">
+                                                    <div class="d-inline-block f5 border-top mr-2 pt-3 pb-2">
                                                         <div class="d-inline-block mr-1">
                                                             Clear status
                                                         </div>
@@ -1096,13 +1111,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         </div>
                                                                     </button>
                                                                 </li>
-                                                                <li class="dropdown-divider" role="separator"></li>
+                                                                <li class="dropdown-divider" role="none"></li>
                                                                 <li>
                                                                     <button
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 30 minutes"
-                                                                        value="2019-04-05T21:42:46+02:00"
+                                                                        value="2019-04-26T01:16:45+02:00"
                                                                     >
                                                                         in 30 minutes
                                                                     </button>
@@ -1112,7 +1127,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 1 hour"
-                                                                        value="2019-04-05T22:12:46+02:00"
+                                                                        value="2019-04-26T01:46:45+02:00"
                                                                     >
                                                                         in 1 hour
                                                                     </button>
@@ -1122,7 +1137,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="in 4 hours"
-                                                                        value="2019-04-06T01:12:46+02:00"
+                                                                        value="2019-04-26T04:46:45+02:00"
                                                                     >
                                                                         in 4 hours
                                                                     </button>
@@ -1132,7 +1147,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="today"
-                                                                        value="2019-04-05T23:59:59+02:00"
+                                                                        value="2019-04-26T23:59:59+02:00"
                                                                     >
                                                                         today
                                                                     </button>
@@ -1142,7 +1157,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         type="button"
                                                                         class="btn-link dropdown-item ws-normal js-user-status-expire-button"
                                                                         title="this week"
-                                                                        value="2019-04-07T23:59:59+02:00"
+                                                                        value="2019-04-28T23:59:59+02:00"
                                                                     >
                                                                         this week
                                                                     </button>
@@ -1167,15 +1182,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 >
                                                     <button
                                                         type="submit"
-                                                        disabled=""
                                                         class="width-full btn btn-primary mr-2 js-user-status-submit"
                                                     >
                                                         Set status
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        disabled=""
-                                                        class="width-full js-clear-user-status-button btn ml-2 "
+                                                        class="width-full js-clear-user-status-button btn ml-2 js-user-status-exists"
                                                     >
                                                         Clear status
                                                     </button>
@@ -1245,7 +1258,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                 <input name="utf8" type="hidden" value="✓" /><input
                                     type="hidden"
                                     name="authenticity_token"
-                                    value="aaPk8gcbhKbm7uOeQ5D2fBhiE5CE+jPbMxofTfuv6kVub4fKroXXCrb98hDj5J6Ed/7hyyab1iKWFzSxJrjUGQ=="
+                                    value="88DBzzJ0Kgx6JEUHtISMbqPJp84XYVOvQAVX8+AyClX0DKL3m+p5oCo3VIkU8OSWzFVVlbUAtlblCHwPPSU0CQ=="
                                 />
 
                                 <button
@@ -1285,15 +1298,15 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <input name="utf8" type="hidden" value="✓" /><input
                                             type="hidden"
                                             name="authenticity_token"
-                                            value="fU3E2AXw0FeLgTCOT/2CbQiuPU3wKGQQXQlNCFrGYQzlOJmqn6vYsrzMg2kd5iW2rwpp0LSW7/WNtovuNYLf5g=="
+                                            value="/QTmC++KZkdVAWrfT4uPPfNqUaUIbJV1isy932BBD2tlcbt5ddFuomJM2TgdkCjmVM4FOEzSHpBac3s5DwWxgQ=="
                                         />
                                         <input type="hidden" name="repository_id" value="41288708" />
 
                                         <details class="details-reset details-overlay select-menu float-left">
                                             <summary
                                                 class="select-menu-button float-left btn btn-sm btn-with-count"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DA99:03EE:861855:EA7DDE:5CA7AE46","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257","user_id":10532611}}'
-                                                data-hydro-click-hmac="430d16c5b37039cd8c79233ad568a36fe611bea491b31daf648ae789440c8197"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"WATCH_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"D021:2AC2E:22E001B:34B1FC9:5CC238D4","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="1590442ad653c84a0ae6c120349b61421e345ac283fba016ed4c923b5bb77cf0"
                                                 data-ga-click="Repository, click Watch settings, action:pull_requests#show"
                                                 aria-haspopup="menu"
                                             >
@@ -1316,7 +1329,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             </summary>
                                             <details-menu
                                                 class="select-menu-modal position-absolute mt-5"
-                                                style="z-index: 99; "
+                                                style="z-index: 99;"
                                                 role="menu"
                                             >
                                                 <div class="select-menu-header">
@@ -1520,9 +1533,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         <a
                                             class="social-count js-social-count"
                                             href="/sourcegraph/sourcegraph/watchers"
-                                            aria-label="39 users are watching this repository"
+                                            aria-label="42 users are watching this repository"
                                         >
-                                            39
+                                            42
                                         </a>
                                     </form>
                                 </li>
@@ -1539,7 +1552,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="fJPSpV4toAiamYqyWV/trKMHAaqfxbFEJyjMP9avusLwMb0FQhMXODdwEWCgYS4CN6kORMZtr1B20ASyf2K9jA=="
+                                                value="85WQbb8Tl1f+pfCPp6iPyMaT1puRi0AV2/1A9KZLKFh/N//Noy0gZ1NMa11elkxmUj3ZdcgjXgGKBYh5D4YvFg=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1547,8 +1560,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Unstar sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DA99:03EE:861855:EA7DDE:5CA7AE46","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257","user_id":10532611}}'
-                                                data-hydro-click-hmac="159361ef524e855c055f301f2bd44057eae3da21c3d404a8a795d7ac2da532fa"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"UNSTAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"D021:2AC2E:22E001B:34B1FC9:5CC238D4","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="9410581b4939178492a159b68541accee6fc416e028f1cc78833b167bbfcdc99"
                                                 data-ga-click="Repository, click unstar button, action:pull_requests#show; text:Unstar"
                                             >
                                                 <svg
@@ -1569,9 +1582,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                         <!-- '"` --><!-- </textarea></xmp> -->
@@ -1584,7 +1597,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <input name="utf8" type="hidden" value="✓" /><input
                                                 type="hidden"
                                                 name="authenticity_token"
-                                                value="vnFqi+7/twtMhjrC6ZTl8L2ibb1mJBcs386hzXAVmE4HSqr6Z5oDQn2kltsMNuIt+DPu1xtDr9SqFOvWYgWi3A=="
+                                                value="Ll27zdUhZVdxs7DriCfYbubK/vvdKZgTz4kfuCI3FmiXZnu8XETRHkCRHPJthd+zo1t9kaBOIOu6U1WjMCcs+g=="
                                             />
                                             <input type="hidden" name="context" value="repository" />
                                             <button
@@ -1592,8 +1605,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 class="btn btn-sm btn-with-count js-toggler-target"
                                                 aria-label="Unstar this repository"
                                                 title="Star sourcegraph/sourcegraph"
-                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DA99:03EE:861855:EA7DDE:5CA7AE46","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257","user_id":10532611}}'
-                                                data-hydro-click-hmac="4e3a7649ade1ec7b4bb213bd7eedc774adf19ec11c6844700cf19446677e9503"
+                                                data-hydro-click='{"event_type":"repository.click","payload":{"target":"STAR_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"D021:2AC2E:22E001B:34B1FC9:5CC238D4","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                                data-hydro-click-hmac="54f0b7ab91d5ff661c605a45ebb1ff27366a72442e7307bfd3c99920a9a57336"
                                                 data-ga-click="Repository, click star button, action:pull_requests#show; text:Star"
                                             >
                                                 <svg
@@ -1614,9 +1627,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                             <a
                                                 class="social-count js-social-count"
                                                 href="/sourcegraph/sourcegraph/stargazers"
-                                                aria-label="1926 users starred this repository"
+                                                aria-label="2048 users starred this repository"
                                             >
-                                                1,926
+                                                2,048
                                             </a>
                                         </form>
                                     </div>
@@ -1628,12 +1641,10 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                     >
                                         <summary
                                             class="btn btn-sm btn-with-count"
-                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"DA99:03EE:861855:EA7DDE:5CA7AE46","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257","user_id":10532611}}'
-                                            data-hydro-click-hmac="1854884579d7cfb34750c83914ce574c83cfab39ea6abb2a1a966733c1936497"
+                                            data-hydro-click='{"event_type":"repository.click","payload":{"target":"FORK_BUTTON","repository_id":41288708,"client_id":"2008835310.1548448452","originating_request_id":"D021:2AC2E:22E001B:34B1FC9:5CC238D4","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null,"user_id":10532611}}'
+                                            data-hydro-click-hmac="67312f1bf1dae7200401fdb91078d7ad8267a832a6638bde185b4462008c017a"
                                             data-ga-click="Repository, show fork modal, action:pull_requests#show; text:Fork"
-                                            type="submit"
                                             title="Fork your own copy of sourcegraph/sourcegraph to your account"
-                                            aria-label="Fork your own copy of sourcegraph/sourcegraph to your account"
                                             aria-haspopup="dialog"
                                         >
                                             <svg
@@ -1653,6 +1664,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         </summary>
                                         <details-dialog
                                             class="anim-fade-in fast Box Box--overlay d-flex flex-column"
+                                            src="/sourcegraph/sourcegraph/fork?fragment=1"
+                                            preload=""
                                             role="dialog"
                                         >
                                             <div class="Box-header">
@@ -1679,162 +1692,14 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 <h3 class="Box-title">Fork sourcegraph</h3>
                                             </div>
                                             <div class="overflow-auto text-center">
-                                                <div class="p-4 ">
-                                                    <h3 class="h3 pb-3 text-normal">
-                                                        Where should we fork sourcegraph?
-                                                    </h3>
-
-                                                    <div class="d-flex flex-column flex-items-start">
-                                                        <!-- '"` --><!-- </textarea></xmp> -->
-                                                        <form
-                                                            class="button_to"
-                                                            method="post"
-                                                            action="/sourcegraph/sourcegraph/fork"
-                                                        >
-                                                            <button
-                                                                type="submit"
-                                                                name="organization"
-                                                                value="felixfbecker"
-                                                                tabindex="0"
-                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
-                                                                aria-label="Will be created as felixfbecker/sourcegraph."
-                                                            >
-                                                                <div class="d-flex flex-items-center">
-                                                                    <img
-                                                                        class="avatar avatar-small mr-2"
-                                                                        src="https://avatars0.githubusercontent.com/u/10532611?s=60&amp;v=4"
-                                                                        width="30"
-                                                                        height="30"
-                                                                        alt="@felixfbecker"
-                                                                    />
-                                                                    felixfbecker
-                                                                </div></button
-                                                            ><input
-                                                                type="hidden"
-                                                                name="authenticity_token"
-                                                                value="57F4QBdUXQOnRqSiswituoWDtj+SBUgJp0K41je0A8ZEW8bkKjNOXKJsMfc0yg8rc3rzusIZlbCrUjU2IbXLUg=="
-                                                            />
-                                                        </form>
-
-                                                        <!-- '"` --><!-- </textarea></xmp> -->
-                                                        <form
-                                                            class="button_to"
-                                                            method="get"
-                                                            action="/sourcegraph/sourcegraph"
-                                                        >
-                                                            <button
-                                                                type="submit"
-                                                                name="organization"
-                                                                value="sourcegraph"
-                                                                tabindex="0"
-                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
-                                                                aria-label="You’re already looking at sourcegraph/sourcegraph."
-                                                                disabled="disabled"
-                                                            >
-                                                                <div class="d-flex flex-items-center">
-                                                                    <svg
-                                                                        class="octicon octicon-repo-forked mr-2"
-                                                                        viewBox="0 0 10 16"
-                                                                        version="1.1"
-                                                                        width="10"
-                                                                        height="16"
-                                                                        aria-hidden="true"
-                                                                    >
-                                                                        <path
-                                                                            fill-rule="evenodd"
-                                                                            d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
-                                                                        ></path>
-                                                                    </svg>
-                                                                    sourcegraph/sourcegraph
-                                                                </div>
-                                                            </button>
-                                                        </form>
-                                                        <!-- '"` --><!-- </textarea></xmp> -->
-                                                        <form
-                                                            class="button_to"
-                                                            method="post"
-                                                            action="/sourcegraph/sourcegraph/fork"
-                                                        >
-                                                            <button
-                                                                type="submit"
-                                                                name="organization"
-                                                                value="types"
-                                                                tabindex="0"
-                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
-                                                                aria-label="Will be created as types/sourcegraph."
-                                                            >
-                                                                <div class="d-flex flex-items-center">
-                                                                    <img
-                                                                        class="avatar avatar-small mr-2"
-                                                                        src="https://avatars3.githubusercontent.com/u/17114560?s=60&amp;v=4"
-                                                                        width="30"
-                                                                        height="30"
-                                                                        alt="@types"
-                                                                    />
-                                                                    types
-                                                                </div></button
-                                                            ><input
-                                                                type="hidden"
-                                                                name="authenticity_token"
-                                                                value="hgu0/NEG2Mus/EsWNI2s5nWQJEZ595BeO/DQCH91IQUl4QpY7GHLlKnW3kOzTw53g2lhwynrTec34F3oaXTpkQ=="
-                                                            />
-                                                        </form>
-
-                                                        <!-- '"` --><!-- </textarea></xmp> -->
-                                                        <form
-                                                            class="button_to"
-                                                            method="post"
-                                                            action="/sourcegraph/sourcegraph/fork"
-                                                        >
-                                                            <button
-                                                                type="submit"
-                                                                name="organization"
-                                                                value="typings"
-                                                                tabindex="0"
-                                                                class="btn-link f5 text-bold my-2 tooltipped tooltipped-se tooltipped-align-left-1"
-                                                                aria-label="Will be created as typings/sourcegraph."
-                                                            >
-                                                                <div class="d-flex flex-items-center">
-                                                                    <img
-                                                                        class="avatar avatar-small mr-2"
-                                                                        src="https://avatars0.githubusercontent.com/u/15212838?s=60&amp;v=4"
-                                                                        width="30"
-                                                                        height="30"
-                                                                        alt="@typings"
-                                                                    />
-                                                                    typings
-                                                                </div></button
-                                                            ><input
-                                                                type="hidden"
-                                                                name="authenticity_token"
-                                                                value="dUadnoyrud0+09kDuCSTsqC9jLqgcXL2i81RnLAEMFHWrCM6scyqgjv5TFY/5jEjVkTJP/Btr0+H3dx8pgX4xQ=="
-                                                            />
-                                                        </form>
-                                                    </div>
-                                                </div>
-
-                                                <div class="p-4 border-top">
-                                                    <h3 class="h3 pb-3 text-normal">
-                                                        Can’t find what you’re looking for?
-                                                    </h3>
-
-                                                    <p>You don’t have permission to fork to these organizations:</p>
-
-                                                    <ul class="list-style-none">
-                                                        <li class="mb-1">
-                                                            <a class="d-block" href="/sabre-io">
-                                                                <img
-                                                                    class="avatar"
-                                                                    src="https://avatars1.githubusercontent.com/u/28524376?s=40&amp;v=4"
-                                                                    width="20"
-                                                                    height="20"
-                                                                    alt="@sabre-io"
-                                                                />
-                                                                sabre-io
-                                                            </a>
-                                                        </li>
-                                                    </ul>
-                                                </div>
+                                                <include-fragment>
+                                                    <div class="octocat-spinner my-3" aria-label="Loading..."></div>
+                                                    <p class="f5 text-gray">
+                                                        If this dialog fails to load, you can visit
+                                                        <a href="/sourcegraph/sourcegraph/fork">the fork page</a>
+                                                        directly.
+                                                    </p>
+                                                </include-fragment>
                                             </div>
                                         </details-dialog>
                                     </details>
@@ -1842,9 +1707,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                     <a
                                         href="/sourcegraph/sourcegraph/network/members"
                                         class="social-count"
-                                        aria-label="129 users forked this repository"
+                                        aria-label="138 users forked this repository"
                                     >
-                                        129
+                                        138
                                     </a>
                                 </li>
                             </ul>
@@ -1938,7 +1803,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Issues</span>
-                                    <span class="Counter">655</span>
+                                    <span class="Counter">696</span>
                                     <meta itemprop="position" content="2" />
                                 </a>
                             </span>
@@ -1966,7 +1831,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         ></path>
                                     </svg>
                                     <span itemprop="name">Pull requests</span>
-                                    <span class="Counter">94</span>
+                                    <span class="Counter">83</span>
                                     <meta itemprop="position" content="3" />
                                 </a>
                             </span>
@@ -2061,7 +1926,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                     <div class="container new-discussion-timeline experiment-repo-nav  ">
                         <div class="repository-content ">
                             <div
-                                class="issues-listing js-review-state-classes  js-suggested-changes-files-tab "
+                                class="position-relative js-review-state-classes  js-suggested-changes-files-tab "
                                 data-pjax=""
                                 data-issue-and-pr-hovercards-enabled=""
                             >
@@ -2074,7 +1939,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         class="gh-header js-details-container Details js-socket-channel js-updatable-content pull request js-pull-header-details"
                                         data-channel="pull_request:267881853"
                                         data-url="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Ftitle&amp;sticky=false"
-                                        data-pull-is-open="true"
+                                        data-pull-is-open="false"
                                         data-gid="MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz"
                                     >
                                         <div class="gh-header-show ">
@@ -2113,7 +1978,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 /><input
                                                     type="hidden"
                                                     name="authenticity_token"
-                                                    value="SABwVzdjX3cgY/jYD9Yz59ib3EduFWsyOGLtgZl3im3J1Mo50U2jrqUeFzhrvNJLnOAhuN0uZFPk3A8yJdl7qg=="
+                                                    value="aktqLjahseQniH7Nh9X00iR3/Ee9UAUM422CV8RyM8Prn9BA0I9NPaL1kS3jvxV+YAwBuA5rCm0/02DkeNzCBA=="
                                                 />
                                                 <input
                                                     class="form-control edit-issue-title js-quick-submit"
@@ -2145,10 +2010,10 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                         </div>
                                         <div class="TableObject gh-header-meta">
                                             <div class="TableObject-item">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -2156,30 +2021,27 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
                                             <div class="TableObject-item TableObject-item--primary">
                                                 <a
                                                     class="author link-gray text-bold css-truncate css-truncate-target expandable"
                                                     data-hovercard-type="user"
-                                                    data-hovercard-url="/hovercards?user_id=187831"
+                                                    data-hovercard-url="/hovercards?user_id=1646931"
                                                     data-octo-click="hovercard-link-click"
                                                     data-octo-dimensions="link_type:self"
-                                                    href="/keegancsmith"
-                                                    >keegancsmith</a
+                                                    href="/beyang"
+                                                    >beyang</a
                                                 >
-
-                                                wants to merge
-                                                <span class="js-updating-pull-request-commits-count">1</span>
-                                                commit into
+                                                merged 1 commit into
 
                                                 <span
                                                     title="sourcegraph/sourcegraph:master"
-                                                    class="commit-ref css-truncate user-select-contain expandable base-ref"
+                                                    class="commit-ref css-truncate user-select-contain expandable "
                                                     ><a
                                                         title="sourcegraph/sourcegraph:master"
                                                         class="no-underline"
@@ -2187,51 +2049,6 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         ><span class="css-truncate-target">master</span></a
                                                     ></span
                                                 ><span></span>
-
-                                                <div class="commit-ref-dropdown">
-                                                    <details
-                                                        class="details-reset details-overlay select-menu commitish-suggester"
-                                                    >
-                                                        <summary
-                                                            class="btn btn-sm select-menu-button branch"
-                                                            title="Choose a base branch"
-                                                            aria-haspopup="menu"
-                                                        >
-                                                            <i>base:</i>
-                                                            <span
-                                                                class="css-truncate css-truncate-target"
-                                                                title="master"
-                                                                >master</span
-                                                            >
-                                                        </summary>
-                                                        <details-menu
-                                                            class="select-menu-modal position-absolute"
-                                                            style="z-index: 90;"
-                                                            src="/sourcegraph/sourcegraph/pull/3257/show_partial?partial=pull_requests%2Fdescription_branches_dropdown"
-                                                            preload=""
-                                                            role="menu"
-                                                        >
-                                                            <include-fragment
-                                                                class="select-menu-loading-overlay anim-pulse"
-                                                                aria-label="Loading"
-                                                            >
-                                                                <svg
-                                                                    height="32"
-                                                                    class="octicon octicon-octoface"
-                                                                    viewBox="0 0 16 16"
-                                                                    version="1.1"
-                                                                    width="32"
-                                                                    aria-hidden="true"
-                                                                >
-                                                                    <path
-                                                                        fill-rule="evenodd"
-                                                                        d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"
-                                                                    ></path>
-                                                                </svg>
-                                                            </include-fragment>
-                                                        </details-menu>
-                                                    </details>
-                                                </div>
 
                                                 from
 
@@ -2278,12 +2095,20 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
                                                             ></path></svg></clipboard-copy
                                                 ></span>
+
+                                                <relative-time
+                                                    datetime="2019-04-08T00:40:04Z"
+                                                    title="8 Apr 2019, 02:40 CEST"
+                                                    >18 days ago</relative-time
+                                                >
                                             </div>
                                         </div>
                                     </div>
 
                                     <div class="tabnav tabnav-pr">
                                         <nav class="tabnav-tabs">
+                                            <link rel="pjax-prefetch" href="/sourcegraph/sourcegraph/pull/3257" />
+
                                             <a
                                                 href="/sourcegraph/sourcegraph/pull/3257"
                                                 class="tabnav-tab  js-pjax-history-navigate"
@@ -2304,7 +2129,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 Conversation
 
                                                 <span id="conversation_tab_counter" class="Counter">
-                                                    1
+                                                    2
                                                 </span>
                                             </a>
 
@@ -2330,8 +2155,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 <span
                                                     id="commits_tab_counter"
                                                     class="Counter js-updateable-pull-request-commits-count"
-                                                    >1</span
                                                 >
+                                                    1
+                                                </span>
                                             </a>
 
                                             <a
@@ -2388,10 +2214,10 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                     <div class="pr-toolbar js-sticky js-sticky-offset-scroll" style="position: sticky;">
                                         <div class="diffbar details-collapse js-details-container Details">
                                             <div class="show-if-stuck float-left mr-2 mt-2">
-                                                <span class="State State--green  " title="Status: Open">
+                                                <span class="State State--purple  " title="Status: Merged">
                                                     <svg
                                                         height="16"
-                                                        class="octicon octicon-git-pull-request"
+                                                        class="octicon octicon-git-merge"
                                                         viewBox="0 0 12 16"
                                                         version="1.1"
                                                         width="12"
@@ -2399,10 +2225,10 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     >
                                                         <path
                                                             fill-rule="evenodd"
-                                                            d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                                                            d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
                                                         ></path>
                                                     </svg>
-                                                    Open
+                                                    Merged
                                                 </span>
                                             </div>
 
@@ -2497,7 +2323,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                                 <relative-time
                                                                                     datetime="2019-04-05T16:05:51Z"
                                                                                     title="5 Apr 2019, 18:05 CEST"
-                                                                                    >4 hours ago</relative-time
+                                                                                    >20 days ago</relative-time
                                                                                 >
                                                                             </span>
                                                                         </div>
@@ -2781,7 +2607,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     <button
                                                                         type="button"
                                                                         class="btn btn-outline mt-2 text-bold js-dismiss-batched-suggested-changes-onboarding-notice"
-                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=rwfjCo5V/bo/ISGm0u5oNBvDf+6VoTIK/kXMBcqVMevG806iRU6HrPjnVzuqU/Q4JhDIaqU1xsaYUxIygzgj9Q=="
+                                                                        data-url="/settings/dismiss-notice/batched_suggested_changes_onboarding_prompt#csrf-token=9jVEi2F8pOLrNOGF/IZ+BIpB3C+H6TI5C0O9REpxCf+fwekjqmfe9CzylxiEO+IIt5Jrq7d9xvVtVWNzA9wb4Q=="
                                                                     >
                                                                         Got it
                                                                     </button>
@@ -2803,7 +2629,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 <input name="utf8" type="hidden" value="✓" /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="l0rXZdBpQp4cgHUvRE3r82tB/MU2Ups3zvNuQhlokWVRwG/GSSj62OnRRuJACzwLzNrpfHxQ5fCqZEBGI6AweA=="
+                                                                    value="FIzog1UCCpLG4mi297lyN878KTrTOROEMHk/oUzWkx7SBlAgzEOy1DOzW3vz/6XPaWc8g5k7bUNU7hGldh4yAw=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2832,8 +2658,8 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     <button
                                                                         type="submit"
                                                                         class="btn btn-sm btn-primary float-left js-suggestion-batch-submit"
-                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DA99:03EE:861855:EA7DDE:5CA7AE46","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257"}}'
-                                                                        data-hydro-click-hmac="142c1d4b359b4434a5869f89bfd587ab10a2e382600567f7089a57e554ebdbee"
+                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"commit_changes","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"D021:2AC2E:22E001B:34B1FC9:5CC238D4","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?diff=unified","referrer":null}}'
+                                                                        data-hydro-click-hmac="0923820e4ef88d3860e766a2de3de25db2580586aeac07e2c14842aa59d76e09"
                                                                         data-ga-click="Markdown Toolbar, click, insert code suggestion"
                                                                         data-disable-invalid="true"
                                                                         data-disable-with="Applying commits..."
@@ -2866,7 +2692,13 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                 <div class="diffbar-item dropdown js-reviews-container">
                                                     <details class="details-reset details-overlay js-dropdown-details">
                                                         <summary class="btn btn-sm btn-primary js-reviews-toggle">
-                                                            Review changes
+                                                            <span
+                                                                class="js-review-changes"
+                                                                data-pending-message="Finish your review"
+                                                                data-message="Review changes"
+                                                            >
+                                                                Review changes
+                                                            </span>
                                                             <span class="Counter js-pending-review-comment-count">
                                                                 0
                                                             </span>
@@ -2889,7 +2721,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 /><input
                                                                     type="hidden"
                                                                     name="authenticity_token"
-                                                                    value="30Lo+NhjO7FHZBIYIfYul6u0vvAjaD/YrC/E7K51CPFFWdKrJFV4c1SZ2dpZqhVN9SiiSnSfj5Z1BD4a9DemOA=="
+                                                                    value="Ba9UP7auSDaxV5C8UST5soBq9S7X0s6ZwmzzYy0zyRGftG5sSpgL9KKqW34peMJo3vbplIAlftcbRwmVd3Fn2A=="
                                                                 />
                                                                 <input
                                                                     type="hidden"
@@ -2901,7 +2733,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 <div
                                                                     class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                     data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                    data-preview-authenticity-token="OJaTlh2YmBfADl/JbYRZWrS9H19XBIOvqi+WlPNDVYP4hs7unrSi/P8HSDzBRBhJ9q4YFO26tyzYM1Mx3g6/rQ=="
+                                                                    data-preview-authenticity-token="iII7/Z4l5iL9ikqKKnPs3aaMnxOGUhept/1ZEhnY7fJIkmaFHQncycKDXX+Gs63O5J+YWDzsIyrF4Zy3NJUH3A=="
                                                                 >
                                                                     <div class="comment-form-head tabnav ">
                                                                         <markdown-toolbar
@@ -3261,7 +3093,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                         class="js-upload-markdown-image is-default"
                                                                         data-upload-repository-id="41288708"
                                                                         data-upload-policy-url="/upload/policies/assets"
-                                                                        data-upload-policy-authenticity-token="HSWCTIGxw7wDRzxYJFTMjqfg5QgmDE1ftu+TEisAvLUvM87dztw/9/ZIacsQgTv3aK3RHgKLAS12JibdWrzJhQ=="
+                                                                        data-upload-policy-authenticity-token="LCGfwBYXPwVXX+Lpj1RZoHXUPV48zZ9ZSREhV6z2fqIeN9NRWXrDTqJQt3q7ga7ZupkJSBhK0yuJ2JSY3UoLkg=="
                                                                     >
                                                                         <div
                                                                             class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -3286,7 +3118,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                                 data-suggest-mention="/suggestions/pull_request/267881853?repository=sourcegraph&amp;user_id=sourcegraph&amp;mention_suggester=1"
                                                                             ></textarea>
 
-                                                                            <p class="drag-and-drop position-relative">
+                                                                            <p
+                                                                                class="drag-and-drop position-relative d-flex flex-justify-between"
+                                                                            >
                                                                                 <input
                                                                                     accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
                                                                                     type="file"
@@ -3428,6 +3262,32 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                                         </span>
                                                                                     </span>
                                                                                 </span>
+                                                                                <span
+                                                                                    class="tooltipped tooltipped-nw"
+                                                                                    aria-label="Styling with Markdown is supported"
+                                                                                >
+                                                                                    <a
+                                                                                        class="tabnav-extra position-relative d-inline"
+                                                                                        href="https://guides.github.com/features/mastering-markdown/"
+                                                                                        target="_blank"
+                                                                                        data-ga-click="Markdown Toolbar, click, help"
+                                                                                        aria-label="Learn about styling with Markdown"
+                                                                                    >
+                                                                                        <svg
+                                                                                            class="octicon octicon-markdown v-align-bottom"
+                                                                                            viewBox="0 0 16 16"
+                                                                                            version="1.1"
+                                                                                            width="16"
+                                                                                            height="16"
+                                                                                            aria-hidden="true"
+                                                                                        >
+                                                                                            <path
+                                                                                                fill-rule="evenodd"
+                                                                                                d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                            ></path>
+                                                                                        </svg>
+                                                                                    </a>
+                                                                                </span>
                                                                             </p>
                                                                         </div>
                                                                     </file-attachment>
@@ -3469,51 +3329,11 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     ></div>
                                                                 </div>
 
-                                                                <div class="form-checkbox mx-3 mb-2 mt-0">
-                                                                    <label class="d-block">
-                                                                        <input
-                                                                            type="radio"
-                                                                            name="pull_request_review[event]"
-                                                                            value="comment"
-                                                                            checked=""
-                                                                        />
-                                                                        Comment
-                                                                        <p class="text-normal text-gray-light">
-                                                                            Submit general feedback without explicit
-                                                                            approval.
-                                                                        </p>
-                                                                    </label>
-                                                                </div>
-
-                                                                <div class="form-checkbox mx-3 my-2">
-                                                                    <label class="d-block">
-                                                                        <input
-                                                                            type="radio"
-                                                                            name="pull_request_review[event]"
-                                                                            value="approve"
-                                                                        />
-                                                                        Approve
-                                                                        <p class="text-normal text-gray-light">
-                                                                            Submit feedback and approve merging these
-                                                                            changes.
-                                                                        </p>
-                                                                    </label>
-                                                                </div>
-
-                                                                <div class="form-checkbox mx-3 my-2">
-                                                                    <label class="d-block">
-                                                                        <input
-                                                                            type="radio"
-                                                                            name="pull_request_review[event]"
-                                                                            value="reject"
-                                                                        />
-                                                                        Request changes
-                                                                        <p class="text-normal text-gray-light">
-                                                                            Submit feedback that must be addressed
-                                                                            before merging.
-                                                                        </p>
-                                                                    </label>
-                                                                </div>
+                                                                <input
+                                                                    type="hidden"
+                                                                    name="pull_request_review[event]"
+                                                                    value="comment"
+                                                                />
 
                                                                 <div
                                                                     class="form-actions p-2 m-0 bg-gray-light border-top"
@@ -3567,24 +3387,6 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                         <div
                                                             class="inline-comment-form-container js-inline-comment-form-container review-comment-form-container"
                                                         >
-                                                            <div class="inline-comment-form-actions">
-                                                                <button
-                                                                    type="button"
-                                                                    class="btn js-toggle-new-thread-form"
-                                                                    data-ga-click="Start a new conversation, click"
-                                                                    data-side=""
-                                                                >
-                                                                    Start a new conversation
-                                                                </button>
-
-                                                                <a
-                                                                    href="/sourcegraph/sourcegraph/pull/3257/files#submit-review"
-                                                                    class="finish-review-label btn ml-1"
-                                                                >
-                                                                    Finish your review
-                                                                </a>
-                                                            </div>
-
                                                             <div class="inline-comment-form">
                                                                 <!-- '"` --><!-- </textarea></xmp> -->
                                                                 <form
@@ -3596,7 +3398,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     <input name="utf8" type="hidden" value="✓" /><input
                                                                         type="hidden"
                                                                         name="authenticity_token"
-                                                                        value="j8tekR7XpWjExThH4RRv/hdwszeQg+8F4zUxik8KjAOalPnkn0EMDdW2r12yVpqpKgRPRac2sv//yy/0n7kOjw=="
+                                                                        value="QPVRFK44cIE57P//oF/VB4meYJM4Ki1MUwlfmQ+Sa6tVqvZhL67Z5CifaOXzHSBQtOqc4Q+fcLZP90Hn3yHpJw=="
                                                                     />
                                                                     <input
                                                                         type="hidden"
@@ -3633,40 +3435,15 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                     <input type="hidden" name="position" value="" />
 
                                                                     <div
-                                                                        class="js-previewable-comment-form js-suggested-changes-container previewable-comment-form write-selected"
+                                                                        class="js-previewable-comment-form previewable-comment-form write-selected"
                                                                         data-preview-url="/preview?markdown_unsupported=false&amp;repository=41288708&amp;subject=3257&amp;subject_type=PullRequest"
-                                                                        data-preview-authenticity-token="HiCcVffP55iXmextnDxPdtobf8pVTIhQIYRfTgH80SPeMMEtdOPdc6iQ+5gw/A5lmAh4ge/yvNNTmJrrLLE7DQ=="
+                                                                        data-preview-authenticity-token="p8wKWE8tQKT/NmnIwx81TCEWMr3uVgVR3ylcx5+8Uktn3FcgzAF6T8A/fj1v33RfYwU19lToMdKtNZlisvG4ZQ=="
                                                                     >
                                                                         <div class="comment-form-head tabnav ">
                                                                             <markdown-toolbar
-                                                                                for="r123420 new_inline_comment_diff_${anchor}_${position}"
+                                                                                for="r1017000 new_inline_comment_diff_${anchor}_${position}"
                                                                                 class="toolbar-commenting "
                                                                             >
-                                                                                <div class="toolbar-group">
-                                                                                    <button
-                                                                                        type="button"
-                                                                                        class="toolbar-item tooltipped tooltipped-n js-suggested-change-toolbar-item"
-                                                                                        aria-label="Insert a suggestion <cmd-g>"
-                                                                                        data-hydro-click='{"event_type":"suggested_changes.target.click","payload":{"user_id":10532611,"target_type":"insert_suggestion","pull_request_id":"MDExOlB1bGxSZXF1ZXN0MjY3ODgxODUz","relationship_to_suggestion":"reviewer","client_id":"2008835310.1548448452","originating_request_id":"DA99:03EE:861855:EA7DDE:5CA7AE46","originating_url":"https://github.com/sourcegraph/sourcegraph/pull/3257/files?_pjax=%23js-repo-pjax-container","referrer":"https://github.com/sourcegraph/sourcegraph/pull/3257"}}'
-                                                                                        data-hydro-click-hmac="791b0fd3986c14f35bf1074ccfe6f344d00eba88578a252adad9481edd660285"
-                                                                                        data-ga-click="Markdown Toolbar, click, insert code suggestion"
-                                                                                        hotkey="g"
-                                                                                    >
-                                                                                        <svg
-                                                                                            class="octicon octicon-diff"
-                                                                                            viewBox="0 0 13 16"
-                                                                                            version="1.1"
-                                                                                            width="13"
-                                                                                            height="16"
-                                                                                            aria-hidden="true"
-                                                                                        >
-                                                                                            <path
-                                                                                                fill-rule="evenodd"
-                                                                                                d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"
-                                                                                            ></path>
-                                                                                        </svg>
-                                                                                    </button>
-                                                                                </div>
                                                                                 <div class="toolbar-group">
                                                                                     <md-header
                                                                                         tabindex="-1"
@@ -4022,7 +3799,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                             class="js-upload-markdown-image is-default"
                                                                             data-upload-repository-id="41288708"
                                                                             data-upload-policy-url="/upload/policies/assets"
-                                                                            data-upload-policy-authenticity-token="kBtlYGQ5JXhvaEpFB/0nO0krhufb8uvC6tydh5LX3QyiDSnxK1TZM5pnH9YzKNBChmay8f91p7AqFShI42uoPA=="
+                                                                            data-upload-policy-authenticity-token="K9X5ZrCZD0+yw5gim/YibbyHhhNNZS/lbceiPAnCDyQZw7X3//TzBEfMzbGvI9UUc8qyBWniY5etDhfzeH56FA=="
                                                                         >
                                                                             <div
                                                                                 class="write-content js-write-bucket upload-enabled  js-reaction-suggestion tooltipped tooltipped-ne tooltipped-no-delay tooltipped-align-left-1 hide-reaction-suggestion"
@@ -4038,7 +3815,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
 
                                                                                 <textarea
                                                                                     name="comment[body]"
-                                                                                    id="r123420 new_inline_comment_diff_${anchor}_${position}"
+                                                                                    id="r1017000 new_inline_comment_diff_${anchor}_${position}"
                                                                                     placeholder="Leave a comment"
                                                                                     aria-label="Comment body"
                                                                                     class="form-control input-contrast comment-form-textarea js-comment-field js-paste-markdown js-task-list-field js-quick-submit js-session-resumable js-saved-reply-shortcut-comment-field"
@@ -4049,7 +3826,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                                 ></textarea>
 
                                                                                 <p
-                                                                                    class="drag-and-drop position-relative"
+                                                                                    class="drag-and-drop position-relative d-flex flex-justify-between"
                                                                                 >
                                                                                     <input
                                                                                         accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip"
@@ -4199,6 +3976,32 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                                             </span>
                                                                                         </span>
                                                                                     </span>
+                                                                                    <span
+                                                                                        class="tooltipped tooltipped-nw"
+                                                                                        aria-label="Styling with Markdown is supported"
+                                                                                    >
+                                                                                        <a
+                                                                                            class="tabnav-extra position-relative d-inline"
+                                                                                            href="https://guides.github.com/features/mastering-markdown/"
+                                                                                            target="_blank"
+                                                                                            data-ga-click="Markdown Toolbar, click, help"
+                                                                                            aria-label="Learn about styling with Markdown"
+                                                                                        >
+                                                                                            <svg
+                                                                                                class="octicon octicon-markdown v-align-bottom"
+                                                                                                viewBox="0 0 16 16"
+                                                                                                version="1.1"
+                                                                                                width="16"
+                                                                                                height="16"
+                                                                                                aria-hidden="true"
+                                                                                            >
+                                                                                                <path
+                                                                                                    fill-rule="evenodd"
+                                                                                                    d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
+                                                                                                ></path>
+                                                                                            </svg>
+                                                                                        </a>
+                                                                                    </span>
                                                                                 </p>
                                                                             </div>
                                                                         </file-attachment>
@@ -4233,30 +4036,6 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                                     <p>Nothing to preview</p>
                                                                                 </div>
                                                                             </div>
-                                                                        </div>
-
-                                                                        <div class="float-left ">
-                                                                            <a
-                                                                                class="tabnav-extra "
-                                                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                                                target="_blank"
-                                                                                data-ga-click="Markdown Toolbar, click, help"
-                                                                            >
-                                                                                <svg
-                                                                                    class="octicon octicon-markdown v-align-bottom"
-                                                                                    viewBox="0 0 16 16"
-                                                                                    version="1.1"
-                                                                                    width="16"
-                                                                                    height="16"
-                                                                                    aria-hidden="true"
-                                                                                >
-                                                                                    <path
-                                                                                        fill-rule="evenodd"
-                                                                                        d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"
-                                                                                    ></path>
-                                                                                </svg>
-                                                                                Styling with Markdown is supported
-                                                                            </a>
                                                                         </div>
 
                                                                         <div
@@ -4337,103 +4116,116 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                     data-file-deleted="false"
                                                 >
                                                     <div class="file-actions">
-                                                        <span class="show-file-notes pt-1">
-                                                            <label>
-                                                                <input
-                                                                    type="checkbox"
-                                                                    checked="checked"
-                                                                    class="js-toggle-file-notes"
-                                                                />
-                                                                Show comments
-                                                            </label>
-                                                        </span>
+                                                        <div class="mt-1">
+                                                            <details
+                                                                class="js-file-header-dropdown dropdown details-overlay details-reset d-inline-block pr-2 pl-2"
+                                                            >
+                                                                <summary
+                                                                    class="btn-link v-align-middle"
+                                                                    aria-haspopup="menu"
+                                                                >
+                                                                    <svg
+                                                                        class="octicon octicon-kebab-horizontal text-gray"
+                                                                        aria-label="Show options"
+                                                                        viewBox="0 0 13 16"
+                                                                        version="1.1"
+                                                                        width="13"
+                                                                        height="16"
+                                                                        role="img"
+                                                                    >
+                                                                        <path
+                                                                            fill-rule="evenodd"
+                                                                            d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </summary>
+                                                                <details-menu
+                                                                    class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark position-absolute f5"
+                                                                    style="width:185px; z-index:99; right: -4px;"
+                                                                    role="menu"
+                                                                >
+                                                                    <label
+                                                                        role="menuitem"
+                                                                        class="dropdown-item btn-link text-normal d-block pl-5"
+                                                                        tabindex="0"
+                                                                    >
+                                                                        <span
+                                                                            class="file-notes-check position-absolute ml-n3"
+                                                                            ><svg
+                                                                                class="octicon octicon-check"
+                                                                                viewBox="0 0 12 16"
+                                                                                version="1.1"
+                                                                                width="12"
+                                                                                height="16"
+                                                                                aria-hidden="true"
+                                                                            >
+                                                                                <path
+                                                                                    fill-rule="evenodd"
+                                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                                ></path></svg
+                                                                        ></span>
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            checked="checked"
+                                                                            class="d-none js-toggle-file-notes"
+                                                                        />
+                                                                        Show comments
+                                                                    </label>
 
-                                                        <div class="BtnGroup">
-                                                            <clipboard-copy
-                                                                value="cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                tabindex="0"
-                                                                role="button"
-                                                            >
-                                                                Copy path
-                                                            </clipboard-copy>
-                                                            <a
-                                                                href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
-                                                                class="btn btn-sm BtnGroup-item"
-                                                                rel="nofollow"
-                                                            >
-                                                                View file
-                                                            </a>
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        href="/sourcegraph/sourcegraph/blob/a537a324138be6b8a47d544d9ce7ed0cd7bce7dd/cmd/gitserver/server/server.go"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        rel="nofollow"
+                                                                        role="menuitem"
+                                                                        data-ga-click="View file, click, location:files_changed_dropdown"
+                                                                    >
+                                                                        View file
+                                                                    </a>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to make changes."
+                                                                    >
+                                                                        Edit file
+                                                                    </button>
+
+                                                                    <button
+                                                                        type="button"
+                                                                        disabled=""
+                                                                        role="menuitem"
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        aria-label="You must be signed in and have push access to delete this file."
+                                                                    >
+                                                                        Delete file
+                                                                    </button>
+
+                                                                    <div role="none" class="dropdown-divider"></div>
+
+                                                                    <a
+                                                                        class="pl-5 dropdown-item btn-link"
+                                                                        role="menuitem"
+                                                                        href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
+                                                                        aria-label="Open this file in GitHub Desktop"
+                                                                        data-ga-click="Repository, open with desktop, type:mac"
+                                                                    >
+                                                                        Open in desktop
+                                                                    </a>
+                                                                </details-menu>
+                                                            </details>
                                                         </div>
-
-                                                        <a
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            href="x-github-client://openRepo/https://github.com/sourcegraph/sourcegraph?branch=core%2Fgitserver-tracing&amp;filepath=cmd%2Fgitserver%2Fserver%2Fserver.go"
-                                                            aria-label="Open this file in GitHub Desktop"
-                                                            data-ga-click="Repository, open with desktop, type:mac"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-device-desktop"
-                                                                viewBox="0 0 16 16"
-                                                                version="1.1"
-                                                                width="16"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/edit/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Change this file using the online editor"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-pencil"
-                                                                viewBox="0 0 14 16"
-                                                                version="1.1"
-                                                                width="14"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
-                                                        <a
-                                                            href="/sourcegraph/sourcegraph/delete/core/gitserver-tracing/cmd/gitserver/server/server.go?pr=%2Fsourcegraph%2Fsourcegraph%2Fpull%2F3257"
-                                                            class="btn-octicon btn-octicon-danger tooltipped tooltipped-w"
-                                                            rel="nofollow"
-                                                            data-skip-pjax=""
-                                                            aria-label="Delete this file"
-                                                        >
-                                                            <svg
-                                                                class="octicon octicon-trashcan"
-                                                                viewBox="0 0 12 16"
-                                                                version="1.1"
-                                                                width="12"
-                                                                height="16"
-                                                                aria-hidden="true"
-                                                            >
-                                                                <path
-                                                                    fill-rule="evenodd"
-                                                                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                                                                ></path>
-                                                            </svg>
-                                                        </a>
+                                                    </div>
+                                                    <div class="file-info">
                                                         <button
                                                             type="button"
-                                                            class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-w"
+                                                            class="btn-octicon js-details-target"
                                                             aria-label="Toggle diff contents"
                                                             aria-expanded="true"
+                                                            style="width: 22px;"
                                                         >
                                                             <svg
                                                                 class="octicon octicon-chevron-down Details-content--hidden"
@@ -4449,21 +4241,19 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                                 ></path>
                                                             </svg>
                                                             <svg
-                                                                class="octicon octicon-chevron-up Details-content--shown"
-                                                                viewBox="0 0 10 16"
+                                                                class="octicon octicon-chevron-right Details-content--shown"
+                                                                viewBox="0 0 8 16"
                                                                 version="1.1"
-                                                                width="10"
+                                                                width="8"
                                                                 height="16"
                                                                 aria-hidden="true"
                                                             >
                                                                 <path
                                                                     fill-rule="evenodd"
-                                                                    d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"
+                                                                    d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"
                                                                 ></path>
                                                             </svg>
                                                         </button>
-                                                    </div>
-                                                    <div class="file-info">
                                                         <span
                                                             class="diffstat tooltipped tooltipped-e"
                                                             aria-label="22 additions &amp; 16 deletions"
@@ -4480,6 +4270,41 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
                                                             title="cmd/gitserver/server/server.go"
                                                             >cmd/gitserver/server/server.go</a
                                                         >
+
+                                                        <clipboard-copy
+                                                            value="cmd/gitserver/server/server.go"
+                                                            aria-label="Copied!"
+                                                            class="js-clipboard-copy zeroclipboard-link text-gray link-hover-blue"
+                                                            tabindex="0"
+                                                            role="button"
+                                                        >
+                                                            <svg
+                                                                class="octicon octicon-clippy d-inline-block mx-1 js-clipboard-clippy-icon"
+                                                                viewBox="0 0 14 16"
+                                                                version="1.1"
+                                                                width="14"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                                                ></path>
+                                                            </svg>
+                                                            <svg
+                                                                class="octicon octicon-check js-clipboard-check-icon mx-1 d-inline-block d-none text-green"
+                                                                viewBox="0 0 12 16"
+                                                                version="1.1"
+                                                                width="12"
+                                                                height="16"
+                                                                aria-hidden="true"
+                                                            >
+                                                                <path
+                                                                    fill-rule="evenodd"
+                                                                    d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                                                                ></path>
+                                                            </svg>
+                                                        </clipboard-copy>
                                                     </div>
                                                 </div>
                                                 <div class="js-file-content Details-content--hidden">
@@ -9314,7 +9139,7 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
             >
                 <ul class="list-style-none d-flex flex-wrap ">
                     <li class="mr-3">
-                        © 2019 <span title="0.44246s from unicorn-8456ccc87d-zsmcs">GitHub</span>, Inc.
+                        © 2019 <span title="0.58265s from unicorn-5675df497d-nfg9p">GitHub</span>, Inc.
                     </li>
                     <li class="mr-3">
                         <a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms"
@@ -9418,17 +9243,17 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
 
         <script
             crossorigin="anonymous"
-            integrity="sha512-bphhLbLcXwgzeVnBMcSG8SOa16cgriNbZcgA9uWXAlGEFY58lcBmENXevq9CR1d+61CN6gKopmvT9eMxqQAvdA=="
+            integrity="sha512-znYYMX+Ozti23C6Tyo0HKKjG0BPEZICHfEWMgOV7pBypdUmo42DBzCMKUgB80IiwSYIrZBO5F02NXRrZUIHy1Q=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/frameworks-bf3c39df.js"
+            src="https://github.githubassets.com/assets/frameworks-7404f2c3.js"
         ></script>
 
         <script
             crossorigin="anonymous"
             async="async"
-            integrity="sha512-XI/rhcvulwKFLPlHbYi81zUJQCq+F1v9dZElmEn84DLxovRUW/NhmTcF/buTFvUC7JhKWBFlTAoFvETEKevBgg=="
+            integrity="sha512-LNQ/6T+w3Smgq2vX5BgLuf6fUzzJMD7trUvysuob1CXIVO8W+T3VpGB6+nludzQgWBIYyr0OEdFuZnhV70+RXQ=="
             type="application/javascript"
-            src="https://github.githubassets.com/assets/github-bootstrap-cca2ad18.js"
+            src="https://github.githubassets.com/assets/github-bootstrap-54184628.js"
         ></script>
 
         <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden="">
@@ -9481,13 +9306,9 @@ Co-Authored-By: ijsnow <isaacjsnow@gmail.com>"
             </details>
         </template>
 
-        <div
-            class="Popover js-hovercard-content position-absolute"
-            style="display: none; outline: none; top: 98.3281px; left: 507.359px; z-index: 100;"
-            tabindex="0"
-        >
+        <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
             <div
-                class="Popover-message Popover-message--large Box box-shadow-large Popover-message--bottom-left"
+                class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large"
                 style="width:360px;"
             ></div>
         </div>

--- a/client/browser/src/libs/github/code_intelligence.test.ts
+++ b/client/browser/src/libs/github/code_intelligence.test.ts
@@ -45,10 +45,10 @@ describe('github/code_intelligence', () => {
                                 describe(`${startCase(view)} view`, () => {
                                     const directory = `${__dirname}/__fixtures__/${version}/${page}/${extension}/${view}`
                                     testCodeHost(`${directory}/page.html`)
-                                    describe('createCodeViewToolbarMount()', () => {
+                                    describe('createFileActionsToolbarMount()', () => {
                                         testMountGetter(
                                             createFileActionsToolbarMount,
-                                            'createCodeViewToolbarMount()',
+                                            'createFileActionsToolbarMount()',
                                             `${directory}/code-view.html`
                                         )
                                     })

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -32,37 +32,26 @@ import { getFileContainers, parseURL } from './util'
  * - An older GHE single file code view (newer GitHub.com code views use createFileLineContainerToolbarMount)
  */
 export function createFileActionsToolbarMount(codeView: HTMLElement): HTMLElement {
-    const className = 'sourcegraph-app-annotator'
+    const className = 'github-file-actions-toolbar-mount'
     const existingMount = codeView.querySelector('.' + className) as HTMLElement
     if (existingMount) {
         return existingMount
     }
 
     const mountEl = document.createElement('div')
-    mountEl.style.display = 'inline-flex'
-    mountEl.style.verticalAlign = 'middle'
-    mountEl.style.alignItems = 'center'
     mountEl.className = className
 
     const fileActions = codeView.querySelector('.file-actions')
     if (!fileActions) {
-        throw new Error(
-            "File actions not found. Make sure you aren't trying to create " +
-                "a toolbar mount for a code snippet that shouldn't have one"
-        )
+        throw new Error('Could not find GitHub file actions with selector .file-actions')
     }
 
-    const buttonGroup = fileActions.querySelector('.BtnGroup')
-    if (buttonGroup && buttonGroup.parentNode && !codeView.querySelector('.show-file-notes')) {
-        // blob view
-        buttonGroup.parentNode.insertBefore(mountEl, buttonGroup)
+    // Old GitHub Enterprise PR views have a "☑ show comments" text that we want to insert *after*
+    const showCommentsElement = codeView.querySelector('.show-file-notes')
+    if (showCommentsElement) {
+        showCommentsElement.insertAdjacentElement('afterend', mountEl)
     } else {
-        // commit & pull request view
-        const note = codeView.querySelector('.show-file-notes')
-        if (!note || !note.parentNode) {
-            throw new Error('cannot find toolbar mount location')
-        }
-        note.parentNode.insertBefore(mountEl, note.nextSibling)
+        fileActions.prepend(mountEl)
     }
 
     return mountEl

--- a/client/browser/src/libs/github/style.scss
+++ b/client/browser/src/libs/github/style.scss
@@ -18,6 +18,12 @@
     margin-right: 4px;
 }
 
+// This naturally only has one element but we add the toolbar mount
+// so we need to make sure they don't stack
+.file-actions {
+    display: flex;
+}
+
 .code-view-toolbar__item--github {
     // The space provides enough margin
     margin-left: 0 !important;


### PR DESCRIPTION
Fixes #3577 

Changes the toolbar mount creation function and updates all fixtures.

What made this difficult was that DOM function tests rely on _specific_ PRs to be used as fixtures, so I couldn't update them with just any PR and had to find out which one was used before. I added a comment for each file with a URL, but really we should change them to assert snapshots/selectors instead.

#### Test Plan

##### Code Hosts

- [x] GitHub
- [x] GitHub Enterprise
- [x] Refined GitHub
- [ ] Phabricator
- [ ] Phabricator integration
- [ ] Bitbucket
- [ ] Gitlab

##### Browsers

- [x] Chrome
- [ ] Firefox
