### PR TITLE
migrations: Enforce ID constraints via go tests

### DIFF
--- a/dev/add_migration.sh
+++ b/dev/add_migration.sh
@@ -3,11 +3,12 @@
 cd $(dirname "${BASH_SOURCE[0]}")/../migrations
 set -e
 
-# The name is intentionally empty ('') so that it forces a merge conflict if two branches attempt to
-# create a migration at the same sequence number (because they will both add a file with the same
-# name, like `migrations/1528277032_.up.sql`).
+if [ -z "$1" ]; then
+    echo "USAGE: $0 <name>"
+    exit 1
+fi
 
-migrate create -ext sql -dir . -digits 10 -seq ''
+migrate create -ext sql -dir . -digits 10 -seq "$1"
 
 files=$(ls -1 | grep '^[0-9]'.*\.sql | sort -n | tail -n2)
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -18,7 +18,7 @@ are terminated.
 Run the following:
 
 ```
-./dev/add_migration.sh
+./dev/add_migration.sh MIGRATION_NAME
 ```
 
 There will be up/down `.sql` migration files created in this directory. Add

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -1,0 +1,51 @@
+package migrations_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/migrations"
+)
+
+func TestIDConstraints(t *testing.T) {
+	ups, err := filepath.Glob("*.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byID := map[int][]string{}
+	for _, name := range ups {
+		id, err := strconv.Atoi(name[:strings.IndexByte(name, '_')])
+		if err != nil {
+			t.Fatalf("failed to parse name %q: %v", name, err)
+		}
+		byID[id] = append(byID[id], name)
+	}
+
+	for id, names := range byID {
+		// Check if we are using sequential migrations from a certain point.
+		if _, hasPrev := byID[id-1]; id > 1528395544 && !hasPrev {
+			t.Errorf("migration with ID %d exists, but previous one (%d) does not", id, id-1)
+		}
+		if len(names) > 1 {
+			t.Errorf("multiple migrations with ID %d: %s", id, strings.Join(names, " "))
+		}
+	}
+}
+
+func TestNeedsGenerate(t *testing.T) {
+	want, err := filepath.Glob("*.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := migrations.AssetNames()
+	sort.Strings(want)
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("bindata out of date. Please run:\n  go generate github.com/sourcegraph/sourcegraph/migrations")
+	}
+}


### PR DESCRIPTION
Previously we did not set names on migrations to catch conflicts on the
migration ID. We now enforce the constraints on migration IDs via go
tests. This allows us to set names again, which makes the migrations more
readable.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3910