### PR TITLE
Show Disabled label when extension hasn't been activated yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed an issue where the Phabricator native integration would be broken on recent Phabricator versions. This fix depends on v1.2 of the [Phabricator extension](https://github.com/sourcegraph/phabricator-extension).
 - Fixed an issue where the "Empty repository" banner would be shown on a repository page when starting to clone a repository.
 - Prevent data inconsistency on cached archives due to restarts. (#4366)
+- Show `Disabled` next to the extension activation toggle when the extension hasn't been activated yet. (#4446)
 
 ## 3.4.4 (unreleased)
 

--- a/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
@@ -73,7 +73,13 @@ exports[`ExtensionCard renders 1`] = `
         />
         <li
           className="nav-item"
-        />
+        >
+          <span
+            className="text-muted "
+          >
+            Disabled
+          </span>
+        </li>
       </ul>
     </div>
   </div>

--- a/web/src/extensions/extension/ExtensionConfigurationState.tsx
+++ b/web/src/extensions/extension/ExtensionConfigurationState.tsx
@@ -10,14 +10,10 @@ export const ExtensionConfigurationState: React.FunctionComponent<{
 
     className?: string
 }> = ({ isAdded, isEnabled, enabledIconOnly, className = '' }) =>
-    isAdded ? (
-        isEnabled ? (
-            <span className={`text-success ${className}`}>
-                <CheckIcon className="icon-inline" /> {!enabledIconOnly && 'Enabled'}
-            </span>
-        ) : (
-            <span className={`text-muted ${className}`}>Disabled</span>
-        )
+    isAdded && isEnabled ? (
+        <span className={`text-success ${className}`}>
+            <CheckIcon className="icon-inline" /> {!enabledIconOnly && 'Enabled'}
+        </span>
     ) : (
         <span className={`text-muted ${className}`}>Disabled</span>
     )

--- a/web/src/extensions/extension/ExtensionConfigurationState.tsx
+++ b/web/src/extensions/extension/ExtensionConfigurationState.tsx
@@ -18,4 +18,6 @@ export const ExtensionConfigurationState: React.FunctionComponent<{
         ) : (
             <span className={`text-muted ${className}`}>Disabled</span>
         )
-    ) : null
+    ) : (
+        <span className={`text-muted ${className}`}>Disabled</span>
+    )


### PR DESCRIPTION
Show Disabled label when extension hasn't been activated yet.
Resolves: #4446
Before:
![image](https://user-images.githubusercontent.com/9110008/59393526-e0255380-8d30-11e9-9cf6-45b6f8a3cdab.png)

After:
![image](https://user-images.githubusercontent.com/9110008/59393570-fcc18b80-8d30-11e9-93b7-9ae55ba6222a.png)

