### PR TITLE
support PersonLink elements without a separate displayName

### DIFF
--- a/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -54,7 +54,7 @@ const RepositoryContributorNode: React.FunctionComponent<RepositoryContributorNo
         <div className="repository-contributor-node list-group-item py-2">
             <div className="repository-contributor-node__person">
                 <UserAvatar className="icon-inline mr-2" user={node.person} />
-                <PersonLink userClassName="font-weight-bold" {...node.person} />
+                <PersonLink userClassName="font-weight-bold" user={node.person.user || node.person.displayName} />
             </div>
             <div className="repository-contributor-node__commits">
                 <div className="repository-contributor-node__commit">

--- a/web/src/user/PersonLink.test.tsx
+++ b/web/src/user/PersonLink.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router'
+import renderer from 'react-test-renderer'
+import { PersonLink } from './PersonLink'
+
+describe('PersonLink', () => {
+    test('no user account', () =>
+        expect(renderer.create(<PersonLink user="alice" className="a" userClassName="b" />).toJSON()).toMatchSnapshot())
+
+    test('with user account', () =>
+        expect(
+            renderer
+                .create(
+                    <MemoryRouter>
+                        <PersonLink
+                            user={{ displayName: 'Alice', username: 'alice', url: 'u' }}
+                            className="a"
+                            userClassName="b"
+                        />
+                    </MemoryRouter>
+                )
+                .toJSON()
+        ).toMatchSnapshot())
+})

--- a/web/src/user/PersonLink.tsx
+++ b/web/src/user/PersonLink.tsx
@@ -3,28 +3,26 @@ import { Link } from 'react-router-dom'
 import * as GQL from '../../../shared/src/graphql/schema'
 
 /**
- * A person's name, with a link to their Sourcegraph user profile if an associated user is found.
+ * A person's name, with a link to their Sourcegraph user profile if an associated user is found. It
+ * is intended to be used to display the a value of the GraphQL type Person, which represents a
+ * person that may or may not have an associated user account on Sourcegraph.
  */
 export const PersonLink: React.FunctionComponent<{
-    displayName: string
-    user?: GQL.IUser | null
+    /**
+     * The Sourcegraph user, or if there is no user account associated with this person, then the
+     * person's display name (as a string).
+     */
+    user: Pick<GQL.IUser, 'displayName' | 'username' | 'url'> | string
+
     className?: string
+
+    /** A class name applied when there is an associated user account. */
     userClassName?: string
-}> = ({ displayName, user, className = '', userClassName }) => (
-    <>
-        <span className={className}>{displayName}</span>
-        {user && (
-            <>
-                {' '}
-                &mdash;{' '}
-                <Link
-                    to={user.url}
-                    className={`${className} ${userClassName || ''}`}
-                    title={user.displayName || displayName}
-                >
-                    {user.username}
-                </Link>
-            </>
-        )}
-    </>
-)
+}> = ({ user, className = '', userClassName = '' }) =>
+    typeof user === 'string' ? (
+        <span className={className}>{user}</span>
+    ) : (
+        <Link to={user.url} className={`${className} ${userClassName}`} title={user.displayName || ''}>
+            {user.username}
+        </Link>
+    )

--- a/web/src/user/__snapshots__/PersonLink.test.tsx.snap
+++ b/web/src/user/__snapshots__/PersonLink.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PersonLink no user account 1`] = `
+<span
+  className="a"
+>
+  alice
+</span>
+`;
+
+exports[`PersonLink with user account 1`] = `
+<a
+  className="a b"
+  href="/u"
+  onClick={[Function]}
+  title="Alice"
+>
+  alice
+</a>
+`;


### PR DESCRIPTION
**Low priority**

This makes it possible to render a `<PersonLink />` when all you have is a `GQL.IUser`. There is no good reason for requiring a `displayName`. The only reason it was required was to avoid a case where the component's API implied that you could render it with neither a displayName nor a user. The new component API prevents that.
