### PR TITLE
make "no searcher endpoints" error message more helpful

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -174,7 +174,7 @@ func endpointsToMap(u *k8sURL, eps *corev1.Endpoints) (*hashMap, error) {
 		}
 	}
 	if len(urls) == 0 {
-		return nil, errors.Errorf("No %s endpoints", u.Service)
+		return nil, errors.Errorf("no %s endpoints could be found; possibly solvable by adding more searcher replicas (see https://github.com/sourcegraph/sourcegraph/issues/4101)", u.Service)
 	}
 	return newConsistentHashMap(urls), nil
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -174,7 +174,7 @@ func endpointsToMap(u *k8sURL, eps *corev1.Endpoints) (*hashMap, error) {
 		}
 	}
 	if len(urls) == 0 {
-		return nil, errors.Errorf("no %s endpoints could be found; possibly solvable by adding more searcher replicas (see https://github.com/sourcegraph/sourcegraph/issues/4101)", u.Service)
+		return nil, errors.Errorf("no %s endpoints could be found (this may indicate more searcher replicas are needed, contact support@sourcegraph.com for assistance)", u.Service)
 	}
 	return newConsistentHashMap(urls), nil
 }


### PR DESCRIPTION
Before it wasn't clear what to do about the error.

Fixes #4101 in the sense that it will give users some idea what to do when they encounter that error. A better solution is incremental (a.k.a. "streaming") search #3991, but that is a larger project.

Test plan: Manually trigger #4101 again on k8s.sgdev.org by setting the search replicas back to 1 and issuing the query shown on that issue. Check that the error message looks reasonable.
