### PR TITLE
search: improve API docs & remove field ambiguity

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -894,13 +894,17 @@ type SearchResults {
     # The results. Inside each SearchResult there may be multiple matches, e.g.
     # a FileMatch may contain multiple line matches.
     results: [SearchResult!]!
-    # The total number of results, taking into account the SearchResult type.
-    # This is different than the length of the results array in that e.g. the
-    # results array may contain two file matches and this resultCount would
-    # report 6 ("3 line matches per file").
+    # The total number of matches returned by this search. This is different
+    # than the length of the results array in that e.g. a single results array
+    # entry may contain multiple matches. For example, the results array may
+    # contain two file matches and this field would report 6 ("3 line matches
+    # per file") while the length of the results array would report 3
+    # ("3 FileMatch results").
     #
     # Typically, 'approximateResultCount', not this field, is shown to users.
-    resultCount: Int!
+    matchCount: Int!
+    # DEPRECATED: Renamed to 'matchCount' for less ambiguity.
+    resultCount: Int! @deprecated(reason: "renamed to matchCount for less ambiguity")
     # The approximate number of results. This is like the length of the results
     # array, except it can indicate the number of results regardless of whether
     # or not the limit was hit. Currently, this is represented as e.g. "5+"

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -901,13 +901,17 @@ type SearchResults {
     # The results. Inside each SearchResult there may be multiple matches, e.g.
     # a FileMatch may contain multiple line matches.
     results: [SearchResult!]!
-    # The total number of results, taking into account the SearchResult type.
-    # This is different than the length of the results array in that e.g. the
-    # results array may contain two file matches and this resultCount would
-    # report 6 ("3 line matches per file").
+    # The total number of matches returned by this search. This is different
+    # than the length of the results array in that e.g. a single results array
+    # entry may contain multiple matches. For example, the results array may
+    # contain two file matches and this field would report 6 ("3 line matches
+    # per file") while the length of the results array would report 3
+    # ("3 FileMatch results").
     #
     # Typically, 'approximateResultCount', not this field, is shown to users.
-    resultCount: Int!
+    matchCount: Int!
+    # DEPRECATED: Renamed to 'matchCount' for less ambiguity.
+    resultCount: Int! @deprecated(reason: "renamed to matchCount for less ambiguity")
     # The approximate number of results. This is like the length of the results
     # array, except it can indicate the number of results regardless of whether
     # or not the limit was hit. Currently, this is represented as e.g. "5+"

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -155,13 +155,15 @@ func (sr *searchResultsResolver) Results() []*searchResultResolver {
 	return sr.results
 }
 
-func (sr *searchResultsResolver) ResultCount() int32 {
+func (sr *searchResultsResolver) MatchCount() int32 {
 	var totalResults int32
 	for _, result := range sr.results {
 		totalResults += result.resultCount()
 	}
 	return totalResults
 }
+
+func (sr *searchResultsResolver) ResultCount() int32 { return sr.MatchCount() }
 
 func (sr *searchResultsResolver) ApproximateResultCount() string {
 	count := sr.ResultCount()


### PR DESCRIPTION
This PR improves documentation of the GraphQL search API by:

1. Clarifying that `resultCount` is counting the number of returned results, NOT the number of overall results (i.e. if `count:1000` and there are more than 1,000 results, `resultCount` would be 1000 and not the total number of results the search theoretically has if a higher `count` parameter was specified).
2. Renaming `resultCount` to `matchCount` to remove the (currently documented) ambiguity that exists between "what is the difference between resultCount and len(results)? When should I use one or the other?"

Test plan: existing tests / not needed