### PR TITLE
web: use Bitbucket icon for go-to-code-host action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Kinds of external services in use are now included in [server pings](https://docs.sourcegraph.com/admin/pings).
+- Bitbucket Server: An actual Bitbucket icon is now used for the jump-to-bitbucket action on repository pages instead of the previously generic icon.
 
 ### Removed
 

--- a/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -1,5 +1,6 @@
 import { Position, Range } from '@sourcegraph/extension-api-types'
 import { upperFirst } from 'lodash'
+import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import ExportIcon from 'mdi-react/ExportIcon'
 import GithubCircleIcon from 'mdi-react/GithubCircleIcon'
 import * as React from 'react'
@@ -144,7 +145,7 @@ function serviceTypeDisplayNameAndIcon(
         case 'gitlab':
             return { displayName: 'GitLab' }
         case 'bitbucketserver':
-            return { displayName: 'Bitbucket Server' }
+            return { displayName: 'Bitbucket Server', icon: BitbucketIcon }
         case 'phabricator':
             return { displayName: 'Phabricator', icon: PhabricatorIcon }
         case 'awscodecommit':

--- a/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -144,7 +144,10 @@ function serviceTypeDisplayNameAndIcon(
             return { displayName: 'GitHub', icon: GithubCircleIcon }
         case 'gitlab':
             return { displayName: 'GitLab' }
-        case 'bitbucketserver':
+        case 'bitbucketServer':
+            // TODO: Why is bitbucketServer (correctly) camelCase but
+            // awscodecommit is (correctly) lowercase? Why is serviceType
+            // not type-checked for validity?
             return { displayName: 'Bitbucket Server', icon: BitbucketIcon }
         case 'phabricator':
             return { displayName: 'Phabricator', icon: PhabricatorIcon }


### PR DESCRIPTION
Fixes #3355

Test plan: Manually tested