### PR TITLE
db: SetConnMaxLifetime

### DIFF
--- a/cmd/repo-updater/repos/db.go
+++ b/cmd/repo-updater/repos/db.go
@@ -69,6 +69,7 @@ func NewDB(dsn string) (*sql.DB, error) {
 
 	db.SetMaxOpenConns(maxOpen)
 	db.SetMaxIdleConns(maxOpen)
+	db.SetConnMaxLifetime(time.Minute)
 
 	return db, nil
 }

--- a/pkg/db/dbconn/dbconn.go
+++ b/pkg/db/dbconn/dbconn.go
@@ -206,6 +206,7 @@ func configureConnectionPool(db *sql.DB) {
 	}
 	db.SetMaxOpenConns(maxOpen)
 	db.SetMaxIdleConns(maxOpen)
+	db.SetConnMaxLifetime(time.Minute)
 }
 
 func NewMigrate(db *sql.DB) *migrate.Migrate {


### PR DESCRIPTION
Setting this we won't hold onto an idle connection forever. Instead every
connection has a lifetime of 1 minute. Note: This does not mean we kill
connections after 1 minute. The db package scans all idle connections
periodically. If an idle connection is older than 1 minute (what we have
hardcoded), it will close it.

Part of https://github.com/sourcegraph/sourcegraph/issues/3473