### PR TITLE
redirect unauthed users on sourcegraph.com to about.sourcegraph.com

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -233,12 +233,12 @@ func serveHome(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if envvar.SourcegraphDotComMode() && !actor.FromContext(r.Context()).IsAuthenticated() {
-		// The user is not signed in and tried to access Sourcegraph.com.  Redirect to /welcome so
-		// they see the welcome page.
-		http.Redirect(w, r, "/welcome", http.StatusTemporaryRedirect)
+		// The user is not signed in and tried to access Sourcegraph.com.  Redirect to
+		// about.sourcegraph.com so they see general info page.
+		http.Redirect(w, r, (&url.URL{Scheme: aboutRedirectScheme, Host: aboutRedirectHost}).String(), http.StatusTemporaryRedirect)
 		return nil
 	}
-	// sourcegraph.com (not about) homepage. There is none, redirect them to /search.
+	// On non-Sourcegraph.com instances, there is no separate homepage, so redirect to /search.
 	r.URL.Path = "/search"
 	http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)
 	return nil

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -1,10 +1,56 @@
 package ui
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/siteid"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/db/globalstatedb"
 )
+
+func TestServeHome(t *testing.T) {
+	globalstatedb.Mock.Get = func(ctx context.Context) (*globalstatedb.State, error) {
+		return &globalstatedb.State{SiteID: "a"}, nil
+	}
+	defer func() { globalstatedb.Mock.Get = nil }()
+	siteid.Init()
+
+	globals.ConfigurationServerFrontendOnly = &conf.Server{}
+	defer func() { globals.ConfigurationServerFrontendOnly = nil }()
+
+	check := func(t *testing.T, wantRedirectLocation string) {
+		t.Helper()
+
+		rw := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/", nil)
+		_ = serveHome(rw, req)
+		if want := http.StatusTemporaryRedirect; rw.Code != want {
+			t.Errorf("got HTTP response code %d, want %d", rw.Code, want)
+		}
+		if got := rw.Header().Get("Location"); got != wantRedirectLocation {
+			t.Errorf("got redirect location %q, want %q", got, wantRedirectLocation)
+		}
+	}
+
+	t.Run("on Sourcegraph.com", func(t *testing.T) {
+		orig := envvar.SourcegraphDotComMode()
+		envvar.MockSourcegraphDotComMode(true)
+		defer envvar.MockSourcegraphDotComMode(orig) // reset
+		check(t, "https://about.sourcegraph.com")
+	})
+	t.Run("non-Sourcegraph.com", func(t *testing.T) {
+		orig := envvar.SourcegraphDotComMode()
+		envvar.MockSourcegraphDotComMode(false)
+		defer envvar.MockSourcegraphDotComMode(orig) // reset
+		check(t, "/search")
+	})
+}
 
 func TestRepoShortName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Now that https://about.sourcegraph.com is our preferred informational homepage for all users, the app needs to redirect unauthed Sourcegraph.com (not self-hosted) users to it.

Partially reverts 6fe8201dd00be6ccb4e8e2bb23295af6eb2eb9f6.

**Blocked on** adding sign-in and sign-up links to the top nav on https://about.sourcegraph.com to avoid confusing users who want to use Sourcegraph.com.