### PR TITLE
use more compatible flexbox align-items: flex-start value

### DIFF
--- a/shared/src/notifications/NotificationItem.scss
+++ b/shared/src/notifications/NotificationItem.scss
@@ -10,7 +10,7 @@
 
     &__body-container {
         display: flex;
-        align-items: start;
+        align-items: flex-start;
     }
     &__body {
         flex: 1;

--- a/web/src/marketing/Toast.scss
+++ b/web/src/marketing/Toast.scss
@@ -5,7 +5,7 @@
     z-index: 50; // Overlay repository/blob contents
     padding: 1rem;
     display: flex;
-    align-items: start;
+    align-items: flex-start;
     border-radius: 0.25rem;
     background-color: $color-light-bg-2;
     color: $color-light-text-1;

--- a/web/src/org/invite/InviteForm.scss
+++ b/web/src/org/invite/InviteForm.scss
@@ -18,7 +18,7 @@
 .invited-notification {
     display: flex;
     justify-content: space-between;
-    align-items: start;
+    align-items: flex-start;
 
     &__message {
         flex: 1;


### PR DESCRIPTION
Fixes CSS compatibility warning: `start value has mixed support, consider using flex-start instead` (from Webpack).

See https://stackoverflow.com/questions/50919447/flexbox-flex-start-self-start-and-start-whats-the-difference for more information. The 2 values are different (so this can't be automatically fixed in PostCSS), but for our purposes they are equivalent, so it's better to use the more compatible one.