### PR TITLE
web: Change error message in site-admin externalservice form

### DIFF
--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -29,7 +29,7 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
             <Form className="external-service-form" onSubmit={this.props.onSubmit}>
                 {this.props.error && (
                     <div className="alert alert-danger">
-                        <p>Error saving invalid configuration:</p>
+                        <p>Error saving configuration:</p>
                         <Markdown dangerousInnerHTML={renderMarkdown(this.props.error.message)} />
                     </div>
                 )}


### PR DESCRIPTION
This adresses a minor part of #4052 by changing the wording so that it doesn't sound like the user did something wrong or that their configuration is invalid when we failed to save it in the backend.
