### PR TITLE
Faster Webpack builds

### DIFF
--- a/web/gulpfile.ts
+++ b/web/gulpfile.ts
@@ -11,9 +11,6 @@ const WEBPACK_STATS_OPTIONS: Stats.ToStringOptions & { colors?: boolean } = {
     timings: true,
     errors: true,
     warnings: true,
-    warningsFilter: warning =>
-        // This is intended, so ignore warning
-        /node_modules\/monaco-editor\/.*\/editorSimpleWorker.js.*\n.*dependency is an expression/.test(warning),
     colors: true,
 }
 const logWebpackStats = (stats: Stats) => log(stats.toString(WEBPACK_STATS_OPTIONS))

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -45,6 +45,8 @@ import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
 
+import './SourcegraphWebApp.scss'
+
 export interface SourcegraphWebAppProps extends KeybindingsProps {
     exploreSections: ReadonlyArray<ExploreSectionDescriptor>
     extensionAreaRoutes: ReadonlyArray<ExtensionAreaRoute>

--- a/web/src/util/empty.css
+++ b/web/src/util/empty.css
@@ -1,0 +1,10 @@
+/*
+This CSS file is intentionally empty in development mode.
+
+In production mode, we use https://github.com/webpack-contrib/mini-css-extract-plugin to extract CSS
+to a separate CSS file for better caching and faster client rendering.
+
+In development, we do NOT use mini-css-extract-plugin because it slows down Webpack (initial builds
+by ~5s and incremental reloads by ~2s). To avoid the browser console log reporting noisy 404s, this
+empty file is used as the Webpack style entrypoint.
+*/

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -59,6 +59,14 @@ const config: webpack.Configuration = {
                 },
             }),
         ],
+
+        ...(mode === 'development'
+            ? {
+                  removeAvailableModules: false,
+                  removeEmptyChunks: false,
+                  splitChunks: false,
+              }
+            : {}),
     },
     entry: {
         // Enterprise vs. OSS builds use different entrypoints. For app (TypeScript), a single entrypoint is used

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -11,7 +11,7 @@ import TerserPlugin from 'terser-webpack-plugin'
 import * as webpack from 'webpack'
 
 const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
-console.log('Using mode', mode)
+console.error('Using mode', mode)
 
 const devtool = mode === 'production' ? 'source-map' : 'cheap-module-eval-source-map'
 

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -5,8 +5,6 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin'
 import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin'
 import * as path from 'path'
-// @ts-ignore
-import rxPaths from 'rxjs/_esm5/path-mapping'
 import TerserPlugin from 'terser-webpack-plugin'
 import * as webpack from 'webpack'
 
@@ -114,7 +112,6 @@ const config: webpack.Configuration = {
     resolve: {
         extensions: ['.mjs', '.ts', '.tsx', '.js'],
         mainFields: ['es2015', 'module', 'browser', 'main'],
-        alias: { ...rxPaths() },
     },
     module: {
         rules: [


### PR DESCRIPTION
This PR significantly speeds up Webpack initial and incremental builds of TypeScript and SCSS:

- 25% faster initial build time (31s -> 23s)
- 74% faster TypeScript incremental builds (3.7s -> 1.0s)
- 47% faster SCSS incremental builds (5.5s -> 2.9s)

See commit messages for a discussion of each change.

---

**Benchmarks:**

- Initial build: `goreman run restart web` and look for `Time: ...`
- TypeScript incremental build: `echo '/* a */' >> web/src/SourcegraphWebApp.tsx` and look for `Time: ...`
- SCSS incremental build: `echo '/* a */' >> web/src/SourcegraphWebApp.scss` and look for `Time: ...`

(All on the same computer, with nothing else running.)

**`master` branch:**

- Initial build: 31067ms
- TypeScript incremental build: 3684ms
- SCSS incremental build: 5519ms

**`faster-webpack` branch:**

- Initial build: 23310ms (-25%)
- TypeScript incremental build: 966ms (-74%)
- SCSS incremental build: 2938ms (-47%)