### PR TITLE
frontend: Speed up repository listing by increasing batch size

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -98,7 +99,14 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 		if opt2.LimitOffset != nil {
 			tmp := *opt2.LimitOffset
 			opt2.LimitOffset = &tmp
-			opt2.Limit++ // so we can detect if there is a next page
+			// We purposefully load more repos into memory than requested in
+			// order to save roundtrips to gitserver in case we need to do
+			// filtering by clone status.
+			// The trade-off here is memory/cpu vs. network roundtrips to
+			// database/gitserver and we choose smaller latency over smaller
+			// memory footprint
+			// At the end of this method we return the requested number of repos
+			opt2.Limit += 500
 		}
 
 		var indexed map[api.RepoName]bool
@@ -165,13 +173,22 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			}
 
 			r.repos = append(r.repos, repos...)
+			// TODO(@mrnugget): This needs to take the sort-column into account
+			sort.Slice(r.repos, func(i, j int) bool { return r.repos[i].Name < r.repos[j].Name })
+
 			if opt2.LimitOffset == nil {
 				break
 			} else {
-				if len(r.repos) >= opt2.Limit {
+				if len(r.repos) >= r.opt.Limit {
+					// Cut off the repos we additionally loaded to save
+					// roundtrips to `gitserver` and only return the number
+					// that was requested.
+					// But, when possible, we add one more so we can detect if
+					// there is a "next page" that could be loaded
+					r.repos = r.repos[:r.opt.Limit+1]
 					break
 				}
-				if reposFromDB < opt2.Limit {
+				if reposFromDB < r.opt.Limit {
 					break
 				}
 				opt2.Offset += opt2.Limit

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRepositories(t *testing.T) {
 	resetMocks()
-	db.Mocks.Repos.MockList(t, "repo3", "repo1", "repo2")
+	db.Mocks.Repos.MockList(t, "repo1", "repo2", "repo3")
 	db.Mocks.Repos.Count = func(context.Context, db.ReposListOptions) (int, error) { return 3, nil }
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestRepositories(t *testing.T) {
 	resetMocks()
-	db.Mocks.Repos.MockList(t, "repo1", "repo2")
-	db.Mocks.Repos.Count = func(context.Context, db.ReposListOptions) (int, error) { return 2, nil }
+	db.Mocks.Repos.MockList(t, "repo3", "repo1", "repo2")
+	db.Mocks.Repos.Count = func(context.Context, db.ReposListOptions) (int, error) { return 3, nil }
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: GraphQLSchema,
@@ -20,6 +20,7 @@ func TestRepositories(t *testing.T) {
 					repositories {
 						nodes { name }
 						totalCount
+						pageInfo { hasNextPage }
 					}
 				}
 			`,
@@ -27,14 +28,34 @@ func TestRepositories(t *testing.T) {
 				{
 					"repositories": {
 						"nodes": [
-							{
-								"name": "repo1"
-							},
-							{
-								"name": "repo2"
-							}
+							{ "name": "repo1" },
+							{ "name": "repo2" },
+							{ "name": "repo3" }
 						],
-						"totalCount": null
+						"totalCount": null,
+						"pageInfo": {"hasNextPage": false}
+					}
+				}
+			`,
+		},
+		{
+			Schema: GraphQLSchema,
+			Query: `
+				{
+					repositories(first: 2) {
+						nodes { name }
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"repositories": {
+						"nodes": [
+							{ "name": "repo1" },
+							{ "name": "repo2" }
+						],
+						"pageInfo": {"hasNextPage": true}
 					}
 				}
 			`,


### PR DESCRIPTION
This fixes #4093 by increasing the number of repositories the GraphQL backend
loads into memory before it filters them based on their clone status.

The previous code was slow when a user applied a filter that doesn't yield any
repositories, e.g.: filtering for "not cloned" when every repository has been
cloned.

Why? Because in order to display 20 repositories on the site-admin page, what
the code did was to...

1. load 20 repositories from the database
2. ask gitserver for their clone-status
3. throw away the ones that away that didn't match the filter
4. if number of repositories left was under 20, goto 1

In other words: we scanned the database in batches of 20 until we found 20
repositories that matched the criteria or we reached the end of the database
table.

What this PR does is to change the code to always load at least 500 repositories
from the database. That decreases the number of required roundtrips to the
database and gitserver to scan the whole table for the clone status.

The trade-off we're making here is to trade in memory footprint and CPU cost for
decreased latency.

Before this change, with ~4200 entries in the `repo` table, it took ~20
seconds to fetch the first 20 repositories.

    $ time curl 'http://localhost:3080/.api/graphql?Repositories' \
      -H 'Authorization: token-sudo user="mrnugget",token="secret-token"' \
      -H 'Content-Type: application/json' \
      -H 'Accept: application/json' \
      --data-binary '{"query":"query Repositories( $first: Int $query: String $cloned: Boolean $cloneInProgress: Boolean $notCloned: Boolean $indexed: Boolean $notIndexed: Boolean ) { repositories( first: $first query: $query cloned: $cloned cloneInProgress: $cloneInProgress notCloned: $notCloned indexed: $indexed notIndexed: $notIndexed ) { nodes { id name createdAt viewerCanAdminister url mirrorInfo { cloned cloneInProgress updatedAt } } totalCount(precise: true) pageInfo { hasNextPage } } }","variables":{"cloned":true,"cloneInProgress":false,"notCloned":false,"indexed":true,"notIndexed":true,"first":20,"query":""}}'

    [...]

    0.01s user 0.01s system 0% cpu 20.357 total

With the changes in this PR, the request is ~13 times faster:

    0.01s user 0.01s system 1% cpu 1.569 total

The big caveat of this solution is that we need to do an in-memory sort after
filtering through the whole list of repositories and currently do not take into
account sorting by a column other than `name`.

But _that was already broken_, since in the middle of the loop we reconstruct
the slice of repos (which came sorted from the database) by looping over the
_map_ of results returned by gitserver. Iterating over maps is unstable in Go,
so the resulting slice has a different order than the one we got from the
database.

With the previous code, though, the problem was nuanced, but now the results can
vary a lot, since you pick a different 20-item-window out of 500 with every
reload on the repositories page. To fix that, I put in the sort-by-name at the
end.

Test plan: go test & manual testing of repository page in site-admin area

**Note to reviewers**: I'll try to tackle the preexisting-sorting-issue mentioned in the commit message in a  separate commit/branch. Wanted to get your input on this change first.

@slimsag I added you because I think you were the last one to optimize that code and probably have a good mental model of how it works :)