### PR TITLE
Remove tslint-language-service

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "EditorConfig.editorconfig",
-    "eg2.tslint",
+    "ms-vscode.vscode-typescript-tslint-plugin",
     "esbenp.prettier-vscode",
     "kumar-harsh.graphql-for-vscode",
     "ms-vscode.Go",
@@ -12,5 +12,8 @@
     "bierner.markdown-mermaid",
     "zignd.html-css-class-completion",
     "orta.vscode-jest"
+  ],
+  "unwantedRecommendations": [
+    "eg2.tslint" // deprecated
   ]
 }

--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
     "ts-loader": "^5.4.5",
     "ts-node": "^7.0.1",
     "tslint": "^5.16.0",
-    "tslint-language-service": "^0.9.9",
     "typedoc": "^0.14.2",
     "typescript": "3.5.0-dev.20190406",
     "utc-version": "^1.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,7 @@
     "skipLibCheck": true,
     "noErrorTruncation": true,
     "importHelpers": true,
-    "resolveJsonModule": true,
-    "plugins": [
-      {
-        "name": "tslint-language-service"
-      }
-    ]
+    "resolveJsonModule": true
   },
 
   "files": ["gulpfile.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,13 +4212,6 @@ caller-callsite@^2.0.0:
   dependencies:
     callsites "^2.0.0"
 
-caller-id@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz#59bdac0893d12c3871408279231f97458364f07b"
-  integrity sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=
-  dependencies:
-    stack-trace "~0.0.7"
-
 caller-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
@@ -9943,13 +9936,6 @@ mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.
   dependencies:
     minimist "0.0.8"
 
-mock-require@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz#1eaa71aad23013773d127dc7e91a3fbb4837d60d"
-  integrity sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=
-  dependencies:
-    caller-id "^0.1.0"
-
 mockdate@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
@@ -13495,7 +13481,7 @@ stable@~0.1.6:
   resolved "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
-stack-trace@0.0.10, stack-trace@0.0.x, stack-trace@~0.0.7:
+stack-trace@0.0.10, stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
@@ -14326,13 +14312,6 @@ tslint-config-prettier@^1.18.0:
   version "1.18.0"
   resolved "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
   integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-
-tslint-language-service@^0.9.9:
-  version "0.9.9"
-  resolved "https://registry.npmjs.org/tslint-language-service/-/tslint-language-service-0.9.9.tgz#f546dc38483979e6fb3cfa59584ad8525b3ad4da"
-  integrity sha1-9UbcOEg5eeb7PPpZWErYUls61No=
-  dependencies:
-    mock-require "^2.0.2"
 
 tslint-react@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
It's deprecated and the new TSLint extension works great without it.
It always printed a invalid peerDependency warning when running yarn.



<!-- Reminder: Have you updated the changelog? -->

Test plan: <!-- Required: What is the test plan for this change? -->
