### PR TITLE
remove hacks for importing LoadingSpinner CSS

### DIFF
--- a/.storybook/webpack.config.ts
+++ b/.storybook/webpack.config.ts
@@ -15,17 +15,6 @@ export default ({ config }: { config: webpack.Configuration }) => {
     })
     config.resolve.extensions.push('.ts', '.tsx')
 
-    config.resolve.alias = {
-        ...config.resolve.alias, // HACK: This is required because the codeintellify package has a hardcoded import that assumes that
-        // ../node_modules/@sourcegraph/react-loading-spinner is a valid path. This is not a correct assumption
-        // in general, and it also breaks in this build because CSS imports URLs are not resolved (we would
-        // need to use resolve-url-loader). There are many possible fixes that are more complex, but this hack
-        // works fine for now.
-        '../node_modules/@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css': require.resolve(
-            '@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css'
-        ),
-    }
-
     // Put our style rules at the beginning so they're processed by the time it
     // gets to storybook's style rules.
     config.module.rules.unshift({

--- a/browser/config/webpack/base.config.ts
+++ b/browser/config/webpack/base.config.ts
@@ -37,16 +37,6 @@ const config: webpack.Configuration = {
     ],
     resolve: {
         extensions: ['.ts', '.tsx', '.js'],
-        alias: {
-            // HACK: This is required because the codeintellify package has a hardcoded import that assumes that
-            // ../node_modules/@sourcegraph/react-loading-spinner is a valid path. This is not a correct assumption
-            // in general, and it also breaks in this build because CSS imports URLs are not resolved (we would
-            // need to use resolve-url-loader). There are many possible fixes that are more complex, but this hack
-            // works fine for now.
-            '../node_modules/@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css': require.resolve(
-                '@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css'
-            ),
-        },
     },
     module: {
         rules: [

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -1,4 +1,4 @@
-@import '../node_modules/@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
+@import '~@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
 
 .hover-overlay {
     position: absolute;

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -279,7 +279,7 @@ hr {
 @import './repo/blob/discussions/DiscussionsTree';
 @import './components/SearchResult';
 @import './components/SearchResultMatch';
-@import '../node_modules/@sourcegraph/react-loading-spinner/lib/LoadingSpinner';
+@import '~@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
 
 @import './extensions/shared';
 @import './integrations/explore/IntegrationsExploreSection';

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -103,18 +103,7 @@ const config: webpack.Configuration = {
     resolve: {
         extensions: ['.mjs', '.ts', '.tsx', '.js'],
         mainFields: ['es2015', 'module', 'browser', 'main'],
-        alias: {
-            ...rxPaths(),
-
-            // HACK: This is required because the codeintellify package has a hardcoded import that assumes that
-            // ../node_modules/@sourcegraph/react-loading-spinner is a valid path. This is not a correct assumption
-            // in general, and it also breaks in this build because CSS imports URLs are not resolved (we would
-            // need to use resolve-url-loader). There are many possible fixes that are more complex, but this hack
-            // works fine for now.
-            '../node_modules/@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css': require.resolve(
-                '@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css'
-            ),
-        },
+        alias: { ...rxPaths() },
     },
     module: {
         rules: [


### PR DESCRIPTION
These were necessary previously because of complexity around how a dependency's (codeintellify's) CSS imported the same CSS file. Now codeintellify no longer imports this CSS file, so the hacks are not needed anymore.