### PR TITLE
repo-updater: Support external_id migrations

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -162,8 +162,8 @@ func (d Diff) Repos() Repos {
 func NewDiff(sourced, stored []*Repo) (diff Diff) {
 	byID := make(map[api.ExternalRepoSpec]*Repo, len(sourced))
 	for _, r := range sourced {
-		if r.ExternalRepo == (api.ExternalRepoSpec{}) {
-			panic(fmt.Errorf("%s has no external repo spec", r.Name))
+		if !r.ExternalRepo.IsSet() {
+			panic(fmt.Errorf("%s has no valid external repo spec: %s", r.Name, r.ExternalRepo))
 		} else if old := byID[r.ExternalRepo]; old != nil {
 			merge(old, r)
 		} else {
@@ -189,7 +189,7 @@ func NewDiff(sourced, stored []*Repo) (diff Diff) {
 
 	for _, old := range stored {
 		src := byID[old.ExternalRepo]
-		if src == nil && old.ExternalRepo == (api.ExternalRepoSpec{}) && !seenName[old.Name] {
+		if src == nil && old.ExternalRepo.ID == "" && !seenName[old.Name] {
 			src = byName[old.Name]
 		}
 
@@ -285,8 +285,8 @@ type byExternalRepoSpecSet []*Repo
 func (rs byExternalRepoSpecSet) Len() int      { return len(rs) }
 func (rs byExternalRepoSpecSet) Swap(i, j int) { rs[i], rs[j] = rs[j], rs[i] }
 func (rs byExternalRepoSpecSet) Less(i, j int) bool {
-	iSet := rs[i].ExternalRepo != (api.ExternalRepoSpec{})
-	jSet := rs[j].ExternalRepo != (api.ExternalRepoSpec{})
+	iSet := rs[i].ExternalRepo.IsSet()
+	jSet := rs[j].ExternalRepo.IsSet()
 	if iSet == jSet {
 		return false
 	}

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -192,7 +192,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource(tc.svc.Clone(), nil, tc.repo.Clone())),
 				store:   s,
 				stored: repos.Repos{tc.repo.With(func(r *repos.Repo) {
-					r.ExternalRepo = api.ExternalRepoSpec{}
+					r.ExternalRepo.ID = ""
 				})},
 				now: clock.Now,
 				diff: repos.Diff{Modified: repos.Repos{
@@ -475,7 +475,9 @@ func TestDiff(t *testing.T) {
 
 	eid := func(id string) api.ExternalRepoSpec {
 		return api.ExternalRepoSpec{
-			ID: id,
+			ID:          id,
+			ServiceType: "fake",
+			ServiceID:   "https://fake.com",
 		}
 	}
 	now := time.Now()

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -72,6 +72,11 @@ type ExternalRepoSpec struct {
 	ServiceID string
 }
 
+// IsSet returns true if all fields of the external repo spec are set.
+func (r ExternalRepoSpec) IsSet() bool {
+	return r.ID != "" && r.ServiceType != "" && r.ServiceID != ""
+}
+
 // Equal returns true if r is equal to s.
 func (r *ExternalRepoSpec) Equal(s *ExternalRepoSpec) bool {
 	if r == s { // handles the case when r and s are both nil
@@ -94,7 +99,7 @@ func (r ExternalRepoSpec) Compare(s ExternalRepoSpec) int {
 	return cmp(r.ID, s.ID)
 }
 
-func (r *ExternalRepoSpec) String() string {
+func (r ExternalRepoSpec) String() string {
 	return fmt.Sprintf("ExternalRepoSpec{%s %s %s}", r.ServiceID, r.ServiceType, r.ID)
 }
 


### PR DESCRIPTION
This change set makes it so we can support changes in what gets stored
in `external_id` by the `Syncer`. Previously we enforced that all three
of `external_id`, `external_service_type` and `external_service_id`
would be set OR unset, together.

But in order to change what gets stored in the `external_id` column
using the `Syncer` to essentially perform the migration, we need the
`external_service_id` and `external_service_type` columns to remain
intact, because we rely on `external_service_type` to filter by kind in
`DBStore.ListRepos`.

If we'd unset all of the three columns together, we wouldn't list any
repos, since they wouldn't be matched by the `external_service_type`
column.

Precursor to solving #3465 because it needs to change what we store in
the `external_id` columns of AWS Code Commit repos to a stable
identifier.

Test plan: go test
