### PR TITLE
globals: Keep ExternalURL up to date

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -143,7 +143,7 @@ func SendUserEmailVerificationEmail(ctx context.Context, email, code string) err
 			URL   string
 		}{
 			Email: email,
-			URL: globals.ExternalURL.ResolveReference(&url.URL{
+			URL: globals.ExternalURL().ResolveReference(&url.URL{
 				Path:     verifyEmailPath.Path,
 				RawQuery: q.Encode(),
 			}).String(),

--- a/cmd/frontend/external/globals/globals.go
+++ b/cmd/frontend/external/globals/globals.go
@@ -9,5 +9,5 @@ import (
 )
 
 func ExternalURL() *url.URL {
-	return globals.ExternalURL
+	return globals.ExternalURL()
 }

--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -4,62 +4,58 @@ package globals
 import (
 	"net/url"
 	"reflect"
-	"sync"
+	"sync/atomic"
 
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
-var (
-	externalURLWatch sync.Once
-	externalURLMutex sync.RWMutex
-	externalURL      = &url.URL{Scheme: "http", Host: "example.com"}
-)
+var externalURLWatchers uint32
+
+var externalURL = func() atomic.Value {
+	var v atomic.Value
+	v.Store(&url.URL{Scheme: "http", Host: "example.com"})
+	return v
+}()
 
 // WatchExternalURL watches for changes in the ExternalURL critical config
 // so that changes are reflected in what is returned by the ExternalURL function.
 // In case the setting is not set, defaultURL is used.
+// This should only be called once and will panic otherwise.
 func WatchExternalURL(defaultURL *url.URL) {
-	externalURLWatch.Do(func() {
-		conf.Watch(func() {
-			after := defaultURL
-			if val := conf.Get().Critical.ExternalURL; val != "" {
-				var err error
-				if after, err = url.Parse(val); err != nil {
-					log15.Error("globals.ExternalURL", "value", val, "error", err)
-					return
-				}
+	if atomic.AddUint32(&externalURLWatchers, 1) != 1 {
+		panic("WatchExternalURL called more than once")
+	}
+
+	conf.Watch(func() {
+		after := defaultURL
+		if val := conf.Get().Critical.ExternalURL; val != "" {
+			var err error
+			if after, err = url.Parse(val); err != nil {
+				log15.Error("globals.ExternalURL", "value", val, "error", err)
+				return
 			}
+		}
 
-			externalURLMutex.Lock()
-			defer externalURLMutex.Unlock()
-
-			before := *externalURL
-			if !reflect.DeepEqual(&before, after) {
-				externalURL = after
+		before := externalURL.Load().(*url.URL)
+		if !reflect.DeepEqual(before, after) {
+			externalURL.Store(after)
+			if before.Host != "example.com" {
 				log15.Info(
 					"globals.ExternalURL",
 					"updated", true,
-					"before", &before,
+					"before", before,
 					"after", after,
 				)
 			}
-		})
+		}
 	})
 }
 
 // ExternalURL returns the fully-resolved, externally accessible frontend URL.
+// Callers must not mutate the returned pointer.
 func ExternalURL() *url.URL {
-	externalURLMutex.RLock()
-	defer externalURLMutex.RUnlock()
-
-	u := *externalURL
-	if u.User != nil {
-		user := *(u.User)
-		u.User = &user
-	}
-
-	return &u
+	return externalURL.Load().(*url.URL)
 }
 
 // ConfigurationServerFrontendOnly provides the contents of the site configuration

--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -37,9 +37,8 @@ func WatchExternalURL(defaultURL *url.URL) {
 			}
 		}
 
-		before := externalURL.Load().(*url.URL)
-		if !reflect.DeepEqual(before, after) {
-			externalURL.Store(after)
+		if before := ExternalURL(); !reflect.DeepEqual(before, after) {
+			SetExternalURL(after)
 			if before.Host != "example.com" {
 				log15.Info(
 					"globals.ExternalURL",
@@ -56,6 +55,11 @@ func WatchExternalURL(defaultURL *url.URL) {
 // Callers must not mutate the returned pointer.
 func ExternalURL() *url.URL {
 	return externalURL.Load().(*url.URL)
+}
+
+// SetExternalURL sets the fully-resolved, externally accessible frontend URL.
+func SetExternalURL(u *url.URL) {
+	externalURL.Store(u)
 }
 
 // ConfigurationServerFrontendOnly provides the contents of the site configuration

--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -3,12 +3,64 @@ package globals
 
 import (
 	"net/url"
+	"reflect"
+	"sync"
 
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
-// ExternalURL is the fully-resolved, externally accessible frontend URL.
-var ExternalURL = &url.URL{Scheme: "http", Host: "example.com"}
+var (
+	externalURLWatch sync.Once
+	externalURLMutex sync.RWMutex
+	externalURL      = &url.URL{Scheme: "http", Host: "example.com"}
+)
+
+// WatchExternalURL watches for changes in the ExternalURL critical config
+// so that changes are reflected in what is returned by the ExternalURL function.
+// In case the setting is not set, defaultURL is used.
+func WatchExternalURL(defaultURL *url.URL) {
+	externalURLWatch.Do(func() {
+		conf.Watch(func() {
+			after := defaultURL
+			if val := conf.Get().Critical.ExternalURL; val != "" {
+				var err error
+				if after, err = url.Parse(val); err != nil {
+					log15.Error("globals.ExternalURL", "value", val, "error", err)
+					return
+				}
+			}
+
+			externalURLMutex.Lock()
+			defer externalURLMutex.Unlock()
+
+			before := *externalURL
+			if !reflect.DeepEqual(&before, after) {
+				externalURL = after
+				log15.Info(
+					"globals.ExternalURL",
+					"updated", true,
+					"before", &before,
+					"after", after,
+				)
+			}
+		})
+	})
+}
+
+// ExternalURL returns the fully-resolved, externally accessible frontend URL.
+func ExternalURL() *url.URL {
+	externalURLMutex.RLock()
+	defer externalURLMutex.RUnlock()
+
+	u := *externalURL
+	if u.User != nil {
+		user := *(u.User)
+		u.User = &user
+	}
+
+	return &u
+}
 
 // ConfigurationServerFrontendOnly provides the contents of the site configuration
 // to other services and manages modifications to it.

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -84,7 +84,7 @@ func (*schemaResolver) InviteUserToOrganization(ctx context.Context, args *struc
 		return nil, err
 	}
 	result := &inviteUserToOrganizationResult{
-		invitationURL: globals.ExternalURL.ResolveReference(orgInvitationURL(org)).String(),
+		invitationURL: globals.ExternalURL().ResolveReference(orgInvitationURL(org)).String(),
 	}
 
 	// Send a notification to the recipient. If disabled, the frontend will still show the
@@ -255,7 +255,7 @@ func sendOrgInvitationNotification(ctx context.Context, org *types.Org, sender *
 		}{
 			FromName: fromName,
 			OrgName:  org.Name,
-			URL:      globals.ExternalURL.ResolveReference(orgInvitationURL(org)).String(),
+			URL:      globals.ExternalURL().ResolveReference(orgInvitationURL(org)).String(),
 		},
 	})
 }

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -58,6 +58,6 @@ func (r *createUserResult) ResetPasswordURL(ctx context.Context) (*string, error
 	if err != nil {
 		return nil, err
 	}
-	urlStr := globals.ExternalURL.ResolveReference(resetURL).String()
+	urlStr := globals.ExternalURL().ResolveReference(resetURL).String()
 	return &urlStr, nil
 }

--- a/cmd/frontend/graphqlbackend/users_randomize_password.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password.go
@@ -26,7 +26,7 @@ func (r *randomizeUserPasswordResult) ResetPasswordURL(ctx context.Context) (*st
 	if err != nil {
 		return nil, err
 	}
-	urlStr := globals.ExternalURL.ResolveReference(resetURL).String()
+	urlStr := globals.ExternalURL().ResolveReference(resetURL).String()
 	return &urlStr, nil
 }
 

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -21,7 +21,9 @@ import (
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
 func NewHandler() http.Handler {
-	session.SetSessionStore(session.NewRedisStore(globals.ExternalURL().Scheme == "https"))
+	session.SetSessionStore(session.NewRedisStore(func() bool {
+		return globals.ExternalURL().Scheme == "https"
+	}))
 
 	r := router.Router()
 

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -21,7 +21,7 @@ import (
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
 func NewHandler() http.Handler {
-	session.SetSessionStore(session.NewRedisStore(globals.ExternalURL.Scheme == "https"))
+	session.SetSessionStore(session.NewRedisStore(globals.ExternalURL().Scheme == "https"))
 
 	r := router.Router()
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -86,7 +86,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 	actor := actor.FromContext(req.Context())
 
 	headers := make(map[string]string)
-	headers["x-sourcegraph-client"] = globals.ExternalURL.String()
+	headers["x-sourcegraph-client"] = globals.ExternalURL().String()
 	headers["X-Requested-With"] = "Sourcegraph" // required for httpapi to use cookie auth
 
 	// -- currently we don't associate XHR calls with the parent page's span --
@@ -137,7 +137,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 	// authentication above, but do not include e.g. hard-coded secrets about
 	// the server instance here as they would be sent to anonymous users.
 	return JSContext{
-		ExternalURL:         globals.ExternalURL.String(),
+		ExternalURL:         globals.ExternalURL().String(),
 		XHRHeaders:          headers,
 		CSRFToken:           csrfToken,
 		UserAgentIsBot:      isBot(req.UserAgent()),

--- a/cmd/frontend/internal/app/opensearch.go
+++ b/cmd/frontend/internal/app/opensearch.go
@@ -25,14 +25,16 @@ func openSearch(w http.ResponseWriter, r *http.Request) {
 		BaseURL   string
 		SearchURL string
 	}
+	externalURL := globals.ExternalURL()
+	externalURLStr := externalURL.String()
 	data := vars{
-		BaseURL:   globals.ExternalURL().String(),
-		SearchURL: globals.ExternalURL().String() + "/search?q={searchTerms}",
+		BaseURL:   externalURLStr,
+		SearchURL: externalURLStr + "/search?q={searchTerms}",
 	}
-	if globals.ExternalURL().String() == "https://sourcegraph.com" {
+	if externalURLStr == "https://sourcegraph.com" {
 		data.SiteName = "Sourcegraph"
 	} else {
-		data.SiteName = "Sourcegraph (" + globals.ExternalURL().Host + ")"
+		data.SiteName = "Sourcegraph (" + externalURL.Host + ")"
 	}
 
 	var buf bytes.Buffer

--- a/cmd/frontend/internal/app/opensearch.go
+++ b/cmd/frontend/internal/app/opensearch.go
@@ -26,13 +26,13 @@ func openSearch(w http.ResponseWriter, r *http.Request) {
 		SearchURL string
 	}
 	data := vars{
-		BaseURL:   globals.ExternalURL.String(),
-		SearchURL: globals.ExternalURL.String() + "/search?q={searchTerms}",
+		BaseURL:   globals.ExternalURL().String(),
+		SearchURL: globals.ExternalURL().String() + "/search?q={searchTerms}",
 	}
-	if globals.ExternalURL.String() == "https://sourcegraph.com" {
+	if globals.ExternalURL().String() == "https://sourcegraph.com" {
 		data.SiteName = "Sourcegraph"
 	} else {
-		data.SiteName = "Sourcegraph (" + globals.ExternalURL.Host + ")"
+		data.SiteName = "Sourcegraph (" + globals.ExternalURL().Host + ")"
 	}
 
 	var buf bytes.Buffer

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -68,7 +68,7 @@ func HandleResetPasswordInit(w http.ResponseWriter, r *http.Request) {
 			URL      string
 		}{
 			Username: usr.Username,
-			URL:      globals.ExternalURL.ResolveReference(resetURL).String(),
+			URL:      globals.ExternalURL().ResolveReference(resetURL).String(),
 		},
 	}); err != nil {
 		httpLogAndError(w, "Could not send reset password email", http.StatusInternalServerError, "err", err)

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -45,9 +45,9 @@ func newExternalHTTPHandler(ctx context.Context) (http.Handler, error) {
 	// App handler (HTML pages).
 	appHandler := app.NewHandler()
 	appHandler = handlerutil.CSRFMiddleware(appHandler, globals.ExternalURL().Scheme == "https") // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
-	appHandler = authMiddlewares.App(appHandler)                                               // 🚨 SECURITY: auth middleware
-	appHandler = session.CookieMiddleware(appHandler)                                          // app accepts cookies
-	appHandler = httpapi.AccessTokenAuthMiddleware(appHandler)                                 // app accepts access tokens
+	appHandler = authMiddlewares.App(appHandler)                                                 // 🚨 SECURITY: auth middleware
+	appHandler = session.CookieMiddleware(appHandler)                                            // app accepts cookies
+	appHandler = httpapi.AccessTokenAuthMiddleware(appHandler)                                   // app accepts access tokens
 
 	// Mount handlers and assets.
 	sm := http.NewServeMux()

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -44,10 +44,12 @@ func newExternalHTTPHandler(ctx context.Context) (http.Handler, error) {
 
 	// App handler (HTML pages).
 	appHandler := app.NewHandler()
-	appHandler = handlerutil.CSRFMiddleware(appHandler, globals.ExternalURL().Scheme == "https") // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
-	appHandler = authMiddlewares.App(appHandler)                                                 // 🚨 SECURITY: auth middleware
-	appHandler = session.CookieMiddleware(appHandler)                                            // app accepts cookies
-	appHandler = httpapi.AccessTokenAuthMiddleware(appHandler)                                   // app accepts access tokens
+	appHandler = handlerutil.CSRFMiddleware(appHandler, func() bool {
+		return globals.ExternalURL().Scheme == "https"
+	}) // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
+	appHandler = authMiddlewares.App(appHandler)               // 🚨 SECURITY: auth middleware
+	appHandler = session.CookieMiddleware(appHandler)          // app accepts cookies
+	appHandler = httpapi.AccessTokenAuthMiddleware(appHandler) // app accepts access tokens
 
 	// Mount handlers and assets.
 	sm := http.NewServeMux()

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -44,7 +44,7 @@ func newExternalHTTPHandler(ctx context.Context) (http.Handler, error) {
 
 	// App handler (HTML pages).
 	appHandler := app.NewHandler()
-	appHandler = handlerutil.CSRFMiddleware(appHandler, globals.ExternalURL.Scheme == "https") // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
+	appHandler = handlerutil.CSRFMiddleware(appHandler, globals.ExternalURL().Scheme == "https") // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
 	appHandler = authMiddlewares.App(appHandler)                                               // 🚨 SECURITY: auth middleware
 	appHandler = session.CookieMiddleware(appHandler)                                          // app accepts cookies
 	appHandler = httpapi.AccessTokenAuthMiddleware(appHandler)                                 // app accepts access tokens

--- a/cmd/frontend/internal/cli/middleware/goimportpath.go
+++ b/cmd/frontend/internal/cli/middleware/goimportpath.go
@@ -61,7 +61,7 @@ func SourcegraphComGoGetHandler(next http.Handler) http.Handler {
 		// It's a vanity import path that maps to "github.com/{sourcegraph,sqs}/*" clone URLs.
 		pathElements := strings.Split(req.URL.Path[1:], "/")
 		if len(pathElements) >= 2 && (pathElements[0] == "sourcegraph" || pathElements[0] == "sqs") {
-			host := globals.ExternalURL.Host
+			host := globals.ExternalURL().Host
 
 			user := pathElements[0]
 			repo := pathElements[1]

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -395,7 +395,7 @@ func serveUserEmailsGetEmail(w http.ResponseWriter, r *http.Request) error {
 }
 
 func serveExternalURL(w http.ResponseWriter, r *http.Request) error {
-	if err := json.NewEncoder(w).Encode(globals.ExternalURL.String()); err != nil {
+	if err := json.NewEncoder(w).Encode(globals.ExternalURL().String()); err != nil {
 		return errors.Wrap(err, "Encode")
 	}
 	return nil

--- a/cmd/frontend/internal/pkg/handlerutil/middleware.go
+++ b/cmd/frontend/internal/pkg/handlerutil/middleware.go
@@ -9,7 +9,7 @@ import (
 // CSRFMiddleware is HTTP middleware that helps prevent cross-site request forgery. To make your
 // forms compliant you will have to submit the token via the X-Csrf-Token header, which is made
 // available in the client-side context.
-func CSRFMiddleware(next http.Handler, secure bool) http.Handler {
+func CSRFMiddleware(next http.Handler, secure func() bool) http.Handler {
 	return csrf.Protect(
 		[]byte("e953612ddddcdd5ec60d74e07d40218c"),
 		// We do not use the name csrf_token since it is a common name. This
@@ -17,6 +17,6 @@ func CSRFMiddleware(next http.Handler, secure bool) http.Handler {
 		// https://github.com/sourcegraph/sourcegraph/issues/65
 		csrf.CookieName("sg_csrf_token"),
 		csrf.Path("/"),
-		csrf.Secure(secure),
+		csrf.Secure(secure()),
 	)(next)
 }

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -86,6 +86,9 @@ func (st *sessionsStore) New(r *http.Request, name string) (s *sessions.Session,
 
 func (st *sessionsStore) setSecureOption(s *sessions.Session) {
 	if s != nil {
+		if s.Options == nil {
+			s.Options = new(sessions.Options)
+		}
 		s.Options.Secure = st.secure()
 	}
 }

--- a/cmd/frontend/registry/extensions.go
+++ b/cmd/frontend/registry/extensions.go
@@ -126,7 +126,7 @@ func GetExtensionByExtensionID(ctx context.Context, extensionID string) (local g
 func getLocalRegistryName() string {
 	u, err := url.Parse(conf.Get().Critical.ExternalURL)
 	if err != nil || u == nil || u.Host == "" {
-		return registry.Name(globals.ExternalURL)
+		return registry.Name(globals.ExternalURL())
 	}
 	return registry.Name(u)
 }

--- a/cmd/frontend/registry/extensions.go
+++ b/cmd/frontend/registry/extensions.go
@@ -124,11 +124,7 @@ func GetExtensionByExtensionID(ctx context.Context, extensionID string) (local g
 
 // getLocalRegistryName returns the name of the local registry.
 func getLocalRegistryName() string {
-	u, err := url.Parse(conf.Get().Critical.ExternalURL)
-	if err != nil || u == nil || u.Host == "" {
-		return registry.Name(globals.ExternalURL())
-	}
-	return registry.Name(u)
+	return registry.Name(globals.ExternalURL())
 }
 
 var mockLocalRegistryExtensionIDPrefix **string

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql_test.go
@@ -1,19 +1,21 @@
 package registry
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/pkg/conf"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestFilteringExtensionIDs(t *testing.T) {
 	t.Run("filterStripLocalExtensionIDs on localhost", func(t *testing.T) {
-		conf.Mock(&conf.Unified{Critical: schema.CriticalConfiguration{ExternalURL: "http://localhost:3080"}})
-		defer conf.Mock(nil)
+		before := globals.ExternalURL()
+		globals.SetExternalURL(&url.URL{Scheme: "http", Host: "localhost:3080"})
+		defer globals.SetExternalURL(before)
+
 		input := []string{"localhost:3080/owner1/name1", "owner2/name2"}
 		want := []string{"owner1/name1"}
 		got := filterStripLocalExtensionIDs(input)


### PR DESCRIPTION
This commit makes the globals package keep up to date with changes to
the configured ExternalURL in the management console (critical config).

Before this change, updates to the external URL were not reflected in
many places in the app before it got restarted.

Fixes #4056

Test plan: Reproduction steps in #4056
