### PR TITLE
frontend: Populate ServiceConnections.GitServers

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -145,8 +145,8 @@ func (c configurationSource) Read(ctx context.Context) (conftypes.RawUnified, er
 		Critical: critical.Contents,
 		Site:     site.Contents,
 
-		// TODO(slimsag): future: pass GitServers list via this.
 		ServiceConnections: conftypes.ServiceConnections{
+			GitServers:  conf.SrcGitServers,
 			PostgresDSN: postgresDSN(),
 		},
 	}, nil


### PR DESCRIPTION
Once this has been deployed we can move all non-frontend services to using
ServiceConnections.

Part of https://github.com/sourcegraph/sourcegraph/issues/3031