### PR TITLE
frontend: Remove Enabled field from types.Repo

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -119,9 +119,6 @@ func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) (
 	if err != nil {
 		return nil, err
 	}
-	if !repo.Enabled {
-		return nil, errors.New("repository is not enabled")
-	}
 	gitRepo, err := CachedGitRepo(ctx, repo)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/backend/go_importers_test.go
+++ b/cmd/frontend/backend/go_importers_test.go
@@ -38,7 +38,6 @@ func TestCountGoImporters(t *testing.T) {
 		return &types.Repo{
 			Name:         repoName,
 			ExternalRepo: &api.ExternalRepoSpec{ServiceType: github.ServiceType},
-			Enabled:      true,
 		}, nil
 	}
 	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -17,9 +17,8 @@ func TestReposService_Get(t *testing.T) {
 	ctx := testContext()
 
 	wantRepo := &types.Repo{
-		ID:      1,
-		Name:    "github.com/u/r",
-		Enabled: true,
+		ID:   1,
+		Name: "github.com/u/r",
 	}
 
 	calledGet := db.Mocks.Repos.MockGet_Return(t, wantRepo)

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -101,7 +101,7 @@ func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
 }
 
 const getRepoByQueryFmtstr = `
-SELECT id, name, description, language, enabled, created_at,
+SELECT id, name, description, language, created_at,
   updated_at, external_id, external_service_type, external_service_id
 FROM repo
 WHERE deleted_at IS NULL AND enabled = true AND %s`
@@ -124,7 +124,6 @@ func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types
 			&repo.Name,
 			&repo.Description,
 			&repo.Language,
-			&repo.Enabled,
 			&repo.CreatedAt,
 			&repo.UpdatedAt,
 			&spec.id, &spec.serviceType, &spec.serviceID,
@@ -656,7 +655,7 @@ func (s *repos) Upsert(ctx context.Context, op api.InsertRepoOp) error {
 		}
 		insert = true // missing
 	} else {
-		enabled = r.Enabled
+		enabled = true
 		language = r.Language
 		// Ignore Enabled for deciding to update
 		insert = ((op.Description != r.Description) ||

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -104,7 +104,7 @@ const getRepoByQueryFmtstr = `
 SELECT id, name, description, language, enabled, created_at,
   updated_at, external_id, external_service_type, external_service_id
 FROM repo
-WHERE deleted_at IS NULL AND %s`
+WHERE deleted_at IS NULL AND enabled = true AND %s`
 
 func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	q := sqlf.Sprintf(getRepoByQueryFmtstr, querySuffix)

--- a/cmd/frontend/db/repos_mock.go
+++ b/cmd/frontend/db/repos_mock.go
@@ -52,7 +52,7 @@ func (s *MockRepos) MockGetByName(t *testing.T, want api.RepoName, repo api.Repo
 			t.Errorf("got repo name %q, want %q", name, want)
 			return nil, &repoNotFoundErr{Name: name}
 		}
-		return &types.Repo{ID: repo, Name: name, Enabled: true}, nil
+		return &types.Repo{ID: repo, Name: name}, nil
 	}
 	return
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -90,12 +90,6 @@ func (r *repositoryResolver) ViewerCanAdminister(ctx context.Context) (bool, err
 }
 
 func (r *repositoryResolver) CloneInProgress(ctx context.Context) (bool, error) {
-	// Asking gitserver may trigger a clone of the repo, so ensure it is
-	// enabled.
-	if !r.repo.Enabled {
-		return false, nil
-	}
-
 	return r.MirrorInfo().CloneInProgress(ctx)
 }
 
@@ -105,12 +99,6 @@ type repositoryCommitArgs struct {
 }
 
 func (r *repositoryResolver) Commit(ctx context.Context, args *repositoryCommitArgs) (*gitCommitResolver, error) {
-	// Asking gitserver may trigger a clone of the repo, so ensure it is
-	// enabled.
-	if !r.repo.Enabled {
-		return nil, nil
-	}
-
 	commitID, err := backend.Repos.ResolveRev(ctx, r.repo, args.Rev)
 	if err != nil {
 		if git.IsRevisionNotFound(err) {
@@ -134,12 +122,6 @@ func (r *repositoryResolver) Commit(ctx context.Context, args *repositoryCommitA
 }
 
 func (r *repositoryResolver) DefaultBranch(ctx context.Context) (*gitRefResolver, error) {
-	// Asking gitserver may trigger a clone of the repo, so ensure it is
-	// enabled.
-	if !r.repo.Enabled {
-		return nil, nil
-	}
-
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo)
 	if err != nil {
 		return nil, err
@@ -168,7 +150,7 @@ func (r *repositoryResolver) Language() string {
 	return r.repo.Language
 }
 
-func (r *repositoryResolver) Enabled() bool { return r.repo.Enabled }
+func (r *repositoryResolver) Enabled() bool { return true }
 
 func (r *repositoryResolver) CreatedAt() string {
 	return r.repo.CreatedAt.Format(time.RFC3339)

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -24,9 +24,6 @@ type Repo struct {
 	Description string
 	// Language is the primary programming language used in this repository.
 	Language string
-	// Enabled is whether the repository is enabled. Disabled repositories are
-	// not accessible by users (except site admins).
-	Enabled bool
 	// Fork is whether this repository is a fork of another repository.
 	Fork bool
 	// CreatedAt is when this repository was created on Sourcegraph.


### PR DESCRIPTION
We remove this field from all internal reads. We adjust all reads of the field
to act as if it was true. Additionally we update the database listing code to
always have the conditional `enabled = true`. Once the first sync of the new
syncer has run, all rows in the table will have enabled = true.

Part of #3291