### PR TITLE
frontend: Return URI in Graphql API

### DIFF
--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -117,7 +117,7 @@ func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
 }
 
 const getRepoByQueryFmtstr = `
-SELECT id, name, description, language, created_at,
+SELECT id, name, COALESCE(uri, ''), description, language, created_at,
   updated_at, external_id, external_service_type, external_service_id
 FROM repo
 WHERE deleted_at IS NULL AND enabled = true AND %s`
@@ -138,6 +138,7 @@ func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types
 		if err := rows.Scan(
 			&repo.ID,
 			&repo.Name,
+			&repo.URI,
 			&repo.Description,
 			&repo.Language,
 			&repo.CreatedAt,

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -65,6 +65,7 @@ func TestRepos_Get(t *testing.T) {
 
 	want := mustCreate(ctx, t, &types.Repo{
 		Name: "r",
+		URI:  "u",
 		ExternalRepo: &api.ExternalRepoSpec{
 			ID:          "a",
 			ServiceType: "b",

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -66,9 +66,8 @@ func (r *repositoryResolver) Name() string {
 	return string(r.repo.Name)
 }
 
-// TODO(chris): Remove URI in favor of Name.
 func (r *repositoryResolver) URI() string {
-	return string(r.repo.Name)
+	return r.repo.URI
 }
 
 func (r *repositoryResolver) Description() string {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1151,8 +1151,9 @@ type Repository implements Node & GenericSearchResultInterface {
     # - my-code-host.example.com/myrepo
     # - myrepo
     name: String!
-    # An alias for name.
-    uri: String! @deprecated(reason: "use name instead")
+    # URI is the full name for this repository (e.g., "github.com/user/repo").
+    # See the documentation for the name field.
+    uri: String!
     # The repository's description.
     description: String!
     # The primary programming language in the repository.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1158,8 +1158,9 @@ type Repository implements Node & GenericSearchResultInterface {
     # - my-code-host.example.com/myrepo
     # - myrepo
     name: String!
-    # An alias for name.
-    uri: String! @deprecated(reason: "use name instead")
+    # URI is the full name for this repository (e.g., "github.com/user/repo").
+    # See the documentation for the name field.
+    uri: String!
     # The repository's description.
     description: String!
     # The primary programming language in the repository.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -279,7 +279,7 @@ func (sr *searchResultsResolver) DynamicFilters() []*searchFilterResolver {
 			// It should be fine to leave this blank since revision specifiers
 			// can only be used with the 'repo:' scope. In that case,
 			// we shouldn't be getting any repositoy name matches back.
-			addRepoFilter(result.repo.URI(), "", 1)
+			addRepoFilter(result.repo.Name(), "", 1)
 		}
 		// Add `case:yes` filter to offer easier access to search results matching with case sensitive set to yes
 		// We use count == 0 and limitHit == false since we can't determine that information without

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -16,10 +16,17 @@ type Repo struct {
 	// service itself).
 	ExternalRepo *api.ExternalRepoSpec
 
-	// Name is the name for this repository (e.g., "github.com/user/repo").
+	// Name is the name for this repository (e.g., "github.com/user/repo"). It
+	// is the same as URI, unless the user configures a non-default
+	// repositoryPathPattern.
 	//
 	// Previously, this was called RepoURI.
 	Name api.RepoName
+
+	// URI is the full name for this repository (e.g.,
+	// "github.com/user/repo"). See the documentation for the Name field.
+	URI string
+
 	// Description is a brief description of the repository.
 	Description string
 	// Language is the primary programming language used in this repository.


### PR DESCRIPTION
No clients currently use this field (it has been deprecated for several
releases). However, extensions may start using this field when they want
access to the "full name".

Test plan: unit tests

Part of https://github.com/sourcegraph/sourcegraph/issues/462