### PR TITLE
httpcli: Separate Doer and Client methods in Factory

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -300,7 +300,7 @@ func updateBitbucketServerRepos(ctx context.Context, conn *bitbucketServerConnec
 // still have 50 API requests left-over to serve users.
 const rateLimitReservationSize = 250
 
-func newBitbucketServerConnection(config *schema.BitbucketServerConnection, cf httpcli.Factory) (*bitbucketServerConnection, error) {
+func newBitbucketServerConnection(config *schema.BitbucketServerConnection, cf *httpcli.Factory) (*bitbucketServerConnection, error) {
 	baseURL, err := url.Parse(config.Url)
 	if err != nil {
 		return nil, err
@@ -320,7 +320,7 @@ func newBitbucketServerConnection(config *schema.BitbucketServerConnection, cf h
 		opts = append(opts, httpcli.NewCertPoolOpt(pool))
 	}
 
-	cli, err := cf.NewClient(opts...)
+	cli, err := cf.Doer(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -318,7 +318,7 @@ func updateGitHubRepositories(ctx context.Context, conn *githubConnection) {
 	}
 }
 
-func newGitHubConnection(config *schema.GitHubConnection, cf httpcli.Factory) (*githubConnection, error) {
+func newGitHubConnection(config *schema.GitHubConnection, cf *httpcli.Factory) (*githubConnection, error) {
 	baseURL, err := url.Parse(config.Url)
 	if err != nil {
 		return nil, err
@@ -341,7 +341,7 @@ func newGitHubConnection(config *schema.GitHubConnection, cf httpcli.Factory) (*
 		opts = append(opts, httpcli.NewCertPoolOpt(pool))
 	}
 
-	cli, err := cf.NewClient(opts...)
+	cli, err := cf.Doer(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -239,7 +239,7 @@ func updateGitLabProjects(ctx context.Context, conn *gitlabConnection) {
 	}
 }
 
-func newGitLabConnection(config *schema.GitLabConnection, cf httpcli.Factory) (*gitlabConnection, error) {
+func newGitLabConnection(config *schema.GitLabConnection, cf *httpcli.Factory) (*gitlabConnection, error) {
 	baseURL, err := url.Parse(config.Url)
 	if err != nil {
 		return nil, err
@@ -259,7 +259,7 @@ func newGitLabConnection(config *schema.GitLabConnection, cf httpcli.Factory) (*
 		opts = append(opts, httpcli.NewCertPoolOpt(pool))
 	}
 
-	cli, err := cf.NewClient(opts...)
+	cli, err := cf.Doer(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -579,7 +579,7 @@ func TestSources_ListRepos(t *testing.T) {
 	}
 }
 
-func newClientFactory(t testing.TB, name string) (httpcli.Factory, func(testing.TB)) {
+func newClientFactory(t testing.TB, name string) (*httpcli.Factory, func(testing.TB)) {
 	cassete := filepath.Join("testdata", "sources", strings.Replace(name, " ", "-", -1))
 	rec := newRecorder(t, cassete, *update)
 	mw := httpcli.NewMiddleware(

--- a/cmd/repo-updater/repos/util.go
+++ b/cmd/repo-updater/repos/util.go
@@ -38,7 +38,7 @@ func NormalizeBaseURL(baseURL *url.URL) *url.URL {
 
 // NewHTTPClientFactory returns an httpcli.Factory with common
 // options and middleware pre-set.
-func NewHTTPClientFactory() httpcli.Factory {
+func NewHTTPClientFactory() *httpcli.Factory {
 	return httpcli.NewFactory(
 		// TODO(tsenart): Use middle for Prometheus instrumentation later.
 		httpcli.NewMiddleware(

--- a/pkg/extsvc/phabricator/client_test.go
+++ b/pkg/extsvc/phabricator/client_test.go
@@ -245,7 +245,7 @@ func newClient(t testing.TB, name string) (*phabricator.Client, func()) {
 		t.Fatal(err)
 	}
 
-	hc, err := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec)).NewClient()
+	hc, err := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec)).Doer()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/httpcli/client.go
+++ b/pkg/httpcli/client.go
@@ -90,10 +90,10 @@ func (f Factory) Client(base ...Opt) (*http.Client, error) {
 }
 
 // NewFactory returns a Factory that applies the given common
-// Opts after the ones provided on each invocation of New.
+// Opts after the ones provided on each invocation of Client or Doer.
 //
 // If the given Middleware stack is not nil, the final configured client
-// will be wrapped by it before being returned.
+// will be wrapped by it before being returned from a call to Doer, but not Client.
 func NewFactory(stack Middleware, common ...Opt) *Factory {
 	return &Factory{stack: stack, common: common}
 }

--- a/pkg/httpcli/client.go
+++ b/pkg/httpcli/client.go
@@ -50,12 +50,43 @@ type Opt func(*http.Client) error
 // A Factory constructs an http.Client with the given functional
 // options applied, returning an aggreagte error of the errors returned by
 // all those options.
-type Factory func(...Opt) (Doer, error)
+type Factory struct {
+	stack  Middleware
+	common []Opt
+}
 
-// NewClient returns a new http.Client from the factory with the given opts
-// applied to it.
-func (f Factory) NewClient(opts ...Opt) (Doer, error) {
-	return f(opts...)
+// Doer returns a new Doer wrapped with the middleware stack
+// provided in the Factory constructor and with the given common
+// and base opts applied to it.
+func (f Factory) Doer(base ...Opt) (Doer, error) {
+	cli, err := f.Client(base...)
+	if err != nil {
+		return nil, err
+	}
+
+	if f.stack != nil {
+		return f.stack(cli), nil
+	}
+
+	return cli, nil
+}
+
+// Client returns a new http.Client configured with the
+// given common and base opts, but not wrapped with any
+// middleware.
+func (f Factory) Client(base ...Opt) (*http.Client, error) {
+	opts := make([]Opt, 0, len(f.common)+len(base))
+	opts = append(opts, base...)
+	opts = append(opts, f.common...)
+
+	var cli http.Client
+	var err *multierror.Error
+
+	for _, opt := range opts {
+		err = multierror.Append(err, opt(&cli))
+	}
+
+	return &cli, err.ErrorOrNil()
 }
 
 // NewFactory returns a Factory that applies the given common
@@ -63,26 +94,8 @@ func (f Factory) NewClient(opts ...Opt) (Doer, error) {
 //
 // If the given Middleware stack is not nil, the final configured client
 // will be wrapped by it before being returned.
-func NewFactory(stack Middleware, common ...Opt) Factory {
-	return func(base ...Opt) (do Doer, _ error) {
-		opts := make([]Opt, 0, len(common)+len(base))
-		opts = append(opts, base...)
-		opts = append(opts, common...)
-
-		var cli http.Client
-		var err *multierror.Error
-
-		for _, opt := range opts {
-			err = multierror.Append(err, opt(&cli))
-		}
-
-		do = &cli
-		if stack != nil {
-			do = stack(do)
-		}
-
-		return do, err.ErrorOrNil()
-	}
+func NewFactory(stack Middleware, common ...Opt) *Factory {
+	return &Factory{stack: stack, common: common}
 }
 
 //


### PR DESCRIPTION
This commit renames the `NewClient` method in `httpcli.Factory` to
`Doer` and introduces a new `Client` method that returns a concrete
`*http.Client` with all options applied to it but without middleware.

This is to integrate with packages that can't easily be made to work
with a `Doer` interface like the AWS client package.
