### PR TITLE
make command list in global nav have same color as other nav links

### DIFF
--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -291,6 +291,9 @@ export function filterAndRankItems(
 }
 
 export interface CommandListPopoverButtonProps extends CommandListProps {
+    /** The class name for the root button element. */
+    className?: string
+
     toggleVisibilityKeybinding?: Pick<ShortcutProps, 'held' | 'ordered'>[]
 }
 
@@ -303,6 +306,7 @@ export class CommandListPopoverButton extends React.PureComponent<
     public render(): JSX.Element | null {
         return (
             <PopoverButton
+                className={this.props.className}
                 popoverClassName={this.props.popoverClassName}
                 placement="bottom-end"
                 toggleVisibilityKeybinding={this.props.toggleVisibilityKeybinding}

--- a/web/src/components/PopoverButton.scss
+++ b/web/src/components/PopoverButton.scss
@@ -12,7 +12,6 @@
     user-select: none;
     cursor: pointer;
 
-    color: $color-text;
     background-color: transparent;
 
     &__btn {

--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -18,6 +18,7 @@ WebHoverOverlay.displayName = 'WebHoverOverlay'
 export const WebCommandListPopoverButton: React.FunctionComponent<CommandListPopoverButtonProps> = props => (
     <CommandListPopoverButton
         {...props}
+        className="btn-link"
         popoverClassName="rounded"
         formClassName="form"
         inputClassName="form-control px-2 py-1 rounded-0"


### PR DESCRIPTION
Previously, the command list's icon foreground color was black (in the light theme) or white (in the dark theme), whereas the other links were slightly more muted. Now, the command list icon is the same color as the text labels of the surrounding global navbar items.