### PR TITLE
use node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/sourcegraph/sourcegraph"
   },
   "engines": {
-    "node": ">=8.0.0 <12.0.0",
+    "node": ">=8.0.0 <13.0.0",
     "yarn": "^1.10.1"
   },
   "scripts": {


### PR DESCRIPTION
This will require an update to the buildkite-agent Docker images and for everyone to install Node 12 locally. I sent up this PR to start the discussion.

Why? Because I want faster/simpler TS tests (#3959), Webpack builds (#3960), hot reloading (#3961), and future eslint migration (because tslint is deprecated).

Why do these things require Node 12? Because they rely on us using Babel 7 for TypeScript transpilation. Due to https://github.com/babel/babel/issues/9609 and https://github.com/istanbuljs/istanbuljs/issues/237, Babel's TypeScript transpiler is incompatible with Jest's (which is just Istanbul's) code coverage instrumentation because of how it interacts with @babel/plugin-proposal-class-properties. Therefore, when running tests, we require Node 12 (which doesn't need that Babel plugin).