### PR TITLE
Add online extension editor and publishing

### DIFF
--- a/shared/src/api/extension/api/extensions.ts
+++ b/shared/src/api/extension/api/extensions.ts
@@ -35,8 +35,9 @@ export class ExtExtensions implements ExtExtensionsAPI, Unsubscribable, ProxyVal
         // Load the extension bundle and retrieve the extension entrypoint module's exports on
         // the global `module` property.
         try {
-            self.exports = {}
-            self.module = {}
+            const exports = {}
+            self.exports = exports
+            self.module = { exports }
             self.importScripts(bundleURL)
         } catch (err) {
             throw new Error(

--- a/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -49,8 +49,6 @@ interface Props {
     /** The extension that is the subject of the page. */
     extension: ConfiguredRegistryExtension<GQL.IRegistryExtension>
 
-    onDidUpdateExtension: () => void
-
     authenticatedUser: GQL.IUser
     isLightTheme: boolean
     history: H.History

--- a/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -1,7 +1,7 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import H from 'history'
 import ErrorIcon from 'mdi-react/ErrorIcon'
-import React, { useCallback, useState, useEffect } from 'react'
+import React, { useCallback, useState } from 'react'
 import { map, catchError, tap, concatMap } from 'rxjs/operators'
 import { ConfiguredRegistryExtension } from '../../../../../shared/src/extensions/extension'
 import { ExtensionManifest } from '../../../../../shared/src/extensions/extensionManifest'

--- a/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -1,21 +1,219 @@
-import * as React from 'react'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import H from 'history'
+import ErrorIcon from 'mdi-react/ErrorIcon'
+import React, { useCallback, useEffect, useState } from 'react'
+import { map } from 'rxjs/operators'
+import { ConfiguredRegistryExtension } from '../../../../../shared/src/extensions/extension'
+import { ExtensionManifest } from '../../../../../shared/src/extensions/extensionManifest'
+import { gql } from '../../../../../shared/src/graphql/graphql'
+import * as GQL from '../../../../../shared/src/graphql/schema'
+import extensionSchemaJSON from '../../../../../shared/src/schema/extension.schema.json'
+import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
+import { mutateGraphQL } from '../../../backend/graphql'
+import { Form } from '../../../components/Form'
+import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
+import { DynamicallyImportedMonacoSettingsEditor } from '../../../settings/DynamicallyImportedMonacoSettingsEditor'
+import { useLocalStorage } from '../../../util/useLocalStorage'
+
+const publishExtension = (
+    args: Pick<GQL.IPublishExtensionOnExtensionRegistryMutationArguments, 'extensionID' | 'manifest' | 'bundle'>
+): Promise<GQL.IExtensionRegistryCreateExtensionResult> =>
+    mutateGraphQL(
+        gql`
+            mutation PublishRegistryExtension($extensionID: String!, $manifest: String!, $bundle: String!) {
+                extensionRegistry {
+                    publishExtension(extensionID: $extensionID, manifest: $manifest, bundle: $bundle) {
+                        extension {
+                            url
+                        }
+                    }
+                }
+            }
+        `,
+        args
+    )
+        .pipe(
+            map(({ data, errors }) => {
+                if (
+                    !data ||
+                    !data.extensionRegistry ||
+                    !data.extensionRegistry.publishExtension ||
+                    (errors && errors.length > 0)
+                ) {
+                    throw createAggregateError(errors)
+                }
+                return data.extensionRegistry.publishExtension
+            })
+        )
+        .toPromise()
+
+interface Props {
+    /** The extension that is the subject of the page. */
+    extension: ConfiguredRegistryExtension<GQL.IRegistryExtension>
+
+    onDidUpdateExtension: () => void
+
+    authenticatedUser: GQL.IUser
+    isLightTheme: boolean
+    history: H.History
+}
+
+const DEFAULT_MANIFEST: Pick<ExtensionManifest, 'activationEvents'> = {
+    activationEvents: ['*'],
+}
+
+const LOADING: 'loading' = 'loading'
 
 /** A page for publishing a new release of an extension to the extension registry. */
-export const RegistryExtensionNewReleasePage = withAuthenticatedUser(() => (
-    <div className="registry-extension-new-release-page">
-        <PageTitle title="Publish new release" />
-        <h2>Publish new release</h2>
-        <p>
-            Use the{' '}
-            <a href="https://github.com/sourcegraph/src-cli" target="_blank" rel="noopener noreferrer">
-                <code>src</code> CLI tool
-            </a>{' '}
-            to publish a new release:
-        </p>
-        <pre>
-            <code>$ src extensions publish</code>
-        </pre>
-    </div>
-))
+// tslint:disable: react-hooks-nesting
+export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
+    ({ extension, onDidUpdateExtension, isLightTheme, history }) => {
+        const [updateOrError, setUpdateOrError] = useState<
+            null | typeof LOADING | GQL.IExtensionRegistryCreateExtensionResult | ErrorLike
+        >(null)
+
+        // Omit the `url` field from the extension so that it gets set to the URL of the bundle
+        // we're uploading.
+        const manifestWithoutUrl = extension.rawManifest ? JSON.parse(extension.rawManifest) : { ...DEFAULT_MANIFEST }
+        delete manifestWithoutUrl.url
+        const [manifest, setManifest] = useState(JSON.stringify(manifestWithoutUrl, null, 2))
+
+        const [bundle, setBundle] = useState<string | ErrorLike>()
+
+        useEffect(() => {
+            if (extension.manifest && !isErrorLike(extension.manifest) && extension.manifest.url) {
+                const extensionManifestUrl = extension.manifest.url
+                ;(async () => {
+                    const resp = await fetch(extensionManifestUrl)
+                    setBundle(resp.status === 200 ? await resp.text() : '')
+                })().catch(err => setBundle(asError(err)))
+            } else {
+                setBundle(undefined)
+            }
+        }, [extension])
+
+        useEffect(() => {
+            setUpdateOrError(null) // reset
+        }, [manifest, bundle])
+
+        const onSubmit = useCallback<React.FormEventHandler>(
+            async e => {
+                e.preventDefault()
+                setUpdateOrError(LOADING)
+                try {
+                    if (isErrorLike(bundle)) {
+                        throw new Error('invalid bundle')
+                    }
+                    setUpdateOrError(await publishExtension({ extensionID: extension.id, manifest, bundle }))
+                    onDidUpdateExtension()
+                } catch (err) {
+                    setUpdateOrError(asError(err))
+                }
+            },
+            [extension.id, manifest, bundle, onDidUpdateExtension]
+        )
+
+        const [showEditor, setShowEditor] = useLocalStorage('RegistryExtensionNewReleasePage.showEditor', false)
+        const onShowEditorClick = useCallback(() => setShowEditor(true), [setShowEditor])
+
+        return !extension.registryExtension || !extension.registryExtension.viewerCanAdminister ? (
+            <HeroPage
+                icon={ErrorIcon}
+                title="Unauthorized"
+                subtitle="You are not authorized to adminster this extension."
+            />
+        ) : (
+            <div className="registry-extension-new-release-page">
+                <PageTitle title="Publish new release" />
+                <h2>Publish new release</h2>
+                <p>
+                    Use the{' '}
+                    <a href="https://github.com/sourcegraph/src-cli" target="_blank" rel="noopener noreferrer">
+                        <code>src</code> CLI tool
+                    </a>{' '}
+                    to publish a new release:
+                </p>
+                <pre>
+                    <code>$ src extensions publish</code>
+                </pre>
+                {showEditor ? (
+                    <>
+                        <hr className="my-4" />
+                        <h2>Extension editor (experimental)</h2>
+                        <p>
+                            Edit or paste in an extension JSON manifest and JavaScript bundle. The JavaScript bundle
+                            source must be self-contained; dependency bundling and TypeScript transpilation is not yet
+                            supported.
+                        </p>
+                        <Form onSubmit={onSubmit} className="mb-3">
+                            <div className="row">
+                                <div className="col-lg-6">
+                                    <div className="form-group">
+                                        <label htmlFor="registry-extension-new-release-page__manifest">Manifest</label>
+                                        <DynamicallyImportedMonacoSettingsEditor
+                                            id="registry-extension-new-release-page__manifest"
+                                            className="d-block"
+                                            value={manifest}
+                                            onChange={setManifest}
+                                            jsonSchema={extensionSchemaJSON}
+                                            readOnly={updateOrError === LOADING}
+                                            isLightTheme={isLightTheme}
+                                            history={history}
+                                        />
+                                    </div>
+                                </div>
+                                <div className="col-lg-6">
+                                    <div className="form-group">
+                                        <label htmlFor="registry-extension-new-release-page__bundle">Source</label>
+                                        {bundle === undefined ? (
+                                            <div>
+                                                <LoadingSpinner className="icon-inline" />
+                                            </div>
+                                        ) : isErrorLike(bundle) ? (
+                                            <div className="alert alert-danger">{bundle.message}</div>
+                                        ) : (
+                                            <DynamicallyImportedMonacoSettingsEditor
+                                                id="registry-extension-new-release-page__bundle"
+                                                language="javascript"
+                                                className="d-block"
+                                                // Only 1 component can block navigation, and the
+                                                // other editor does, so we don't.
+                                                noBlockNavigationIfDirty={true}
+                                                value={bundle}
+                                                onChange={setBundle}
+                                                readOnly={updateOrError === LOADING}
+                                                isLightTheme={isLightTheme}
+                                                history={history}
+                                            />
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                            <button
+                                type="submit"
+                                disabled={updateOrError === LOADING || isErrorLike(bundle)}
+                                className="btn btn-primary"
+                            >
+                                {updateOrError === LOADING ? <LoadingSpinner className="icon-inline" /> : 'Publish'}
+                            </button>
+                        </Form>
+                        {updateOrError &&
+                            (isErrorLike(updateOrError) ? (
+                                <div className="alert alert-danger">{updateOrError.message}</div>
+                            ) : (
+                                updateOrError !== LOADING && (
+                                    <div className="alert alert-success">Published release successfully.</div>
+                                )
+                            ))}
+                    </>
+                ) : (
+                    <button type="button" className="btn btn-secondary" onClick={onShowEditorClick}>
+                        Experimental: Use in-browser extension editor
+                    </button>
+                )}
+            </div>
+        )
+    }
+)

--- a/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -1,7 +1,7 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import H from 'history'
 import ErrorIcon from 'mdi-react/ErrorIcon'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import { map, catchError, tap, concatMap } from 'rxjs/operators'
 import { ConfiguredRegistryExtension } from '../../../../../shared/src/extensions/extension'
 import { ExtensionManifest } from '../../../../../shared/src/extensions/extensionManifest'
@@ -20,6 +20,7 @@ import { useEventObservable } from '../../../../../shared/src/util/useObservable
 import { fromFetch } from '../../../../../shared/src/graphql/fromFetch'
 import { of, Observable, concat, from } from 'rxjs'
 import { ErrorAlert } from '../../../components/alerts'
+import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 
 const publishExtension = (
     args: Pick<GQL.IPublishExtensionOnExtensionRegistryMutationArguments, 'extensionID' | 'manifest' | 'bundle'>
@@ -74,155 +75,153 @@ module.exports = { activate }
 `
 
 /** A page for publishing a new release of an extension to the extension registry. */
-export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
-    ({ extension, onDidUpdateExtension, isLightTheme, history }) => {
-        // Omit the `url` field from the extension so that it gets set to the URL of the bundle we're uploading.
-        const manifestWithoutUrl = extension.rawManifest ? JSON.parse(extension.rawManifest) : { ...DEFAULT_MANIFEST }
-        delete manifestWithoutUrl.url
-        const [manifest, setManifest] = useState(JSON.stringify(manifestWithoutUrl, null, 2))
+export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(({ extension, isLightTheme, history }) => {
+    // Omit the `url` field from the extension so that it gets set to the URL of the bundle we're uploading.
+    const manifestWithoutUrl = extension.rawManifest ? JSON.parse(extension.rawManifest) : { ...DEFAULT_MANIFEST }
+    delete manifestWithoutUrl.url
+    const [manifest, setManifest] = useState(JSON.stringify(manifestWithoutUrl, null, 2))
 
-        const [onChangeBundle, bundleOrError] = useEventObservable(
-            useCallback(
-                (bundleChanges: Observable<string>) =>
-                    concat(
-                        isErrorLike(extension.manifest) || !extension.manifest?.url
-                            ? of(DEFAULT_SOURCE)
-                            : fromFetch(extension.manifest.url, undefined, resp => resp.text()).pipe(
-                                  catchError(err => [asError(err)])
-                              ),
-                        bundleChanges
-                    ),
-                [extension.manifest]
-            )
+    const [onChangeBundle, bundleOrError] = useEventObservable(
+        useCallback(
+            (bundleChanges: Observable<string>) =>
+                concat(
+                    isErrorLike(extension.manifest) || !extension.manifest?.url
+                        ? of(DEFAULT_SOURCE)
+                        : fromFetch(extension.manifest.url, undefined, resp => resp.text()).pipe(
+                              catchError(err => [asError(err)])
+                          ),
+                    bundleChanges
+                ),
+            [extension.manifest]
         )
+    )
 
-        const [onSubmit, updateOrError] = useEventObservable(
-            useCallback(
-                (submits: Observable<React.FormEvent>) =>
-                    submits.pipe(
-                        tap(event => event.preventDefault()),
-                        concatMap(() => {
-                            if (isErrorLike(bundleOrError)) {
-                                throw new Error('Invalid bundle')
-                            }
-                            return concat(
-                                LOADING,
-                                from(
-                                    publishExtension({ extensionID: extension.id, manifest, bundle: bundleOrError })
-                                ).pipe(
-                                    tap(() => onDidUpdateExtension()),
-                                    catchError(err => [asError(err)])
-                                )
+    const [onSubmit, updateOrError] = useEventObservable(
+        useCallback(
+            (submits: Observable<React.FormEvent>) =>
+                submits.pipe(
+                    tap(event => event.preventDefault()),
+                    concatMap(() => {
+                        if (isErrorLike(bundleOrError)) {
+                            throw new Error('Invalid bundle')
+                        }
+                        return concat(
+                            [LOADING],
+                            from(publishExtension({ extensionID: extension.id, manifest, bundle: bundleOrError })).pipe(
+                                catchError(err => [asError(err)])
                             )
-                        })
-                    ),
-                [bundleOrError, extension.id, manifest, onDidUpdateExtension]
-            )
+                        )
+                    })
+                ),
+            [bundleOrError, extension.id, manifest]
         )
+    )
 
-        const [showEditor, setShowEditor] = useLocalStorage('RegistryExtensionNewReleasePage.showEditor', false)
-        const onShowEditorClick = useCallback(() => setShowEditor(true), [setShowEditor])
+    const [showEditor, setShowEditor] = useLocalStorage('RegistryExtensionNewReleasePage.showEditor', false)
+    const onShowEditorClick = useCallback(() => setShowEditor(true), [setShowEditor])
 
-        return !extension.registryExtension || !extension.registryExtension.viewerCanAdminister ? (
-            <HeroPage
-                icon={ErrorIcon}
-                title="Unauthorized"
-                subtitle="You are not authorized to adminster this extension."
-            />
-        ) : (
-            <div className="registry-extension-new-release-page">
-                <PageTitle title="Publish new release" />
-                <h2>Publish new release</h2>
-                <p>
-                    Use the{' '}
-                    <a href="https://github.com/sourcegraph/src-cli" target="_blank" rel="noopener noreferrer">
-                        <code>src</code> CLI tool
-                    </a>{' '}
-                    to publish a new release:
-                </p>
-                <pre>
-                    <code>$ src extensions publish</code>
-                </pre>
-                {showEditor ? (
-                    <>
-                        <hr className="my-4" />
-                        <h2>Extension editor (experimental)</h2>
-                        <p>
-                            Edit or paste in an extension JSON manifest and JavaScript bundle. The JavaScript bundle
-                            source must be self-contained; dependency bundling and TypeScript transpilation is not yet
-                            supported.
-                        </p>
-                        <Form onSubmit={onSubmit} className="mb-3">
-                            <div className="row">
-                                <div className="col-lg-6">
-                                    <div className="form-group">
-                                        <label htmlFor="registry-extension-new-release-page__manifest">
-                                            <h3>Manifest</h3>
-                                        </label>
+    return !extension.registryExtension || !extension.registryExtension.viewerCanAdminister ? (
+        <HeroPage
+            icon={ErrorIcon}
+            title="Unauthorized"
+            subtitle="You are not authorized to adminster this extension."
+        />
+    ) : (
+        <div className="registry-extension-new-release-page">
+            <PageTitle title="Publish new release" />
+            <h2>Publish new release</h2>
+            <p>
+                Use the{' '}
+                <a href="https://github.com/sourcegraph/src-cli" target="_blank" rel="noopener noreferrer">
+                    <code>src</code> CLI tool
+                </a>{' '}
+                to publish a new release:
+            </p>
+            <pre>
+                <code>$ src extensions publish</code>
+            </pre>
+            {showEditor ? (
+                <>
+                    <hr className="my-4" />
+                    <h2>Extension editor (experimental)</h2>
+                    <p>
+                        Edit or paste in an extension JSON manifest and JavaScript bundle. The JavaScript bundle source
+                        must be self-contained; dependency bundling and TypeScript transpilation is not yet supported.
+                    </p>
+                    <Form onSubmit={onSubmit} className="mb-3">
+                        <div className="row">
+                            <div className="col-lg-6">
+                                <div className="form-group">
+                                    <label htmlFor="registry-extension-new-release-page__manifest">
+                                        <h3>Manifest</h3>
+                                    </label>
+                                    <DynamicallyImportedMonacoSettingsEditor
+                                        id="registry-extension-new-release-page__manifest"
+                                        className="d-block"
+                                        value={manifest}
+                                        onChange={setManifest}
+                                        jsonSchema={extensionSchemaJSON}
+                                        readOnly={updateOrError === LOADING}
+                                        isLightTheme={isLightTheme}
+                                        history={history}
+                                    />
+                                </div>
+                            </div>
+                            <div className="col-lg-6">
+                                <div className="form-group">
+                                    <label htmlFor="registry-extension-new-release-page__bundle">
+                                        <h3>Source</h3>
+                                    </label>
+                                    {bundleOrError === undefined ? (
+                                        <div>
+                                            <LoadingSpinner className="icon-inline" />
+                                        </div>
+                                    ) : isErrorLike(bundleOrError) ? (
+                                        <ErrorAlert error={bundleOrError} />
+                                    ) : (
                                         <DynamicallyImportedMonacoSettingsEditor
-                                            id="registry-extension-new-release-page__manifest"
+                                            id="registry-extension-new-release-page__bundle"
+                                            language="javascript"
                                             className="d-block"
-                                            value={manifest}
-                                            onChange={setManifest}
-                                            jsonSchema={extensionSchemaJSON}
+                                            // Only 1 component can block navigation, and the
+                                            // other editor does, so we don't.
+                                            blockNavigationIfDirty={false}
+                                            value={bundleOrError}
+                                            onChange={onChangeBundle}
                                             readOnly={updateOrError === LOADING}
                                             isLightTheme={isLightTheme}
                                             history={history}
                                         />
-                                    </div>
-                                </div>
-                                <div className="col-lg-6">
-                                    <div className="form-group">
-                                        <label htmlFor="registry-extension-new-release-page__bundle">
-                                            <h3>Source</h3>
-                                        </label>
-                                        {bundleOrError === undefined ? (
-                                            <div>
-                                                <LoadingSpinner className="icon-inline" />
-                                            </div>
-                                        ) : isErrorLike(bundleOrError) ? (
-                                            <ErrorAlert error={bundleOrError} />
-                                        ) : (
-                                            <DynamicallyImportedMonacoSettingsEditor
-                                                id="registry-extension-new-release-page__bundle"
-                                                language="javascript"
-                                                className="d-block"
-                                                // Only 1 component can block navigation, and the
-                                                // other editor does, so we don't.
-                                                blockNavigationIfDirty={false}
-                                                value={bundleOrError}
-                                                onChange={onChangeBundle}
-                                                readOnly={updateOrError === LOADING}
-                                                isLightTheme={isLightTheme}
-                                                history={history}
-                                            />
-                                        )}
-                                    </div>
+                                    )}
                                 </div>
                             </div>
+                        </div>
+                        <div className="d-flex align-items-center">
                             <button
                                 type="submit"
                                 disabled={updateOrError === LOADING || isErrorLike(bundleOrError)}
-                                className="btn btn-primary"
+                                className="btn btn-primary mr-2"
                             >
-                                {updateOrError === LOADING ? <LoadingSpinner className="icon-inline" /> : 'Publish'}
-                            </button>
-                        </Form>
-                        {updateOrError &&
-                            (isErrorLike(updateOrError) ? (
-                                <div className="alert alert-danger">{updateOrError.message}</div>
-                            ) : (
-                                updateOrError !== LOADING && (
-                                    <div className="alert alert-success">Published release successfully.</div>
-                                )
-                            ))}
-                    </>
-                ) : (
-                    <button type="button" className="btn btn-secondary" onClick={onShowEditorClick}>
-                        Experimental: Use in-browser extension editor
-                    </button>
-                )}
-            </div>
-        )
-    }
-)
+                                Publish
+                            </button>{' '}
+                            {updateOrError &&
+                                !isErrorLike(updateOrError) &&
+                                (updateOrError === LOADING ? (
+                                    <LoadingSpinner className="icon-inline" />
+                                ) : (
+                                    <span className="text-success">
+                                        <CheckCircleIcon className="icon-inline" /> Published release successfully.
+                                    </span>
+                                ))}
+                        </div>
+                        {isErrorLike(updateOrError) && <ErrorAlert error={updateOrError} />}
+                    </Form>
+                </>
+            ) : (
+                <button type="button" className="btn btn-secondary" onClick={onShowEditorClick}>
+                    Experimental: Use in-browser extension editor
+                </button>
+            )}
+        </div>
+    )
+})

--- a/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -27,7 +27,13 @@ interface Props
 
     className?: string
 
-    noBlockNavigationIfDirty?: boolean
+    /**
+     * Block navigation if the editor contents were changed.
+     * Set to `false` if another component already blocks navigation.
+     *
+     * @default true
+     */
+    blockNavigationIfDirty?: boolean
 
     onSave?: (value: string) => void
     onChange?: (value: string) => void
@@ -54,7 +60,7 @@ export class DynamicallyImportedMonacoSettingsEditor extends React.PureComponent
     private configEditor?: _monaco.editor.ICodeEditor
 
     public componentDidMount(): void {
-        if (!this.props.noBlockNavigationIfDirty) {
+        if (this.props.blockNavigationIfDirty !== false) {
             // Prevent navigation when dirty.
             this.subscriptions.add(
                 this.props.history.block((location: H.Location, action: H.Action) => {

--- a/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -27,6 +27,8 @@ interface Props
 
     className?: string
 
+    noBlockNavigationIfDirty?: boolean
+
     onSave?: (value: string) => void
     onChange?: (value: string) => void
     onDirtyChange?: (dirty: boolean) => void
@@ -52,18 +54,20 @@ export class DynamicallyImportedMonacoSettingsEditor extends React.PureComponent
     private configEditor?: _monaco.editor.ICodeEditor
 
     public componentDidMount(): void {
-        // Prevent navigation when dirty.
-        this.subscriptions.add(
-            this.props.history.block((location: H.Location, action: H.Action) => {
-                if (action === 'REPLACE') {
-                    return undefined
-                }
-                if (this.props.loading || this.isDirty) {
-                    return 'Discard changes?'
-                }
-                return undefined // allow navigation
-            })
-        )
+        if (!this.props.noBlockNavigationIfDirty) {
+            // Prevent navigation when dirty.
+            this.subscriptions.add(
+                this.props.history.block((location: H.Location, action: H.Action) => {
+                    if (action === 'REPLACE') {
+                        return undefined
+                    }
+                    if (this.props.loading || this.isDirty) {
+                        return 'Discard changes?'
+                    }
+                    return undefined // allow navigation
+                })
+            )
+        }
     }
 
     public componentWillUnmount(): void {

--- a/web/src/util/useLocalStorage.ts
+++ b/web/src/util/useLocalStorage.ts
@@ -7,18 +7,23 @@ import { useState } from 'react'
  * @param initialValue The initial value to use when there is no value in localStorage for the key.
  * @returns A getter and setter for the value (`const [foo, setFoo] = useLocalStorage('key', 123)`).
  */
-export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T) => void] => {
+export const useLocalStorage = <T>(
+    key: string,
+    initialValue: T
+): [T, (value: T | ((previousValue: T) => T)) => void] => {
     const [storedValue, setStoredValue] = useState<T>(() => {
         try {
             const item = localStorage.getItem(key)
-            return item ? JSON.parse(item) : initialValue
+            return item ? (JSON.parse(item) as T) : initialValue
         } catch (error) {
             return initialValue
         }
     })
 
-    const setValue = (value: T): void => {
-        const valueToStore = typeof value === 'function' ? value(storedValue) : value
+    const setValue = (value: T | ((previousValue: T) => T)): void => {
+        // We need to cast here because T could be a function type itself,
+        // but we cannot tell TypeScript that functions are not allowed as T.
+        const valueToStore = typeof value === 'function' ? (value as (previousValue: T) => T)(storedValue) : value
         setStoredValue(valueToStore)
         window.localStorage.setItem(key, JSON.stringify(valueToStore))
     }

--- a/web/src/util/useLocalStorage.ts
+++ b/web/src/util/useLocalStorage.ts
@@ -12,20 +12,16 @@ export const useLocalStorage = <T>(
     initialValue: T
 ): [T, (value: T | ((previousValue: T) => T)) => void] => {
     const [storedValue, setStoredValue] = useState<T>(() => {
-        try {
-            const item = localStorage.getItem(key)
-            return item ? (JSON.parse(item) as T) : initialValue
-        } catch (error) {
-            return initialValue
-        }
+        const item = localStorage.getItem(key)
+        return item ? (JSON.parse(item) as T) : initialValue
     })
 
     const setValue = (value: T | ((previousValue: T) => T)): void => {
         // We need to cast here because T could be a function type itself,
         // but we cannot tell TypeScript that functions are not allowed as T.
         const valueToStore = typeof value === 'function' ? (value as (previousValue: T) => T)(storedValue) : value
-        setStoredValue(valueToStore)
         window.localStorage.setItem(key, JSON.stringify(valueToStore))
+        setStoredValue(valueToStore)
     }
 
     return [storedValue, setValue]

--- a/web/src/util/useLocalStorage.ts
+++ b/web/src/util/useLocalStorage.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+
+/**
+ * A React hook to use and set state that is persisted in localStorage.
+ *
+ * @param key The localStorage key to use for persistence.
+ * @param initialValue The initial value to use when there is no value in localStorage for the key.
+ * @returns A getter and setter for the value (`const [foo, setFoo] = useLocalStorage('key', 123)`).
+ */
+export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T) => void] => {
+    const [storedValue, setStoredValue] = useState<T>(() => {
+        try {
+            const item = localStorage.getItem(key)
+            return item ? JSON.parse(item) : initialValue
+        } catch (error) {
+            return initialValue
+        }
+    })
+
+    const setValue = (value: T): void => {
+        const valueToStore = typeof value === 'function' ? value(storedValue) : value
+        setStoredValue(valueToStore)
+        window.localStorage.setItem(key, JSON.stringify(valueToStore))
+    }
+
+    return [storedValue, setValue]
+}


### PR DESCRIPTION
This lets users interactively create and publish extensions on the web app, editing the JavaScript source code in a Monaco editor. There is no TypeScript compilation or dependency packaging provided, so this is quite limited.

This is intended to support quick, live iteration with customers and at events. This was not a lot of work and is not a major feature or intended for actual extension development.


![exteditor-off](https://user-images.githubusercontent.com/1976/63231008-187e5d80-c1ca-11e9-93ab-b0bf50986d00.png)


![exteditor-on2](https://user-images.githubusercontent.com/1976/63231007-187e5d80-c1ca-11e9-8b81-95e01ff1d7c7.png)
