### PR TITLE
Release 3.3.8 and 3.2.6 + add missing CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ All notable changes to Sourcegraph are documented in this file.
 - Substantially improved the performance of updating Bitbucket Server external service configurations on instances with thousands of repositories, going from e.g. several minutes to about a minute for ~20k repositories (#4037).
 - Fully resolved the search performance regression in v3.2.0, restoring performance of search back to the same levels it was before changes made in v3.2.0.
 - Fix a bug where using a repo search filter with the prefix `github.com` only searched for repos whose name starts with `github.com`, even though no `^` was specified in the search filter. (#4103)
+- Fixed an issue where files that fail syntax highlighting would incorrectly render an error instead of gracefully falling back to their plaintext form.
+
+## 3.3.8
+
+### Fixed
+
+- Fully resolved the search performance regression in v3.2.0, restoring performance of search back to the same levels it was before changes made in v3.2.0.
+- Fixed an issue where files that fail syntax highlighting would incorrectly render an error instead of gracefully falling back to their plaintext form.
+- Fixed an issue introduced in v3.3 where Sourcegraph would under specific circumstances incorrectly have to re-clone and re-index repositories from Bitbucket Server and AWS CodeCommit.
 
 ## 3.3.7
 
@@ -164,6 +173,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed an issue where the site-admin repositories page `Cloning`, `Not Cloned`, `Needs Index` tabs were very slow on instances with thousands of repositories.
 - Fixed an issue where failing to syntax highlight a single file would take down the entire syntax highlighting service.
+
+## 3.2.6
+
+### Fixed
+
+- Fully resolved the search performance regression in v3.2.0, restoring performance of search back to the same levels it was before changes made in v3.2.0.
 
 ## 3.2.5
 

--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -27,7 +27,7 @@
                             <details-menu aria-label="Sourcegraph version" class="dropdown-menu" aria-labelledby="Version Dropdown">
 
                                 {{/* Update these after each release. */}}
-                                {{$previousReleaseRevspec := "v3.3.7"}}
+                                {{$previousReleaseRevspec := "v3.3.8"}}
                                 {{$previousReleaseVersion := "3.3"}}
                                 {{$currentReleaseRevspec := "v3.4.0"}}
                                 {{$currentReleaseVersion := "3.4"}}


### PR DESCRIPTION
This updates the CHANGELOG and other docs to reflect the release of 3.3.8 and 3.2.6 patch releases.

Additionally, it adds a few entries that were missing from the CHANGELOG.