### PR TITLE
Open ActionItem links in new tabs

### DIFF
--- a/shared/src/actions/ActionItem.tsx
+++ b/shared/src/actions/ActionItem.tsx
@@ -213,6 +213,8 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
                     urlForClientCommandOpen(this.props.action, this.props.location) ||
                     (this.props.altAction && urlForClientCommandOpen(this.props.altAction, this.props.location))
                 }
+                target="_blank"
+                rel="noopener"
                 onSelect={this.runAction}
             >
                 {content}

--- a/shared/src/components/LinkOrButton.tsx
+++ b/shared/src/components/LinkOrButton.tsx
@@ -10,6 +10,9 @@ interface Props {
     /** The link target. */
     target?: '_self' | '_blank' | string
 
+    /** Use "noopener" for external URLs */
+    rel?: string
+
     /**
      * Called when the user clicks or presses enter on this element.
      */
@@ -72,7 +75,7 @@ export class LinkOrButton extends React.PureComponent<Props> {
         }
 
         return (
-            <Link {...commonProps} to={this.props.to} target={this.props.target}>
+            <Link {...commonProps} to={this.props.to} target={this.props.target} rel={this.props.rel}>
                 {this.props.children}
             </Link>
         )


### PR DESCRIPTION
Open ActionItem links in new tabs

This matches the behavior of when the open command is invoked programmatically.

Fixes #4023
