### PR TITLE
browser: Check if repository is cloned for resolveRev

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -84,7 +84,7 @@ const createMockPlatformContext = (
                 data: {
                     repository: {
                         mirrorInfo: {
-                            cloneInProgress: false,
+                            cloned: true,
                         },
                         commit: {
                             oid: 'foo',
@@ -99,9 +99,6 @@ const createMockPlatformContext = (
             return of({
                 data: {
                     repository: {
-                        mirrorInfo: {
-                            cloneInProgress: false,
-                        },
                         commit: {
                             file: {
                                 content: '',

--- a/browser/src/shared/repo/backend.tsx
+++ b/browser/src/shared/repo/backend.tsx
@@ -56,7 +56,7 @@ export const resolveRev = memoizeObservable(
                     query ResolveRev($repoName: String!, $rev: String!) {
                         repository(name: $repoName) {
                             mirrorInfo {
-                                cloneInProgress
+                                cloned
                             }
                             commit(rev: $rev) {
                                 oid
@@ -73,7 +73,7 @@ export const resolveRev = memoizeObservable(
                 if (!repository) {
                     throw new RepoNotFoundError(ctx.repoName)
                 }
-                if (repository.mirrorInfo.cloneInProgress) {
+                if (!repository.mirrorInfo.cloned) {
                     throw new CloneInProgressError(ctx.repoName)
                 }
                 if (!repository.commit) {


### PR DESCRIPTION
Previously we relied on cloneInProgress. However, while a repository is in the
queue to be cloned this is false. Instead we use the more reliable "cloned"
field.

Follow-up on https://github.com/sourcegraph/sourcegraph/pull/4335#discussion_r290241304

Test plan: unit tests
