### PR TITLE
handle @babel/polyfill deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-    "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/runtime": "^7.2.0",
     "@gql2ts/from-schema": "^1.10.1",
@@ -235,6 +234,7 @@
     "react-stripe-elements": "^3.0.0",
     "react-visibility-sensor": "^5.0.2",
     "reactstrap": "https://registry.npmjs.org/@sqs/reactstrap/-/reactstrap-6.5.0-tmp1.tgz",
+    "regenerator-runtime": "^0.13.2",
     "rxjs": "^6.4.0",
     "sanitize-html": "^1.20.0",
     "semver": "^6.0.0",

--- a/shared/src/polyfills.ts
+++ b/shared/src/polyfills.ts
@@ -3,9 +3,9 @@ import 'core-js/web/immediate'
 
 import 'symbol-observable'
 
-// This gets automatically expanded into
-// imports that only pick what we need
-import '@babel/polyfill'
+// This gets automatically expanded into imports that only pick what we need.
+import 'core-js/stable'
+import 'regenerator-runtime/runtime'
 
 // Polyfill URL because Chrome and Firefox are not spec-compliant
 // Hostnames of URIs with custom schemes (e.g. git) are not parsed out

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,14 +698,6 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@^7.2.5":
-  version "7.2.5"
-  resolved "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz#6c54b964f71ad27edddc567d065e57e87ed7fa7d"
-  integrity sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==
-  dependencies:
-    core-js "^2.5.7"
-    regenerator-runtime "^0.12.0"
-
 "@babel/preset-env@7.3.1":
   version "7.3.1"
   resolved "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz#389e8ca6b17ae67aaf9a2111665030be923515db"


### PR DESCRIPTION
Fixes the warning:

```
`@babel/polyfill` is deprecated. Please, use required parts of `core-js` and `regenerator-runtime/runtime` separately
```

See https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#babelpolyfill for more information.