### PR TITLE
Remove global sourcegraphUrl

### DIFF
--- a/client/browser/src/extension/scripts/background.tsx
+++ b/client/browser/src/extension/scripts/background.tsx
@@ -17,7 +17,7 @@ import { createBlobURLForBundle } from '../../platform/worker'
 import { getHeaders } from '../../shared/backend/headers'
 import { resolveClientConfiguration } from '../../shared/backend/server'
 import { fromBrowserEvent } from '../../shared/util/browser'
-import { DEFAULT_SOURCEGRAPH_URL, getPlatformName, setSourcegraphUrl } from '../../shared/util/context'
+import { DEFAULT_SOURCEGRAPH_URL, getPlatformName } from '../../shared/util/context'
 import { assertEnv } from '../envAssertion'
 
 assertEnv('BACKGROUND')
@@ -78,7 +78,6 @@ async function main(): Promise<void> {
     // If no sourcegraphURL is set ensure we default back to https://sourcegraph.com.
     if (!sourcegraphURL) {
         await storage.sync.set({ sourcegraphURL: DEFAULT_SOURCEGRAPH_URL })
-        setSourcegraphUrl(DEFAULT_SOURCEGRAPH_URL)
         sourcegraphURL = DEFAULT_SOURCEGRAPH_URL
     }
 
@@ -120,7 +119,6 @@ async function main(): Promise<void> {
         }
 
         if (changes.sourcegraphURL && changes.sourcegraphURL.newValue) {
-            setSourcegraphUrl(changes.sourcegraphURL.newValue)
             await syncClientConfiguration()
             configureOmnibox(changes.sourcegraphURL.newValue)
         }

--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -27,6 +27,8 @@ setLinkComponent(({ to, children, ...props }) => (
     </a>
 ))
 
+const IS_EXTENSION = true
+
 /**
  * Main entry point into browser extension.
  */
@@ -85,8 +87,7 @@ async function main(): Promise<void> {
     // For the life time of the content script, add features in reaction to DOM changes
     if (codeHost) {
         console.log('Detected code host', codeHost.name)
-        const isExtension = true
-        subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost, isExtension))
+        subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost, IS_EXTENSION))
     }
 }
 

--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -85,7 +85,8 @@ async function main(): Promise<void> {
     // For the life time of the content script, add features in reaction to DOM changes
     if (codeHost) {
         console.log('Detected code host', codeHost.name)
-        subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost))
+        const isExtension = true
+        subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost, isExtension))
     }
 }
 

--- a/client/browser/src/extension/scripts/inject.tsx
+++ b/client/browser/src/extension/scripts/inject.tsx
@@ -9,7 +9,7 @@ import { storage } from '../../browser/storage'
 import { determineCodeHost as detectCodeHost, injectCodeIntelligenceToCodeHost } from '../../libs/code_intelligence'
 import { initSentry } from '../../libs/sentry'
 import { checkIsSourcegraph, injectSourcegraphApp } from '../../libs/sourcegraph/inject'
-import { DEFAULT_SOURCEGRAPH_URL, setSourcegraphUrl } from '../../shared/util/context'
+import { DEFAULT_SOURCEGRAPH_URL } from '../../shared/util/context'
 import { MutationRecordLike, observeMutations } from '../../shared/util/dom'
 import { featureFlags } from '../../shared/util/featureFlags'
 import { assertEnv } from '../envAssertion'
@@ -60,7 +60,6 @@ async function main(): Promise<void> {
     }
 
     const sourcegraphServerUrl = items.sourcegraphURL || DEFAULT_SOURCEGRAPH_URL
-    setSourcegraphUrl(sourcegraphServerUrl)
 
     const isSourcegraphServer = checkIsSourcegraph(sourcegraphServerUrl)
 

--- a/client/browser/src/libs/cli/search.ts
+++ b/client/browser/src/libs/cli/search.ts
@@ -25,7 +25,7 @@ export class SearchCommand {
             this.suggestionFetcher({
                 query,
                 handler: async suggestions => {
-                    const sourcegraphURL = await observeSourcegraphURL()
+                    const sourcegraphURL = await observeSourcegraphURL(true) // isExtension=true, this feature is only supported in the browser extension
                         .pipe(take(1))
                         .toPromise()
                     const built = suggestions.map(({ title, url, urlLabel }) => ({
@@ -44,7 +44,7 @@ export class SearchCommand {
         })
 
     public action = async (query: string, disposition?: string): Promise<void> => {
-        const sourcegraphURL = await observeSourcegraphURL()
+        const sourcegraphURL = await observeSourcegraphURL(true) // isExtension=true, this feature is only supported in the browser extension
             .pipe(take(1))
             .toPromise()
         const props = {

--- a/client/browser/src/libs/code_intelligence/ extensions.test.tsx
+++ b/client/browser/src/libs/code_intelligence/ extensions.test.tsx
@@ -4,10 +4,13 @@ import { initializeExtensions } from './extensions'
 describe('Extensions controller', () => {
     it('Blocks GraphQL requests from extensions if they risk leaking private information to the public sourcegraph.com instance', () => {
         window.SOURCEGRAPH_URL = DEFAULT_SOURCEGRAPH_URL
-        const { extensionsController } = initializeExtensions({
-            urlToFile: () => '',
-            getContext: () => ({ repoName: 'foo', privateRepository: true }),
-        })
+        const { extensionsController } = initializeExtensions(
+            {
+                urlToFile: () => '',
+                getContext: () => ({ repoName: 'foo', privateRepository: true }),
+            },
+            DEFAULT_SOURCEGRAPH_URL
+        )
         return expect(
             extensionsController.executeCommand({
                 command: 'queryGraphQL',

--- a/client/browser/src/libs/code_intelligence/ extensions.test.tsx
+++ b/client/browser/src/libs/code_intelligence/ extensions.test.tsx
@@ -9,7 +9,8 @@ describe('Extensions controller', () => {
                 urlToFile: () => '',
                 getContext: () => ({ repoName: 'foo', privateRepository: true }),
             },
-            DEFAULT_SOURCEGRAPH_URL
+            DEFAULT_SOURCEGRAPH_URL,
+            false
         )
         return expect(
             extensionsController.executeCommand({

--- a/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -17,6 +17,7 @@ import { SuccessGraphQLResult } from '../../../../../shared/src/graphql/graphql'
 import { IMutation, IQuery } from '../../../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../../../shared/src/platform/context'
 import { isDefined } from '../../../../../shared/src/util/types'
+import { DEFAULT_SOURCEGRAPH_URL } from '../../shared/util/context'
 import { MutationRecordLike } from '../../shared/util/dom'
 import { createGlobalDebugMount, createOverlayMount, FileInfo, handleCodeHost } from './code_intelligence'
 import { toCodeViewResolver } from './code_views'
@@ -139,6 +140,7 @@ describe('code_intelligence', () => {
                     extensionsController: createMockController(services),
                     showGlobalDebug: false,
                     platformContext: createMockPlatformContext(),
+                    sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                 })
             )
             const overlayMount = document.body.querySelector('.hover-overlay-mount')
@@ -163,6 +165,7 @@ describe('code_intelligence', () => {
                     extensionsController: createMockController(services),
                     showGlobalDebug: false,
                     platformContext: createMockPlatformContext(),
+                    sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                 })
             )
             const renderedCommandPalette = elementRenderedAtMount(commandPaletteMount)
@@ -182,6 +185,7 @@ describe('code_intelligence', () => {
                     extensionsController: createMockController(services),
                     showGlobalDebug: true,
                     platformContext: createMockPlatformContext(),
+                    sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                 })
             )
             const globalDebugMount = document.body.querySelector('.global-debug')
@@ -218,11 +222,11 @@ describe('code_intelligence', () => {
                                 getToolbarMount: () => toolbarMount,
                             }),
                         ],
-                        selectionsChanges: () => of([]),
                     },
                     extensionsController: createMockController(services),
                     showGlobalDebug: true,
                     platformContext: createMockPlatformContext(),
+                    sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                 })
             )
             const editors = await from(services.editor.editors)
@@ -284,6 +288,7 @@ describe('code_intelligence', () => {
                     extensionsController: createMockController(services),
                     showGlobalDebug: true,
                     platformContext: createMockPlatformContext(),
+                    sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                 })
             )
             const activeEditor = await from(extensionAPI.app.activeWindowChanges)
@@ -369,6 +374,7 @@ describe('code_intelligence', () => {
                     extensionsController: createMockController(services),
                     showGlobalDebug: true,
                     platformContext: createMockPlatformContext(),
+                    sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                 })
             )
             let editors = await from(services.editor.editors)

--- a/client/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/client/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -659,13 +659,14 @@ export const determineCodeHost = (): CodeHost | undefined => CODE_HOSTS.find(cod
 export async function injectCodeIntelligenceToCodeHost(
     mutations: Observable<MutationRecordLike[]>,
     codeHost: CodeHost,
+    isExtension: boolean,
     showGlobalDebug = SHOW_DEBUG()
 ): Promise<Subscription> {
     const subscriptions = new Subscription()
-    const sourcegraphURL = await observeSourcegraphURL()
+    const sourcegraphURL = await observeSourcegraphURL(isExtension)
         .pipe(take(1))
         .toPromise()
-    const { platformContext, extensionsController } = initializeExtensions(codeHost, sourcegraphURL)
+    const { platformContext, extensionsController } = initializeExtensions(codeHost, sourcegraphURL, isExtension)
     subscriptions.add(extensionsController)
     subscriptions.add(
         handleCodeHost({

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -31,9 +31,10 @@ import { CodeHost } from './code_intelligence'
  */
 export function initializeExtensions(
     { urlToFile, getContext }: Pick<CodeHost, 'urlToFile' | 'getContext'>,
-    sourcegraphURL: string
+    sourcegraphURL: string,
+    isExtension: boolean
 ): PlatformContextProps & ExtensionsControllerProps {
-    const platformContext = createPlatformContext({ urlToFile, getContext }, sourcegraphURL)
+    const platformContext = createPlatformContext({ urlToFile, getContext }, sourcegraphURL, isExtension)
     const extensionsController = createExtensionsController(platformContext)
     return { platformContext, extensionsController }
 }

--- a/client/browser/src/libs/code_intelligence/extensions.tsx
+++ b/client/browser/src/libs/code_intelligence/extensions.tsx
@@ -29,11 +29,11 @@ import { CodeHost } from './code_intelligence'
  * Initializes extensions for a page. It creates the {@link PlatformContext} and extensions controller.
  *
  */
-export function initializeExtensions({
-    urlToFile,
-    getContext,
-}: Pick<CodeHost, 'urlToFile' | 'getContext'>): PlatformContextProps & ExtensionsControllerProps {
-    const platformContext = createPlatformContext({ urlToFile, getContext })
+export function initializeExtensions(
+    { urlToFile, getContext }: Pick<CodeHost, 'urlToFile' | 'getContext'>,
+    sourcegraphURL: string
+): PlatformContextProps & ExtensionsControllerProps {
+    const platformContext = createPlatformContext({ urlToFile, getContext }, sourcegraphURL)
     const extensionsController = createExtensionsController(platformContext)
     return { platformContext, extensionsController }
 }
@@ -70,12 +70,14 @@ export const renderGlobalDebug = ({
     extensionsController,
     platformContext,
     history,
-}: InjectProps & { showGlobalDebug?: boolean }) => (mount: HTMLElement): void => {
+    sourcegraphURL,
+}: InjectProps & { sourcegraphURL: string; showGlobalDebug?: boolean }) => (mount: HTMLElement): void => {
     render(
         <GlobalDebug
             extensionsController={extensionsController}
             location={history.location}
             platformContext={platformContext}
+            sourcegraphURL={sourcegraphURL}
         />,
         mount
     )

--- a/client/browser/src/libs/code_intelligence/external_links.test.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.test.tsx
@@ -13,7 +13,7 @@ describe('<ViewOnSourcegraphButton />', () => {
 
     it('renders a link', () => {
         renderViewContextOnSourcegraph({
-            sourcegraphUrl: 'https://test.com',
+            sourcegraphURL: 'https://test.com',
             getContext: () => ({ repoName: 'test', privateRepository: false }),
             viewOnSourcegraphButtonClassProps: {
                 className: 'test',
@@ -28,7 +28,7 @@ describe('<ViewOnSourcegraphButton />', () => {
 
     it('renders a link with the rev when provided', () => {
         renderViewContextOnSourcegraph({
-            sourcegraphUrl: 'https://test.com',
+            sourcegraphURL: 'https://test.com',
             getContext: () => ({
                 repoName: 'test',
                 rev: 'test',
@@ -49,7 +49,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         const configureClickSpy = sinon.spy()
 
         renderViewContextOnSourcegraph({
-            sourcegraphUrl: 'https://sourcegraph.com',
+            sourcegraphURL: 'https://sourcegraph.com',
             getContext: () => ({
                 repoName: 'test',
                 rev: 'test',
@@ -74,7 +74,7 @@ describe('<ViewOnSourcegraphButton />', () => {
         const configureClickSpy = sinon.spy()
 
         renderViewContextOnSourcegraph({
-            sourcegraphUrl: 'https://test.com',
+            sourcegraphURL: 'https://test.com',
             getContext: () => ({
                 repoName: 'test',
                 rev: 'test',

--- a/client/browser/src/libs/code_intelligence/external_links.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.tsx
@@ -37,14 +37,14 @@ class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonPro
         this.subscriptions.add(
             this.componentUpdates
                 .pipe(
-                    map(({ context, sourcegraphURL: sourcegraphUrl, ensureRepoExists }) => ({
+                    map(({ context, sourcegraphURL, ensureRepoExists }) => ({
                         context,
-                        sourcegraphUrl,
+                        sourcegraphURL,
                         ensureRepoExists,
                     })),
                     distinctUntilChanged((a, b) => isEqual(a, b)),
-                    switchMap(({ context, sourcegraphUrl, ensureRepoExists }) =>
-                        ensureRepoExists(context, sourcegraphUrl)
+                    switchMap(({ context, sourcegraphURL, ensureRepoExists }) =>
+                        ensureRepoExists(context, sourcegraphURL)
                     )
                 )
                 .subscribe(repoExists => {

--- a/client/browser/src/libs/code_intelligence/external_links.tsx
+++ b/client/browser/src/libs/code_intelligence/external_links.tsx
@@ -15,7 +15,7 @@ export interface ViewOnSourcegraphButtonClassProps {
 
 interface ViewOnSourcegraphButtonProps extends ViewOnSourcegraphButtonClassProps {
     context: CodeHostContext
-    sourcegraphUrl: string
+    sourcegraphURL: string
     ensureRepoExists: (context: CodeHostContext, sourcegraphUrl: string) => Observable<boolean>
     onConfigureSourcegraphClick?: () => void
 }
@@ -37,7 +37,7 @@ class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonPro
         this.subscriptions.add(
             this.componentUpdates
                 .pipe(
-                    map(({ context, sourcegraphUrl, ensureRepoExists }) => ({
+                    map(({ context, sourcegraphURL: sourcegraphUrl, ensureRepoExists }) => ({
                         context,
                         sourcegraphUrl,
                         ensureRepoExists,
@@ -74,7 +74,7 @@ class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonPro
         // user to configure Sourcegraph.
         if (
             !this.state.repoExists &&
-            this.props.sourcegraphUrl === DEFAULT_SOURCEGRAPH_URL &&
+            this.props.sourcegraphURL === DEFAULT_SOURCEGRAPH_URL &&
             this.props.onConfigureSourcegraphClick
         ) {
             return (
@@ -101,18 +101,18 @@ class ViewOnSourcegraphButton extends React.Component<ViewOnSourcegraphButtonPro
     private getURL(): string {
         const rev = this.props.context.rev ? `@${this.props.context.rev}` : ''
 
-        return `${this.props.sourcegraphUrl}/${this.props.context.repoName}${rev}`
+        return `${this.props.sourcegraphURL}/${this.props.context.repoName}${rev}`
     }
 }
 
 export const renderViewContextOnSourcegraph = ({
-    sourcegraphUrl,
+    sourcegraphURL,
     getContext,
     ensureRepoExists,
     viewOnSourcegraphButtonClassProps,
     onConfigureSourcegraphClick,
 }: {
-    sourcegraphUrl: string
+    sourcegraphURL: string
     ensureRepoExists: ViewOnSourcegraphButtonProps['ensureRepoExists']
     onConfigureSourcegraphClick?: ViewOnSourcegraphButtonProps['onConfigureSourcegraphClick']
 } & Required<Pick<CodeHost, 'getContext'>> &
@@ -121,7 +121,7 @@ export const renderViewContextOnSourcegraph = ({
         <ViewOnSourcegraphButton
             {...viewOnSourcegraphButtonClassProps}
             context={getContext()}
-            sourcegraphUrl={sourcegraphUrl}
+            sourcegraphURL={sourcegraphURL}
             ensureRepoExists={ensureRepoExists}
             onConfigureSourcegraphClick={onConfigureSourcegraphClick}
         />,

--- a/client/browser/src/libs/github/code_intelligence.ts
+++ b/client/browser/src/libs/github/code_intelligence.ts
@@ -309,12 +309,13 @@ export const githubCodeHost: CodeHost = {
     setElementTooltip,
     linkPreviewContentClass: 'text-small text-gray p-1 mx-1 border rounded-1 bg-gray text-gray-dark',
     urlToFile: (
+        sourcegraphURL: string,
         location: RepoSpec & RevSpec & FileSpec & Partial<PositionSpec> & Partial<ViewStateSpec> & { part?: DiffPart }
     ) => {
         if (location.viewState) {
             // A view state means that a panel must be shown, and panels are currently only supported on
             // Sourcegraph (not code hosts).
-            return toAbsoluteBlobURL(location)
+            return toAbsoluteBlobURL(sourcegraphURL, location)
         }
 
         const rev = location.rev || 'HEAD'

--- a/client/browser/src/libs/phabricator/backend.tsx
+++ b/client/browser/src/libs/phabricator/backend.tsx
@@ -7,7 +7,6 @@ import { memoizeObservable } from '../../../../../shared/src/util/memoizeObserva
 import { storage } from '../../browser/storage'
 import { isExtension } from '../../context'
 import { resolveRepo } from '../../shared/repo/backend'
-import { sourcegraphUrl } from '../../shared/util/context'
 import { normalizeRepoName } from './util'
 
 interface PhabEntity {
@@ -117,18 +116,14 @@ function createConduitRequestForm(): FormData {
  * Native installation of the Phabricator extension does not allow for us to fetch the style.bundle from a script element.
  * To get around this we fetch the bundled CSS contents and append it to the DOM.
  */
-export function getPhabricatorCSS(): Promise<string> {
+export async function getPhabricatorCSS(sourcegraphURL: string): Promise<string> {
     const bundleUID = process.env.BUNDLE_UID
-    return new Promise((resolve, reject) => {
-        fetch(sourcegraphUrl + `/.assets/extension/css/style.bundle.css?v=${bundleUID}`, {
-            method: 'GET',
-            credentials: 'include',
-            headers: new Headers({ Accept: 'text/html' }),
-        })
-            .then(resp => resp.text())
-            .then(resolve)
-            .catch(reject)
+    const resp = await fetch(sourcegraphURL + `/.assets/extension/css/style.bundle.css?v=${bundleUID}`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: new Headers({ Accept: 'text/html' }),
     })
+    return resp.text()
 }
 
 function getDiffDetailsFromConduit(diffID: number, differentialID: number): Promise<ConduitDiffDetails> {

--- a/client/browser/src/libs/phabricator/extension.tsx
+++ b/client/browser/src/libs/phabricator/extension.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import { Observable } from 'rxjs'
 import { startWith } from 'rxjs/operators'
 import { setLinkComponent } from '../../../../../shared/src/components/Link'
-import { setSourcegraphUrl } from '../../shared/util/context'
 import { MutationRecordLike, observeMutations } from '../../shared/util/dom'
 import { determineCodeHost, injectCodeIntelligenceToCodeHost } from '../code_intelligence'
 import { getPhabricatorCSS, getSourcegraphURLFromConduit } from './backend'
@@ -57,24 +56,19 @@ function init(): void {
         }
 
         getSourcegraphURLFromConduit()
-            .then(sourcegraphUrl => {
-                getPhabricatorCSS()
-                    .then(css => {
-                        const style = document.createElement('style')
-                        style.setAttribute('type', 'text/css')
-                        style.id = 'sourcegraph-styles'
-                        style.textContent = css
-                        document.getElementsByTagName('head')[0].appendChild(style)
-                        window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphUrl)
-                        window.SOURCEGRAPH_URL = sourcegraphUrl
-                        setSourcegraphUrl(sourcegraphUrl)
-                        metaClickOverride()
-                        injectModules().catch(err => console.error('Unable to inject modules', err))
-                    })
-                    .catch(e => {
-                        console.error(e)
-                    })
-            })
+            .then(sourcegraphURL =>
+                getPhabricatorCSS(sourcegraphURL).then(css => {
+                    const style = document.createElement('style')
+                    style.setAttribute('type', 'text/css')
+                    style.id = 'sourcegraph-styles'
+                    style.textContent = css
+                    document.getElementsByTagName('head')[0].appendChild(style)
+                    window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
+                    window.SOURCEGRAPH_URL = sourcegraphURL
+                    metaClickOverride()
+                    injectModules().catch(err => console.error('Unable to inject modules', err))
+                })
+            )
             .catch(e => console.error(e))
     } else {
         console.log(
@@ -85,8 +79,4 @@ function init(): void {
     }
 }
 
-const url = window.SOURCEGRAPH_URL || window.localStorage.getItem('SOURCEGRAPH_URL')
-if (url) {
-    setSourcegraphUrl(url)
-}
 init()

--- a/client/browser/src/libs/phabricator/extension.tsx
+++ b/client/browser/src/libs/phabricator/extension.tsx
@@ -31,7 +31,8 @@ async function injectModules(): Promise<void> {
     // TODO handle subscription
     const codeHost = await determineCodeHost()
     if (codeHost) {
-        await injectCodeIntelligenceToCodeHost(mutations, codeHost)
+        const isExtension = false
+        await injectCodeIntelligenceToCodeHost(mutations, codeHost, isExtension)
     }
 }
 

--- a/client/browser/src/libs/phabricator/extension.tsx
+++ b/client/browser/src/libs/phabricator/extension.tsx
@@ -13,6 +13,8 @@ import { metaClickOverride } from './util'
 // Just for informational purposes (see getPlatformContext())
 window.SOURCEGRAPH_PHABRICATOR_EXTENSION = true
 
+const IS_EXTENSION = false
+
 // NOT idempotent.
 async function injectModules(): Promise<void> {
     // This is added so that the browser extension doesn't
@@ -31,8 +33,7 @@ async function injectModules(): Promise<void> {
     // TODO handle subscription
     const codeHost = await determineCodeHost()
     if (codeHost) {
-        const isExtension = false
-        await injectCodeIntelligenceToCodeHost(mutations, codeHost, isExtension)
+        await injectCodeIntelligenceToCodeHost(mutations, codeHost, IS_EXTENSION)
     }
 }
 

--- a/client/browser/src/platform/context.test.tsx
+++ b/client/browser/src/platform/context.test.tsx
@@ -6,10 +6,13 @@ describe('Platform Context', () => {
     describe('requestGraphQL()', () => {
         it('throws if the request risks leaking private information to the public sourcegraph.com', () => {
             window.SOURCEGRAPH_URL = DEFAULT_SOURCEGRAPH_URL
-            const { requestGraphQL } = createPlatformContext({
-                urlToFile: () => '',
-                getContext: () => ({ repoName: 'foo', privateRepository: true }),
-            })
+            const { requestGraphQL } = createPlatformContext(
+                {
+                    urlToFile: () => '',
+                    getContext: () => ({ repoName: 'foo', privateRepository: true }),
+                },
+                DEFAULT_SOURCEGRAPH_URL
+            )
             return expect(
                 requestGraphQL({
                     request: gql`

--- a/client/browser/src/platform/context.test.tsx
+++ b/client/browser/src/platform/context.test.tsx
@@ -11,7 +11,8 @@ describe('Platform Context', () => {
                     urlToFile: () => '',
                     getContext: () => ({ repoName: 'foo', privateRepository: true }),
                 },
-                DEFAULT_SOURCEGRAPH_URL
+                DEFAULT_SOURCEGRAPH_URL,
+                false
             )
             return expect(
                 requestGraphQL({

--- a/client/browser/src/platform/context.ts
+++ b/client/browser/src/platform/context.ts
@@ -13,7 +13,7 @@ import { observeStorageKey } from '../browser/storage'
 import { isInPage } from '../context'
 import { CodeHost } from '../libs/code_intelligence'
 import { PrivateRepoPublicSourcegraphComError } from '../shared/backend/errors'
-import { DEFAULT_SOURCEGRAPH_URL, observeSourcegraphURL, sourcegraphUrl } from '../shared/util/context'
+import { DEFAULT_SOURCEGRAPH_URL, observeSourcegraphURL } from '../shared/util/context'
 import { createExtensionHost } from './extensionHost'
 import { editClientSettings, fetchViewerSettings, mergeCascades, storageSettingsCascade } from './settings'
 import { createBlobURLForBundle } from './worker'
@@ -21,10 +21,10 @@ import { createBlobURLForBundle } from './worker'
 /**
  * Creates the {@link PlatformContext} for the browser extension.
  */
-export function createPlatformContext({
-    urlToFile,
-    getContext,
-}: Pick<CodeHost, 'urlToFile' | 'getContext'>): PlatformContext {
+export function createPlatformContext(
+    { urlToFile, getContext }: Pick<CodeHost, 'urlToFile' | 'getContext'>,
+    sourcegraphURL: string
+): PlatformContext {
     const updatedViewerSettings = new ReplaySubject<Pick<GQL.ISettingsCascade, 'subjects' | 'final'>>(1)
     const requestGraphQL: PlatformContext['requestGraphQL'] = <T extends GQL.IQuery | GQL.IMutation>({
         request,
@@ -136,12 +136,12 @@ export function createPlatformContext({
         urlToFile: location => {
             if (urlToFile) {
                 // Construct URL to file on code host, if possible.
-                return urlToFile(location)
+                return urlToFile(sourcegraphURL, location)
             }
             // Otherwise fall back to linking to Sourcegraph (with an absolute URL).
-            return `${sourcegraphUrl}${toPrettyBlobURL(location)}`
+            return `${sourcegraphURL}${toPrettyBlobURL(location)}`
         },
-        sourcegraphURL: sourcegraphUrl,
+        sourcegraphURL,
         clientApplication: 'other',
         sideloadedExtensionURL: isInPage
             ? new LocalStorageSubject<string | null>('sideloadedExtensionURL', null)

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -36,8 +36,8 @@ export interface CodeViewToolbarProps
         FileInfoWithContents,
         TelemetryProps,
         CodeViewToolbarClassProps {
+    sourcegraphURL: string
     onEnabledChange?: (enabled: boolean) => void
-
     buttonProps?: ButtonProps
     location: H.Location
 }
@@ -87,6 +87,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                             className={this.props.actionItemClass}
                             iconClassName={this.props.actionItemIconClass}
                             openProps={{
+                                sourcegraphURL: this.props.sourcegraphURL,
                                 repoName: this.props.baseRepoName || this.props.repoName,
                                 filePath: this.props.baseFilePath || this.props.filePath,
                                 rev: this.props.baseRev || this.props.baseCommitID,
@@ -112,6 +113,7 @@ export class CodeViewToolbar extends React.Component<CodeViewToolbarProps, CodeV
                             className={this.props.actionItemClass}
                             iconClassName={this.props.actionItemIconClass}
                             openProps={{
+                                sourcegraphURL: this.props.sourcegraphURL,
                                 repoName: this.props.repoName,
                                 filePath: this.props.filePath,
                                 rev: this.props.rev || this.props.commitID,

--- a/client/browser/src/shared/components/GlobalDebug.tsx
+++ b/client/browser/src/shared/components/GlobalDebug.tsx
@@ -3,16 +3,16 @@ import * as React from 'react'
 import { Controller as ClientController } from '../../../../../shared/src/extensions/controller'
 import { ExtensionStatusPopover } from '../../../../../shared/src/extensions/ExtensionStatus'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
-import { sourcegraphUrl } from '../util/context'
 import { ShortcutProvider } from './ShortcutProvider'
 
 interface Props extends PlatformContextProps<'sideloadedExtensionURL'> {
     location: H.Location
     extensionsController: ClientController
+    sourcegraphURL: string
 }
 
-const ExtensionLink: React.FunctionComponent<{ id: string }> = props => {
-    const extensionURL = new URL(sourcegraphUrl)
+const makeExtensionLink = (sourcegraphURL: string): React.FunctionComponent<{ id: string }> => props => {
+    const extensionURL = new URL(sourcegraphURL)
     extensionURL.pathname = `extensions/${props.id}`
     return <a href={extensionURL.href}>{props.id}</a>
 }
@@ -28,7 +28,7 @@ export const GlobalDebug: React.FunctionComponent<Props> = props => (
                     <ExtensionStatusPopover
                         location={props.location}
                         extensionsController={props.extensionsController}
-                        link={ExtensionLink}
+                        link={makeExtensionLink(props.sourcegraphURL)}
                         platformContext={props.platformContext}
                     />
                 </ShortcutProvider>

--- a/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
@@ -5,7 +5,7 @@ import { IFileDiffConnection } from '../../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { queryRepositoryComparisonFileDiffs } from '../backend/diffs'
 import { OpenDiffInSourcegraphProps } from '../repo'
-import { getPlatformName, sourcegraphUrl } from '../util/context'
+import { getPlatformName } from '../util/context'
 import { SourcegraphIconButton } from './Button'
 
 interface Props extends PlatformContextProps<'requestGraphQL'> {
@@ -81,7 +81,7 @@ export class OpenDiffOnSourcegraph extends React.Component<Props, State> {
     }
 
     private getOpenInSourcegraphUrl(props: OpenDiffInSourcegraphProps): string {
-        const baseUrl = sourcegraphUrl
+        const baseUrl = props.sourcegraphURL
         const url = `${baseUrl}/${props.repoName}`
         const urlToCommit = `${url}/-/compare/${props.commit.baseRev}...${
             props.commit.headRev

--- a/client/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { OpenInSourcegraphProps } from '../repo'
-import { getPlatformName, sourcegraphUrl } from '../util/context'
+import { getPlatformName } from '../util/context'
 import { SourcegraphIconButton } from './Button'
 
 interface Props {
@@ -25,7 +25,7 @@ export class OpenOnSourcegraph extends React.Component<Props, {}> {
     }
 
     private getOpenInSourcegraphUrl(props: OpenInSourcegraphProps): string {
-        const baseUrl = sourcegraphUrl
+        const baseUrl = props.sourcegraphURL
         // Build URL for Web
         let url = `${baseUrl}/${props.repoName}`
         if (props.commit) {

--- a/client/browser/src/shared/repo/index.tsx
+++ b/client/browser/src/shared/repo/index.tsx
@@ -4,6 +4,7 @@ export interface DiffResolvedRevSpec {
 }
 
 export interface OpenInSourcegraphProps {
+    sourcegraphURL: string
     repoName: string
     rev: string
     filePath?: string

--- a/client/browser/src/shared/util/context.tsx
+++ b/client/browser/src/shared/util/context.tsx
@@ -4,8 +4,8 @@ import { observeStorageKey } from '../../browser/storage'
 
 export const DEFAULT_SOURCEGRAPH_URL = 'https://sourcegraph.com'
 
-export function observeSourcegraphURL(): Observable<string> {
-    if (window.SG_ENV === 'EXTENSION') {
+export function observeSourcegraphURL(isExtension: boolean): Observable<string> {
+    if (isExtension) {
         return observeStorageKey('sync', 'sourcegraphURL').pipe(
             map(sourcegraphURL => sourcegraphURL || DEFAULT_SOURCEGRAPH_URL)
         )

--- a/client/browser/src/shared/util/context.tsx
+++ b/client/browser/src/shared/util/context.tsx
@@ -1,32 +1,19 @@
 import { Observable, of } from 'rxjs'
-import { observeStorageKey, storage } from '../../browser/storage'
+import { map } from 'rxjs/operators'
+import { observeStorageKey } from '../../browser/storage'
 
 export const DEFAULT_SOURCEGRAPH_URL = 'https://sourcegraph.com'
 
-export let sourcegraphUrl =
-    window.localStorage.getItem('SOURCEGRAPH_URL') || window.SOURCEGRAPH_URL || DEFAULT_SOURCEGRAPH_URL
-
-if (window.SG_ENV === 'EXTENSION' && globalThis.browser) {
-    // tslint:disable-next-line: no-floating-promises TODO just get rid of the global sourcegraphUrl
-    storage.sync.get().then(items => {
-        if (items.sourcegraphURL) {
-            sourcegraphUrl = items.sourcegraphURL
-        }
-    })
-}
-
-export function observeSourcegraphURL(): Observable<string | undefined> {
+export function observeSourcegraphURL(): Observable<string> {
     if (window.SG_ENV === 'EXTENSION') {
-        return observeStorageKey('sync', 'sourcegraphURL')
+        return observeStorageKey('sync', 'sourcegraphURL').pipe(
+            map(sourcegraphURL => sourcegraphURL || DEFAULT_SOURCEGRAPH_URL)
+        )
     }
-    return of(sourcegraphUrl)
+    return of(window.SOURCEGRAPH_URL || window.localStorage.getItem('SOURCEGRAPH_URL') || DEFAULT_SOURCEGRAPH_URL)
 }
 
-export function setSourcegraphUrl(url: string): void {
-    sourcegraphUrl = url
-}
-
-export function isSourcegraphDotCom(url: string = sourcegraphUrl): boolean {
+export function isSourcegraphDotCom(url: string): boolean {
     return url === DEFAULT_SOURCEGRAPH_URL
 }
 

--- a/client/browser/src/shared/util/url.test.ts
+++ b/client/browser/src/shared/util/url.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SOURCEGRAPH_URL } from './context'
 import { toAbsoluteBlobURL } from './url'
 
 describe('toAbsoluteBlobURL', () => {
@@ -7,40 +8,22 @@ describe('toAbsoluteBlobURL', () => {
         commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
         filePath: 'mux.go',
     }
-    // const cache = {
-    //     [ctx.repoName]: 'https://sourcegraph.private.org',
-    // }
+
     test('default sourcegraph URL, default context', () => {
-        expect(toAbsoluteBlobURL(ctx)).toBe('https://sourcegraph.com/github.com/gorilla/mux/-/blob/mux.go')
+        expect(toAbsoluteBlobURL(DEFAULT_SOURCEGRAPH_URL, ctx)).toBe(
+            'https://sourcegraph.com/github.com/gorilla/mux/-/blob/mux.go'
+        )
     })
 
     test('default sourcegraph URL, specified rev', () => {
-        expect(toAbsoluteBlobURL({ ...ctx, rev: 'branch' })).toBe(
+        expect(toAbsoluteBlobURL(DEFAULT_SOURCEGRAPH_URL, { ...ctx, rev: 'branch' })).toBe(
             'https://sourcegraph.com/github.com/gorilla/mux@branch/-/blob/mux.go'
         )
     })
 
     test('default sourcegraph URL, with position', () => {
-        expect(toAbsoluteBlobURL({ ...ctx, position: { line: 1, character: 1 } })).toBe(
+        expect(toAbsoluteBlobURL(DEFAULT_SOURCEGRAPH_URL, { ...ctx, position: { line: 1, character: 1 } })).toBe(
             'https://sourcegraph.com/github.com/gorilla/mux/-/blob/mux.go#L1:1'
         )
     })
-
-    // test('sourcegraph URL from cache, default context', () => {
-    //     expect(toAbsoluteBlobURL(ctx, cache)).toBe(
-    //         'https://sourcegraph.private.org/github.com/gorilla/mux/-/blob/mux.go'
-    //     )
-    // })
-
-    // test('sourcegraph URL from cache, specified rev', () => {
-    //     expect(toAbsoluteBlobURL({ ...ctx, rev: 'branch' }, cache)).toBe(
-    //         'https://sourcegraph.private.org/github.com/gorilla/mux@branch/-/blob/mux.go'
-    //     )
-    // })
-
-    // test('sourcegraph URL from cache, with position', () => {
-    //     expect(toAbsoluteBlobURL({ ...ctx, position: { line: 1, character: 1 } }, cache)).toBe(
-    //         'https://sourcegraph.private.org/github.com/gorilla/mux/-/blob/mux.go#L1:1'
-    //     )
-    // })
 })

--- a/client/browser/src/shared/util/url.ts
+++ b/client/browser/src/shared/util/url.ts
@@ -6,15 +6,15 @@ import {
     toPrettyBlobURL,
     ViewStateSpec,
 } from '../../../../../shared/src/util/url'
-import { sourcegraphUrl } from './context'
 
 /**
  * Returns an absolute URL to the blob (file) on the Sourcegraph instance.
  */
 export function toAbsoluteBlobURL(
+    sourcegraphURL: string,
     ctx: RepoSpec & RevSpec & FileSpec & Partial<PositionSpec> & Partial<ViewStateSpec>
 ): string {
     // toPrettyBlobURL() always returns an URL starting with a forward slash,
     // no need to add one here
-    return `${sourcegraphUrl.replace(/\/$/, '')}${toPrettyBlobURL(ctx)}`
+    return `${sourcegraphURL.replace(/\/$/, '')}${toPrettyBlobURL(ctx)}`
 }


### PR DESCRIPTION
Refactors the browser extension code to either inject the sourcegraphURL, or observe it directly from sync storage / local storage / `window.SOURCEGRAPH_URL`.


#### Test Plan

##### Code Hosts

- [x] GitHub
- [ ] GitHub Enterprise
- [ ] Refined GitHub
- [ ] Phabricator
- [x] Phabricator integration
- [ ] Bitbucket
- [ ] Gitlab

##### Browsers

- [x] Chrome
- [x] Firefox
