### PR TITLE
use conventional opaque (base64-encoded) GraphQL IDs for Discussion{Thread,Comment}

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -79,6 +79,16 @@ func (r *nodeResolver) ToAccessToken() (*accessTokenResolver, bool) {
 	return n, ok
 }
 
+func (r *nodeResolver) ToDiscussionComment() (*discussionCommentResolver, bool) {
+	n, ok := r.node.(*discussionCommentResolver)
+	return n, ok
+}
+
+func (r *nodeResolver) ToDiscussionThread() (*discussionThreadResolver, bool) {
+	n, ok := r.node.(*discussionThreadResolver)
+	return n, ok
+}
+
 func (r *nodeResolver) ToProductLicense() (ProductLicense, bool) {
 	n, ok := r.node.(ProductLicense)
 	return n, ok
@@ -130,6 +140,9 @@ func (r *nodeResolver) ToGitCommit() (*gitCommitResolver, bool) {
 }
 
 func (r *nodeResolver) ToRegistryExtension() (RegistryExtension, bool) {
+	if NodeToRegistryExtension == nil {
+		return nil, false
+	}
 	return NodeToRegistryExtension(r.node)
 }
 
@@ -179,6 +192,10 @@ func nodeByID(ctx context.Context, id graphql.ID) (node, error) {
 	switch relay.UnmarshalKind(id) {
 	case "AccessToken":
 		return accessTokenByID(ctx, id)
+	case "DiscussionComment":
+		return discussionCommentByID(ctx, id)
+	case "DiscussionThread":
+		return discussionThreadByID(ctx, id)
 	case "ProductLicense":
 		if f := ProductLicenseByID; f != nil {
 			return f(ctx, id)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -751,6 +751,8 @@ type Query {
         # Return discussion threads matching the query.
         query: String
         # When present, lists only the thread with this ID.
+        #
+        # DEPRECATED: use Query#node instead.
         threadID: ID
         # When present, lists only the threads created by this author.
         authorUserID: ID
@@ -771,6 +773,10 @@ type Query {
         # If the path ends with "/**", any path below that is matched.
         targetRepositoryPath: String
     ): DiscussionThreadConnection!
+    # Looks up a discussion thread by its DiscussionThread#idWithoutKind value.
+    #
+    # To get a discussion thread by its globally unique GraphQL ID, use Query#node.
+    discussionThread(idWithoutKind: String!): DiscussionThread
     # Lists discussion comments.
     discussionComments(
         # Returns the first n comments from the list.
@@ -2536,9 +2542,14 @@ type DiscussionThreadTargetRepo {
 union DiscussionThreadTarget = DiscussionThreadTargetRepo
 
 # A discussion thread around some target (e.g. a file in a repo).
-type DiscussionThread {
+type DiscussionThread implements Node {
     # The discussion thread ID (globally unique).
     id: ID!
+
+    # The discussion thread ID without its kind, which is globally unique among threads but not
+    # among all GraphQL nodes. For example, this is a string like "123" (and DiscussionThread#id is
+    # a string like "RGlzY3Vzc2l...").
+    idWithoutKind: String!
 
     # The user who authored this discussion thread.
     author: User!
@@ -2575,9 +2586,14 @@ type DiscussionThread {
 }
 
 # A comment made within a discussion thread.
-type DiscussionComment {
+type DiscussionComment implements Node {
     # The discussion comment ID (globally unique).
     id: ID!
+
+    # The discussion comment ID without its kind, which is globally unique among comments but not
+    # among all GraphQL nodes. For example, this is a string like "123" (and DiscussionComment#id is
+    # a string like "RGlzY3Vzc2l...").
+    idWithoutKind: String!
 
     # The discussion thread the comment was made in.
     thread: DiscussionThread!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -758,6 +758,8 @@ type Query {
         # Return discussion threads matching the query.
         query: String
         # When present, lists only the thread with this ID.
+        #
+        # DEPRECATED: use Query#node instead.
         threadID: ID
         # When present, lists only the threads created by this author.
         authorUserID: ID
@@ -778,6 +780,10 @@ type Query {
         # If the path ends with "/**", any path below that is matched.
         targetRepositoryPath: String
     ): DiscussionThreadConnection!
+    # Looks up a discussion thread by its DiscussionThread#idWithoutKind value.
+    #
+    # To get a discussion thread by its globally unique GraphQL ID, use Query#node.
+    discussionThread(idWithoutKind: String!): DiscussionThread
     # Lists discussion comments.
     discussionComments(
         # Returns the first n comments from the list.
@@ -2543,9 +2549,14 @@ type DiscussionThreadTargetRepo {
 union DiscussionThreadTarget = DiscussionThreadTargetRepo
 
 # A discussion thread around some target (e.g. a file in a repo).
-type DiscussionThread {
+type DiscussionThread implements Node {
     # The discussion thread ID (globally unique).
     id: ID!
+
+    # The discussion thread ID without its kind, which is globally unique among threads but not
+    # among all GraphQL nodes. For example, this is a string like "123" (and DiscussionThread#id is
+    # a string like "RGlzY3Vzc2l...").
+    idWithoutKind: String!
 
     # The user who authored this discussion thread.
     author: User!
@@ -2582,9 +2593,14 @@ type DiscussionThread {
 }
 
 # A comment made within a discussion thread.
-type DiscussionComment {
+type DiscussionComment implements Node {
     # The discussion comment ID (globally unique).
     id: ID!
+
+    # The discussion comment ID without its kind, which is globally unique among comments but not
+    # among all GraphQL nodes. For example, this is a string like "123" (and DiscussionComment#id is
+    # a string like "RGlzY3Vzc2l...").
+    idWithoutKind: String!
 
     # The discussion thread the comment was made in.
     thread: DiscussionThread!

--- a/web/src/discussions/DiscussionsComment.tsx
+++ b/web/src/discussions/DiscussionsComment.tsx
@@ -61,7 +61,7 @@ export class DiscussionsComment extends React.PureComponent<Props> {
 
     public render(): JSX.Element | null {
         const { location, comment, onReport, onClearReports, onDelete } = this.props
-        const isTargeted = new URLSearchParams(location.hash).get('commentID') === comment.id
+        const isTargeted = new URLSearchParams(location.hash).get('commentID') === comment.idWithoutKind
 
         // TODO(slimsag:discussions): ASAP: markdown links, headings, etc lead to #
 

--- a/web/src/discussions/DiscussionsList.tsx
+++ b/web/src/discussions/DiscussionsList.tsx
@@ -9,7 +9,10 @@ import { Timestamp } from '../components/time/Timestamp'
 import { fetchDiscussionThreads } from './backend'
 
 interface DiscussionNodeProps {
-    node: GQL.IDiscussionThread
+    node: Pick<
+        GQL.IDiscussionThread,
+        'idWithoutKind' | 'title' | 'author' | 'inlineURL' | 'comments' | 'createdAt' | 'target'
+    >
     location: H.Location
     withRepo?: boolean
 }
@@ -32,7 +35,7 @@ const DiscussionNode: React.FunctionComponent<DiscussionNodeProps> = ({ node, lo
                 </Link>
             </div>
             <div className="text-muted">
-                #{node.id} created <Timestamp date={node.createdAt} /> by{' '}
+                #{node.idWithoutKind} created <Timestamp date={node.createdAt} /> by{' '}
                 <Link to={`/users/${node.author.username}`} data-tooltip={node.author.displayName}>
                     {node.author.username}
                 </Link>{' '}
@@ -47,7 +50,7 @@ const DiscussionNode: React.FunctionComponent<DiscussionNodeProps> = ({ node, lo
 }
 
 class FilteredDiscussionsConnection extends FilteredConnection<
-    GQL.IDiscussionThread,
+    DiscussionNodeProps['node'],
     Pick<DiscussionNodeProps, 'location'>
 > {}
 

--- a/web/src/repo/blob/discussions/DiscussionsCreate.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsCreate.tsx
@@ -99,7 +99,7 @@ export class DiscussionsCreate extends React.PureComponent<Props, State> {
                 const location = this.props.location
                 const hash = new URLSearchParams(location.hash.slice('#'.length))
                 hash.set('tab', 'discussions')
-                hash.set('threadID', thread.id)
+                hash.set('threadID', thread.idWithoutKind)
                 // TODO(slimsag:discussions): ASAP: focus the new thread's range
                 this.props.history.push(location.pathname + location.search + '#' + hash.toString())
             }),

--- a/web/src/repo/blob/discussions/DiscussionsTree.tsx
+++ b/web/src/repo/blob/discussions/DiscussionsTree.tsx
@@ -32,14 +32,20 @@ export class DiscussionsTree extends React.PureComponent<Props> {
 
     public render(): JSX.Element | null {
         const hash = new URLSearchParams(this.props.location.hash.slice('#'.length))
-        const threadID = hash.get('threadID') as GQL.ID
-        const commentID = hash.get('commentID') as GQL.ID
+        const threadIDWithoutKind = hash.get('threadID')
+        const commentIDWithoutKind = hash.get('commentID')
 
-        if (threadID && commentID) {
-            return <DiscussionsThread threadID={threadID} commentID={commentID} {...this.props} />
+        if (threadIDWithoutKind && commentIDWithoutKind) {
+            return (
+                <DiscussionsThread
+                    threadIDWithoutKind={threadIDWithoutKind}
+                    commentIDWithoutKind={commentIDWithoutKind}
+                    {...this.props}
+                />
+            )
         }
-        if (threadID) {
-            return <DiscussionsThread threadID={threadID} {...this.props} />
+        if (threadIDWithoutKind) {
+            return <DiscussionsThread threadIDWithoutKind={threadIDWithoutKind} {...this.props} />
         }
         if (hash.get('createThread') === 'true') {
             return <DiscussionsCreate {...this.props} />


### PR DESCRIPTION
**Low priority**

Previously, the GraphQL ID values were strings of the form `"123"`, not opaque identifiers. This goes against Facebook's recommendations (https://facebook.github.io/relay/docs/en/graphql-server-specification.html):

> The IDs we got back were base64 strings. IDs are designed to be opaque (the only thing that should be passed to the id argument on node is the unaltered result of querying id on some object in the system), and base64ing a string is a useful convention in GraphQL to remind viewers that the string is an opaque identifier.

and is different from how all other IDs work in our own GraphQL API. It also means that DiscussionThread and DiscussionComment don't implement the GraphQL Node type, so you can't look up threads and comments solely given their ID in the `Query.node` resolver.

(See related discussion at https://sourcegraph.slack.com/archives/C07KZF47K/p1556217341197600.)

This commit makes DiscussionThread and DiscussionComment use standard GraphQL IDs that are opaque and that are globally addressable. It preserves backcompat for old GraphQL API clients (such as the code discussions Sourcegraph extension). It also preserves existing URLs (i.e., the URLs still just use the same numeric ID, not some base64 monstrosity).