### PR TITLE
repo-updater: Simplify EnabledStateDeprecationMigration

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -111,7 +111,7 @@ func main() {
 			"GITOLITE",
 		)
 		migrations = append(migrations,
-			repos.EnabledStateDeprecationMigration(src, clock, kinds...),
+			repos.EnabledStateDeprecationMigration(clock, kinds...),
 		)
 	}
 


### PR DESCRIPTION
This commit simplifies the `EnabledStateDeprecationMigration`.

It removes old complexity associated with the longer valid requirement adding
deleted repos to an include list as well as removing the need to source
repos at all, which makes repo-updater startup much faster.

Since all repos in a Diff are Enabled, we know that we can
simply access the disabled stored repos, add them to the relevant
exclude lists and delete them.

The tests have been reworked to be slightly more readable and maintainable, also eliminating now defunct test cases.

Test plan: go test
