### PR TITLE
factor out genericSearchResultInterfaceFields in GraphQL search query

### DIFF
--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -7,6 +7,30 @@ import { asError, createAggregateError, ErrorLike } from '../../../shared/src/ut
 import { memoizeObservable } from '../../../shared/src/util/memoizeObservable'
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 
+const genericSearchResultInterfaceFields = gql`
+  __typename
+  label {
+      html
+  }
+  url
+  icon
+  detail {
+      html
+  }
+  matches {
+      url
+      body {
+          text
+          html
+      }
+      highlights {
+          line
+          character
+          length
+      }
+  }
+`
+
 export function search(
     query: string,
     { extensionsController }: ExtensionsControllerProps<'services'>
@@ -43,33 +67,13 @@ export function search(
                                     kind
                                 }
                                 results {
+                                    __typename
                                     ... on Repository {
-                                        __typename
                                         id
                                         name
-                                        url
-                                        label {
-                                            html
-                                        }
-                                        icon
-                                        detail {
-                                            html
-                                        }
-                                        matches {
-                                            url
-                                            body {
-                                                text
-                                                html
-                                            }
-                                            highlights {
-                                                line
-                                                character
-                                                length
-                                            }
-                                        }
+                                        ${genericSearchResultInterfaceFields}
                                     }
                                     ... on FileMatch {
-                                        __typename
                                         file {
                                             path
                                             url
@@ -95,27 +99,7 @@ export function search(
                                         }
                                     }
                                     ... on CommitSearchResult {
-                                        __typename
-                                        label {
-                                            html
-                                        }
-                                        url
-                                        icon
-                                        detail {
-                                            html
-                                        }
-                                        matches {
-                                            url
-                                            body {
-                                                text
-                                                html
-                                            }
-                                            highlights {
-                                                line
-                                                character
-                                                length
-                                            }
-                                        }
+                                        ${genericSearchResultInterfaceFields}
                                     }
                                 }
                                 alert {


### PR DESCRIPTION
This removes code duplication.