### PR TITLE
Clarification regarding upgrading Docker image tags

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -37,6 +37,8 @@ We actively maintain the two most recent [monthly releases of Sourcegraph](dev/r
 
 For example, if you are running Sourcegraph 3.1, then you can upgrade directly to 3.2 and 3.3. If you want to upgrade to 3.4, then you first need to upgrade to 3.3 before you can upgrade to 3.4.
 
+> The Docker server image tags follow SemVer semantics, so version 3.3 can be found at `sourcegraph/server:3.3.0`. You can see the full list of tags on our [Docker Hub page](https://hub.docker.com/r/sourcegraph/server/tags).
+
 ## Documentation
 
 Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph). Need help? Use the [issue tracker](https://github.com/sourcegraph/sourcegraph/issues).


### PR DESCRIPTION
The version naming for Sourcegraph is confusing.
- Branches are `3.0`
- Releases/Tags are `v3.0.0`
- Docker Hub tags are `3.0.0`

That is 3 different types and when one tries to change the docker tag to something like `3.0` or `v3.0.0` it won't work.
This clarifies that and adds a link to the Docker Hub page so once can investigate and find the correct Docker image tag they want to use.



<!-- Reminder: Have you updated the changelog? -->

Test plan: <!-- Required: What is the test plan for this change? -->
