### PR TITLE
pkg/conf: deadlock detector: clarify prod error messages + use lenient timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where submitting a saved query without selecting the location would fail for non-site admins (#3628).
 - Fixed settings editors only having a few pixels height.
 - Fixed a bug where browser extension and code review integration usage stats were not being captured on the site-admin Usage Stats page.
+- Fixed an issue where in some rare cases PostgreSQL starting up slowly could incorrectly trigger a panic in the `frontend` service.
 
 ## 3.3.7
 


### PR DESCRIPTION
`pkg/conf` has logic to detect deadlocks where someone relies on configuration
in the frontend and inadvertently prevents the frontend configuration server
from starting (hence, a deadlock).

In some cases where PostgreSQL takes very long to startup this logic can trigger,
thus we should only do so aggressively in dev mode. However, it is still useful
in prod so that we can debug any other case where the frontend config server is
blocked from starting for a very long period of time.

Fixes #2812

Test plan: not necessary (making logic more lenient)