### PR TITLE
highlighting: add support for simulating highlighting timeouts

### DIFF
--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -64,7 +64,7 @@ func (*schemaResolver) HighlightCode(ctx context.Context, args *struct {
 }) (string, error) {
 	language := highlight.SyntectLanguageMap[strings.ToLower(args.FuzzyLanguage)]
 	filePath := "file." + language
-	html, _, err := highlight.Code(ctx, []byte(args.Code), filePath, args.DisableTimeout, args.IsLightTheme)
+	html, _, err := highlight.Code(ctx, []byte(args.Code), filePath, args.DisableTimeout, args.IsLightTheme, false)
 	if err != nil {
 		return args.Code, err
 	}
@@ -110,7 +110,8 @@ func (r *gitTreeEntryResolver) Highlight(ctx context.Context, args *struct {
 		html   template.HTML
 		result = &highlightedFileResolver{}
 	)
-	html, result.aborted, err = highlight.Code(ctx, content, r.path, args.DisableTimeout, args.IsLightTheme)
+	simulateTimeout := r.commit.repo.repo.Name == "github.com/sourcegraph/AlwaysHighlightTimeoutTest"
+	html, result.aborted, err = highlight.Code(ctx, content, r.path, args.DisableTimeout, args.IsLightTheme, simulateTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/pkg/discussions/format.go
+++ b/cmd/frontend/internal/pkg/discussions/format.go
@@ -78,7 +78,7 @@ func formatTargetRepoLinesHTML(ctx context.Context, tr *types.DiscussionThreadTa
 		// contents along here.
 		isLightTheme := false
 		disableTimeout := false
-		html, _, err := highlight.Code(ctx, []byte(code), *tr.Path, disableTimeout, isLightTheme)
+		html, _, err := highlight.Code(ctx, []byte(code), *tr.Path, disableTimeout, isLightTheme, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/highlight/highlight.go
+++ b/pkg/highlight/highlight.go
@@ -43,11 +43,14 @@ func IsBinary(content []byte) bool {
 //
 // The returned boolean represents whether or not highlighting was aborted due
 // to timeout. In this scenario, a plain text table is returned.
-func Code(ctx context.Context, content []byte, filepath string, disableTimeout bool, isLightTheme bool) (template.HTML, bool, error) {
+func Code(ctx context.Context, content []byte, filepath string, disableTimeout bool, isLightTheme bool, simulateTimeout bool) (template.HTML, bool, error) {
 	if !disableTimeout {
 		var cancel func()
 		ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
+	}
+	if simulateTimeout {
+		time.Sleep(4 * time.Second)
 	}
 
 	// Never pass binary files to the syntax highlighter.


### PR DESCRIPTION
This is useful for confirming our behavior of highlighting timeouts, and can be
used in the future to automate testing of this behavior as part of an e2e test.

Primarily adding to reproduce https://github.com/sourcegraph/sourcegraph/issues/4267

Note: This matches other cases where e.g. github.com/sourcegraphtest/AlwaysCloningTest
is a special repository for testing gitserver cloning states end-to-end.

To use this you just need to add github.com/sourcegraph/AlwaysHighlightTimeoutTest to your instance and view a file in there or search results coming from that repository.

Helps #4267