### PR TITLE
repo-updater: Improve Store pagination tests

### DIFF
--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -218,12 +218,13 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 			set[r] = true
 		}
 
-		if args.Limit > 0 && int64(len(repos)) == args.Limit {
-			break
-		}
 	}
 
 	sort.Sort(repos)
+
+	if args.Limit > 0 && args.Limit <= int64(len(repos)) {
+		repos = repos[:args.Limit]
+	}
 
 	return repos, nil
 }


### PR DESCRIPTION
This commit change the store pagination tests to not only test that the
returned number of repos matches the given limit, but also to check that
the listed repos are in the exact order they should be in.