### PR TITLE
move DidSearch activation step recording to central submitSearch function

### DIFF
--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -286,7 +286,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                                         autoFocus={true}
                                         placeholder=""
                                     />
-                                    <SearchButton activation={this.props.activation} />
+                                    <SearchButton />
                                 </Form>
                             </section>
                             <TreeEntriesSection
@@ -364,7 +364,8 @@ export class TreePage extends React.PureComponent<Props, State> {
         submitSearch(
             this.props.history,
             this.getQueryPrefix() + this.state.query,
-            this.props.filePath ? 'tree' : 'repo'
+            this.props.filePath ? 'tree' : 'repo',
+            this.props.activation
         )
     }
 

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -1,12 +1,18 @@
 import * as H from 'history'
+import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { eventLogger } from '../tracking/eventLogger'
 
+/**
+ * @param activation If set, records the DidSearch activation event for the new user activation
+ * flow.
+ */
 export function submitSearch(
     history: H.History,
     query: string,
-    source: 'home' | 'nav' | 'repo' | 'tree' | 'filter'
+    source: 'home' | 'nav' | 'repo' | 'tree' | 'filter',
+    activation?: ActivationProps['activation']
 ): void {
     // Go to search results page
     const path = '/search?' + buildSearchURLQuery(query)
@@ -18,6 +24,9 @@ export function submitSearch(
         },
     })
     history.push(path, { ...history.location.state, query })
+    if (activation) {
+        activation.update({ DidSearch: true })
+    }
 }
 
 /**

--- a/web/src/search/input/SearchButton.tsx
+++ b/web/src/search/input/SearchButton.tsx
@@ -3,9 +3,8 @@ import HelpCircleOutlineIcon from 'mdi-react/HelpCircleOutlineIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
 import * as React from 'react'
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
-import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
 
-interface Props extends ActivationProps {
+interface Props {
     /** Hide the "help" icon and dropdown. */
     noHelp?: boolean
 
@@ -18,22 +17,17 @@ interface State {
 }
 
 /**
- * A search button with a dropdown with related links.
+ * A search button with a dropdown with related links. It must be wrapped in a form whose onSubmit
+ * handler performs the search.
  */
 export class SearchButton extends React.Component<Props, State> {
     public state: State = { isOpen: false }
-
-    private onClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
-        if (this.props.activation) {
-            this.props.activation.update({ DidSearch: true })
-        }
-    }
 
     public render(): JSX.Element | null {
         const docsURLPrefix = window.context.sourcegraphDotComMode ? 'https://docs.sourcegraph.com' : '/help'
         return (
             <div className="search-button d-flex">
-                <button className="btn btn-primary search-button__btn" type="submit" onClick={this.onClick}>
+                <button className="btn btn-primary search-button__btn" type="submit">
                     <SearchIcon className="icon-inline" />
                     {!this.props.noLabel && <span className="search-button__label">Search</span>}
                 </button>

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import * as React from 'react'
+import React, { useCallback } from 'react'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
 import { Form } from '../../components/Form'
 import { submitSearch } from '../helpers'
@@ -12,32 +12,41 @@ interface Props extends ActivationProps {
     navbarSearchQuery: string
     onChange: (newValue: string) => void
 }
+
 /**
  * The search item in the navbar
  */
-export class SearchNavbarItem extends React.Component<Props> {
-    public render(): JSX.Element | null {
-        // Only autofocus the query input on search result pages (otherwise we
-        // capture down-arrow keypresses that the user probably intends to scroll down
-        // in the page).
-        const autoFocus = this.props.location.pathname === '/search'
+export const SearchNavbarItem: React.FunctionComponent<Props> = ({
+    navbarSearchQuery,
+    onChange,
+    activation,
+    location,
+    history,
+}) => {
+    // Only autofocus the query input on search result pages (otherwise we
+    // capture down-arrow keypresses that the user probably intends to scroll down
+    // in the page).
+    const autoFocus = location.pathname === '/search'
 
-        return (
-            <Form className="search search--navbar-item d-flex" onSubmit={this.onSubmit}>
-                <QueryInput
-                    {...this.props}
-                    value={this.props.navbarSearchQuery}
-                    onChange={this.props.onChange}
-                    autoFocus={autoFocus ? 'cursor-at-end' : undefined}
-                    hasGlobalQueryBehavior={true}
-                />
-                <SearchButton activation={this.props.activation} />
-            </Form>
-        )
-    }
+    const onSubmit = useCallback(
+        (e: React.FormEvent<HTMLFormElement>): void => {
+            e.preventDefault()
+            submitSearch(history, navbarSearchQuery, 'nav', activation)
+        },
+        [history, navbarSearchQuery, activation]
+    )
 
-    private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
-        event.preventDefault()
-        submitSearch(this.props.history, this.props.navbarSearchQuery, 'nav')
-    }
+    return (
+        <Form className="search search--navbar-item d-flex align-items-start" onSubmit={onSubmit}>
+            <QueryInput
+                value={navbarSearchQuery}
+                onChange={onChange}
+                autoFocus={autoFocus ? 'cursor-at-end' : undefined}
+                hasGlobalQueryBehavior={true}
+                location={location}
+                history={history}
+            />
+            <SearchButton />
+        </Form>
+    )
 }

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -87,7 +87,7 @@ export class SearchPage extends React.Component<Props, State> {
                             autoFocus={'cursor-at-end'}
                             hasGlobalQueryBehavior={true}
                         />
-                        <SearchButton activation={this.props.activation} />
+                        <SearchButton />
                     </div>
                     {hasScopes ? (
                         <>
@@ -149,7 +149,7 @@ export class SearchPage extends React.Component<Props, State> {
     private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
         const query = [this.state.builderQuery, this.state.userQuery].filter(s => !!s).join(' ')
-        submitSearch(this.props.history, query, 'home')
+        submitSearch(this.props.history, query, 'home', this.props.activation)
     }
 
     private getPageTitle(): string | undefined {


### PR DESCRIPTION
This makes it possible to have a query input without a SearchButton (previously the activation step was recorded in the onClick handler of the SearchButton, which requires it to be in the form).