### PR TITLE
Fix GitHub snippet resolution

### DIFF
--- a/browser/src/libs/github/__snapshots__/util.test.ts.snap
+++ b/browser/src/libs/github/__snapshots__/util.test.ts.snap
@@ -102,6 +102,25 @@ Object {
 }
 `;
 
+exports[`util parseURL() snippet permalink 1`] = `
+Object {
+  "filePath": "client/browser/src/shared/repo/backend.tsx",
+  "ghRepoName": "sourcegraph",
+  "isCodePage": true,
+  "isCommit": false,
+  "isCompare": false,
+  "isDelta": false,
+  "isPullRequest": false,
+  "position": Object {
+    "character": 0,
+    "line": 128,
+  },
+  "repoName": "github.com/sourcegraph/sourcegraph",
+  "rev": "6a91ccec97a46bfb511b7ff58d790554a7d075c8",
+  "user": "sourcegraph",
+}
+`;
+
 exports[`util parseURL() tree page 1`] = `
 Object {
   "filePath": undefined,

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -163,7 +163,7 @@ export const fileLineContainerResolver: ViewResolver<CodeView> = {
         if (embeddedBlobWrapper) {
             // This is a snippet embedded in a comment.
             // Resolve to `.blob-wrapper-embedded`'s parent element,
-            // the smallest elemebt that contains both the code and
+            // the smallest element that contains both the code and
             // the HTML anchor allowing to resolve the file info.
             const element = embeddedBlobWrapper.parentElement!
             return {

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -124,12 +124,11 @@ const searchResultCodeViewResolver = toCodeViewResolver('.code-list-item', {
     toolbarButtonProps,
 })
 
-const commentSnippetCodeViewResolver = toCodeViewResolver('.js-comment-body', {
+const snippetCodeView: Omit<CodeView, 'element'> = {
     dom: singleFileDOMFunctions,
     resolveFileInfo: resolveSnippetFileInfo,
     getPositionAdjuster: getSnippetPositionAdjuster,
-    toolbarButtonProps,
-})
+}
 
 export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolbarMount']> = (
     codeViewElement: HTMLElement
@@ -154,12 +153,24 @@ export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolb
 }
 
 /**
- * The modern single file blob view.
+ * Matches the modern single-file code view, or snippets embedded in comments.
  *
  */
 export const fileLineContainerResolver: ViewResolver<CodeView> = {
     selector: '.js-file-line-container',
     resolveView: (fileLineContainer: HTMLElement): CodeView | null => {
+        const embeddedBlobWrapper = fileLineContainer.closest('.blob-wrapper-embedded')
+        if (embeddedBlobWrapper) {
+            // This is a snippet embedded in a comment.
+            // Resolve to `.blob-wrapper-embedded`'s parent element,
+            // the smallest elemebt that contains both the code and
+            // the HTML anchor allowing to resolve the file info.
+            const element = embeddedBlobWrapper.parentElement!
+            return {
+                element,
+                ...snippetCodeView,
+            }
+        }
         const { filePath } = parseURL()
         if (!filePath) {
             // this is not a single-file code view
@@ -252,12 +263,7 @@ export const createOpenOnSourcegraphIfNotExists: MountGetter = (container: HTMLE
 
 export const githubCodeHost: CodeHost = {
     name: 'github',
-    codeViewResolvers: [
-        genericCodeViewResolver,
-        fileLineContainerResolver,
-        searchResultCodeViewResolver,
-        commentSnippetCodeViewResolver,
-    ],
+    codeViewResolvers: [genericCodeViewResolver, fileLineContainerResolver, searchResultCodeViewResolver],
     contentViewResolvers: [markdownBodyViewResolver],
     textFieldResolvers: [commentTextFieldResolver],
     getContext: () => {

--- a/browser/src/libs/github/index.tsx
+++ b/browser/src/libs/github/index.tsx
@@ -9,38 +9,3 @@ export interface GitHubURL extends ParsedRepoURI {
     isCodePage?: boolean
     isCompare?: boolean
 }
-
-export interface GitHubBlobUrl {
-    mode: GitHubMode
-    owner: string
-    ghRepoName: string
-    revAndPath: string
-    lineNumber: string | undefined
-    rev: string
-    filePath: string
-}
-
-export interface GitHubPullUrl {
-    mode: GitHubMode
-    owner: string
-    ghRepoName: string
-    view: string
-    rev: string
-    id: number
-    filePath?: string
-}
-
-export interface GitHubRepositoryUrl {
-    mode: GitHubMode
-    owner: string
-    ghRepoName: string
-    rev?: string
-    filePath?: string
-}
-
-export enum GitHubMode {
-    Blob,
-    Commit,
-    PullRequest,
-    Repository,
-}

--- a/browser/src/libs/github/util.test.ts
+++ b/browser/src/libs/github/util.test.ts
@@ -46,6 +46,11 @@ describe('util', () => {
                 name: 'selections - range',
                 url: 'https://github.com/sourcegraph/sourcegraph/blob/master/jest.config.base.js#L5-L12',
             },
+            {
+                name: 'snippet permalink',
+                url:
+                    'https://github.com/sourcegraph/sourcegraph/blob/6a91ccec97a46bfb511b7ff58d790554a7d075c8/client/browser/src/shared/repo/backend.tsx#L128-L151',
+            },
         ]
         for (const { name, url } of testcases) {
             test(name, () => {

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -1,5 +1,5 @@
 import { DiffResolvedRevSpec } from '../../shared/repo'
-import { GitHubBlobUrl, GitHubMode, GitHubPullUrl, GitHubRepositoryUrl, GitHubURL } from '../github'
+import { GitHubURL } from '../github'
 
 /**
  * getFileContainers returns the elements on the page which should be marked
@@ -180,73 +180,6 @@ function getDiffResolvedRevFromPageSource(pageSource: string, isPullRequest: boo
     }
 }
 
-const GITHUB_BLOB_REGEX = /^(https?):\/\/(github.com)\/([A-Za-z0-9_]+)\/([A-Za-z0-9-]+)\/blob\/([^#]*)(#L[0-9]+)?/i
-const GITHUB_PULL_REGEX = /^(https?):\/\/(github.com)\/([A-Za-z0-9_]+)\/([A-Za-z0-9-]+)\/pull\/([0-9]+)(\/(commits|files))?/i
-const COMMIT_HASH_REGEX = /^([0-9a-f]{40})/i
-export function getGitHubState(url: string): GitHubBlobUrl | GitHubPullUrl | GitHubRepositoryUrl | null {
-    const blobMatch = GITHUB_BLOB_REGEX.exec(url)
-    if (blobMatch) {
-        const match = {
-            protocol: blobMatch[1],
-            hostname: blobMatch[2],
-            org: blobMatch[3],
-            repo: blobMatch[4],
-            revAndPath: blobMatch[5],
-            lineNumber: blobMatch[6],
-        }
-        const rev = getRevOrBranch(match.revAndPath)
-        if (!rev) {
-            return null
-        }
-        const filePath = match.revAndPath.replace(rev + '/', '')
-        return {
-            mode: GitHubMode.Blob,
-            owner: match.org,
-            ghRepoName: match.repo,
-            revAndPath: match.revAndPath,
-            lineNumber: match.lineNumber,
-            rev,
-            filePath,
-        }
-    }
-    const pullMatch = GITHUB_PULL_REGEX.exec(url)
-    if (pullMatch) {
-        const match = {
-            protocol: pullMatch[1],
-            hostname: pullMatch[2],
-            org: pullMatch[3],
-            repo: pullMatch[4],
-            id: pullMatch[5],
-            view: pullMatch[7],
-        }
-        const numId: number = parseInt(match.id, 10)
-        if (isNaN(numId)) {
-            console.error(`match.id ${match.id} is parsing to NaN`)
-            return null
-        }
-        return {
-            mode: GitHubMode.PullRequest,
-            ghRepoName: match.repo,
-            owner: match.org,
-            view: match.view,
-            rev: '',
-            id: numId,
-        }
-    }
-    const parsed = parseURL()
-    if (parsed && parsed.ghRepoName && parsed.repoName && parsed.user) {
-        return {
-            mode: GitHubMode.Repository,
-            owner: parsed.user,
-            ghRepoName: parsed.ghRepoName,
-            rev: parsed.rev,
-            filePath: parsed.filePath,
-        }
-    }
-
-    return null
-}
-
 function getBranchName(): string | null {
     const branchButtons = document.getElementsByClassName('btn btn-sm select-menu-button js-menu-target css-truncate')
     if (branchButtons.length === 0) {
@@ -265,22 +198,6 @@ function getBranchName(): string | null {
     }
     // otherwise, the branch name is fully rendered in the button
     return (innerButtonEls[0] as HTMLElement).innerText
-}
-
-function getRevOrBranch(revAndPath: string): string | null {
-    const matchesCommit = COMMIT_HASH_REGEX.exec(revAndPath)
-    if (matchesCommit) {
-        return matchesCommit[1].substring(0, 40)
-    }
-    const branch = getBranchName()
-    if (!branch) {
-        return null
-    }
-    if (!revAndPath.startsWith(branch)) {
-        console.error(`branch and path is ${revAndPath}, and branch is ${branch}`)
-        return null
-    }
-    return branch
 }
 
 export function parseURL(loc: Pick<Location, 'host' | 'hash' | 'pathname'> = window.location): GitHubURL {


### PR DESCRIPTION
Fixes #771
Fixes #3105
Fixes #3110

Deprecates `commentSnippetCodeViewResolver`, which:
- Matched entire comments, even though they may have contained several snippets (#3110)
- Used the first link whose href could be parsed by `getGitHubState()`, which could be any inline link in a GitHub comment (#771)

Snippet code views are now resolved using the `fileLineContainerResolver`, to the closes element containing both the code and the permalink. Several snippets contained in the same comment can be accurately resolved.

#### Test Plan

##### Code Hosts

- [x] GitHub
- [x] GitHub Enterprise
- [ ] Refined GitHub
- [ ] Phabricator
- [ ] Phabricator integration
- [ ] Bitbucket
- [ ] Gitlab

##### Browsers

- [x] Chrome
- [ ] Firefox

![image](https://user-images.githubusercontent.com/1741180/57527409-decaca80-732f-11e9-9bf3-d599d7becdc5.png)
![image](https://user-images.githubusercontent.com/1741180/57527422-e8543280-732f-11e9-9eb4-46310b4cf343.png)
