### PR TITLE
all: Demote regular low value logs to Debug

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -205,7 +205,7 @@ func (s *Server) cleanupRepos() {
 		log15.Error("finding mount point for dir containing repos", "error", err)
 		mount = "<not found>"
 	}
-	log15.Info("cleanup",
+	log15.Debug("cleanup",
 		"free space in GiB", float64(actualFreeBytes)/G,
 		"desired free space in GiB", float64(s.DesiredFreeDiskSpace)/G,
 		"mount point", mount)

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -172,7 +172,7 @@ func main() {
 		diffs := make(chan repos.Diff)
 		syncer = repos.NewSyncer(store, src, diffs, clock)
 
-		log15.Info("starting new syncer", "external service kinds", kinds)
+		log15.Debug("starting new syncer", "external service kinds", kinds)
 		go func() { log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval(), kinds...)) }()
 
 		gps := repos.NewGitolitePhabricatorMetadataSyncer(store)

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -116,7 +116,7 @@ func (s *GitolitePhabricatorMetadataSyncer) Sync(ctx context.Context, repos []*R
 	defer s.sem.Release(1)
 
 	if s.counter++; s.counter%10 != 0 { // Only run every ten times.
-		log15.Info("phabricator metadata sync only runs every 10th gitolite sync. skipping", "counter", s.counter)
+		log15.Debug("phabricator metadata sync only runs every 10th gitolite sync. skipping", "counter", s.counter)
 		return nil
 	}
 
@@ -136,7 +136,7 @@ func (s *GitolitePhabricatorMetadataSyncer) Sync(ctx context.Context, repos []*R
 	}
 
 	if len(ids) == 0 {
-		log15.Info("phabricator metadata: nothing to sync")
+		log15.Debug("phabricator metadata: nothing to sync")
 		return nil
 	}
 

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -61,7 +61,7 @@ func RunScheduler(ctx context.Context) {
 			go Scheduler.runScheduleLoop(ctx2)
 		}
 
-		log15.Info(
+		log15.Debug(
 			"started configured scheduler",
 			"version", "new",
 			"auto-git-updates", want.autoGitUpdatesEnabled,


### PR DESCRIPTION
Noticed from running sourcegraph locally. These are regular messages which do
not provide any value for most users. As such they are demoted to Debug.