### PR TITLE
remove focus ring around clicked icons

### DIFF
--- a/browser/src/global-styles/icons.scss
+++ b/browser/src/global-styles/icons.scss
@@ -6,6 +6,12 @@
     vertical-align: bottom;
     display: inline-flex;
     align-items: center;
+
+    &:focus {
+        // Remove browser default focus ring that appears in Chrome when clicking on an icon that
+        // has a data-tooltip.
+        outline: 0;
+    }
 }
 
 svg.icon-inline,

--- a/web/src/global-styles/icons.scss
+++ b/web/src/global-styles/icons.scss
@@ -13,6 +13,12 @@
     vertical-align: bottom;
     display: inline-flex;
     align-items: center;
+
+    &:focus {
+        // Remove browser default focus ring that appears in Chrome when clicking on an icon that
+        // has a data-tooltip.
+        outline: 0;
+    }
 }
 
 svg.icon-inline,


### PR DESCRIPTION
**Low priority**

When an icon is focused, such as when it's in a button, it acquires the standard OS focus ring (in my case, a blue border). This is undesirable.

For example, if you click-and-hold on the lock icon on a code discussion comment header and then move your mouse away, the focus ring displays on the icon, even though it is not a button and should not have a focus ring.