### PR TITLE
frontend: handle config overrides _after_ config server is up

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -97,8 +97,8 @@ func Main() error {
 	if err := dbconn.ConnectToDB(""); err != nil {
 		log.Fatal(err)
 	}
-	handleConfigOverrides()
 	globals.ConfigurationServerFrontendOnly = conf.InitConfigurationServerFrontendOnly(&configurationSource{})
+	handleConfigOverrides()
 	conf.MustValidateDefaults()
 
 	// Filter trace logs


### PR DESCRIPTION
This fixes #4123, or at least attempts to.

When `DEV_OVERRIDE_EXTSVC_CONFIG` or `EXTSVC_CONFIG_FILE` are set,
`handleConfigOverrides` calls `db.ExternalServices.Create`, which in
turn calls `conf.Get()`, which waits for the configuration server to
have booted up.

But with 507371f2 this call to `handleConfigOverrides` was now made
_before_ the configuration server has booted up, with the result that
the whole frontend process ran into a deadlock since every goroutine
was waiting for the conf server to start up, including the goroutine
responsible to do so.

This commit does _not_ move the `handleConfigOverrides` call to its
original place but instead in between the configuration-server-start-up
and the validation of the configuration.

I assume that this was the intention behind moving
`handleConfigOverrides()` in the first place: the overrides should take
place before the defaults are validated.

Test plan: `./dev/launch.sh` and `./enterprise/dev/start.sh` (one sets the ENV vars and one does not)