### PR TITLE
all: fsync path and directory when we rely on atomic renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed an issue where the Phabricator native integration would be broken on recent Phabricator versions. This fix depends on v1.2 of the [Phabricator extension](https://github.com/sourcegraph/phabricator-extension).
 - Fixed an issue where the "Empty repository" banner would be shown on a repository page when starting to clone a repository.
 - Repositories containing submodules not on Sourcegraph will now load without error (#2947)
+- Prevent data inconsistency on cached archives due to restarts. (#4366)
 
 ## 3.4.3 (unreleased)
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -414,7 +414,7 @@ func (s *Server) removeRepoDirectory(dir string) error {
 		return err
 	}
 	defer os.RemoveAll(tmp)
-	if err := os.Rename(dir, filepath.Join(tmp, "repo")); err != nil {
+	if err := renameAndSync(dir, filepath.Join(tmp, "repo")); err != nil {
 		return err
 	}
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -767,7 +767,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, url string, o
 
 		if overwrite {
 			// remove the current repo by putting it into our temporary directory
-			err := os.Rename(dstPath, filepath.Join(filepath.Dir(tmpPath), "old"))
+			err := renameAndSync(dstPath, filepath.Join(filepath.Dir(tmpPath), "old"))
 			if err != nil && !os.IsNotExist(err) {
 				return errors.Wrapf(err, "failed to remove old clone")
 			}
@@ -776,7 +776,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, url string, o
 		if err := os.MkdirAll(filepath.Dir(dstPath), os.ModePerm); err != nil {
 			return err
 		}
-		if err := os.Rename(tmpPath, dstPath); err != nil {
+		if err := renameAndSync(tmpPath, dstPath); err != nil {
 			return err
 		}
 

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -375,5 +375,35 @@ func updateFileIfDifferent(path string, content []byte) (bool, error) {
 	if err := f.Close(); err != nil {
 		return false, err
 	}
-	return true, os.Rename(f.Name(), path)
+	return true, renameAndSync(f.Name(), path)
+}
+
+// renameAndSync will do an os.Rename followed by fsync to ensure the rename
+// is recorded
+func renameAndSync(oldpath, newpath string) error {
+	err := os.Rename(oldpath, newpath)
+	if err != nil {
+		return err
+	}
+
+	oldparent, newparent := filepath.Dir(oldpath), filepath.Dir(newpath)
+	err = fsync(newparent)
+	if oldparent != newparent {
+		if err1 := fsync(oldparent); err == nil {
+			err = err1
+		}
+	}
+	return err
+}
+
+func fsync(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	err = f.Sync()
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
 }

--- a/pkg/diskcache/cache.go
+++ b/pkg/diskcache/cache.go
@@ -179,12 +179,12 @@ func doFetch(ctx context.Context, path string, fetcher FetcherWithPath) (file *F
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temporary archive cache item")
 	}
+	f.Close()
 	defer os.Remove(tmpPath)
 
 	// We are now ready to actually fetch the file.
 	err = fetcher(ctx, tmpPath)
 	if err != nil {
-		f.Close()
 		return nil, errors.Wrap(err, "failed to fetch missing archive cache item")
 	}
 

--- a/pkg/diskcache/cache.go
+++ b/pkg/diskcache/cache.go
@@ -173,7 +173,8 @@ func doFetch(ctx context.Context, path string, fetcher FetcherWithPath) (file *F
 	}
 
 	// We write to a temporary path to prevent another Open finding a
-	// partially written file.
+	// partially written file. We ensure the file is writeable and truncate
+	// it.
 	tmpPath := path + ".part"
 	f, err = os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {


### PR DESCRIPTION
We have seen cases where corrupt zip files exist on disk. We fixed that by
evicting bad archives. However, this was likely due to OS caches not being
flushed. We now flush both the file and the directory.

For context on why we call fsync see https://lwn.net/Articles/457667/