### PR TITLE
pkg/trace: include GraphQL ?Type parameter in route name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Repository names are now treated as case-sensitive, fixing an issue where users saw `pq: duplicate key value violates unique constraint \"repo_name_unique\"` [#4283](https://github.com/sourcegraph/sourcegraph/issues/4283)
 - Fixed an issue with `sourcegraph/server` Docker deployments where syntax highlighting could produce `server closed idle connection` errors. [#4269](https://github.com/sourcegraph/sourcegraph/issues/4269)
 - Repositories containing submodules not on Sourcegraph will now load without error [#2947](https://github.com/sourcegraph/sourcegraph/issues/2947)
+- HTTP metrics in Prometheus/Grafana now distinguish between different types of GraphQL requests.
 
 ## 3.4.2
 

--- a/pkg/trace/httptrace.go
+++ b/pkg/trace/httptrace.go
@@ -110,6 +110,15 @@ func Middleware(next http.Handler) http.Handler {
 
 		m := httpsnoop.CaptureMetrics(next, rw, r.WithContext(ctx))
 
+		if routeName == "graphql" {
+			// We use the query to denote the type of a GraphQL request, e.g. /.api/graphql?Repositories
+			if r.URL.RawQuery != "" {
+				routeName = "graphql: " + r.URL.RawQuery
+			} else {
+				routeName = "graphql: unknown"
+			}
+		}
+
 		// route name is only known after the request has been handled
 		span.SetOperationName("Serve: " + routeName)
 		span.SetTag("Route", routeName)


### PR DESCRIPTION
Today our HTTP metrics are pretty nice, but when it comes to any GraphQL requests
they are all grouped under the `graphql` route which makes them mostly useless.

For example, you can see HTTP latency is quite bad or that there are lots of error
codes on GraphQL requests -- but it is impossible to know if those are search
requests or some super-slow request made on e.g. the admin-only repository list
page.

I chose to include this in the route name (`graphql: Search`) instead of adding a
different field because it is nice to not have to deal with the separate field in
dashboard queries and because the route field would be mostly useless on GraphQL
requests otherwise.

Fixes #4246

Test plan: Visited metrics debug endpoint to confirm it works as expected.
