### PR TITLE
repo-updater: Exclude bitbucket repositories which are unavailable

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -359,7 +359,7 @@ func (c *bitbucketServerConnection) excludes(r *bitbucketserver.Repo) bool {
 	if r.Project != nil {
 		name = r.Project.Key + "/" + name
 	}
-	return r.State == "AVAILABLE" &&
+	return r.State != "AVAILABLE" ||
 		c.exclude[strings.ToLower(name)] ||
 		c.exclude[strconv.Itoa(r.ID)] ||
 		(c.config.ExcludePersonalRepositories && r.IsPersonalRepository())

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-both.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-both.golden
@@ -1,0 +1,11 @@
+{
+  "Include": [
+    "SG/go-langserver",
+    "SG/python-langserver"
+  ],
+  "Exclude": [
+    "SG/python-langserver-fork",
+    "~KEEGAN/rgp",
+    "~KEEGAN/rgp-unavailable"
+  ]
+}

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-id.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-id.golden
@@ -1,0 +1,11 @@
+{
+  "Include": [
+    "SG/go-langserver",
+    "SG/python-langserver",
+    "SG/python-langserver-fork"
+  ],
+  "Exclude": [
+    "~KEEGAN/rgp",
+    "~KEEGAN/rgp-unavailable"
+  ]
+}

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-name.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-name.golden
@@ -1,0 +1,11 @@
+{
+  "Include": [
+    "SG/go-langserver",
+    "SG/python-langserver"
+  ],
+  "Exclude": [
+    "SG/python-langserver-fork",
+    "~KEEGAN/rgp",
+    "~KEEGAN/rgp-unavailable"
+  ]
+}

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-none.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-none.golden
@@ -1,0 +1,11 @@
+{
+  "Include": [
+    "SG/go-langserver",
+    "SG/python-langserver",
+    "SG/python-langserver-fork",
+    "~KEEGAN/rgp"
+  ],
+  "Exclude": [
+    "~KEEGAN/rgp-unavailable"
+  ]
+}

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-path-pattern.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-path-pattern.golden
@@ -78,5 +78,25 @@
       "ServiceType": "bitbucketServer",
       "ServiceID": "bitbucket.example.com/"
     }
+  },
+  {
+    "Name": "bb/~KEEGAN/rgp-unavailable",
+    "Description": "rgp-unavailable",
+    "Fork": false,
+    "Archived": false,
+    "VCS": {
+      "URL": "https://bitbucket.example.com/scm/~keegan/rgp.git"
+    },
+    "Links": {
+      "Root": "https://bitbucket.example.com/users/keegan/repos/rgp/browse",
+      "Tree": "https://bitbucket.example.com/users/keegan/repos/rgp/browse/{path}?at={rev}",
+      "Blob": "https://bitbucket.example.com/users/keegan/repos/rgp/browse/{path}?at={rev}",
+      "Commit": "https://bitbucket.example.com/users/keegan/repos/rgp/commits/{commit}"
+    },
+    "ExternalRepo": {
+      "ID": "4",
+      "ServiceType": "bitbucketServer",
+      "ServiceID": "bitbucket.example.com/"
+    }
   }
 ]

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-simple.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-simple.golden
@@ -78,5 +78,25 @@
       "ServiceType": "bitbucketServer",
       "ServiceID": "bitbucket.example.com/"
     }
+  },
+  {
+    "Name": "/~KEEGAN/rgp-unavailable",
+    "Description": "rgp-unavailable",
+    "Fork": false,
+    "Archived": false,
+    "VCS": {
+      "URL": "https://bitbucket.example.com/scm/~keegan/rgp.git"
+    },
+    "Links": {
+      "Root": "https://bitbucket.example.com/users/keegan/repos/rgp/browse",
+      "Tree": "https://bitbucket.example.com/users/keegan/repos/rgp/browse/{path}?at={rev}",
+      "Blob": "https://bitbucket.example.com/users/keegan/repos/rgp/browse/{path}?at={rev}",
+      "Commit": "https://bitbucket.example.com/users/keegan/repos/rgp/commits/{commit}"
+    },
+    "ExternalRepo": {
+      "ID": "4",
+      "ServiceType": "bitbucketServer",
+      "ServiceID": "bitbucket.example.com/"
+    }
   }
 ]

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-username.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-username.golden
@@ -1,11 +1,11 @@
 [
   {
-    "Name": "/SG/go-langserver",
+    "Name": "bb/SG/go-langserver",
     "Description": "go-langserver",
     "Fork": false,
     "Archived": false,
     "VCS": {
-      "URL": "ssh://git@bitbucket.example.com:7999/sg/go-langserver.git"
+      "URL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
     },
     "Links": {
       "Root": "https://bitbucket.example.com/projects/SG/repos/go-langserver/browse",
@@ -20,12 +20,12 @@
     }
   },
   {
-    "Name": "/SG/python-langserver",
+    "Name": "bb/SG/python-langserver",
     "Description": "python-langserver",
     "Fork": false,
     "Archived": false,
     "VCS": {
-      "URL": "ssh://git@bitbucket.example.com:7999/sg/python-langserver.git"
+      "URL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
     },
     "Links": {
       "Root": "https://bitbucket.example.com/projects/SG/repos/python-langserver/browse",
@@ -40,12 +40,12 @@
     }
   },
   {
-    "Name": "/SG/python-langserver-fork",
+    "Name": "bb/SG/python-langserver-fork",
     "Description": "python-langserver-fork",
     "Fork": true,
     "Archived": false,
     "VCS": {
-      "URL": "ssh://git@bitbucket.example.com:7999/sg/python-langserver-fork.git"
+      "URL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
     },
     "Links": {
       "Root": "https://bitbucket.example.com/projects/SG/repos/python-langserver-fork/browse",
@@ -60,12 +60,12 @@
     }
   },
   {
-    "Name": "/~KEEGAN/rgp",
+    "Name": "bb/~KEEGAN/rgp",
     "Description": "rgp",
     "Fork": false,
     "Archived": false,
     "VCS": {
-      "URL": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git"
+      "URL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
     },
     "Links": {
       "Root": "https://bitbucket.example.com/users/keegan/repos/rgp/browse",
@@ -80,12 +80,12 @@
     }
   },
   {
-    "Name": "/~KEEGAN/rgp-unavailable",
+    "Name": "bb/~KEEGAN/rgp-unavailable",
     "Description": "rgp-unavailable",
     "Fork": false,
     "Archived": false,
     "VCS": {
-      "URL": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git"
+      "URL": "https://foo:secret@bitbucket.example.com/scm/~keegan/rgp.git"
     },
     "Links": {
       "Root": "https://bitbucket.example.com/users/keegan/repos/rgp/browse",

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos.json
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos.json
@@ -218,5 +218,61 @@
         }
       ]
     }
+  },
+  {
+    "slug": "rgp-unavailable",
+    "id": 4,
+    "name": "rgp-unavailable",
+    "scmId": "git",
+    "state": "UNAVAILABLE",
+    "statusMessage": "Unavailable",
+    "forkable": true,
+    "project": {
+      "key": "~KEEGAN",
+      "id": 2,
+      "name": "Keegan",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "keegan",
+        "emailAddress": "keegan@sourcegraph.com",
+        "id": 1,
+        "displayName": "Keegan",
+        "active": true,
+        "slug": "keegan",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://bitbucket.example.com/users/keegan"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://bitbucket.example.com/users/keegan"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "https://bitbucket.example.com/scm/~keegan/rgp.git",
+          "name": "http"
+        },
+        {
+          "href": "ssh://git@bitbucket.example.com:7999/~keegan/rgp.git",
+          "name": "ssh"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://bitbucket.example.com/users/keegan/repos/rgp/browse"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
This was a regression from when we refactored exclude support in 3.3. We
previously always excluded unavailable repositories. In 3.3 we accidentally would
never exclude unavailable repositories.

Test plan: unit tests