### PR TITLE
use correct Bootstrap alert class for errors

### DIFF
--- a/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
+++ b/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
@@ -147,7 +147,7 @@ export class RegistryExtensionContributionsPage extends React.PureComponent<Prop
                     {this.props.extension.manifest === null ? (
                         <ExtensionNoManifestAlert extension={this.props.extension} />
                     ) : isErrorLike(this.props.extension.manifest) ? (
-                        <div className="alert alert-error">
+                        <div className="alert alert-danger">
                             Error parsing extension manifest: {this.props.extension.manifest.message}
                         </div>
                     ) : (


### PR DESCRIPTION
**Low priority**

`alert-error` is not a thing; `alert-danger` is what was intended.