### PR TITLE
incremental search proposal / technical research

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -787,9 +787,40 @@ type Query {
     # The configuration for clients.
     clientConfiguration: ClientConfigurationDetails!
     # Runs a search.
+    #
+    # In Sourcegraph versions before 3.5, requesting more results could be done
+    # by first making a request with only specifying a 'query', and then
+    # checking the 'SearchResults' 'limitHit' field. If the limit was hit, it
+    # indicated more results existed and the query could be retried with a
+    # larger 'count:' query parameter. All original results and some new
+    # results would be returned. In other words, there was no true pagination
+    # of search results and search results arrived in a random (fastest-first)
+    # order.
+    #
+    # In Sourcegraph 3.5, pagination was introduced which unlike the prior
+    # approach allows for:
+    #
+    # - Getting subsequent results faster (as prior results are no longer computed and transferred).
+    # - Consuming the entire result set (using multiple requests).
+    # - Getting results in a defined order.
+    #
+    # All new API consumers should make use of this API by specifying 'offset'
+    # and 'limit' parameters.
     search(
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""
+
+        # When specified, indicates that this request should be paginated and
+        # results should be returned starting at this offset.
+        #
+        # All new clients should specify this field.
+        offset: SearchOffset
+
+        # When specified, indicates that this request should be paginated and
+        # results should be limited to this amount.
+        #
+        # All new clients should specify this field.
+        limit: SearchLimit
     ): Search
     # All saved searches configured for the current user, merged from all configurations.
     savedSearches: [SavedSearch!]!
@@ -836,6 +867,72 @@ type ClientConfigurationDetails {
 type ParentSourcegraphDetails {
     # Sourcegraph instance URL.
     url: String!
+}
+
+# An offset for pagination in search.
+input SearchOffset {
+    # Indicates that Sourcegraph should skip searching the first N repositories
+    # out of all repositories determined to be searchable based on the search
+    # query.
+    repositories: Int!
+
+    # Indicates that repositories containing no results should be skipped when
+    # possible. For example, if:
+    #
+    # - Sourcegraph has 100 repositories
+    # - 'SearchOffset.repositories = 50'
+    # - 'SearchOffset.skipEmptyRepositories = true'
+    # - 'SearchLimit.repositories = 10'
+    #
+    # Sourcegraph will begin searching at the 50th repository and continue
+    # searching until either:
+    #
+    # - 10 repositories with results are found (or less if there are not 10
+    #   such repositories overall).
+    # - More than 1 second has passed (in this case, the client should
+    #   continue by making a subsequent paginated request using the
+    #   'SearchResults.repositoryOffset' to continue searching where the server
+    #   left off). This gives the client an opportunity to present an updated
+    #   number of repositories searched and how many remain unsearched.
+    #
+    skipEmptyRepositories: Boolean = true
+
+    # Indicates that Sourcegraph should skip the first N results found in each
+    # repository searched.
+    #
+    # In most cases, using just 'repositories' above is sufficient.
+    #
+    # This field is useful when there is a desire to paginate results within a
+    # single repository. Usually, this is only useful when there are extremely
+    # large repositories in Sourcegraph which could produce more results than
+    # can be searched in a reasonable timeframe.
+    results: Int
+}
+
+# A limit on the number of search results returned by the GraphQL query.
+input SearchLimit {
+    # Indicates that the results should at max include results from N
+    # repositories out of all repositories determined to be searchable based on
+    # the search query.
+    repositories: Int! = 10
+
+    # Indicates that if more than N results are encountered in a repository,
+    # only that many results should be returned and no further repositories
+    # should be searched. This allows clients to paginate results within very
+    # large repositories. In this case, to determine if there are more results
+    # overall the client would need to check if
+    # 'length(SearchResults.repositories) > SearchLimit.repositories'
+    # OR
+    # 'length(SearchResults.results) == SearchLimit.results'
+    # are true.
+    #
+    # In most cases, using just 'repositories' above is sufficient.
+    #
+    # This field is useful when there is a desire to paginate results within a
+    # single repository. Usually, this is only useful when there are extremely
+    # large repositories in Sourcegraph which could produce more results than
+    # can be searched in a reasonable timeframe.
+    results: Int
 }
 
 # A search.
@@ -913,9 +1010,19 @@ type SearchResults {
     # This string is typically shown to users to indicate the true result count.
     approximateResultCount: String!
     # Whether or not the results limit was hit.
+    #
+    # For paginated requests, this field is meaningless.
     limitHit: Boolean!
     # Integers representing the sparkline for the search results.
     sparkline: [Int!]!
+    # The last repository that was searched while running this query.
+    #
+    # This differs from the input 'SearchOffset.repositories' value when
+    # repositories have been skipped due to not having results (i.e. when
+    # 'SearchOffset.skipEmptyRepositories = true').
+    #
+    # Always zero for non-paginated searches.
+    repositoryOffset: Int!
     # Repositories that were eligible to be searched.
     repositories: [Repository!]!
     # Repositories that were actually searched. Excludes repositories that would have been searched but were not

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -794,9 +794,40 @@ type Query {
     # The configuration for clients.
     clientConfiguration: ClientConfigurationDetails!
     # Runs a search.
+    #
+    # In Sourcegraph versions before 3.5, requesting more results could be done
+    # by first making a request with only specifying a 'query', and then
+    # checking the 'SearchResults' 'limitHit' field. If the limit was hit, it
+    # indicated more results existed and the query could be retried with a
+    # larger 'count:' query parameter. All original results and some new
+    # results would be returned. In other words, there was no true pagination
+    # of search results and search results arrived in a random (fastest-first)
+    # order.
+    #
+    # In Sourcegraph 3.5, pagination was introduced which unlike the prior
+    # approach allows for:
+    #
+    # - Getting subsequent results faster (as prior results are no longer computed and transferred).
+    # - Consuming the entire result set (using multiple requests).
+    # - Getting results in a defined order.
+    #
+    # All new API consumers should make use of this API by specifying 'offset'
+    # and 'limit' parameters.
     search(
         # The search query (such as "foo" or "repo:myrepo foo").
         query: String = ""
+
+        # When specified, indicates that this request should be paginated and
+        # results should be returned starting at this offset.
+        #
+        # All new clients should specify this field.
+        offset: SearchOffset
+
+        # When specified, indicates that this request should be paginated and
+        # results should be limited to this amount.
+        #
+        # All new clients should specify this field.
+        limit: SearchLimit
     ): Search
     # All saved searches configured for the current user, merged from all configurations.
     savedSearches: [SavedSearch!]!
@@ -843,6 +874,72 @@ type ClientConfigurationDetails {
 type ParentSourcegraphDetails {
     # Sourcegraph instance URL.
     url: String!
+}
+
+# An offset for pagination in search.
+input SearchOffset {
+    # Indicates that Sourcegraph should skip searching the first N repositories
+    # out of all repositories determined to be searchable based on the search
+    # query.
+    repositories: Int!
+
+    # Indicates that repositories containing no results should be skipped when
+    # possible. For example, if:
+    #
+    # - Sourcegraph has 100 repositories
+    # - 'SearchOffset.repositories = 50'
+    # - 'SearchOffset.skipEmptyRepositories = true'
+    # - 'SearchLimit.repositories = 10'
+    #
+    # Sourcegraph will begin searching at the 50th repository and continue
+    # searching until either:
+    #
+    # - 10 repositories with results are found (or less if there are not 10
+    #   such repositories overall).
+    # - More than 1 second has passed (in this case, the client should
+    #   continue by making a subsequent paginated request using the
+    #   'SearchResults.repositoryOffset' to continue searching where the server
+    #   left off). This gives the client an opportunity to present an updated
+    #   number of repositories searched and how many remain unsearched.
+    #
+    skipEmptyRepositories: Boolean = true
+
+    # Indicates that Sourcegraph should skip the first N results found in each
+    # repository searched.
+    #
+    # In most cases, using just 'repositories' above is sufficient.
+    #
+    # This field is useful when there is a desire to paginate results within a
+    # single repository. Usually, this is only useful when there are extremely
+    # large repositories in Sourcegraph which could produce more results than
+    # can be searched in a reasonable timeframe.
+    results: Int
+}
+
+# A limit on the number of search results returned by the GraphQL query.
+input SearchLimit {
+    # Indicates that the results should at max include results from N
+    # repositories out of all repositories determined to be searchable based on
+    # the search query.
+    repositories: Int! = 10
+
+    # Indicates that if more than N results are encountered in a repository,
+    # only that many results should be returned and no further repositories
+    # should be searched. This allows clients to paginate results within very
+    # large repositories. In this case, to determine if there are more results
+    # overall the client would need to check if
+    # 'length(SearchResults.repositories) > SearchLimit.repositories'
+    # OR
+    # 'length(SearchResults.results) == SearchLimit.results'
+    # are true.
+    #
+    # In most cases, using just 'repositories' above is sufficient.
+    #
+    # This field is useful when there is a desire to paginate results within a
+    # single repository. Usually, this is only useful when there are extremely
+    # large repositories in Sourcegraph which could produce more results than
+    # can be searched in a reasonable timeframe.
+    results: Int
 }
 
 # A search.
@@ -920,9 +1017,19 @@ type SearchResults {
     # This string is typically shown to users to indicate the true result count.
     approximateResultCount: String!
     # Whether or not the results limit was hit.
+    #
+    # For paginated requests, this field is meaningless.
     limitHit: Boolean!
     # Integers representing the sparkline for the search results.
     sparkline: [Int!]!
+    # The last repository that was searched while running this query.
+    #
+    # This differs from the input 'SearchOffset.repositories' value when
+    # repositories have been skipped due to not having results (i.e. when
+    # 'SearchOffset.skipEmptyRepositories = true').
+    #
+    # Always zero for non-paginated searches.
+    repositoryOffset: Int!
     # Repositories that were eligible to be searched.
     repositories: [Repository!]!
     # Repositories that were actually searched. Excludes repositories that would have been searched but were not


### PR DESCRIPTION
### Explanation

See this [public google doc](https://docs.google.com/document/d/1mFOlyYi2D_H_jqqOH44t_d3D2yJF2-E0BqjB5jL2tTQ/edit?usp=sharing)

### State of this PR

- Implements a repository-level pagination API, both in the backend and GraphQL layer.
- I spent maybe ~8hr total on this + the doc above, so it proves my idea would be a
  quick way for us to support this from a technical standpoint.
- The GraphQL layer is just for seeing what it would look like if we did expose
  repository-level pagination via GraphQL. It would **NOT** be actually committed if
  we went forward with my proposal / PR here. Instead, it would be replaced with a
  cursor-based result-level pagination API which has multiple benefits over exposing
  the repository-level API as I discovered and detailed in my proposal google doc.
- The backend implementation of this *would* be used if we moved forward with this.

Not done in this PR currently, but would be done if we move forward with this approach:

- Building the cursor-based result-level pagination GraphQL API which has multiple
  benefits over the repository-level pagination GraphQL API exposed in this PR,
  it would improve performance considerably.
- The webapp / TypeScript implementation of this, depends on the above.
- Support for non-text-matches, i.e. queries that include symbol search results or
  file path search results. Have to add `type:file` to your query to limit
  results to just text matches (which are the most complex in terms of implementation)
  for it to work right now.
- Proper tuning of the concurrency division, with cursor-based result-level API we
  could do more concurrent work to get results even quicker. e.g. right now we do
  totalRepos/8 but we could divide that further into concurrent work to potentially
  return to the client much sooner.
- Proper testing of this implementation.

### Trying this out

To try this out, you can run the dev server normally then use the API console [like this](http://localhost:3080/api/console#%7B%22variables%22%3A%22%7B%5Cn%20%20%5C%22query%5C%22%3A%20%5C%22error%20type%3Afile%5C%22%2C%5Cn%20%20%5C%22offset%5C%22%3A%20%7B%5Cn%20%20%20%20%5C%22repositories%5C%22%3A%200%2C%5Cn%20%20%20%20%5C%22skipEmptyRepositories%5C%22%3A%20true%5Cn%20%20%7D%2C%5Cn%20%20%5C%22limit%5C%22%3A%20%7B%5Cn%20%20%20%20%5C%22repositories%5C%22%3A%202%5Cn%20%20%7D%5Cn%7D%22%2C%22query%22%3A%22query%20Search(%24query%3A%20String%2C%20%24offset%3A%20SearchOffset%2C%20%24limit%3A%20SearchLimit)%20%7B%5Cn%20%20search(query%3A%20%24query%2C%20offset%3A%20%24offset%2C%20limit%3A%20%24limit)%20%7B%5Cn%20%20%20%20results%20%7B%5Cn%20%20%20%20%20%20results%20%7B%5Cn%20%20%20%20%20%20%20%20...%20on%20FileMatch%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20repository%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D)