### PR TITLE
fix: incorrect db query to fetch all saved searches if multiple orgs

### DIFF
--- a/cmd/frontend/db/saved_searches.go
+++ b/cmd/frontend/db/saved_searches.go
@@ -155,7 +155,7 @@ func (s *savedSearches) ListSavedSearchesByUserID(ctx context.Context, userID in
 	conds := sqlf.Sprintf("WHERE user_id=%d", userID)
 
 	if len(orgConditions) > 0 {
-		conds = sqlf.Sprintf("%v OR %v", conds, sqlf.Join(orgConditions, " ) OR ("))
+		conds = sqlf.Sprintf("%v OR %v", conds, sqlf.Join(orgConditions, " OR "))
 	}
 
 	query := sqlf.Sprintf(`SELECT


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/4058. 

Fixes a bug where the saved searches page would not load at all if the user viewing it is part of more than one org. Also adds a test for this function.

This must be cherry-picked onto 3.4 cc @sourcegraph/distribution 