### PR TITLE
docs: changed nested auth providers to level 2 headings

### DIFF
--- a/doc/admin/config/critical_config.md
+++ b/doc/admin/config/critical_config.md
@@ -14,13 +14,13 @@ All critical configuration options and their default values are shown below.
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/config/critical.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/doc/admin/config/critical_config) to see rendered content.</div>
 
-### Authentication providers `auth.providers`
+## Authentication providers `auth.providers`
 
 The `auth.providers` critical configuration property defines how users can authenticate to the Sourcegraph instance. It is an array of values, each of which defines an authentication provider. If the array has more than one element, users may use any of the configured authentication methods.
 
 All authentication providers support the (optional) `displayName` property, which is used to distinguish the authentication provider when there are multiple providers configured.
 
-#### Builtin password authentication
+## Builtin password authentication
 
 Defines an authentication provider that stores and validates passwords for each user account. It also allows users (and site admins) to reset passwords.
 
@@ -28,7 +28,7 @@ To use this authentication method, add an element to the `auth.providers` array 
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/config/critical.schema.json" jsonschemadoc:ref="#/definitions/BuiltinAuthProvider">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/doc/admin/config/critical_config) to see rendered content.</div>
 
-#### SAML
+## SAML
 
 Defines an authentication provider backed by SAML.
 
@@ -38,7 +38,7 @@ To use this authentication method, add an element to the `auth.providers` array 
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/config/critical.schema.json" jsonschemadoc:ref="#/definitions/SAMLAuthProvider">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/doc/admin/config/critical_config) to see rendered content.</div>
 
-#### OpenID Connect (including G Suite)
+## OpenID Connect (including G Suite)
 
 Defines an authentication provider backed by OpenID Connect. The most common case is G Suite (Google) authentication.
 
@@ -46,7 +46,7 @@ To use this authentication method, add an element to the `auth.providers` array 
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/config/critical.schema.json" jsonschemadoc:ref="#/definitions/OpenIDConnectAuthProvider">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/doc/admin/config/critical_config) to see rendered content.</div>
 
-#### HTTP authentication proxy
+## HTTP authentication proxy
 
 Defines an authentication provider that authenticates users by consulting an HTTP request header set by an authentication proxy, such as https://github.com/bitly/oauth2_proxy.
 
@@ -54,7 +54,7 @@ To use this authentication method, add an element to the `auth.providers` array 
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/config/critical.schema.json" jsonschemadoc:ref="#/definitions/HTTPHeaderAuthProvider">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/doc/admin/config/critical_config) to see rendered content.</div>
 
-#### Known bugs
+## Known bugs
 
 The following critical configuration options require the server to be restarted for the changes to take effect:
 


### PR DESCRIPTION
Although this technically invalidates the hierarchical structure of the document, it adds each auth provider to the about this page index (RHS column) and makes it easier to scan the page.
