### PR TITLE
web: Handle uncloned repository which isn't yet cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed repository search patterns which contain `.*`. Previously our optimizer would ignore `.*`, which in some cases would lead to our repository search excluding some repositories from the results.
 - Fixed an issue where the Phabricator native integration would be broken on recent Phabricator versions. This fix depends on v1.2 of the [Phabricator extension](https://github.com/sourcegraph/phabricator-extension).
+- Fixed an issue where the "Empty repository" banner would be shown on a repository page when starting to clone a repository.
 
 ## 3.4.3 (unreleased)
 

--- a/web/src/repo/backend.tsx
+++ b/web/src/repo/backend.tsx
@@ -140,7 +140,7 @@ export const resolveRev = memoizeObservable(
                     )
                 }
                 if (!data.repository.mirrorInfo.cloned) {
-                    throw createCloneInProgressError(ctx.repoName, 'this repository is in the queue to be cloned')
+                    throw createCloneInProgressError(ctx.repoName, 'queued for cloning')
                 }
                 if (!data.repository.commit) {
                     throw createRevNotFoundError(ctx.rev)

--- a/web/src/repo/backend.tsx
+++ b/web/src/repo/backend.tsx
@@ -106,6 +106,7 @@ export const resolveRev = memoizeObservable(
                         mirrorInfo {
                             cloneInProgress
                             cloneProgress
+                            cloned
                         }
                         commit(rev: $rev) {
                             oid
@@ -137,6 +138,9 @@ export const resolveRev = memoizeObservable(
                         ctx.repoName,
                         data.repository.mirrorInfo.cloneProgress || undefined
                     )
+                }
+                if (!data.repository.mirrorInfo.cloned) {
+                    throw createCloneInProgressError(ctx.repoName, 'this repository is in the queue to be cloned')
                 }
                 if (!data.repository.commit) {
                     throw createRevNotFoundError(ctx.rev)


### PR DESCRIPTION
A repository may be in the queue to be cloned, but not yet cloning. As such
the cloneInProgress value will be false. The error checking code in the webapp
would treat cloneInProgress being false as the repo is cloned. Therefore it
treated resolveRev to uncloned repositories as a missing revision.

The only way to get back missing revision when resolveRev on the default
branch, is if the repository has no commits. So this lead to uncloned
repositories being reported as empty repositories.

This commit checks if the repository is cloned. If not, it returns a
CloneInProgressError. This seems a bit hacky, but in fact works well. Since
the page presented will update when the repository is cloning. Additionally
the repository is placed in the high priority clone queue.

Test plan: Added a large number of repositories to be cloned. Visited a non-cloned repository and observed fixed behaviour.

![Kapture 2019-06-03 at 21 24 59](https://user-images.githubusercontent.com/187831/58829151-6c57bc80-8647-11e9-86e7-1786b1489bfa.gif)


Fixes https://github.com/sourcegraph/sourcegraph/issues/1744