### PR TITLE
graphqlbackend: Escape path in TreeEntry.url

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -30,18 +30,20 @@ func TestGitTree(t *testing.T) {
 	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &git.Commit{ID: exampleCommitSHA1})
 
 	git.Mocks.Stat = func(commit api.CommitID, path string) (os.FileInfo, error) {
-		if string(commit) != exampleCommitSHA1 || path != "/foo" {
+		if string(commit) != exampleCommitSHA1 || path != "foo bar" {
 			t.Error("wrong arguments to Stat")
 		}
 		return &util.FileInfo{Name_: "", Mode_: os.ModeDir}, nil
 	}
 	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error) {
-		if string(commit) != exampleCommitSHA1 || name != "/foo" {
+		if string(commit) != exampleCommitSHA1 || name != "foo bar" || recurse {
 			t.Error("wrong arguments to RepoTree.Get")
 		}
 		return []os.FileInfo{
 			&util.FileInfo{Name_: "testDirectory", Mode_: os.ModeDir},
+			&util.FileInfo{Name_: "Geoffrey's random queries.32r242442bf", Mode_: os.ModeDir},
 			&util.FileInfo{Name_: "testFile", Mode_: 0},
+			&util.FileInfo{Name_: "% token.4288249258.sql", Mode_: 0},
 		}, nil
 	}
 	defer git.ResetMocks()
@@ -53,12 +55,16 @@ func TestGitTree(t *testing.T) {
 				{
 					repository(name: "github.com/gorilla/mux") {
 						commit(rev: "` + exampleCommitSHA1 + `") {
-							tree(path: "/foo") {
+							tree(path: "foo bar") {
 								directories {
 									name
+									path
+									url
 								}
 								files {
 									name
+									path
+									url
 								}
 							}
 						}
@@ -66,20 +72,38 @@ func TestGitTree(t *testing.T) {
 				}
 			`,
 			ExpectedResult: `
-				{
-					"repository": {
-						"commit": {
-							"tree": {
-								"directories": [
-									{"name": "testDirectory"}
-								],
-								"files": [
-									{"name": "testFile"}
-								]
-							}
-						}
-					}
-				}
+{
+  "repository": {
+    "commit": {
+      "tree": {
+        "directories": [
+          {
+            "name": "Geoffrey's random queries.32r242442bf",
+            "path": "foo bar/Geoffrey's random queries.32r242442bf",
+            "url": "/github.com/gorilla/mux@1234567890123456789012345678901234567890/-/tree/foo%20bar/Geoffrey%27s%20random%20queries.32r242442bf"
+          },
+          {
+            "name": "testDirectory",
+            "path": "foo bar/testDirectory",
+            "url": "/github.com/gorilla/mux@1234567890123456789012345678901234567890/-/tree/foo%20bar/testDirectory"
+          }
+        ],
+        "files": [
+          {
+            "name": "% token.4288249258.sql",
+            "path": "foo bar/% token.4288249258.sql",
+            "url": "/github.com/gorilla/mux@1234567890123456789012345678901234567890/-/blob/foo%20bar/%25%20token.4288249258.sql"
+          },
+          {
+            "name": "testFile",
+            "path": "foo bar/testFile",
+            "url": "/github.com/gorilla/mux@1234567890123456789012345678901234567890/-/blob/foo%20bar/testFile"
+          }
+        ]
+      }
+    }
+  }
+}
 			`,
 		},
 	})

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,7 @@ golang.org/x/oauth2 v0.0.0-20190426200222-9f3314589c9a h1:nmml9VKepA01xC5LUDn/1v
 golang.org/x/oauth2 v0.0.0-20190426200222-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190602172753-aaccbc9213b0 h1:CXghSJpU62ldyURqmA7kvki7OVzr5HSC57FwWi3/b5E=
 golang.org/x/oauth2 v0.0.0-20190602172753-aaccbc9213b0/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190604060849-0f29369cfe45 h1:TCfob1wf79EYzd0A5DtY8Fqx7lOBHNwfRM+Gjlhy0Fw=
 golang.org/x/oauth2 v0.0.0-20190604060849-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -669,6 +670,8 @@ golang.org/x/sys v0.0.0-20190602172818-4c4f7f33c9ed h1:bgjqB+1ZPX+IeX5VubQLaMyCV
 golang.org/x/sys v0.0.0-20190602172818-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606131206-79a91cf218c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606171843-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606212808-7fc4e5ec1444 h1:gmKy/SaqFWnWO0RM/E9ox+LZ3G+Y2DK9BKb5uoox0pM=
 golang.org/x/sys v0.0.0-20190606212808-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
Test plan: unit and browsing locally github.com/ggilmore/q-test

Part of https://github.com/sourcegraph/sourcegraph/issues/4408