### PR TITLE
fix issue where management console password would reset on user account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed settings editors only having a few pixels height.
 - Fixed a bug where browser extension and code review integration usage stats were not being captured on the site-admin Usage Stats page.
 - Fixed an issue where in some rare cases PostgreSQL starting up slowly could incorrectly trigger a panic in the `frontend` service.
+- Fixed an issue where the management console password would incorrectly reset to a new secure one after a user account was created.
 
 ## 3.3.7
 

--- a/pkg/db/globalstatedb/globalstatedb.go
+++ b/pkg/db/globalstatedb/globalstatedb.go
@@ -37,7 +37,7 @@ func Get(ctx context.Context) (*State, error) {
 }
 
 func SiteInitialized(ctx context.Context) (alreadyInitialized bool, err error) {
-	if err := dbconn.Global.QueryRowContext(ctx, `SELECT initialized FROM global_state LIMIT 1`).Scan(&alreadyInitialized); err != nil {
+	if err := dbconn.Global.QueryRowContext(ctx, `SELECT initialized FROM global_state ORDER BY site_id LIMIT 1`).Scan(&alreadyInitialized); err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
 		}
@@ -66,7 +66,7 @@ func EnsureInitialized(ctx context.Context, dbh interface {
 
 	// The "SELECT ... FOR UPDATE" prevents a race condition where two calls, each in their own transaction,
 	// would see this initialized value as false and then set it to true below.
-	if err := dbh.QueryRowContext(ctx, `SELECT initialized FROM global_state FOR UPDATE LIMIT 1`).Scan(&alreadyInitialized); err != nil {
+	if err := dbh.QueryRowContext(ctx, `SELECT initialized FROM global_state ORDER BY site_id FOR UPDATE LIMIT 1`).Scan(&alreadyInitialized); err != nil {
 		return false, err
 	}
 
@@ -79,7 +79,7 @@ func EnsureInitialized(ctx context.Context, dbh interface {
 
 func getConfiguration(ctx context.Context) (*State, error) {
 	configuration := &State{}
-	err := dbconn.Global.QueryRowContext(ctx, "SELECT site_id, initialized FROM global_state LIMIT 1").Scan(
+	err := dbconn.Global.QueryRowContext(ctx, "SELECT site_id, initialized FROM global_state ORDER BY site_id LIMIT 1").Scan(
 		&configuration.SiteID,
 		&configuration.Initialized,
 	)
@@ -111,8 +111,8 @@ func tryInsertNew(ctx context.Context, dbh interface {
 	) values(
 		$1,
 		EXISTS (SELECT 1 FROM users WHERE deleted_at IS NULL),
-		(SELECT COALESCE((SELECT mgmt_password_plaintext FROM global_state LIMIT 1), '')),
-		(SELECT COALESCE((SELECT mgmt_password_bcrypt FROM global_state LIMIT 1), ''))
+		(SELECT COALESCE((SELECT mgmt_password_plaintext FROM global_state ORDER BY site_id LIMIT 1), '')),
+		(SELECT COALESCE((SELECT mgmt_password_bcrypt FROM global_state ORDER BY site_id LIMIT 1), ''))
 	);`, siteID)
 	if err != nil {
 		if pqErr, ok := err.(*pq.Error); ok {
@@ -277,7 +277,7 @@ func getManagementConsoleState(ctx context.Context) (*ManagementConsoleState, er
 
 func doGetManagementConsoleState(ctx context.Context, tx *sql.Tx) (*ManagementConsoleState, error) {
 	mgmt := &ManagementConsoleState{}
-	err := dbconn.Global.QueryRowContext(ctx, "SELECT mgmt_password_plaintext, mgmt_password_bcrypt FROM global_state LIMIT 1").Scan(
+	err := dbconn.Global.QueryRowContext(ctx, "SELECT mgmt_password_plaintext, mgmt_password_bcrypt FROM global_state ORDER BY site_id LIMIT 1").Scan(
 		&mgmt.PasswordPlaintext,
 		&mgmt.PasswordBcrypt,
 	)


### PR DESCRIPTION
This fixes a highly annoying (but NOT a security risk) issue where the management
console password would incorrectly be reset to a newly generated secure password
each time a user account was created.

This issue accurately describes the problem in detail: https://github.com/sourcegraph/sourcegraph/issues/3201

The fix here is the quick and easily verifiable one: we carry over the result from
the prior row, so that all rows in the table have the same mgmt console password
fields.

A separate issue (and higher risk to make, which is why I am not doing it now) is
to correct this code such that it does not create duplicate entries in the
`global_state` table. This is tricky to do because there is a high risk of
introducing performance regressions as every Sourcegraph action goes through this
initalization check. If memory serves me correctly, duplicate entries was a known
property of the implementation at the time this code was written in order to avoid
locking the table and harming perf but thought to not be a concern (clearly
incorrectly, as we the site_id field also changes regularly which harms our metrics
in small various ways according to Dan).

I am confident this is a safe, good, incremental change to make (famous last words).

Helps #3201

After merge, that issue will become:

- "Cleanup global_state DB code to remove duplicate entries and prevent site_id from changing"

Test plan: Tested manually and against existing tests for this code (which caught one bug in my first implementation)