### PR TITLE
remove trailing margin-bottom in Markdown p and pre

### DIFF
--- a/shared/src/components/Markdown.scss
+++ b/shared/src/components/Markdown.scss
@@ -61,6 +61,13 @@
         white-space: nowrap;
     }
 
+    p,
+    pre {
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
     blockquote {
         padding: 0 1rem;
         color: #93a9c8;


### PR DESCRIPTION
**Low priority**

This makes Markdown content's vertical spacing appear more even.