### PR TITLE
repo-updater: Fix flaky test & make Github client consistent

### DIFF
--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
 	"github.com/sourcegraph/sourcegraph/pkg/httptestutil"
+	"github.com/sourcegraph/sourcegraph/pkg/rcache"
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
@@ -833,7 +834,13 @@ func TestGithubSource_GetRepo(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		tc.name = "GITHUB-DOT-COM/" + tc.name
+
 		t.Run(tc.name, func(t *testing.T) {
+			// The GithubSource uses the github.Client under the hood, which
+			// uses rcache, a caching layer that uses Redis.
+			// We need to clear the cache before we run the tests
+			rcache.SetupForTest(t)
+
 			cf, save := newClientFactory(t, tc.name)
 			defer save(t)
 

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -790,7 +790,7 @@ func TestGithubSource_GetRepo(t *testing.T) {
 		{
 			name:          "not found",
 			nameWithOwner: "foobarfoobarfoobar/please-let-this-not-exist",
-			err:           `request to http://github-proxy/repos/foobarfoobarfoobar/please-let-this-not-exist returned status 404: Not Found`,
+			err:           `GitHub repository not found`,
 		},
 		{
 			name:          "found",

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -252,6 +253,9 @@ func (c *Client) getRepositoryFromAPI(ctx context.Context, owner, name string) (
 	// http://[sourcegraph-hostname]/github.com/foo/bar.
 	var result restRepository
 	if err := c.requestGet(ctx, "", fmt.Sprintf("/repos/%s/%s", owner, name), &result); err != nil {
+		if HTTPErrorCode(err) == http.StatusNotFound {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	return convertRestRepo(result), nil

--- a/pkg/extsvc/github/repos_test.go
+++ b/pkg/extsvc/github/repos_test.go
@@ -140,6 +140,9 @@ func TestClient_GetRepository_nonexistent(t *testing.T) {
 	if !IsNotFound(err) {
 		t.Errorf("got err == %v, want IsNotFound(err) == true", err)
 	}
+	if err != ErrNotFound {
+		t.Errorf("got err == %q, want ErrNotFound", err)
+	}
 	if repo != nil {
 		t.Error("repo != nil")
 	}


### PR DESCRIPTION
This fixes #4002 by clearing the Redis cache, that's used by the underlying `github.Client`, before running the tests.

The flaky test failed because sometimes the error returned by the `GithubSource` (which uses the `github.Client`) was the generic `github.APIError` "request to xxx resulted in 404" error message that we expect in the tests:

https://github.com/sourcegraph/sourcegraph/blob/9ecfe95dd5ea073dc05cd6ea962e4e588829d767/cmd/repo-updater/repos/sources_test.go#L793

And sometimes it returned the `github.ErrNotFound` error:

https://github.com/sourcegraph/sourcegraph/blob/9ecfe95dd5ea073dc05cd6ea962e4e588829d767/pkg/extsvc/github/client.go#L308

I found out that the `ErrNotFound` error is only returned when the Github client looked into the cache and found a "repository not found"-cache-entry there:
 https://github.com/sourcegraph/sourcegraph/blob/9ecfe95dd5ea073dc05cd6ea962e4e588829d767/pkg/extsvc/github/repos.go#L139-L145

But if there is *no* cache hit, then the no `ErrNotFound` is ever returned. Neither in the `getRepositoryFromAPI` method: 
https://github.com/sourcegraph/sourcegraph/blob/9ecfe95dd5ea073dc05cd6ea962e4e588829d767/pkg/extsvc/github/repos.go#L253-L256

Nor in underlying method where the response is turned into a `github.APIError`:

https://github.com/sourcegraph/sourcegraph/blob/9ecfe95dd5ea073dc05cd6ea962e4e588829d767/pkg/extsvc/github/client.go#L219-L227

So, I did two things in this PR:
1. Clear the cache before we run the tests
2. Make sure `getRepositoryFromAPI` checks the status code and if it's a 404 it also returns `ErrNotFound`

Test plan: go test && running the tests on CI
