### PR TITLE
never show "Search" text on search query button

### DIFF
--- a/web/src/search/input/SearchButton.scss
+++ b/web/src/search/input/SearchButton.scss
@@ -4,14 +4,4 @@
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
     }
-
-    &__label {
-        margin-left: 0.25rem;
-    }
-
-    @media (max-width: $media-lg) {
-        &__label {
-            display: none;
-        }
-    }
 }

--- a/web/src/search/input/SearchButton.tsx
+++ b/web/src/search/input/SearchButton.tsx
@@ -7,9 +7,6 @@ import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap
 interface Props {
     /** Hide the "help" icon and dropdown. */
     noHelp?: boolean
-
-    /** Never show the "Search" button label. */
-    noLabel?: boolean
 }
 
 interface State {
@@ -29,7 +26,6 @@ export class SearchButton extends React.Component<Props, State> {
             <div className="search-button d-flex">
                 <button className="btn btn-primary search-button__btn" type="submit">
                     <SearchIcon className="icon-inline" />
-                    {!this.props.noLabel && <span className="search-button__label">Search</span>}
                 </button>
                 <Dropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="d-flex">
                     {!this.props.noHelp && (

--- a/web/src/search/input/SearchButton.tsx
+++ b/web/src/search/input/SearchButton.tsx
@@ -24,8 +24,8 @@ export class SearchButton extends React.Component<Props, State> {
         const docsURLPrefix = window.context.sourcegraphDotComMode ? 'https://docs.sourcegraph.com' : '/help'
         return (
             <div className="search-button d-flex">
-                <button className="btn btn-primary search-button__btn" type="submit">
-                    <SearchIcon className="icon-inline" />
+                <button className="btn btn-primary search-button__btn" type="submit" aria-label="Search">
+                    <SearchIcon className="icon-inline" aria-hidden="true" />
                 </button>
                 <Dropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="d-flex">
                     {!this.props.noHelp && (
@@ -34,8 +34,9 @@ export class SearchButton extends React.Component<Props, State> {
                                 tag="span"
                                 caret={false}
                                 className="px-2 btn btn-link d-flex align-items-center"
+                                aria-label="Quick help for search"
                             >
-                                <HelpCircleOutlineIcon className="icon-inline small" />
+                                <HelpCircleOutlineIcon className="icon-inline small" aria-hidden="true" />
                             </DropdownToggle>
                             <DropdownMenu right={true} className="pb-0">
                                 <DropdownItem header={true}>


### PR DESCRIPTION
It is not necessary and adds visual noise. This also helps declutter the top nav and organize things together when we add regexp/word/case toggle buttons to the search query field (as we are likely to do, eg in #4447).


### before

![image](https://user-images.githubusercontent.com/1976/59324541-2ed0e000-8c94-11e9-8f24-721f76abad86.png)

### after

![image](https://user-images.githubusercontent.com/1976/59324563-40b28300-8c94-11e9-8c29-7454fde378dd.png)
