### PR TITLE
repo-updater: Use original metadata object in Exclude

### DIFF
--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -60,8 +60,11 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 			ServiceType: "github",
 			ServiceID:   "http://github.com",
 		},
-		Sources:  map[string]*repos.SourceInfo{},
-		Metadata: new(github.Repository),
+		Sources: map[string]*repos.SourceInfo{},
+		Metadata: &github.Repository{
+			ID:            "bar",
+			NameWithOwner: "foo/bar",
+		},
 	}
 
 	gitlabService := repos.ExternalService{
@@ -85,8 +88,13 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 			ServiceType: "gitlab",
 			ServiceID:   "http://gitlab.com",
 		},
-		Sources:  map[string]*repos.SourceInfo{},
-		Metadata: new(gitlab.Project),
+		Sources: map[string]*repos.SourceInfo{},
+		Metadata: &gitlab.Project{
+			ProjectCommon: gitlab.ProjectCommon{
+				ID:                1,
+				PathWithNamespace: "foo/bar",
+			},
+		},
 	}
 
 	bitbucketServerService := repos.ExternalService{
@@ -111,8 +119,14 @@ func testEnabledStateDeprecationMigration(store repos.Store) func(*testing.T) {
 			ServiceType: "bitbucketServer",
 			ServiceID:   "http://bitbucketserver.mycorp.com",
 		},
-		Sources:  map[string]*repos.SourceInfo{},
-		Metadata: new(bitbucketserver.Repo),
+		Sources: map[string]*repos.SourceInfo{},
+		Metadata: &bitbucketserver.Repo{
+			ID:   1,
+			Slug: "bar",
+			Project: &bitbucketserver.Project{
+				Key: "foo",
+			},
+		},
 	}
 
 	var testCases []testCase

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -102,32 +102,15 @@ func (e *ExternalService) Exclude(rs ...*Repo) error {
 	case "bitbucketserver":
 		return e.excludeBitbucketServerRepos(rs...)
 	case "other":
-		return e.updateOtherRepos(false, rs...)
+		return e.excludeOtherRepos(rs...)
 	default:
 		return errors.Errorf("external service kind %q doesn't have an exclude list", e.Kind)
 	}
 }
 
-// Include changes the configuration of an external service to explicitly enlist the
-// given repos to be synced.
-func (e *ExternalService) Include(rs ...*Repo) error {
-	switch strings.ToLower(e.Kind) {
-	case "github":
-		return e.includeGithubRepos(rs...)
-	case "gitlab":
-		return e.includeGitLabRepos(rs...)
-	case "bitbucketserver":
-		return e.includeBitbucketServerRepos(rs...)
-	case "other":
-		return e.updateOtherRepos(true, rs...)
-	default:
-		return errors.Errorf("external service kind %q doesn't have an include list", e.Kind)
-	}
-}
-
-// updateOtherRepos changes the configuration of an OTHER external service to exclude
-// or include the given repos.
-func (e *ExternalService) updateOtherRepos(include bool, rs ...*Repo) error {
+// excludeOtherRepos changes the configuration of an OTHER external service to exclude
+// the given repos.
+func (e *ExternalService) excludeOtherRepos(rs ...*Repo) error {
 	if len(rs) == 0 {
 		return nil
 	}
@@ -174,11 +157,7 @@ func (e *ExternalService) updateOtherRepos(include bool, rs ...*Repo) error {
 				name = nameWithOwner(r.Name)
 			}
 
-			if include {
-				set[name] = true
-			} else {
-				delete(set, name)
-			}
+			delete(set, name)
 		}
 
 		repos := make([]string, 0, len(set))
@@ -344,102 +323,6 @@ func nameWithOwner(name string) string {
 		name = strings.TrimPrefix(u.Path, "/")
 	}
 	return strings.ToLower(name)
-}
-
-// includeGithubRepos changes the configuration of a Github external service to explicitly enlist the
-// given repos to be synced.
-func (e *ExternalService) includeGithubRepos(rs ...*Repo) error {
-	if len(rs) == 0 {
-		return nil
-	}
-
-	return e.config("github", func(v interface{}) (string, interface{}, error) {
-		c := v.(*schema.GitHubConnection)
-
-		set := make(map[string]bool, len(c.Repos))
-		for _, name := range c.Repos {
-			set[strings.ToLower(name)] = true
-		}
-
-		for _, r := range rs {
-			if r.ExternalRepo.ServiceType != "github" {
-				continue
-			}
-
-			if name := nameWithOwner(r.Name); !set[name] {
-				c.Repos = append(c.Repos, name)
-				set[name] = true
-			}
-		}
-
-		return "repos", c.Repos, nil
-	})
-}
-
-// includeGitLabRepos changes the configuration of a GitLab external service to explicitly enlist the
-// given repos to be synced.
-func (e *ExternalService) includeGitLabRepos(rs ...*Repo) error {
-	if len(rs) == 0 {
-		return nil
-	}
-
-	return e.config("gitlab", func(v interface{}) (string, interface{}, error) {
-		c := v.(*schema.GitLabConnection)
-
-		set := make(map[string]bool, len(c.Projects))
-		for _, p := range c.Projects {
-			set[p.Name] = true
-			set[strconv.Itoa(p.Id)] = true
-		}
-
-		for _, r := range rs {
-			if r.ExternalRepo.ServiceType != "gitlab" {
-				continue
-			}
-
-			if name := nameWithOwner(r.Name); !set[name] && !set[r.ExternalRepo.ID] {
-				n, _ := strconv.Atoi(r.ExternalRepo.ID)
-				c.Projects = append(c.Projects, &schema.GitLabProject{
-					Name: name,
-					Id:   n,
-				})
-				set[name] = true
-				set[r.ExternalRepo.ID] = true
-			}
-		}
-
-		return "projects", c.Projects, nil
-	})
-}
-
-// includeBitbucketServerRepos changes the configuration of a BitbucketServer external service to explicitly enlist the
-// given repos to be synced.
-func (e *ExternalService) includeBitbucketServerRepos(rs ...*Repo) error {
-	if len(rs) == 0 {
-		return nil
-	}
-
-	return e.config("bitbucketserver", func(v interface{}) (string, interface{}, error) {
-		c := v.(*schema.BitbucketServerConnection)
-
-		set := make(map[string]bool, len(c.Repos))
-		for _, name := range c.Repos {
-			set[strings.ToLower(name)] = true
-		}
-
-		for _, r := range rs {
-			if strings.ToLower(r.ExternalRepo.ServiceType) != "bitbucketserver" {
-				continue
-			}
-
-			if name := nameWithOwner(r.Name); !set[name] {
-				c.Repos = append(c.Repos, name)
-				set[name] = true
-			}
-		}
-
-		return "repos", c.Repos, nil
-	})
 }
 
 func (e *ExternalService) config(kind string, opt func(c interface{}) (string, interface{}, error)) error {

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
 )
 
-func TestExternalService_IncludeExclude(t *testing.T) {
+func TestExternalService_Exclude(t *testing.T) {
 	now := time.Now()
 
 	type testCase struct {
-		method string
 		name   string
 		svcs   ExternalServices
 		repos  Repos
@@ -180,7 +179,6 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 		}
 
 		testCases = append(testCases, testCase{
-			method: "exclude",
 			name:   "already excluded repos are ignored",
 			svcs:   svcs,
 			repos:  repos,
@@ -240,10 +238,9 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 		}
 
 		testCases = append(testCases, testCase{
-			method: "exclude",
-			name:   "repos are excluded",
-			svcs:   svcs,
-			repos:  repos,
+			name:  "repos are excluded",
+			svcs:  svcs,
+			repos: repos,
 			assert: Assert.ExternalServicesEqual(
 				github.With(func(e *ExternalService) {
 					e.Config = formatJSON(t, `
@@ -300,181 +297,6 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 			),
 		})
 	}
-	{
-		svcs := ExternalServices{
-			github.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-					{
-						// Some comment
-						"url": "https://github.com",
-						"token": "secret",
-						"repositoryQuery": ["none"],
-						"repos": [
-							"org/FOO",
-							"org/baz"
-						]
-					}`)
-			}),
-			gitlab.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-				{
-					// Some comment
-					"url": "https://gitlab.com",
-					"token": "secret",
-					"projectQuery": ["none"],
-					"projects": [
-						{"id": 1},
-						{"name": "org/baz"}
-					]
-				}`)
-			}),
-			bitbucketServer.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-				{
-					// Some comment
-					"url": "https://bitbucketserver.mycorp.com",
-					"username": "admin",
-					"token": "secret",
-					"repositoryQuery": ["none"],
-					"repos": [
-						"org/FOO",
-						"org/baz"
-					]
-				}`)
-			}),
-			otherService.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-				{
-					"repos": [
-						"https://git-host.mycorp.com/org/baz",
-						"https://git-host.mycorp.com/org/foo"
-					]
-				}`)
-			}),
-		}
-
-		testCases = append(testCases, testCase{
-			method: "include",
-			name:   "already included repos are ignored",
-			svcs:   svcs,
-			repos:  repos,
-			assert: Assert.ExternalServicesEqual(svcs...),
-		})
-	}
-
-	{
-		svcs := ExternalServices{
-			github.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-				{
-					// Some comment
-					"url": "https://github.com",
-					"token": "secret",
-					"repositoryQuery": ["none"],
-					"repos": [
-						"org/boo"
-					]
-				}`)
-			}),
-			gitlab.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-				{
-					// Some comment
-					"url": "https://gitlab.com",
-					"token": "secret",
-					"projectQuery": ["none"],
-					"projects": [
-						{"name": "org/boo"},
-					]
-				}`)
-			}),
-			bitbucketServer.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-				{
-					// Some comment
-					"url": "https://bitbucketserver.mycorp.com",
-					"username": "admin",
-					"token": "secret",
-					"repositoryQuery": ["none"],
-					"repos": [
-						"org/boo"
-					]
-				}`)
-			}),
-			otherService.With(func(e *ExternalService) {
-				e.Config = formatJSON(t, `
-				{
-					"url": "https://git-host.mycorp.com",
-					"repos": [
-						"org/boo"
-					]
-				}`)
-			}),
-		}
-
-		testCases = append(testCases, testCase{
-			method: "include",
-			name:   "repos are included",
-			svcs:   svcs,
-			repos:  repos,
-			assert: Assert.ExternalServicesEqual(
-				github.With(func(e *ExternalService) {
-					e.Config = formatJSON(t, `
-					{
-						// Some comment
-						"url": "https://github.com",
-						"token": "secret",
-						"repositoryQuery": ["none"],
-						"repos": [
-							"org/boo",
-							"org/foo",
-							"org/baz"
-						]
-					}`)
-				}),
-				gitlab.With(func(e *ExternalService) {
-					e.Config = formatJSON(t, `
-					{
-						// Some comment
-						"url": "https://gitlab.com",
-						"token": "secret",
-						"projectQuery": ["none"],
-						"projects": [
-							{"name": "org/boo"},
-							{"id": 1, "name": "org/foo"},
-							{"name": "org/baz"}
-						]
-					}`)
-				}),
-				bitbucketServer.With(func(e *ExternalService) {
-					e.Config = formatJSON(t, `
-					{
-						// Some comment
-						"url": "https://bitbucketserver.mycorp.com",
-						"username": "admin",
-						"token": "secret",
-						"repositoryQuery": ["none"],
-						"repos": [
-							"org/boo",
-							"org/foo",
-							"org/baz"
-						]
-					}`)
-				}),
-				otherService.With(func(e *ExternalService) {
-					e.Config = formatJSON(t, `
-					{
-						"url": "https://git-host.mycorp.com",
-						"repos": [
-							"org/baz",
-							"org/boo",
-							"org/foo"
-						]
-					}`)
-				}),
-			),
-		})
-	}
 
 	for _, tc := range testCases {
 		tc := tc
@@ -483,14 +305,7 @@ func TestExternalService_IncludeExclude(t *testing.T) {
 
 			var err error
 			for _, svc := range svcs {
-				switch tc.method {
-				case "include":
-					err = svc.Include(repos...)
-				case "exclude":
-					err = svc.Exclude(repos...)
-				}
-
-				if err != nil {
+				if err = svc.Exclude(repos...); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -269,8 +269,11 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 			ServiceType: "github",
 			ServiceID:   "http://github.com",
 		},
-		Sources:  map[string]*repos.SourceInfo{},
-		Metadata: new(github.Repository),
+		Sources: map[string]*repos.SourceInfo{},
+		Metadata: &github.Repository{
+			ID:            "bar",
+			NameWithOwner: "foo/bar",
+		},
 	}).With(repos.Opt.RepoSources(githubService.URN()))
 
 	gitlabService := &repos.ExternalService{
@@ -294,8 +297,13 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 			ServiceType: "gitlab",
 			ServiceID:   "http://gitlab.com",
 		},
-		Sources:  map[string]*repos.SourceInfo{},
-		Metadata: new(gitlab.Project),
+		Sources: map[string]*repos.SourceInfo{},
+		Metadata: &gitlab.Project{
+			ProjectCommon: gitlab.ProjectCommon{
+				ID:                1,
+				PathWithNamespace: "foo/bar",
+			},
+		},
 	}).With(repos.Opt.RepoSources(gitlabService.URN()))
 
 	bitbucketServerService := &repos.ExternalService{
@@ -320,8 +328,14 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 			ServiceType: "bitbucketServer",
 			ServiceID:   "http://bitbucketserver.mycorp.com",
 		},
-		Sources:  map[string]*repos.SourceInfo{},
-		Metadata: new(bitbucketserver.Repo),
+		Sources: map[string]*repos.SourceInfo{},
+		Metadata: &bitbucketserver.Repo{
+			ID:   1,
+			Slug: "bar",
+			Project: &bitbucketserver.Project{
+				Key: "foo",
+			},
+		},
 	}).With(repos.Opt.RepoSources(bitbucketServerService.URN()))
 
 	type testCase struct {


### PR DESCRIPTION
This change set removes our unused `ExternalService.Include` code and makes `ExternalService.Exclude` extract the names and IDs to add to the exclude list from the metadata object, instead of trying to extract it from the repo name which is unreliable in the case of a `repositoryPathPattern` being set to something non-standard.

Test plan: go test