### PR TITLE
remove unneeded Webpack hack for @sqs/jsonc-parser

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -90,7 +90,6 @@ const config: webpack.Configuration = {
                 NODE_ENV: JSON.stringify(mode),
             },
         }),
-        new webpack.ContextReplacementPlugin(/\/node_modules\/@sqs\/jsonc-parser\/lib\/edit\.js$/, /.*/),
         new MiniCssExtractPlugin({ filename: 'styles/[name].bundle.css' }) as any, // @types package is incorrect
         new OptimizeCssAssetsPlugin(),
         // Don't build the files referenced by dynamic imports for all the basic languages monaco supports.


### PR DESCRIPTION
JSONC editing works without this. It is not needed anymore.

Note that we are not yet able to remove the @sqs/jsonc-parser fork because we need the `setProperty` function, which is not mentioned in any of the `.d.ts` files published in `jsonc-parser`.