### PR TITLE
Update Search section of Roadmap

### DIFF
--- a/doc/dev/roadmap/index.md
+++ b/doc/dev/roadmap/index.md
@@ -31,11 +31,10 @@ We're also working toward making Sourcegraph the [**infrastructure for developer
 
 Owners: @ijt, @ijsnow
 
-We're making search faster, more powerful, and more comprehensive (so it includes issues, documents, and other data sources you might want to search).
+We're making search more reliable, powerful, and comprehensive (so it includes issues, documents, and other data sources you might want to search).
 
-- 🏃 [Enable indexed search by default](https://github.com/sourcegraph/sourcegraph/issues/2176)
-- 🏃 [Nested search queries](https://github.com/sourcegraph/sourcegraph/issues/1005) (e.g., in all repositories whose `package.json` contains `foo`, find matches of `bar`)
-  - [Multi-line searches](https://github.com/sourcegraph/sourcegraph/issues/35)
+- 🏃 [Multi-line searches](https://github.com/sourcegraph/sourcegraph/issues/35)
+- [Nested search queries](https://github.com/sourcegraph/sourcegraph/issues/1005) (e.g., in all repositories whose `package.json` contains `foo`, find matches of `bar`)
 - Streaming search results to reduce time to first result.
 - More ways to filter queries (provided by extensions), such as by authorship, recency, and language-specific or dependency graph information
 - [More types/sources of search results](https://github.com/sourcegraph/sourcegraph/issues/738) (provided by extensions), such as documentation (wiki, Markdown, and Google Docs), issues, PR comments, logs, and configuration data

--- a/doc/dev/roadmap/index.md
+++ b/doc/dev/roadmap/index.md
@@ -31,9 +31,9 @@ We're also working toward making Sourcegraph the [**infrastructure for developer
 
 Owners: @ijt, @ijsnow
 
-We're making search more reliable, powerful, and comprehensive (so it includes issues, documents, and other data sources you might want to search).
+Currently we're prioritizing speed and stability of search. Here are some more things we plan to tackle in the near future.
 
-- 🏃 [Multi-line searches](https://github.com/sourcegraph/sourcegraph/issues/35)
+- [Multi-line searches](https://github.com/sourcegraph/sourcegraph/issues/35)
 - [Nested search queries](https://github.com/sourcegraph/sourcegraph/issues/1005) (e.g., in all repositories whose `package.json` contains `foo`, find matches of `bar`)
 - Streaming search results to reduce time to first result.
 - More ways to filter queries (provided by extensions), such as by authorship, recency, and language-specific or dependency graph information


### PR DESCRIPTION
The current work is about stability and speed, so this updates the roadmap to reflect that. Also it moves multiline search to no longer be a sub-project of nested search, since they are independent goals.
