### PR TITLE
Add tests for GitHub parseUrl()

### DIFF
--- a/browser/src/libs/github/__snapshots__/util.test.ts.snap
+++ b/browser/src/libs/github/__snapshots__/util.test.ts.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`util parseURL() blob page 1`] = `
+Object {
+  "filePath": "shared/src/hover/HoverOverlay.tsx",
+  "ghRepoName": "sourcegraph",
+  "isCodePage": true,
+  "isCommit": false,
+  "isCompare": false,
+  "isDelta": false,
+  "isPullRequest": false,
+  "position": undefined,
+  "repoName": "github.com/sourcegraph/sourcegraph",
+  "rev": "3.3",
+  "user": "sourcegraph",
+}
+`;
+
+exports[`util parseURL() commit page 1`] = `
+Object {
+  "filePath": undefined,
+  "ghRepoName": "sourcegraph",
+  "isCodePage": false,
+  "isCommit": true,
+  "isCompare": false,
+  "isDelta": true,
+  "isPullRequest": false,
+  "position": undefined,
+  "repoName": "github.com/sourcegraph/sourcegraph",
+  "rev": "fb054666c12b40f180c794db4829cbfd1a5fabae",
+  "user": "sourcegraph",
+}
+`;
+
+exports[`util parseURL() compare page 1`] = `
+Object {
+  "filePath": undefined,
+  "ghRepoName": "sourcegraph-basic-code-intel",
+  "isCodePage": false,
+  "isCommit": false,
+  "isCompare": true,
+  "isDelta": true,
+  "isPullRequest": false,
+  "position": undefined,
+  "repoName": "github.com/sourcegraph/sourcegraph-basic-code-intel",
+  "rev": undefined,
+  "user": "sourcegraph",
+}
+`;
+
+exports[`util parseURL() pull request page 1`] = `
+Object {
+  "filePath": undefined,
+  "ghRepoName": "sourcegraph",
+  "isCodePage": false,
+  "isCommit": false,
+  "isCompare": false,
+  "isDelta": true,
+  "isPullRequest": true,
+  "position": undefined,
+  "repoName": "github.com/sourcegraph/sourcegraph",
+  "rev": undefined,
+  "user": "sourcegraph",
+}
+`;
+
+exports[`util parseURL() selections - range 1`] = `
+Object {
+  "filePath": "jest.config.base.js",
+  "ghRepoName": "sourcegraph",
+  "isCodePage": true,
+  "isCommit": false,
+  "isCompare": false,
+  "isDelta": false,
+  "isPullRequest": false,
+  "position": Object {
+    "character": 0,
+    "line": 5,
+  },
+  "repoName": "github.com/sourcegraph/sourcegraph",
+  "rev": "master",
+  "user": "sourcegraph",
+}
+`;
+
+exports[`util parseURL() selections - single line 1`] = `
+Object {
+  "filePath": "jest.config.base.js",
+  "ghRepoName": "sourcegraph",
+  "isCodePage": true,
+  "isCommit": false,
+  "isCompare": false,
+  "isDelta": false,
+  "isPullRequest": false,
+  "position": Object {
+    "character": 0,
+    "line": 5,
+  },
+  "repoName": "github.com/sourcegraph/sourcegraph",
+  "rev": "master",
+  "user": "sourcegraph",
+}
+`;
+
+exports[`util parseURL() tree page 1`] = `
+Object {
+  "filePath": undefined,
+  "ghRepoName": "sourcegraph",
+  "isCodePage": true,
+  "isCommit": false,
+  "isCompare": false,
+  "isDelta": false,
+  "isPullRequest": false,
+  "position": undefined,
+  "repoName": "github.com/sourcegraph/sourcegraph",
+  "rev": "master",
+  "user": "sourcegraph",
+}
+`;

--- a/browser/src/libs/github/util.test.ts
+++ b/browser/src/libs/github/util.test.ts
@@ -1,13 +1,56 @@
-import { parseGitHubHash } from './util'
+import { parseGitHubHash, parseURL } from './util'
 
 describe('util', () => {
     describe('parseGitHubHash()', () => {
-        it('parses nonexistent', () => expect(parseGitHubHash('')).toBe(undefined))
-        it('parses empty', () => expect(parseGitHubHash('#')).toBe(undefined))
-        it('parses single line', () => expect(parseGitHubHash('#L123')).toEqual({ startLine: 123, endLine: undefined }))
-        it('parses range', () => expect(parseGitHubHash('#L123-L456')).toEqual({ startLine: 123, endLine: 456 }))
-        it('handles invalid value', () => expect(parseGitHubHash('#Lfoo')).toBe(undefined))
-        it('allows extra after', () =>
+        test('parses nonexistent', () => expect(parseGitHubHash('')).toBe(undefined))
+        test('parses empty', () => expect(parseGitHubHash('#')).toBe(undefined))
+        test('parses single line', () =>
+            expect(parseGitHubHash('#L123')).toEqual({ startLine: 123, endLine: undefined }))
+        test('parses range', () => expect(parseGitHubHash('#L123-L456')).toEqual({ startLine: 123, endLine: 456 }))
+        test('handles invalid value', () => expect(parseGitHubHash('#Lfoo')).toBe(undefined))
+        test('allows extra after', () =>
             expect(parseGitHubHash('#L123-L456-foo')).toEqual({ startLine: 123, endLine: 456 }))
+    })
+
+    describe('parseURL()', () => {
+        const testcases: {
+            name: string
+            url: string
+        }[] = [
+            {
+                name: 'tree page',
+                url: 'https://github.com/sourcegraph/sourcegraph/tree/master/client',
+            },
+            {
+                name: 'blob page',
+                url: 'https://github.com/sourcegraph/sourcegraph/blob/3.3/shared/src/hover/HoverOverlay.tsx',
+            },
+            {
+                name: 'commit page',
+                url: 'https://github.com/sourcegraph/sourcegraph/commit/fb054666c12b40f180c794db4829cbfd1a5fabae',
+            },
+            {
+                name: 'pull request page',
+                url: 'https://github.com/sourcegraph/sourcegraph/pull/3849',
+            },
+            {
+                name: 'compare page',
+                url:
+                    'https://github.com/sourcegraph/sourcegraph-basic-code-intel/compare/new-extension-api-usage...fuzzy-locations',
+            },
+            {
+                name: 'selections - single line',
+                url: 'https://github.com/sourcegraph/sourcegraph/blob/master/jest.config.base.js#L5',
+            },
+            {
+                name: 'selections - range',
+                url: 'https://github.com/sourcegraph/sourcegraph/blob/master/jest.config.base.js#L5-L12',
+            },
+        ]
+        for (const { name, url } of testcases) {
+            test(name, () => {
+                expect(parseURL(new URL(url))).toMatchSnapshot()
+            })
+        }
     })
 })

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -283,9 +283,8 @@ function getRevOrBranch(revAndPath: string): string | null {
     return branch
 }
 
-export function parseURL(loc: Location = window.location): GitHubURL {
+export function parseURL(loc: Pick<Location, 'host' | 'hash' | 'pathname'> = window.location): GitHubURL {
     // TODO(john): this method has problems handling branch revisions with "/" character.
-    // TODO(john): this all needs unit testing!
 
     let user: string | undefined
     let ghRepoName: string | undefined // in "github.com/foo/bar", just "bar"
@@ -309,7 +308,7 @@ export function parseURL(loc: Location = window.location): GitHubURL {
         filePath = urlsplit.slice(3 + revParts).join('/')
     }
     if (user && ghRepoName) {
-        repoName = `${window.location.host}/${user}/${ghRepoName}`
+        repoName = `${loc.host}/${user}/${ghRepoName}`
     } else {
         repoName = ''
     }


### PR DESCRIPTION
I filed https://github.com/sourcegraph/sourcegraph/issues/3882 in the process.