### PR TITLE
server: Parse cli flags

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -5,6 +5,7 @@ package shared
 
 import (
 	"encoding/json"
+	"flag"
 	"log"
 	"os"
 	"path/filepath"
@@ -58,6 +59,7 @@ var verbose = os.Getenv("SRC_LOG_LEVEL") == "dbug" || os.Getenv("SRC_LOG_LEVEL")
 // Main is the main server command function which is shared between Sourcegraph
 // server's open-source and enterprise variant.
 func Main() {
+	flag.Parse()
 	log.SetFlags(0)
 
 	// Ensure CONFIG_DIR and DATA_DIR


### PR DESCRIPTION
server takes no command line flags, so we did not parse the flags. However, it
is easy to accidently pass flags into server instead of docker. By parsing the
flags, we should error out if an admin makes that mistake.

Fixes https://github.com/sourcegraph/sourcegraph/issues/1038