### PR TITLE
search: Do not set URL in gitserver repo

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -42,7 +42,7 @@ type Request struct {
 }
 
 // GitserverRepo returns the repository information necessary to perform gitserver requests.
-func (r Request) GitserverRepo() gitserver.Repo { return gitserver.Repo{Name: r.Repo, URL: r.URL} }
+func (r Request) GitserverRepo() gitserver.Repo { return gitserver.Repo{Name: r.Repo} }
 
 // PatternInfo describes a search request on a repo. Most of the fields
 // are based on PatternInfo used in vscode.


### PR DESCRIPTION
The URL is supposed to be the clone URL. Setting the URL to the name is
incorrect. It is best to just not set the URL at all. In the case of searcher,
we shouldn't need it since we only receive requests for commits that have
already been resolved.