### PR TITLE
Simplify ViewResolver type

### DIFF
--- a/browser/src/libs/code_intelligence/code_views.test.ts
+++ b/browser/src/libs/code_intelligence/code_views.test.ts
@@ -2,7 +2,7 @@ import { of, Subject } from 'rxjs'
 import { toArray } from 'rxjs/operators'
 import * as sinon from 'sinon'
 import { Omit } from 'utility-types'
-import { MutationRecordLike } from '../../shared/util/dom'
+import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
 import { FileInfo } from './code_intelligence'
 import { CodeView, toCodeViewResolver, trackCodeViews } from './code_views'
 
@@ -48,7 +48,9 @@ describe('code_views', () => {
             const detected = await of([{ addedNodes: [document.body], removedNodes: [] }])
                 .pipe(
                     trackCodeViews({
-                        codeViewResolvers: [{ selector, resolveView }],
+                        codeViewResolvers: [
+                            container => [...querySelectorAllOrSelf<HTMLElement>(container, selector)].map(resolveView),
+                        ],
                     }),
                     toArray()
                 )

--- a/browser/src/libs/code_intelligence/code_views.ts
+++ b/browser/src/libs/code_intelligence/code_views.ts
@@ -2,12 +2,12 @@ import { DOMFunctions, PositionAdjuster } from '@sourcegraph/codeintellify'
 import { Selection } from '@sourcegraph/extension-api-types'
 import { Observable, of, zip } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
-import { Omit } from 'utility-types'
 import { PlatformContext } from '../../../../shared/src/platform/context'
 import { FileSpec, RepoSpec, ResolvedRevSpec, RevSpec } from '../../../../shared/src/util/url'
 import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM, isErrorLike } from '../../shared/backend/errors'
 import { ButtonProps } from '../../shared/components/CodeViewToolbar'
 import { fetchBlobContentLines } from '../../shared/repo/backend'
+import { querySelectorAllOrSelf } from '../../shared/util/dom'
 import { CodeHost, FileInfo } from './code_intelligence'
 import { ensureRevisionsAreCloned } from './util/file_info'
 import { trackViews, ViewResolver } from './views'
@@ -17,14 +17,10 @@ import { trackViews, ViewResolver } from './views'
  * Exposes operations for manipulating it, and CSS classes to be applied to injected UI elements.
  */
 export interface CodeView {
-    /**
-     * The code view element on the page.
-     */
-    element: HTMLElement
     /** The DOMFunctions for the code view. */
     dom: DOMFunctions
     /**
-     * Finds or creates a DOM element where we should inject the
+     * Finds or creates a DOM element where we should inject the3
      * `CodeViewToolbar`. This function is responsible for ensuring duplicate
      * mounts aren't created.
      */
@@ -58,10 +54,8 @@ export interface CodeView {
 /**
  * Builds a CodeViewResolver from a static CodeView and a selector.
  */
-export const toCodeViewResolver = (selector: string, spec: Omit<CodeView, 'element'>): ViewResolver<CodeView> => ({
-    selector,
-    resolveView: element => ({ ...spec, element }),
-})
+export const toCodeViewResolver = (selector: string, spec: CodeView): ViewResolver<CodeView> => container =>
+    [...querySelectorAllOrSelf<HTMLElement>(container, selector)].map(element => ({ ...spec, element }))
 
 /**
  * Find all the code views on a page using both the code view specs and the code view spec

--- a/browser/src/libs/code_intelligence/content_views.ts
+++ b/browser/src/libs/code_intelligence/content_views.ts
@@ -10,10 +10,7 @@ import { trackViews } from './views'
 /**
  * Defines a content view that is present on a page and exposes operations for manipulating it.
  */
-export interface ContentView {
-    /** The content view HTML element. */
-    element: HTMLElement
-}
+export interface ContentView {}
 
 /**
  * Handles added and removed content views according to the {@link CodeHost} configuration.

--- a/browser/src/libs/code_intelligence/text_fields.test.tsx
+++ b/browser/src/libs/code_intelligence/text_fields.test.tsx
@@ -12,7 +12,7 @@ import { Services } from '../../../../shared/src/api/client/services'
 import { CodeEditor } from '../../../../shared/src/api/client/services/editorService'
 import { integrationTestContext } from '../../../../shared/src/api/integration-test/testHelpers'
 import { Controller } from '../../../../shared/src/extensions/controller'
-import { MutationRecordLike } from '../../shared/util/dom'
+import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
 import { handleTextFields } from './text_fields'
 
 jest.mock('uuid', () => ({
@@ -62,7 +62,12 @@ describe('text_fields', () => {
                     { extensionsController: createMockController(services) },
                     {
                         textFieldResolvers: [
-                            { selector: 'textarea', resolveView: () => ({ element: textFieldElement }) },
+                            container =>
+                                [...querySelectorAllOrSelf<HTMLTextAreaElement>(container, 'textarea')].map(
+                                    element => ({
+                                        element,
+                                    })
+                                ),
                         ],
                     }
                 )

--- a/browser/src/libs/code_intelligence/views.ts
+++ b/browser/src/libs/code_intelligence/views.ts
@@ -1,44 +1,24 @@
 import { from, merge, Observable } from 'rxjs'
-import { concatAll, filter, map, mergeMap } from 'rxjs/operators'
-import { isDefined, isInstanceOf } from '../../../../shared/src/util/types'
-import { MutationRecordLike, querySelectorAllOrSelf } from '../../shared/util/dom'
-
-/**
- * Finds and resolves elements matched by a MutationObserver to views.
- *
- * @template V The type of view, such as a code view.
- */
-export interface ViewResolver<V> {
-    /**
-     * The element selector (used with {@link Window#querySelectorAll}) that matches candidate
-     * elements to be passed to {@link ViewResolver#resolveView}.
-     */
-    selector: string
-
-    /**
-     * Resolve an element matched by {@link ViewResolver#selector} to a view, or `null` if it's not
-     * a a valid view upon further examination.
-     */
-    resolveView: (element: HTMLElement) => V | null
-}
-
-interface AddedViewEvent {
-    type: 'added'
-}
-
-interface RemovedViewEvent {
-    type: 'removed'
-
-    /** The HTML element that was removed. */
-    element: HTMLElement
-}
+import { concatAll, filter, mergeMap } from 'rxjs/operators'
+import { isInstanceOf } from '../../../../shared/src/util/types'
+import { MutationRecordLike } from '../../shared/util/dom'
 
 /**
  * An addition or removal of a view observed by a {@link MutationObserver}.
  *
  * @template V The type of view, such as a code view.
  */
-export type ViewEvent<V> = (AddedViewEvent & V) | RemovedViewEvent
+export interface ViewEvent {
+    type: 'added' | 'removed'
+    element: HTMLElement
+}
+
+/**
+ * Finds and resolves elements matched by a MutationObserver to views.
+ *
+ * @template V The type of view, such as a code view.
+ */
+export type ViewResolver<V = {}> = (container: Element) => Iterable<V & Pick<ViewEvent, 'element'>>
 
 /**
  * Find all the views (e.g., code views) on a page using view resolvers (defined in
@@ -51,51 +31,27 @@ export type ViewEvent<V> = (AddedViewEvent & V) | RemovedViewEvent
  * @template V The type of view, such as a code view.
  */
 export function trackViews<V>(
-    viewResolvers: ViewResolver<V>[]
-): (mutations: Observable<MutationRecordLike[]>) => Observable<ViewEvent<V>> {
+    viewResolvers: ViewResolver<V & Pick<ViewEvent, 'element'>>[]
+): (mutations: Observable<MutationRecordLike[]>) => Observable<V & ViewEvent> {
+    const observeViewEvents = (
+        nodeList: ArrayLike<Node> & Iterable<Node>,
+        type: ViewEvent['type']
+    ): Observable<V & ViewEvent> =>
+        from(nodeList).pipe(
+            filter(isInstanceOf(HTMLElement)),
+            mergeMap(addedElement =>
+                from(viewResolvers).pipe(
+                    mergeMap(resolveViews => [...resolveViews(addedElement)].map(view => ({ ...view, type })))
+                )
+            )
+        )
     return mutations =>
         mutations.pipe(
             concatAll(),
             mergeMap(mutation =>
                 merge(
-                    // Find all new code views within the added nodes
-                    // (MutationObservers don't emit all descendant nodes of an addded node recursively)
-                    from(mutation.addedNodes).pipe(
-                        filter(isInstanceOf(HTMLElement)),
-                        mergeMap(addedElement =>
-                            from(viewResolvers).pipe(
-                                mergeMap(spec =>
-                                    [...querySelectorAllOrSelf<HTMLElement>(addedElement, spec.selector)]
-                                        .map(element => {
-                                            const view = spec.resolveView(element)
-                                            return (
-                                                view && {
-                                                    ...view,
-                                                    type: 'added' as const,
-                                                }
-                                            )
-                                        })
-                                        .filter(isDefined)
-                                )
-                            )
-                        )
-                    ),
-                    // For removed nodes, find the removed elements, but don't resolve the kind (it's not relevant)
-                    from(mutation.removedNodes).pipe(
-                        filter(isInstanceOf(HTMLElement)),
-                        mergeMap(removedElement =>
-                            from(viewResolvers).pipe(
-                                mergeMap(
-                                    ({ selector }) =>
-                                        querySelectorAllOrSelf(removedElement, selector) as Iterable<HTMLElement>
-                                ),
-                                map(element => ({
-                                    element,
-                                    type: 'removed' as const,
-                                }))
-                            )
-                        )
-                    )
+                    observeViewEvents(mutation.addedNodes, 'added'),
+                    observeViewEvents(mutation.removedNodes, 'removed')
                 )
             )
         )

--- a/browser/src/libs/github/content_views.ts
+++ b/browser/src/libs/github/content_views.ts
@@ -1,11 +1,9 @@
-import { ContentView } from '../code_intelligence/content_views'
+import { querySelectorAllOrSelf } from '../../shared/util/dom'
 import { ViewResolver } from '../code_intelligence/views'
 
 /**
  * Matches all GitHub Markdown body content, including comment bodies, issue/PR descriptions, review
  * comments, and rendered Markdown files.
  */
-export const markdownBodyViewResolver: ViewResolver<ContentView> = {
-    selector: '.markdown-body',
-    resolveView: element => ({ element }),
-}
+export const markdownBodyViewResolver: ViewResolver = container =>
+    [...querySelectorAllOrSelf<HTMLElement>(container, '.markdown-body')].map(element => ({ element }))

--- a/browser/src/libs/github/text_fields.ts
+++ b/browser/src/libs/github/text_fields.ts
@@ -1,12 +1,6 @@
+import { querySelectorAllOrSelf } from '../../shared/util/dom'
 import { TextField } from '../code_intelligence/text_fields'
 import { ViewResolver } from '../code_intelligence/views'
 
-export const commentTextFieldResolver: ViewResolver<TextField> = {
-    selector: '.comment-form-textarea',
-    resolveView: element => {
-        if (!(element instanceof HTMLTextAreaElement)) {
-            return null
-        }
-        return { element }
-    },
-}
+export const commentTextFieldResolver: ViewResolver<TextField> = container =>
+    [...querySelectorAllOrSelf<HTMLTextAreaElement>(container, '.comment-form-textarea')].map(element => ({ element }))

--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -1,4 +1,5 @@
 import { Omit } from 'utility-types'
+import { querySelectorAllOrSelf } from '../../shared/util/dom'
 import { CodeHost } from '../code_intelligence'
 import { CodeView } from '../code_intelligence/code_views'
 import { getSelectionsFromHash, observeSelectionsFromHash } from '../code_intelligence/util/selections'
@@ -69,24 +70,20 @@ const commitCodeView: Omit<CodeView, 'element'> = {
     toolbarButtonProps,
 }
 
-const resolveView = (element: HTMLElement): CodeView => {
-    const { pageKind } = getPageInfo()
+const codeViewResolver: ViewResolver<CodeView> = container =>
+    [...querySelectorAllOrSelf<HTMLElement>(container, '.file-holder')].map(element => {
+        const { pageKind } = getPageInfo()
 
-    if (pageKind === GitLabPageKind.File) {
-        return { element, ...singleFileCodeView }
-    }
+        if (pageKind === GitLabPageKind.File) {
+            return { element, ...singleFileCodeView }
+        }
 
-    if (pageKind === GitLabPageKind.MergeRequest) {
-        return { element, ...mergeRequestCodeView }
-    }
+        if (pageKind === GitLabPageKind.MergeRequest) {
+            return { element, ...mergeRequestCodeView }
+        }
 
-    return { element, ...commitCodeView }
-}
-
-const codeViewResolver: ViewResolver<CodeView> = {
-    selector: '.file-holder',
-    resolveView,
-}
+        return { element, ...commitCodeView }
+    })
 
 export const gitlabCodeHost: CodeHost = {
     name: 'gitlab',


### PR DESCRIPTION
A `ViewResolver` is now simply a function that takes a container as input and returns `Iterable<View>`, instead of being defined with a selector and a `resolveView()` function.
