### PR TITLE
schema/docs: Explain when `serviceProviderIssuer` is required

### DIFF
--- a/schema/critical.schema.json
+++ b/schema/critical.schema.json
@@ -221,7 +221,7 @@
         },
         "displayName": { "$ref": "#/definitions/AuthProviderCommon/properties/displayName" },
         "serviceProviderIssuer": {
-          "description": "The name of this SAML Service Provider, which is used by the Identity Provider to identify this Service Provider. It defaults to https://sourcegraph.example.com/.auth/saml/metadata (where https://sourcegraph.example.com is replaced with this Sourcegraph instance's \"externalURL\"). It is only necessary to explicitly set the issuer if you are using multiple SAML authentication providers or if no \"externalURL\" has been set yet, which is also required when you're using a SAML provider.",
+          "description": "The SAML Service Provider name, used to identify this Service Provider. This is required if the \"externalURL\" field is not set (as the SAML metadata endpoint is computed as \"<externalURL>.auth/saml/metadata\"), or when using multiple SAML authentication providers.",
           "type": "string"
         },
         "identityProviderMetadataURL": {

--- a/schema/critical.schema.json
+++ b/schema/critical.schema.json
@@ -221,7 +221,7 @@
         },
         "displayName": { "$ref": "#/definitions/AuthProviderCommon/properties/displayName" },
         "serviceProviderIssuer": {
-          "description": "The name of this SAML Service Provider, which is used by the Identity Provider to identify this Service Provider. It defaults to https://sourcegraph.example.com/.auth/saml/metadata (where https://sourcegraph.example.com is replaced with this Sourcegraph instance's \"externalURL\"). It is only necessary to explicitly set the issuer if you are using multiple SAML authentication providers.",
+          "description": "The name of this SAML Service Provider, which is used by the Identity Provider to identify this Service Provider. It defaults to https://sourcegraph.example.com/.auth/saml/metadata (where https://sourcegraph.example.com is replaced with this Sourcegraph instance's \"externalURL\"). It is only necessary to explicitly set the issuer if you are using multiple SAML authentication providers or if no \"externalURL\" has been set yet, which is also required when you're using a SAML provider.",
           "type": "string"
         },
         "identityProviderMetadataURL": {

--- a/schema/critical_stringdata.go
+++ b/schema/critical_stringdata.go
@@ -226,7 +226,7 @@ const CriticalSchemaJSON = `{
         },
         "displayName": { "$ref": "#/definitions/AuthProviderCommon/properties/displayName" },
         "serviceProviderIssuer": {
-          "description": "The name of this SAML Service Provider, which is used by the Identity Provider to identify this Service Provider. It defaults to https://sourcegraph.example.com/.auth/saml/metadata (where https://sourcegraph.example.com is replaced with this Sourcegraph instance's \"externalURL\"). It is only necessary to explicitly set the issuer if you are using multiple SAML authentication providers.",
+          "description": "The name of this SAML Service Provider, which is used by the Identity Provider to identify this Service Provider. It defaults to https://sourcegraph.example.com/.auth/saml/metadata (where https://sourcegraph.example.com is replaced with this Sourcegraph instance's \"externalURL\"). It is only necessary to explicitly set the issuer if you are using multiple SAML authentication providers or if no \"externalURL\" has been set yet, which is also required when you're using a SAML provider.",
           "type": "string"
         },
         "identityProviderMetadataURL": {

--- a/schema/critical_stringdata.go
+++ b/schema/critical_stringdata.go
@@ -226,7 +226,7 @@ const CriticalSchemaJSON = `{
         },
         "displayName": { "$ref": "#/definitions/AuthProviderCommon/properties/displayName" },
         "serviceProviderIssuer": {
-          "description": "The name of this SAML Service Provider, which is used by the Identity Provider to identify this Service Provider. It defaults to https://sourcegraph.example.com/.auth/saml/metadata (where https://sourcegraph.example.com is replaced with this Sourcegraph instance's \"externalURL\"). It is only necessary to explicitly set the issuer if you are using multiple SAML authentication providers or if no \"externalURL\" has been set yet, which is also required when you're using a SAML provider.",
+          "description": "The SAML Service Provider name, used to identify this Service Provider. This is required if the \"externalURL\" field is not set (as the SAML metadata endpoint is computed as \"<externalURL>.auth/saml/metadata\"), or when using multiple SAML authentication providers.",
           "type": "string"
         },
         "identityProviderMetadataURL": {


### PR DESCRIPTION
I ran into this error message when I didn't have `externalURL` set yet
when setting up a SAML provider.

This addition makes it clear that the case I ran into also produces this
message and that you need to set `externalURL`.

Slack discussion: https://sourcegraph.slack.com/archives/C07KZF47K/p1558686548007400?thread_ts=1558686168.006600&cid=C07KZF47K
