### PR TITLE
Fix selection after running a settings quick action #2756

### DIFF
--- a/web/src/settings/MonacoSettingsEditor.tsx
+++ b/web/src/settings/MonacoSettingsEditor.tsx
@@ -249,8 +249,6 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
                     }
                 }
                 if (!selection) {
-                    // TODO: This is buggy. See
-                    // https://github.com/sourcegraph/sourcegraph/issues/2756.
                     selection = monaco.Selection.fromPositions(
                         monacoEdits[0].range.getStartPosition(),
                         monacoEdits[monacoEdits.length - 1].range.getEndPosition()

--- a/web/src/site-admin/configHelpers.ts
+++ b/web/src/site-admin/configHelpers.ts
@@ -11,7 +11,7 @@ const defaultFormattingOptions: FormattingOptions = {
 
 const setSearchContextLines: ConfigInsertionFunction = config => {
     const DEFAULT = 3 // a reasonable value that will be clearly different from the default 1
-    return { edits: setProperty(config, ['search.contextLines'], DEFAULT, defaultFormattingOptions) }
+    return { edits: setProperty(config, ['search.contextLines'], DEFAULT, defaultFormattingOptions), selectText: `${DEFAULT}` }
 }
 
 const addSearchScopeToSettings: ConfigInsertionFunction = config => {
@@ -28,7 +28,7 @@ const addSlackWebhook: ConfigInsertionFunction = config => {
         webhookURL: 'get webhook URL at https://YOUR-WORKSPACE-NAME.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks',
     }
     const edits = setProperty(config, ['notifications.slack'], value, defaultFormattingOptions)
-    return { edits, selectText: '""', cursorOffset: 1 }
+    return { edits, selectText: 'YOUR-WORKSPACE-NAME' }
 }
 
 export interface EditorAction {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2756

Assumption: there are some quick configure actions for which a `selectText` may be set *a priori*, and then there are other quick configure actions for which this is not possible.  

The change that I am proposing offers a handy way to generate `selectText` *a posteriori*, taking the whole editor into consideration, after all changes have been applied.