### PR TITLE
use core-js@3

### DIFF
--- a/browser/babel.config.js
+++ b/browser/babel.config.js
@@ -9,6 +9,7 @@ const config = {
       {
         modules: false,
         useBuiltIns: 'entry',
+        corejs: 3,
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.1.0",
+    "core-js": "^3.0.1",
     "d3-axis": "^1.0.12",
     "d3-scale": "^3.0.0",
     "d3-selection": "^1.4.0",

--- a/web/babel.config.js
+++ b/web/babel.config.js
@@ -10,6 +10,7 @@ const config = {
         modules: false,
         targets: require('../package.json').browserslist,
         useBuiltIns: 'entry',
+        corejs: 3,
       },
     ],
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,7 +1502,8 @@
   integrity sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.0.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -5144,7 +5145,7 @@ core-js-pure@3.0.1:
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.1.tgz#37358fb0d024e6b86d443d794f4e37e949098cbe"
   integrity sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==
 
-core-js@3.0.1:
+core-js@3.0.1, core-js@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
   integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
@@ -13803,7 +13804,8 @@ source-map@^0.7.2:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "23.0.1"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
It is recommended to be explicit about the desired core-js version. See https://babeljs.io/blog/2019/03/19/7.4.0#migration-from-core-js-2.

This was printing a warning message to the console that told us to do this.