### PR TITLE
E2e tests: log browser console messages for debugging

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -79,6 +79,7 @@ describe('e2e test suite', function(this: any): void {
             }
             browser = await puppeteer.launch(launchOpt)
             page = await browser.newPage()
+            page.on('console', message => console.log('Browser console message:', JSON.stringify(message)))
             await init()
         },
         // Cloning the repositories takes ~1 minute, so give initialization 2


### PR DESCRIPTION
This logs console messages from the browser during e2e tests:

```
$ env SOURCEGRAPH_BASE_URL=http://localhost:7080 yarn --cwd web run test-e2e
...
  console.log src/e2e/index.e2e.test.tsx:82
    Browser console message: {"_type":"error","_text":"Failed to load resource: the server responded with a status of 401 (Unauthorized)","_args":[],"_location":{"url":"http://localhost:7080/.api/graphql?ViewerSettings"}}
...
```

JSON output isn't the prettiest. The goal here is to start logging these.

This might have helped debug some e2e errors https://sourcegraph.slack.com/archives/C08JA8Q1H/p1556718040031600