### PR TITLE
Make context expression evaluation efficient

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -268,7 +268,7 @@ describe('code_intelligence', () => {
             )
             const editors = await from(services.editor.editors)
                 .pipe(
-                    skip(2),
+                    skip(1),
                     take(1)
                 )
                 .toPromise()
@@ -420,7 +420,7 @@ describe('code_intelligence', () => {
             )
             let editors = await from(services.editor.editors)
                 .pipe(
-                    skip(3),
+                    skip(2),
                     take(1)
                 )
                 .toPromise()

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -24,6 +24,7 @@ import {
     withLatestFrom,
 } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../shared/src/actions/ActionItem'
+import { PartialCodeEditor } from '../../../../shared/src/api/client/context/context'
 import { CodeEditorData } from '../../../../shared/src/api/client/services/editorService'
 import { WorkspaceRootWithMetadata } from '../../../../shared/src/api/client/services/workspaceService'
 import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
@@ -502,6 +503,11 @@ export function handleCodeHost({
                     isActive: true,
                 }
                 const editorId = extensionsController.services.editor.addEditor(editorData)
+                const scope: PartialCodeEditor = {
+                    ...editorData,
+                    ...editorId,
+                    model,
+                }
                 const codeViewState: CodeViewState = {
                     subscriptions: new Subscription(),
                     roots: [{ uri: toRootURI(fileInfo), inputRevision: fileInfo.rev || '' }],
@@ -626,7 +632,7 @@ export function handleCodeHost({
                             extensionsController={extensionsController}
                             buttonProps={toolbarButtonProps}
                             location={H.createLocation(window.location)}
-                            scope={{ ...editorData, model }}
+                            scope={scope}
                         />,
                         mount
                     )

--- a/browser/src/libs/code_intelligence/text_fields.test.tsx
+++ b/browser/src/libs/code_intelligence/text_fields.test.tsx
@@ -64,7 +64,7 @@ describe('text_fields', () => {
             mutations.next([{ addedNodes: [document.body], removedNodes: [] }])
             const editors = await from(services.editor.editors)
                 .pipe(
-                    skip(2),
+                    skip(1),
                     take(1)
                 )
                 .toPromise()

--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { from, Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, mergeMap, startWith, tap } from 'rxjs/operators'
 import { ExecuteCommandParams } from '../api/client/services/command'
-import { EvaluatedActionContribution } from '../api/protocol'
+import { ActionContribution, Evaluated } from '../api/protocol'
 import { urlForOpenPanel } from '../commands/commands'
 import { LinkOrButton } from '../components/LinkOrButton'
 import { ExtensionsControllerProps } from '../extensions/controller'
@@ -18,13 +18,13 @@ export interface ActionItemAction {
      * The action specified in the menu item's {@link module:sourcegraph.module/protocol.MenuItemContribution#action}
      * property.
      */
-    action: EvaluatedActionContribution
+    action: Evaluated<ActionContribution>
 
     /**
      * The alternative action specified in the menu item's
      * {@link module:sourcegraph.module/protocol.MenuItemContribution#alt} property.
      */
-    altAction?: EvaluatedActionContribution
+    altAction?: Evaluated<ActionContribution>
 }
 
 export interface ActionItemComponentProps
@@ -268,13 +268,21 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
     }
 }
 
-function urlForClientCommandOpen(action: EvaluatedActionContribution, location: H.Location): string | undefined {
-    if (action.command === 'open' && action.commandArguments && typeof action.commandArguments[0] === 'string') {
-        return action.commandArguments[0]
+function urlForClientCommandOpen(action: Evaluated<ActionContribution>, location: H.Location): string | undefined {
+    if (action.command === 'open' && action.commandArguments) {
+        const url = action.commandArguments[0]
+        if (typeof url !== 'string') {
+            return undefined
+        }
+        return url
     }
 
-    if (action.command === 'openPanel' && action.commandArguments && typeof action.commandArguments[0] === 'string') {
-        return urlForOpenPanel(action.commandArguments[0], location.hash)
+    if (action.command === 'openPanel' && action.commandArguments) {
+        const url = action.commandArguments[0]
+        if (typeof url !== 'string') {
+            return undefined
+        }
+        return urlForOpenPanel(url, location.hash)
     }
 
     return undefined

--- a/shared/src/actions/actions.ts
+++ b/shared/src/actions/actions.ts
@@ -1,6 +1,6 @@
-import { EvaluatedContributions } from '../api/protocol'
+import { Contributions, Evaluated } from '../api/protocol'
 
 export interface ActionsState {
     /** The contributions, merged from all extensions, or undefined before the initial emission. */
-    contributions?: EvaluatedContributions
+    contributions?: Evaluated<Contributions>
 }

--- a/shared/src/api/client/api/extensions.ts
+++ b/shared/src/api/client/api/extensions.ts
@@ -1,5 +1,4 @@
 import { ProxyResult } from '@sourcegraph/comlink'
-import { isEqual } from 'lodash'
 import { from, Subscription } from 'rxjs'
 import { bufferCount, startWith } from 'rxjs/operators'
 import { ExtExtensionsAPI } from '../../extension/api/extensions'
@@ -30,7 +29,7 @@ export class ClientExtensions {
                     const next: ExecutableExtension[] = []
                     if (oldExtensions) {
                         for (const x of oldExtensions) {
-                            const newIndex = toActivate.findIndex(({ id }) => isEqual(x.id, id))
+                            const newIndex = toActivate.findIndex(({ id }) => x.id === id)
                             if (newIndex === -1) {
                                 // Extension is no longer activated
                                 toDeactivate.push(x)

--- a/shared/src/api/client/connection.ts
+++ b/shared/src/api/client/connection.ts
@@ -17,7 +17,6 @@ import { ClientRoots } from './api/roots'
 import { ClientSearch } from './api/search'
 import { ClientViews } from './api/views'
 import { ClientWindows } from './api/windows'
-import { applyContextUpdate } from './context/context'
 import { Services } from './services'
 import {
     MessageActionItem,
@@ -67,9 +66,7 @@ export async function createExtensionHostClientConnection(
     const clientConfiguration = new ClientConfiguration<any>(proxy.configuration, services.settings)
     subscription.add(clientConfiguration)
 
-    const clientContext = new ClientContext((updates: ContextValues) =>
-        services.context.data.next(applyContextUpdate(services.context.data.value, updates))
-    )
+    const clientContext = new ClientContext((updates: ContextValues) => services.context.updateContext(updates))
     subscription.add(clientContext)
 
     // Sync models and editors to the extension host

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -1,16 +1,6 @@
 import { Selection } from '@sourcegraph/extension-api-types'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { applyContextUpdate, Context, getComputedContextProperty, PartialCodeEditor } from './context'
-
-describe('applyContextUpdate', () => {
-    test('merges properties', () =>
-        expect(applyContextUpdate({ a: 1, b: null, c: 2, d: 3, e: null }, { a: null, b: 1, c: 3 })).toEqual({
-            b: 1,
-            c: 3,
-            d: 3,
-            e: null,
-        } as Context))
-})
+import { getComputedContextProperty, PartialCodeEditor } from './context'
 
 describe('getComputedContextProperty', () => {
     test('provides config', () => {
@@ -31,6 +21,7 @@ describe('getComputedContextProperty', () => {
     describe('with code editors', () => {
         const editors: PartialCodeEditor[] = [
             {
+                editorId: 'editor1',
                 type: 'CodeEditor',
                 resource: 'file:///inactive',
                 model: {
@@ -49,6 +40,7 @@ describe('getComputedContextProperty', () => {
                 isActive: false,
             },
             {
+                editorId: 'editor2',
                 type: 'CodeEditor',
                 resource: 'file:///a/b.c',
                 model: {
@@ -179,6 +171,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there is no selection', () => {
                 assertNoSelection([
                     {
+                        editorId: 'editor1',
                         type: 'CodeEditor' as const,
                         resource: 'file:///a/b.c',
                         model: {

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -3,22 +3,6 @@ import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/setti
 import { CodeEditor } from '../services/editorService'
 
 /**
- * Returns a new context created by applying the update context to the base context. It is equivalent to `{...base,
- * ...update}` in JavaScript except that null values in the update result in deletion of the property.
- */
-export function applyContextUpdate(base: Context, update: Context): Context {
-    const result = { ...base }
-    for (const [key, value] of Object.entries(update)) {
-        if (value === null) {
-            delete result[key]
-        } else {
-            result[key] = value
-        }
-    }
-    return result
-}
-
-/**
  * Context is an arbitrary, immutable set of key-value pairs. Its value can be any JSON object.
  *
  * @template T If you have a value with a property of type T that is not one of the primitive types listed below
@@ -31,7 +15,7 @@ export interface Context<T = never>
         string | number | boolean | null | Context | T | (string | number | boolean | null | Context | T)[]
     > {}
 
-export type PartialCodeEditor = Pick<CodeEditor, 'type' | 'resource' | 'selections' | 'isActive'> & {
+export type PartialCodeEditor = Pick<CodeEditor, 'editorId' | 'type' | 'resource' | 'selections' | 'isActive'> & {
     model: Pick<CodeEditor['model'], 'uri' | 'languageId'>
 }
 

--- a/shared/src/api/client/context/contextService.test.ts
+++ b/shared/src/api/client/context/contextService.test.ts
@@ -1,10 +1,14 @@
+import * as sinon from 'sinon'
 import { createContextService } from './contextService'
 
 describe('createContextService()', () => {
     describe('updateContext()', () => {
-        it('merges properties', () => {
+        it('adds properties', () => {
             const service = createContextService({ clientApplication: 'other' })
-            service.updateContext({ a: 1, b: null, c: 2, d: 3, e: null })
+            service.updateContext({ a: 1, c: 2, d: 3 })
+            const spy = sinon.spy()
+            service.data.subscribe(spy)
+            sinon.assert.calledOnce(spy)
             expect(service.data.value).toEqual({
                 'clientApplication.isSourcegraph': false,
                 'clientApplication.extensionAPIVersion.major': 3,
@@ -12,13 +16,104 @@ describe('createContextService()', () => {
                 c: 2,
                 d: 3,
             })
-            service.updateContext({ a: null, b: 1, c: 3 })
+            service.updateContext({ b: 1, e: 4 })
+            sinon.assert.calledTwice(spy)
             expect(service.data.value).toEqual({
                 'clientApplication.isSourcegraph': false,
                 'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+                b: 1,
+                c: 2,
+                d: 3,
+                e: 4,
+            })
+        })
+        it('modifies properties', () => {
+            const service = createContextService({ clientApplication: 'other' })
+            service.updateContext({ a: 1, c: 2, d: 3 })
+            const spy = sinon.spy()
+            service.data.subscribe(spy)
+            sinon.assert.calledOnce(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+                c: 2,
+                d: 3,
+            })
+            service.updateContext({ a: 2 })
+            sinon.assert.calledTwice(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 2,
+                c: 2,
+                d: 3,
+            })
+        })
+        it('merges properties', () => {
+            const service = createContextService({ clientApplication: 'other' })
+            service.updateContext({ a: 1, c: 2, d: 3 })
+            const spy = sinon.spy()
+            service.data.subscribe(spy)
+            sinon.assert.calledOnce(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+                c: 2,
+                d: 3,
+            })
+            service.updateContext({ b: 1, c: 3 })
+            sinon.assert.calledTwice(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
                 b: 1,
                 c: 3,
                 d: 3,
+            })
+        })
+        it('removes a key if it is null', () => {
+            const service = createContextService({ clientApplication: 'other' })
+            service.updateContext({ a: 1, b: 2 })
+            const spy = sinon.spy()
+            service.data.subscribe(spy)
+            sinon.assert.calledOnce(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+                b: 2,
+            })
+            service.updateContext({ a: 1, b: null })
+            sinon.assert.calledTwice(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+            })
+        })
+        it('does not emit if values are the same', () => {
+            const service = createContextService({ clientApplication: 'other' })
+            service.updateContext({ a: 1, c: 2 })
+            const spy = sinon.spy()
+            service.data.subscribe(spy)
+            sinon.assert.calledOnce(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+                c: 2,
+            })
+            service.updateContext({ a: 1 })
+            sinon.assert.calledOnce(spy)
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+                c: 2,
             })
         })
     })

--- a/shared/src/api/client/context/contextService.test.ts
+++ b/shared/src/api/client/context/contextService.test.ts
@@ -1,0 +1,25 @@
+import { createContextService } from './contextService'
+
+describe('createContextService()', () => {
+    describe('updateContext()', () => {
+        it('merges properties', () => {
+            const service = createContextService({ clientApplication: 'other' })
+            service.updateContext({ a: 1, b: null, c: 2, d: 3, e: null })
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                a: 1,
+                c: 2,
+                d: 3,
+            })
+            service.updateContext({ a: null, b: 1, c: 3 })
+            expect(service.data.value).toEqual({
+                'clientApplication.isSourcegraph': false,
+                'clientApplication.extensionAPIVersion.major': 3,
+                b: 1,
+                c: 3,
+                d: 3,
+            })
+        })
+    })
+})

--- a/shared/src/api/client/context/contextService.ts
+++ b/shared/src/api/client/context/contextService.ts
@@ -1,4 +1,5 @@
-import { BehaviorSubject, NextObserver, Subscribable } from 'rxjs'
+import { isMatch } from 'lodash'
+import { BehaviorSubject, Subscribable } from 'rxjs'
 import { PlatformContext } from '../../../platform/context'
 import { Context } from './context'
 
@@ -10,23 +11,49 @@ export interface ContextService {
     /**
      * The context data.
      */
-    readonly data: Subscribable<Context> & { value: Context } & NextObserver<Context>
+    readonly data: Subscribable<Context> & { value: Context }
+
+    /**
+     * Sets the given context keys and values.
+     * If a value is `null`, the context key is removed.
+     *
+     * @param update Object with context keys as values
+     */
+    updateContext(update: object): void
 }
 
 /** Create a {@link ContextService} instance. */
 export function createContextService({
     clientApplication,
 }: Pick<PlatformContext, 'clientApplication'>): ContextService {
-    return {
-        data: new BehaviorSubject<Context>({
-            'clientApplication.isSourcegraph': clientApplication === 'sourcegraph',
+    const data = new BehaviorSubject<Context>({
+        'clientApplication.isSourcegraph': clientApplication === 'sourcegraph',
 
-            // Arbitrary, undocumented versioning for extensions that need different behavior for different
-            // Sourcegraph versions.
-            //
-            // TODO: Make this more advanced if many extensions need this (although we should try to avoid
-            // extensions needing this).
-            'clientApplication.extensionAPIVersion.major': 3,
-        }),
+        // Arbitrary, undocumented versioning for extensions that need different behavior for different
+        // Sourcegraph versions.
+        //
+        // TODO: Make this more advanced if many extensions need this (although we should try to avoid
+        // extensions needing this).
+        'clientApplication.extensionAPIVersion.major': 3,
+    })
+    return {
+        data,
+        updateContext(update: { [k: string]: unknown }): void {
+            if (isMatch(this.data.value, update)) {
+                return
+            }
+            const result: any = {}
+            for (const [key, oldValue] of Object.entries(data.value)) {
+                if (update[key] !== null) {
+                    result[key] = oldValue
+                }
+            }
+            for (const [key, value] of Object.entries(update)) {
+                if (value !== null) {
+                    result[key] = value
+                }
+            }
+            data.next(result)
+        },
     }
 }

--- a/shared/src/api/client/context/expr/evaluator.test.ts
+++ b/shared/src/api/client/context/expr/evaluator.test.ts
@@ -1,4 +1,4 @@
-import { evaluate, evaluateTemplate } from './evaluator'
+import { parse, parseTemplate } from './evaluator'
 
 const FIXTURE_CONTEXT = new Map<string, any>(
     Object.entries({
@@ -10,7 +10,7 @@ const FIXTURE_CONTEXT = new Map<string, any>(
     })
 )
 
-describe('evaluate', () => {
+describe('Expression', () => {
     // tslint:disable:no-invalid-template-strings
     const TESTS = {
         a: 1,
@@ -43,13 +43,13 @@ describe('evaluate', () => {
     // tslint:enable:no-invalid-template-strings
     for (const [expr, want] of Object.entries(TESTS)) {
         test(expr, () => {
-            const value = evaluate(expr, FIXTURE_CONTEXT)
+            const value = parse<unknown>(expr).exec(FIXTURE_CONTEXT)
             expect(value).toBe(want)
         })
     }
 })
 
-describe('evaluateTemplate', () => {
+describe('TemplateExpression', () => {
     // tslint:disable:no-invalid-template-strings
     const TESTS = {
         a: 'a',
@@ -61,7 +61,7 @@ describe('evaluateTemplate', () => {
     // tslint:enable:no-invalid-template-strings
     for (const [template, want] of Object.entries(TESTS)) {
         test(template, () => {
-            const value = evaluateTemplate(template, FIXTURE_CONTEXT)
+            const value = parseTemplate(template).exec(FIXTURE_CONTEXT)
             expect(value).toBe(want)
         })
     }

--- a/shared/src/api/client/context/expr/parser.test.ts
+++ b/shared/src/api/client/context/expr/parser.test.ts
@@ -1,8 +1,8 @@
 import { TokenType } from './lexer'
-import { Expression, Parser, TemplateParser } from './parser'
+import { ExpressionNode, Parser, TemplateParser } from './parser'
 
 describe('Parser', () => {
-    const TESTS: { [expr: string]: Expression } = {
+    const TESTS: { [expr: string]: ExpressionNode } = {
         '!a': {
             Unary: {
                 operator: '!',
@@ -208,7 +208,7 @@ describe('Parser', () => {
 })
 
 describe('TemplateParser', () => {
-    const TESTS: { [template: string]: Expression } = {
+    const TESTS: { [template: string]: ExpressionNode } = {
         // tslint:disable-next-line:no-invalid-template-strings
         '${x}': {
             Template: {

--- a/shared/src/api/integration-test/windows.test.ts
+++ b/shared/src/api/integration-test/windows.test.ts
@@ -130,7 +130,7 @@ describe('Windows (integration)', () => {
                     filter(isDefined),
                     switchMap(w => w.activeViewComponentChanges),
                     filter(isDefined),
-                    take(3)
+                    take(2)
                 )
                 .toPromise()
 

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -8,7 +8,7 @@ import { Subscription } from 'rxjs'
 import stringScore from 'string-score'
 import { Key } from 'ts-key-enum'
 import { ActionItem, ActionItemAction } from '../actions/ActionItem'
-import { ContributableMenu, EvaluatedContributions } from '../api/protocol'
+import { ContributableMenu, Contributions, Evaluated } from '../api/protocol'
 import { HighlightedMatches } from '../components/HighlightedMatches'
 import { PopoverButton } from '../components/PopoverButton'
 import { getContributedActionItems } from '../contributions/contributions'
@@ -48,7 +48,7 @@ export interface CommandListProps
 
 interface State {
     /** The contributions, merged from all extensions, or undefined before the initial emission. */
-    contributions?: EvaluatedContributions
+    contributions?: Evaluated<Contributions>
 
     input: string
     selectedIndex: number

--- a/shared/src/commands/commands.ts
+++ b/shared/src/commands/commands.ts
@@ -4,7 +4,7 @@ import { concat, from, of, Subscription, Unsubscribable } from 'rxjs'
 import { first } from 'rxjs/operators'
 import { Services } from '../api/client/services'
 import { KeyPath, SettingsEdit } from '../api/client/services/settings'
-import { ActionContributionClientCommandUpdateConfiguration } from '../api/protocol'
+import { ActionContributionClientCommandUpdateConfiguration, Evaluated } from '../api/protocol'
 import { gql } from '../graphql/graphql'
 import { PlatformContext } from '../platform/context'
 
@@ -69,7 +69,9 @@ export function registerBuiltinClientCommands(
         commandRegistry.registerCommand({
             command: 'updateConfiguration',
             run: (...anyArgs: any[]): Promise<void> => {
-                const args = anyArgs as ActionContributionClientCommandUpdateConfiguration['commandArguments']
+                const args = anyArgs as Evaluated<
+                    ActionContributionClientCommandUpdateConfiguration
+                >['commandArguments']
                 return settingsService.update(convertUpdateConfigurationCommandArgs(args))
             },
         })
@@ -129,7 +131,7 @@ export function urlForOpenPanel(viewID: string, urlHash: string): string {
  * to {@link SettingsUpdate}.
  */
 export function convertUpdateConfigurationCommandArgs(
-    args: ActionContributionClientCommandUpdateConfiguration['commandArguments']
+    args: Evaluated<ActionContributionClientCommandUpdateConfiguration>['commandArguments']
 ): SettingsEdit {
     if (!isArray(args) || !(args.length >= 2 && args.length <= 4)) {
         throw new Error(
@@ -158,6 +160,5 @@ export function convertUpdateConfigurationCommandArgs(
         throw new Error(`invalid updateConfiguration arguments: ${JSON.stringify(args)} (3rd element must be null)`)
     }
 
-    const valueIsJSONEncoded = args.length === 4 && args[3] === 'json'
-    return { path: keyPath, value: valueIsJSONEncoded ? JSON.parse(args[1]) : args[1] }
+    return { path: keyPath, value: args.length === 4 && args[3] === 'json' ? JSON.parse(args[1]) : args[1] }
 }

--- a/shared/src/contributions/contributions.ts
+++ b/shared/src/contributions/contributions.ts
@@ -1,16 +1,16 @@
 import { sortBy } from 'lodash'
 import { ActionItemAction } from '../actions/ActionItem'
-import { ContributableMenu, EvaluatedContributions } from '../api/protocol'
+import { ContributableMenu, Contributions, Evaluated } from '../api/protocol'
 
 const MENU_ITEMS_PROP_SORT_ORDER = ['group', 'id']
 
 /**
- * Collect all command contrbutions for the menu.
+ * Collect all command contributions for the menu.
  *
  * @param prioritizeActions sort these actions first
  */
 export function getContributedActionItems(
-    contributions: EvaluatedContributions,
+    contributions: Evaluated<Contributions>,
     menu: ContributableMenu
 ): ActionItemAction[] {
     if (!contributions.actions) {

--- a/shared/src/extensions/extensionManifest.ts
+++ b/shared/src/extensions/extensionManifest.ts
@@ -7,19 +7,18 @@ import { parseJSONCOrError } from '../util/jsonc'
  * Represents an input object that is validated against a subset of properties of the {@link ExtensionManifest}
  * JSON Schema. For simplicity, only necessary fields are validated and included here.
  */
-export interface ExtensionManifest
-    extends Pick<
-        ExtensionManifestSchema,
-        | 'description'
-        | 'repository'
-        | 'categories'
-        | 'tags'
-        | 'readme'
-        | 'url'
-        | 'icon'
-        | 'activationEvents'
-        | 'contributes'
-    > {}
+export type ExtensionManifest = Pick<
+    ExtensionManifestSchema,
+    | 'description'
+    | 'repository'
+    | 'categories'
+    | 'tags'
+    | 'readme'
+    | 'url'
+    | 'icon'
+    | 'activationEvents'
+    | 'contributes'
+>
 
 /**
  * Parses and validates the extension manifest. If parsing or validation fails, an error value is returned (not

--- a/shared/src/hover/actions.test.ts
+++ b/shared/src/hover/actions.test.ts
@@ -279,7 +279,7 @@ describe('getDefinitionURL', () => {
         ).resolves.toEqual({ url: '/r@v/-/blob/f#L2:2&tab=def', multiple: true }))
 })
 
-describe('registerHoverContributions', () => {
+describe('registerHoverContributions()', () => {
     const contribution = new ContributionRegistry(
         createTestEditorService(of([])),
         { data: of(EMPTY_SETTINGS_CASCADE) },
@@ -313,13 +313,17 @@ describe('registerHoverContributions', () => {
             )
             .toPromise()
 
-    describe('getHoverActions', () => {
+    describe('getHoverActions()', () => {
         const GO_TO_DEFINITION_ACTION: ActionItemAction = {
             action: {
                 command: 'goToDefinition',
                 commandArguments: ['{"textDocument":{"uri":"git://r?c#f"},"position":{"line":1,"character":1}}'],
                 id: 'goToDefinition',
                 title: 'Go to definition',
+                actionItem: undefined,
+                category: undefined,
+                description: undefined,
+                iconURL: undefined,
             },
             altAction: undefined,
         }
@@ -342,7 +346,7 @@ describe('registerHoverContributions', () => {
             altAction: undefined,
         }
 
-        test('shows goToDefinition (non-preloaded) when the definition is loading', async () =>
+        it.only('shows goToDefinition (non-preloaded) when the definition is loading', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': true,
@@ -354,7 +358,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([GO_TO_DEFINITION_ACTION]))
 
-        test('shows goToDefinition (non-preloaded) when the definition had an error', async () =>
+        it('shows goToDefinition (non-preloaded) when the definition had an error', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': false,
@@ -366,7 +370,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([GO_TO_DEFINITION_ACTION]))
 
-        test('hides goToDefinition when the definition was not found', async () =>
+        it('hides goToDefinition when the definition was not found', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': false,
@@ -378,7 +382,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([]))
 
-        test('shows goToDefinition.preloaded when goToDefinition.url is available', async () =>
+        it('shows goToDefinition.preloaded when goToDefinition.url is available', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': false,
@@ -390,7 +394,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([GO_TO_DEFINITION_PRELOADED_ACTION]))
 
-        test('shows findReferences when the definition exists', async () =>
+        it('shows findReferences when the definition exists', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': false,
@@ -402,7 +406,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([GO_TO_DEFINITION_PRELOADED_ACTION, FIND_REFERENCES_ACTION]))
 
-        test('hides findReferences when the definition might exist (and is still loading)', async () =>
+        it('hides findReferences when the definition might exist (and is still loading)', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': true,
@@ -414,7 +418,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([GO_TO_DEFINITION_ACTION, FIND_REFERENCES_ACTION]))
 
-        test('shows findReferences when the definition had an error', async () =>
+        it('shows findReferences when the definition had an error', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': false,
@@ -426,7 +430,7 @@ describe('registerHoverContributions', () => {
                 })
             ).resolves.toEqual([GO_TO_DEFINITION_ACTION, FIND_REFERENCES_ACTION]))
 
-        test('does not show findReferences when the definition was not found', async () =>
+        it('does not show findReferences when the definition was not found', async () =>
             expect(
                 getHoverActions({
                     'goToDefinition.showLoading': false,

--- a/shared/src/hover/actions.ts
+++ b/shared/src/hover/actions.ts
@@ -16,6 +16,7 @@ import {
 } from 'rxjs/operators'
 import { ActionItemAction } from '../actions/ActionItem'
 import { Context } from '../api/client/context/context'
+import { parse, parseTemplate } from '../api/client/context/expr/evaluator'
 import { Services } from '../api/client/services'
 import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 import { ContributableMenu, TextDocumentPositionParams } from '../api/protocol'
@@ -275,11 +276,11 @@ export function registerHoverContributions({
                 actions: [
                     {
                         id: 'goToDefinition',
-                        title: 'Go to definition',
+                        title: parseTemplate('Go to definition'),
                         command: 'goToDefinition',
                         commandArguments: [
                             // tslint:disable:no-invalid-template-strings
-                            '${json(hoverPosition)}',
+                            parseTemplate('${json(hoverPosition)}'),
                             // tslint:enable:no-invalid-template-strings
                         ],
                     },
@@ -287,10 +288,10 @@ export function registerHoverContributions({
                         // This action is used when preloading the definition succeeded and at least 1
                         // definition was found.
                         id: 'goToDefinition.preloaded',
-                        title: 'Go to definition',
+                        title: parseTemplate('Go to definition'),
                         command: 'open',
                         // tslint:disable-next-line:no-invalid-template-strings
-                        commandArguments: ['${goToDefinition.url}'],
+                        commandArguments: [parseTemplate('${goToDefinition.url}')],
                     },
                 ],
                 menus: {
@@ -299,11 +300,11 @@ export function registerHoverContributions({
                         // goToDefinition.{error, loading, url} will all be falsey.)
                         {
                             action: 'goToDefinition',
-                            when: 'goToDefinition.error || goToDefinition.showLoading',
+                            when: parse('goToDefinition.error || goToDefinition.showLoading'),
                         },
                         {
                             action: 'goToDefinition.preloaded',
-                            when: 'goToDefinition.url',
+                            when: parse('goToDefinition.url'),
                         },
                     ],
                 },
@@ -349,10 +350,10 @@ export function registerHoverContributions({
                 actions: [
                     {
                         id: 'findReferences',
-                        title: 'Find references',
+                        title: parseTemplate('Find references'),
                         command: 'open',
                         // tslint:disable-next-line:no-invalid-template-strings
-                        commandArguments: ['${findReferences.url}'],
+                        commandArguments: [parseTemplate('${findReferences.url}')],
                     },
                 ],
                 menus: {
@@ -363,8 +364,9 @@ export function registerHoverContributions({
                         // logic is implemented in the observable pipe that sets findReferences.url above.
                         {
                             action: 'findReferences',
-                            when:
-                                'findReferences.url && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)',
+                            when: parse(
+                                'findReferences.url && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)'
+                            ),
                         },
                     ],
                 },

--- a/shared/src/panel/views/HierarchicalLocationsView.test.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.test.tsx
@@ -8,9 +8,9 @@ import H from 'history'
 import { noop } from 'lodash'
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { BehaviorSubject, concat, NEVER, Observable, of } from 'rxjs'
+import { concat, NEVER, Observable, of } from 'rxjs'
 import * as sinon from 'sinon'
-import { ContextService } from '../../api/client/context/contextService'
+import { createContextService } from '../../api/client/context/contextService'
 import { parseTemplate } from '../../api/client/context/expr/evaluator'
 import { ContributionsEntry, ContributionUnsubscribable } from '../../api/client/services/contribution'
 import { setLinkComponent } from '../../components/Link'
@@ -23,15 +23,8 @@ describe('<HierarchicalLocationsView />', () => {
         setLinkComponent((props: any) => <a {...props} />)
     })
     const getProps = () => {
-        const contextData = new BehaviorSubject<{}>({})
-        const contextService: ContextService = {
-            data: contextData,
-            updateContext(update: any): void {
-                contextData.next(update)
-            },
-        }
         const services = {
-            context: contextService,
+            context: createContextService({ clientApplication: 'other' }),
             contribution: {
                 registerContributions: sinon.spy(
                     (entry: ContributionsEntry): ContributionUnsubscribable => ({ entry, unsubscribe: noop })

--- a/shared/src/panel/views/HierarchicalLocationsView.tsx
+++ b/shared/src/panel/views/HierarchicalLocationsView.tsx
@@ -79,13 +79,13 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                                     catchError((error): [ErrorLike] => [asError(error)]),
                                     startWith<State['locationsOrError']>({ results: undefined, loading: true }),
                                     tap(locationsOrError => {
-                                        this.props.extensionsController.services.context.data.next({
-                                            ...this.props.extensionsController.services.context.data.value,
-                                            'panel.locations.hasResults':
-                                                locationsOrError &&
-                                                !isErrorLike(locationsOrError) &&
-                                                !!locationsOrError.results &&
-                                                locationsOrError.results.length > 0,
+                                        const hasResults =
+                                            locationsOrError &&
+                                            !isErrorLike(locationsOrError) &&
+                                            !!locationsOrError.results &&
+                                            locationsOrError.results.length > 0
+                                        this.props.extensionsController.services.context.updateContext({
+                                            'panel.locations.hasResults': hasResults,
                                         })
                                     }),
                                     endWith<State['locationsOrError']>({ loading: false })

--- a/shared/src/panel/views/contributions.ts
+++ b/shared/src/panel/views/contributions.ts
@@ -1,11 +1,12 @@
 import { Unsubscribable } from 'rxjs'
+import { parseContributionExpressions } from '../../api/client/services/contribution'
 import { ExtensionsControllerProps } from '../../extensions/controller'
 
 export function registerPanelToolbarContributions({
     extensionsController,
 }: ExtensionsControllerProps<'services'>): Unsubscribable {
     return extensionsController.services.contribution.registerContributions({
-        contributions: {
+        contributions: parseContributionExpressions({
             actions: [
                 {
                     id: 'panel.locations.groupByFile',
@@ -31,6 +32,6 @@ export function registerPanelToolbarContributions({
                     },
                 ],
             },
-        },
+        }),
     })
 }

--- a/shared/src/schema/extensionSchema.ts
+++ b/shared/src/schema/extensionSchema.ts
@@ -1,4 +1,4 @@
-import { Contributions } from '../api/protocol/contribution'
+import { Contributions, Raw } from '../api/protocol/contribution'
 
 /**
  * See the extensions.schema.json JSON Schema for canonical documentation on these types.
@@ -51,7 +51,7 @@ export interface ExtensionManifest {
     tags?: string[]
     icon?: string
     activationEvents: string[]
-    contributes?: Contributions & { configuration?: { [key: string]: any } }
+    contributes?: Raw<Contributions> & { configuration?: { [key: string]: any } }
 }
 
 /** TypeScript helper for making an array type with constant string union elements, not just string[]. */

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -206,10 +206,10 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         )
         const goToDefinition = (ev: MouseEvent) => {
             const goToDefinitionAction =
-                this.state.actionsOrError instanceof Array &&
+                Array.isArray(this.state.actionsOrError) &&
                 this.state.actionsOrError.find(action => action.action.id === 'goToDefinition.preloaded')
             if (goToDefinitionAction) {
-                this.props.history.push(goToDefinitionAction.action.commandArguments![0])
+                this.props.history.push(goToDefinitionAction.action.commandArguments![0] as string)
                 ev.stopPropagation()
             }
         }

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { concat, Observable, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators'
 import { parseSearchURLQuery } from '..'
-import { EvaluatedContributions } from '../../../../shared/src/api/protocol'
+import { Contributions, Evaluated } from '../../../../shared/src/api/protocol'
 import { FetchFileCtx } from '../../../../shared/src/components/CodeExcerpt'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
@@ -53,7 +53,7 @@ interface SearchResultsState {
     showSavedQueryModal: boolean
     didSaveQuery: boolean
     /** The contributions, merged from all extensions, or undefined before the initial emission. */
-    contributions?: EvaluatedContributions
+    contributions?: Evaluated<Contributions>
 }
 
 export class SearchResults extends React.Component<SearchResultsProps, SearchResultsState> {


### PR DESCRIPTION
Fixes #3778
Fixes #3192 

Seperates the parsing from the evaluation by requiring that the expressions must be parsed before registration into `Expression<T>`/`TemplateExpression` objects.
Those objects can then be directly evaluated. It uses mapped types to represent `Evaluated` and `Raw` contributions. This also makes the schema way more type safe.

In addition, I vetted all sources that cause the parsing and evaluation of expressions (context, active extensions, editors, ...) and optimized them to not emit when they didn't change:
- change `ContextService` have an `updateContext()` method that checks first if there are any changes instead of exposing raw Subject
- make sure `editors` doesn't emit if an underlying model content changed
- add `publishReplay(1)` in places with multiple Subscribers and expensive comparisons.

#### Test Plan

##### Code Hosts

- [x] GitHub
- [ ] GitHub Enterprise
- [ ] Refined GitHub
- [ ] Phabricator
- [ ] Phabricator integration
- [ ] Bitbucket
- [ ] Gitlab

##### Browsers

- [x] Chrome
- [ ] Firefox
