### PR TITLE
Symbols: show file path in symbol search results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -171,6 +171,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 			fileMatch.symbols = append(fileMatch.symbols, symbolRes)
 		} else {
 			fileMatch := &fileMatchResolver{
+				JPath:   symbolRes.symbol.Path,
 				symbols: []*searchSymbolResult{symbolRes},
 				uri:     uri,
 				repo:    symbolRes.commit.repo.repo,


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1387653/57742828-866d3300-7677-11e9-8d80-02b690c4f769.png)

After:

![image](https://user-images.githubusercontent.com/1387653/57742821-80775200-7677-11e9-9dad-1ac86be27e5d.png)

Test plan: visit http://localhost:3080/search?q=repo:%5Egithub%5C.com/gorilla/mux%24+test+type:symbol and make sure paths show up

Fixes https://github.com/sourcegraph/sourcegraph/issues/1548