### PR TITLE
flatten admin area in DiscussionsComment

### DIFF
--- a/web/src/discussions/DiscussionsComment.scss
+++ b/web/src/discussions/DiscussionsComment.scss
@@ -62,16 +62,6 @@
     &__reports:hover {
         text-decoration: underline;
     }
-    &__admin {
-        background: $color-bg-5;
-        color: var(--link-color);
-        height: 100%;
-        display: flex;
-        align-items: center;
-        border-radius: 1rem;
-        padding-left: 0.5rem;
-        padding-right: 0.325rem;
-    }
 }
 
 @keyframes highlight-light {

--- a/web/src/discussions/DiscussionsComment.tsx
+++ b/web/src/discussions/DiscussionsComment.tsx
@@ -4,7 +4,6 @@ import CommentCheckIcon from 'mdi-react/CommentCheckIcon'
 import CommentRemoveIcon from 'mdi-react/CommentRemoveIcon'
 import FlagVariantIcon from 'mdi-react/FlagVariantIcon'
 import LinkIcon from 'mdi-react/LinkIcon'
-import SecurityLockIcon from 'mdi-react/SecurityLockIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable } from 'rxjs'
@@ -108,38 +107,33 @@ export class DiscussionsComment extends React.PureComponent<Props> {
                                 <FlagVariantIcon className="icon-inline" />
                             </button>
                         )}
-                        {(comment.canClearReports || comment.reports.length > 0 || comment.canDelete) && (
-                            <span className="discussions-comment__admin">
-                                <SecurityLockIcon className="icon-inline icon-sm" data-tooltip="Admin area" />
-                                {comment.reports.length > 0 && (
-                                    <>
-                                        <span
-                                            className="ml-1 mr-1 discussions-comment__reports"
-                                            data-tooltip={comment.reports.join('\n\n')}
-                                        >
-                                            {comment.reports.length} reports
-                                        </span>
-                                        {comment.canClearReports && onClearReports && (
-                                            <button
-                                                className="btn btn-link btn-sm discussions-comment__toolbar-btn"
-                                                data-tooltip="Clear reports / mark as good message"
-                                                onClick={this.onClearReportsClick}
-                                            >
-                                                <CommentCheckIcon className="icon-inline" />
-                                            </button>
-                                        )}
-                                    </>
-                                )}
-                                {comment.canDelete && onDelete && (
+                        {comment.reports.length > 0 && (
+                            <>
+                                <span
+                                    className="ml-1 mr-1 discussions-comment__reports"
+                                    data-tooltip={comment.reports.join('\n\n')}
+                                >
+                                    {comment.reports.length} reports
+                                </span>
+                                {comment.canClearReports && onClearReports && (
                                     <button
                                         className="btn btn-link btn-sm discussions-comment__toolbar-btn"
-                                        data-tooltip="Delete comment forever"
-                                        onClick={this.onDeleteClick}
+                                        data-tooltip="Clear reports / mark as good message"
+                                        onClick={this.onClearReportsClick}
                                     >
-                                        <CommentRemoveIcon className="icon-inline" />
+                                        <CommentCheckIcon className="icon-inline" />
                                     </button>
                                 )}
-                            </span>
+                            </>
+                        )}
+                        {comment.canDelete && onDelete && (
+                            <button
+                                className="btn btn-link btn-sm discussions-comment__toolbar-btn"
+                                data-tooltip="Delete comment forever"
+                                onClick={this.onDeleteClick}
+                            >
+                                <CommentRemoveIcon className="icon-inline" />
+                            </button>
                         )}
                     </span>
                 </div>


### PR DESCRIPTION
**Low priority**

Previously, there was a rounded area with a lock icon and admin actions (clear reports, and delete the comment forever). By far the most common state was for there to be only 1 admin action because "clear reports" only appears when there are reports (ie complaints) on a comment. This was confusing because the lock icon seemed just as clickable as the icon next to it.

Now, the action icons are all shown adjacent to each other. This is sufficient and removes code and visual complexity.