### PR TITLE
fakehub: show config on front page

### DIFF
--- a/dev/fakehub/main.go
+++ b/dev/fakehub/main.go
@@ -27,7 +27,7 @@ func main() {
 fakehub will serve any number (controlled with -n) of copies of the repo over
 HTTP at /repo/1/.git, /repo/2/.git etc. These can be git cloned, and they can
 be used as test data for sourcegraph. The easiest way to get them into
-sourcegraph is to visit http://127.0.0.1:3434/config and paste the contents
+sourcegraph is to visit the URL printed out on startup and paste the contents
 into the text box for adding single repos in sourcegraph Site Admin.
 `)
 		flag.PrintDefaults()
@@ -71,7 +71,7 @@ func fakehub(n int, ln net.Listener, reposRoot string) (*http.Server, error) {
 	// Start the HTTP server.
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		handleDefault(tvars, w)
+		handleConfig(tvars, w)
 	})
 
 	if n == 1 {
@@ -83,9 +83,6 @@ func fakehub(n int, ln net.Listener, reposRoot string) (*http.Server, error) {
 		}
 	}
 
-	mux.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
-		handleConfig(tvars, w)
-	})
 	s := &http.Server{
 		Handler: logger(mux),
 	}

--- a/dev/fakehub/main_test.go
+++ b/dev/fakehub/main_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -37,18 +36,9 @@ func Test_fakehub(t *testing.T) {
 			return s.Serve(ln)
 		})
 
-		// Main page should link to config.
+		// Main page should show config.
 		addr := ln.Addr()
-		page, err := fetch(addr, "/")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(page, `<a href="/config">`) {
-			t.Fatalf("page is `%s`, want it to contain a link to /config", page)
-		}
-
-		// Config should have no repos.
-		confStr, err := fetch(addr, "/config")
+		confStr, err := fetch(addr, "/")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -63,7 +53,7 @@ func Test_fakehub(t *testing.T) {
 		confStr = comments.ReplaceAllString(confStr, "")
 		var conf Conf
 		if err := json.Unmarshal([]byte(confStr), &conf); err != nil {
-			t.Fatal(err)
+			t.Fatal(err, " while parsing \n", confStr)
 		}
 
 		// Clean up.


### PR DESCRIPTION
This change removes a click from the workflow.

Test plan: Updated the unit test.

Before:
![Screen Shot 2019-05-03 at 1 51 25 PM](https://user-images.githubusercontent.com/15530/57164964-9bf67900-6daa-11e9-85d8-9b7bf97a092f.png)

After:
![Screen Shot 2019-05-03 at 1 49 49 PM](https://user-images.githubusercontent.com/15530/57164973-a6187780-6daa-11e9-8f59-5407a85e133f.png)
