### PR TITLE
use non-const enums in graphql schema TypeScript file

### DIFF
--- a/shared/gulpfile.ts
+++ b/shared/gulpfile.ts
@@ -41,7 +41,7 @@ export async function graphQLTypes(): Promise<void> {
                 interfaceBuilder: (name: string, body: string) =>
                     'export ' + DEFAULT_OPTIONS.interfaceBuilder(name, body),
                 enumTypeBuilder: (name: string, values: string) =>
-                    'export ' + DEFAULT_OPTIONS.enumTypeBuilder(name, values),
+                    'export ' + DEFAULT_OPTIONS.enumTypeBuilder(name, values).replace(/^const enum/, 'enum'),
                 typeBuilder: (name: string, body: string) => 'export ' + DEFAULT_OPTIONS.typeBuilder(name, body),
                 wrapList: (type: string) => `${type}[]`,
                 postProcessor: (code: string) => format(code, { ...formatOptions, parser: 'typescript' }),


### PR DESCRIPTION
This is in preparation for using Babel 7 for TypeScript transpilation, which doesn't support const enums (see Caveats at https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats).

https://github.com/avantcredit/gql2ts/issues/107 is why this was added to gql2ts (but now non-const enums can be used in the same way, so const enums are no longer necessary).