### PR TITLE
fix infinite loading indicator on empty commit results

### DIFF
--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -162,7 +162,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                 offset={this.visibilitySensorOffset}
             >
                 <>
-                    {this.state.HTML && (
+                    {this.state.HTML !== undefined ? (
                         <Link key={this.props.item.url} to={this.props.item.url} className="search-result-match">
                             {this.bodyIsCode ? (
                                 <code>
@@ -180,8 +180,7 @@ export class SearchResultMatch extends React.Component<SearchResultMatchProps, S
                                 />
                             )}
                         </Link>
-                    )}
-                    {!this.state.HTML && (
+                    ) : (
                         <>
                             <LoadingSpinner className="icon-inline search-result-match__loader" />
                             <table>


### PR DESCRIPTION
If a commit is empty (i.e., it contains no changes, which is possible with e.g. `git commit --allow-empty`), then `this.state.HTML === ''`. This causes the loading indicator to be shown forever. Instead, it should check for `undefined`.