### PR TITLE
conf: Do not default sslmode in ServiceConnections.PostgresDSN

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -188,9 +188,8 @@ func doPostgresDSN(currentUser string, getenv func(string) string) string {
 	// TODO match logic in lib/pq
 	// https://sourcegraph.com/github.com/lib/pq@d6156e141ac6c06345c7c73f450987a9ed4b751f/-/blob/connector.go#L42
 	dsn := &url.URL{
-		Scheme:   "postgres",
-		Host:     "127.0.0.1:5432",
-		RawQuery: "sslmode=disable",
+		Scheme: "postgres",
+		Host:   "127.0.0.1:5432",
 	}
 
 	// Username preference: PGUSER, $USER, postgres

--- a/cmd/frontend/internal/cli/config_test.go
+++ b/cmd/frontend/internal/cli/config_test.go
@@ -10,7 +10,7 @@ func TestPostgresDSN(t *testing.T) {
 	}{{
 		name: "default",
 		env:  map[string]string{},
-		dsn:  "postgres://testuser@127.0.0.1:5432?sslmode=disable",
+		dsn:  "postgres://testuser@127.0.0.1:5432",
 	}, {
 		name: "deploy-sourcegraph",
 		env: map[string]string{


### PR DESCRIPTION
Test plan: run launch.sh locally and e2e CI tests.

Fixes https://github.com/sourcegraph/sourcegraph/issues/4118