### PR TITLE
config file override fixes + improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,17 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- You may now specify `DISABLE_CONFIG_UPDATES=true` on the management console to prevent updates to the critical configuration. This is useful when loading critical config via a file using `CRITICAL_CONFIG_FILE` on the frontend.
+
 ### Changed
+
+- When `EXTSVC_CONFIG_FILE` or `SITE_CONFIG_FILE` are specified, updates to external services and the site config are now prevented.
 
 ### Removed
 
 ### Fixed
+
+- Fixed an issue where `EXTSVC_CONFIG_FILE` being specified would incorrectly cause a panic.
 
 ## 3.4.0
 

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -184,9 +184,15 @@ func (e *ExternalServicesStore) validateGitlabConnection(c *schema.GitLabConnect
 
 // Create creates a external service.
 //
+// Since this method is used before the configuration server has started
+// (search for "EXTSVC_CONFIG_FILE") you must pass the conf.Get function in so
+// that an alternative can be used when the configuration server has not
+// started, otherwise a panic would occur once pkg/conf's deadlock detector
+// determines a deadlock occurred.
+//
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Create(ctx context.Context, externalService *types.ExternalService) error {
-	ps := conf.Get().Critical.AuthProviders
+func (c *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error {
+	ps := confGet().Critical.AuthProviders
 	if err := c.ValidateConfig(externalService.Kind, externalService.Config, ps); err != nil {
 		return err
 	}

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 )
 
@@ -34,7 +35,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *struct {
 		Config:      args.Input.Config,
 	}
 
-	if err := db.ExternalServices.Create(ctx, externalService); err != nil {
+	if err := db.ExternalServices.Create(ctx, conf.Get, externalService); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -18,10 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 )
 
-func haveExternalServiceConfigFile() bool {
-	return os.Getenv("EXTSVC_CONFIG_FILE") != ""
-}
-
 func (r *schemaResolver) AddExternalService(ctx context.Context, args *struct {
 	Input *struct {
 		Kind        string
@@ -33,7 +29,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *struct {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if haveExternalServiceConfigFile() {
+	if os.Getenv("EXTSVC_CONFIG_FILE") != "" && !conf.IsDev(conf.DeployType()) {
 		return nil, errors.New("adding external service not allowed when using EXTSVC_CONFIG_FILE")
 	}
 
@@ -70,7 +66,7 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *struct {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if haveExternalServiceConfigFile() {
+	if os.Getenv("EXTSVC_CONFIG_FILE") != "" && !conf.IsDev(conf.DeployType()) {
 		return nil, errors.New("updating external service not allowed when using EXTSVC_CONFIG_FILE")
 	}
 
@@ -124,7 +120,7 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *struct {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if haveExternalServiceConfigFile() {
+	if os.Getenv("EXTSVC_CONFIG_FILE") != "" && !conf.IsDev(conf.DeployType()) {
 		return nil, errors.New("deleting external service not allowed when using EXTSVC_CONFIG_FILE")
 	}
 

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -187,7 +187,7 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return false, err
 	}
-	if os.Getenv("SITE_CONFIG_FILE") != "" {
+	if os.Getenv("SITE_CONFIG_FILE") != "" && !conf.IsDev(conf.DeployType()) {
 		return false, errors.New("updating site configuration not allowed when using SITE_CONFIG_FILE")
 	}
 	if strings.TrimSpace(args.Input) == "" {

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -2,7 +2,9 @@ package graphqlbackend
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	graphql "github.com/graph-gophers/graphql-go"
@@ -184,6 +186,9 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	// so only admins may view it.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return false, err
+	}
+	if os.Getenv("SITE_CONFIG_FILE") != "" {
+		return false, errors.New("updating site configuration not allowed when using SITE_CONFIG_FILE")
 	}
 	if strings.TrimSpace(args.Input) == "" {
 		return false, fmt.Errorf("blank site configuration is invalid (you can clear the site configuration by entering an empty JSON object: {})")

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -102,8 +102,11 @@ func handleConfigOverrides() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			if len(existing) > 0 {
-				return
+			for _, existing := range existing {
+				err := db.ExternalServices.Delete(ctx, existing.ID)
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 
 			extsvc, err := ioutil.ReadFile(overrideExtSvcConfig)

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -58,10 +58,6 @@ func handleConfigOverrides() error {
 			return errors.Wrap(err, "reading existing config for applying overrides")
 		}
 
-		legacyOverrideCriticalConfig := os.Getenv("DEV_OVERRIDE_CRITICAL_CONFIG")
-		if overrideCriticalConfig == "" && legacyOverrideCriticalConfig != "" {
-			overrideCriticalConfig = legacyOverrideCriticalConfig
-		}
 		if overrideCriticalConfig != "" {
 			critical, err := ioutil.ReadFile(overrideCriticalConfig)
 			if err != nil {
@@ -70,10 +66,6 @@ func handleConfigOverrides() error {
 			raw.Critical = string(critical)
 		}
 
-		legacyOverrideSiteConfig := os.Getenv("DEV_OVERRIDE_SITE_CONFIG")
-		if overrideSiteConfig == "" && legacyOverrideSiteConfig != "" {
-			overrideSiteConfig = legacyOverrideSiteConfig
-		}
 		if overrideSiteConfig != "" {
 			site, err := ioutil.ReadFile(overrideSiteConfig)
 			if err != nil {
@@ -89,10 +81,6 @@ func handleConfigOverrides() error {
 			}
 		}
 
-		legacyOverrideExtSvcConfig := os.Getenv("DEV_OVERRIDE_EXTSVC_CONFIG")
-		if overrideExtSvcConfig == "" && legacyOverrideExtSvcConfig != "" {
-			overrideExtSvcConfig = legacyOverrideExtSvcConfig
-		}
 		if overrideExtSvcConfig != "" {
 			parsed, err := conf.ParseConfig(raw)
 			if err != nil {

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -139,6 +139,7 @@ func handleConfigOverrides() error {
 			}
 		}
 	}
+	return nil
 }
 
 type configurationSource struct{}

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -119,6 +119,9 @@ func handleConfigOverrides() error {
 			if err := jsonc.Unmarshal(string(extsvc), &configs); err != nil {
 				return errors.Wrap(err, "parsing EXTSVC_CONFIG_FILE")
 			}
+			if len(configs) == 0 {
+				log15.Warn("EXTSVC_CONFIG_FILE contains zero external service configurations")
+			}
 			for key, cfgs := range configs {
 				for i, cfg := range cfgs {
 					marshaledCfg, err := json.MarshalIndent(cfg, "", "  ")

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -114,7 +114,7 @@ func handleConfigOverrides() error {
 				for i, cfg := range cfgs {
 					marshaledCfg, err := json.MarshalIndent(cfg, "", "  ")
 					if err != nil {
-						return errors.Wrap(err, fmt.Sprintf("marshaling extsvc config ([%s][%i])", key, i))
+						return errors.Wrap(err, fmt.Sprintf("marshaling extsvc config ([%v][%v])", key, i))
 					}
 					if err := db.ExternalServices.Create(ctx, confGet, &types.ExternalService{
 						Kind:        key,

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -92,6 +92,12 @@ func handleConfigOverrides() {
 			overrideExtSvcConfig = legacyOverrideExtSvcConfig
 		}
 		if overrideExtSvcConfig != "" {
+			parsed, err := conf.ParseConfig(raw)
+			if err != nil {
+				log.Fatal(err)
+			}
+			confGet := func() *conf.Unified { return parsed }
+
 			existing, err := db.ExternalServices.List(context.Background(), db.ExternalServicesListOptions{})
 			if err != nil {
 				log.Fatal(err)
@@ -114,7 +120,7 @@ func handleConfigOverrides() {
 					if err != nil {
 						log.Fatal(err)
 					}
-					if err := db.ExternalServices.Create(context.Background(), &types.ExternalService{
+					if err := db.ExternalServices.Create(context.Background(), confGet, &types.ExternalService{
 						Kind:        key,
 						DisplayName: fmt.Sprintf("Dev %s #%d", key, i+1),
 						Config:      string(marshaledCfg),

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -122,7 +122,7 @@ func handleConfigOverrides() {
 					}
 					if err := db.ExternalServices.Create(context.Background(), confGet, &types.ExternalService{
 						Kind:        key,
-						DisplayName: fmt.Sprintf("Dev %s #%d", key, i+1),
+						DisplayName: fmt.Sprintf("%s #%d", key, i+1),
 						Config:      string(marshaledCfg),
 					}); err != nil {
 						log.Fatal(err)

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -97,7 +97,9 @@ func Main() error {
 	if err := dbconn.ConnectToDB(""); err != nil {
 		log.Fatal(err)
 	}
-	handleConfigOverrides()
+	if err := handleConfigOverrides(); err != nil {
+		log.Fatal("applying config overrides:", err)
+	}
 	globals.ConfigurationServerFrontendOnly = conf.InitConfigurationServerFrontendOnly(&configurationSource{})
 	conf.MustValidateDefaults()
 

--- a/dev/launch.sh
+++ b/dev/launch.sh
@@ -66,8 +66,8 @@ export ZOEKT_HOST=localhost:3070
 export SRC_HTTP_ADDR=":3082"
 export WEBPACK_DEV_SERVER=1
 
-export DEV_OVERRIDE_CRITICAL_CONFIG=${DEV_OVERRIDE_CRITICAL_CONFIG:-./dev/critical-config.json}
-export DEV_OVERRIDE_SITE_CONFIG=${DEV_OVERRIDE_SITE_CONFIG:-./dev/site-config.json}
+export CRITICAL_CONFIG_FILE=${CRITICAL_CONFIG_FILE:-./dev/critical-config.json}
+export SITE_CONFIG_FILE=${SITE_CONFIG_FILE:-./dev/site-config.json}
 
 # WebApp
 export NODE_ENV=development

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -18,9 +18,9 @@ source "$DEV_PRIVATE_PATH/enterprise/dev/env"
 # set to true if unset so set -u won't break us
 : ${SOURCEGRAPH_COMBINE_CONFIG:=false}
 
-export DEV_OVERRIDE_CRITICAL_CONFIG=$DEV_PRIVATE_PATH/enterprise/dev/critical-config.json
-export DEV_OVERRIDE_SITE_CONFIG=$DEV_PRIVATE_PATH/enterprise/dev/site-config.json
-export DEV_OVERRIDE_EXTSVC_CONFIG=$DEV_PRIVATE_PATH/enterprise/dev/external-services-config.json
+export CRITICAL_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/critical-config.json
+export SITE_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/site-config.json
+export EXTSVC_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/external-services-config.json
 export GOMOD_ROOT=$PWD
 export PROCFILE=$PWD/dev/Procfile
 export ENTERPRISE_COMMANDS="frontend management-console"

--- a/pkg/conf/confdefaults/confdefaults.go
+++ b/pkg/conf/confdefaults/confdefaults.go
@@ -18,8 +18,7 @@ import (
 // Tests that wish to use a specific configuration should use conf.Mock.
 //
 // Note: This actually generally only applies to 'go test' because we always
-// override this configuration via DEV_OVERRIDE_*_CONFIG environment
-// variables.
+// override this configuration via *_CONFIG_FILE environment variables.
 var DevAndTesting = conftypes.RawUnified{
 	Critical: `{
 	"auth.providers": [


### PR DESCRIPTION
This PR:

1. Fixes a deadlock that was introduced when specifying `EXTSVC_CONFIG_FILE` (caught by our deadlock detector in dev environments https://github.com/sourcegraph/sourcegraph/issues/4123).
2. Removes an incorrect "Dev" label applied to `EXTSVC_CONFIG_FILE`-created services
3. Fixes the previously extremely poor behavior of `EXTSVC_CONFIG_FILE` where it would do nothing if you have external services already (see https://github.com/sourcegraph/sourcegraph/commit/d3a714eb8d35ffb6df949eeeed34b0a8e7246e75 for why this sucked particularly bad in dev environments, too).
4. Improves error messages returned by config override files.
5. Prevents updates to extsvc/site/critical configs when they are loaded from a file (the latter requires setting an env var on the management console). This does not apply in dev mode.

My intent is to cherry-pick for release in 3.4.1.

Supercedes #4126 (in particular the first commit b46bc7d does)
Fixes #4123
Fixes #4108

Test plan: manual (very difficult to test automatically currently)
