### PR TITLE
resolve major search perf regression in v3.2.0 (add redis cache to git commit OID resolution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ## Changed
 
 - All 24 language extensions are enabled by default.
-- Fixed a major performance regression in search that occurred in v3.2.0. (#3685)
+- Fixed a major indexed search performance regression that occurred in v3.2.0. (#3685)
 
 ## 3.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ## Changed
 
 - All 24 language extensions are enabled by default.
+- Fixed a major performance regression in search that occurred in v3.2.0. (#3685)
 
 ## 3.3.5
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -105,7 +105,7 @@ func (r *gitCommitResolver) OID() (gitObjectID, error) {
 		// The cache doesn't have it, so compute it and update the cache if we
 		// resolved it successfully.
 		start = time.Now()
-		r.doResolveCommitOIDUncached()
+		r.resolveCommitIODUncached()
 		oidResolutionDuration.Observe(time.Since(start).Seconds())
 		if r.oidErr == nil {
 			oidResolutionCounter.WithLabelValues("miss").Inc()
@@ -117,7 +117,7 @@ func (r *gitCommitResolver) OID() (gitObjectID, error) {
 	return r.oid, r.oidErr
 }
 
-func (r *gitCommitResolver) doResolveCommitOIDUncached() {
+func (r *gitCommitResolver) resolveCommitIODUncached() {
 	if r.oid != "" || r.oidErr != nil {
 		// Possible scenarios for this case:
 		//

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -150,7 +150,6 @@ func (r *gitCommitResolver) doResolveCommitOIDUncached() {
 			break
 		}
 	}
-	return
 }
 
 func (r *gitCommitResolver) AbbreviatedOID() (string, error) {

--- a/cmd/frontend/graphqlbackend/git_commit_resolution_cache.go
+++ b/cmd/frontend/graphqlbackend/git_commit_resolution_cache.go
@@ -25,6 +25,9 @@ type resolutionCache struct {
 	// checks for entries to evict. Defaults ttl / 2.
 	workerInterval time.Duration
 
+	// mockSleep, if non-nil can be used to mock time.Sleep for testing purposes.
+	mockSleep func(d time.Duration)
+
 	m sync.Map
 }
 
@@ -53,9 +56,13 @@ func (r *resolutionCache) startWorker() *resolutionCache {
 	if r.workerInterval == 0 {
 		r.workerInterval = r.ttl / 2
 	}
+	sleep := time.Sleep
+	if r.mockSleep != nil {
+		sleep = r.mockSleep
+	}
 	go func() {
 		for {
-			time.Sleep(r.workerInterval)
+			sleep(r.workerInterval)
 			size := 0
 			r.m.Range(func(key, value interface{}) bool {
 				size++

--- a/cmd/frontend/graphqlbackend/git_commit_resolution_cache.go
+++ b/cmd/frontend/graphqlbackend/git_commit_resolution_cache.go
@@ -1,0 +1,116 @@
+package graphqlbackend
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type resolutionCacheEntry struct {
+	t     time.Time
+	value string
+}
+
+type resolutionCache struct {
+	// ttl indicates how long before cache entries expire. There is no limit on
+	// the size of the cache except the effective # of repositories on the
+	// Sourcegraph instance.
+	ttl time.Duration
+
+	// cacheEntries, if non-nil, is used to record the number of entries in the cache.
+	cacheEntries prometheus.Histogram
+
+	// workerInterval, if non-zero, specifies the interval at which the worker
+	// checks for entries to evict. Defaults ttl / 2.
+	workerInterval time.Duration
+
+	m sync.Map
+}
+
+func (r *resolutionCache) Set(k, v string) {
+	r.m.Store(k, resolutionCacheEntry{
+		t:     time.Now(),
+		value: v,
+	})
+}
+
+func (r *resolutionCache) Get(k string) (string, bool) {
+	v, ok := r.m.Load(k)
+	if !ok {
+		return "", false
+	}
+	e := v.(resolutionCacheEntry)
+	if time.Since(e.t) >= r.ttl {
+		// entry has expired
+		r.m.Delete(k)
+		return "", false
+	}
+	return e.value, true
+}
+
+func (r *resolutionCache) startWorker() *resolutionCache {
+	if r.workerInterval == 0 {
+		r.workerInterval = r.ttl / 2
+	}
+	go func() {
+		for {
+			time.Sleep(r.workerInterval)
+			size := 0
+			r.m.Range(func(key, value interface{}) bool {
+				size++
+				e := value.(resolutionCacheEntry)
+				if time.Since(e.t) >= r.ttl {
+					// entry has expired
+					r.m.Delete(key)
+				}
+				return true
+			})
+			r.cacheEntries.Observe(float64(size))
+		}
+	}()
+	return r
+}
+
+var (
+	// oidResolutionCache is used to cache Git commit OID resolution. This is
+	// used because OID resolution happens extremely often (e.g. multiple times
+	// per search result).
+	oidResolutionCache = (&resolutionCache{
+		ttl: 60 * time.Second,
+		cacheEntries: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "src",
+			Subsystem: "graphql",
+			Name:      "git_commit_oid_resolution_cache_entries",
+			Help:      "Total number of entries in the in-memory Git commit OID resolution cache.",
+		}),
+	}).startWorker()
+
+	oidResolutionCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "src",
+		Subsystem: "graphql",
+		Name:      "git_commit_oid_resolution_cache_hit",
+		Help:      "Counts cache hits and misses for Git commit OID resolution.",
+	}, []string{"type"})
+
+	oidResolutionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "src",
+		Subsystem: "graphql",
+		Name:      "git_commit_oid_resolution_duration_seconds",
+		Help:      "Total time spent performing uncached Git commit OID resolution.",
+	})
+
+	oidResolutionCacheLookupDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "src",
+		Subsystem: "graphql",
+		Name:      "git_commit_oid_resolution_cache_lookup_duration_seconds",
+		Help:      "Total time spent performing cache lookups for Git commit OID resolution.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(oidResolutionCache.cacheEntries)
+	prometheus.MustRegister(oidResolutionCounter)
+	prometheus.MustRegister(oidResolutionDuration)
+	prometheus.MustRegister(oidResolutionCacheLookupDuration)
+}

--- a/cmd/frontend/graphqlbackend/git_commit_resolution_cache_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_resolution_cache_test.go
@@ -1,0 +1,91 @@
+package graphqlbackend
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestGitCommitResolutionCache(t *testing.T) {
+	cache := (&resolutionCache{
+		ttl: 2 * time.Second,
+		cacheEntries: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "src",
+			Subsystem: "graphql",
+			Name:      "git_commit_oid_resolution_cache_entries",
+			Help:      "Total number of entries in the in-memory Git commit OID resolution cache.",
+		}),
+	}).startWorker()
+
+	cache.Set("repo-1", "commit-1")
+	cache.Set("repo-2", "commit-2")
+	if v, ok := cache.Get("repo-1"); !ok || v != "commit-1" {
+		t.Fatal("expected cache get to succeed")
+	}
+	if v, ok := cache.Get("repo-2"); !ok || v != "commit-2" {
+		t.Fatal("expected cache get to succeed")
+	}
+	time.Sleep(5 * time.Second)
+	if _, ok := cache.Get("repo-1"); ok {
+		t.Fatal("expected cache entry to have expired")
+	}
+	if _, ok := cache.Get("repo-2"); ok {
+		t.Fatal("expected cache entry to have expired")
+	}
+}
+
+// Merely shows that the cache can support a very high concurrent read rate
+// with a low write rate. Run it like:
+//
+// 	$ go test -bench BenchmarkGitCommitResolutionCache -benchtime=30s ./cmd/frontend/graphqlbackend/
+// 	BenchmarkGitCommitResolutionCache/8-8 	200000000              202 ns/op
+// 	BenchmarkGitCommitResolutionCache/16-8         	100000000	       410 ns/op
+// 	BenchmarkGitCommitResolutionCache/32-8         	50000000	       879 ns/op
+// 	BenchmarkGitCommitResolutionCache/64-8         	30000000	      1709 ns/op
+// 	BenchmarkGitCommitResolutionCache/128-8        	20000000	      3345 ns/op
+// 	BenchmarkGitCommitResolutionCache/256-8        	20000000	      6177 ns/op
+//
+// The last one shows that while 256 concurrent cache reads are occurring we
+// can perform 8 cache reads in 6177ns.
+func BenchmarkGitCommitResolutionCache(b *testing.B) {
+	cache := (&resolutionCache{
+		ttl: 10 * time.Minute,
+		cacheEntries: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "src",
+			Subsystem: "graphql",
+			Name:      "git_commit_oid_resolution_cache_entries",
+			Help:      "Total number of entries in the in-memory Git commit OID resolution cache.",
+		}),
+	}).startWorker()
+
+	cache.Set("repo-1", "commit-1")
+
+	for _, concurrentReads := range []int{8, 16, 32, 64, 128, 256} {
+		b.Run(fmt.Sprint(concurrentReads), func(b *testing.B) {
+			done := make(chan bool)
+			defer close(done)
+			for i := 0; i < concurrentReads; i++ {
+				go func() {
+					for {
+						select {
+						case <-done:
+							return
+						default:
+							cache.Get("repo-1")
+						}
+					}
+				}()
+			}
+			time.Sleep(1 * time.Second) // Time for goroutines to start running.
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				if v, ok := cache.Get("repo-1"); !ok || v != "commit-1" {
+					b.Fatal("expected cache get to succeed")
+				}
+			}
+		})
+	}
+}

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -11,7 +11,7 @@ nginx: nginx -p . -g 'daemon off;' -c $PWD/dev/nginx.conf 2>&1 | grep -v 'could 
 web: ENTERPRISE=1 ./node_modules/.bin/gulp --color watch
 syntect_server: ./dev/syntect_server
 zoekt-indexserver: ./dev/zoekt-wrapper zoekt-sourcegraph-indexserver -sourcegraph_url http://localhost:3090 -index $HOME/.sourcegraph/zoekt/index -interval 1m -listen :6072
-zoekt-webserver: ./dev/zoekt-wrapper zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc
+zoekt-webserver: ./dev/zoekt-wrapper zoekt-webserver -index $HOME/.sourcegraph/zoekt/index -pprof -rpc -listen :3070
 management-console: PROJECT_ROOT=./cmd/management-console TLS_CERT=$HOME/.sourcegraph/management/cert.pem TLS_KEY=$HOME/.sourcegraph/management/key.pem management-console
 management-console-web: cd ./cmd/management-console/web && ./serve.sh
 keycloak: ./enterprise/dev/auth-provider/keycloak.sh


### PR DESCRIPTION
In Sourcegraph v3.2.0 a major search performance regression was introduced by accident. **It affected all instances using indexed search.** It went unnoticed because we currently don't have sufficient load testing of search (which is something we are addressing very soon).

The regression was introduced in https://github.com/sourcegraph/sourcegraph/pull/2318 (cc @ijsnow @keegancsmith) by accident due to some complex code interaction. The change made the assumption that using a `sync.Once` associated with the `*gitCommitResolver` was enough to prevent doing too much duplicative work. However, [since there is a one-to-one mapping of search results and `gitCommitResolver`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/textsearch.go#L79-83) we regressed significantly on search performance as after that change for every search result we would:

1. [Resolve the default branch of the repo, which requires making an HTTP request to gitserver to ask it to execute `git symbolic-ref HEAD`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7e568f120f90df64d1421e4130df68dea4350d4d/-/blob/cmd/frontend/graphqlbackend/repository_text_search_index.go#L87) (and in some cases [executing a second command](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7e568f120f90df64d1421e4130df68dea4350d4d/-/blob/cmd/frontend/graphqlbackend/repository.go#L153)).
2. [Ask zoekt to list indexed git refs for the repo over HTTP](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7e568f120f90df64d1421e4130df68dea4350d4d/-/blob/cmd/frontend/graphqlbackend/repository_text_search_index.go#L113) (expensive given it is also wrapped in `sync.Once`).
3. [Resolve the git ref zoekt says is indexed back to a concrete git OID](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/git_commit.go#L111:22).

This is all to say: after that change we would do a substantial amount of work per search result after https://github.com/sourcegraph/sourcegraph/pull/2318 was merged.

This PR resolves the issue by putting in place a Redis cache with a TTL of 60s. This makes computing this information just a simple cache lookup, which should be substantially faster. The `sync.Once` logic remains because we may still call `OID` repetitively on the same `*gitCommitObject` (I didn't vet all call sites.)

Additionally, this PR adds metrics for us to monitor (which should've probably been added earlier as part of #2318):

- How much time we spend computing this information.
- How often we hit / miss the cache.
- How much time we spend performing cache lookups (in case a Redis cache isn't sufficient and we need a process-local cache in the future).

Test plan: 

Manual load testing performed by benchmarking search with vegeta (see "Raw data / details on how tests were ran" at end for exact steps I performed to test this change).

# Comparison

All tests performed with this search query returning only 10 results: `repo:^github\\.com/sourcegraph/sourcegraph$ error count:10 timeout:60s`

Initially I tried higher result counts (11,000, 1000) but the perf before this change was so bad ALL requests would timeout at just 1 QPS and vegeta can't send requests slower than that (or I couldn't find the option).

| QPS | Mean change (before -> after)   | P95 change (before -> after) | before: non-200s / total req | after: non-200s / total req |
|-----|---------------------------------|------------------------------|------------------------------|-----------------------------|
| 1   | (-92.98%) 228ms -> 16ms         | (-93.67%) 332ms -> 21ms      | 0/60                         | 0/60                        |
| 5   | (-99.37%) 2,230ms -> 14ms       | (-99.60%) 4,321ms -> 17ms    | 0/300                        | 0/300                       |
| 50  | (-99.845) 60,000ms -> 92ms      | (-99.92%) 63,543ms -> 52ms   | 166/250 (502 timeouts)       | 0/250                       |

- Negative percent above indicates e.g. 92% less time spent after change.
- Last row before time I believe is not super accurate because high number of timeouts skewed the request duration mean / P95..

## All tests

Before: Lots of warnings: `gitserver | WARN Long exec request, repo: github.com/sourcegraph/sourcegraph, args: [symbolic-ref HEAD], duration: 3.183s`

After: No warnings.

<details>
<summary>Raw data / details on how tests were ran</summary>

## Details

- `search.body.json` is the exact GraphQL search query we send when a user does a search request, copied from Chrome network tab.

## 1 QPS for 60s

Before:

```
$ echo 'POST http://localhost:3080/.api/graphql?SearchBenchmark' | vegeta attack -body ./search.body.json -timeout=120s -name=1qps -rate=1 -duration=60s | tee results.bin | vegeta report
Requests      [total, rate]            60, 1.02
Duration      [total, attack, wait]    59.1882914s, 59.004040464s, 184.250936ms
Latencies     [mean, 50, 95, 99, max]  228.168332ms, 213.124139ms, 332.409ms, 554.912644ms, 575.35818ms
Bytes In      [total, mean]            508206, 8470.10
Bytes Out     [total, mean]            327300, 5455.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:60  
Error Set:
```

After:

```
$ echo 'POST http://localhost:3080/.api/graphql?SearchBenchmark' | vegeta attack -body ./search.body.json -timeout=120s -name=1qps -rate=1 -duration=60s | tee results.bin | vegeta report
Requests      [total, rate]            60, 1.02
Duration      [total, attack, wait]    59.01640499s, 59.004437167s, 11.967823ms
Latencies     [mean, 50, 95, 99, max]  16.430629ms, 13.723219ms, 20.86999ms, 133.612645ms, 145.057061ms
Bytes In      [total, mean]            508201, 8470.02
Bytes Out     [total, mean]            327300, 5455.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:60  
Error Set:
```

## 5 QPS for 60s

Before:

```
$ echo 'POST http://localhost:3080/.api/graphql?SearchBenchmark' | vegeta attack -body ./search.body.json -timeout=120s -name=5qps -rate=5 -duration=60s | tee results.bin | vegeta report
Requests      [total, rate]            300, 5.02
Duration      [total, attack, wait]    1m2.116713558s, 59.803600375s, 2.313113183s
Latencies     [mean, 50, 95, 99, max]  2.231654701s, 2.644444083s, 4.321173379s, 4.960104982s, 5.056616823s
Bytes In      [total, mean]            2541017, 8470.06
Bytes Out     [total, mean]            1636500, 5455.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:300  
Error Set:
```


After:

```
$ echo 'POST http://localhost:3080/.api/graphql?SearchBenchmark' | vegeta attack -body ./search.body.json -timeout=120s -name=5qps -rate=5 -duration=60s | tee results.bin | vegeta report
Requests      [total, rate]            300, 5.02
Duration      [total, attack, wait]    59.815219217s, 59.804088472s, 11.130745ms
Latencies     [mean, 50, 95, 99, max]  13.718213ms, 13.242097ms, 16.508382ms, 25.167756ms, 129.288757ms
Bytes In      [total, mean]            2541003, 8470.01
Bytes Out     [total, mean]            1636500, 5455.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:300  
Error Set:
```

## 50 QPS for 5s

Before:

```
$ echo 'POST http://localhost:3080/.api/graphql?SearchBenchmark' | vegeta attack -body ./search.body.json -timeout=120s -name=50qps -rate=50 -duration=5s | tee results.bin | vegeta report
Requests      [total, rate]            250, 50.18
Duration      [total, attack, wait]    1m7.318174155s, 4.982542856s, 1m2.335631299s
Latencies     [mean, 50, 95, 99, max]  1m0.103715429s, 1m0.957090646s, 1m3.543040632s, 1m4.220043201s, 1m4.250048319s
Bytes In      [total, mean]            736409, 2945.64
Bytes Out     [total, mean]            1363750, 5455.00
Success       [ratio]                  33.60%
Status Codes  [code:count]             200:84  502:166  
Error Set:
502 Bad Gateway
```

After:

```
$ echo 'POST http://localhost:3080/.api/graphql?SearchBenchmark' | vegeta attack -body ./search.body.json -timeout=120s -name=50qps -rate=50 -duration=5s | tee results.bin | vegeta report
Requests      [total, rate]            250, 50.17
Duration      [total, attack, wait]    4.993111979s, 4.983242598s, 9.869381ms
Latencies     [mean, 50, 95, 99, max]  92.333272ms, 13.51449ms, 52.175179ms, 1.841178441s, 1.869576507s
Bytes In      [total, mean]            2117508, 8470.03
Bytes Out     [total, mean]            1363750, 5455.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:250  
Error Set:
```

</details>