### PR TITLE
docs: fix broken links to GraphQL API documentation

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -2,5 +2,5 @@
 
 Sourcegraph exposes the following APIs:
 
-- [Sourcegraph GraphQL API](graphql.md), for accessing data stored or computed by Sourcegraph
+- [Sourcegraph GraphQL API](graphql/index.md), for accessing data stored or computed by Sourcegraph
 - [Sourcegraph extension API](../extensions.md), for extending the functionality of Sourcegraph and other tools (including code hosts)

--- a/doc/dev/architecture.md
+++ b/doc/dev/architecture.md
@@ -32,7 +32,7 @@ Here are the services that compose Sourcegraph.
 
 ### frontend ([code](https://github.com/sourcegraph/sourcegraph/tree/master/cmd/frontend))
 
-The frontend serves our [web app](web_app.md) and hosts our [GraphQL API](../api/graphql.md).
+The frontend serves our [web app](web_app.md) and hosts our [GraphQL API](../api/graphql/index.md).
 
 Application data is stored in our Postgresql database.
 
@@ -58,7 +58,7 @@ Mirrors repositories from their code host. All other Sourcegraph services talk t
 
 gitserver's memory usage consists of short lived git subprocesses.
 
-This is an IO and compute heavy service since most Sourcegraph requests will trigger 1 or more git commands. As such we shard requests for a repo to a specific replica. This allows us to horizontally scale out the service. 
+This is an IO and compute heavy service since most Sourcegraph requests will trigger 1 or more git commands. As such we shard requests for a repo to a specific replica. This allows us to horizontally scale out the service.
 
 The service is stateful (maintaining git clones). However, it only contains data mirrored from upstream code hosts.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -59,7 +59,7 @@ Sourcegraph development is open source at [github.com/sourcegraph/sourcegraph](h
 - [Integrations](integration/index.md) with GitHub, GitLab, Bitbucket, etc.
 - [Chrome and Firefox browser extensions](integration/browser_extension.md)
 - [Query syntax reference](user/search/queries.md)
-- [GraphQL API](api/graphql.md)
+- [GraphQL API](api/graphql/index.md)
 - [Sourcegraph Enterprise](admin/subscriptions/index.md)
 
 <!-- TODO(sqs): Add link to ./graphbook when it has more content. -->


### PR DESCRIPTION
This commit changes all invalid references of the GraphQL API page from `graphql.md` to `graphql/index.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sourcegraph/sourcegraph/3834)
<!-- Reviewable:end -->
