### PR TITLE
GitHub authz: fetch repository permissions in batches of 100

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/github/github_cache_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_cache_test.go
@@ -26,11 +26,13 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 	})
 	github.GetRepositoryByNodeIDMock = githubMock.GetRepositoryByNodeID
 	defer func() { github.GetRepositoryByNodeIDMock = nil }()
+	github.GetRepositoriesByNodeIDFromAPIMock = githubMock.GetRepositoriesByNodeIDFromAPI
+	defer func() { github.GetRepositoriesByNodeIDFromAPIMock = nil }()
 
 	provider := NewProvider(mustURL(t, "https://github.com"), "base-token", 3*time.Hour, make(authz.MockCache))
 	ctx := context.Background()
 
-	githubMock.getRepositoryByNodeIDCount = 0
+	githubMock.getRepositoriesByNodeIDCount = 0
 	userAccount := ua("u0", "t0")
 	repos := map[authz.Repo]struct{}{
 		rp("r0", "u0/r0", "https://github.com/"):     {},
@@ -52,10 +54,10 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 			t.Errorf("wantPerms != gotPerms:\n%s",
 				dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(wantPerms), spew.Sdump(gotPerms), false)))
 		}
-		if want, got := 3, githubMock.getRepositoryByNodeIDCount; want != got {
+		if want, got := 1, githubMock.getRepositoriesByNodeIDCount; want != got {
 			t.Errorf("expected %d cache misses, but got %d", want, got)
 		}
-		githubMock.getRepositoryByNodeIDCount = 0
+		githubMock.getRepositoriesByNodeIDCount = 0
 	}
 	{
 		gotPerms, gotErr := provider.RepoPerms(ctx, userAccount, repos)
@@ -67,10 +69,10 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 			t.Errorf("wantPerms != gotPerms:\n%s",
 				dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(wantPerms), spew.Sdump(gotPerms), false)))
 		}
-		if want, got := 0, githubMock.getRepositoryByNodeIDCount; want != got {
+		if want, got := 0, githubMock.getRepositoriesByNodeIDCount; want != got {
 			t.Errorf("expected %d cache misses, but got %d", want, got)
 		}
-		githubMock.getRepositoryByNodeIDCount = 0
+		githubMock.getRepositoriesByNodeIDCount = 0
 	}
 
 	provider.cacheTTL = 1 * time.Hour // lower cache TTL
@@ -84,9 +86,9 @@ func TestProvider_RepoPerms_cacheTTL(t *testing.T) {
 			t.Errorf("wantPerms != gotPerms:\n%s",
 				dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(wantPerms), spew.Sdump(gotPerms), false)))
 		}
-		if want, got := 3, githubMock.getRepositoryByNodeIDCount; want != got {
+		if want, got := 1, githubMock.getRepositoriesByNodeIDCount; want != got {
 			t.Errorf("expected %d cache misses, but got %d", want, got)
 		}
-		githubMock.getRepositoryByNodeIDCount = 0
+		githubMock.getRepositoriesByNodeIDCount = 0
 	}
 }

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -46,6 +46,8 @@ func (p *Provider_RepoPerms_Test) run(t *testing.T) {
 	})
 	github.GetRepositoryByNodeIDMock = githubMock.GetRepositoryByNodeID
 	defer func() { github.GetRepositoryByNodeIDMock = nil }()
+	github.GetRepositoriesByNodeIDFromAPIMock = githubMock.GetRepositoriesByNodeIDFromAPI
+	defer func() { github.GetRepositoriesByNodeIDFromAPIMock = nil }()
 
 	provider := NewProvider(p.githubURL, "base-token", p.cacheTTL, make(authz.MockCache))
 	for j := 0; j < 2; j++ { // run twice for cache coherency
@@ -283,6 +285,9 @@ type mockGitHub struct {
 
 	// getRepositoryByNodeIDCount tracks the number of times GetRepositoryByNodeID is called
 	getRepositoryByNodeIDCount int
+
+	// getRepositoriesByNodeIDCount tracks the number of times GetRepositoriesByNodeIDFromAPI is called
+	getRepositoriesByNodeIDCount int
 }
 
 func newMockGitHub(repos []*github.Repository, tokenRepos map[string][]string) *mockGitHub {
@@ -339,6 +344,8 @@ func (m *mockGitHub) GetRepositoryByNodeID(ctx context.Context, token, id string
 }
 
 func (m *mockGitHub) GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*github.Repository, error) {
+	m.getRepositoriesByNodeIDCount++
+
 	repos := make(map[string]*github.Repository)
 	for rid := range m.PublicRepos {
 		repos[rid] = m.Repos[rid]

--- a/pkg/extsvc/github/client.go
+++ b/pkg/extsvc/github/client.go
@@ -252,6 +252,7 @@ func (c *Client) requestGraphQL(ctx context.Context, token, query string, vars m
 	if err != nil {
 		return err
 	}
+
 	req, err := http.NewRequest("POST", "/graphql", bytes.NewReader(reqBody))
 	if err != nil {
 		return err
@@ -263,15 +264,19 @@ func (c *Client) requestGraphQL(ctx context.Context, token, query string, vars m
 	if err := c.do(ctx, token, req, &respBody); err != nil {
 		return err
 	}
+
+	// If the GraphQL response has errors, still attempt to unmarshal the data portion, as some
+	// requests may expect errors but have useful responses (e.g., querying a list of repositories,
+	// some of which you expect to 404).
 	if len(respBody.Errors) > 0 {
-		return respBody.Errors
+		err = respBody.Errors
 	}
 	if result != nil && respBody.Data != nil {
-		if err := unmarshal(respBody.Data, result); err != nil {
-			return err
+		if err0 := unmarshal(respBody.Data, result); err0 != nil && err == nil {
+			return err0
 		}
 	}
-	return nil
+	return err
 }
 
 // unmarshal wraps json.Unmarshal, but includes extra context in the case of
@@ -352,9 +357,9 @@ func IsRateLimitExceeded(err error) bool {
 // graphqlErrors describes the errors in a GraphQL response. It contains at least 1 element when returned by
 // requestGraphQL. See https://facebook.github.io/graphql/#sec-Errors.
 type graphqlErrors []struct {
-	Message   string   `json:"message"`
-	Type      string   `json:"type"`
-	Path      []string `json:"path"`
+	Message   string        `json:"message"`
+	Type      string        `json:"type"`
+	Path      []interface{} `json:"path"`
 	Locations []struct {
 		Line   int `json:"line"`
 		Column int `json:"column"`

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -325,7 +325,12 @@ query Repository($id: ID!) {
 	return result.Node, nil
 }
 
-const MaxNodeIDs = 100
+// MaxNodeIDs is the maximum number of repository nodes that can be queried in one call to the
+// GitHub GraphQL API.
+var MaxNodeIDs = 100
+
+// GetRepositoryByNodeIDMock is set by tests to mock (*Client).GetRepositoryByNodeID.
+var GetRepositoriesByNodeIDFromAPIMock func(ctx context.Context, token string, nodeIDs []string) (map[string]*Repository, error)
 
 // GetRepositoriesByNodeIDFromAPI fetches the specified repositories (nodeIDs) and returns a map
 // from node ID to repository metadata. If a repository is not found, it will not be present in the
@@ -333,6 +338,10 @@ const MaxNodeIDs = 100
 // time of writing, is 100 (if the caller does not respect this match, this method will return an
 // error). This method does not cache.
 func (c *Client) GetRepositoriesByNodeIDFromAPI(ctx context.Context, token string, nodeIDs []string) (map[string]*Repository, error) {
+	if GetRepositoriesByNodeIDFromAPIMock != nil {
+		return GetRepositoriesByNodeIDFromAPIMock(ctx, token, nodeIDs)
+	}
+
 	var result struct {
 		Nodes []*Repository
 	}

--- a/pkg/extsvc/github/repos_test.go
+++ b/pkg/extsvc/github/repos_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
 	"github.com/sourcegraph/sourcegraph/pkg/ratelimit"
 	"github.com/sourcegraph/sourcegraph/pkg/rcache"
@@ -131,8 +133,13 @@ func TestClient_GetRepository(t *testing.T) {
 }
 
 func TestClient_GetRepositoriesByNodeFromAPI(t *testing.T) {
-	mock := mockHTTPResponseBody{
-		responseBody: `
+	tests := []struct {
+		responseBody string
+		want         map[string]*Repository
+		nodeIDs      []string
+	}{
+		{
+			responseBody: `
 {
   "data": {
     "nodes": [
@@ -160,34 +167,100 @@ func TestClient_GetRepositoriesByNodeFromAPI(t *testing.T) {
     ]
   }
 }
-`}
-	c := newTestClient(t, &mock)
-	want := map[string]*Repository{
-		"i0": {
-			ID:            "i0",
-			NameWithOwner: "o/r0",
-			Description:   "d0",
-			URL:           "https://github.example.com/o/r0",
+`,
+			want: map[string]*Repository{
+				"i0": {
+					ID:            "i0",
+					NameWithOwner: "o/r0",
+					Description:   "d0",
+					URL:           "https://github.example.com/o/r0",
+				},
+				"i1": {
+					ID:            "i1",
+					NameWithOwner: "o/r1",
+					Description:   "d1",
+					URL:           "https://github.example.com/o/r1",
+				},
+				"i2": {
+					ID:            "i2",
+					NameWithOwner: "o/r2",
+					Description:   "d2",
+					URL:           "https://github.example.com/o/r2",
+				},
+			},
+			nodeIDs: []string{"i0", "i1", "i2"},
 		},
-		"i1": {
-			ID:            "i1",
-			NameWithOwner: "o/r1",
-			Description:   "d1",
-			URL:           "https://github.example.com/o/r1",
-		},
-		"i2": {
-			ID:            "i2",
-			NameWithOwner: "o/r2",
-			Description:   "d2",
-			URL:           "https://github.example.com/o/r2",
+		{
+			responseBody: `
+{
+  "data": {
+    "nodes": [
+      {
+		"id": "i0",
+		"nameWithOwner": "o/r0",
+		"description": "d0",
+		"url": "https://github.example.com/o/r0",
+		"isFork": false
+      },
+      {
+		"id": "i1",
+		"nameWithOwner": "o/r1",
+		"description": "d1",
+		"url": "https://github.example.com/o/r1",
+		"isFork": false
+      },
+      null
+    ]
+  },
+  "errors": [
+    {
+      "type": "NOT_FOUND",
+      "path": [
+        "nodes",
+        2
+      ],
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "message": "Could not resolve to a node with the global id of 'asdf'"
+    }
+  ]
+}
+`,
+			want: map[string]*Repository{
+				"i0": {
+					ID:            "i0",
+					NameWithOwner: "o/r0",
+					Description:   "d0",
+					URL:           "https://github.example.com/o/r0",
+				},
+				"i1": {
+					ID:            "i1",
+					NameWithOwner: "o/r1",
+					Description:   "d1",
+					URL:           "https://github.example.com/o/r1",
+				},
+			},
+			nodeIDs: []string{"i0", "i1", "asdf"},
 		},
 	}
-	gotRepos, err := c.GetRepositoriesByNodeIDFromAPI(context.Background(), "", []string{"i0", "i1", "i2"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(gotRepos, want) {
-		t.Errorf("got repos %+v, want %+v", gotRepos, want)
+
+	for _, test := range tests {
+		mock := mockHTTPResponseBody{
+			responseBody: test.responseBody,
+		}
+		c := newTestClient(t, &mock)
+		gotRepos, err := c.GetRepositoriesByNodeIDFromAPI(context.Background(), "", test.nodeIDs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(gotRepos, test.want) {
+			dmp := diffmatchpatch.New()
+			t.Error("gotRepos != test.want", dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(test.want), spew.Sdump(gotRepos), false)))
+		}
 	}
 }
 

--- a/pkg/extsvc/github/repos_test.go
+++ b/pkg/extsvc/github/repos_test.go
@@ -130,6 +130,67 @@ func TestClient_GetRepository(t *testing.T) {
 	}
 }
 
+func TestClient_GetRepositoriesByNodeFromAPI(t *testing.T) {
+	mock := mockHTTPResponseBody{
+		responseBody: `
+{
+  "data": {
+    "nodes": [
+      {
+		"id": "i0",
+		"nameWithOwner": "o/r0",
+		"description": "d0",
+		"url": "https://github.example.com/o/r0",
+		"isFork": false
+      },
+      {
+		"id": "i1",
+		"nameWithOwner": "o/r1",
+		"description": "d1",
+		"url": "https://github.example.com/o/r1",
+		"isFork": false
+      },
+      {
+		"id": "i2",
+		"nameWithOwner": "o/r2",
+		"description": "d2",
+		"url": "https://github.example.com/o/r2",
+		"isFork": false
+      }
+    ]
+  }
+}
+`}
+	c := newTestClient(t, &mock)
+	want := map[string]*Repository{
+		"i0": {
+			ID:            "i0",
+			NameWithOwner: "o/r0",
+			Description:   "d0",
+			URL:           "https://github.example.com/o/r0",
+		},
+		"i1": {
+			ID:            "i1",
+			NameWithOwner: "o/r1",
+			Description:   "d1",
+			URL:           "https://github.example.com/o/r1",
+		},
+		"i2": {
+			ID:            "i2",
+			NameWithOwner: "o/r2",
+			Description:   "d2",
+			URL:           "https://github.example.com/o/r2",
+		},
+	}
+	gotRepos, err := c.GetRepositoriesByNodeIDFromAPI(context.Background(), "", []string{"i0", "i1", "i2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotRepos, want) {
+		t.Errorf("got repos %+v, want %+v", gotRepos, want)
+	}
+}
+
 // TestClient_GetRepository_nonexistent tests the behavior of GetRepository when called
 // on a repository that does not exist.
 func TestClient_GetRepository_nonexistent(t *testing.T) {


### PR DESCRIPTION
Partially addresses https://github.com/sourcegraph/sourcegraph/issues/3634

We compute GitHub repository permissions for a given user by attempting to fetch repositories from the GitHub API using the user's GitHub credentials (OAuth token). Prior to this change, one GitHub API request would be issued for each user-repository permission. In the case of a search query on a Sourcegraph instance with 1000s of repositories, this could mean the search result would be blocked on 1000 serial GitHub API requests. This results in a timeout error on the frontend.

This changeset uses the GitHub GraphQL API to fetch repositories in batches of 100 (the max allowed by GitHub) when computing permissions. This partially addresses the performance issue described above.