### PR TITLE
db: Handle .* in repository regex search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed repository search patterns which contain `.*`. Previously our optimizer would ignore `.*`, which in some cases would lead to our repository search excluding some repositories from the results.
+
 ## 3.4.2 (unreleased)
 
 ### Added

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -482,6 +482,11 @@ func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffi
 		}
 		return nil, nil, nil, nil, nil
 
+	case regexpsyntax.OpStar:
+		if len(re.Sub) == 1 && (re.Sub[0].Op == regexpsyntax.OpAnyCharNotNL || re.Sub[0].Op == regexpsyntax.OpAnyChar) {
+			return nil, []string{""}, nil, nil, nil
+		}
+
 	case regexpsyntax.OpBeginText:
 		return nil, nil, []string{""}, nil, nil
 

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -450,15 +450,15 @@ func parseIncludePattern(pattern string) (exact, like []string, regexp string, e
 // allMatchingStrings returns a complete list of the strings that re
 // matches, if it's possible to determine the list.
 func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffix []string, err error) {
-	prog, err := regexpsyntax.Compile(re)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
 	switch re.Op {
 	case regexpsyntax.OpEmptyMatch:
 		return []string{""}, nil, nil, nil, nil
 	case regexpsyntax.OpLiteral:
+		prog, err := regexpsyntax.Compile(re)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+
 		prefix, complete := prog.Prefix()
 		if complete {
 			return nil, []string{prefix}, nil, nil, nil

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -455,17 +455,17 @@ func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffi
 		return nil, nil, nil, nil, err
 	}
 
-	switch {
-	case re.Op == regexpsyntax.OpEmptyMatch:
+	switch re.Op {
+	case regexpsyntax.OpEmptyMatch:
 		return []string{""}, nil, nil, nil, nil
-	case re.Op == regexpsyntax.OpLiteral:
+	case regexpsyntax.OpLiteral:
 		prefix, complete := prog.Prefix()
 		if complete {
 			return nil, []string{prefix}, nil, nil, nil
 		}
 		return nil, nil, nil, nil, nil
 
-	case re.Op == regexpsyntax.OpCharClass:
+	case regexpsyntax.OpCharClass:
 		// Only handle simple case of one range.
 		if len(re.Rune) == 2 {
 			len := int(re.Rune[1] - re.Rune[0] + 1)
@@ -482,16 +482,16 @@ func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffi
 		}
 		return nil, nil, nil, nil, nil
 
-	case re.Op == regexpsyntax.OpBeginText:
+	case regexpsyntax.OpBeginText:
 		return nil, nil, []string{""}, nil, nil
 
-	case re.Op == regexpsyntax.OpEndText:
+	case regexpsyntax.OpEndText:
 		return nil, nil, nil, []string{""}, nil
 
-	case re.Op == regexpsyntax.OpCapture:
+	case regexpsyntax.OpCapture:
 		return allMatchingStrings(re.Sub0[0])
 
-	case re.Op == regexpsyntax.OpConcat:
+	case regexpsyntax.OpConcat:
 		var begin, end bool
 		for i, sub := range re.Sub {
 			if sub.Op == regexpsyntax.OpBeginText && i == 0 {
@@ -542,7 +542,7 @@ func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffi
 		}
 		return nil, exact, nil, nil, nil
 
-	case re.Op == regexpsyntax.OpAlternate:
+	case regexpsyntax.OpAlternate:
 		for _, sub := range re.Sub {
 			subexact, subcontains, subprefix, subsuffix, err := allMatchingStrings(sub)
 			if err != nil {

--- a/cmd/frontend/db/repos_test.go
+++ b/cmd/frontend/db/repos_test.go
@@ -43,6 +43,12 @@ func TestParseIncludePattern(t *testing.T) {
 		`github.com`:  {regexp: `github.com`},
 		`github\.com`: {like: []string{`%github.com%`}},
 
+		// https://github.com/sourcegraph/sourcegraph/issues/4166
+		`golang/oauth.*`:       {like: []string{"%golang/oauth%"}},
+		`^golang/oauth.*`:      {like: []string{"golang/oauth%"}},
+		`golang/(oauth.*|bla)`: {like: []string{"%golang/oauth%", "%golang/bla%"}},
+		`golang/(oauth|bla)`:   {like: []string{"%golang/oauth%", "%golang/bla%"}},
+
 		`(^github\.com/Microsoft/vscode$)|(^github\.com/sourcegraph/go-langserver$)`: {exact: []string{"github.com/Microsoft/vscode", "github.com/sourcegraph/go-langserver"}},
 
 		// Avoid DoS when there are too many possible matches to enumerate.


### PR DESCRIPTION
This fixes an issue where we ignored `.*`, leading to incorrect patterns in some cases. There are likely more cases where we incorrectly do not fallback to regex. However, that should be solved in another PR.

Test plan: unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/4166