### PR TITLE
repo-updater: Only purge repos for 1 hour on saturday night

### DIFF
--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -53,12 +53,6 @@ var (
 		Name:      "purge_failed",
 		Help:      "Incremented each time we try and fail to remove a repository clone.",
 	})
-	purgeSkipped = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "src",
-		Subsystem: "repoupdater",
-		Name:      "purge_skipped",
-		Help:      "Incremented each time we skip a repository clone to remove.",
-	})
 
 	schedError = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "src",


### PR DESCRIPTION
We can remove the shouldKeep behaviour. We intentionally keep the 10min sleep
behaviour so we can run multiples times on Saturday night (in case of an
ephemeral error).

See the linked issue for motivation for this approach to purge repositories.

Part of https://github.com/sourcegraph/sourcegraph/issues/2572