### PR TITLE
gitserver: Move alwayscloningtest check into clone function

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -546,10 +546,6 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 
 	dir := path.Join(s.ReposDir, string(req.Repo))
 	cloneProgress, cloneInProgress := s.locker.Status(dir)
-	if strings.ToLower(string(req.Repo)) == "github.com/sourcegraphtest/alwayscloningtest" {
-		cloneInProgress = true
-		cloneProgress = "This will never finish cloning"
-	}
 	if cloneInProgress {
 		status = "clone-in-progress"
 		w.WriteHeader(http.StatusNotFound)
@@ -672,6 +668,10 @@ type cloneOptions struct {
 // cloneRepo issues a git clone command for the given repo. It is
 // non-blocking.
 func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, url string, opts *cloneOptions) (string, error) {
+	if strings.ToLower(string(repo)) == "github.com/sourcegraphtest/alwayscloningtest" {
+		return "This will never finish cloning", nil
+	}
+
 	dir := filepath.Join(s.ReposDir, string(protocol.NormalizeRepo(repo)))
 
 	// PERF: Before doing the network request to check if isCloneable, lets


### PR DESCRIPTION
With the scheduler we end up cloning the repository due to it using the
repoUpdater handler. By moving the check into our clone repo function, we ensure
we never clone the repository and always return a status of clone in progress.

Test plan: unit tests and testing in dev mode.
