### PR TITLE
make search results take up full width, less spacing

### DIFF
--- a/shared/src/components/FileMatchChildren.scss
+++ b/shared/src/components/FileMatchChildren.scss
@@ -20,13 +20,13 @@
             text-decoration: none;
         }
 
-        &:not(:first-child) {
-            border-top: 1px solid #2a3a51;
+        &:not(:last-child) {
+            border-bottom: 1px solid #2a3a51;
         }
 
         .theme-light & {
             background-color: $color-light-bg-1;
-            border-top: 1px solid $color-light-border;
+            border-color: $color-light-border;
 
             &:hover {
                 background-color: $color-light-bg-4;

--- a/shared/src/components/FileMatchChildren.scss
+++ b/shared/src/components/FileMatchChildren.scss
@@ -20,8 +20,8 @@
             text-decoration: none;
         }
 
-        &:not(:last-child) {
-            border-bottom: 1px solid #2a3a51;
+        &:not(:first-child) {
+            border-top: 1px solid #2a3a51;
         }
 
         .theme-light & {
@@ -32,9 +32,6 @@
                 background-color: $color-light-bg-4;
                 text-decoration: none;
             }
-        }
-        &:first-of-type {
-            border-top: none;
         }
     }
 

--- a/shared/src/components/ResultContainer.scss
+++ b/shared/src/components/ResultContainer.scss
@@ -1,7 +1,12 @@
 .result-container {
     position: relative;
-    border-radius: 2px;
-    border-top: 1px solid #2b3750;
+
+    border-width: 0 0 1px 0;
+    border-style: solid;
+    border-color: #2b3750;
+    &:first-child {
+        border-top-width: 1px;
+    }
 
     &__header {
         padding: 0.5rem 0.5rem;

--- a/shared/src/components/ResultContainer.scss
+++ b/shared/src/components/ResultContainer.scss
@@ -1,8 +1,7 @@
 .result-container {
     position: relative;
-    margin-bottom: 1rem;
     border-radius: 2px;
-    border: 1px solid #2b3750;
+    border-top: 1px solid #2b3750;
 
     &__header {
         padding: 0.5rem 0.5rem;
@@ -59,7 +58,7 @@
 
 .theme-light {
     .result-container {
-        border: 1px solid $color-light-border;
+        border-color: $color-light-border;
         &__header {
             background-color: $color-light-bg-2;
 

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -38,7 +38,7 @@ interface SearchResultsInfoBarProps {
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => (
-    <div className="search-results-info-bar" data-testid="results-info-bar">
+    <div className="search-results-info-bar px-2" data-testid="results-info-bar">
         {(props.results.timedout.length > 0 ||
             props.results.cloning.length > 0 ||
             props.results.results.length > 0 ||

--- a/web/src/search/results/SearchResultsList.scss
+++ b/web/src/search/results/SearchResultsList.scss
@@ -4,7 +4,6 @@
 
 .search-results-list {
     overflow-y: auto;
-    padding: 0 2.5rem 1rem;
 
     &__more {
         width: 100%;

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -53,7 +53,7 @@ describe('SearchResultsList', () => {
             </BrowserRouter>
         )
 
-        expect(getByText(container, 'Loading')).toBeTruthy()
+        expect(queryByTestId(container, 'loading-container')).toBeTruthy()
     })
 
     it('shows error message when the search GraphQL request returns an error', () => {

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -1,7 +1,7 @@
 import { createBrowserHistory } from 'history'
 import * as React from 'react'
 import { BrowserRouter } from 'react-router-dom'
-import { cleanup, getAllByTestId, getByTestId, getByText, queryByTestId, render } from 'react-testing-library'
+import { cleanup, getAllByTestId, getByTestId, queryByTestId, render } from 'react-testing-library'
 import sinon from 'sinon'
 import { setLinkComponent } from '../../../../shared/src/components/Link'
 import { HIGHLIGHTED_FILE_LINES_REQUEST, MULTIPLE_SEARCH_REQUEST, SEARCH_REQUEST } from '../testHelpers'

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -321,12 +321,12 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     )}
 
                     {this.props.resultsOrError === undefined ? (
-                        <div className="text-center" data-testid="loading-container">
-                            <LoadingSpinner className="icon-inline" /> Loading
+                        <div className="text-center mt-2" data-testid="loading-container">
+                            <LoadingSpinner className="icon-inline" />
                         </div>
                     ) : isErrorLike(this.props.resultsOrError) ? (
                         /* GraphQL, network, query syntax error */
-                        <div className="alert alert-warning" data-testid="search-results-list-error">
+                        <div className="alert alert-warning m-2" data-testid="search-results-list-error">
                             <AlertCircleIcon className="icon-inline" />
                             {upperFirst(this.props.resultsOrError.message)}
                         </div>
@@ -373,7 +373,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
 
                                     {/* Server-provided help message */}
                                     {results.alert ? (
-                                        <div className="alert alert-info">
+                                        <div className="alert alert-info m-2">
                                             <h3>
                                                 <AlertCircleIcon className="icon-inline" /> {results.alert.title}
                                             </h3>
@@ -406,7 +406,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         results.results.length === 0 &&
                                         (results.timedout.length > 0 ? (
                                             /* No results, but timeout hit */
-                                            <div className="alert alert-warning">
+                                            <div className="alert alert-warning m-2">
                                                 <h3>
                                                     <TimerSandIcon className="icon-inline" /> Search timed out
                                                 </h3>
@@ -432,7 +432,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                             </div>
                                         ) : (
                                             <>
-                                                <div className="alert alert-info d-flex">
+                                                <div className="alert alert-info d-flex m-2">
                                                     <h3 className="m-0">
                                                         <SearchIcon className="icon-inline" /> No results
                                                     </h3>
@@ -447,7 +447,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
 
                     <div className="pb-4" />
                     {this.props.resultsOrError !== undefined && (
-                        <Link className="mb-2" to="/help/user/search">
+                        <Link className="mb-4 p-3" to="/help/user/search">
                             Not seeing expected results?
                         </Link>
                     )}


### PR DESCRIPTION
This increases the info density of search results, which is a common user request. It also makes the UI look a lot cleaner and have less dead space.

- The left/right margins are unnecessary and severely limit readability on small screens.
- The vertical spacing between search result containers is unnecessary.
- The loading indicator actually needed more margin to the top. This is slightly unrelated, but worth doing and not too different to merit a different commit.

## Before (the margins take up a lot of space, esp. on narrow screens)
![search-border-current-tiny](https://user-images.githubusercontent.com/1976/57124852-2eabff00-6d3c-11e9-9398-38ca11f99957.png)

## After
![search-border-narrow](https://user-images.githubusercontent.com/1976/57124854-2eabff00-6d3c-11e9-93bd-364aa449ad2e.png)
![search-border-error](https://user-images.githubusercontent.com/1976/57124855-2f449580-6d3c-11e9-8b82-c1a42255bd73.png)
![search-border-misc-bottom](https://user-images.githubusercontent.com/1976/57124856-2f449580-6d3c-11e9-8cbd-b86f63abb373.png)
![search-border-bottom](https://user-images.githubusercontent.com/1976/57124857-2f449580-6d3c-11e9-9ca4-e172919c99c9.png)
![search-border-dark2](https://user-images.githubusercontent.com/1976/57124858-2f449580-6d3c-11e9-8e61-81765c210d45.png)
![search-border-light](https://user-images.githubusercontent.com/1976/57124859-2f449580-6d3c-11e9-8bac-981adb507169.png)
![search-border-dark](https://user-images.githubusercontent.com/1976/57124860-2fdd2c00-6d3c-11e9-8824-148b9a56152c.png)
