### PR TITLE
mock other GraphQL requests needed by code_intelligence browser ext test

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -51,7 +51,39 @@ const createMockPlatformContext = (
     }: {
         request: string
     }): Observable<SuccessGraphQLResult<R>> => {
+        if (request.trim().startsWith('query SiteProductVersion')) {
+            // tslint:disable-next-line: no-object-literal-type-assertion
+            return of({
+                data: {
+                    site: {
+                        productVersion: 'dev',
+                        buildVersion: 'dev',
+                        hasCodeIntelligence: true,
+                    },
+                },
+                errors: undefined,
+            } as SuccessGraphQLResult<R>)
+        }
+        if (request.trim().startsWith('query CurrentUser')) {
+            // tslint:disable-next-line: no-object-literal-type-assertion
+            return of({
+                data: {
+                    currentUser: {
+                        id: 'u1',
+                        displayName: 'Alice',
+                        username: 'alice',
+                        avatarURL: null,
+                        url: 'https://example.com/alice',
+                        settingsURL: 'https://example.com/alice/settings',
+                        emails: [{ email: 'alice@example.com' }],
+                        siteAdmin: false,
+                    },
+                },
+                errors: undefined,
+            } as SuccessGraphQLResult<R>)
+        }
         if (request.trim().startsWith('query ResolveRev')) {
+            // tslint:disable-next-line: no-object-literal-type-assertion
             return of({
                 data: {
                     repository: {
@@ -67,6 +99,7 @@ const createMockPlatformContext = (
             } as SuccessGraphQLResult<R>)
         }
         if (request.trim().startsWith('query BlobContent')) {
+            // tslint:disable-next-line: no-object-literal-type-assertion
             return of({
                 data: {
                     repository: {


### PR DESCRIPTION
For some reason, `requestGraphQL` exceptions for these 2 new GraphQL queries (SiteProductVersion and CurrentUser) started appearing when running with Babel 7. It's harmless to handle them here.

Also ignores the cast (which is useful in this case).