### PR TITLE
Add an example for `branding` site configuration

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -101,6 +101,8 @@ type BrandAssets struct {
 }
 
 // Branding description: Customize Sourcegraph homepage logo and search icon.
+//
+// Only available in Sourcegraph Enterprise.
 type Branding struct {
 	Dark    *BrandAssets `json:"dark,omitempty"`
 	Favicon string       `json:"favicon,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -151,7 +151,7 @@
       "group": "Security"
     },
     "branding": {
-      "description": "Customize Sourcegraph homepage logo and search icon.",
+      "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -166,7 +166,20 @@
           "type": "string",
           "format": "uri"
         }
-      }
+      },
+      "examples": [
+        {
+          "favicon": "https://example.com/favicon.ico",
+          "light": {
+            "logo": "https://example.com/logo_light.png",
+            "symbol": "https://example.com/search_symbol_light_24x24.png"
+          },
+          "dark": {
+            "logo": "https://example.com/logo_dark.png",
+            "symbol": "https://example.com/search_symbol_dark_24x24.png"
+          }
+        }
+      ]
     },
     "email.smtp": {
       "title": "SMTPServerConfig",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -156,7 +156,7 @@ const SiteSchemaJSON = `{
       "group": "Security"
     },
     "branding": {
-      "description": "Customize Sourcegraph homepage logo and search icon.",
+      "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -171,7 +171,20 @@ const SiteSchemaJSON = `{
           "type": "string",
           "format": "uri"
         }
-      }
+      },
+      "examples": [
+        {
+          "favicon": "https://example.com/favicon.ico",
+          "light": {
+            "logo": "https://example.com/logo_light.png",
+            "symbol": "https://example.com/search_symbol_light_24x24.png"
+          },
+          "dark": {
+            "logo": "https://example.com/logo_dark.png",
+            "symbol": "https://example.com/search_symbol_dark_24x24.png"
+          }
+        }
+      ]
     },
     "email.smtp": {
       "title": "SMTPServerConfig",


### PR DESCRIPTION
This adds an example to the schema for the `branding` property to
showcase on the docs page how to use it.

Looks like this:

<img width="640" alt="Screen Shot 2019-05-02 at 18 29 30" src="https://user-images.githubusercontent.com/1185253/57090912-3ea9eb80-6d08-11e9-8d43-97e8db4c9f45.png">


Relevant: https://github.com/sourcegraph/about/pull/114
Test plan: manually looked at docs site to check whether it's correctly rendered
