### PR TITLE
store: Include repo@commit in error returned from store

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -242,7 +242,7 @@ func (s *Store) fetch(ctx context.Context, repo gitserver.Repo, commit api.Commi
 			err = err1
 		}
 		done(err)
-		// CloseWithError is gaurenteed not to return a nil error
+		// CloseWithError is guaranteed to return a nil error
 		_ = pw.CloseWithError(errors.Wrapf(err, "failed to fetch %s@%s", repo, commit))
 	}()
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -242,7 +242,8 @@ func (s *Store) fetch(ctx context.Context, repo gitserver.Repo, commit api.Commi
 			err = err1
 		}
 		done(err)
-		pw.CloseWithError(errors.Wrapf(err, "failed to fetch %s@%s", repo, commit))
+		// CloseWithError is gaurenteed not to return a nil error
+		_ = pw.CloseWithError(errors.Wrapf(err, "failed to fetch %s@%s", repo, commit))
 	}()
 
 	return pr, nil

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -242,7 +242,7 @@ func (s *Store) fetch(ctx context.Context, repo gitserver.Repo, commit api.Commi
 			err = err1
 		}
 		done(err)
-		pw.CloseWithError(err)
+		pw.CloseWithError(errors.Wrapf(err, "failed to fetch %s@%s", repo, commit))
 	}()
 
 	return pr, nil


### PR DESCRIPTION
This is to help diagnose `invalid tar header` errors. https://github.com/sourcegraph/sourcegraph/issues/3799
