### PR TITLE
repoupdater: Remove ExternalRepo from RepoLookupArgs

### DIFF
--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -55,8 +55,7 @@ func GitRepo(ctx context.Context, repo *types.Repo) (gitserver.Repo, error) {
 	}
 
 	result, err := repoupdater.DefaultClient.RepoLookup(ctx, protocol.RepoLookupArgs{
-		Repo:         repo.Name,
-		ExternalRepo: repo.ExternalRepo,
+		Repo: repo.Name,
 	})
 	if err != nil {
 		return gitserver.Repo{Name: repo.Name}, err

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -120,8 +120,7 @@ func linksForRepository(ctx context.Context, repo *types.Repo) (phabRepo *types.
 
 	// Look up repo links in the repo-updater. This supplies links from code host APIs.
 	info, err := repoupdater.DefaultClient.RepoLookup(ctx, protocol.RepoLookupArgs{
-		Repo:         repo.Name,
-		ExternalRepo: repo.ExternalRepo,
+		Repo: repo.Name,
 	})
 	if err != nil {
 		ext.Error.Set(span, true)

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -65,8 +65,7 @@ func (r *repositoryMirrorInfoResolver) RemoteURL(ctx context.Context) (string, e
 	{
 		// Look up the remote URL in repo-updater.
 		result, err := repoupdater.DefaultClient.RepoLookup(ctx, repoupdaterprotocol.RepoLookupArgs{
-			Repo:         r.repository.repo.Name,
-			ExternalRepo: r.repository.repo.ExternalRepo,
+			Repo: r.repository.repo.Name,
 		})
 		if err != nil {
 			return "", err

--- a/cmd/frontend/internal/httpapi/repo_refresh.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh.go
@@ -17,8 +17,7 @@ func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 	repoMeta, err := repoupdater.DefaultClient.RepoLookup(context.Background(), protocol.RepoLookupArgs{
-		Repo:         repo.Name,
-		ExternalRepo: repo.ExternalRepo,
+		Repo: repo.Name,
 	})
 	if err != nil {
 		return err

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -303,8 +303,8 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		tr.Finish()
 	}()
 
-	if args.Repo == "" && args.ExternalRepo == nil {
-		return nil, errors.New("at least one of Repo and ExternalRepo must be set (both are empty)")
+	if args.Repo == "" {
+		return nil, errors.New("Repo must be set (is blank)")
 	}
 
 	if mockRepoLookup != nil {

--- a/pkg/repoupdater/client.go
+++ b/pkg/repoupdater/client.go
@@ -92,11 +92,6 @@ func (c *Client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		}
 		span.Finish()
 	}()
-	if args.ExternalRepo != nil {
-		span.SetTag("ExternalRepo.ID", args.ExternalRepo.ID)
-		span.SetTag("ExternalRepo.ServiceType", args.ExternalRepo.ServiceType)
-		span.SetTag("ExternalRepo.ServiceID", args.ExternalRepo.ServiceID)
-	}
 	if args.Repo != "" {
 		span.SetTag("Repo", string(args.Repo))
 	}

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -63,18 +63,11 @@ type ExcludeRepoResponse struct {
 //
 // Exactly one of Repo and ExternalRepo should be set.
 type RepoLookupArgs struct {
-	// Repo is the repository name to look up. If the ExternalRepo information is available to the
-	// caller, it is preferred to use that (because it is robust to renames).
+	// Repo is the repository name to look up.
 	Repo api.RepoName `json:",omitempty"`
-
-	// ExternalRepo specifies the repository to look up by its external repository identity.
-	ExternalRepo *api.ExternalRepoSpec
 }
 
 func (a *RepoLookupArgs) String() string {
-	if a.ExternalRepo != nil {
-		return fmt.Sprintf("RepoLookupArgs{%s}", a.ExternalRepo)
-	}
 	return fmt.Sprintf("RepoLookupArgs{%s}", a.Repo)
 }
 


### PR DESCRIPTION
This fixes #3996.

As discussed in that ticket: the `name` of `repo` is unique,the
syncer now handles renames and every call site of `RepoLookup` passes in
the `Name`. That means it's safe to get rid of `ExternalRepo`.

Test plan: go test
