### PR TITLE
do not show errors for trailing commas in web JSON editors

### DIFF
--- a/schema/aws_codecommit.schema.json
+++ b/schema/aws_codecommit.schema.json
@@ -3,6 +3,7 @@
   "$id": "aws_codecommit.schema.json#",
   "title": "AWSCodeCommitConnection",
   "description": "Configuration for a connection to AWS CodeCommit.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["region", "accessKeyID", "secretAccessKey", "gitCredentials"],

--- a/schema/aws_codecommit_stringdata.go
+++ b/schema/aws_codecommit_stringdata.go
@@ -8,6 +8,7 @@ const AWSCodeCommitSchemaJSON = `{
   "$id": "aws_codecommit.schema.json#",
   "title": "AWSCodeCommitConnection",
   "description": "Configuration for a connection to AWS CodeCommit.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["region", "accessKeyID", "secretAccessKey", "gitCredentials"],

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -3,6 +3,7 @@
   "$id": "bitbucket_server.schema.json#",
   "title": "BitbucketServerConnection",
   "description": "Configuration for a connection to Bitbucket Server.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["username", "url", "repositoryQuery"],

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -8,6 +8,7 @@ const BitbucketServerSchemaJSON = `{
   "$id": "bitbucket_server.schema.json#",
   "title": "BitbucketServerConnection",
   "description": "Configuration for a connection to Bitbucket Server.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["username", "url", "repositoryQuery"],

--- a/schema/critical.schema.json
+++ b/schema/critical.schema.json
@@ -3,6 +3,7 @@
   "$id": "critical.schema.json#",
   "title": "Critical configuration",
   "description": "Critical configuration for a Sourcegraph site.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/schema/critical_stringdata.go
+++ b/schema/critical_stringdata.go
@@ -8,6 +8,7 @@ const CriticalSchemaJSON = `{
   "$id": "critical.schema.json#",
   "title": "Critical configuration",
   "description": "Critical configuration for a Sourcegraph site.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -3,6 +3,7 @@
   "$id": "github.schema.json#",
   "title": "GitHubConnection",
   "description": "Configuration for a connection to GitHub or GitHub Enterprise.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["url", "token", "repositoryQuery"],

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -8,6 +8,7 @@ const GitHubSchemaJSON = `{
   "$id": "github.schema.json#",
   "title": "GitHubConnection",
   "description": "Configuration for a connection to GitHub or GitHub Enterprise.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["url", "token", "repositoryQuery"],

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -3,6 +3,7 @@
   "$id": "gitlab.schema.json#",
   "title": "GitLabConnection",
   "description": "Configuration for a connection to GitLab (GitLab.com or GitLab self-managed).",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["url", "token", "projectQuery"],

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -8,6 +8,7 @@ const GitLabSchemaJSON = `{
   "$id": "gitlab.schema.json#",
   "title": "GitLabConnection",
   "description": "Configuration for a connection to GitLab (GitLab.com or GitLab self-managed).",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["url", "token", "projectQuery"],

--- a/schema/gitolite.schema.json
+++ b/schema/gitolite.schema.json
@@ -3,6 +3,7 @@
   "$id": "gitolite.schema.json#",
   "title": "GitoliteConnection",
   "description": "Configuration for a connection to Gitolite.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["prefix", "host"],

--- a/schema/gitolite_stringdata.go
+++ b/schema/gitolite_stringdata.go
@@ -8,6 +8,7 @@ const GitoliteSchemaJSON = `{
   "$id": "gitolite.schema.json#",
   "title": "GitoliteConnection",
   "description": "Configuration for a connection to Gitolite.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["prefix", "host"],

--- a/schema/other_external_service.schema.json
+++ b/schema/other_external_service.schema.json
@@ -3,6 +3,7 @@
   "$id": "other_external_service.schema.json#",
   "title": "OtherExternalServiceConnection",
   "description": "Configuration for a Connection to Git repositories for which an external service integration isn't yet available.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["repos"],

--- a/schema/other_external_service_stringdata.go
+++ b/schema/other_external_service_stringdata.go
@@ -8,6 +8,7 @@ const OtherExternalServiceSchemaJSON = `{
   "$id": "other_external_service.schema.json#",
   "title": "OtherExternalServiceConnection",
   "description": "Configuration for a Connection to Git repositories for which an external service integration isn't yet available.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["repos"],

--- a/schema/phabricator.schema.json
+++ b/schema/phabricator.schema.json
@@ -3,6 +3,7 @@
   "$id": "phabricator.schema.json#",
   "title": "PhabricatorConnection",
   "description": "Configuration for a connection to Phabricator.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "anyOf": [{ "required": ["token"] }, { "required": ["repos"] }],

--- a/schema/phabricator_stringdata.go
+++ b/schema/phabricator_stringdata.go
@@ -8,6 +8,7 @@ const PhabricatorSchemaJSON = `{
   "$id": "phabricator.schema.json#",
   "title": "PhabricatorConnection",
   "description": "Configuration for a connection to Phabricator.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "anyOf": [{ "required": ["token"] }, { "required": ["repos"] }],

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -3,6 +3,7 @@
   "$id": "settings.schema.json#",
   "title": "Settings",
   "description": "Configuration settings for users and organizations on Sourcegraph.",
+  "allowComments": true,
   "type": "object",
   "properties": {
     "search.savedQueries": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -8,6 +8,7 @@ const SettingsSchemaJSON = `{
   "$id": "settings.schema.json#",
   "title": "Settings",
   "description": "Configuration settings for users and organizations on Sourcegraph.",
+  "allowComments": true,
   "type": "object",
   "properties": {
     "search.savedQueries": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3,6 +3,7 @@
   "$id": "site.schema.json#",
   "title": "Site configuration",
   "description": "Configuration for a Sourcegraph site.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -8,6 +8,7 @@ const SiteSchemaJSON = `{
   "$id": "site.schema.json#",
   "title": "Site configuration",
   "description": "Configuration for a Sourcegraph site.",
+  "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "properties": {


### PR DESCRIPTION
fix #4008

All JSON documents we use (for settings, site config, external services, and extension manifests) support trailing commas on the frontend and backend. However, an upgrade to monaco-editor unexpectedly caused the Monaco JSON editors in our UI to show red squiggly errors for trailing commas.

The (undocumented) way to do this is to add `allowComments` to the root of the JSON Schema. It is not sufficient to set `allowComments: true` in a `monaco.languages.json.jsonDefaults.setDiagnosticsOptions` call. I found this secret fix by finding https://github.com/microsoft/vscode/issues/19992#issuecomment-347124969 and then inferring what changes that might entail, to discover `allowComments` in the JSON Schema is responsible for ignoring trailing comma errors.

Verification (the trailing comma has no error, and validation/completion still works):

![image](https://user-images.githubusercontent.com/1976/57906276-4d2af380-782e-11e9-80fc-b02e83d3421a.png)
