### PR TITLE
frontend: Fallback to generic not found error page

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -148,16 +148,6 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 				http.Redirect(w, r, u.String(), http.StatusSeeOther)
 				return nil, nil
 			}
-			if errcode.IsNotFound(err) || errors.Cause(err) == repoupdater.ErrNotFound {
-				// Repo does not exist.
-				serveError(w, r, err, http.StatusNotFound)
-				return nil, nil
-			}
-			if errors.Cause(err) == repoupdater.ErrUnauthorized {
-				// Not authorized to access repository.
-				serveError(w, r, err, http.StatusUnauthorized)
-				return nil, nil
-			}
 			if git.IsRevisionNotFound(errors.Cause(err)) {
 				// Revision does not exist.
 				serveError(w, r, err, http.StatusNotFound)
@@ -175,6 +165,16 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 				}
 				// Repo does not exist.
 				serveError(w, r, err, http.StatusNotFound)
+				return nil, nil
+			}
+			if errcode.IsNotFound(err) || errors.Cause(err) == repoupdater.ErrNotFound {
+				// Repo does not exist.
+				serveError(w, r, err, http.StatusNotFound)
+				return nil, nil
+			}
+			if errors.Cause(err) == repoupdater.ErrUnauthorized {
+				// Not authorized to access repository.
+				serveError(w, r, err, http.StatusUnauthorized)
 				return nil, nil
 			}
 			return nil, err

--- a/go.sum
+++ b/go.sum
@@ -631,11 +631,13 @@ golang.org/x/oauth2 v0.0.0-20181120190819-8f65e3013eba/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190426200222-9f3314589c9a h1:nmml9VKepA01xC5LUDn/1vBQst7k51M6gQKpUm9+nIs=
 golang.org/x/oauth2 v0.0.0-20190426200222-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190602172753-aaccbc9213b0 h1:CXghSJpU62ldyURqmA7kvki7OVzr5HSC57FwWi3/b5E=
 golang.org/x/oauth2 v0.0.0-20190602172753-aaccbc9213b0/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190602191015-112230192c58 h1:4DVYpTHXnL5aQR7t0kK+Y8UsFTG+43u9qfXpYxnt72c=
 golang.org/x/sync v0.0.0-20190602191015-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20171026204733-164713f0dfce/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180614134839-8883426083c0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -658,6 +660,7 @@ golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc h1:4gbWbmmPFp4ySWICouJl6emP0
 golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190520165911-ad400b127469 h1:kaecDhtQZZC3xFcK4PsPU1n+zY8mmuxcnE1OVtgp88o=
 golang.org/x/sys v0.0.0-20190520165911-ad400b127469/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190602172818-4c4f7f33c9ed h1:bgjqB+1ZPX+IeX5VubQLaMyCVtI1XHQmAC8jO6h6B8U=
 golang.org/x/sys v0.0.0-20190602172818-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
This was accidentally changed in a refactoring. Previously we would only check
`errcode.IsNotFound` once doing other more specific not found error
handling. However, the check was moved earlier into our ui handler leading to
repositories that are cloning to have a 404 response (instead of 200).

Test plan: Locally by visiting `github.com/sourcegraphtest/AlwaysCloningTest` and added unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/4081