### PR TITLE
test-e2e: Dump Docker logs if tests failed

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -60,4 +60,12 @@ pushd web
 # `-pix_fmt yuv420p` makes a QuickTime-compatible mp4.
 ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp4 > ffmpeg.log 2>&1 &
 env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run test-e2e
+
+if [ $? -ne 0 ]; then
+    echo "^^^ +++"
+    echo "Tests failed. Here's the output of docker inspect and docker logs:"
+    docker inspect "$CONTAINER"
+    docker logs --timestamps "$CONTAINER"
+    exit 1
+fi
 popd


### PR DESCRIPTION
This helped a ton when debugging failing e2e tests on Buildkite because I could see the server logging a "bad credentials" message.

Test plan: `cd web && yarn run test-e2e` and Buildkite