### PR TITLE
gitserver: Improve perf by not specifying git protocol version

### DIFF
--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -33,10 +33,6 @@ func (s *Server) runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress 
 	extraArgs := []string{
 		// Unset credential helper because the command is non-interactive.
 		"-c", "credential.helper=",
-
-		// Use Git wire protocol version 2.
-		// https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html
-		"-c", "protocol.version=2",
 	}
 	cmd.Args = append(cmd.Args[:1], append(extraArgs, cmd.Args[1:]...)...)
 


### PR DESCRIPTION
(@keegancsmith and I just ran into this when trying to find out why visiting the page of a repository was so slow)

The blog post mentioned in the code that's being removed here got an
update in December 2018 that specifies:

    Previously the example above used the more rarely used "git ls-remote"
    command. A recent change to improve the correctness of that command's
    output causes it to request more references.

This change causes `git ls-remote` with `protocol.version=2` to be
consistently _slower_ than the variant without a protocol specified.

In order to improve performance, we remove the code and use the older
protocol for ls-remote.