### PR TITLE
repo-updater: Use NewDiff instead of Upsert for sourcegraph.com repoLookup

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -53,6 +53,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/ListRepos", testStoreListRepos(store)},
 		{"DBStore/ListRepos/Pagination", testStoreListReposPagination(store)},
 		{"DBStore/Syncer/Sync", testSyncerSync(store)},
+		{"DBStore/Syncer/SyncSubset", testSyncSubset(store)},
 		{"Migrations/GithubSetDefaultRepositoryQuery",
 			testGithubSetDefaultRepositoryQueryMigration(store)},
 		{"Migrations/GitLabSetDefaultProjectQuery",

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -765,6 +765,32 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 		repos: repos.Assert.ReposEqual(&github, &gitlab),
 	})
 
+	testCases = append(testCases, testCase{
+		name:   "use or",
+		stored: repositories,
+		args: func(repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				Names: []string{"gitlab.com/bar/foo"},
+				Kinds: []string{"github"},
+				UseOr: true,
+			}
+		},
+		repos: repos.Assert.ReposEqual(&github, &gitlab),
+	})
+
+	testCases = append(testCases, testCase{
+		name:   "use and",
+		stored: repositories,
+		args: func(repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				Names: []string{"gitlab.com/bar/foo"},
+				Kinds: []string{"github"},
+				UseOr: false,
+			}
+		},
+		repos: repos.Assert.ReposEqual(),
+	})
+
 	return func(t *testing.T) {
 		t.Helper()
 

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -108,6 +108,10 @@ func (s *Syncer) SyncSubset(ctx context.Context, sourcedSubset ...*Repo) (diff D
 	ctx, save := s.observe(ctx, "Syncer.SyncSubset", strings.Join(Repos(sourcedSubset).Names(), " "))
 	defer save(&diff, &err)
 
+	if len(sourcedSubset) == 0 {
+		return Diff{}, nil
+	}
+
 	store := s.store
 	if tr, ok := s.store.(Transactor); ok {
 		var txs TxStore
@@ -255,7 +259,7 @@ func NewDiff(sourced, stored []*Repo) (diff Diff) {
 	}
 
 	for _, r := range byID {
-		if !seenID[r.ExternalRepo] && !seenName[r.Name] {
+		if !seenID[r.ExternalRepo] {
 			diff.Added = append(diff.Added, r)
 		}
 	}

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -706,6 +706,17 @@ func (rs Repos) Kinds() (kinds []string) {
 	return kinds
 }
 
+// ExternalRepos returns the list of set ExternalRepoSpecs from all Repos.
+func (rs Repos) ExternalRepos() []api.ExternalRepoSpec {
+	specs := make([]api.ExternalRepoSpec, 0, len(rs))
+	for _, r := range rs {
+		if r.ExternalRepo.IsSet() {
+			specs = append(specs, r.ExternalRepo)
+		}
+	}
+	return specs
+}
+
 func (rs Repos) Len() int {
 	return len(rs)
 }

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -650,6 +650,9 @@ func (r *Repo) Update(n *Repo) (modified bool) {
 
 // Clone returns a clone of the given repo.
 func (r *Repo) Clone() *Repo {
+	if r == nil {
+		return nil
+	}
 	clone := *r
 	return &clone
 }

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -326,7 +326,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 			return nil, err
 		}
 
-		err = s.Store.UpsertRepos(ctx, repo)
+		_, err = s.Syncer.SyncSubset(ctx, repo)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -270,14 +270,6 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if s.Syncer == nil {
-		respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
-			ExternalService: req.ExternalService,
-			Error:           errors.New("Syncer is not enabled"),
-		})
-		return
-	}
-
 	_, err := s.Syncer.Sync(r.Context(), req.ExternalService.Kind)
 	switch {
 	case err == nil:

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -569,7 +569,8 @@ func apiExternalServices(es ...*repos.ExternalService) []api.ExternalService {
 }
 
 func TestRepoLookup(t *testing.T) {
-	now := time.Now().UTC()
+	clock := repos.NewFakeClock(time.Now(), 0)
+	now := clock.Now()
 
 	githubRepository := &repos.Repo{
 		Name:        "github.com/foo/bar",
@@ -579,6 +580,7 @@ func TestRepoLookup(t *testing.T) {
 		Archived:    false,
 		Fork:        false,
 		CreatedAt:   now,
+		UpdatedAt:   now,
 		ExternalRepo: api.ExternalRepoSpec{
 			ID:          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
 			ServiceType: "github",
@@ -777,7 +779,8 @@ func TestRepoLookup(t *testing.T) {
 			store := new(repos.FakeStore)
 			must(store.UpsertRepos(ctx, tc.stored.Clone()...))
 
-			s := &Server{Syncer: &repos.Syncer{}, Store: store}
+			syncer := repos.NewSyncer(store, nil, nil, clock.Now)
+			s := &Server{Syncer: syncer, Store: store}
 			if tc.githubDotComSource != nil {
 				s.GithubDotComSource = tc.githubDotComSource
 			}


### PR DESCRIPTION
Previously we directly used upsert, which doesn't actually upsert unless the
repos correctly have ID set. It relied on ID to decide between an update or an
insert. Since we directly passed a sourced repo, it would never have ID
set (nor would we have updated_at fields, etc set).

So we introduce SyncSubset. SyncSubset takes a list of sourced repositories
and runs the diff algorithm on related repositories from the store. IE those
with matching names or external repository specs. Additionally this allows us
to detect renames on Sourcegraph.com.

Fixes https://github.com/sourcegraph/sourcegraph/issues/4046