### PR TITLE
gitserver: improve tracing for handleExec

### DIFF
--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -206,8 +206,9 @@ func BenchmarkQuickRevParseHead_packed_refs(b *testing.B) {
 	// Exclude setup
 	b.ResetTimer()
 
+	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-		rev, err := quickRevParseHead(dir)
+		rev, err := quickRevParseHead(ctx, dir)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -249,8 +250,9 @@ func BenchmarkQuickRevParseHead_unpacked_refs(b *testing.B) {
 	// Exclude setup
 	b.ResetTimer()
 
+	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-		rev, err := quickRevParseHead(dir)
+		rev, err := quickRevParseHead(ctx, dir)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
* extend the span for `handleExec` to the whole func
* add trace for `quickRevParseHead`
* extract `execGitCommand` and give it a trace of its own

Test plan: Run a search and visit /-/debug for gitserver to see the traces.
