### PR TITLE
repo-updater: Exclude patterns for Bitbucket Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- The `bitbucketserver.exclude` setting in [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration) additionally allows you to exclude repositories matched by a regular expression (so that they won't be synced).
+
 ### Changed
 
 ### Removed

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -326,6 +326,7 @@ func newBitbucketServerConnection(config *schema.BitbucketServerConnection, cf h
 	}
 
 	exclude := make(map[string]bool, len(config.Exclude))
+	var excludePatterns []*regexp.Regexp
 	for _, r := range config.Exclude {
 		if r.Name != "" {
 			exclude[strings.ToLower(r.Name)] = true
@@ -333,6 +334,14 @@ func newBitbucketServerConnection(config *schema.BitbucketServerConnection, cf h
 
 		if r.Id != 0 {
 			exclude[strconv.Itoa(r.Id)] = true
+		}
+
+		if r.Pattern != "" {
+			re, err := regexp.Compile(r.Pattern)
+			if err != nil {
+				return nil, err
+			}
+			excludePatterns = append(excludePatterns, re)
 		}
 	}
 
@@ -342,16 +351,18 @@ func newBitbucketServerConnection(config *schema.BitbucketServerConnection, cf h
 	client.Password = config.Password
 
 	return &bitbucketServerConnection{
-		config:  config,
-		exclude: exclude,
-		client:  client,
+		config:          config,
+		exclude:         exclude,
+		excludePatterns: excludePatterns,
+		client:          client,
 	}, nil
 }
 
 type bitbucketServerConnection struct {
-	config  *schema.BitbucketServerConnection
-	exclude map[string]bool
-	client  *bitbucketserver.Client
+	config          *schema.BitbucketServerConnection
+	exclude         map[string]bool
+	excludePatterns []*regexp.Regexp
+	client          *bitbucketserver.Client
 }
 
 func (c *bitbucketServerConnection) excludes(r *bitbucketserver.Repo) bool {
@@ -359,10 +370,19 @@ func (c *bitbucketServerConnection) excludes(r *bitbucketserver.Repo) bool {
 	if r.Project != nil {
 		name = r.Project.Key + "/" + name
 	}
-	return r.State != "AVAILABLE" ||
+	if r.State != "AVAILABLE" ||
 		c.exclude[strings.ToLower(name)] ||
 		c.exclude[strconv.Itoa(r.ID)] ||
-		(c.config.ExcludePersonalRepositories && r.IsPersonalRepository())
+		(c.config.ExcludePersonalRepositories && r.IsPersonalRepository()) {
+		return true
+	}
+
+	for _, re := range c.excludePatterns {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *bitbucketServerConnection) listAllRepos(ctx context.Context) ([]*bitbucketserver.Repo, error) {

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -110,15 +110,26 @@ func TestBitbucketServerExclude(t *testing.T) {
 			Token:   "secret",
 			Exclude: []*schema.ExcludedBitbucketServerRepo{{Id: 4}},
 		},
+		"pattern": {
+			Url:   "bitbucket.example.com",
+			Token: "secret",
+			Exclude: []*schema.ExcludedBitbucketServerRepo{{
+				Pattern: "SG/python.*",
+			}, {
+				Pattern: "~KEEGAN/.*",
+			}},
+		},
 		"both": {
 			Url:   "bitbucket.example.com",
 			Token: "secret",
 			// We match on the bitbucket server repo name, not the repository path pattern.
 			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
 			Exclude: []*schema.ExcludedBitbucketServerRepo{{
-				Id: 5,
+				Id: 1,
 			}, {
 				Name: "~KEEGAN/rgp",
+			}, {
+				Pattern: ".*-fork",
 			}},
 		},
 	}

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -276,8 +277,9 @@ func TestSources_ListRepos(t *testing.T) {
 						"?visibility=private",
 					},
 					Exclude: []*schema.ExcludedBitbucketServerRepo{
-						{Name: "ORG/Foo"}, // test case insensitivity
-						{Id: 3},           // baz id
+						{Name: "ORG/Foo"},   // test case insensitivity
+						{Id: 3},             // baz id
+						{Pattern: ".*/bar"}, // only matches org/bar
 					},
 				}),
 			},
@@ -290,6 +292,7 @@ func TestSources_ListRepos(t *testing.T) {
 				t.Helper()
 
 				set := make(map[string]bool)
+				var patterns []*regexp.Regexp
 				for _, s := range svcs {
 					c, err := s.Configuration()
 					if err != nil {
@@ -297,7 +300,7 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 
 					type excluded struct {
-						name, id string
+						name, id, pattern string
 					}
 
 					var ex []excluded
@@ -312,7 +315,7 @@ func TestSources_ListRepos(t *testing.T) {
 						}
 					case *schema.BitbucketServerConnection:
 						for _, e := range cfg.Exclude {
-							ex = append(ex, excluded{name: e.Name, id: strconv.Itoa(e.Id)})
+							ex = append(ex, excluded{name: e.Name, id: strconv.Itoa(e.Id), pattern: e.Pattern})
 						}
 					}
 
@@ -327,12 +330,24 @@ func TestSources_ListRepos(t *testing.T) {
 							name = strings.ToLower(name)
 						}
 						set[name], set[e.id] = true, true
+						if e.pattern != "" {
+							re, err := regexp.Compile(e.pattern)
+							if err != nil {
+								t.Fatal(err)
+							}
+							patterns = append(patterns, re)
+						}
 					}
 				}
 
 				for _, r := range rs {
 					if set[r.Name] || set[r.ExternalRepo.ID] {
 						t.Errorf("excluded repo{name=%s, id=%s} was yielded", r.Name, r.ExternalRepo.ID)
+					}
+					for _, re := range patterns {
+						if re.MatchString(r.Name) {
+							t.Errorf("excluded repo{name=%s} matching %q was yielded", r.Name, re.String())
+						}
 					}
 				}
 			},

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-pattern.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-exclude-pattern.golden
@@ -1,9 +1,9 @@
 {
   "Include": [
-    "SG/python-langserver"
+    "SG/go-langserver"
   ],
   "Exclude": [
-    "SG/go-langserver",
+    "SG/python-langserver",
     "SG/python-langserver-fork",
     "~KEEGAN/rgp",
     "~KEEGAN/rgp-unavailable"

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -257,7 +257,8 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				"token": "very-secret-token",
 				"repositoryQuery": ["none"],
 				"exclude": [
-					{"name": "foo/bar", "id": 1234}
+					{"name": "foo/bar", "id": 1234},
+					{"pattern": "^private/.*"}
 				]
 			}`,
 			assert: equals(`<nil>`),
@@ -273,6 +274,21 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			desc:   "invalid empty repos item",
 			config: `{"repos": [""]}`,
 			assert: includes(`repos.0: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+		},
+		{
+			kind: "BITBUCKETSERVER",
+			desc: "invalid exclude pattern",
+			config: `
+			{
+				"url": "https://bitbucketserver.corp.com",
+				"username": "admin",
+				"token": "very-secret-token",
+				"repositoryQuery": ["none"],
+				"exclude": [
+					{"pattern": "["}
+				]
+			}`,
+			assert: includes(`exclude.0.pattern: Does not match format 'regex'`),
 		},
 		{
 			kind: "BITBUCKETSERVER",

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -98,7 +98,7 @@
         "type": "object",
         "title": "ExcludedBitbucketServerRepo",
         "additionalProperties": false,
-        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }, { "required": ["pattern"] }],
         "properties": {
           "name": {
             "description": "The name of a Bitbucket Server repo (\"projectKey/repositorySlug\") to exclude from mirroring.",
@@ -108,12 +108,17 @@
           "id": {
             "description": "The ID of a Bitbucket Server repo (as returned by the Bitbucket Server instance's API) to exclude from mirroring.",
             "type": "integer"
+          },
+          "pattern": {
+            "description": "Regular expression which matches against the name of a Bitbucket Server repo.",
+            "type": "string",
+            "format": "regex"
           }
         }
       },
       "examples": [
         [{ "name": "myproject/myrepo" }, { "id": 42 }],
-        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }]
+        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }, { "pattern": "^topsecretproject/.*" }]
       ]
     },
     "initialRepositoryEnablement": {

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -103,7 +103,7 @@ const BitbucketServerSchemaJSON = `{
         "type": "object",
         "title": "ExcludedBitbucketServerRepo",
         "additionalProperties": false,
-        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }, { "required": ["pattern"] }],
         "properties": {
           "name": {
             "description": "The name of a Bitbucket Server repo (\"projectKey/repositorySlug\") to exclude from mirroring.",
@@ -113,12 +113,17 @@ const BitbucketServerSchemaJSON = `{
           "id": {
             "description": "The ID of a Bitbucket Server repo (as returned by the Bitbucket Server instance's API) to exclude from mirroring.",
             "type": "integer"
+          },
+          "pattern": {
+            "description": "Regular expression which matches against the name of a Bitbucket Server repo.",
+            "type": "string",
+            "format": "regex"
           }
         }
       },
       "examples": [
         [{ "name": "myproject/myrepo" }, { "id": 42 }],
-        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }]
+        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }, { "pattern": "^topsecretproject/.*" }]
       ]
     },
     "initialRepositoryEnablement": {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -146,8 +146,9 @@ type Discussions struct {
 	AbuseProtection bool     `json:"abuseProtection,omitempty"`
 }
 type ExcludedBitbucketServerRepo struct {
-	Id   int    `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	Id      int    `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Pattern string `json:"pattern,omitempty"`
 }
 type ExcludedGitHubRepo struct {
 	Id   string `json:"id,omitempty"`


### PR DESCRIPTION
For some customers it is impractical to enumerate the valid repository patterns,
since the list is large and constantly changing. However, they just want to
exclude a specific project. This commit adds the more general ability to exclude
based on a regular expression for Bitbucket Server. Its approach can be extended
to other code hosts as needed.

Test plan: unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/3558