### PR TITLE
ci: Set coverpkg to record dependency code coverage

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -160,7 +160,7 @@ func main() {
 
 		pipeline.AddStep(":go:",
 			bk.Cmd("./cmd/symbols/build.sh buildLibsqlite3Pcre"), // for symbols tests
-			bk.Cmd("go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./..."),
+			bk.Cmd("go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -coverpkg github.com/sourcegraph/sourcegraph/... -race ./..."),
 			bk.ArtifactPaths("coverage.txt"))
 
 		pipeline.AddStep(":go:",


### PR DESCRIPTION
We will now record coverage in all sourcegraph packages. Previously we only
recorded the coverage per package test, so missed things like our DB tests
covering the migrations bindata.

We used to set this flag, but I think we lost it during our OSS process.