### PR TITLE
server: Fix /etc/hosts DNS resolution

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -54,5 +54,7 @@ COPY --from=libsqlite3-pcre /sqlite3-pcre/pcre.so /libsqlite3-pcre.so
 ENV LIBSQLITE3_PCRE /libsqlite3-pcre.so
 COPY . /
 
+RUN echo "hosts: files dns" > /etc/nsswitch.conf
+
 ENV GO111MODULES=on LANG=en_US.utf8
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/server"]

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -39,7 +39,13 @@ for pkg in $server_pkg \
     github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver \
     github.com/google/zoekt/cmd/zoekt-webserver $additional_images; do
 
-    go build -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION" -buildmode exe -tags dist -o "$bindir/$(basename "$pkg")" "$pkg"
+    go build \
+      -a \
+      -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION"  \
+      -buildmode exe \
+      -installsuffix netgo \
+      -tags "dist netgo" \
+      -o "$bindir/$(basename "$pkg")" "$pkg"
 done
 
 echo "--- build sqlite for symbols"


### PR DESCRIPTION
This commit makes our server image binaries be built with the netgo
network stack. Together with an added `/etc/nsswitch.conf`, this fixes /etc/host based DNS resolution in alpine images, which we use.

References:

1. https://miek.nl/2015/june/06/go-and-alpine-linux/
2. https://giedrius.blog/2018/11/22/etc-nsswitch-conf-and-etc-hosts-woes-with-the-alpine-and-others-docker-image-and-golang/

Fixes #3526

