### PR TITLE
search: add test via GraphQL queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -1,5 +1,16 @@
 package graphqlbackend
 
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
+)
+
 func testStringResult(result *searchSuggestionResolver) string {
 	var name string
 	switch r := result.result.(type) {
@@ -15,3 +26,166 @@ func testStringResult(result *searchSuggestionResolver) string {
 	}
 	return name
 }
+
+func TestSearch(t *testing.T) {
+	type Results struct {
+		Results []interface{}
+		LimitHit bool
+		ResultCount int
+	}
+	tcs := []struct {
+		name          string
+		searchQuery   string
+		reposListMock func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
+		wantResults	  Results
+	}{
+		{
+			name:        "empty query against no repos gets no results",
+			searchQuery: "",
+			reposListMock: func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error) {
+				return nil, nil
+			},
+			wantResults: Results{},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			conf.Mock(&conf.Unified{})
+			defer conf.Mock(nil)
+			vars := map[string]interface{}{"query": tc.searchQuery}
+			db.Mocks.Repos.List = tc.reposListMock
+			result := GraphQLSchema.Exec(context.Background(), testSearchGQLQuery, "", vars)
+			if len(result.Errors) > 0 {
+				t.Fatalf("graphQL query returned errors: %+v", result.Errors)
+			}
+			var search struct {
+				Results Results
+			}
+			if err := json.Unmarshal(result.Data, &search); err != nil {
+				t.Fatalf("parsing JSON response: %v", err)
+			}
+			gotResults := search.Results
+			if !reflect.DeepEqual(gotResults, tc.wantResults) {
+				t.Fatalf("results = %+v, want %+v", gotResults, tc.wantResults)
+			}
+		})
+	}
+}
+
+var testSearchGQLQuery = `
+		fragment FileMatchFields on FileMatch {
+			repository {
+				name
+				url
+			}
+			file {
+				name
+				path
+				url
+				commit {
+					oid
+				}
+			}
+			lineMatches {
+				preview
+				lineNumber
+				offsetAndLengths
+				limitHit
+			}
+		}
+
+		fragment CommitSearchResultFields on CommitSearchResult {
+			messagePreview {
+				value
+				highlights{
+					line
+					character
+					length
+				}
+			}
+			diffPreview {
+				value
+				highlights {
+					line
+					character
+					length
+				}
+			}
+			label {
+				html
+			}
+			url
+			matches {
+				url
+				body {
+					html
+					text
+				}
+				highlights {
+					character
+					line
+					length
+				}
+			}
+			commit {
+				repository {
+					name
+				}
+				oid
+				url
+				subject
+				author {
+					date
+					person {
+						displayName
+					}
+				}
+			}
+		}
+
+		fragment RepositoryFields on Repository {
+			name
+			url
+			externalURLs {
+				serviceType
+				url
+			}
+			label {
+				html
+			}
+		}
+
+		query ($query: String!) {
+			site {
+				buildVersion
+			}
+			search(query: $query) {
+				results {
+					results{
+						__typename
+						... on FileMatch {
+						...FileMatchFields
+					}
+						... on CommitSearchResult {
+						...CommitSearchResultFields
+					}
+						... on Repository {
+						...RepositoryFields
+					}
+					}
+					limitHit
+					cloning {
+						name
+					}
+					missing {
+						name
+					}
+					timedout {
+						name
+					}
+					resultCount
+					elapsedMilliseconds
+				}
+			}
+		}
+`

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -13,15 +13,14 @@ import (
 
 func TestSearch(t *testing.T) {
 	type Results struct {
-		Results []interface{}
-		LimitHit bool
+		Results     []interface{}
 		ResultCount int
 	}
 	tcs := []struct {
 		name          string
 		searchQuery   string
 		reposListMock func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
-		wantResults	  Results
+		wantResults   Results
 	}{
 		{
 			name:        "empty query against no repos gets no results",
@@ -29,7 +28,10 @@ func TestSearch(t *testing.T) {
 			reposListMock: func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error) {
 				return nil, nil
 			},
-			wantResults: Results{},
+			wantResults: Results{
+				Results:     nil,
+				ResultCount: 0,
+			},
 		},
 	}
 	for _, tc := range tcs {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -11,22 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
 
-func testStringResult(result *searchSuggestionResolver) string {
-	var name string
-	switch r := result.result.(type) {
-	case *repositoryResolver:
-		name = "repo:" + string(r.repo.Name)
-	case *gitTreeEntryResolver:
-		name = "file:" + r.path
-	default:
-		panic("never here")
-	}
-	if result.score == 0 {
-		return "<removed>"
-	}
-	return name
-}
-
 func TestSearch(t *testing.T) {
 	type Results struct {
 		Results []interface{}
@@ -189,3 +173,19 @@ var testSearchGQLQuery = `
 			}
 		}
 `
+
+func testStringResult(result *searchSuggestionResolver) string {
+	var name string
+	switch r := result.result.(type) {
+	case *repositoryResolver:
+		name = "repo:" + string(r.repo.Name)
+	case *gitTreeEntryResolver:
+		name = "file:" + r.path
+	default:
+		panic("never here")
+	}
+	if result.score == 0 {
+		return "<removed>"
+	}
+	return name
+}


### PR DESCRIPTION
This should make it easier for us to write clear tests that work regardless of how search is implemented.

This PR just adds the empty case so we get the structure in place. Later changes will add additional test cases.
