### PR TITLE
fix SQL for thread lookup by target

### DIFF
--- a/cmd/frontend/db/discussion_threads.go
+++ b/cmd/frontend/db/discussion_threads.go
@@ -561,7 +561,7 @@ func (*discussionThreads) getListSQL(opts *DiscussionThreadsListOptions) (conds 
 				targetRepoConds = append(targetRepoConds, sqlf.Sprintf("path!=%v", *opts.NotTargetRepoPath))
 			}
 		}
-		conds = append(conds, sqlf.Sprintf("id IN (SELECT id FROM discussion_threads_target_repo WHERE %v)", sqlf.Join(targetRepoConds, "AND")))
+		conds = append(conds, sqlf.Sprintf("id IN (SELECT thread_id FROM discussion_threads_target_repo WHERE %v)", sqlf.Join(targetRepoConds, "AND")))
 	}
 	return conds
 }


### PR DESCRIPTION
So long as threads are 1-to-1 with targets, this luckily works because the IDs were always incremented in a lockstep fashion (although this was not guaranteed, if a crash occurred during create-thread operations, because DB transactions aren't in use).

If threads ever become not 1-to-1 with targets, the existing code would break. This code makes it not break now or if that future change is made.