### PR TITLE
blob: correct handling of syntax highlighting timeouts

### DIFF
--- a/web/src/repo/blob/BlobPage.scss
+++ b/web/src/repo/blob/BlobPage.scss
@@ -14,7 +14,8 @@
         position: relative;
     }
 
-    &__aborted {
-        margin: 2rem;
+    &__aborted-alert {
+        margin-bottom: 0;
+        border: none;
     }
 }

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -282,6 +282,7 @@ export class BlobPage extends React.PureComponent<Props, State> {
                         </div>
                     </div>
                 )}
+                {/* Render the (unhighlighted) blob also in the case highlighting timed out */}
                 {renderMode === 'code' && (
                     <Blob
                         {...this.props}

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -272,16 +272,6 @@ export class BlobPage extends React.PureComponent<Props, State> {
                 {this.state.blobOrError.richHTML && renderMode === 'rendered' && (
                     <RenderedFile dangerousInnerHTML={this.state.blobOrError.richHTML} location={this.props.location} />
                 )}
-                {renderMode === 'code' && !this.state.blobOrError.highlight.aborted && (
-                    <Blob
-                        {...this.props}
-                        className="blob-page__blob"
-                        content={this.state.blobOrError.content}
-                        html={this.state.blobOrError.highlight.html}
-                        wrapCode={this.state.wrapCode}
-                        renderMode={renderMode}
-                    />
-                )}
                 {!this.state.blobOrError.richHTML && this.state.blobOrError.highlight.aborted && (
                     <div className="blob-page__aborted">
                         <div className="alert alert-info">
@@ -291,6 +281,16 @@ export class BlobPage extends React.PureComponent<Props, State> {
                             </button>
                         </div>
                     </div>
+                )}
+                {renderMode === 'code' && (
+                    <Blob
+                        {...this.props}
+                        className="blob-page__blob"
+                        content={this.state.blobOrError.content}
+                        html={this.state.blobOrError.highlight.html}
+                        wrapCode={this.state.wrapCode}
+                        renderMode={renderMode}
+                    />
                 )}
                 <BlobPanel
                     {...this.props}


### PR DESCRIPTION
A regression (which apparently must've occurred awfully long ago, like around 8mo ago)
means that today when syntax highlighting takes too long (which can happen for
multiple reasons: due to very large files, bugs in the language grammar, or
bugs in syntect itself) we are incorrectly _just_ displaying the message and action:

> Syntax-highlighting this file took too long. [Try again]

Despite the fact that the server returned an unhighlighted version of the
file, we're just discarding it instead of presenting it to the user as this
was originally designed / intended to work.

What this means in practice is that today Sourcegraph is very unusable on large
files because as soon as you view them you get the above error and have to hit
`Try again` and wait a very long time.

Instead, we now once again properly show the above error and action (for users
who are willing to wait longer for syntax highlighting on these files) AND the
actual plaintext version of the file.

How it looks:

![image](https://user-images.githubusercontent.com/3173176/58941602-faf43880-8730-11e9-880f-f0f571fe3c63.png)

Fixes #4267

See also #4364 which adds something that will allow us to e2e test this in the future.

Test plan: Manually tested using #4364, in the future we will e2e test it.
