### PR TITLE
repo-updater: Use IdleConnTimeout for GitHub to avoid EOF errors

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -60,7 +60,12 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 		cf = NewHTTPClientFactory()
 	}
 
-	var opts []httpcli.Opt
+	opts := []httpcli.Opt{
+		// Use a 30s timeout to avoid running into EOF errors, because GitHub
+		// closes idle connections after 60s
+		httpcli.NewIdleConnTimeoutOpt(30 * time.Second),
+	}
+
 	if c.Certificate != "" {
 		pool, err := newCertPool(c.Certificate)
 		if err != nil {

--- a/pkg/httpcli/client.go
+++ b/pkg/httpcli/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/gregjones/httpcache"
 	"github.com/hashicorp/go-multierror"
@@ -190,4 +191,23 @@ func TracedTransportOpt(cli *http.Client) error {
 
 	cli.Transport = &nethttp.Transport{RoundTripper: cli.Transport}
 	return nil
+}
+
+// NewIdleConnTimeoutOpt returns a Opt that sets the IdleConnTimeout of an
+// http.Client's transport.
+func NewIdleConnTimeoutOpt(timeout time.Duration) Opt {
+	return func(cli *http.Client) error {
+		if cli.Transport == nil {
+			cli.Transport = http.DefaultTransport
+		}
+
+		tr, ok := cli.Transport.(*http.Transport)
+		if !ok {
+			return errors.New("httpcli.NewIdleConnTimeoutOpt: http.Client.Transport is not an *http.Transport")
+		}
+
+		tr.IdleConnTimeout = timeout
+
+		return nil
+	}
 }


### PR DESCRIPTION
This is a follow-up to #4345 and makes sure that the GitHub source used
in repo-updater uses the same `IdleConnTimeout` that `github-proxy`
uses, making repo-updater resilient against this error without
`github-proxy`


Test plan: go test
