### PR TITLE
Import bootstrap alert scss in options.scss

### DIFF
--- a/browser/src/options.scss
+++ b/browser/src/options.scss
@@ -14,6 +14,7 @@
 @import 'bootstrap/scss/custom-forms';
 @import 'bootstrap/scss/buttons';
 @import 'bootstrap/scss/button-group';
+@import 'bootstrap/scss/alert';
 @import './libs/options/OptionsContainer';
 
 :root {


### PR DESCRIPTION
This is necessary so that the permissions alert is properly styled.


![image](https://user-images.githubusercontent.com/1741180/57518514-6e18b380-7319-11e9-8a1b-2ca965cb5262.png)

