### PR TITLE
use Bootstrap z-indexes for our custom popover

### DIFF
--- a/shared/src/components/PopoverButton.scss
+++ b/shared/src/components/PopoverButton.scss
@@ -67,7 +67,7 @@ TODO(sqs): Suffix with "2" to avoid conflict with sourcegraph/sourcegraph compon
     background-color: var(--dropdown-bg);
     border: solid 1px var(--dropdown-border-color);
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
-    z-index: 250; // higher than .global-navbar
+    z-index: 1060; // higher than .global-navbar, equal to bootstrap $zindex-popover
     margin-left: 1px;
     margin-top: -1px;
 }

--- a/web/src/components/PopoverButton.scss
+++ b/web/src/components/PopoverButton.scss
@@ -56,7 +56,7 @@
         transform: rotate(180deg) translateY(-1px);
     }
     &--open#{&}__btn {
-        z-index: 101;
+        z-index: $zindex-popover + 1;
     }
 
     &__popover {
@@ -65,7 +65,7 @@
 
         box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
 
-        z-index: 100;
+        z-index: $zindex-popover;
 
         // Align with button (when possible).
         //


### PR DESCRIPTION
**Low priority**

This ensures they layer correctly with respect to Bootstrap dropdowns.