### PR TITLE
add some context to a frequently occurring error

### DIFF
--- a/pkg/vcs/git/errors.go
+++ b/pkg/vcs/git/errors.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
 
@@ -20,8 +20,13 @@ func (e *RevisionNotFoundError) HTTPStatusCode() int {
 	return 404
 }
 
-// IsRevisionNotFound reports if err is a RevisionNotFoundError.
+// IsRevisionNotFound reports if err or its cause is a RevisionNotFoundError.
 func IsRevisionNotFound(err error) bool {
 	_, ok := err.(*RevisionNotFoundError)
+	if !ok {
+		err = errors.Cause(err)
+		_, ok := err.(*RevisionNotFoundError)
+		return ok
+	}
 	return ok
 }

--- a/pkg/vcs/git/revisions.go
+++ b/pkg/vcs/git/revisions.go
@@ -102,7 +102,7 @@ func ResolveRevision(ctx context.Context, repo gitserver.Repo, remoteURLFunc fun
 		retryer.remoteURLFunc = nil
 	}
 	err = retryer.run()
-	return commit, err
+	return commit, errors.Wrapf(err, "finding absolute commit for a commit-ish spec in repo %+v", repo)
 }
 
 // runRevParse sends the git rev-parse command to gitserver. It interprets


### PR DESCRIPTION
I keep seeing things like this in the logs when I type queries into the sourcegraph search bar:
![Screen Shot 2019-05-30 at 16 15 52](https://user-images.githubusercontent.com/15530/58672637-bd407b80-82fc-11e9-852a-da83c9bcf90d.png)

This change adds a bit of context to help track down the issue, in case someone else runs into it and has some clue as to what is going on:
![Screen Shot 2019-05-30 at 16 25 54](https://user-images.githubusercontent.com/15530/58672612-a7cb5180-82fc-11e9-86ed-d73996d73929.png)

Test plan: manual
