### PR TITLE
Core/syncer diff bug

### DIFF
--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -116,7 +116,7 @@ func EnabledStateDeprecationMigration(sourcer Sourcer, clock func() time.Time, k
 			return nil
 		}
 
-		diff := NewDiff(sourced, stored)
+		diff := NewDiff(sourced, stored, clock())
 
 		err = group(
 			func(r *Repo) bool { return !r.Enabled },

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -529,7 +529,7 @@ WITH batch AS (
 updated AS (
   UPDATE repo
   SET
-    name                  = batch.name,
+    name                  = COALESCE(NULLIF(batch.name, repo.name), '!tmp!' || batch.name),
     description           = batch.description,
     language              = batch.language,
     created_at            = COALESCE(batch.created_at, repo.created_at),
@@ -545,6 +545,14 @@ updated AS (
     metadata              = batch.metadata
   FROM batch
   WHERE repo.id = batch.id
+  RETURNING repo.*
+),
+
+renamed AS (
+  UPDATE repo
+  SET name = batch.name
+  FROM batch
+  WHERE repo.id = batch.id AND repo.name <> batch.name
   RETURNING repo.*
 ),
 

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -544,17 +544,7 @@ updated AS (
     sources               = batch.sources,
     metadata              = batch.metadata
   FROM batch
-  WHERE repo.name = batch.name OR (
-    repo.external_id IS NOT NULL
-    AND repo.external_service_id IS NOT NULL
-    AND repo.external_service_type IS NOT NULL
-    AND batch.external_id IS NOT NULL
-    AND batch.external_service_id IS NOT NULL
-    AND batch.external_service_type IS NOT NULL
-    AND repo.external_service_id = batch.external_service_id
-    AND repo.external_id = batch.external_id
-    AND repo.external_service_type = batch.external_service_type
-  )
+  WHERE repo.id = batch.id
   RETURNING repo.*
 ),
 
@@ -597,20 +587,7 @@ inserted AS (
     sources,
     metadata
   FROM batch
-  WHERE NOT EXISTS (SELECT 1 FROM repo WHERE repo.name = batch.name)
-  AND NOT EXISTS (
-    SELECT 1
-    FROM repo
-    WHERE repo.external_id IS NOT NULL
-      AND repo.external_service_type IS NOT NULL
-      AND repo.external_service_id IS NOT NULL
-      AND batch.external_id IS NOT NULL
-      AND batch.external_service_type IS NOT NULL
-      AND batch.external_service_id IS NOT NULL
-      AND repo.external_service_id = batch.external_service_id
-      AND repo.external_id = batch.external_id
-      AND repo.external_service_type = batch.external_service_type
-    )
+  WHERE batch.id = 0
   RETURNING repo.*
 )
 

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -529,7 +529,7 @@ WITH batch AS (
 updated AS (
   UPDATE repo
   SET
-    name                  = COALESCE(NULLIF(batch.name, repo.name), '!tmp!' || batch.name),
+    name                  = CASE WHEN batch.name = repo.name THEN repo.name ELSE '!tmp!' || batch.name END,
     description           = batch.description,
     language              = batch.language,
     created_at            = COALESCE(batch.created_at, repo.created_at),

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -161,7 +161,6 @@ func (d Diff) Repos() Repos {
 // NewDiff returns a diff from the given sourced and stored repos.
 func NewDiff(sourced, stored []*Repo) (diff Diff) {
 	byID := make(map[api.ExternalRepoSpec]*Repo, len(sourced))
-	byName := make(map[string]*Repo, len(sourced))
 
 	for _, r := range sourced {
 		if r.ExternalRepo == (api.ExternalRepoSpec{}) {
@@ -169,8 +168,13 @@ func NewDiff(sourced, stored []*Repo) (diff Diff) {
 		} else if old := byID[r.ExternalRepo]; old != nil {
 			merge(old, r)
 		} else {
-			byID[r.ExternalRepo], byName[r.Name] = r, r
+			byID[r.ExternalRepo] = r
 		}
+	}
+
+	byName := make(map[string]*Repo, len(byID))
+	for _, r := range byID {
+		byName[r.Name] = r
 	}
 
 	seenID := make(map[api.ExternalRepoSpec]bool, len(stored))


### PR DESCRIPTION
Current state: Postgres does not seem to be able to update where repos "swap" names. I am running into unique name constraints violations. The code currently contains hacky attempts to update the SQL query to work around this.

Alternative to https://github.com/sourcegraph/sourcegraph/pull/3682
Fixes https://github.com/sourcegraph/sourcegraph/issues/3680