### PR TITLE
cleaner base CSS for <hr/>

### DIFF
--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -129,6 +129,9 @@ $progress-border-radius: 0;
 $progress-bg: transparent;
 $progress-height: auto;
 
+$hr-border-color: var(--border-color);
+$hr-margin-y: 0.25rem;
+
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins';
@@ -204,14 +207,6 @@ body,
             padding: 1rem;
         }
     }
-}
-
-hr {
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
-    background-color: #93a9c8;
-    height: 0.0625rem;
-    border: none;
 }
 
 .form-control::placeholder {

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -214,7 +214,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                 subtitle = (
                     <div className="app__error">
                         {subtitle}
-                        {subtitle && <hr />}
+                        {subtitle && <hr className="my-3" />}
                         <pre>{errorMessage}</pre>
                     </div>
                 )

--- a/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -218,7 +218,7 @@ class _ProductSubscriptionForm extends React.Component<Props & ReactStripeElemen
                                         A user account on Sourcegraph.com is required to create a subscription so you
                                         can view the license key and invoice.
                                     </small>
-                                    <hr />
+                                    <hr className="my-3" />
                                     <small className="form-text text-muted">
                                         Next, you'll enter payment information and buy the subscription.
                                     </small>

--- a/web/src/search/input/QueryBuilder.scss
+++ b/web/src/search/input/QueryBuilder.scss
@@ -97,11 +97,6 @@
     &__docs-link {
         padding-top: 1.5rem;
     }
-
-    &__rule {
-        background-color: $input-border-color;
-        color: $input-border-color;
-    }
 }
 
 .theme-light {

--- a/web/src/search/input/QueryBuilder.tsx
+++ b/web/src/search/input/QueryBuilder.tsx
@@ -243,9 +243,7 @@ export class QueryBuilder extends React.Component<Props, QueryBuilderState> {
                                     />
                                 </>
                             )}
-                            <div className="query-builder__rule-container">
-                                <hr className="query-builder__rule" />
-                            </div>
+                            <hr className="my-3" />
                             <QueryBuilderInputRow
                                 onInputChange={this.fieldsChanged}
                                 placeholder="(read|write)File"


### PR DESCRIPTION
**Low priority**

This lets us remove overrides for its styles and makes it more visually appealing. Previously it was black (on the light theme) or white (on the dark theme), which was too much contrast. Now it is the border color, which is much subtler.

In cases where we actually want a lot of vertical margin, this commit adds that explicitly.