### PR TITLE
Revert "test-e2e: Dump Docker logs if tests failed (#4311)"

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -60,12 +60,4 @@ pushd web
 # `-pix_fmt yuv420p` makes a QuickTime-compatible mp4.
 ffmpeg -y -f x11grab -video_size 1280x1024 -i "$DISPLAY" -pix_fmt yuv420p e2e.mp4 > ffmpeg.log 2>&1 &
 env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run test-e2e
-
-if [ $? -ne 0 ]; then
-    echo "^^^ +++"
-    echo "Tests failed. Here's the output of docker inspect and docker logs:"
-    docker inspect "$CONTAINER"
-    docker logs --timestamps "$CONTAINER"
-    exit 1
-fi
 popd


### PR DESCRIPTION
This reverts the changes in #4311 after we found out [in this comment chain](https://github.com/sourcegraph/sourcegraph/pull/4311#discussion_r290012247) that what I added is actually a noop.

Test plan: `cd web && yarn run test-e2e`
