### PR TITLE
authz: Fix logic for repos without external repo set

### DIFF
--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -13,9 +13,28 @@ import (
 
 var mockAuthzFilter func(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error)
 
-// authzFilter is the enforcement mechanism for repository permissions. It accepts a list of repositories
-// and a permission type `p` and returns a subset of those repositories (no guarantee on order) for
-// which the currently authenticated user has the specified permission.
+// authzFilter is the enforcement mechanism for repository permissions. It is the root
+// repository-permission-enforcing function (i.e., all other code that wants to check/enforce
+// permissions and is not itself part of the permission-checking code should call this function).
+//
+// It accepts a list of repositories and a permission type `p` and returns a subset of those
+// repositories (no guarantee on order) for which the currently authenticated user has the specified
+// permission.
+//
+// The enforcement policy:
+//
+// - If there are no authz providers and `authzAllowByDefault` is true, then the repository is
+//   accessible to everyone.
+//
+// - Otherwise, each repository must have an external repo spec. If a repo doesn't have one, we
+//   cannot definitively associate the repository with an authz provider, and therefore we
+//   *never* return the repository.
+//
+// - Scan through the list of authz providers until we find one that matches the repository. Return
+//   whether or not the repository accessible according to that authz provider.
+//
+// - If no authz providers match the repository, consult `authzAllowByDefault`. If true, then return
+//   the repository; otherwise, do not.
 func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
 	if mockAuthzFilter != nil {
 		return mockAuthzFilter(ctx, repos, p)
@@ -73,13 +92,15 @@ func getFilteredRepoNames(ctx context.Context, currentUser *types.User, repos ma
 		}
 	}
 
-	accepted = make(map[api.RepoName]struct{})  // repositories that have been claimed and have read permissions
-	unverified := make(map[authz.Repo]struct{}) // repositories that have not been claimed by any authz provider
+	accepted = make(map[api.RepoName]struct{}) // repositories that have been claimed and have read permissions
+	toverify := make(map[authz.Repo]struct{})  // repositories that have not been claimed by any authz provider
 	for repo := range repos {
 		// 🚨 SECURITY: Defensively bar access to repos with no external repo spec (we don't know
-		// where they came from, so can't reliably enforce permissions)
+		// where they came from, so can't reliably enforce permissions). If external repo spec is
+		// NOT set, then we exclude the repo (unless there are no authz providers and
+		// `authzAllowByDefault` is true).
 		if repo.ExternalRepoSpec.IsSet() {
-			unverified[repo] = struct{}{}
+			toverify[repo] = struct{}{}
 		} else if authzAllowByDefault && len(authzProviders) == 0 {
 			accepted[repo.RepoName] = struct{}{}
 		}
@@ -88,7 +109,7 @@ func getFilteredRepoNames(ctx context.Context, currentUser *types.User, repos ma
 	// Walk through all authz providers, checking repo permissions against each. If any own a given
 	// repo, we use its permissions for that repo.
 	for _, authzProvider := range authzProviders {
-		if len(unverified) == 0 {
+		if len(toverify) == 0 {
 			break
 		}
 
@@ -115,24 +136,24 @@ func getFilteredRepoNames(ctx context.Context, currentUser *types.User, repos ma
 		}
 
 		// determine which repos "belong" to this authz provider
-		myUnverified, nextUnverified := authzProvider.Repos(ctx, unverified)
+		myToVerify, nextToVerify := authzProvider.Repos(ctx, toverify)
 
 		// check the perms on those repos
-		perms, err := authzProvider.RepoPerms(ctx, providerAcct, myUnverified)
+		perms, err := authzProvider.RepoPerms(ctx, providerAcct, myToVerify)
 		if err != nil {
 			return nil, err
 		}
-		for unverifiedRepo := range myUnverified {
-			if repoPerms, ok := perms[unverifiedRepo.RepoName]; ok && repoPerms[p] {
-				accepted[unverifiedRepo.RepoName] = struct{}{}
+		for repoToVerify := range myToVerify {
+			if repoPerms, ok := perms[repoToVerify.RepoName]; ok && repoPerms[p] {
+				accepted[repoToVerify.RepoName] = struct{}{}
 			}
 		}
 		// continue checking repos that didn't belong to this authz provider
-		unverified = nextUnverified
+		toverify = nextToVerify
 	}
 
 	if authzAllowByDefault {
-		for r := range unverified {
+		for r := range toverify {
 			accepted[r.RepoName] = struct{}{}
 		}
 	}

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -78,10 +78,11 @@ func getFilteredRepoNames(ctx context.Context, currentUser *types.User, repos ma
 	for repo := range repos {
 		// 🚨 SECURITY: Defensively bar access to repos with no external repo spec (we don't know
 		// where they came from, so can't reliably enforce permissions)
-		if s := repo.ExternalRepoSpec; s.ID == "" || s.ServiceID == "" || s.ServiceType == "" {
-			continue
+		if repo.ExternalRepoSpec.IsSet() {
+			unverified[repo] = struct{}{}
+		} else if authzAllowByDefault && len(authzProviders) == 0 {
+			accepted[repo.RepoName] = struct{}{}
 		}
-		unverified[repo] = struct{}{}
 	}
 
 	// Walk through all authz providers, checking repo permissions against each. If any own a given


### PR DESCRIPTION
This commit makes `authzFilter` include repositories that have no
`ExternalRepoSpec` set when `authzAllowByDefault` is true and there are
not external services configured with `auth` fields (at the moment,
GitHub and GitLab are only ones).

With this patch, Gitolite repos that were created without external repo
set (before [Gitolite special chars #2972](https://github.com/sourcegraph/sourcegraph/pull/2972/files#diff-98794744316d86c4b1200c84d018faf1R132))
can be read by normal users before repo-updater has a chance to sync
those repos, and, hence, persisting their external repo field.

Part of https://github.com/sourcegraph/infrastructure/issues/1505

Test plan: go test
