### PR TITLE
consistent spacing for CommandList in global navbar

### DIFF
--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -18,7 +18,7 @@ WebHoverOverlay.displayName = 'WebHoverOverlay'
 export const WebCommandListPopoverButton: React.FunctionComponent<CommandListPopoverButtonProps> = props => (
     <CommandListPopoverButton
         {...props}
-        className="btn-link"
+        className="btn btn-link"
         popoverClassName="rounded"
         formClassName="form"
         inputClassName="form-control px-2 py-1 rounded-0"

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -111,11 +111,14 @@ export class NavLinks extends React.PureComponent<Props> {
                     </>
                 )}
                 {this.props.location.pathname !== '/welcome' && (
-                    <WebCommandListPopoverButton
-                        {...this.props}
-                        menu={ContributableMenu.CommandPalette}
-                        toggleVisibilityKeybinding={this.props.keybindings.commandPalette}
-                    />
+                    <li className="nav-item">
+                        <WebCommandListPopoverButton
+                            {...this.props}
+                            className="nav-link"
+                            menu={ContributableMenu.CommandPalette}
+                            toggleVisibilityKeybinding={this.props.keybindings.commandPalette}
+                        />
+                    </li>
                 )}
                 {this.props.authenticatedUser && (
                     <li className="nav-item">

--- a/web/src/nav/UserNavItem.tsx
+++ b/web/src/nav/UserNavItem.tsx
@@ -35,7 +35,7 @@ export class UserNavItem extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <ButtonDropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="nav-link py-0">
+            <ButtonDropdown isOpen={this.state.isOpen} toggle={this.toggleIsOpen} className="py-0">
                 <DropdownToggle
                     caret={true}
                     className="bg-transparent d-flex align-items-center e2e-user-nav-item-toggle"

--- a/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`UserNavItem simple 1`] = `
 <div
-  className="nav-link py-0 btn-group"
+  className="py-0 btn-group"
   onKeyDown={[Function]}
 >
   <a


### PR DESCRIPTION
**Low priority**

Previously, it had too much spacing on one side.

### before

![image](https://user-images.githubusercontent.com/1976/59326045-16fc5a80-8c9a-11e9-8b36-95e50d932a68.png)


### after

![image](https://user-images.githubusercontent.com/1976/59326027-0b109880-8c9a-11e9-80b3-803f5c5e3c0f.png)
