### PR TITLE
frontend: Only do github.com prefix search optimization on dot-com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fix a bug where using a repo search filter with the prefix `github.com` only searched for repos with the prefix `github.com`. (#4103)
+
 ## 3.4.0 (unreleased)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Fix a bug where using a repo search filter with the prefix `github.com` only searched for repos with the prefix `github.com`. (#4103)
+- Fix a bug where using a repo search filter with the prefix `github.com` only searched for repos whose name starts with `github.com`, even though no `^` was specified in the search filter. (#4103)
 
 ## 3.4.0 (unreleased)
 

--- a/cmd/frontend/db/repos_test.go
+++ b/cmd/frontend/db/repos_test.go
@@ -40,6 +40,9 @@ func TestParseIncludePattern(t *testing.T) {
 
 		`^github\.com/foo/bar`: {like: []string{"github.com/foo/bar%"}},
 
+		`github.com`:  {regexp: `github.com`},
+		`github\.com`: {like: []string{`%github.com%`}},
+
 		`(^github\.com/Microsoft/vscode$)|(^github\.com/sourcegraph/go-langserver$)`: {exact: []string{"github.com/Microsoft/vscode", "github.com/sourcegraph/go-langserver"}},
 
 		// Avoid DoS when there are too many possible matches to enumerate.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -505,7 +505,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 func optimizeRepoPatternWithHeuristics(repoPattern string) string {
 	// Optimization: make the "." in "github.com" a literal dot
 	// so that the regexp can be optimized more effectively.
-	if strings.HasPrefix(string(repoPattern), "github.com") {
+	if envvar.SourcegraphDotComMode() && strings.HasPrefix(string(repoPattern), "github.com") {
 		repoPattern = "^" + repoPattern
 	}
 	repoPattern = strings.Replace(string(repoPattern), "github.com", `github\.com`, -1)


### PR DESCRIPTION
We have a heuristic which translates repo queries with the prefix `github.com`
into `^github.com`. This was likely added with the sourcegraph.com use case in
mind (3.5mil repos in the table and they all start with github.com). However,
for customers github.com can appear in other parts of the repo string. As such
we only use this optimization on Sourcegraph.com

This commit additionally includes some extra checks to ensure our include
pattern parsing doesn't make the same mistake.

Fixes https://github.com/sourcegraph/sourcegraph/issues/4079