### PR TITLE
pkg/store: corrupted tars from git are ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed an issue where `EXTSVC_CONFIG_FILE` being specified would incorrectly cause a panic.
 - Fixed an issue where user/org/global settings from old Sourcegraph versions (2.x) could incorrectly be null, leading to various errors.
+- Fixed an issue where an ephemeral infrastructure error (`tar/archive: invalid tar header`) would fail a search.
 
 ## 3.4.0
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -261,6 +261,13 @@ func copySearchable(tr *tar.Reader, zw *zip.Writer, largeFilePatterns []string) 
 			return nil
 		}
 		if err != nil {
+			// Gitserver sometimes returns invalid headers. However, it only
+			// seems to occur in situations where a retry would likely solve
+			// it. So mark the error as temporary, to avoid failing the whole
+			// search. https://github.com/sourcegraph/sourcegraph/issues/3799
+			if err == tar.ErrHeader {
+				return temporaryError{error: err}
+			}
 			return err
 		}
 
@@ -395,6 +402,17 @@ var (
 		Help:      "The total number of archive fetches that failed.",
 	})
 )
+
+// temporaryError wraps an error but adds the Temporary method. It does not
+// implement Cause so that errors.Cause() returns an error which implements
+// Temporary.
+type temporaryError struct {
+	error
+}
+
+func (temporaryError) Temporary() bool {
+	return true
+}
 
 func init() {
 	prometheus.MustRegister(cacheSizeBytes)


### PR DESCRIPTION
In some cases gitserver would return a corrupted archive. It seems this would
be an ephemeral issue. This would cause searches to fail. However, it should
be treated as a temporary error. This change ensures the failure is marked as
temporary, leading to the graphql layer to not fail the full search.

Test plan: unit tests, forcing corrupted error (like the test) and running a search in dev mode.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3799