### PR TITLE
Browser extension: fix GitHub file info detection

### DIFF
--- a/browser/src/libs/github/__snapshots__/file_info.test.ts.snap
+++ b/browser/src/libs/github/__snapshots__/file_info.test.ts.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`github/file_info ghe-2.14.11 Refined Github finds the file path 1`] = `"bench_test.go"`;
-
-exports[`github/file_info ghe-2.14.11 Vanilla finds the file path 1`] = `"bench_test.go"`;
-
-exports[`github/file_info github.com Refined Github finds the file path 1`] = `"shared/src/api/extension/types/url.ts"`;
-
-exports[`github/file_info github.com Vanilla finds the file path 1`] = `"shared/src/api/extension/types/url.ts"`;

--- a/browser/src/libs/github/__snapshots__/file_info.test.ts.snap
+++ b/browser/src/libs/github/__snapshots__/file_info.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`github/file_info ghe-2.14.11 Refined Github finds the file path 1`] = `"bench_test.go"`;
+
+exports[`github/file_info ghe-2.14.11 Vanilla finds the file path 1`] = `"bench_test.go"`;
+
+exports[`github/file_info github.com Refined Github finds the file path 1`] = `"shared/src/api/extension/types/url.ts"`;
+
+exports[`github/file_info github.com Vanilla finds the file path 1`] = `"shared/src/api/extension/types/url.ts"`;

--- a/browser/src/libs/github/file_info.test.ts
+++ b/browser/src/libs/github/file_info.test.ts
@@ -1,0 +1,21 @@
+import { startCase } from 'lodash'
+import { readFile } from 'mz/fs'
+import { getFilePath } from './util'
+
+describe('github/file_info', () => {
+    for (const version of ['github.com', 'ghe-2.14.11']) {
+        describe(version, () => {
+            for (const extension of ['vanilla', 'refined-github']) {
+                describe(startCase(extension), () => {
+                    it('finds the file path', async () => {
+                        document.body.innerHTML = await readFile(
+                            `${__dirname}/__fixtures__/${version}/blob/${extension}/page.html`,
+                            'utf-8'
+                        )
+                        expect(getFilePath()).toMatchSnapshot()
+                    })
+                })
+            }
+        })
+    }
+})

--- a/browser/src/libs/github/file_info.test.ts
+++ b/browser/src/libs/github/file_info.test.ts
@@ -9,10 +9,12 @@ const tests = [
 ]
 
 describe('github/file_info', () => {
-    for (const [fixture, expectedFilePath] of tests) {
-        it(`getFilePath() finds the file path in ${fixture}`, async () => {
-            document.body.innerHTML = await readFile(`${__dirname}/__fixtures__/${fixture}`, 'utf-8')
-            expect(getFilePath()).toBe(expectedFilePath)
-        })
-    }
+    describe('getFilePath()', () => {
+        for (const [fixture, expectedFilePath] of tests) {
+            it(`finds the file path in ${fixture}`, async () => {
+                document.body.innerHTML = await readFile(`${__dirname}/__fixtures__/${fixture}`, 'utf-8')
+                expect(getFilePath()).toBe(expectedFilePath)
+            })
+        }
+    })
 })

--- a/browser/src/libs/github/file_info.test.ts
+++ b/browser/src/libs/github/file_info.test.ts
@@ -1,21 +1,18 @@
-import { startCase } from 'lodash'
 import { readFile } from 'mz/fs'
 import { getFilePath } from './util'
 
+const tests = [
+    ['github.com/blob/vanilla/page.html', 'shared/src/api/extension/types/url.ts'],
+    ['github.com/blob/refined-github/page.html', 'shared/src/api/extension/types/url.ts'],
+    ['ghe-2.14.11/blob/vanilla/page.html', 'bench_test.go'],
+    ['ghe-2.14.11/blob/refined-github/page.html', 'bench_test.go'],
+]
+
 describe('github/file_info', () => {
-    for (const version of ['github.com', 'ghe-2.14.11']) {
-        describe(version, () => {
-            for (const extension of ['vanilla', 'refined-github']) {
-                describe(startCase(extension), () => {
-                    it('finds the file path', async () => {
-                        document.body.innerHTML = await readFile(
-                            `${__dirname}/__fixtures__/${version}/blob/${extension}/page.html`,
-                            'utf-8'
-                        )
-                        expect(getFilePath()).toMatchSnapshot()
-                    })
-                })
-            }
+    for (const [fixture, expectedFilePath] of tests) {
+        it(`finds the file path in ${fixture}`, async () => {
+            document.body.innerHTML = await readFile(`${__dirname}/__fixtures__/${fixture}`, 'utf-8')
+            expect(getFilePath()).toBe(expectedFilePath)
         })
     }
 })

--- a/browser/src/libs/github/file_info.test.ts
+++ b/browser/src/libs/github/file_info.test.ts
@@ -10,7 +10,7 @@ const tests = [
 
 describe('github/file_info', () => {
     for (const [fixture, expectedFilePath] of tests) {
-        it(`finds the file path in ${fixture}`, async () => {
+        it(`getFilePath() finds the file path in ${fixture}`, async () => {
             document.body.innerHTML = await readFile(`${__dirname}/__fixtures__/${fixture}`, 'utf-8')
             expect(getFilePath()).toBe(expectedFilePath)
         })

--- a/browser/src/libs/github/file_info.ts
+++ b/browser/src/libs/github/file_info.ts
@@ -80,9 +80,6 @@ export const resolveFileInfo = (codeView: HTMLElement): Observable<FileInfo> => 
         const { revAndFilePath, repoName } = parsedURL
 
         const filePath = getFilePath()
-        if (!filePath) {
-            throw new Error(`Failed to find the file path.`)
-        }
         if (!revAndFilePath.endsWith(filePath)) {
             throw new Error(
                 `The file path ${filePath} should always be a suffix of revAndFilePath ${revAndFilePath}, but isn't in this case.`

--- a/browser/src/libs/github/file_info.ts
+++ b/browser/src/libs/github/file_info.ts
@@ -80,7 +80,7 @@ export const resolveFileInfo = (codeView: HTMLElement): Observable<FileInfo> => 
         const { revAndFilePath, repoName } = parsedURL
 
         const filePath = getFilePath()
-        if (filePath === undefined) {
+        if (!filePath) {
             throw new Error(`Failed to find the file path.`)
         }
         if (!revAndFilePath.endsWith(filePath)) {

--- a/browser/src/libs/github/file_info.ts
+++ b/browser/src/libs/github/file_info.ts
@@ -92,7 +92,7 @@ export const resolveFileInfo = (codeView: HTMLElement): Observable<FileInfo> => 
             repoName,
             filePath,
             commitID: getCommitIDFromPermalink(),
-            rev: revAndFilePath.slice(0, revAndFilePath.length - filePath.length),
+            rev: revAndFilePath.slice(0, -filePath.length),
         })
     } catch (error) {
         return throwError(error)

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -209,8 +209,8 @@ export function getFilePath(): string {
             `Unable to determine the file path because the .js-permalink-shortcut element did not have an href attribute.`
         )
     }
-    // @ts-ignore these unused variables aid readability
-    const [_, _user, _repo, _blob, _commitID, ...path] = href.split('/')
+    // <empty>/<user>/<repo>/blob/<commitID>/<path/to/file>
+    const [, , , , , ...path] = href.split('/')
     if (path.length === 0) {
         throw new Error(
             `Unable to determine the file path because the .js-permalink-shortcut element's href attribute was ${href} (it is expected to be of the form /<user>/<repo>/blob/<commitID>/<path/to/file>).`

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -199,21 +199,18 @@ function getDiffResolvedRevFromPageSource(pageSource: string, isPullRequest: boo
  * TODO ideally, this should only scrape the code view itself.
  */
 export function getFilePath(): string {
-    const permalink = document.querySelector('.js-permalink-shortcut')
+    const permalink = document.querySelector<HTMLAnchorElement>('a.js-permalink-shortcut')
     if (!permalink) {
-        throw new Error(`Unable to determine the file path because no .js-permalink-shortcut element was found.`)
+        throw new Error(`Unable to determine the file path because no a.js-permalink-shortcut element was found.`)
     }
-    const href = permalink.getAttribute('href')
-    if (!href) {
-        throw new Error(
-            `Unable to determine the file path because the .js-permalink-shortcut element did not have an href attribute.`
-        )
-    }
+    const url = new URL(permalink.href)
     // <empty>/<user>/<repo>/blob/<commitID>/<path/to/file>
-    const [, , , , , ...path] = href.split('/')
+    const [, , , , , ...path] = url.pathname.split('/')
     if (path.length === 0) {
         throw new Error(
-            `Unable to determine the file path because the .js-permalink-shortcut element's href attribute was ${href} (it is expected to be of the form /<user>/<repo>/blob/<commitID>/<path/to/file>).`
+            `Unable to determine the file path because the a.js-permalink-shortcut element's href's path was ${
+                url.pathname
+            } (it is expected to be of the form /<user>/<repo>/blob/<commitID>/<path/to/file>).`
         )
     }
     return path.join('/')

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -199,13 +199,9 @@ function getDiffResolvedRevFromPageSource(pageSource: string, isPullRequest: boo
  *
  * TODO ideally, this should only scrape the code view itself.
  */
-export function getFilePath(): string | undefined {
-    return document.evaluate(
-        "//clipboard-copy[contains(text(), 'Copy path')]/@value",
-        document,
-        null,
-        XPathResult.STRING_TYPE
-    ).stringValue
+export function getFilePath(): string | null {
+    const copyButton = document.querySelector('clipboard-copy[value]')
+    return copyButton && copyButton.getAttribute('value')
 }
 
 type GitHubURL =

--- a/browser/src/libs/github/util.tsx
+++ b/browser/src/libs/github/util.tsx
@@ -198,26 +198,23 @@ function getDiffResolvedRevFromPageSource(pageSource: string, isPullRequest: boo
  *
  * TODO ideally, this should only scrape the code view itself.
  */
-export function getFilePath(): string | null {
+export function getFilePath(): string {
     const permalink = document.querySelector('.js-permalink-shortcut')
     if (!permalink) {
-        console.error(`Unable to determine the file path because no .js-permalink-shortcut element was found.`)
-        return null
+        throw new Error(`Unable to determine the file path because no .js-permalink-shortcut element was found.`)
     }
     const href = permalink.getAttribute('href')
     if (!href) {
-        console.error(
+        throw new Error(
             `Unable to determine the file path because the .js-permalink-shortcut element did not have an href attribute.`
         )
-        return null
     }
     // @ts-ignore these unused variables aid readability
     const [_, _user, _repo, _blob, _commitID, ...path] = href.split('/')
     if (path.length === 0) {
-        console.error(
+        throw new Error(
             `Unable to determine the file path because the .js-permalink-shortcut element's href attribute was ${href} (it is expected to be of the form /<user>/<repo>/blob/<commitID>/<path/to/file>).`
         )
-        return null
     }
     return path.join('/')
 }


### PR DESCRIPTION
Prior to this change, the revision was found by inspecting the branch/tree button and whether or not the text was truncated. That seemed error-prone to me.

After this change, the file path is found first (by inspecting the "Copy path" button), then the revision is derived from that and the URL. This seems a bit more robust and simpler.

Test plan: make sure the "Open on Sourcegraph" button appears in the **file header** for these:

- https://github.com/sourcegraph/sourcegraph/blob/alert-bg/cmd/frontend/internal/session/session.go
- https://github.com/sourcegraph/sourcegraph/blob/01d571ba62853db43d5dd0b73436ec47eca7662b/cmd/frontend/internal/session/session.go

Fixes https://github.com/sourcegraph/sourcegraph/issues/4280

#### Test Plan

##### Code Hosts

- [x] GitHub
- [x] GitHub Enterprise
- [x] Refined GitHub
- ~Phabricator~
- ~Phabricator integration~
- ~Bitbucket~
- ~Gitlab~

##### Browsers

- [x] Chrome
- [x] Firefox

