### PR TITLE
[WIP] feat: don't disable pings without a license

### DIFF
--- a/cmd/frontend/graphqlbackend/product_license_info.go
+++ b/cmd/frontend/graphqlbackend/product_license_info.go
@@ -4,17 +4,6 @@ import (
 	"time"
 )
 
-// GetConfiguredProductLicenseInfo is called to obtain the product subscription info when creating
-// the GraphQL resolver for the GraphQL type ProductLicenseInfo.
-//
-// Exactly 1 of its return values must be non-nil.
-//
-// It is overridden in non-OSS builds to return information about the actual product subscription in
-// use.
-var GetConfiguredProductLicenseInfo = func() (*ProductLicenseInfo, error) {
-	return nil, nil // OSS builds have no license
-}
-
 // ProductLicenseInfo implements the GraphQL type ProductLicenseInfo.
 type ProductLicenseInfo struct {
 	TagsValue      []string

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/productlicense"
 )
 
 func (r *siteResolver) NeedsRepositoryConfiguration(ctx context.Context) (bool, error) {
@@ -80,7 +81,7 @@ func (r *siteResolver) FreeUsersExceeded(ctx context.Context) (bool, error) {
 	}
 
 	// If a license exists, warnings never need to be shown.
-	if info, err := GetConfiguredProductLicenseInfo(); info != nil {
+	if info, err := productlicense.GetConfiguredProductLicenseInfo(); info != nil {
 		return false, err
 	}
 	// If OSS, warnings never need to be shown.

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/productlicense"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -78,15 +79,15 @@ func initLicensing() {
 
 	// Make the Site.productSubscription GraphQL field return the actual info about the product license,
 	// if any.
-	graphqlbackend.GetConfiguredProductLicenseInfo = func() (*graphqlbackend.ProductLicenseInfo, error) {
+	productlicense.GetConfiguredProductLicenseInfo = func() (*productlicense.Info, error) {
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if info == nil || err != nil {
 			return nil, err
 		}
-		return &graphqlbackend.ProductLicenseInfo{
-			TagsValue:      info.Tags,
-			UserCountValue: info.UserCount,
-			ExpiresAtValue: info.ExpiresAt,
+		return &productlicense.Info{
+			Tags:      info.Tags,
+			UserCount: info.UserCount,
+			ExpiresAt: info.ExpiresAt,
 		}, nil
 	}
 }

--- a/pkg/productlicense/productlicense.go
+++ b/pkg/productlicense/productlicense.go
@@ -1,0 +1,25 @@
+package productlicense
+
+import (
+	"time"
+)
+
+// Info contains information about a Sourcegraph license key.
+type Info struct {
+	Tags      []string  // tags that denote features/restrictions (e.g., "starter" or "dev")
+	UserCount uint      // the number of users that this license is valid for
+	ExpiresAt time.Time // the date when this license expires
+}
+
+// GetConfiguredProductLicenseInfo is called to obtain the product subscription info when creating
+// the GraphQL resolver for the GraphQL type ProductLicenseInfo.
+//
+// A nil return value for license info indicates the instance either is an OSS build or
+// doesn't have a license key defined in site configuration. If the site license key is invalid,
+// a non-nil error is returned.
+//
+// It is overridden in non-OSS builds to return information about the actual product subscription in
+// use.
+var GetConfiguredProductLicenseInfo = func() (*Info, error) {
+	return nil, nil // OSS builds have no license
+}


### PR DESCRIPTION
Management console and critical config question @slimsag:

(This is obviously still WIP, as I have a bunch of debug statements in here.) I'm seeing some weird behavior where updates to critical config aren't recognized initially on server start. I have to start it, wait for it to load, then shut it down and restart it again for the changes to be propagated.

This seems like a race condition, as my accessing of the critical config is occurring in a function called from a `main()` func.

Here's how it works:

1. Starting with the default critical-config.json from dev-private (which has a valid `licenseKey`), start up Sourcegraph. As expected, my debug line at https://github.com/sourcegraph/sourcegraph/compare/checks?expand=1#diff-96efb391535cae0b63190f5e23ec0f82R220 correctly prints `true`.
2. Shut down Sourcegraph
3. Update critical-config.json to comment out the `licenseKey` property
4. Restart Sourcegraph
4. My debug line prints out `true` (incorrectly)
5. Shut down the server, and then restart it
6. My debug line prints out `false` (correctly)

Any ideas for how to overcome this? I'm only doing this check one time, at startup, but I could do it lazily instead if this is an inherent limitation of how/when critical config is loaded.

<!-- Reminder: Have you updated the changelog? -->

Test plan: <!-- Required: What is the test plan for this change? -->
