### PR TITLE
Add trailing slash to dirs in raw listing

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -218,7 +218,11 @@ func serveRaw(w http.ResponseWriter, r *http.Request) error {
 			}
 			var names []string
 			for _, info := range infos {
-				names = append(names, info.Name())
+				name := info.Name()
+				if info.IsDir() {
+					name = name + "/"
+				}
+				names = append(names, name)
 			}
 			result := strings.Join(names, "\n")
 			fmt.Fprintf(w, "%s", template.HTMLEscapeString(result))


### PR DESCRIPTION
Adds a trailing slash for dirs in the raw file repo listing. There's no indication in the current listings if an entry is a dir or file, and this changes gives (at least some) indication. Unfortunately we can't reflect "IsDir" directly in the URL (see https://github.com/sourcegraph/sourcegraph/pull/800#discussion_r231761557)

Before:

![Screen Shot 2019-05-16 at 9 52 34 PM](https://user-images.githubusercontent.com/888624/57898080-80b55000-7825-11e9-8b85-ce34905df41b.png)

After:

![Screen Shot 2019-05-16 at 9 51 47 PM](https://user-images.githubusercontent.com/888624/57898084-8448d700-7825-11e9-9358-9638ca57d571.png)


Test plan: None. This is a simple change--no existing tests it seems. Give me a hint how to mock this if you have a good idea.
