### PR TITLE
graphqlbackend: Do not return error on failing to resolve submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed repository search patterns which contain `.*`. Previously our optimizer would ignore `.*`, which in some cases would lead to our repository search excluding some repositories from the results.
 - Fixed an issue where the Phabricator native integration would be broken on recent Phabricator versions. This fix depends on v1.2 of the [Phabricator extension](https://github.com/sourcegraph/phabricator-extension).
 - Fixed an issue where the "Empty repository" banner would be shown on a repository page when starting to clone a repository.
+- Repositories containing submodules not on Sourcegraph will now load without error (#2947)
 
 ## 3.4.3 (unreleased)
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -46,7 +46,7 @@ func (r *gitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 		repoName, err := cloneURLToRepoName(ctx, submodule.URL())
 		if err != nil {
 			log15.Error("Failed to resolve submodule repository name from clone URL", "cloneURL", submodule.URL(), "err", err)
-			return "", fmt.Errorf("failed to resolve submodule repository name from clone url: %s", submodule.URL())
+			return "", nil
 		}
 		return "/" + repoName + "@" + submodule.Commit(), nil
 	}


### PR DESCRIPTION
This was a regression introduced in 86bf1b7f654519512d93895c321326b7ef31d89b. It
lead to any repository containing unresolvable submodules to fail to load in
Sourcegraph.

Test plan: visited https://sourcegraph.com/github.com/markus-wa/demoinfocs-golang on my local instance and it loaded.

Fixes https://github.com/sourcegraph/sourcegraph/issues/2947