### PR TITLE
search: Limit concurrent searches relative to number of searcher replicas

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -359,3 +359,10 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		})
 	}
 }
+
+func init() {
+	// Set both URLs to something that will fail in tests. We shouldn't be
+	// contacting them in tests.
+	zoektAddr = "127.0.0.1:101010"
+	searcherURL = "http://127.0.0.1:101010"
+}


### PR DESCRIPTION
This will prevent us starting a large number of goroutine which wait. It will
also limit concurrency before we hit gitserver. Additionally the limit is not
hardcoded, but rather is a multiple of the number of search replicas. However,
this does remove our global rate limiter. The global rate limiter was more an
artifact of implementation, than an intended implementation. So a per request
rate limiter should be sufficient.

This is an attempt to fix https://github.com/sourcegraph/sourcegraph/issues/4101

Test plan: unit tests