### PR TITLE
search: Handle ()() in autofix

### DIFF
--- a/cmd/frontend/internal/pkg/search/query/types/check_test.go
+++ b/cmd/frontend/internal/pkg/search/query/types/check_test.go
@@ -186,6 +186,10 @@ func Test_autoFix(t *testing.T) {
 			{"[)(]", `[)(]`},
 			{"[(]", `[(]`},
 			{"[()]", `[\(\)]`},
+
+			// From quick check with initial seed 1557931765714982622
+			{"()()", `\(\)\(\)`},
+			{"}?}${}.?3]}{()()", `}?}${}.?3]}{\(\)\(\)`},
 		}
 		for _, tt := range tests {
 			t.Run(tt.pat, func(t *testing.T) {


### PR DESCRIPTION
Noticed this flakey test failure in CI. It is a legitimate issue were we do
not properly escape ()(). It escaped it as \(\)(). This is due to the
replacement regex checking for the preceding character being \, which means
when ReplaceAll runs after replacing the first () the regex won't match since
`^` means beginning of string, not match.

I wasn't sure how to make this happen in a regex, so wrote a function
implementing the functionality.