### PR TITLE
reduce padding between action items on the repo header

### DIFF
--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -22,7 +22,7 @@
         // More padding between contributed action items
         &__action-items {
             .nav-item .nav-link {
-                padding: 0.425rem 0.425rem;
+                padding: 0.425rem 0.175rem;
             }
         }
     }

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -18,13 +18,6 @@
             padding: 0.425rem 0.175rem;
             user-select: none;
         }
-
-        // More padding between contributed action items
-        &__action-items {
-            .nav-item .nav-link {
-                padding: 0.425rem 0.175rem;
-            }
-        }
     }
 
     &__repo {


### PR DESCRIPTION
Reduce the padding between action items on the repo header.
New spacing:
![image](https://user-images.githubusercontent.com/9110008/59388523-d0057800-8d20-11e9-89d9-c29cbe3447d4.png)

vs. old spacing:
![image](https://user-images.githubusercontent.com/9110008/59388506-c3811f80-8d20-11e9-8599-3db1b24e5e69.png)
