### PR TITLE
Code nav: do not tokenize code views on Bitbucket

### DIFF
--- a/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -218,4 +218,5 @@ export const bitbucketServerCodeHost: CodeHost = {
         className: 'aui-button',
         iconClassName: 'aui-icon',
     },
+    codeViewsRequireTokenization: false,
 }

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -300,6 +300,7 @@ export function initCodeIntelligence({
             getHover: ({ line, character, part, ...rest }) => getHover({ ...rest, position: { line, character } }),
             getActions: context => getHoverActions({ extensionsController, platformContext }, context),
             pinningEnabled: true,
+            tokenize: codeHost.codeViewsRequireTokenization,
         }
     )
 
@@ -670,7 +671,12 @@ export function handleCodeHost({
             codeViewEvent.subscriptions.add(
                 hoverifier.hoverify({
                     dom: domFunctions,
-                    positionEvents: of(element).pipe(findPositionsFromEvents(domFunctions)),
+                    positionEvents: of(element).pipe(
+                        findPositionsFromEvents({
+                            domFunctions,
+                            tokenize: codeHost.codeViewsRequireTokenization !== false,
+                        })
+                    ),
                     resolveContext,
                     adjustPosition,
                 })

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -181,6 +181,11 @@ export interface CodeHost extends ApplyLinkPreviewOptions {
      * CSS classes for the completion widget to customize styling
      */
     completionWidgetClassProps?: CompletionWidgetClassProps
+
+    /**
+     * Whether or not code views need to be tokenized. Defaults to false.
+     */
+    codeViewsRequireTokenization?: boolean
 }
 
 export interface FileInfo {

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -351,4 +351,5 @@ export const githubCodeHost: CodeHost = {
             : ''
         return `https://${location.repoName}/blob/${rev}/${location.filePath}${fragment}`
     },
+    codeViewsRequireTokenization: true,
 }

--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -115,4 +115,5 @@ export const gitlabCodeHost: CodeHost = {
         actionItemPressedClassName: 'active',
         closeButtonClassName: 'btn',
     },
+    codeViewsRequireTokenization: true,
 }

--- a/browser/src/libs/phabricator/code_intelligence.ts
+++ b/browser/src/libs/phabricator/code_intelligence.ts
@@ -186,4 +186,5 @@ export const phabricatorCodeHost: CodeHost = {
     hoverOverlayClassProps: {
         actionItemClassName: 'button grey hover-overlay-action-item--phabricator',
     },
+    codeViewsRequireTokenization: true,
 }

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
   "dependencies": {
     "@sentry/browser": "^5.4.0",
     "@slimsag/react-shortcuts": "^1.2.1",
-    "@sourcegraph/codeintellify": "^6.1.0",
+    "@sourcegraph/codeintellify": "^6.2.0",
     "@sourcegraph/comlink": "^3.1.1-fork.3",
     "@sourcegraph/extension-api-classes": "^1.0.2",
     "@sourcegraph/extension-api-types": "link:packages/@sourcegraph/extension-api-types",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
   "dependencies": {
     "@sentry/browser": "^5.4.0",
     "@slimsag/react-shortcuts": "^1.2.1",
-    "@sourcegraph/codeintellify": "^6.2.0",
+    "@sourcegraph/codeintellify": "^6.2.1",
     "@sourcegraph/comlink": "^3.1.1-fork.3",
     "@sourcegraph/extension-api-classes": "^1.0.2",
     "@sourcegraph/extension-api-types": "link:packages/@sourcegraph/extension-api-types",

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -188,7 +188,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             hoverifier.hoverify({
                 positionEvents: this.codeViewElements.pipe(
                     filter(isDefined),
-                    findPositionsFromEvents({ domFunctions, tokenize: false })
+                    findPositionsFromEvents({ domFunctions })
                 ),
                 positionJumps: locationPositions.pipe(
                     withLatestFrom(this.codeViewElements, this.blobElements),

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -188,7 +188,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
             hoverifier.hoverify({
                 positionEvents: this.codeViewElements.pipe(
                     filter(isDefined),
-                    findPositionsFromEvents(domFunctions)
+                    findPositionsFromEvents({ domFunctions, tokenize: false })
                 ),
                 positionJumps: locationPositions.pipe(
                     withLatestFrom(this.codeViewElements, this.blobElements),

--- a/web/src/repo/compare/FileDiffHunks.tsx
+++ b/web/src/repo/compare/FileDiffHunks.tsx
@@ -100,7 +100,7 @@ export class FileDiffHunks extends React.Component<FileHunksProps, FileDiffHunks
                 dom: diffDomFunctions,
                 positionEvents: this.codeElements.pipe(
                     filter(isDefined),
-                    findPositionsFromEvents(diffDomFunctions)
+                    findPositionsFromEvents({ domFunctions: diffDomFunctions, tokenize: false })
                 ),
                 positionJumps: NEVER, // TODO support diff URLs
                 resolveContext: hoveredToken => {

--- a/web/src/repo/compare/FileDiffHunks.tsx
+++ b/web/src/repo/compare/FileDiffHunks.tsx
@@ -100,7 +100,7 @@ export class FileDiffHunks extends React.Component<FileHunksProps, FileDiffHunks
                 dom: diffDomFunctions,
                 positionEvents: this.codeElements.pipe(
                     filter(isDefined),
-                    findPositionsFromEvents({ domFunctions: diffDomFunctions, tokenize: false })
+                    findPositionsFromEvents({ domFunctions: diffDomFunctions })
                 ),
                 positionJumps: NEVER, // TODO support diff URLs
                 resolveContext: hoveredToken => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,10 +1466,10 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@sourcegraph/codeintellify@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.2.0.tgz#bd38bae38a79d0fdf2ed179b8e0dd475213fb071"
-  integrity sha512-bOZZnIpHQPo8MErLx8+uW2OaWnpO8VFxqrZ5QkoBAR5OnzjwfEcNp30/U1QXCXmtgR3DX1p7RQP2j3DYlZQbow==
+"@sourcegraph/codeintellify@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.2.1.tgz#426e638a68b8520bc6e742f6d38fb11a6bde2299"
+  integrity sha512-CfnBX2dYEZ8wqmdBFLtK4lLKNsjhe+gIh/fosBowWhEOjnWc2W82GA+Jrpr4GhXhaGdqVJ7br+l9PiNsFXAFRw==
   dependencies:
     "@sourcegraph/event-positions" "^1.0.2"
     "@sourcegraph/extension-api-types" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,10 +1466,10 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@sourcegraph/codeintellify@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.1.0.tgz#cf7b555c817e06d7c6be5137a79152c89b4d209c"
-  integrity sha512-5EbbZMpiNnxGWE4vLnYzstpxjNkCLArICjFbITeFEmnGRBZMllyHouqGkchl1GFk9zD+53ppUra+5c2VMGmVAQ==
+"@sourcegraph/codeintellify@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/codeintellify/-/codeintellify-6.2.0.tgz#bd38bae38a79d0fdf2ed179b8e0dd475213fb071"
+  integrity sha512-bOZZnIpHQPo8MErLx8+uW2OaWnpO8VFxqrZ5QkoBAR5OnzjwfEcNp30/U1QXCXmtgR3DX1p7RQP2j3DYlZQbow==
   dependencies:
     "@sourcegraph/event-positions" "^1.0.2"
     "@sourcegraph/extension-api-types" "^2.0.0"


### PR DESCRIPTION
Motivation: some code hosts have already tokenized the code view (e.g. Bitbucket). The tokenization currently prevents text selection from working on Bitbucket https://github.com/sourcegraph/sourcegraph/issues/4051

Implementation: this adds a boolean `codeViewsRequireTokenization` to the `CodeHost` interface, and passes it to codeintellify.

Depends on https://github.com/sourcegraph/codeintellify/pull/115

![2019-06-03 15 54 38](https://user-images.githubusercontent.com/1387653/59076684-8afec300-8894-11e9-89f5-eb939d062316.gif)

Test plan:

- Run Bitbucket locally
- Open a file
- Make sure text selections work

Fixes https://github.com/sourcegraph/sourcegraph/issues/4051

Slack conversation https://sourcegraph.slack.com/archives/CHXHX7XAS/p1559599129008000