### PR TITLE
feat: log external services in pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Kinds of external services in use are now included in server pings (https://docs.sourcegraph.com/admin/pings).
+
 ### Removed
 
 ### Fixed

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -130,6 +130,11 @@ func updateURL(ctx context.Context) string {
 		logFunc("db.UserEmails.GetInitialSiteAdminEmail failed", "error", err)
 	}
 	q.Set("initAdmin", initAdminEmail)
+	svcs, err := externalServiceKinds()
+	if err != nil {
+		logFunc("externalServicesKinds failed", "error", err)
+	}
+	q.Set("extsvcs", strings.Join(svcs, ","))
 	return baseURL.ResolveReference(&url.URL{RawQuery: q.Encode()}).String()
 }
 
@@ -142,6 +147,18 @@ func authProviderTypes() []string {
 	return types
 }
 
+func externalServiceKinds() ([]string, error) {
+	services, err := db.ExternalServices.List(context.Background(), db.ExternalServicesListOptions{Kinds: []string{}})
+	if err != nil {
+		return nil, err
+	}
+	kinds := make([]string, len(services))
+	for i, s := range services {
+		kinds[i] = s.Kind
+	}
+	return kinds, nil
+}
+
 // check performs an update check. It returns the result and updates the global state
 // (returned by Last and IsPending).
 func check(ctx context.Context) (*Status, error) {
@@ -151,7 +168,6 @@ func check(ctx context.Context) (*Status, error) {
 			return "", err
 		}
 		defer resp.Body.Close()
-
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 			var description string
 			if body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 30)); err != nil {

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -130,7 +130,7 @@ func updateURL(ctx context.Context) string {
 		logFunc("db.UserEmails.GetInitialSiteAdminEmail failed", "error", err)
 	}
 	q.Set("initAdmin", initAdminEmail)
-	svcs, err := externalServiceKinds()
+	svcs, err := externalServiceKinds(ctx)
 	if err != nil {
 		logFunc("externalServicesKinds failed", "error", err)
 	}
@@ -147,8 +147,8 @@ func authProviderTypes() []string {
 	return types
 }
 
-func externalServiceKinds() ([]string, error) {
-	services, err := db.ExternalServices.List(context.Background(), db.ExternalServicesListOptions{Kinds: []string{}})
+func externalServiceKinds(ctx context.Context) ([]string, error) {
+	services, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -143,6 +143,7 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 	q := r.URL.Query()
 	clientSiteID := q.Get("site")
 	authProviders := q.Get("auth")
+	externalServices := q.Get("extsvcs")
 	builtinSignupAllowed := q.Get("signup")
 	hasExtURL := q.Get("hasExtURL")
 	uniqueUsers := q.Get("u")
@@ -177,6 +178,7 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		"site_activity": %s,
 		"installer_email": "%s",
 		"auth_providers": "%s",
+		"ext_services": "%s",
 		"builtin_signup_allowed": "%s",
 		"deploy_type": "%s",
 		"total_user_accounts": "%s",
@@ -194,6 +196,7 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 		activity,
 		initialAdminEmail,
 		authProviders,
+		externalServices,
 		builtinSignupAllowed,
 		deployType,
 		totalUsers,

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -7,7 +7,8 @@ Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and
 - Whether the instance is deployed on localhost (true/false)
 - Randomly generated site identifier
 - The email address of the initial site installer (or if deleted, the first active site admin), to know who to contact regarding sales, product updates, and policy updates
-- Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, or SAML)
+- Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, SAML, GitHub, GitLab)
+- Which categories of external service are in use (GitHub, Bitbucket Server, GitLab, Phabricator, Gitolite, AWS CodeCommit, Other)
 - Whether new user signup is allowed (true/false)
 - Whether a repository has ever been added (true/false)
 - Whether a code search has ever been executed (true/false)

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -50,6 +50,10 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                         Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, or
                         SAML)
                     </li>
+                    <li>
+                        Which categories of external service are in use (GitHub, Bitbucket Server, GitLab, Phabricator,
+                        Gitolite, AWS CodeCommit, Other)
+                    </li>
                     <li>Whether new user signup is allowed (true/false)</li>
                     <li>Whether a repository has ever been added (true/false)</li>
                     <li>Whether a code search has ever been executed (true/false)</li>

--- a/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -47,8 +47,8 @@ export class SiteAdminPingsPage extends React.Component<Props, State> {
                         know who to contact regarding sales, product updates, and policy updates
                     </li>
                     <li>
-                        Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy, or
-                        SAML)
+                        Which category of authentication provider is in use (built-in, OpenID Connect, an HTTP proxy,
+                        SAML, GitHub, GitLab)
                     </li>
                     <li>
                         Which categories of external service are in use (GitHub, Bitbucket Server, GitLab, Phabricator,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/3820
See context in https://github.com/sourcegraph/sourcegraph/pull/3676#issuecomment-489182738

Safe to say that [`ExternalService.Kind`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/types/types.go#L41:2) wouldn't ever contain any sensitive data, correct?

Tested locally.