### PR TITLE
Show warnings when sync failed after External Service creation/update was successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - The saved searches UI has changed. There is now a Saved searches page in the user and organizations settings area. A saved search appears in the settings area of the user or organization it is associated with.
-- Site admins will now see a warning if creating or updating an external service was successful but the process could not complete entirely due to an ephemeral error (such as the GitHub API shedding load and returning incomplete results).
 
 ### Removed
 
@@ -31,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - When `EXTSVC_CONFIG_FILE` or `SITE_CONFIG_FILE` are specified, updates to external services and the site config are now prevented.
+- Site admins will now see a warning if creating or updating an external service was successful but the process could not complete entirely due to an ephemeral error (such as GitHub API search queries running into timeouts and returning incomplete results).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - The saved searches UI has changed. There is now a Saved searches page in the user and organizations settings area. A saved search appears in the settings area of the user or organization it is associated with.
+- Site admins will now see a warning if creating or updating an external service was successful but the process could not complete entirely due to an ephemeral error (such as the GitHub API shedding load and returning incomplete results).
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -15,6 +15,7 @@ import (
 
 type externalServiceResolver struct {
 	externalService *types.ExternalService
+	warning         string
 }
 
 const externalServiceIDKind = "ExternalService"
@@ -73,4 +74,11 @@ func (r *externalServiceResolver) CreatedAt() string {
 
 func (r *externalServiceResolver) UpdatedAt() string {
 	return r.externalService.UpdatedAt.Format(time.RFC3339)
+}
+
+func (r *externalServiceResolver) Warning() *string {
+	if r.warning == "" {
+		return nil
+	}
+	return &r.warning
 }

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -43,11 +43,12 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *struct {
 		return nil, err
 	}
 
+	res := &externalServiceResolver{externalService: externalService}
 	if err := syncExternalService(ctx, externalService); err != nil {
-		return nil, errors.Wrap(err, "warning: external service created, but sync request failed")
+		res.warning = fmt.Sprintf("External service created, but we encountered a problem while syncing the external service: %s", err)
 	}
 
-	return &externalServiceResolver{externalService: externalService}, nil
+	return res, nil
 }
 
 func (*schemaResolver) UpdateExternalService(ctx context.Context, args *struct {
@@ -87,11 +88,12 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *struct {
 		return nil, err
 	}
 
+	res := &externalServiceResolver{externalService: externalService}
 	if err = syncExternalService(ctx, externalService); err != nil {
-		return nil, errors.Wrap(err, "warning: external service updated, but sync request failed")
+		res.warning = fmt.Sprintf("External service updated, but we encountered a problem while syncing the external service: %s", err)
 	}
 
-	return &externalServiceResolver{externalService: externalService}, nil
+	return res, nil
 }
 
 // Eagerly trigger a repo-updater sync.

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -98,7 +98,7 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *struct {
 
 // Eagerly trigger a repo-updater sync.
 func syncExternalService(ctx context.Context, svc *types.ExternalService) error {
-	res, err := repoupdater.DefaultClient.SyncExternalService(ctx, api.ExternalService{
+	_, err := repoupdater.DefaultClient.SyncExternalService(ctx, api.ExternalService{
 		ID:          svc.ID,
 		Kind:        svc.Kind,
 		DisplayName: svc.DisplayName,
@@ -110,10 +110,6 @@ func syncExternalService(ctx context.Context, svc *types.ExternalService) error 
 
 	if err != nil {
 		return err
-	}
-
-	if res.Error != "" {
-		return errors.New(res.Error)
 	}
 
 	return nil

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -112,7 +112,11 @@ func syncExternalService(ctx context.Context, svc *types.ExternalService) error 
 		return err
 	}
 
-	return res.Error
+	if res.Error != "" {
+		return errors.New(res.Error)
+	}
+
+	return nil
 }
 
 func (*schemaResolver) DeleteExternalService(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1104,6 +1104,12 @@ type ExternalService implements Node {
     createdAt: String!
     # When the external service was last updated.
     updatedAt: String!
+    # This is an optional field that's populated when we ran into errors on the
+    # backend side when trying to create/update an ExternalService, but the
+    # create/update still succeeded.
+    # It is a field on ExternalService instead of a separate thing in order to
+    # not break the API and stay backwards compatible.
+    warning: String
 }
 
 # A list of repositories.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1111,6 +1111,12 @@ type ExternalService implements Node {
     createdAt: String!
     # When the external service was last updated.
     updatedAt: String!
+    # This is an optional field that's populated when we ran into errors on the
+    # backend side when trying to create/update an ExternalService, but the
+    # create/update still succeeded.
+    # It is a field on ExternalService instead of a separate thing in order to
+    # not break the API and stay backwards compatible.
+    warning: String
 }
 
 # A list of repositories.

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -283,7 +283,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		log15.Info("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
 		syncResult := &protocol.ExternalServiceSyncResult{
 			ExternalService: req.ExternalService,
-			Error:           err,
+			Error:           err.Error(),
 		}
 		respond(w, http.StatusOK, syncResult)
 	default:

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -270,9 +270,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// TODO: Hackity hack hack just for trying this
-	// _, err := s.Syncer.Sync(r.Context(), req.ExternalService.Kind)
-	err := github.ErrIncompleteResults
+	_, err := s.Syncer.Sync(r.Context(), req.ExternalService.Kind)
 	switch {
 	case err == nil:
 		log15.Info("server.external-service-sync", "synced", req.ExternalService.Kind)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -270,13 +270,22 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	_, err := s.Syncer.Sync(r.Context(), req.ExternalService.Kind)
+	// TODO: Hackity hack hack just for trying this
+	// _, err := s.Syncer.Sync(r.Context(), req.ExternalService.Kind)
+	err := github.ErrIncompleteResults
 	switch {
 	case err == nil:
 		log15.Info("server.external-service-sync", "synced", req.ExternalService.Kind)
 		respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
 			ExternalService: req.ExternalService,
 		})
+	case err == github.ErrIncompleteResults:
+		log15.Info("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
+		syncResult := &protocol.ExternalServiceSyncResult{
+			ExternalService: req.ExternalService,
+			Error:           err,
+		}
+		respond(w, http.StatusOK, syncResult)
 	default:
 		log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/extsvc/github/client.go
+++ b/pkg/extsvc/github/client.go
@@ -396,3 +396,6 @@ func APIRoot(baseURL *url.URL) (apiURL *url.URL, githubDotCom bool) {
 	}
 	return baseURL.ResolveReference(&url.URL{Path: "api"}), false
 }
+
+// ErrIncompleteResults is returned when the GitHub Search API returns an `incomplete_results: true` field in their response
+var ErrIncompleteResults = errors.New("github repository search returned incomplete results. This is an ephemeral error from GitHub, so does not indicate a problem with your configuration. See https://developer.github.com/changes/2014-04-07-understanding-search-results-and-potential-timeouts/ for more information")

--- a/pkg/extsvc/github/repos.go
+++ b/pkg/extsvc/github/repos.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -432,7 +431,7 @@ func (c *Client) ListRepositoriesForSearch(ctx context.Context, searchString str
 		return RepositoryListPage{}, err
 	}
 	if response.IncompleteResults {
-		return RepositoryListPage{}, errors.New("github repository search returned incomplete results. This is an ephemeral error from GitHub, so does not indicate a problem with your configuration. See https://developer.github.com/changes/2014-04-07-understanding-search-results-and-potential-timeouts/ for more information")
+		return RepositoryListPage{}, ErrIncompleteResults
 	}
 	repos := make([]*Repository, 0, len(response.Items))
 	for _, restRepo := range response.Items {

--- a/pkg/extsvc/github/repos_test.go
+++ b/pkg/extsvc/github/repos_test.go
@@ -461,10 +461,9 @@ func TestClient_ListRepositoriesForSearch_incomplete(t *testing.T) {
 	// If we have incomplete results we want to fail. Our syncer requires all
 	// repositories to be returned, otherwise it will delete the missing
 	// repositories.
-	want := `github repository search returned incomplete results. This is an ephemeral error from GitHub, so does not indicate a problem with your configuration. See https://developer.github.com/changes/2014-04-07-understanding-search-results-and-potential-timeouts/ for more information`
 	_, err := c.ListRepositoriesForSearch(context.Background(), "org:sourcegraph", 1)
 
-	if have := fmt.Sprint(err); want != have {
+	if have, want := err, ErrIncompleteResults; want != have {
 		t.Errorf("\nhave: %s\nwant: %s", have, want)
 	}
 }

--- a/pkg/repoupdater/client.go
+++ b/pkg/repoupdater/client.go
@@ -200,6 +200,9 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 		return nil, err
 	}
 
+	if result.Error != "" {
+		return nil, errors.New(result.Error)
+	}
 	return &result, nil
 }
 

--- a/pkg/repoupdater/client.go
+++ b/pkg/repoupdater/client.go
@@ -197,7 +197,6 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 		result.ExternalService = svc
 		return &result, nil
 	} else if err = json.Unmarshal(bs, &result); err != nil {
-		fmt.Printf("unmarshalling is an error. bs=%q, err=%q\n", bs, err)
 		return nil, err
 	}
 

--- a/pkg/repoupdater/client.go
+++ b/pkg/repoupdater/client.go
@@ -197,6 +197,7 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 		result.ExternalService = svc
 		return &result, nil
 	} else if err = json.Unmarshal(bs, &result); err != nil {
+		fmt.Printf("unmarshalling is an error. bs=%q, err=%q\n", bs, err)
 		return nil, err
 	}
 

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -174,5 +174,5 @@ type ExternalServiceSyncRequest struct {
 // ExternalServiceSyncResult is a result type of an external service's sync request.
 type ExternalServiceSyncResult struct {
 	ExternalService api.ExternalService
-	Error           error
+	Error           string
 }

--- a/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
@@ -106,7 +106,7 @@ export class SiteAdminAddExternalServicePage extends React.Component<Props, Stat
                 <h1>Add external service</h1>
                 {createdExternalService && createdExternalService.warning ? (
                     <div>
-                        <div className="mb-3" key={createdExternalService.id}>
+                        <div className="mb-3">
                             <ExternalServiceCard
                                 {...kindMetadata}
                                 title={createdExternalService.displayName}
@@ -115,9 +115,7 @@ export class SiteAdminAddExternalServicePage extends React.Component<Props, Stat
                             />
                         </div>
                         <div className="alert alert-warning">
-                            <p>
-                                <b>Warning</b>
-                            </p>
+                            <h4>Warning</h4>
                             <Markdown dangerousInnerHTML={renderMarkdown(createdExternalService.warning)} />
                         </div>
                     </div>

--- a/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
@@ -1,7 +1,5 @@
 import * as H from 'history'
-import SettingsIcon from 'mdi-react/SettingsIcon'
 import React from 'react'
-import { Link } from 'react-router-dom'
 import { Observable, Subject, Subscription } from 'rxjs'
 import { catchError, map, switchMap, tap } from 'rxjs/operators'
 import { Markdown } from '../../../shared/src/components/Markdown'
@@ -120,7 +118,7 @@ export class SiteAdminAddExternalServicePage extends React.Component<Props, Stat
                             <p>
                                 <b>Warning</b>
                             </p>
-                            <Markdown dangerousInnerHTML={renderMarkdown(this.state.externalService.warning)} />
+                            <Markdown dangerousInnerHTML={renderMarkdown(createdExternalService.warning)} />
                         </div>
                     </div>
                 ) : (

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -14,6 +14,7 @@ interface Props extends Pick<ExternalServiceKindMetadata, 'jsonSchema' | 'editor
     input: GQL.IAddExternalServiceInput
     isLightTheme: boolean
     error?: ErrorLike
+    warning?: string
     mode: 'edit' | 'create'
     loading: boolean
     onSubmit: (event?: React.FormEvent<HTMLFormElement>) => void
@@ -31,6 +32,12 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
                     <div className="alert alert-danger">
                         <p>Error saving configuration:</p>
                         <Markdown dangerousInnerHTML={renderMarkdown(this.props.error.message)} />
+                    </div>
+                )}
+                {this.props.warning && (
+                    <div className="alert alert-warning">
+                        <p>Warning:</p>
+                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.warning)} />
                     </div>
                 )}
                 <div className="form-group">

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -36,7 +36,7 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
                 )}
                 {this.props.warning && (
                     <div className="alert alert-warning">
-                        <p>Warning:</p>
+                        <h4>Warning</h4>
                         <Markdown dangerousInnerHTML={renderMarkdown(this.props.warning)} />
                     </div>
                 )}

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -3,11 +3,11 @@ import { upperFirst } from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { concat, Observable, of, Subject, Subscription } from 'rxjs'
-import { catchError, delay, distinctUntilChanged, map, mapTo, mergeMap, startWith, switchMap } from 'rxjs/operators'
+import { catchError, delay, distinctUntilChanged, map, mergeMap, startWith, switchMap } from 'rxjs/operators'
 import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
-import { queryGraphQL } from '../backend/graphql'
+import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 import { ExternalServiceCard } from './../components/ExternalServiceCard'
@@ -28,6 +28,8 @@ interface State {
      * loading, or an error.
      */
     updatedOrError: null | true | typeof LOADING | ErrorLike
+
+    warning?: string
 }
 
 export class SiteAdminExternalServicePage extends React.Component<Props, State> {
@@ -64,23 +66,27 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                 .pipe(
                     switchMap(input =>
                         concat(
-                            [{ updatedOrError: LOADING }],
+                            [{ updatedOrError: LOADING, warning: null }],
                             updateExternalService(input).pipe(
-                                mapTo(null),
-                                mergeMap(() =>
-                                    concat(
-                                        // Flash "updated" text
-                                        of({ updatedOrError: true }),
-                                        // Hide "updated" text again after 1s
-                                        of({ updatedOrError: null }).pipe(delay(1000))
-                                    )
+                                mergeMap(val =>
+                                    val.warning
+                                        ? of({ warning: val.warning, updatedOrError: null })
+                                        : concat(
+                                              // Flash "updated" text
+                                              of({ updatedOrError: true }),
+                                              // Hide "updated" text again after 1s
+                                              of({ updatedOrError: null }).pipe(delay(1000))
+                                          )
                                 ),
                                 catchError((error: Error) => [{ updatedOrError: asError(error) }])
                             )
                         )
                     )
                 )
-                .subscribe(stateUpdate => this.setState(stateUpdate as State))
+                .subscribe(stateUpdate => {
+                    console.dir(stateUpdate)
+                    this.setState(stateUpdate as State)
+                })
         )
 
         this.componentUpdates.next(this.props)
@@ -131,6 +137,7 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                         editorActions={externalServiceCategory.editorActions}
                         jsonSchema={externalServiceCategory.jsonSchema}
                         error={error}
+                        warning={this.state.warning}
                         mode="edit"
                         loading={this.state.updatedOrError === LOADING}
                         onSubmit={this.onSubmit}
@@ -171,22 +178,21 @@ function isExternalService(
     return externalServiceOrError !== LOADING && !isErrorLike(externalServiceOrError)
 }
 
-function updateExternalService(input: GQL.IUpdateExternalServiceInput): Observable<GQL.IExternalService> {
-    return queryGraphQL(
+function updateExternalService(
+    input: GQL.IUpdateExternalServiceInput
+): Observable<Pick<GQL.IExternalService, 'warning'>> {
+    return mutateGraphQL(
         gql`
             mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
                 updateExternalService(input: $input) {
-                    id
-                    kind
-                    displayName
-                    config
+                    warning
                 }
             }
         `,
         { input }
     ).pipe(
         map(dataOrThrowErrors),
-        map(data => data.node as GQL.IExternalService)
+        map(data => data.updateExternalService)
     )
 }
 

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -83,10 +83,7 @@ export class SiteAdminExternalServicePage extends React.Component<Props, State> 
                         )
                     )
                 )
-                .subscribe(stateUpdate => {
-                    console.dir(stateUpdate)
-                    this.setState(stateUpdate as State)
-                })
+                .subscribe(stateUpdate => this.setState(stateUpdate as State))
         )
 
         this.componentUpdates.next(this.props)


### PR DESCRIPTION
This fixes #4052 by

* changing the actual error message to make it easier to understand
* treating every error after the successful creation/update of an external service as a *warning*
* displaying the warnings in the UI in an `alert-warning` with an added explanation


Notes to reviewers:
1. I haven't done any TypeScript/React programming at Sourcegraph, so let me know if I'm missing something
2. I'm still not sure if this is the best message for the user, since it's not actionable and just a note that says that _something_ they have no clue about didn't work as expected.

Should we maybe add "try updating the service" note to the warning?

@sqs: Maybe you have some suggestions here

---

When *creating* an external service succeeds but syncing the config to `repo-updater` fails with a warning, it looks like this:

![add_external_service_warning](https://user-images.githubusercontent.com/1185253/58099976-0bf36480-7bdd-11e9-8fe7-e381e4ae186b.gif)
(This is a GIF)

(Note: clicking on the `ExternalServiceCard` above the warning redirects the user to the edit-page for the just-created external service)

---

When *updating* an external service succeeds but syncing fails for the same reason:

![update_external_service_warning](https://user-images.githubusercontent.com/1185253/58099990-131a7280-7bdd-11e9-92c5-5fbdd098ca0e.gif)
(This is a GIF)

---

(*Important*: if this needs to be cherry-picked into a 3.4 release, it depends on https://github.com/sourcegraph/sourcegraph/commit/a348d5c995529bbfc9082c58cc9c815196377471 and https://github.com/sourcegraph/sourcegraph/commit/25226c3c1b539f82aada22de8aacc5dc2758d999)

Test plan: manual testing in the browser, creating & updating services and producing the error in the background
