### PR TITLE
update storybooks to point to correct module filenames

### DIFF
--- a/browser/src/libs/options/OptionsHeader.story.tsx
+++ b/browser/src/libs/options/OptionsHeader.story.tsx
@@ -5,7 +5,7 @@ import { storiesOf } from '@storybook/react'
 import '../../app.scss'
 
 import { action } from '@storybook/addon-actions'
-import { OptionsHeader } from './Header'
+import { OptionsHeader } from './OptionsHeader'
 
 storiesOf('Options - OptionsHeader', module).add('Default', () => (
     <div style={{ maxWidth: 400 }}>

--- a/browser/src/libs/options/OptionsMenu.story.tsx
+++ b/browser/src/libs/options/OptionsMenu.story.tsx
@@ -5,7 +5,7 @@ import { storiesOf } from '@storybook/react'
 
 import '../../app.scss'
 
-import { OptionsMenu } from './Menu'
+import { OptionsMenu } from './OptionsMenu'
 
 // tslint:disable: jsx-no-lambda
 


### PR DESCRIPTION
#3839 got merged before #3841, thus requiring this change (the storybooks' underlying modules were renamed)
