### PR TITLE
use darker green for (eg) btn-success for greater contrast (a11y)

### DIFF
--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -40,7 +40,7 @@ $pink: $oc-pink-7;
 $red: $oc-red-7;
 $orange: $oc-orange-7;
 $yellow: $oc-yellow-7;
-$green: $oc-green-7;
+$green: $oc-green-9;
 $teal: $oc-teal-7;
 $cyan: $oc-cyan-7;
 


### PR DESCRIPTION
This is actually not super noticeable, but it's a slight bit more readable. It looks good in both light and dark color themes.