### PR TITLE
Fix the Firefox extension connection status indicator

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,7 +8,6 @@ const config = {
       {
         modules: false,
         useBuiltIns: 'entry',
-        corejs: 3,
       },
     ],
     '@babel/preset-typescript',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+    "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/runtime": "^7.2.0",
     "@gql2ts/from-schema": "^1.10.1",
@@ -209,7 +210,6 @@
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.1.0",
-    "core-js": "^3.0.1",
     "d3-axis": "^1.0.12",
     "d3-scale": "^3.0.0",
     "d3-selection": "^1.4.0",
@@ -235,7 +235,6 @@
     "react-stripe-elements": "^3.0.0",
     "react-visibility-sensor": "^5.0.2",
     "reactstrap": "https://registry.npmjs.org/@sqs/reactstrap/-/reactstrap-6.5.0-tmp1.tgz",
-    "regenerator-runtime": "^0.13.2",
     "rxjs": "^6.5.2",
     "sanitize-html": "^1.20.0",
     "semver": "^6.0.0",

--- a/shared/src/polyfills.ts
+++ b/shared/src/polyfills.ts
@@ -3,9 +3,9 @@ import 'core-js/web/immediate'
 
 import 'symbol-observable'
 
-// This gets automatically expanded into imports that only pick what we need.
-import 'core-js/stable'
-import 'regenerator-runtime/runtime'
+// This gets automatically expanded into
+// imports that only pick what we need
+import '@babel/polyfill'
 
 // Polyfill URL because Chrome and Firefox are not spec-compliant
 // Hostnames of URIs with custom schemes (e.g. git) are not parsed out

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,6 +698,14 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
+"@babel/polyfill@^7.2.5":
+  version "7.2.5"
+  resolved "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz#6c54b964f71ad27edddc567d065e57e87ed7fa7d"
+  integrity sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/preset-env@7.3.1":
   version "7.3.1"
   resolved "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz#389e8ca6b17ae67aaf9a2111665030be923515db"
@@ -1496,8 +1504,7 @@
   integrity sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "0.0.0"
-  uid ""
+  version "2.0.0"
 
 "@sourcegraph/prettierrc@^3.0.1":
   version "3.0.1"
@@ -5138,7 +5145,7 @@ core-js-pure@3.0.1:
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.1.tgz#37358fb0d024e6b86d443d794f4e37e949098cbe"
   integrity sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==
 
-core-js@3.0.1, core-js@^3.0.1:
+core-js@3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
   integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
@@ -13731,8 +13738,7 @@ source-map@^0.7.2:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "0.0.0"
-  uid ""
+  version "23.0.1"
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/4114 by reverting:

- https://github.com/sourcegraph/sourcegraph/pull/3933 which upgraded to core-js@3
- https://github.com/sourcegraph/sourcegraph/pull/3958 which replaced the deprecated `@babel/polyfill` with core-js/stable (which only exists in core-js@3)

I didn't find a solution with core-js@3 within ~30 minutes, so I'm proposing this PR to at least fix the Firefox extension now while we find another solution.

This can be caught by puppeteer-firefox (originally proposed in https://sourcegraph.slack.com/archives/CHXHX7XAS/p1557440150011000)