### PR TITLE
gitserver: use `Server.removeRepoDirectory` instead of `os.RemoveAll`

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -316,8 +316,7 @@ func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
 		if err != nil {
 			return errors.Wrapf(err, "computing size of directory %s", d)
 		}
-		gitDirParent := filepath.Dir(d)
-		if err := s.removeRepoDirectory(gitDirParent); err != nil {
+		if err := s.removeRepoDirectory(d); err != nil {
 			return errors.Wrap(err, "removing repo directory")
 		}
 		spaceFreed += delta

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -317,7 +317,7 @@ func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
 			return errors.Wrapf(err, "computing size of directory %s", d)
 		}
 		gitDirParent := filepath.Dir(d)
-		if err := os.RemoveAll(gitDirParent); err != nil {
+		if err := s.removeRepoDirectory(gitDirParent); err != nil {
 			return errors.Wrap(err, "removing repo directory")
 		}
 		spaceFreed += delta

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -446,16 +446,10 @@ func TestFreeUpSpace(t *testing.T) {
 		}
 
 		// Check.
-		files, err := ioutil.ReadDir(rd)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(files) != 1 {
-			t.Fatalf("got %d items in %s, want exactly 1", len(files), rd)
-		}
-		if files[0].Name() != "repo2" {
-			t.Errorf("name of only item in repos dir is %q, want repo2", files[0].Name())
-		}
+		assertPaths(t, rd,
+			".tmp",
+			"repo2/.git/HEAD",
+			"repo2/.git/space_eater")
 		rds, err := dirSize(rd)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fixes #3972 

Test plan: Update existing test.
