### PR TITLE
repo-updater: Increase sourceTimeout to 30 minutes

### DIFF
--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -109,7 +109,7 @@ func includesGitHubDotComSource(srcs []Source) bool {
 }
 
 // sourceTimeout is the default timeout to use on Source.ListRepos
-const sourceTimeout = 10 * time.Minute
+const sourceTimeout = 30 * time.Minute
 
 // A Source yields repositories to be stored and analysed by Sourcegraph.
 // Successive calls to its ListRepos method may yield different results.


### PR DESCRIPTION
We ran into timeouts when trying to list/source ~13k repositories on our own
Kubernetes dogfood instance of Sourcegraph. In order to fix the issue we
want to increase the timeout used for sourcing all repositories.

Test plan: deploy to k8s dogfood instance and see if the issue is fixed
