### PR TITLE
repo-updater: Do not sort in equality assertions

### DIFF
--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -477,7 +477,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				}
 
 				if st != nil && len(tc.stored) > 0 {
-					if err := st.UpsertRepos(ctx, tc.stored...); err != nil {
+					if err := st.UpsertRepos(ctx, tc.stored.Clone()...); err != nil {
 						t.Fatalf("failed to prepare store: %v", err)
 					}
 				}
@@ -485,25 +485,32 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				syncer := repos.NewSyncer(st, tc.sourcer, nil, now)
 				diff, err := syncer.Sync(ctx)
 
-				var want repos.Repos
-				want.Concat(diff.Added, diff.Modified, diff.Unmodified)
-				sort.Sort(want)
-
-				diff.Repos().Apply(repos.Opt.RepoID(0))
-
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("have error %q, want %q", have, want)
 				}
+
 				if err != nil {
 					return
 				}
 
-				if diff := cmp.Diff(diff, tc.diff); diff != "" {
-					// t.Logf("have: %s\nwant: %s\n", pp.Sprint(have), pp.Sprint(want))
-					t.Fatalf("unexpected diff:\n%s", diff)
+				for _, d := range []struct {
+					name       string
+					have, want repos.Repos
+				}{
+					{"added", diff.Added, tc.diff.Added},
+					{"deleted", diff.Deleted, tc.diff.Deleted},
+					{"modified", diff.Modified, tc.diff.Modified},
+					{"unmodified", diff.Unmodified, tc.diff.Unmodified},
+				} {
+					t.Logf("diff.%s", d.name)
+					repos.Assert.ReposEqual(d.want...)(t, d.have)
 				}
 
 				if st != nil {
+					var want repos.Repos
+					want.Concat(diff.Added, diff.Modified, diff.Unmodified)
+					sort.Sort(want)
+
 					have, _ := st.ListRepos(ctx, repos.StoreListReposArgs{})
 					repos.Assert.ReposEqual(want...)(t, have)
 				}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -280,12 +280,10 @@ var Assert = struct {
 }{
 	ReposEqual: func(rs ...*Repo) ReposAssertion {
 		want := append(Repos{}, rs...).With(Opt.RepoID(0))
-		sort.Sort(want)
 		return func(t testing.TB, have Repos) {
 			t.Helper()
-			have = append(Repos{}, have...)
-			have.Apply(Opt.RepoID(0)) // Exclude auto-generated IDs from equality tests
-			sort.Sort(have)
+			// Exclude auto-generated IDs from equality tests
+			have = append(Repos{}, have...).With(Opt.RepoID(0))
 			if !reflect.DeepEqual(have, want) {
 				t.Errorf("repos: %s", cmp.Diff(have, want))
 			}
@@ -307,8 +305,8 @@ var Assert = struct {
 		want := append(ExternalServices{}, es...).With(Opt.ExternalServiceID(0))
 		return func(t testing.TB, have ExternalServices) {
 			t.Helper()
-			have = append(ExternalServices{}, have...)
-			have.Apply(Opt.ExternalServiceID(0)) // Exclude auto-generated IDs from equality tests
+			// Exclude auto-generated IDs from equality tests
+			have = append(ExternalServices{}, have...).With(Opt.ExternalServiceID(0))
 			if !reflect.DeepEqual(have, want) {
 				t.Errorf("external services: %s", cmp.Diff(have, want))
 			}


### PR DESCRIPTION
We previously made our `repos.Opt.ReposEqual` always sort its arguments.
This wouldn't allow us to test returned order where it's relevant.

Fixes #3777

Test plan: `go test`
