### PR TITLE
make usage of jest.mock for react-dom conform to defined behavior

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -1,10 +1,3 @@
-const RENDER = jest.fn()
-jest.mock('react-dom', () => ({
-    createPortal: jest.fn(el => el),
-    render: RENDER,
-    unmountComponentAtNode: jest.fn(),
-}))
-
 import { Range } from '@sourcegraph/extension-api-classes'
 import { uniqueId } from 'lodash'
 import renderer from 'react-test-renderer'
@@ -22,6 +15,8 @@ import { DEFAULT_SOURCEGRAPH_URL } from '../../shared/util/context'
 import { MutationRecordLike } from '../../shared/util/dom'
 import { createGlobalDebugMount, createOverlayMount, FileInfo, handleCodeHost } from './code_intelligence'
 import { toCodeViewResolver } from './code_views'
+
+const RENDER = jest.fn()
 
 const elementRenderedAtMount = (mount: Element): renderer.ReactTestRendererJSON | undefined => {
     const call = RENDER.mock.calls.find(call => call[1] === mount)
@@ -176,6 +171,7 @@ describe('code_intelligence', () => {
                     platformContext: createMockPlatformContext(),
                     sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                     telemetryService: NOOP_TELEMETRY_SERVICE,
+                    render: RENDER,
                 })
             )
             const overlayMount = document.body.querySelector('.hover-overlay-mount')
@@ -202,6 +198,7 @@ describe('code_intelligence', () => {
                     platformContext: createMockPlatformContext(),
                     sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                     telemetryService: NOOP_TELEMETRY_SERVICE,
+                    render: RENDER,
                 })
             )
             const renderedCommandPalette = elementRenderedAtMount(commandPaletteMount)
@@ -223,6 +220,7 @@ describe('code_intelligence', () => {
                     platformContext: createMockPlatformContext(),
                     sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                     telemetryService: NOOP_TELEMETRY_SERVICE,
+                    render: RENDER,
                 })
             )
             const globalDebugMount = document.body.querySelector('.global-debug')
@@ -265,6 +263,7 @@ describe('code_intelligence', () => {
                     platformContext: createMockPlatformContext(),
                     sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                     telemetryService: NOOP_TELEMETRY_SERVICE,
+                    render: RENDER,
                 })
             )
             const editors = await from(services.editor.editors)
@@ -328,6 +327,7 @@ describe('code_intelligence', () => {
                     platformContext: createMockPlatformContext(),
                     sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                     telemetryService: NOOP_TELEMETRY_SERVICE,
+                    render: RENDER,
                 })
             )
             const activeEditor = await from(extensionAPI.app.activeWindowChanges)
@@ -415,6 +415,7 @@ describe('code_intelligence', () => {
                     platformContext: createMockPlatformContext(),
                     sourcegraphURL: DEFAULT_SOURCEGRAPH_URL,
                     telemetryService: NOOP_TELEMETRY_SERVICE,
+                    render: RENDER,
                 })
             )
             let editors = await from(services.editor.editors)

--- a/browser/src/libs/code_intelligence/extensions.tsx
+++ b/browser/src/libs/code_intelligence/extensions.tsx
@@ -43,11 +43,13 @@ interface InjectProps
     extends PlatformContextProps<'forceUpdateTooltip' | 'sideloadedExtensionURL'>,
         ExtensionsControllerProps {
     history: H.History
+    render: typeof render
 }
 
 export const renderCommandPalette = ({
     extensionsController,
     history,
+    render,
     ...props
 }: TelemetryProps & InjectProps & Pick<CommandListPopoverButtonProps, 'inputClassName' | 'popoverClassName'>) => (
     mount: HTMLElement
@@ -70,6 +72,7 @@ export const renderGlobalDebug = ({
     extensionsController,
     platformContext,
     history,
+    render,
     sourcegraphURL,
 }: InjectProps & { sourcegraphURL: string; showGlobalDebug?: boolean }) => (mount: HTMLElement): void => {
     render(

--- a/browser/src/libs/code_intelligence/text_fields.test.tsx
+++ b/browser/src/libs/code_intelligence/text_fields.test.tsx
@@ -1,10 +1,3 @@
-const RENDER = jest.fn()
-jest.mock('react-dom', () => ({
-    createPortal: jest.fn(el => el),
-    render: RENDER,
-    unmountComponentAtNode: jest.fn(),
-}))
-
 import { uniqueId } from 'lodash'
 import { from, NEVER, Subject, Subscription } from 'rxjs'
 import { first, skip, take } from 'rxjs/operators'
@@ -35,7 +28,6 @@ describe('text_fields', () => {
         let subscriptions = new Subscription()
 
         afterEach(() => {
-            RENDER.mockClear()
             subscriptions.unsubscribe()
             subscriptions = new Subscription()
         })


### PR DESCRIPTION
This helps prepare for using Babel to transpile TypeScript but is good practice regardless.

- In `code_intelligence.test.tsx`, the `jest.mock('react-dom', ...)` was rejected with a fatal error by Babel (in babel-jest) because it referred to an out-of-scope variable (for why it rejects this, see https://github.com/facebook/jest/issues/2567). Also, it was undefined behavior that the `jest.mock` of `react-dom` applied to other modules (see "...mocked only for the file that calls `jest.mock`..." at https://jestjs.io/docs/en/jest-object#jestmockmodulename-factory-options). So, this commit passes the `react-dom` `render` function as an argument to the functions under test to make mocking easier and fully explicit without the need for test harness magic.
- Removes unnecessary mocking of `react-dom` in `text_fields.test.tsx`. The mock was never checked.

I encountered these problems while trying out Babel 7 for TypeScript transpilation, but fixing them is good practice regardless.