### PR TITLE
Enable all language extensions by default

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -20,9 +20,20 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/csharp":     true,
 	"sourcegraph/shell":      true,
 	"sourcegraph/scala":      true,
+	"sourcegraph/swift":      true,
+	"sourcegraph/rust":       true,
 	"sourcegraph/kotlin":     true,
-	"sourcegraph/r":          true,
+	"sourcegraph/elixir":     true,
 	"sourcegraph/perl":       true,
+	"sourcegraph/lua":        true,
+	"sourcegraph/clojure":    true,
+	"sourcegraph/haskell":    true,
+	"sourcegraph/powershell": true,
+	"sourcegraph/lisp":       true,
+	"sourcegraph/erlang":     true,
+	"sourcegraph/dart":       true,
+	"sourcegraph/ocaml":      true,
+	"sourcegraph/r":          true,
 }
 
 const singletonDefaultSettingsGQLID = "DefaultSettings"


### PR DESCRIPTION
- More language support out of the box
- Precludes the question, "Why is language X enabled but not language Y by default?"