### PR TITLE
fix Resizable when resizing element whose position:relative context is specific

### DIFF
--- a/shared/src/components/Resizable.scss
+++ b/shared/src/components/Resizable.scss
@@ -47,10 +47,15 @@
 
     &__ghost {
         position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
+
+        // Add buffer area so that resizables inside a position:relative will continue to receive
+        // onMouseMove events even when enlarging in a direction that causes the cursor to be on top
+        // of elements in a different position:relative context.
+        top: -100px;
+        left: -100px;
+        right: -100px;
+        bottom: -100px;
+
         display: none;
         z-index: 999999;
         &--resizing {


### PR DESCRIPTION
**Low priority**

This occurs when a Resizable's parent `position:relative` element is exactly the same size as the resizable itself, which can occur when a higher-up ancestor can't be `position:relative` for other reasons (eg it itself is absolutely positioned). In this case, as the user drags their mouse, the mouse exits the ghost element (which all resizable implementations use to continue tracking mouse movement beyond the dimensions of the thing being resized) before the event handler can resize the element. Another cause of the problem is when the page is DPI-scaled and the rightmost boundary of the parent `position:relative` element is not actually inside of it. 100px is a suitable buffer because it is large enough to ensure that the event handler is called and that DPI scaling and fractional dimensions won't cause problems.