### PR TITLE
repo-updater: Add AWSCodeCommitSetBogusGitCredentialsMigration

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -98,6 +98,7 @@ func main() {
 		repos.GitLabSetDefaultProjectQueryMigration(clock),
 		repos.BitbucketServerUsernameMigration(clock), // Needs to run before EnabledStateDeprecationMigration
 		repos.BitbucketServerSetDefaultRepositoryQueryMigration(clock),
+		repos.AWSCodeCommitSetBogusGitCredentialsMigration(clock),
 	}
 
 	var kinds []string

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -61,6 +61,8 @@ func TestIntegration(t *testing.T) {
 			testBitbucketServerSetDefaultRepositoryQueryMigration(store)},
 		{"Migrations/BitbucketServerUsername",
 			testBitbucketServerUsernameMigration(store)},
+		{"Migrations/AWSCodeCommitSetBogusGitCredentialsMigration",
+			testAWSCodeCommitSetBogusGitCredentialsMigration(store)},
 		{"Migrations/EnabledStateDeprecationMigration",
 			testEnabledStateDeprecationMigration(store)},
 	} {

--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -411,7 +411,7 @@ func AWSCodeCommitSetBogusGitCredentialsMigration(clock func() time.Time) Migrat
 		for _, svc := range svcs {
 			var c schema.AWSCodeCommitConnection
 			if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
-				return errors.Errorf("%s  external service id=%d config unmarshaling error: %s", prefix, svc.ID, err)
+				return errors.Errorf("%s external service id=%d config unmarshaling error: %s", prefix, svc.ID, err)
 			}
 
 			gitCredentials := c.GitCredentials

--- a/cmd/repo-updater/repos/migrations.go
+++ b/cmd/repo-updater/repos/migrations.go
@@ -381,6 +381,70 @@ func BitbucketServerUsernameMigration(clock func() time.Time) Migration {
 	})
 }
 
+// AWSCodeCommitSetBogusGitCredentialsMigration returns a Migration that
+// changes all configurations of AWS CodeCommit external services to have the
+// `gitCredentials` setting set to bogus defaults. This will only happen if the
+// `gitCredentials` fields is empty or missing either `username` or `password`.
+//
+// This is done so that repo-updater can boot up without an "invalid config"
+// error and accept new external service configuration syncs, which allows the
+// user to fix the wrong credentials.
+func AWSCodeCommitSetBogusGitCredentialsMigration(clock func() time.Time) Migration {
+
+	return migrate(func(ctx context.Context, s Store) error {
+		const (
+			prefix = "migrate.aws-codecommit-set-bogus-git-credentials:"
+
+			defaultUsername = "insert-git-credentials-username-here"
+			defaultPassword = "insert-git-credentials-password-here"
+		)
+
+		svcs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{
+			Kinds: []string{"awscodecommit"},
+		})
+
+		if err != nil {
+			return errors.Wrapf(err, "%s list-external-services", prefix)
+		}
+
+		now := clock()
+		for _, svc := range svcs {
+			var c schema.AWSCodeCommitConnection
+			if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
+				return errors.Errorf("%s  external service id=%d config unmarshaling error: %s", prefix, svc.ID, err)
+			}
+
+			gitCredentials := c.GitCredentials
+
+			if gitCredentials.Username != "" && gitCredentials.Password != "" {
+				continue
+			}
+
+			if gitCredentials.Username == "" {
+				gitCredentials.Username = defaultUsername
+			}
+
+			if gitCredentials.Password == "" {
+				gitCredentials.Password = defaultPassword
+			}
+
+			edited, err := jsonc.Edit(svc.Config, gitCredentials, "gitCredentials")
+			if err != nil {
+				return errors.Wrapf(err, "%s edit-json", prefix)
+			}
+
+			svc.Config = edited
+			svc.UpdatedAt = now
+		}
+
+		if err = s.UpsertExternalServices(ctx, svcs...); err != nil {
+			return errors.Wrapf(err, "%s upsert-external-services", prefix)
+		}
+
+		return nil
+	})
+}
+
 // ErrNoTransactor is returned by a Migration returned by
 // NewTxMigration when it takes in a Store that can't be
 // interface upgraded to a Transactor.

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestEnabledStateDeprecationMigration(t *testing.T) {
@@ -872,6 +873,193 @@ func testBitbucketServerUsernameMigration(store repos.Store) func(*testing.T) {
 
 	}
 }
+
+func TestAWSCodeCommitSetBogusGitCredentialsMigration(t *testing.T) {
+	t.Parallel()
+	testAWSCodeCommitSetBogusGitCredentialsMigration(new(repos.FakeStore))(t)
+}
+
+func testAWSCodeCommitSetBogusGitCredentialsMigration(store repos.Store) func(*testing.T) {
+	awsCodeCommitServiceWithCredentials := repos.ExternalService{
+		Kind:        "AWSCODECOMMIT",
+		DisplayName: "AWS CodeCommit",
+		Config: formatJSON(`{
+			"region": "us-west-1",
+			"accessKeyID": "secret-accessKeyID",
+			"secretAccessKey": "secret-secretAccessKey",
+			"gitCredentials": {"username": "user", "password": "pw"},
+		}`),
+	}
+
+	awsCodeCommitServiceWithoutCredentials := repos.ExternalService{
+		Kind:        "AWSCODECOMMIT",
+		DisplayName: "AWS CodeCommit",
+		Config: formatJSON(`{
+			"region": "us-west-1",
+			"accessKeyID": "secret-accessKeyID",
+			"secretAccessKey": "secret-secretAccessKey"
+		}`),
+	}
+
+	awsCodeCommitServiceWithCredentialsMissingUsername := repos.ExternalService{
+		Kind:        "AWSCODECOMMIT",
+		DisplayName: "AWS CodeCommit",
+		Config: formatJSON(`{
+			"region": "us-west-1",
+			"accessKeyID": "secret-accessKeyID",
+			"secretAccessKey": "secret-secretAccessKey",
+			"gitCredentials": {"password": "pw"},
+		}`),
+	}
+
+	awsCodeCommitServiceWithCredentialsMissingPassword := repos.ExternalService{
+		Kind:        "AWSCODECOMMIT",
+		DisplayName: "AWS CodeCommit",
+		Config: formatJSON(`{
+			"region": "us-west-1",
+			"accessKeyID": "secret-accessKeyID",
+			"secretAccessKey": "secret-secretAccessKey",
+			"gitCredentials": {"username": "username"},
+		}`),
+	}
+
+	gitlab := repos.ExternalService{
+		Kind:        "GITLAB",
+		DisplayName: "Gitlab - Test",
+		Config:      formatJSON(`{"url": "https://gitlab.com"}`),
+	}
+
+	clock := repos.NewFakeClock(time.Now(), 0)
+
+	return func(t *testing.T) {
+		t.Helper()
+
+		for _, tc := range []struct {
+			name   string
+			stored repos.ExternalServices
+			assert repos.ExternalServicesAssertion
+			err    string
+		}{
+			{
+				name:   "no external services",
+				stored: repos.ExternalServices{},
+				assert: repos.Assert.ExternalServicesEqual(),
+				err:    "<nil>",
+			},
+			{
+				name:   "non-awsCodeCommit services are left unchanged",
+				stored: repos.ExternalServices{&gitlab},
+				assert: repos.Assert.ExternalServicesEqual(&gitlab),
+				err:    "<nil>",
+			},
+			{
+				name:   "awsCodeCommit services with gitCredentials set are left unchanged",
+				stored: repos.ExternalServices{&awsCodeCommitServiceWithCredentials},
+				assert: repos.Assert.ExternalServicesEqual(&awsCodeCommitServiceWithCredentials),
+				err:    "<nil>",
+			},
+			{
+				name:   "awsCodeCommit services without credentials are migrated",
+				stored: repos.ExternalServices{&awsCodeCommitServiceWithoutCredentials},
+				assert: repos.Assert.ExternalServicesEqual(
+					awsCodeCommitServiceWithoutCredentials.With(
+						repos.Opt.ExternalServiceModifiedAt(clock.Time(0)),
+						func(e *repos.ExternalService) {
+							var err error
+
+							fmt.Printf("without-credentials -- e.Config=%q\n", e.Config)
+							e.Config, err = jsonc.Edit(e.Config,
+								schema.AWSCodeCommitGitCredentials{
+									Username: "insert-git-credentials-username-here",
+									Password: "insert-git-credentials-password-here",
+								},
+								"gitCredentials",
+							)
+
+							if err != nil {
+								panic(err)
+							}
+						},
+					),
+				),
+				err: "<nil>",
+			},
+			{
+				name:   "awsCodeCommit services with only username in credentials are migrated",
+				stored: repos.ExternalServices{&awsCodeCommitServiceWithCredentialsMissingPassword},
+				assert: repos.Assert.ExternalServicesEqual(
+					awsCodeCommitServiceWithCredentialsMissingPassword.With(
+						repos.Opt.ExternalServiceModifiedAt(clock.Time(0)),
+						func(e *repos.ExternalService) {
+							var err error
+							e.Config, err = jsonc.Edit(e.Config,
+								schema.AWSCodeCommitGitCredentials{
+									Username: "username",
+									Password: "insert-git-credentials-password-here",
+								},
+								"gitCredentials",
+							)
+
+							if err != nil {
+								panic(err)
+							}
+						},
+					),
+				),
+				err: "<nil>",
+			},
+			{
+				name:   "awsCodeCommit services with only password in credentials are migrated",
+				stored: repos.ExternalServices{&awsCodeCommitServiceWithCredentialsMissingUsername},
+				assert: repos.Assert.ExternalServicesEqual(
+					awsCodeCommitServiceWithCredentialsMissingUsername.With(
+						repos.Opt.ExternalServiceModifiedAt(clock.Time(0)),
+						func(e *repos.ExternalService) {
+							var err error
+							e.Config, err = jsonc.Edit(e.Config,
+								schema.AWSCodeCommitGitCredentials{
+									Username: "insert-git-credentials-username-here",
+									Password: "pw",
+								},
+								"gitCredentials",
+							)
+
+							if err != nil {
+								panic(err)
+							}
+						},
+					),
+				),
+				err: "<nil>",
+			},
+		} {
+			tc := tc
+			ctx := context.Background()
+
+			t.Run(tc.name, transact(ctx, store, func(t testing.TB, tx repos.Store) {
+				if err := tx.UpsertExternalServices(ctx, tc.stored.Clone()...); err != nil {
+					t.Fatalf("failed to prepare store: %v", err)
+				}
+
+				err := repos.AWSCodeCommitSetBogusGitCredentialsMigration(clock.Now).Run(ctx, tx)
+				if have, want := fmt.Sprint(err), tc.err; have != want {
+					t.Errorf("error:\nhave: %v\nwant: %v", have, want)
+				}
+
+				es, err := tx.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if tc.assert != nil {
+					tc.assert(t, es)
+				}
+			}))
+		}
+
+	}
+}
+
 func formatJSON(s string) string {
 	formatted, err := jsonc.Format(s, true, 2)
 	if err != nil {

--- a/cmd/repo-updater/repos/migrations_test.go
+++ b/cmd/repo-updater/repos/migrations_test.go
@@ -967,7 +967,6 @@ func testAWSCodeCommitSetBogusGitCredentialsMigration(store repos.Store) func(*t
 						func(e *repos.ExternalService) {
 							var err error
 
-							fmt.Printf("without-credentials -- e.Config=%q\n", e.Config)
 							e.Config, err = jsonc.Edit(e.Config,
 								schema.AWSCodeCommitGitCredentials{
 									Username: "insert-git-credentials-username-here",


### PR DESCRIPTION
PR #3878 introduced a new, *required* setting for AWS CodeCommit external services: `gitCredentials`. Without setting this, the config is invalid and the repo-updater wouldn't boot up, because it failed in the `EnabledStateDeprecationMigration` and retried it indefinitely.

That makes the upgrade for users needlessly hard:

- a user cannot add the `gitCredentials` setting to the config *before*  upgrading, because that would make the config invalid
- *after* upgrading the user *can* add `gitCredentials` to the AWS CodeCommit but syncing the new config to repo-updater would fail since it's busy retrying the `EnabledStateDeprecationMigration`
- the user would have to manually restart repo-updater to pick up the updated and valid config

This commit remedies that problem but introducing a migration that runs automatically when repo-updater boots up. This migration makes the config "valid" by adding bogus `gitCredentials` that allow repo-updater the and the rest of the system to boot up but also signal to the user that they need to be changed.

Test plan: `go test`
