### PR TITLE
e2e-tests: Fix "circular structure" error when printing JSON

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -81,7 +81,7 @@ describe('e2e test suite', function(this: any): void {
             browser = await puppeteer.launch(launchOpt)
             page = await browser.newPage()
             page.on('console', message =>
-                console.log('Browser console message:', util.inspect(message, { breakLength: Infinity }))
+                console.log('Browser console message:', util.inspect(message, { colors: true, depth: 2, breakLength: Infinity }))
             )
             await init()
         },

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import puppeteer, { LaunchOptions } from 'puppeteer'
 import { Key } from 'ts-key-enum'
+import * as util from 'util'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/util/screenshotReporter'
 import { readEnvBoolean, readEnvString, retry } from '../util/e2e-test-utils'
 
@@ -79,7 +80,9 @@ describe('e2e test suite', function(this: any): void {
             }
             browser = await puppeteer.launch(launchOpt)
             page = await browser.newPage()
-            page.on('console', message => console.log('Browser console message:', JSON.stringify(message)))
+            page.on('console', message =>
+                console.log('Browser console message:', util.inspect(message, { breakLength: Infinity }))
+            )
             await init()
         },
         // Cloning the repositories takes ~1 minute, so give initialization 2

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -81,7 +81,10 @@ describe('e2e test suite', function(this: any): void {
             browser = await puppeteer.launch(launchOpt)
             page = await browser.newPage()
             page.on('console', message =>
-                console.log('Browser console message:', util.inspect(message, { colors: true, depth: 2, breakLength: Infinity }))
+                console.log(
+                    'Browser console message:',
+                    util.inspect(message, { colors: true, depth: 2, breakLength: Infinity })
+                )
             )
             await init()
         },


### PR DESCRIPTION
This fixes #4326 by fixing the `TypeError`.

What this does _not_ do is get rid of the message completely. Technically it _is_ possible according to [this comment](https://github.com/facebook/react/issues/12041#issuecomment-358681048), but I couldn't seem to get it to work between webpack/jest/puppeteer. If someone else knows how to set a property on `window` on every puppeteer page, then that should lead us to the solution.

Test plan: `cd web && yarn run test-e2e`
