### PR TITLE
web: Show a 'Clone now' button in repos list if not cloned yet

### DIFF
--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -1,4 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import CloudDownloadIcon from 'mdi-react/CloudDownloadIcon'
 import CloudOutlineIcon from 'mdi-react/CloudOutlineIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
 import * as React from 'react'
@@ -58,6 +59,11 @@ class RepositoryNode extends React.PureComponent<RepositoryNodeProps, Repository
                         )}
                     </div>
                     <div className="repository-node__actions">
+                        {!this.props.node.mirrorInfo.cloneInProgress && !this.props.node.mirrorInfo.cloned && (
+                            <Link className="btn btn-sm btn-secondary" to={this.props.node.url}>
+                                <CloudDownloadIcon className="icon-inline" /> Clone now
+                            </Link>
+                        )}{' '}
                         {
                             <Link
                                 className="btn btn-secondary btn-sm"


### PR DESCRIPTION
This fixes #4232 by making it clearer to the user that they can speed up
the cloning process by clicking on the "Clone now" button.

We (@keegancsmith and I) discussed other solutions (showing the position
in the clone schedule, rewording "Not yet cloned" label, etc.) but
ultimately came to the conclusion that "Not yet cloned" is correct and
that showing any position in a cloning-schedule would be unreliable.

"Clone now" on the other hand makes the tooltip text of the "Not yet
cloned" label actionable as a button and gives the user something to do.

This is what it looks like now:

<img width="1272" alt="Screen Shot 2019-06-04 at 16 30 38" src="https://user-images.githubusercontent.com/1185253/58888884-5817cc00-86e8-11e9-9161-450b1f6b814b.png">

