### PR TITLE
properly handle instances that have empty settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed an issue where `EXTSVC_CONFIG_FILE` being specified would incorrectly cause a panic.
+- Fixed an issue where user/org/global settings from old Sourcegraph versions (2.x) could incorrectly be null, leading to various errors.
 
 ## 3.4.0
 

--- a/cmd/frontend/db/settings.go
+++ b/cmd/frontend/db/settings.go
@@ -147,6 +147,15 @@ func (o *settings) getLatest(ctx context.Context, queryTarget queryable, subject
 		// No configuration has been set for this subject yet.
 		return nil, nil
 	}
+	if settings[0].Contents == "" {
+		// On some instances user, org, and global settings are an invalid
+		// empty string / null.
+		//
+		// This happens particularly on instances that ran old versions of
+		// Sourcegraph where we didn't enforce that settings contents had to be
+		// non-empty for correctness.
+		settings[0].Contents = "{}"
+	}
 	return settings[0], nil
 }
 


### PR DESCRIPTION
In older (2.x) versions of Sourcegraph it was possible to save an empty string
as your user/org/global settings. This lead to various issues including just
completely breaking the settings page: https://github.com/sourcegraph/sourcegraph/issues/1645

We later fixed that issue and made it such that saving empty settings is
forbidden, but it doesn't appear we ever corrected such invalid settings. In
one customer environment we've encountered a user who is reporting their
settings are empty so we should handle this.

This is a quick fix which is cheap for us to maintain, so I opted for this
approach for now. The more correct (but also more complex) approach would be to
write a migration which transforms any empty settings into non-empty ones. I
don't think it is worth the time it would take right now.

Once merged, this will be released in 3.4.1 and can optionally be released as a patch on the customer's older version if @beyang desires.

Test plan: none