### PR TITLE
repo-updater: Collapse testdata files in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 cmd/frontend/graphqlbackend/schema.go linguist-generated=true
+cmd/repo-updater/repos/testdata/** linguist-generated=true
 CHANGELOG.md merge=union


### PR DESCRIPTION
Usually the testdata files are not that useful to always review in a PR. This
git attribute will collapse them by default.