### PR TITLE
repo-updater: use proper nil check for info.CloneTime

### DIFF
--- a/cmd/repo-updater/repos/purge.go
+++ b/cmd/repo-updater/repos/purge.go
@@ -83,12 +83,15 @@ func purge(ctx context.Context, log log15.Logger) error {
 		}
 
 		info := infos.Results[repo]
-		age := time.Since(*info.CloneTime)
-		if info.CloneTime != nil && age < 12*time.Hour {
-			log.Info("skipping repository since it was cloned less than 12 hours ago", "repo", repo, "age", age)
-			purgeSkipped.Inc()
-			skipped++
-			continue
+
+		if info.CloneTime != nil {
+			age := time.Since(*info.CloneTime)
+			if age < 12*time.Hour {
+				log.Info("skipping repository since it was cloned less than 12 hours ago", "repo", repo, "age", age)
+				purgeSkipped.Inc()
+				skipped++
+				continue
+			}
 		}
 
 		// Race condition: A repo can be re-enabled between our listing and

--- a/cmd/repo-updater/repos/purge.go
+++ b/cmd/repo-updater/repos/purge.go
@@ -86,6 +86,7 @@ func purge(ctx context.Context, log log15.Logger) error {
 
 		if info.CloneTime != nil {
 			age := time.Since(*info.CloneTime)
+
 			if age < 12*time.Hour {
 				log.Info("skipping repository since it was cloned less than 12 hours ago", "repo", repo, "age", age)
 				purgeSkipped.Inc()


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/commit/68b1d86ccc16b758b3595c0a54deb8a2d010fa9a introduced a regression caused the `info.CloneTime` pointer to be dereferenced _before_  checking to see if was `nil` on the following line. This caused panics in production. 

This PR swaps the order of the nil check and the pointer deference - which should alleviate this issue.