### PR TITLE
docs: Fix link to Sourcegraph extensions page

### DIFF
--- a/doc/user/code_intelligence/index.md
+++ b/doc/user/code_intelligence/index.md
@@ -16,7 +16,7 @@ You can get more accurate (but usually slower) code intelligence by enabling a d
 - [Python](https://sourcegraph.com/extensions/sourcegraph/python)
 - Check the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22) for more
 
-Code intelligence is provided by [Sourcegraph extensions](../index.md) and language servers that run securely in your self-hosted Sourcegraph instance. The extensions (and associated language servers) perform advanced, scalable code analysis and are derived from our popular open-source language servers in use by hundreds of thousands of developers in editors and on Sourcegraph.com.
+Code intelligence is provided by [Sourcegraph extensions](../../extensions/index.md) and language servers that run securely in your self-hosted Sourcegraph instance. The extensions (and associated language servers) perform advanced, scalable code analysis and are derived from our popular open-source language servers in use by hundreds of thousands of developers in editors and on Sourcegraph.com.
 
 By spinning up Sourcegraph, you can get code intelligence:
 


### PR DESCRIPTION
This fixes a link to the documentation about Sourcegraph extensions.

Test plan: manually tested it on my local build of the docs site
