### PR TITLE
frontend: Deprecate enable/disable fields in GraphQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Kinds of external services in use are now included in server pings (https://docs.sourcegraph.com/admin/pings).
+- Kinds of external services in use are now included in [server pings](https://docs.sourcegraph.com/admin/pings).
 
 ### Removed
 
-- Fields related to Repository enablement have been deprecated. Mutations are now NOOPs, and for repositories returned the value is always true for Enabled. The enabled field and mutation will be removed in 3.6.
+- Fields related to Repository enablement have been deprecated. Mutations are now NOOPs, and for repositories returned the value is always true for Enabled. The enabled field and mutations will be removed in 3.6. Mutations: `setRepositoryEnabled`, `setAllRepositoriesEnabled`, `updateAllMirrorRepositories`, `deleteRepository`. Query parameters: `repositories.enabled`, `repositories.disabled`. Field: `Repository.enabled`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
-- Fields related to Repository enablement have been deprecated. Mutation are now NOOPs, and for repositories returned the value is always true for Enabled. The enabled field and mutation will be removed in 3.6.
+- Fields related to Repository enablement have been deprecated. Mutations are now NOOPs, and for repositories returned the value is always true for Enabled. The enabled field and mutation will be removed in 3.6.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+- Fields related to Repository enablement have been deprecated. Mutation are now NOOPs, and for repositories returned the value is always true for Enabled. The enabled field and mutation will be removed in 3.6.
+
 ### Fixed
 
 - Fixed a bug where submitting a saved query without selecting the location would fail for non-site admins (#3628).

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -49,7 +49,7 @@ type Mutation {
     deleteExternalService(externalService: ID!): EmptyResponse!
     # DEPRECATED: All repositories are accessible or deleted. To prevent a
     # repository from being accessed on Sourcegraph add it to the external
-    # service exclude configuration.
+    # service exclude configuration. This mutation will be removed in 3.6.
     #
     # Enables or disables a repository. A disabled repository is only accessible
     # to site admins and never appears in search results.
@@ -85,14 +85,18 @@ type Mutation {
         # The mirror repository to update.
         repository: ID!
     ): EmptyResponse!
-    # Schedules all repositories to be updated from their original source repositories. Updating
-    # occurs automatically, so this should not normally be needed.
+    # DEPRECATED: All repositories are scheduled for updates periodically. This
+    # mutation will be removed in 3.6.
+    #
+    # Schedules all repositories to be updated from their original source
+    # repositories. Updating occurs automatically, so this should not normally
+    # be needed.
     #
     # Only site admins may perform this mutation.
-    updateAllMirrorRepositories: EmptyResponse!
+    updateAllMirrorRepositories: EmptyResponse! @deprecated(reason: "syncer ensures all repositories are up to date.")
     # DEPRECATED: All repositories are accessible or deleted. To prevent a
     # repository from being accessed on Sourcegraph add it to the external
-    # service exclude configuration. It will be deleted.
+    # service exclude configuration. It will be deleted. This mutation will be removed in 3.6.
     #
     # Deletes a repository and all data associated with it, irreversibly.
     #
@@ -674,9 +678,13 @@ type Query {
         # Return repositories whose names are in the list.
         names: [String!]
         # Include enabled repositories.
-        enabled: Boolean = true @deprecated(reason: "No-op. All repositories are enabled.")
+        #
+        # DEPRECATED: All repositories are enabled. Will be removed in 3.6.
+        enabled: Boolean = true
         # Include disabled repositories.
-        disabled: Boolean = false @deprecated(reason: "No-op. All repositories are enabled.")
+        #
+        # DEPRECATED: No repositories are disabled. Will be removed in 3.6.
+        disabled: Boolean = false
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
@@ -1149,7 +1157,7 @@ type Repository implements Node & GenericSearchResultInterface {
     description: String!
     # The primary programming language in the repository.
     language: String!
-    # DEPRECATED: All repositories are enabled.
+    # DEPRECATED: All repositories are enabled. This field will be removed in 3.6.
     #
     # Whether the repository is enabled. A disabled repository should only be accessible to site admins.
     #

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -47,15 +47,25 @@ type Mutation {
     updateExternalService(input: UpdateExternalServiceInput!): ExternalService!
     # Delete an external service. Only site admins may perform this mutation.
     deleteExternalService(externalService: ID!): EmptyResponse!
-    # Enables or disables a repository. A disabled repository is only
-    # accessible to site admins and never appears in search results.
+    # DEPRECATED: All repositories are accessible or deleted. To prevent a
+    # repository from being accessed on Sourcegraph add it to the external
+    # service exclude configuration.
+    #
+    # Enables or disables a repository. A disabled repository is only accessible
+    # to site admins and never appears in search results.
     #
     # Only site admins may perform this mutation.
     setRepositoryEnabled(repository: ID!, enabled: Boolean!): EmptyResponse
+        @deprecated(reason: "update external service exclude setting.")
+    # DEPRECATED: All repositories are accessible or deleted. To prevent a
+    # repository from being accessed on Sourcegraph add it to the external
+    # service exclude configuration.
+    #
     # Enables or disables all site repositories.
     #
     # Only site admins may perform this mutation.
     setAllRepositoriesEnabled(enabled: Boolean!): EmptyResponse
+        @deprecated(reason: "update external service exclude setting.")
     # Tests the connection to a mirror repository's original source repository. This is an
     # expensive and slow operation, so it should only be used for interactive diagnostics.
     #
@@ -80,6 +90,10 @@ type Mutation {
     #
     # Only site admins may perform this mutation.
     updateAllMirrorRepositories: EmptyResponse!
+    # DEPRECATED: All repositories are accessible or deleted. To prevent a
+    # repository from being accessed on Sourcegraph add it to the external
+    # service exclude configuration. It will be deleted.
+    #
     # Deletes a repository and all data associated with it, irreversibly.
     #
     # If the repository was added because it was present in the site configuration (directly,
@@ -88,7 +102,7 @@ type Mutation {
     # use setRepositoryEnabled to disable the repository instead of deleteRepository.
     #
     # Only site admins may perform this mutation.
-    deleteRepository(repository: ID!): EmptyResponse
+    deleteRepository(repository: ID!): EmptyResponse @deprecated(reason: "update external service exclude setting.")
     # Creates a new user account.
     #
     # Only site admins may perform this mutation.
@@ -660,9 +674,9 @@ type Query {
         # Return repositories whose names are in the list.
         names: [String!]
         # Include enabled repositories.
-        enabled: Boolean = true
+        enabled: Boolean = true @deprecated(reason: "No-op. All repositories are enabled.")
         # Include disabled repositories.
-        disabled: Boolean = false
+        disabled: Boolean = false @deprecated(reason: "No-op. All repositories are enabled.")
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
@@ -1135,11 +1149,13 @@ type Repository implements Node & GenericSearchResultInterface {
     description: String!
     # The primary programming language in the repository.
     language: String!
+    # DEPRECATED: All repositories are enabled.
+    #
     # Whether the repository is enabled. A disabled repository should only be accessible to site admins.
     #
     # NOTE: Disabling a repository does not provide any additional security. This field is merely a
     # guideline to UI implementations.
-    enabled: Boolean!
+    enabled: Boolean! @deprecated(reason: "Always true. All repositories are enabled.")
     # The date when this repository was created on Sourcegraph.
     createdAt: String!
     # The date when this repository's metadata was last updated on Sourcegraph.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -51,7 +51,7 @@ type Mutation {
     deleteExternalService(externalService: ID!): EmptyResponse!
     # DEPRECATED: All repositories are accessible or deleted. To prevent a
     # repository from being accessed on Sourcegraph add it to the external
-    # service exclude configuration.
+    # service exclude configuration. This mutation will be removed in 3.6.
     #
     # Enables or disables a repository. A disabled repository is only accessible
     # to site admins and never appears in search results.
@@ -87,14 +87,18 @@ type Mutation {
         # The mirror repository to update.
         repository: ID!
     ): EmptyResponse!
-    # Schedules all repositories to be updated from their original source repositories. Updating
-    # occurs automatically, so this should not normally be needed.
+    # DEPRECATED: All repositories are scheduled for updates periodically. This
+    # mutation will be removed in 3.6.
+    #
+    # Schedules all repositories to be updated from their original source
+    # repositories. Updating occurs automatically, so this should not normally
+    # be needed.
     #
     # Only site admins may perform this mutation.
-    updateAllMirrorRepositories: EmptyResponse!
+    updateAllMirrorRepositories: EmptyResponse! @deprecated(reason: "syncer ensures all repositories are up to date.")
     # DEPRECATED: All repositories are accessible or deleted. To prevent a
     # repository from being accessed on Sourcegraph add it to the external
-    # service exclude configuration. It will be deleted.
+    # service exclude configuration. It will be deleted. This mutation will be removed in 3.6.
     #
     # Deletes a repository and all data associated with it, irreversibly.
     #
@@ -681,9 +685,13 @@ type Query {
         # Return repositories whose names are in the list.
         names: [String!]
         # Include enabled repositories.
-        enabled: Boolean = true @deprecated(reason: "No-op. All repositories are enabled.")
+        #
+        # DEPRECATED: All repositories are enabled. Will be removed in 3.6.
+        enabled: Boolean = true
         # Include disabled repositories.
-        disabled: Boolean = false @deprecated(reason: "No-op. All repositories are enabled.")
+        #
+        # DEPRECATED: No repositories are disabled. Will be removed in 3.6.
+        disabled: Boolean = false
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
@@ -1156,7 +1164,7 @@ type Repository implements Node & GenericSearchResultInterface {
     description: String!
     # The primary programming language in the repository.
     language: String!
-    # DEPRECATED: All repositories are enabled.
+    # DEPRECATED: All repositories are enabled. This field will be removed in 3.6.
     #
     # Whether the repository is enabled. A disabled repository should only be accessible to site admins.
     #

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -49,15 +49,25 @@ type Mutation {
     updateExternalService(input: UpdateExternalServiceInput!): ExternalService!
     # Delete an external service. Only site admins may perform this mutation.
     deleteExternalService(externalService: ID!): EmptyResponse!
-    # Enables or disables a repository. A disabled repository is only
-    # accessible to site admins and never appears in search results.
+    # DEPRECATED: All repositories are accessible or deleted. To prevent a
+    # repository from being accessed on Sourcegraph add it to the external
+    # service exclude configuration.
+    #
+    # Enables or disables a repository. A disabled repository is only accessible
+    # to site admins and never appears in search results.
     #
     # Only site admins may perform this mutation.
     setRepositoryEnabled(repository: ID!, enabled: Boolean!): EmptyResponse
+        @deprecated(reason: "update external service exclude setting.")
+    # DEPRECATED: All repositories are accessible or deleted. To prevent a
+    # repository from being accessed on Sourcegraph add it to the external
+    # service exclude configuration.
+    #
     # Enables or disables all site repositories.
     #
     # Only site admins may perform this mutation.
     setAllRepositoriesEnabled(enabled: Boolean!): EmptyResponse
+        @deprecated(reason: "update external service exclude setting.")
     # Tests the connection to a mirror repository's original source repository. This is an
     # expensive and slow operation, so it should only be used for interactive diagnostics.
     #
@@ -82,6 +92,10 @@ type Mutation {
     #
     # Only site admins may perform this mutation.
     updateAllMirrorRepositories: EmptyResponse!
+    # DEPRECATED: All repositories are accessible or deleted. To prevent a
+    # repository from being accessed on Sourcegraph add it to the external
+    # service exclude configuration. It will be deleted.
+    #
     # Deletes a repository and all data associated with it, irreversibly.
     #
     # If the repository was added because it was present in the site configuration (directly,
@@ -90,7 +104,7 @@ type Mutation {
     # use setRepositoryEnabled to disable the repository instead of deleteRepository.
     #
     # Only site admins may perform this mutation.
-    deleteRepository(repository: ID!): EmptyResponse
+    deleteRepository(repository: ID!): EmptyResponse @deprecated(reason: "update external service exclude setting.")
     # Creates a new user account.
     #
     # Only site admins may perform this mutation.
@@ -667,9 +681,9 @@ type Query {
         # Return repositories whose names are in the list.
         names: [String!]
         # Include enabled repositories.
-        enabled: Boolean = true
+        enabled: Boolean = true @deprecated(reason: "No-op. All repositories are enabled.")
         # Include disabled repositories.
-        disabled: Boolean = false
+        disabled: Boolean = false @deprecated(reason: "No-op. All repositories are enabled.")
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
@@ -1142,11 +1156,13 @@ type Repository implements Node & GenericSearchResultInterface {
     description: String!
     # The primary programming language in the repository.
     language: String!
+    # DEPRECATED: All repositories are enabled.
+    #
     # Whether the repository is enabled. A disabled repository should only be accessible to site admins.
     #
     # NOTE: Disabling a repository does not provide any additional security. This field is merely a
     # guideline to UI implementations.
-    enabled: Boolean!
+    enabled: Boolean! @deprecated(reason: "Always true. All repositories are enabled.")
     # The date when this repository was created on Sourcegraph.
     createdAt: String!
     # The date when this repository's metadata was last updated on Sourcegraph.


### PR DESCRIPTION
From 3.4 onwards this concept is a no-op. All repositories are "enabled".
Disabled repositories are deleted, and to exclude a repository the external
service configuration needs to be updated.

Part of #3291