### PR TITLE
repo-updater: Set log15 to DiscardHandler in tests

### DIFF
--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater/protocol"
+	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
 func TestReposService_Get(t *testing.T) {
@@ -94,5 +95,11 @@ func TestRepos_Add(t *testing.T) {
 	}
 	if !calledUpsert {
 		t.Error("!calledUpsert")
+	}
+}
+
+func init() {
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
 	}
 }

--- a/cmd/repo-updater/repos/util_test.go
+++ b/cmd/repo-updater/repos/util_test.go
@@ -48,6 +48,6 @@ func TestSetUserinfoBestEffort(t *testing.T) {
 
 func init() {
 	if !testing.Verbose() {
-		log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.Root().GetHandler()))
+		log15.Root().SetHandler(log15.DiscardHandler())
 	}
 }


### PR DESCRIPTION
Quiet test output in the case of failure, unless you opt-in to the verbose flag.
