### PR TITLE
fix display of indexed search multiline results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -571,3 +571,4 @@ func TestCompareSearchResults(t *testing.T) {
 		}
 	}
 }
+

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -571,4 +571,3 @@ func TestCompareSearchResults(t *testing.T) {
 		}
 	}
 }
-

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -558,6 +558,7 @@ func splitMatchesOnNewlines(fms []zoekt.FileMatch) []zoekt.FileMatch {
 func fixupLineMatch(lm zoekt.LineMatch) []zoekt.LineMatch {
 	var lms2 []zoekt.LineMatch
 	offset := 0
+	lnum := lm.LineNumber
 	for i, b := range lm.Line {
 		if b == '\n' {
 			// Add the line match for the line that just ended.
@@ -565,19 +566,20 @@ func fixupLineMatch(lm zoekt.LineMatch) []zoekt.LineMatch {
 				Line:       lm.Line[offset:i],
 				LineStart:  lm.LineStart + offset,
 				LineEnd:    lm.LineStart + i,
-				LineNumber: i - offset,
+				LineNumber: lnum,
 			}
 			lm2.LineFragments = fixupFragments(lm.LineFragments, lm2)
 			lms2 = append(lms2, lm2)
 			// Start again on the next line.
 			offset = i + 1
+			lnum++
 		}
 	}
 	lm2 := zoekt.LineMatch{
 		Line:       lm.Line[offset:len(lm.Line)],
 		LineStart:  lm.LineStart + offset,
 		LineEnd:    lm.LineEnd,
-		LineNumber: lm.LineEnd - (lm.LineStart + offset),
+		LineNumber: lnum,
 	}
 	lm2.LineFragments = fixupFragments(lm.LineFragments, lm2)
 	if len(lm2.LineFragments) > 0 {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"math"
 	"net/http"
 	"net/url"
@@ -530,8 +531,9 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 		limitHit = true
 	}
 
-	// Split the matches into lines.
+	log.Printf("zoekt results: %+v", resp.Files)
 	fileMatches := splitMatchesOnNewlines(resp.Files)
+	log.Printf("split results: %+v", fileMatches)
 	matches, limitHit := fileMatchResolversFromFileMatches(fileMatches, maxLineMatches, limitHit, maxLineFragmentMatches, repoMap, indexedRevisions)
 	return matches, limitHit, reposLimitHit, nil
 }
@@ -578,7 +580,9 @@ func fixupLineMatch(lm zoekt.LineMatch) []zoekt.LineMatch {
 		LineNumber: lm.LineEnd - (lm.LineStart + offset),
 	}
 	lm2.LineFragments = fixupFragments(lm.LineFragments, lm2)
-	lms2 = append(lms2, lm2)
+	if len(lm2.LineFragments) > 0 {
+		lms2 = append(lms2, lm2)
+	}
 	return lms2
 }
 
@@ -610,7 +614,9 @@ func splitFragments(fs []zoekt.LineFragmentMatch, lm zoekt.LineMatch) []zoekt.Li
 			Offset:      f.Offset + uint32(fragOffset),
 			MatchLength: f.MatchLength - fragOffset,
 		}
-		fs2 = append(fs2, f2)
+		if f2.MatchLength > 0 {
+			fs2 = append(fs2, f2)
+		}
 	}
 	return fs2
 }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -545,9 +545,7 @@ func splitMatchesOnNewlines(fms []zoekt.FileMatch) []zoekt.FileMatch {
 		fm2.LineMatches = nil
 		for _, lm := range fm.LineMatches {
 			lms2 := fixupLineMatch(lm)
-			for _, lm2 := range lms2 {
-				fm2.LineMatches = append(fm2.LineMatches, lm2)
-			}
+			fm2.LineMatches = append(fm2.LineMatches, lms2...)
 		}
 		fms2 = append(fms2, fm2)
 	}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -692,14 +692,14 @@ func Test_fixupLineMatch(t *testing.T) {
 	t.Run("line number stays the same", func(t *testing.T) {
 		s := "b"
 		lm := zoekt.LineMatch{
-			Line:          []byte(s),
-			LineStart:     1,
-			LineEnd:       1+len(s),
-			LineNumber:    1,
+			Line:       []byte(s),
+			LineStart:  1,
+			LineEnd:    1 + len(s),
+			LineNumber: 1,
 			LineFragments: []zoekt.LineFragmentMatch{
 				{
 					MatchLength: len(s),
-					Offset: 1,
+					Offset:      1,
 				},
 			},
 		}
@@ -733,14 +733,14 @@ func Test_fixupLineMatch(t *testing.T) {
 		props.Property("line number stays the same for line matches without newlines", prop.ForAll(
 			func(s string, start, lnum int) bool {
 				lm := zoekt.LineMatch{
-					Line:          []byte(s),
-					LineStart:     start,
-					LineEnd:       start + len(s),
-					LineNumber:    lnum,
+					Line:       []byte(s),
+					LineStart:  start,
+					LineEnd:    start + len(s),
+					LineNumber: lnum,
 					LineFragments: []zoekt.LineFragmentMatch{
 						{
 							MatchLength: 1,
-							Offset: 1,
+							Offset:      1,
 						},
 					},
 				}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -635,6 +635,49 @@ func Test_splitMatchesOnNewlines(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "newline at end",
+			args: args{
+				fileMatches: []zoekt.FileMatch{
+					{
+						LineMatches: []zoekt.LineMatch{
+							{
+								Line:       []byte("a\n"),
+								LineStart:  0,
+								LineEnd:    len("a\n"),
+								LineNumber: len("a\n"),
+								LineFragments: []zoekt.LineFragmentMatch{
+									{
+										LineOffset:  0,
+										Offset:      0,
+										MatchLength: len("a\n"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []zoekt.FileMatch{
+				{
+					LineMatches: []zoekt.LineMatch{
+						{
+							Line:       []byte("a"),
+							LineStart:  0,
+							LineEnd:    len("a"),
+							LineNumber: len("a"),
+							LineFragments: []zoekt.LineFragmentMatch{
+								{
+									LineOffset:  0,
+									Offset:      0,
+									MatchLength: len("a"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -696,7 +696,12 @@ func Test_fixupLineMatch(t *testing.T) {
 			LineStart:     1,
 			LineEnd:       1+len(s),
 			LineNumber:    1,
-			LineFragments: []zoekt.LineFragmentMatch{ { MatchLength: 1 } },
+			LineFragments: []zoekt.LineFragmentMatch{
+				{
+					MatchLength: len(s),
+					Offset: 1,
+				},
+			},
 		}
 		lms := fixupLineMatch(lm)
 		if len(lms) != 1 {
@@ -732,7 +737,12 @@ func Test_fixupLineMatch(t *testing.T) {
 					LineStart:     start,
 					LineEnd:       start + len(s),
 					LineNumber:    lnum,
-					LineFragments: []zoekt.LineFragmentMatch{ { MatchLength: 1 } },
+					LineFragments: []zoekt.LineFragmentMatch{
+						{
+							MatchLength: 1,
+							Offset: 1,
+						},
+					},
 				}
 				lms := fixupLineMatch(lm)
 				return len(lms) == 1 && lms[0].LineNumber == lm.LineNumber

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,7 @@ golang.org/x/oauth2 v0.0.0-20190426200222-9f3314589c9a h1:nmml9VKepA01xC5LUDn/1v
 golang.org/x/oauth2 v0.0.0-20190426200222-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190602172753-aaccbc9213b0 h1:CXghSJpU62ldyURqmA7kvki7OVzr5HSC57FwWi3/b5E=
 golang.org/x/oauth2 v0.0.0-20190602172753-aaccbc9213b0/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190604060849-0f29369cfe45 h1:TCfob1wf79EYzd0A5DtY8Fqx7lOBHNwfRM+Gjlhy0Fw=
 golang.org/x/oauth2 v0.0.0-20190604060849-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Indexed searches were already giving results for queries containing `\n`, but the highlighting didn't show up correctly.

Fixes #4138.

Before: 

![Screen Shot 2019-06-04 at 16 05 44](https://user-images.githubusercontent.com/15530/58919374-b2159300-86e2-11e9-89ed-d8ce99fae9d6.png)

After:

![Screen Shot 2019-06-04 at 15 45 52](https://user-images.githubusercontent.com/15530/58919130-d58c0e00-86e1-11e9-96b9-f2cd89e5d979.png)


Test plan: unit test, manually tried some queries like `foo\nbar`