### PR TITLE
repo-updater: Tune pagination params in Store

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -51,6 +51,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/UpsertExternalServices", testStoreUpsertExternalServices(store)},
 		{"DBStore/UpsertRepos", testStoreUpsertRepos(store)},
 		{"DBStore/ListRepos", testStoreListRepos(store)},
+		{"DBStore/ListRepos/Pagination", testStoreListReposPagination(store)},
 		{"Syncer/Sync", testSyncerSync(store)},
 		{"Migrations/GithubSetDefaultRepositoryQuery",
 			testGithubSetDefaultRepositoryQueryMigration(store)},

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -706,8 +706,8 @@ func testStoreListReposPagination(store repos.Store) func(*testing.T) {
 			for page := lo; page < hi; page++ {
 				for limit := lo; limit < hi; limit++ {
 					args := repos.StoreListReposArgs{
-						Page:  int64(page),
-						Limit: int64(limit),
+						PerPage: int64(page),
+						Limit:   int64(limit),
 					}
 
 					listed, err := tx.ListRepos(ctx, args)
@@ -724,6 +724,15 @@ func testStoreListReposPagination(store repos.Store) func(*testing.T) {
 
 					if have := len(listed); have != want {
 						t.Fatalf("page=%d, limit=%d: count:\nhave: %v\nwant: %v", page, limit, have, want)
+					}
+
+					set := make(map[api.ExternalRepoSpec]bool)
+					for _, r := range listed {
+						if _, ok := set[r.ExternalRepo]; !ok {
+							set[r.ExternalRepo] = true
+						} else {
+							t.Errorf("duplicate found: %v", r)
+						}
 					}
 				}
 			}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -217,6 +217,10 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 			repos = append(repos, r)
 			set[r] = true
 		}
+
+		if args.Limit > 0 && int64(len(repos)) == args.Limit {
+			break
+		}
 	}
 
 	sort.Sort(repos)


### PR DESCRIPTION
This commit introduces `Limit` and `Page` parameters on
`StoreListReposArgs` which allow callers to specify the page size and
the total limit of returned repos by `ListRepos`.

Additionally, it also changes the default page size from **500** to
**10000**. The reason for this is that in most configurations, the
network roundtrip and marshalling overhead dominates the total time
taken to list the desired number of repositories.

The value of **10000** has been empirically found with a helper program
that listed repos in sourcegraph.com with different `Limit` and `Page`
parameters.

- Page=500   Limit=20000: 15.699724879s
- Page=5000  Limit=20000:  3.924060726s
- Page=10000 Limit=20000:  **1.106930741s**
- Page=20000 Limit=20000:  3.208471686s

This should fix one part of the performance regressions reported by
@slimsag yesterday.
