### PR TITLE
repo-updater: Test picking when resolving repo conflicts

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -236,11 +236,10 @@ func NewDiff(sourced, stored []*Repo) (diff Diff) {
 		k := strings.ToLower(r.Name)
 		if old := byName[k]; old == nil {
 			byName[k] = r
-		} else if r.Less(old) {
-			delete(byID, old.ExternalRepo)
-			byName[k] = r
 		} else {
-			delete(byID, r.ExternalRepo)
+			keep, discard := pick(r, old)
+			byName[k] = keep
+			delete(byID, discard.ExternalRepo)
 		}
 	}
 

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -731,6 +731,15 @@ func sortedSliceLess(a, b []string) bool {
 	return true
 }
 
+// pick deterministically chooses between a and b a repo to keep and
+// discard. It is used when resolving conflicts on sourced repositories.
+func pick(a *Repo, b *Repo) (keep, discard *Repo) {
+	if a.Less(b) {
+		return a, b
+	}
+	return b, a
+}
+
 // Repos is an utility type with convenience methods for operating on lists of Repos.
 type Repos []*Repo
 

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -437,6 +437,28 @@ func TestExternalService_Exclude(t *testing.T) {
 	}
 }
 
+// Our uses of pick happen from iterating through a map. So we can't guarantee
+// that we test both pick(a, b) and pick(b, a) without writing this specific
+// test.
+func TestPick(t *testing.T) {
+	eid := func(id string) api.ExternalRepoSpec {
+		return api.ExternalRepoSpec{
+			ID:          id,
+			ServiceType: "fake",
+			ServiceID:   "https://fake.com",
+		}
+	}
+	a := &Repo{Name: "bar", ExternalRepo: eid("1")}
+	b := &Repo{Name: "bar", ExternalRepo: eid("2")}
+
+	for _, args := range [][2]*Repo{{a, b}, {b, a}} {
+		keep, discard := pick(args[0], args[1])
+		if keep != a || discard != b {
+			t.Errorf("unexpected pick(%v, %v)", args[0], args[1])
+		}
+	}
+}
+
 func formatJSON(t testing.TB, s string) string {
 	formatted, err := jsonc.Format(s, true, 2)
 	if err != nil {


### PR DESCRIPTION
The current implementation was not tested deterministically since which branch
we took depended on the order we iterated byID. This refactor makes it
deterministic and I believe improves readability.

Discussion: https://sourcegraph.slack.com/archives/C07KZF47K/p1559818667051900