### PR TITLE
authz: Bitbucket Server ACLs documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The `orgs` setting in [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github) allows admins to select all repositories from the specified organizations to be synced.
+- The `authorization` setting in the [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#permissions) enables Sourcegraph to enforce the repository permissions defined in Bitbucket Server.
 
 ### Changed
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -21,6 +21,12 @@ There are four fields for configuring which repositories are mirrored:
 - [`exclude`](bitbucket_server.md#configuration)<br>A list of repositories to exclude which takes precedence over the `repos`, and `repositoryQuery` fields.
 - ['excludePersonalRepositories'](bitbucket_server.md#configuration)<br>With this enabled, Sourcegraph will exclude any personal repositories from being imported, even if it has access to them.
 
+## Repository permissions
+
+By default, all Sourcegraph users can view all repositories. To configure Sourcegraph to use
+Bitbucket Server's repository permissions, see [Repository permissions](../repo/permissions.md#bitbucket_server).
+
+
 ### Authentication for older Bitbucket Server versions
 
 Bitbucket Server versions older than v5.5 require specifying a less secure username and password combination, as those versions of Bitbucket Server do not support [personal access tokens](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -2,7 +2,7 @@
 
 Sourcegraph can be configured to enforce repository permissions from code hosts.
 
-Currently, GitHub, GitHub Enterprise, and GitLab permissions are supported. Check the [roadmap](../../dev/roadmap.md) for plans to
+Currently, GitHub, GitHub Enterprise, GitLab and Bitbucket Server permissions are supported. Check the [roadmap](../../dev/roadmap.md) for plans to
 support other code hosts. If your desired code host is not yet on the roadmap, please [open a
 feature request](https://github.com/sourcegraph/sourcegraph/issues/new?template=feature_request.md).
 
@@ -99,3 +99,69 @@ because Sourcegraph usernames are mutable.
   }
 }
 ```
+
+## Bitbucket Server
+
+Enforcing Bitbucket Server permissions can be configured via the `authorization` setting in its external service configuration.
+
+#### Prerequisites
+
+1. You have the exact same user accounts, **with matching usernames**, in Sourcegraph and Bitbucket Server. This can be accomplished by configuring an [external authentication provider](../auth.md) that mirrors user accounts from a central directory like LDAP or Active Directory. The same should be done on Bitbucket Server with [external user directories](https://confluence.atlassian.com/bitbucketserver/external-user-directories-776640394.html).
+2. Ensure you have set `auth.enableUsernameChanges` to **`false`** in the [Critical site config](../config/critical_config.md) to prevent users from changing their usernames and **escalating their privileges**.
+
+
+#### Setup
+
+This section walks you through the process of setting up an *Application Link between Sourcegraph and Bitbucket Server* and configuring the Bitbucket External service with `authorization` settings. It assumes the above prerequisites are met.
+
+As an admin user, go to the "Application Links" page. You can use the sidebar navigation in the admin dashboard, or go directly to [https://bitbucketserver.mycorp.org/plugins/servlet/applinks/listApplicationLinks](https://bitbucketserver.mycorp.org/plugins/servlet/applinks/listApplicationLinks).
+
+<img src="https://imgur.com/Hg4bzOf.png" width="800">
+
+---
+
+Write Sourcegraph's external URL in the text area (e.g. `https://sourcegraph.mycorp.org`) and click **Create new link**. Click **Continue** even if Bitbucket Server warns you about the given URL not responding.
+
+<img src="https://imgur.com/x6vFKIL.png" width="800">
+
+---
+
+Write `Sourcegraph` as the *Application Name* and select `Generic Application` as the *Application Type*. Leave everything else unset and click **Continue**.
+
+<img src="https://imgur.com/161rbB9.png" width="800">
+
+---
+
+
+Now click the edit button in the `Sourcegraph` Application Link that you just created and select the `Incoming Authentication` panel.
+
+<img src="https://imgur.com/sMGmzhH.png" width="800">
+
+---
+
+
+Generate a *Consumer Key* in your terminal with `echo sourcegraph$(cat /dev/urandom | tr -dc "[:alnum:]" | head -c 32)`. Copy this command's output and paste it in the *Consumer Key* field. Write `Sourcegraph` in the *Consumer Name* field.
+
+<img src="https://imgur.com/1kK2Y5x.png" width="800">
+
+---
+
+Generate an RSA key pair in your terminal with `openssl genrsa -out sourcegraph.pem 4096 && openssl rsa -in sourcegraph.pem -pubout > sourcegraph.pub`. Copy the contents of `sourcegraph.pub` and paste them in the *Public Key* field.
+
+<img src="https://imgur.com/YHm1uSr.png" width="600">
+
+---
+
+Scroll to the bottom and check the *Allow 2-Legged OAuth* checkbox, then write your admin account's username in the *Execute as* field and, lastly, check the *Allow user impersonation through 2-Legged OAuth* checkbox. Press **Save**.
+
+<img src="https://imgur.com/1qxEAye.png" width="800">
+
+---
+
+Go to your Sourcegraph's external services page (i.e. `https://sourcegraph.mycorp.org/site-admin/external-services`) and either edit or create a new *Bitbucket Server* external service. Click on the *Enforce permissions* quick action on top of the configuration editor. Copy the *Consumer Key* you generated before to the `oauth.consumerKey` field and the output of the command `base64 -w0 sourcegraph.pem` to the `oauth.signingKey` field. Finally, **save the configuration**.
+
+<img src="https://imgur.com/ucetesA.png" width="800">
+
+---
+
+You're done! :tada:

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -104,13 +104,13 @@ because Sourcegraph usernames are mutable.
 
 Enforcing Bitbucket Server permissions can be configured via the `authorization` setting in its external service configuration.
 
-#### Prerequisites
+### Prerequisites
 
 1. You have the exact same user accounts, **with matching usernames**, in Sourcegraph and Bitbucket Server. This can be accomplished by configuring an [external authentication provider](../auth.md) that mirrors user accounts from a central directory like LDAP or Active Directory. The same should be done on Bitbucket Server with [external user directories](https://confluence.atlassian.com/bitbucketserver/external-user-directories-776640394.html).
 2. Ensure you have set `auth.enableUsernameChanges` to **`false`** in the [Critical site config](../config/critical_config.md) to prevent users from changing their usernames and **escalating their privileges**.
 
 
-#### Setup
+### Setup
 
 This section walks you through the process of setting up an *Application Link between Sourcegraph and Bitbucket Server* and configuring the Bitbucket External service with `authorization` settings. It assumes the above prerequisites are met.
 
@@ -140,7 +140,7 @@ Now click the edit button in the `Sourcegraph` Application Link that you just cr
 ---
 
 
-Generate a *Consumer Key* in your terminal with `echo sourcegraph$(cat /dev/urandom | tr -dc "[:alnum:]" | head -c 32)`. Copy this command's output and paste it in the *Consumer Key* field. Write `Sourcegraph` in the *Consumer Name* field.
+Generate a *Consumer Key* in your terminal with `echo sourcegraph$(openssl rand -hex 16)`. Copy this command's output and paste it in the *Consumer Key* field. Write `Sourcegraph` in the *Consumer Name* field.
 
 <img src="https://imgur.com/1kK2Y5x.png" width="800">
 
@@ -158,7 +158,7 @@ Scroll to the bottom and check the *Allow 2-Legged OAuth* checkbox, then write y
 
 ---
 
-Go to your Sourcegraph's external services page (i.e. `https://sourcegraph.mycorp.org/site-admin/external-services`) and either edit or create a new *Bitbucket Server* external service. Click on the *Enforce permissions* quick action on top of the configuration editor. Copy the *Consumer Key* you generated before to the `oauth.consumerKey` field and the output of the command `base64 -w0 sourcegraph.pem` to the `oauth.signingKey` field. Finally, **save the configuration**.
+Go to your Sourcegraph's external services page (i.e. `https://sourcegraph.mycorp.org/site-admin/external-services`) and either edit or create a new *Bitbucket Server* external service. Click on the *Enforce permissions* quick action on top of the configuration editor. Copy the *Consumer Key* you generated before to the `oauth.consumerKey` field and the output of the command `base64 sourcegraph.pem | tr -d '\n'` to the `oauth.signingKey` field. Finally, **save the configuration**.
 
 <img src="https://imgur.com/ucetesA.png" width="800">
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -148,7 +148,7 @@ Generate a *Consumer Key* in your terminal with `echo sourcegraph$(cat /dev/uran
 
 Generate an RSA key pair in your terminal with `openssl genrsa -out sourcegraph.pem 4096 && openssl rsa -in sourcegraph.pem -pubout > sourcegraph.pub`. Copy the contents of `sourcegraph.pub` and paste them in the *Public Key* field.
 
-<img src="https://imgur.com/YHm1uSr.png" width="600">
+<img src="https://imgur.com/YHm1uSr.png" width="800">
 
 ---
 

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -5,11 +5,18 @@ You can use Sourcegraph with Git repositories hosted on [Bitbucket Server](https
 Feature | Supported?
 ------- | ----------
 [Repository syncing](../admin/external_service/bitbucket_server.md) | ✅
+[Repository permissions](../admin/external_service/bitbucket_server.md#repository-permissions) | ✅
 [Browser extension](#browser-extension) | ✅
 
 ## Repository syncing
 
 Site admins can [add Bitbucket Server repositories to Sourcegraph](../admin/external_service/bitbucket_server.md).
+
+## Repository permissions
+
+Site admins can [configure Sourcegraph to respect Bitbucket Server's repository access permissions](../admin/external_service/bitbucket_server.md#repository-permissions).
+
+[Browser extension](#browser-extension) | ✅
 
 ## Browser extension
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -35,10 +35,24 @@ func NewProvider(cli *bitbucketserver.Client) *Provider {
 	}
 }
 
-func (p *Provider) Validate() []string  { return nil }
-func (p *Provider) ServiceID() string   { return p.codeHost.ServiceID }
+// Validate validates that the Provider has access to the Bitbucket Server API
+// with the OAuth credentials it was configured with.
+func (p *Provider) Validate() []string {
+	_, err := p.client.UserPermissions(context.Background(), p.client.Username)
+	if err != nil {
+		return []string{err.Error()}
+	}
+	return nil
+}
+
+// ServiceID returns the absolute URL that identifies the Bitbucket Server instance
+// this provider is configured with.
+func (p *Provider) ServiceID() string { return p.codeHost.ServiceID }
+
+// ServiceType returns the type of this Provider, namely, "bitbucketServer".
 func (p *Provider) ServiceType() string { return p.codeHost.ServiceType }
 
+// Repos returns all Bitbucket Server repos as mine, and all others as others.
 func (p *Provider) Repos(ctx context.Context, repos map[authz.Repo]struct{}) (mine map[authz.Repo]struct{}, others map[authz.Repo]struct{}) {
 	return authz.GetCodeHostRepos(p.codeHost, repos)
 }

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
@@ -38,10 +39,14 @@ func NewProvider(cli *bitbucketserver.Client) *Provider {
 // Validate validates that the Provider has access to the Bitbucket Server API
 // with the OAuth credentials it was configured with.
 func (p *Provider) Validate() []string {
-	_, err := p.client.UserPermissions(context.Background(), p.client.Username)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := p.client.UserPermissions(ctx, p.client.Username)
 	if err != nil {
 		return []string{err.Error()}
 	}
+
 	return nil
 }
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -33,7 +33,7 @@ func TestProvider_Validate(t *testing.T) {
 			name:   "problems-when-authenticated-as-non-admin",
 			client: func(c *bitbucketserver.Client) { c.Oauth = nil },
 			problems: []string{
-				"unexpected 401 response from BitBucket Server REST API at http://127.0.0.1:7990/rest/api/1.0/admin/permissions/users?filter=",
+				`Bitbucket API HTTP error: code=401 url="http://127.0.0.1:7990/rest/api/1.0/admin/permissions/users?filter=" body="{\"errors\":[{\"context\":null,\"message\":\"You are not permitted to access this resource\",\"exceptionName\":\"com.atlassian.bitbucket.AuthorisationException\"}]}"`,
 			},
 		},
 	} {

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -20,6 +20,39 @@ import (
 
 var update = flag.Bool("update", false, "update testdata")
 
+func TestProvider_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		client   func(*bitbucketserver.Client)
+		problems []string
+	}{
+		{
+			name: "no-problems-when-authenticated-as-admin",
+		},
+		{
+			name:   "problems-when-authenticated-as-non-admin",
+			client: func(c *bitbucketserver.Client) { c.Oauth = nil },
+			problems: []string{
+				"unexpected 401 response from BitBucket Server REST API at http://127.0.0.1:7990/rest/api/1.0/admin/permissions/users?filter=",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, save := newProvider(t, "Validate/"+tc.name)
+			defer save()
+
+			if tc.client != nil {
+				tc.client(p.client)
+			}
+
+			problems := p.Validate()
+			if have, want := problems, tc.problems; !reflect.DeepEqual(have, want) {
+				t.Error(cmp.Diff(have, want))
+			}
+		})
+	}
+}
+
 func TestProvider_RepoPerms(t *testing.T) {
 	p, save := newProvider(t, "RepoPerms")
 	defer save()
@@ -384,13 +417,18 @@ func (h codeHost) externalAccount(userID int32, u *bitbucketserver.User) *extsvc
 func newProvider(t *testing.T, name string) (*Provider, func()) {
 	cli, save := bitbucketserver.NewTestClient(t, name, *update)
 
-	key := os.Getenv("BITBUCKET_SERVER_KEY")
-	if key == "" {
+	signingKey := os.Getenv("BITBUCKET_SERVER_SIGNING_KEY")
+	if signingKey == "" {
 		// Bogus key
-		key = `LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBUEpIaWprdG1UMUlLYUd0YTVFZXAzQVo5Q2VPZUw4alBESUZUN3dRZ0tabXQzRUZxRGhCCk93bitRVUhKdUs5Zm92UkROSmVWTDJvWTVCT0l6NHJ3L0cwQ0F3RUFBUUpCQU1BK0o5Mks0d2NQVllsbWMrM28KcHU5NmlKTkNwMmp5Nm5hK1pEQlQzK0VvSUo1VFJGdnN3R2kvTHUzZThYUWwxTDNTM21ub0xPSlZNcTF0bUxOMgpIY0VDSVFEK3daeS83RlYxUEFtdmlXeWlYVklETzJnNWJOaUJlbmdKQ3hFa3Nia1VtUUloQVBOMlZaczN6UFFwCk1EVG9vTlJXcnl0RW1URERkamdiOFpzTldYL1JPRGIxQWlCZWNKblNVQ05TQllLMXJ5VTFmNURTbitoQU9ZaDkKWDFBMlVnTDE3bWhsS1FJaEFPK2JMNmRDWktpTGZORWxmVnRkTUtxQnFjNlBIK01heFU2VzlkVlFvR1dkQWlFQQptdGZ5cE9zYTFiS2hFTDg0blovaXZFYkJyaVJHalAya3lERHYzUlg0V0JrPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
+		signingKey = `LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBUEpIaWprdG1UMUlLYUd0YTVFZXAzQVo5Q2VPZUw4alBESUZUN3dRZ0tabXQzRUZxRGhCCk93bitRVUhKdUs5Zm92UkROSmVWTDJvWTVCT0l6NHJ3L0cwQ0F3RUFBUUpCQU1BK0o5Mks0d2NQVllsbWMrM28KcHU5NmlKTkNwMmp5Nm5hK1pEQlQzK0VvSUo1VFJGdnN3R2kvTHUzZThYUWwxTDNTM21ub0xPSlZNcTF0bUxOMgpIY0VDSVFEK3daeS83RlYxUEFtdmlXeWlYVklETzJnNWJOaUJlbmdKQ3hFa3Nia1VtUUloQVBOMlZaczN6UFFwCk1EVG9vTlJXcnl0RW1URERkamdiOFpzTldYL1JPRGIxQWlCZWNKblNVQ05TQllLMXJ5VTFmNURTbitoQU9ZaDkKWDFBMlVnTDE3bWhsS1FJaEFPK2JMNmRDWktpTGZORWxmVnRkTUtxQnFjNlBIK01heFU2VzlkVlFvR1dkQWlFQQptdGZ5cE9zYTFiS2hFTDg0blovaXZFYkJyaVJHalAya3lERHYzUlg0V0JrPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
 	}
 
-	if err := cli.SetOAuth("sourcegraph", key); err != nil {
+	consumerKey := os.Getenv("BITBUCKET_SERVER_CONSUMER_KEY")
+	if consumerKey == "" {
+		consumerKey = "sourcegraph"
+	}
+
+	if err := cli.SetOAuth(consumerKey, signingKey); err != nil {
 		t.Fatal(err)
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/testdata/vcr/RepoPerms.yaml
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/testdata/vcr/RepoPerms.yaml
@@ -7,72 +7,6 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer1
-    method: GET
-  response:
-    body: '{"name":"engineer1","emailAddress":"engineer1@mycorp.com","id":3,"displayName":"Mr.
-      Engineer 1","active":true,"slug":"engineer1","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer1"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache, no-transform
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
-      Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
-      X-Arequestid:
-      - '@U33524x915x1698x0'
-      X-Asen:
-      - SEN-L13737326
-      X-Auserid:
-      - "1"
-      X-Ausername:
-      - admin
-      X-Content-Type-Options:
-      - nosniff
-    status: '200 '
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer2
-    method: GET
-  response:
-    body: '{"name":"engineer2","emailAddress":"engineer2@mycorp.com","id":4,"displayName":"Mr.
-      Engineer 2","active":true,"slug":"engineer2","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer2"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache, no-transform
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
-      Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
-      X-Arequestid:
-      - '@U33524x915x1699x0'
-      X-Asen:
-      - SEN-L13737326
-      X-Auserid:
-      - "1"
-      X-Ausername:
-      - admin
-      X-Content-Type-Options:
-      - nosniff
-    status: '200 '
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
     url: http://127.0.0.1:7990/rest/api/1.0/users/scientist
     method: GET
   response:
@@ -84,13 +18,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1700x0'
+      - '@180MHBDx773x412x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -117,13 +51,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1701x0'
+      - '@180MHBDx773x413x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -139,23 +73,24 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/admin/groups?filter=engineers
+    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer1
     method: GET
   response:
-    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"name":"engineers","deletable":true}],"start":0}'
+    body: '{"name":"engineer1","emailAddress":"engineer1@mycorp.com","id":3,"displayName":"Mr.
+      Engineer 1","active":true,"slug":"engineer1","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer1"}]}}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1702x0'
+      - '@180MHBDx773x414x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -171,23 +106,24 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/admin/groups?filter=scientists
+    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer2
     method: GET
   response:
-    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"name":"scientists","deletable":true}],"start":0}'
+    body: '{"name":"engineer2","emailAddress":"engineer2@mycorp.com","id":4,"displayName":"Mr.
+      Engineer 2","active":true,"slug":"engineer2","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer2"}]}}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1703x0'
+      - '@180MHBDx773x415x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -213,13 +149,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1704x0'
+      - '@180MHBDx773x416x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -245,13 +181,77 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1705x0'
+      - '@180MHBDx773x417x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - admin
+      X-Content-Type-Options:
+      - nosniff
+    status: '200 '
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: http://127.0.0.1:7990/rest/api/1.0/admin/groups?filter=engineers
+    method: GET
+  response:
+    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"name":"engineers","deletable":true}],"start":0}'
+    headers:
+      Cache-Control:
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 11 Jun 2019 12:53:27 GMT
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@180MHBDx773x418x0'
+      X-Asen:
+      - SEN-14109642
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - admin
+      X-Content-Type-Options:
+      - nosniff
+    status: '200 '
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: http://127.0.0.1:7990/rest/api/1.0/admin/groups?filter=scientists
+    method: GET
+  response:
+    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"name":"scientists","deletable":true}],"start":0}'
+    headers:
+      Cache-Control:
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 11 Jun 2019 12:53:27 GMT
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@180MHBDx773x419x0'
+      X-Asen:
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -277,13 +277,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1706x0'
+      - '@180MHBDx773x420x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -309,13 +309,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1707x0'
+      - '@180MHBDx773x421x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -341,13 +341,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1708x0'
+      - '@180MHBDx773x422x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -373,13 +373,45 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1709x0'
+      - '@180MHBDx773x423x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - admin
+      X-Content-Type-Options:
+      - nosniff
+    status: '200 '
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: http://127.0.0.1:7990/rest/api/1.0/projects/PRIVATE/repos/private-repo
+    method: GET
+  response:
+    body: '{"slug":"private-repo","id":3,"name":"private-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"PRIVATE","id":3,"name":"Private","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/PRIVATE"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@127.0.0.1:7999/private/private-repo.git","name":"ssh"},{"href":"http://127.0.0.1:7990/scm/private/private-repo.git","name":"http"}],"self":[{"href":"http://127.0.0.1:7990/projects/PRIVATE/repos/private-repo/browse"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 11 Jun 2019 12:53:27 GMT
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@180MHBDx773x424x0'
+      X-Asen:
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -398,20 +430,20 @@ interactions:
     url: http://127.0.0.1:7990/rest/api/1.0/projects/SECRET/repos/secret-repo
     method: GET
   response:
-    body: '{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"},{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}'
+    body: '{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1710x0'
+      - '@180MHBDx773x425x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -438,13 +470,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1711x0'
+      - '@180MHBDx773x426x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -470,45 +502,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1712x0'
+      - '@180MHBDx773x427x0'
       X-Asen:
-      - SEN-L13737326
-      X-Auserid:
-      - "1"
-      X-Ausername:
-      - admin
-      X-Content-Type-Options:
-      - nosniff
-    status: '200 '
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/projects/PRIVATE/repos/private-repo
-    method: GET
-  response:
-    body: '{"slug":"private-repo","id":3,"name":"private-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"PRIVATE","id":3,"name":"Private","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/PRIVATE"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@127.0.0.1:7999/private/private-repo.git","name":"ssh"},{"href":"http://127.0.0.1:7990/scm/private/private-repo.git","name":"http"}],"self":[{"href":"http://127.0.0.1:7990/projects/PRIVATE/repos/private-repo/browse"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache, no-transform
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
-      Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
-      X-Arequestid:
-      - '@U33524x915x1713x0'
-      X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -534,15 +534,15 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@U33524x915x1714x0'
+      - '@180MHBDx773x428x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -568,15 +568,15 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@U33524x915x1715x0'
+      - '@180MHBDx773x429x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -602,15 +602,15 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@U33524x915x1716x0'
+      - '@180MHBDx773x430x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -636,15 +636,15 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@U33524x915x1717x0'
+      - '@180MHBDx773x431x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -670,15 +670,15 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@U33524x915x1718x0'
+      - '@180MHBDx773x432x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -704,15 +704,15 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@U33524x915x1719x0'
+      - '@180MHBDx773x433x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -738,15 +738,15 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@U33524x915x1720x0'
+      - '@180MHBDx773x434x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -772,13 +772,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1721x0'
+      - '@180MHBDx773x435x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "1"
       X-Ausername:
@@ -804,13 +804,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1722x0'
+      - '@180MHBDx773x436x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "3"
       X-Ausername:
@@ -836,13 +836,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1723x0'
+      - '@180MHBDx773x437x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "3"
       X-Ausername:
@@ -861,20 +861,20 @@ interactions:
     url: http://127.0.0.1:7990/rest/api/1.0/repos?limit=1&start=2&user_id=engineer1
     method: GET
   response:
-    body: '{"size":1,"limit":1,"isLastPage":true,"values":[{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"},{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}],"start":2}'
+    body: '{"size":1,"limit":1,"isLastPage":true,"values":[{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}],"start":2}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1724x0'
+      - '@180MHBDx773x438x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "3"
       X-Ausername:
@@ -900,13 +900,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1725x0'
+      - '@180MHBDx773x439x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "4"
       X-Ausername:
@@ -932,13 +932,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1726x0'
+      - '@180MHBDx773x440x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "4"
       X-Ausername:
@@ -964,13 +964,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1727x0'
+      - '@180MHBDx773x441x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "2"
       X-Ausername:
@@ -996,13 +996,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1728x0'
+      - '@180MHBDx773x442x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "2"
       X-Ausername:
@@ -1021,20 +1021,20 @@ interactions:
     url: http://127.0.0.1:7990/rest/api/1.0/repos?limit=1&start=2&user_id=scientist
     method: GET
   response:
-    body: '{"size":1,"limit":1,"isLastPage":true,"values":[{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"},{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}],"start":2}'
+    body: '{"size":1,"limit":1,"isLastPage":true,"values":[{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}],"start":2}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1729x0'
+      - '@180MHBDx773x443x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "2"
       X-Ausername:
@@ -1060,13 +1060,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1730x0'
+      - '@180MHBDx773x444x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "5"
       X-Ausername:
@@ -1092,13 +1092,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1731x0'
+      - '@180MHBDx773x445x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "5"
       X-Ausername:
@@ -1117,20 +1117,20 @@ interactions:
     url: http://127.0.0.1:7990/rest/api/1.0/repos?limit=1&start=2&user_id=ceo
     method: GET
   response:
-    body: '{"size":1,"limit":1,"isLastPage":false,"values":[{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"},{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}],"start":2,"nextPageStart":3}'
+    body: '{"size":1,"limit":1,"isLastPage":false,"values":[{"slug":"secret-repo","id":1,"name":"secret-repo","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":false,"project":{"key":"SECRET","id":1,"name":"Secret","public":false,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/SECRET"}]}},"public":false,"links":{"clone":[{"href":"http://127.0.0.1:7990/scm/secret/secret-repo.git","name":"http"},{"href":"ssh://git@127.0.0.1:7999/secret/secret-repo.git","name":"ssh"}],"self":[{"href":"http://127.0.0.1:7990/projects/SECRET/repos/secret-repo/browse"}]}}],"start":2,"nextPageStart":3}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1732x0'
+      - '@180MHBDx773x446x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "5"
       X-Ausername:
@@ -1157,13 +1157,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Sat, 08 Jun 2019 15:15:37 GMT
+      - Tue, 11 Jun 2019 12:53:28 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@U33524x915x1733x0'
+      - '@180MHBDx773x447x0'
       X-Asen:
-      - SEN-L13737326
+      - SEN-14109642
       X-Auserid:
       - "5"
       X-Ausername:

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/testdata/vcr/Validate-no-problems-when-authenticated-as-admin.yaml
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/testdata/vcr/Validate-no-problems-when-authenticated-as-admin.yaml
@@ -7,72 +7,6 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer1
-    method: GET
-  response:
-    body: '{"name":"engineer1","emailAddress":"engineer1@mycorp.com","id":3,"displayName":"Mr.
-      Engineer 1","active":true,"slug":"engineer1","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer1"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache, no-transform
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
-      Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
-      X-Arequestid:
-      - '@180MHBDx773x448x0'
-      X-Asen:
-      - SEN-14109642
-      X-Auserid:
-      - "1"
-      X-Ausername:
-      - admin
-      X-Content-Type-Options:
-      - nosniff
-    status: '200 '
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer2
-    method: GET
-  response:
-    body: '{"name":"engineer2","emailAddress":"engineer2@mycorp.com","id":4,"displayName":"Mr.
-      Engineer 2","active":true,"slug":"engineer2","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer2"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache, no-transform
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
-      Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
-      X-Arequestid:
-      - '@180MHBDx773x449x0'
-      X-Asen:
-      - SEN-14109642
-      X-Auserid:
-      - "1"
-      X-Ausername:
-      - admin
-      X-Content-Type-Options:
-      - nosniff
-    status: '200 '
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
     url: http://127.0.0.1:7990/rest/api/1.0/users/scientist
     method: GET
   response:
@@ -84,11 +18,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x450x0'
+      - '@180MHBDx773x388x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -117,11 +51,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x451x0'
+      - '@180MHBDx773x389x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -139,21 +73,55 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/admin/groups?filter=management
+    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer1
     method: GET
   response:
-    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"name":"management","deletable":true}],"start":0}'
+    body: '{"name":"engineer1","emailAddress":"engineer1@mycorp.com","id":3,"displayName":"Mr.
+      Engineer 1","active":true,"slug":"engineer1","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer1"}]}}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x452x0'
+      - '@180MHBDx773x390x0'
+      X-Asen:
+      - SEN-14109642
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - admin
+      X-Content-Type-Options:
+      - nosniff
+    status: '200 '
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: http://127.0.0.1:7990/rest/api/1.0/users/engineer2
+    method: GET
+  response:
+    body: '{"name":"engineer2","emailAddress":"engineer2@mycorp.com","id":4,"displayName":"Mr.
+      Engineer 2","active":true,"slug":"engineer2","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/engineer2"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 11 Jun 2019 12:53:27 GMT
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@180MHBDx773x391x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -181,11 +149,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x453x0'
+      - '@180MHBDx773x392x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -213,11 +181,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x454x0'
+      - '@180MHBDx773x393x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -245,11 +213,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x455x0'
+      - '@180MHBDx773x394x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -267,21 +235,21 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/projects/PUBLIC
+    url: http://127.0.0.1:7990/rest/api/1.0/admin/groups?filter=management
     method: GET
   response:
-    body: '{"key":"PUBLIC","id":4,"name":"Public","public":true,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/PUBLIC"}]}}'
+    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"name":"management","deletable":true}],"start":0}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x456x0'
+      - '@180MHBDx773x395x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -309,11 +277,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x457x0'
+      - '@180MHBDx773x396x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -341,11 +309,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x458x0'
+      - '@180MHBDx773x397x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -373,11 +341,43 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x459x0'
+      - '@180MHBDx773x398x0'
+      X-Asen:
+      - SEN-14109642
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - admin
+      X-Content-Type-Options:
+      - nosniff
+    status: '200 '
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: http://127.0.0.1:7990/rest/api/1.0/projects/PUBLIC
+    method: GET
+  response:
+    body: '{"key":"PUBLIC","id":4,"name":"Public","public":true,"type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/projects/PUBLIC"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 11 Jun 2019 12:53:27 GMT
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@180MHBDx773x399x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -405,11 +405,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x460x0'
+      - '@180MHBDx773x400x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -438,11 +438,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x461x0'
+      - '@180MHBDx773x401x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -470,11 +470,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x462x0'
+      - '@180MHBDx773x402x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -502,11 +502,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x463x0'
+      - '@180MHBDx773x403x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -534,13 +534,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@180MHBDx773x464x0'
+      - '@180MHBDx773x404x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -568,13 +568,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@180MHBDx773x465x0'
+      - '@180MHBDx773x405x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -602,13 +602,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@180MHBDx773x466x0'
+      - '@180MHBDx773x406x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -636,13 +636,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@180MHBDx773x467x0'
+      - '@180MHBDx773x407x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -670,13 +670,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@180MHBDx773x468x0'
+      - '@180MHBDx773x408x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -704,13 +704,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@180MHBDx773x469x0'
+      - '@180MHBDx773x409x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -738,13 +738,13 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - X-AUSERNAME
       - X-AUSERID
       - Cookie
       X-Arequestid:
-      - '@180MHBDx773x470x0'
+      - '@180MHBDx773x410x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:
@@ -762,54 +762,21 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/users?filter=john&limit=1
+    url: http://127.0.0.1:7990/rest/api/1.0/admin/permissions/users?filter=
     method: GET
   response:
-    body: '{"size":0,"limit":1,"isLastPage":true,"values":[],"start":0}'
+    body: '{"size":1,"limit":25,"isLastPage":true,"values":[{"user":{"name":"admin","emailAddress":"tomas@sourcegraph.com","id":1,"displayName":"Admin","active":true,"slug":"admin","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/admin"}]}},"permission":"SYS_ADMIN"}],"start":0}'
     headers:
       Cache-Control:
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
+      - Tue, 11 Jun 2019 12:53:27 GMT
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@180MHBDx773x471x0'
-      X-Asen:
-      - SEN-14109642
-      X-Auserid:
-      - "1"
-      X-Ausername:
-      - admin
-      X-Content-Type-Options:
-      - nosniff
-    status: '200 '
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    url: http://127.0.0.1:7990/rest/api/1.0/users?filter=ceo&limit=1
-    method: GET
-  response:
-    body: '{"size":1,"limit":1,"isLastPage":true,"values":[{"name":"ceo","emailAddress":"ceo@mycorp.com","id":5,"displayName":"Mrs.
-      CEO","active":true,"slug":"ceo","type":"NORMAL","links":{"self":[{"href":"http://127.0.0.1:7990/users/ceo"}]}}],"start":0}'
-    headers:
-      Cache-Control:
-      - no-cache, no-transform
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 11 Jun 2019 12:53:28 GMT
-      Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
-      X-Arequestid:
-      - '@180MHBDx773x472x0'
+      - '@180MHBDx773x411x0'
       X-Asen:
       - SEN-14109642
       X-Auserid:

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/testdata/vcr/Validate-problems-when-authenticated-as-non-admin.yaml
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/testdata/vcr/Validate-problems-when-authenticated-as-non-admin.yaml
@@ -1,0 +1,34 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: http://127.0.0.1:7990/rest/api/1.0/admin/permissions/users?filter=
+    method: GET
+  response:
+    body: '{"errors":[{"context":null,"message":"You are not permitted to access this
+      resource","exceptionName":"com.atlassian.bitbucket.AuthorisationException"}]}'
+    headers:
+      Cache-Control:
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 11 Jun 2019 13:00:11 GMT
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      Www-Authenticate:
+      - OAuth realm="http%3A%2F%2F127.0.0.1%3A7990"
+      X-Arequestid:
+      - '@180MHBDx780x572x0'
+      X-Asen:
+      - SEN-14109642
+      X-Content-Type-Options:
+      - nosniff
+    status: '401 '
+    code: 401
+    duration: ""

--- a/pkg/extsvc/bitbucketserver/client.go
+++ b/pkg/extsvc/bitbucketserver/client.go
@@ -69,7 +69,7 @@ type Client struct {
 
 	// OAuth client used to authenticate requests, if set via SetOAuth.
 	// Takes precedence over Token and Username / Password authentication.
-	oauth *oauth.Client
+	Oauth *oauth.Client
 }
 
 // NewClient returns a new Bitbucket Server API client at url. If a nil
@@ -115,7 +115,7 @@ func (c *Client) SetOAuth(consumerKey, signingKey string) error {
 		return err
 	}
 
-	c.oauth = &oauth.Client{
+	c.Oauth = &oauth.Client{
 		Credentials:     oauth.Credentials{Token: consumerKey},
 		PrivateKey:      key,
 		SignatureMethod: oauth.RSASHA1,
@@ -239,6 +239,36 @@ func (c *Client) Users(ctx context.Context, pageToken *PageToken, fs ...UserFilt
 	var users []*User
 	next, err := c.page(ctx, "rest/api/1.0/users", qry, pageToken, &users)
 	return users, next, err
+}
+
+// UserPermissions retrieves the global permissions assigned to the user with the given
+// username. Used to validate that the client is authenticated as an admin.
+func (c *Client) UserPermissions(ctx context.Context, username string) (perms []Perm, _ error) {
+	qry := url.Values{"filter": {username}}
+
+	type permission struct {
+		User       *User `json:"user"`
+		Permission Perm  `json:"permission"`
+	}
+
+	var ps []permission
+	err := c.send(ctx, "GET", "rest/api/1.0/admin/permissions/users", qry, nil, &struct {
+		Values []permission `json:"values"`
+	}{
+		Values: ps,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range ps {
+		if p.User.Name == username {
+			perms = append(perms, p.Permission)
+		}
+	}
+
+	return perms, nil
 }
 
 // CreateUser creates the given User returning an error in case of failure.
@@ -470,14 +500,14 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 
 func (c *Client) authenticate(req *http.Request) error {
 	// Authenticate request, in order of preference.
-	if c.oauth != nil {
+	if c.Oauth != nil {
 		if c.Username != "" {
 			qry := req.URL.Query()
 			qry.Set("user_id", c.Username)
 			req.URL.RawQuery = qry.Encode()
 		}
 
-		if err := c.oauth.SetAuthorizationHeader(
+		if err := c.Oauth.SetAuthorizationHeader(
 			req.Header,
 			&oauth.Credentials{Token: ""}, // Token must be empty
 			req.Method,

--- a/pkg/extsvc/bitbucketserver/client.go
+++ b/pkg/extsvc/bitbucketserver/client.go
@@ -129,7 +129,7 @@ func (c *Client) SetOAuth(consumerKey, signingKey string) error {
 // Application Link in Bitbucket Server is configured to allow user impersonation,
 // returning an error otherwise.
 func (c *Client) Sudo(username string) (*Client, error) {
-	if c.oauth == nil {
+	if c.Oauth == nil {
 		return nil, errors.New("bitbucketserver.Client: OAuth not configured")
 	}
 

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -405,6 +405,24 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
                     return { edits, selectText: value }
                 },
             },
+            {
+                id: 'enablePermissions',
+                label: 'Enforce permissions',
+                run: config => {
+                    const value = {
+                        COMMENT_SENTINEL: true,
+                        identityProvider: { type: 'username' },
+                        oauth: {
+                            consumerKey: '<consumer key>',
+                            signingKey: '<signing key>',
+                        },
+                        ttl: '5m',
+                    }
+                    const comment = `// Follow setup instructions in https://docs.sourcegraph.com/admin/repo/permissions#bitbucket_server`
+                    const edit = editWithComment(config, ['authorization'], value, comment)
+                    return { edits: [edit], selectText: comment }
+                },
+            },
         ],
     },
     [GQL.ExternalServiceKind.GITLAB]: {


### PR DESCRIPTION
This PR adds documentation of, and a few code changes to, the Bitbucket Server ACLs feature, including the CHANGELOG.

Test plan:

I'd like to have reviewers follow the documentation that is added in this PR.

1. Check-out this branch locally and run `./enterprise/dev/start.sh`.
2. Follow the docs to setup Bitbucket Server authorization.
3. Validate that it works as expected (i.e. Sourcegraph enforces permissions defined in Bitbucket Server) 
