### PR TITLE
conf: Custom reposource validates proposed config

### DIFF
--- a/pkg/conf/reposource/custom.go
+++ b/pkg/conf/reposource/custom.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	conf.ContributeValidator(func(c conf.Unified) (problems []string) {
-		for _, c := range conf.Get().GitCloneURLToRepositoryName {
+		for _, c := range c.GitCloneURLToRepositoryName {
 			if _, err := regexp.Compile(c.From); err != nil {
 				problems = append(problems, fmt.Sprintf("Not a valid regexp: %s. See the valid syntax: https://golang.org/pkg/regexp/", c.From))
 			}


### PR DESCRIPTION
The validator was broken since it validated the global configuration, not the
proposed configuration that is passed into the validator.

Note: This field is currently unread anyways and likely will be removed.
