### PR TITLE
remove old browser extension graphql schema generation step

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -12,7 +12,6 @@
     "release": "yarn release:chrome",
     "release:chrome": "webstore upload --auto-publish --source build/bundles/chrome-bundle.zip --extension-id dgjhfomjieaadpoljlnidmbgkdffpack --client-id $GOOGLE_CLIENT_ID --client-secret $GOOGLE_CLIENT_SECRET --refresh-token $GOOGLE_REFRESH_TOKEN",
     "release:ff": "./scripts/release-ff.sh",
-    "graphql": "get-graphql-schema http://localhost:3080/.api/graphql --json | gql2ts -o app/gqlschema.d.ts",
     "lint": "yarn run tslint && yarn run stylelint",
     "tslint": "tslint -t stylish -c tslint.json -p tsconfig.json './**/*.ts?(x)'",
     "stylelint": "stylelint 'src/**/*.scss'",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "esm": "^3.2.22",
     "execa": "^1.0.0",
     "fancy-log": "^1.3.3",
-    "get-graphql-schema": "^2.1.2",
     "gql2ts": "^1.10.1",
     "graphql": "^14.3.0",
     "graphql-schema-linter": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,16 +7183,6 @@ get-func-name@^2.0.0:
   resolved "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
-get-graphql-schema@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/get-graphql-schema/-/get-graphql-schema-2.1.2.tgz#ffa418534224a75cd7afc8f87b70109ca9ec3fe9"
-  integrity sha512-1z5Hw91VrE3GrpCZE6lE8Dy+jz4kXWesLS7rCSjwOxf5BOcIedAZeTUJRIeIzmmR+PA9CKOkPTYFRJbdgUtrxA==
-  dependencies:
-    chalk "^2.4.1"
-    graphql "^14.0.2"
-    minimist "^1.2.0"
-    node-fetch "^2.2.0"
-
 get-own-enumerable-property-symbols@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
@@ -7533,7 +7523,7 @@ graphql-schema-linter@^0.2.0:
     graphql "^14.0.0"
     lodash "^4.17.4"
 
-"graphql@>= 0.10 <15", graphql@^14.0.0, graphql@^14.0.2, graphql@^14.3.0:
+"graphql@>= 0.10 <15", graphql@^14.0.0, graphql@^14.3.0:
   version "14.3.0"
   resolved "https://registry.npmjs.org/graphql/-/graphql-14.3.0.tgz#34dd36faa489ff642bcd25df6c3b4f988a1a2f3e"
   integrity sha512-MdfI4v7kSNC3NhB7cF8KNijDsifuWO2XOtzpyququqaclO8wVuChYv+KogexDwgP5sp7nFI9Z6N4QHgoLkfjrg==


### PR DESCRIPTION
This was not used. The browser extension code now uses the GraphQL schema in `shared/`.