### PR TITLE
fix websocket reload loop

### DIFF
--- a/web/gulpfile.ts
+++ b/web/gulpfile.ts
@@ -41,7 +41,6 @@ export async function webpackDevServer(): Promise<void> {
         proxy: {
             '/': {
                 target: 'http://localhost:3081',
-                ws: true,
                 // Avoid crashing on "read ECONNRESET".
                 onError: err => console.error(err),
                 onProxyReqWs: (_proxyReq, _req, socket) =>


### PR DESCRIPTION
For some reason, Webpack started showing "Invalid frame header" JS console errors on all pages, and on Monaco editor pages it would get into a reload loop. This only occurred on dev servers, not in prod. I don't know why this happened; even after reverting the recent changes related to Webpack, it was still occurring.

Removing WebSocket proxying in webpack-dev-server fixes the issue. We don't need it to proxy WebSockets anymore because the main Sourcegraph app no longer exposes any WebSocket endpoints.