### PR TITLE
Support toggling display of a code host's native tooltips

### DIFF
--- a/browser/src/app.scss
+++ b/browser/src/app.scss
@@ -70,6 +70,7 @@ $theme-colors-light: (
 @import './libs/phabricator/style.scss';
 @import './libs/code_intelligence/HoverOverlay.scss';
 @import './libs/code_intelligence/external_links';
+@import './libs/code_intelligence/native_tooltips';
 @import './shared';
 
 .sourcegraph-options-menu {

--- a/browser/src/browser/types.ts
+++ b/browser/src/browser/types.ts
@@ -59,6 +59,9 @@ export interface StorageItems {
      */
     clientSettings: string
     sideloadedExtensionURL: string | null
+    dismissedHoverAlerts: {
+        [alertType: string]: boolean
+    }
 }
 
 interface ClientConfigurationDetails {
@@ -86,6 +89,7 @@ export const defaultStorageItems: StorageItems = {
     },
     clientSettings: '',
     sideloadedExtensionURL: null,
+    dismissedHoverAlerts: {},
 }
 
 /**

--- a/browser/src/browser/types.ts
+++ b/browser/src/browser/types.ts
@@ -1,5 +1,6 @@
 import { GraphQLResult } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
+import { ExtensionHoverAlertType } from '../libs/code_intelligence/hover_alerts'
 import { DEFAULT_SOURCEGRAPH_URL } from '../shared/util/context'
 
 interface RepoLocations {
@@ -60,7 +61,7 @@ export interface StorageItems {
     clientSettings: string
     sideloadedExtensionURL: string | null
     dismissedHoverAlerts: {
-        [alertType: string]: boolean
+        [alertType in ExtensionHoverAlertType]?: boolean
     }
 }
 

--- a/browser/src/extension/scripts/inject.tsx
+++ b/browser/src/extension/scripts/inject.tsx
@@ -100,7 +100,7 @@ async function main(): Promise<void> {
 
     // For the life time of the content script, add features in reaction to DOM changes
     if (codeHost) {
-        console.log('Detected code host', codeHost.name)
+        console.log('Detected code host', codeHost.type)
         subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost, IS_EXTENSION))
     }
 }

--- a/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -189,7 +189,8 @@ export const checkIsBitbucket = (): boolean =>
     !!document.querySelector('.aui-header-logo.aui-header-logo-bitbucket')
 
 export const bitbucketServerCodeHost: CodeHost = {
-    name: 'bitbucket-server',
+    type: 'bitbucket-server',
+    name: 'Bitbucket Server',
     check: checkIsBitbucket,
     codeViewResolvers: [codeViewResolver],
     getCommandPaletteMount,

--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -167,6 +167,7 @@ describe('code_intelligence', () => {
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
                         type: 'github',
+                        name: 'GitHub',
                         check: () => true,
                         codeViewResolvers: [],
                     },
@@ -193,6 +194,7 @@ describe('code_intelligence', () => {
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
                         type: 'github',
+                        name: 'GitHub',
                         check: () => true,
                         getCommandPaletteMount: () => commandPaletteMount,
                         codeViewResolvers: [],
@@ -216,6 +218,7 @@ describe('code_intelligence', () => {
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
                         type: 'github',
+                        name: 'GitHub',
                         check: () => true,
                         codeViewResolvers: [],
                     },
@@ -249,6 +252,7 @@ describe('code_intelligence', () => {
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
                         type: 'github',
+                        name: 'GitHub',
                         check: () => true,
                         codeViewResolvers: [
                             toCodeViewResolver('#code', {
@@ -317,6 +321,7 @@ describe('code_intelligence', () => {
                         mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                         codeHost: {
                             type: 'github',
+                            name: 'GitHub',
                             check: () => true,
                             codeViewResolvers: [
                                 toCodeViewResolver('#code', {
@@ -419,6 +424,7 @@ describe('code_intelligence', () => {
                         mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                         codeHost: {
                             type: 'github',
+                            name: 'GitHub',
                             check: () => true,
                             codeViewResolvers: [
                                 toCodeViewResolver('#code', {
@@ -563,6 +569,7 @@ describe('code_intelligence', () => {
                     mutations,
                     codeHost: {
                         type: 'github',
+                        name: 'GitHub',
                         check: () => true,
                         codeViewResolvers: [
                             toCodeViewResolver('.code', {

--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -166,7 +166,7 @@ describe('code_intelligence', () => {
                 handleCodeHost({
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
-                        name: 'test',
+                        type: 'github',
                         check: () => true,
                         codeViewResolvers: [],
                     },
@@ -192,7 +192,7 @@ describe('code_intelligence', () => {
                 handleCodeHost({
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
-                        name: 'test',
+                        type: 'github',
                         check: () => true,
                         getCommandPaletteMount: () => commandPaletteMount,
                         codeViewResolvers: [],
@@ -215,7 +215,7 @@ describe('code_intelligence', () => {
                 handleCodeHost({
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
-                        name: 'test',
+                        type: 'github',
                         check: () => true,
                         codeViewResolvers: [],
                     },
@@ -248,7 +248,7 @@ describe('code_intelligence', () => {
                 handleCodeHost({
                     mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                     codeHost: {
-                        name: 'test',
+                        type: 'github',
                         check: () => true,
                         codeViewResolvers: [
                             toCodeViewResolver('#code', {
@@ -316,7 +316,7 @@ describe('code_intelligence', () => {
                     handleCodeHost({
                         mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                         codeHost: {
-                            name: 'test',
+                            type: 'github',
                             check: () => true,
                             codeViewResolvers: [
                                 toCodeViewResolver('#code', {
@@ -418,7 +418,7 @@ describe('code_intelligence', () => {
                     handleCodeHost({
                         mutations: of([{ addedNodes: [document.body], removedNodes: [] }]),
                         codeHost: {
-                            name: 'test',
+                            type: 'github',
                             check: () => true,
                             codeViewResolvers: [
                                 toCodeViewResolver('#code', {
@@ -562,7 +562,7 @@ describe('code_intelligence', () => {
                 handleCodeHost({
                     mutations,
                     codeHost: {
-                        name: 'test',
+                        type: 'github',
                         check: () => true,
                         codeViewResolvers: [
                             toCodeViewResolver('.code', {

--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -9,12 +9,17 @@ import { integrationTestContext } from '../../../../shared/src/api/integration-t
 import { Controller } from '../../../../shared/src/extensions/controller'
 import { SuccessGraphQLResult } from '../../../../shared/src/graphql/graphql'
 import { IMutation, IQuery } from '../../../../shared/src/graphql/schema'
-import { PlatformContext } from '../../../../shared/src/platform/context'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../shared/src/telemetry/telemetryService'
 import { isDefined } from '../../../../shared/src/util/types'
 import { DEFAULT_SOURCEGRAPH_URL } from '../../shared/util/context'
 import { MutationRecordLike } from '../../shared/util/dom'
-import { createGlobalDebugMount, createOverlayMount, FileInfo, handleCodeHost } from './code_intelligence'
+import {
+    CodeIntelligenceProps,
+    createGlobalDebugMount,
+    createOverlayMount,
+    FileInfo,
+    handleCodeHost,
+} from './code_intelligence'
 import { toCodeViewResolver } from './code_views'
 
 const RENDER = jest.fn()
@@ -36,8 +41,8 @@ const createMockController = (services: Services): Controller => ({
 })
 
 const createMockPlatformContext = (
-    partialMocks?: Partial<Pick<PlatformContext, 'forceUpdateTooltip' | 'sideloadedExtensionURL' | 'urlToFile'>>
-): Pick<PlatformContext, 'forceUpdateTooltip' | 'sideloadedExtensionURL' | 'urlToFile' | 'requestGraphQL'> => ({
+    partialMocks?: Partial<CodeIntelligenceProps['platformContext']>
+): CodeIntelligenceProps['platformContext'] => ({
     forceUpdateTooltip: jest.fn(),
     urlToFile: jest.fn(),
     // Mock implementation of `requestGraphQL()` that returns successful
@@ -113,6 +118,7 @@ const createMockPlatformContext = (
         return throwError(new Error('GraphQL request failed'))
     },
     sideloadedExtensionURL: new Subject<string | null>(),
+    settings: NEVER,
     ...partialMocks,
 })
 

--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -181,7 +181,7 @@ describe('code_intelligence', () => {
             )
             const overlayMount = document.body.querySelector('.hover-overlay-mount')
             expect(overlayMount).toBeDefined()
-            expect(overlayMount!.className).toBe('hover-overlay-mount hover-overlay-mount__test')
+            expect(overlayMount!.className).toBe('hover-overlay-mount hover-overlay-mount__github')
             const renderedOverlay = elementRenderedAtMount(overlayMount!)
             expect(renderedOverlay).not.toBeUndefined()
         })

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -32,7 +32,6 @@ import {
     observeOn,
     switchMap,
     take,
-    tap,
     withLatestFrom,
 } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../shared/src/actions/ActionItem'

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -120,10 +120,18 @@ export type MountGetter = (container: HTMLElement) => HTMLElement | null
  */
 export type CodeHostContext = RepoSpec & Partial<RevSpec> & { privateRepository: boolean }
 
+type CodeHostType = 'github' | 'phabricator' | 'bitbucket-server' | 'gitlab'
+
 /** Information for adding code intelligence to code views on arbitrary code hosts. */
 export interface CodeHost extends ApplyLinkPreviewOptions {
     /**
-     * The name of the code host. This will be added as a className to the overlay mount.
+     * The type of the code host. This will be added as a className to the overlay mount.
+     * Use {@link CodeHost#name} if you need a human-readable name for the code host to display in the UI.
+     */
+    type: CodeHostType
+
+    /**
+     * A human-readable name for the code host, to be displayed in the UI.
      */
     name: string
 
@@ -391,7 +399,7 @@ export function initCodeIntelligence({
 
     // This renders to document.body, which we can assume is never removed,
     // so we don't need to subscribe to mutations.
-    const overlayMount = createOverlayMount(codeHost.name)
+    const overlayMount = createOverlayMount(codeHost.type)
     render(<HoverOverlayContainer />, overlayMount)
 
     return { hoverifier, subscription }

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -52,6 +52,7 @@ import {
     HoverData,
     HoverOverlay,
     HoverOverlayClassProps,
+    HoverOverlayProps,
 } from '../../../../shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '../../../../shared/src/languages'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
@@ -379,7 +380,7 @@ export function initCodeIntelligence({
                     platformContext={platformContext}
                     location={H.createLocation(window.location)}
                     onCloseButtonClick={nextCloseButtonClick}
-                    onAlertDismissed={onHoverAlertDismissed}
+                    onAlertDismissed={onHoverAlertDismissed as HoverOverlayProps['onAlertDismissed']}
                 />
             ) : null
         }

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -716,26 +716,22 @@ export function handleCodeHost({
             const adjustPosition = getPositionAdjuster && getPositionAdjuster(platformContext.requestGraphQL)
             let hoverSubscription = new Subscription()
             codeViewEvent.subscriptions.add(
-                nativeTooltipsEnabled
-                    .pipe(
-                        tap(useNativeTooltips => {
-                            hoverSubscription.unsubscribe()
-                            if (!useNativeTooltips) {
-                                hoverSubscription = hoverifier.hoverify({
-                                    dom: domFunctions,
-                                    positionEvents: of(element).pipe(
-                                        findPositionsFromEvents({
-                                            domFunctions,
-                                            tokenize: codeHost.codeViewsRequireTokenization !== false,
-                                        })
-                                    ),
-                                    resolveContext,
-                                    adjustPosition,
+                nativeTooltipsEnabled.subscribe(useNativeTooltips => {
+                    hoverSubscription.unsubscribe()
+                    if (!useNativeTooltips) {
+                        hoverSubscription = hoverifier.hoverify({
+                            dom: domFunctions,
+                            positionEvents: of(element).pipe(
+                                findPositionsFromEvents({
+                                    domFunctions,
+                                    tokenize: codeHost.codeViewsRequireTokenization !== false,
                                 })
-                            }
+                            ),
+                            resolveContext,
+                            adjustPosition,
                         })
-                    )
-                    .subscribe()
+                    }
+                })
             )
             codeViewEvent.subscriptions.add(() => hoverSubscription.unsubscribe())
 

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -765,7 +765,7 @@ export function handleCodeHost({
                     }
                 })
             )
-            codeViewEvent.subscriptions.add(() => hoverSubscription.unsubscribe())
+            codeViewEvent.subscriptions.add(hoverSubscription)
 
             element.classList.add('sg-mounted')
 

--- a/browser/src/libs/code_intelligence/hover_alerts.tsx
+++ b/browser/src/libs/code_intelligence/hover_alerts.tsx
@@ -26,7 +26,7 @@ export function getActiveHoverAlerts(codeHostName?: string): Observable<HoverAle
     )
 }
 /**
- * Marks a hovewr alert as dismissed in sync storage.
+ * Marks a hover alert as dismissed in sync storage.
  */
 export async function onHoverAlertDismissed(alertType: ExtensionHoverAlertType): Promise<void> {
     try {

--- a/browser/src/libs/code_intelligence/hover_alerts.tsx
+++ b/browser/src/libs/code_intelligence/hover_alerts.tsx
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { catchError, map } from 'rxjs/operators'
 import { HoverAlert } from '../../../../shared/src/hover/HoverOverlay'
 import { observeStorageKey, storage } from '../../browser/storage'
 import { nativeTooltipsAlert } from './native_tooltips'
@@ -12,10 +12,14 @@ const getAllHoverAlerts = (codeHostName?: string): HoverAlert[] => [
  * Returns an Osbervable of all hover alerts that have not yet
  * been dismissed by the user.
  */
-export function getActiveHoverAlerts(codeHostName?: string): Observable<HoverAlert[]> {
+export function getActiveHoverAlerts(codeHostName?: string): Observable<HoverAlert[] | undefined> {
     const allAlerts = getAllHoverAlerts(codeHostName)
     return observeStorageKey('sync', 'dismissedHoverAlerts').pipe(
-        map(dismissedAlerts => (dismissedAlerts ? allAlerts.filter(({ type }) => !dismissedAlerts[type]) : allAlerts))
+        map(dismissedAlerts => (dismissedAlerts ? allAlerts.filter(({ type }) => !dismissedAlerts[type]) : allAlerts)),
+        catchError(err => {
+            console.error('Error getting hover alerts', err)
+            return [undefined]
+        })
     )
 }
 /**

--- a/browser/src/libs/code_intelligence/hover_alerts.tsx
+++ b/browser/src/libs/code_intelligence/hover_alerts.tsx
@@ -4,7 +4,7 @@ import { HoverAlert } from '../../../../shared/src/hover/HoverOverlay'
 import { observeStorageKey, storage } from '../../browser/storage'
 import { nativeTooltipsAlert } from './native_tooltips'
 
-const getAllHoverAlerts = (codeHostName: string): HoverAlert[] => [
+const getAllHoverAlerts = (codeHostName?: string): HoverAlert[] => [
     { type: 'nativeTooltips', content: nativeTooltipsAlert(codeHostName) },
 ]
 
@@ -12,7 +12,7 @@ const getAllHoverAlerts = (codeHostName: string): HoverAlert[] => [
  * Returns an Osbervable of all hover alerts that have not yet
  * been dismissed by the user.
  */
-export function getActiveHoverAlerts(codeHostName: string): Observable<HoverAlert[]> {
+export function getActiveHoverAlerts(codeHostName?: string): Observable<HoverAlert[]> {
     const allAlerts = getAllHoverAlerts(codeHostName)
     return observeStorageKey('sync', 'dismissedHoverAlerts').pipe(
         map(dismissedAlerts => (dismissedAlerts ? allAlerts.filter(({ type }) => !dismissedAlerts[type]) : allAlerts))

--- a/browser/src/libs/code_intelligence/hover_alerts.tsx
+++ b/browser/src/libs/code_intelligence/hover_alerts.tsx
@@ -15,7 +15,9 @@ const getAllHoverAlerts = (codeHostName?: string): HoverAlert<ExtensionHoverAler
  * Returns an Osbervable of all hover alerts that have not yet
  * been dismissed by the user.
  */
-export function getActiveHoverAlerts(codeHostName?: string): Observable<HoverAlert[] | undefined> {
+export function getActiveHoverAlerts(
+    codeHostName?: string
+): Observable<HoverAlert<ExtensionHoverAlertType>[] | undefined> {
     const allAlerts = getAllHoverAlerts(codeHostName)
     return observeStorageKey('sync', 'dismissedHoverAlerts').pipe(
         map(dismissedAlerts => (dismissedAlerts ? allAlerts.filter(({ type }) => !dismissedAlerts[type]) : allAlerts)),

--- a/browser/src/libs/code_intelligence/hover_alerts.tsx
+++ b/browser/src/libs/code_intelligence/hover_alerts.tsx
@@ -1,0 +1,35 @@
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { HoverAlert } from '../../../../shared/src/hover/HoverOverlay'
+import { observeStorageKey, storage } from '../../browser/storage'
+import { nativeTooltipsAlert } from './native_tooltips'
+
+const getAllHoverAlerts = (codeHostName: string): HoverAlert[] => [
+    { type: 'nativeTooltips', content: nativeTooltipsAlert(codeHostName) },
+]
+
+/**
+ * Returns an Osbervable of all hover alerts that have not yet
+ * been dismissed by the user.
+ */
+export function getActiveHoverAlerts(codeHostName: string): Observable<HoverAlert[]> {
+    const allAlerts = getAllHoverAlerts(codeHostName)
+    return observeStorageKey('sync', 'dismissedHoverAlerts').pipe(
+        map(dismissedAlerts => (dismissedAlerts ? allAlerts.filter(({ type }) => !dismissedAlerts[type]) : allAlerts))
+    )
+}
+/**
+ * Marks a hovewr alert as dismissed in sync storage.
+ */
+export async function onHoverAlertDismissed(alertType: string): Promise<void> {
+    try {
+        const partialStorageItems = {
+            dismissedHoverAlerts: {},
+            ...(await storage.sync.get('dismissedHoverAlerts')),
+        }
+        partialStorageItems.dismissedHoverAlerts[alertType] = true
+        await storage.sync.set(partialStorageItems)
+    } catch (err) {
+        console.error('Error dismissing alert', err)
+    }
+}

--- a/browser/src/libs/code_intelligence/hover_alerts.tsx
+++ b/browser/src/libs/code_intelligence/hover_alerts.tsx
@@ -2,9 +2,12 @@ import { Observable } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
 import { HoverAlert } from '../../../../shared/src/hover/HoverOverlay'
 import { observeStorageKey, storage } from '../../browser/storage'
+import { StorageItems } from '../../browser/types'
 import { nativeTooltipsAlert } from './native_tooltips'
 
-const getAllHoverAlerts = (codeHostName?: string): HoverAlert[] => [
+export type ExtensionHoverAlertType = 'nativeTooltips'
+
+const getAllHoverAlerts = (codeHostName?: string): HoverAlert<ExtensionHoverAlertType>[] => [
     { type: 'nativeTooltips', content: nativeTooltipsAlert(codeHostName) },
 ]
 
@@ -25,9 +28,9 @@ export function getActiveHoverAlerts(codeHostName?: string): Observable<HoverAle
 /**
  * Marks a hovewr alert as dismissed in sync storage.
  */
-export async function onHoverAlertDismissed(alertType: string): Promise<void> {
+export async function onHoverAlertDismissed(alertType: ExtensionHoverAlertType): Promise<void> {
     try {
-        const partialStorageItems = {
+        const partialStorageItems: Pick<StorageItems, 'dismissedHoverAlerts'> = {
             dismissedHoverAlerts: {},
             ...(await storage.sync.get('dismissedHoverAlerts')),
         }

--- a/browser/src/libs/code_intelligence/native_tooltips.scss
+++ b/browser/src/libs/code_intelligence/native_tooltips.scss
@@ -1,0 +1,5 @@
+.native-tooltip {
+    &--hidden {
+        display: none;
+    }
+}

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -74,12 +74,14 @@ export function registerNativeTooltipContributions(extensionsController: {
                     category: parseTemplate('Code host'),
                     commandArguments: [
                         parseTemplate('codeHost.useNativeTooltips'),
+                        // tslint:disable-next-line no-invalid-template-strings
                         parseTemplate('${!config.codeHost.useNativeTooltips}'),
                         null,
                         parseTemplate('json'),
                     ],
                     title: parseTemplate(
-                        'Use ${config.codeHost.useNativeTooltips && "Sourcegraph" || "native"} hover tooltips'
+                        // tslint:disable-next-line no-invalid-template-strings
+                        'Prefer ${config.codeHost.useNativeTooltips && "Sourcegraph" || "non-Sourcegraph"} hover tooltips'
                     ),
                 },
             ],

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash'
 import { from, Observable, Unsubscribable } from 'rxjs'
-import { distinctUntilChanged, filter, map, publishReplay, refCount, tap } from 'rxjs/operators'
+import { distinctUntilChanged, filter, map, publishReplay, refCount } from 'rxjs/operators'
 import { parseTemplate } from '../../../../shared/src/api/client/context/expr/evaluator'
 import { Services } from '../../../../shared/src/api/client/services'
 import { PlatformContext } from '../../../../shared/src/platform/context'

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -47,7 +47,7 @@ export function nativeTooltipsEnabledFromSettings(settings: PlatformContext['set
     return from(settings).pipe(
         map(({ final }) => final),
         filter(isDefined),
-        filter((s: Settings | ErrorLike): s is Settings => !isErrorLike(s)),
+        filter((s: Settings | ErrorLike): s is Exclude<typeof s, ErrorLike> => !isErrorLike(s)),
         map(s => !!s['codeHost.useNativeTooltips']),
         distinctUntilChanged((a, b) => isEqual(a, b)),
         publishReplay(1),

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -1,4 +1,5 @@
 import { isEqual } from 'lodash'
+import * as React from 'react'
 import { from, Observable, Unsubscribable } from 'rxjs'
 import { distinctUntilChanged, filter, map, publishReplay, refCount } from 'rxjs/operators'
 import { parseTemplate } from '../../../../shared/src/api/client/context/expr/evaluator'
@@ -89,6 +90,10 @@ export function registerNativeTooltipContributions(extensionsController: {
     })
 }
 
-export const nativeTooltipsAlert = (codeHostName?: string) =>
-    `Sourcegraph has hidden ${codeHostName ||
-        'the code host'}'s native hover tooltips. You can toggle this at any time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from the command palette or set \`"codeHost.useNativeTooltips": true\` in your user settings.`
+export const nativeTooltipsAlert = (codeHostName?: string): React.ReactElement => (
+    <>
+        `Sourcegraph has hidden {codeHostName || 'the code host'}'s native hover tooltips. You can toggle this at any
+        time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from the command
+        palette or set <code>"codeHost.useNativeTooltips": true`</code> in your user settings.`
+    </>
+)

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -35,17 +35,10 @@ export function handleNativeTooltips(
     return nativeTooltips.subscribe(({ element, subscriptions }) => {
         subscriptions.add(
             nativeTooltipsEnabled
-                .pipe(
-                    tap(enabled => {
-                        if (enabled) {
-                            element.classList.remove(NATIVE_TOOLTIP_HIDDEN)
-                        } else {
-                            element.classList.add(NATIVE_TOOLTIP_HIDDEN)
-                        }
-                    })
-                )
                 // This subscription is correctly handled through the view's subscriptions.
-                .subscribe()
+                .subscribe(enabled => {
+                    element.classList.toggle(NATIVE_TOOLTIP_HIDDEN, !enabled)
+                })
         )
     })
 }

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -49,7 +49,7 @@ export function nativeTooltipsEnabledFromSettings(settings: PlatformContext['set
         filter(isDefined),
         filter((s: Settings | ErrorLike): s is Settings => !isErrorLike(s)),
         map(s => !!s['codeHost.useNativeTooltips']),
-        distinctUntilChanged(isEqual),
+        distinctUntilChanged((a, b) => isEqual(a, b)),
         publishReplay(1),
         refCount()
     )

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -6,7 +6,7 @@ import { Services } from '../../../../shared/src/api/client/services'
 import { PlatformContext } from '../../../../shared/src/platform/context'
 import { Settings } from '../../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
-import { isDefined } from '../../../../shared/src/util/types'
+import { isDefined, isNot } from '../../../../shared/src/util/types'
 import { MutationRecordLike } from '../../shared/util/dom'
 import { CodeHost } from './code_intelligence'
 import { trackViews } from './views'
@@ -47,7 +47,7 @@ export function nativeTooltipsEnabledFromSettings(settings: PlatformContext['set
     return from(settings).pipe(
         map(({ final }) => final),
         filter(isDefined),
-        filter((s: Settings | ErrorLike): s is Exclude<typeof s, ErrorLike> => !isErrorLike(s)),
+        filter(isNot<ErrorLike | Settings, ErrorLike>(isErrorLike)),
         map(s => !!s['codeHost.useNativeTooltips']),
         distinctUntilChanged((a, b) => isEqual(a, b)),
         publishReplay(1),

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -38,7 +38,7 @@ export function handleNativeTooltips(
                 <>
                     Sourcegraph has hidden {name || 'the code host'}'s native hover tooltips. You can toggle this at any
                     time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from the
-                    command palette or set <code>"codeHost.useNativeTooltips": true`</code> in your user settings.
+                    command palette or set <code>"codeHost.useNativeTooltips": true</code> in your user settings.
                 </>
             ),
         }),

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -95,3 +95,6 @@ export function registerNativeTooltipContributions(extensionsController: {
         },
     })
 }
+
+export const nativeTooltipsAlert = (codeHostName: string) =>
+    `Sourcegraph has hidden ${codeHostName}'s native hover tooltips. You can toggle this at any time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from the command palette or set \`"codeHost.useNativeTooltips": true\` in your user settings.`

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -89,5 +89,6 @@ export function registerNativeTooltipContributions(extensionsController: {
     })
 }
 
-export const nativeTooltipsAlert = (codeHostName: string) =>
-    `Sourcegraph has hidden ${codeHostName}'s native hover tooltips. You can toggle this at any time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from the command palette or set \`"codeHost.useNativeTooltips": true\` in your user settings.`
+export const nativeTooltipsAlert = (codeHostName?: string) =>
+    `Sourcegraph has hidden ${codeHostName ||
+        'the code host'}'s native hover tooltips. You can toggle this at any time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from the command palette or set \`"codeHost.useNativeTooltips": true\` in your user settings.`

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -83,6 +83,7 @@ export function registerNativeTooltipContributions(extensionsController: {
                     category: parseTemplate('Code host'),
                     commandArguments: [
                         parseTemplate('codeHost.useNativeTooltips'),
+                        // tslint:disable-next-line no-invalid-template-strings
                         parseTemplate('${!config.codeHost.useNativeTooltips}'),
                         null,
                         parseTemplate('json'),

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -1,0 +1,95 @@
+import { isEqual } from 'lodash'
+import { from, Observable, Unsubscribable } from 'rxjs'
+import { distinctUntilChanged, filter, map, publishReplay, refCount, tap } from 'rxjs/operators'
+import { parseTemplate } from '../../../../shared/src/api/client/context/expr/evaluator'
+import { Services } from '../../../../shared/src/api/client/services'
+import { PlatformContext } from '../../../../shared/src/platform/context'
+import { Settings } from '../../../../shared/src/settings/settings'
+import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
+import { isDefined } from '../../../../shared/src/util/types'
+import { MutationRecordLike } from '../../shared/util/dom'
+import { CodeHost } from './code_intelligence'
+import { trackViews } from './views'
+
+const NATIVE_TOOLTIP_HIDDEN = 'native-tooltip--hidden'
+
+/**
+ * Defines a native tooltip that is present on a page and exposes operations for manipulating it.
+ */
+export interface NativeTooltip {
+    /** The native tooltip HTML element. */
+    element: HTMLElement
+}
+
+/**
+ * Handles added and removed native tooltips according to the {@link CodeHost} configuration.
+ */
+export function handleNativeTooltips(
+    mutations: Observable<MutationRecordLike[]>,
+    nativeTooltipsEnabled: Observable<boolean>,
+    nativeTooltipResolvers: NonNullable<CodeHost['nativeTooltipResolvers']>
+): Unsubscribable {
+    /** A stream of added or removed native tooltips. */
+    const nativeTooltips = mutations.pipe(trackViews(nativeTooltipResolvers))
+
+    return nativeTooltips.subscribe(({ element, subscriptions }) => {
+        subscriptions.add(
+            nativeTooltipsEnabled
+                .pipe(
+                    tap(enabled => {
+                        if (enabled) {
+                            element.classList.remove(NATIVE_TOOLTIP_HIDDEN)
+                        } else {
+                            element.classList.add(NATIVE_TOOLTIP_HIDDEN)
+                        }
+                    })
+                )
+                // This subscription is correctly handled through the view's subscriptions.
+                .subscribe()
+        )
+    })
+}
+
+export function nativeTooltipsEnabledFromSettings(settings: PlatformContext['settings']): Observable<boolean> {
+    return from(settings).pipe(
+        map(({ final }) => final),
+        filter(isDefined),
+        filter((s: Settings | ErrorLike): s is Settings => !isErrorLike(s)),
+        map(s => !!s['codeHost.useNativeTooltips']),
+        distinctUntilChanged(isEqual),
+        publishReplay(1),
+        refCount()
+    )
+}
+
+export function registerNativeTooltipContributions(extensionsController: {
+    services: Pick<Services, 'contribution'>
+}): Unsubscribable {
+    return extensionsController.services.contribution.registerContributions({
+        contributions: {
+            actions: [
+                {
+                    id: 'codeHost.toggleUseNativeTooltips',
+                    command: 'updateConfiguration',
+                    category: parseTemplate('Code host'),
+                    commandArguments: [
+                        parseTemplate('codeHost.useNativeTooltips'),
+                        parseTemplate('${!config.codeHost.useNativeTooltips}'),
+                        null,
+                        parseTemplate('json'),
+                    ],
+                    title: parseTemplate(
+                        'Use ${config.codeHost.useNativeTooltips && "Sourcegraph" || "native"} hover tooltips'
+                    ),
+                },
+            ],
+            menus: {
+                commandPalette: [
+                    {
+                        action: 'codeHost.toggleUseNativeTooltips',
+                    },
+                ],
+            },
+        },
+    })
+}

--- a/browser/src/libs/code_intelligence/native_tooltips.tsx
+++ b/browser/src/libs/code_intelligence/native_tooltips.tsx
@@ -36,9 +36,9 @@ export function handleNativeTooltips(
             type: 'nativeTooltips' as const,
             content: (
                 <>
-                    `Sourcegraph has hidden {name || 'the code host'}'s native hover tooltips. You can toggle this at
-                    any time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from
-                    the command palette or set <code>"codeHost.useNativeTooltips": true`</code> in your user settings.`
+                    Sourcegraph has hidden {name || 'the code host'}'s native hover tooltips. You can toggle this at any
+                    time: to enable the native tooltips run “Code host: prefer non-Sourcegraph hover tooltips” from the
+                    command palette or set <code>"codeHost.useNativeTooltips": true`</code> in your user settings.
                 </>
             ),
         }),
@@ -49,7 +49,7 @@ export function handleNativeTooltips(
         nativeTooltipsAlert,
         subscription: nativeTooltips.subscribe(({ element, subscriptions }) => {
             subscriptions.add(
-                // This subscription is correctly handled through the view's subscriptions.
+                // This subscription is correctly handled through the view's `subscriptions`
                 // tslint:disable-next-line rxjs-no-nested-subscribe
                 nativeTooltipsEnabled.subscribe(enabled => {
                     element.classList.toggle(NATIVE_TOOLTIP_HIDDEN, !enabled)
@@ -83,7 +83,6 @@ export function registerNativeTooltipContributions(extensionsController: {
                     category: parseTemplate('Code host'),
                     commandArguments: [
                         parseTemplate('codeHost.useNativeTooltips'),
-                        // tslint:disable-next-line no-invalid-template-strings
                         parseTemplate('${!config.codeHost.useNativeTooltips}'),
                         null,
                         parseTemplate('json'),

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -268,11 +268,11 @@ const nativeTooltipResolver: ViewResolver<NativeTooltip> = {
 }
 
 export const githubCodeHost: CodeHost = {
-    name: 'github',
+    name: 'GitHub',
     codeViewResolvers: [genericCodeViewResolver, fileLineContainerResolver, searchResultCodeViewResolver],
     contentViewResolvers: [markdownBodyViewResolver],
     textFieldResolvers: [commentTextFieldResolver],
-    nativeTooltipResolvers: [nativeTooltipResolver],
+    nativeTooltipResolvers: checkIsGitHubDotCom() ? [nativeTooltipResolver] : undefined,
     getContext: () => {
         const header = document.querySelector('.repohead-details-container')
         const repoHeaderHasPrivateMarker = !!(header && header.querySelector('.private'))

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -273,7 +273,7 @@ export const githubCodeHost: CodeHost = {
     codeViewResolvers: [genericCodeViewResolver, fileLineContainerResolver, searchResultCodeViewResolver],
     contentViewResolvers: [markdownBodyViewResolver],
     textFieldResolvers: [commentTextFieldResolver],
-    nativeTooltipResolvers: checkIsGitHubDotCom() ? [nativeTooltipResolver] : undefined,
+    nativeTooltipResolvers: [nativeTooltipResolver],
     getContext: () => {
         const header = document.querySelector('.repohead-details-container')
         const repoHeaderHasPrivateMarker = !!(header && header.querySelector('.private'))

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -268,7 +268,8 @@ const nativeTooltipResolver: ViewResolver<NativeTooltip> = {
 }
 
 export const githubCodeHost: CodeHost = {
-    name: 'GitHub',
+    type: 'github',
+    name: checkIsGitHubEnterprise() ? 'GitHub Enterprise' : 'GitHub',
     codeViewResolvers: [genericCodeViewResolver, fileLineContainerResolver, searchResultCodeViewResolver],
     contentViewResolvers: [markdownBodyViewResolver],
     textFieldResolvers: [commentTextFieldResolver],

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -320,6 +320,7 @@ export const githubCodeHost: CodeHost = {
         actionItemClassName: 'btn btn-secondary',
         actionItemPressedClassName: 'active',
         closeButtonClassName: 'btn',
+        alertClassName: 'alert-info',
     },
     setElementTooltip,
     linkPreviewContentClass: 'text-small text-gray p-1 mx-1 border rounded-1 bg-gray text-gray-dark',

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -16,6 +16,7 @@ import { querySelectorOrSelf } from '../../shared/util/dom'
 import { toAbsoluteBlobURL } from '../../shared/util/url'
 import { CodeHost, MountGetter } from '../code_intelligence'
 import { CodeView, toCodeViewResolver } from '../code_intelligence/code_views'
+import { NativeTooltip } from '../code_intelligence/native_tooltips'
 import { getSelectionsFromHash, observeSelectionsFromHash } from '../code_intelligence/util/selections'
 import { ViewResolver } from '../code_intelligence/views'
 import { markdownBodyViewResolver } from './content_views'
@@ -261,11 +262,17 @@ export const createOpenOnSourcegraphIfNotExists: MountGetter = (container: HTMLE
     return mount
 }
 
+const nativeTooltipResolver: ViewResolver<NativeTooltip> = {
+    selector: '.js-tagsearch-popover',
+    resolveView: element => ({ element }),
+}
+
 export const githubCodeHost: CodeHost = {
     name: 'github',
     codeViewResolvers: [genericCodeViewResolver, fileLineContainerResolver, searchResultCodeViewResolver],
     contentViewResolvers: [markdownBodyViewResolver],
     textFieldResolvers: [commentTextFieldResolver],
+    nativeTooltipResolvers: [nativeTooltipResolver],
     getContext: () => {
         const header = document.querySelector('.repohead-details-container')
         const repoHeaderHasPrivateMarker = !!(header && header.querySelector('.private'))

--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -89,7 +89,8 @@ const codeViewResolver: ViewResolver<CodeView> = {
 }
 
 export const gitlabCodeHost: CodeHost = {
-    name: 'gitlab',
+    type: 'gitlab',
+    name: 'GitLab',
     check: checkIsGitlab,
     codeViewResolvers: [codeViewResolver],
     adjustOverlayPosition,

--- a/browser/src/libs/phabricator/code_intelligence.ts
+++ b/browser/src/libs/phabricator/code_intelligence.ts
@@ -174,7 +174,8 @@ export const phabricatorCodeHost: CodeHost = {
         diffusionSourceCodeViewResolver,
         phabSourceCodeViewResolver,
     ],
-    name: 'phabricator',
+    type: 'phabricator',
+    name: 'Phabricator',
     check: checkIsPhabricator,
 
     // TODO: handle parsing selected line number from Phabricator href,

--- a/browser/src/libs/sentry/index.ts
+++ b/browser/src/libs/sentry/index.ts
@@ -53,7 +53,7 @@ export function initSentry(script: 'content' | 'options' | 'background'): void {
             scope.setTag('extension_version', getExtensionVersion())
             const codeHost = determineCodeHost()
             if (codeHost) {
-                scope.setTag('code_host', codeHost.name)
+                scope.setTag('code_host', codeHost.type)
             }
         })
     })

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -465,15 +465,16 @@ type Sentry struct {
 
 // Settings description: Configuration settings for users and organizations on Sourcegraph.
 type Settings struct {
-	AlertsShowPatchUpdates bool                      `json:"alerts.showPatchUpdates,omitempty"`
-	Extensions             map[string]bool           `json:"extensions,omitempty"`
-	Motd                   []string                  `json:"motd,omitempty"`
-	Notices                []*Notice                 `json:"notices,omitempty"`
-	NotificationsSlack     *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
-	SearchContextLines     int                       `json:"search.contextLines,omitempty"`
-	SearchRepositoryGroups map[string][]string       `json:"search.repositoryGroups,omitempty"`
-	SearchSavedQueries     []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
-	SearchScopes           []*SearchScope            `json:"search.scopes,omitempty"`
+	AlertsShowPatchUpdates    bool                      `json:"alerts.showPatchUpdates,omitempty"`
+	CodeHostUseNativeTooltips bool                      `json:"codeHost.useNativeTooltips,omitempty"`
+	Extensions                map[string]bool           `json:"extensions,omitempty"`
+	Motd                      []string                  `json:"motd,omitempty"`
+	Notices                   []*Notice                 `json:"notices,omitempty"`
+	NotificationsSlack        *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
+	SearchContextLines        int                       `json:"search.contextLines,omitempty"`
+	SearchRepositoryGroups    map[string][]string       `json:"search.repositoryGroups,omitempty"`
+	SearchSavedQueries        []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
+	SearchScopes              []*SearchScope            `json:"search.scopes,omitempty"`
 }
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -112,6 +112,11 @@
         "type": "boolean",
         "description": "`true` to enable the extension, `false` to disable the extension (if it was previously enabled)"
       }
+    },
+    "codeHost.useNativeTooltips": {
+      "description": "Whether to use the code host's native hover tooltips when they exist (GitHub's jump-to-definition tooltips, for example).",
+      "type": "boolean",
+      "default": false
     }
   },
   "definitions": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -117,6 +117,11 @@ const SettingsSchemaJSON = `{
         "type": "boolean",
         "description": "` + "`" + `true` + "`" + ` to enable the extension, ` + "`" + `false` + "`" + ` to disable the extension (if it was previously enabled)"
       }
+    },
+    "codeHost.useNativeTooltips": {
+      "description": "Whether to use the code host's native hover tooltips when they exist (GitHub's jump-to-definition tooltips, for example).",
+      "type": "boolean",
+      "default": false
     }
   },
   "definitions": {

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -44,21 +44,10 @@
 
     &__alert {
         padding: 0.5rem;
-        display: flex;
-        flex-direction: column;
     }
 
-    &__alert-actions {
-        align-self: flex-end;
-        margin-top: 0.25rem;
-    }
-
-    &__alert-close-button {
-        border: 1px solid #0c5360;
-        border-radius: 3px;
-        background: transparent;
-        color: #0c5360;
-        padding-left: 0.5rem;
+    &__alert-close {
+        float: right;
     }
 
     // __content elements are a subset of the __row elements

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -4,7 +4,6 @@
     position: absolute;
     min-width: 6rem;
     max-width: 32rem;
-    max-height: 15rem;
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -44,18 +43,26 @@
     }
 
     &__alert {
-        flex: 1 1 auto;
+        padding: 0.5rem;
+        display: flex;
+        align-items: baseline;
     }
 
-    &__alert-content {
-        p {
-            display: inline;
-        }
+    &__alert-logo {
+        padding: 0 0.5rem 0 0;
+    }
+
+    &__alert-close-button {
+        border: none;
+        background: transparent;
+        color: #0c5360;
+        padding-left: 0.5rem;
     }
 
     // __content elements are a subset of the __row elements
     // (the ones that contain markdown or code, but not errors or the actions)
     &__content {
+        max-height: 15rem;
         padding: 0.5rem;
         overflow-x: auto;
         word-wrap: normal;

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -43,6 +43,16 @@
         overflow-y: auto;
     }
 
+    &__alert {
+        flex: 1 1 auto;
+    }
+
+    &__alert-content {
+        p {
+            display: inline;
+        }
+    }
+
     // __content elements are a subset of the __row elements
     // (the ones that contain markdown or code, but not errors or the actions)
     &__content {

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -48,12 +48,6 @@
         flex-direction: column;
     }
 
-    &__alert-content {
-        p {
-            display: inline;
-        }
-    }
-
     &__alert-actions {
         align-self: flex-end;
         margin-top: 0.25rem;

--- a/shared/src/hover/HoverOverlay.scss
+++ b/shared/src/hover/HoverOverlay.scss
@@ -45,15 +45,23 @@
     &__alert {
         padding: 0.5rem;
         display: flex;
-        align-items: baseline;
+        flex-direction: column;
     }
 
-    &__alert-logo {
-        padding: 0 0.5rem 0 0;
+    &__alert-content {
+        p {
+            display: inline;
+        }
+    }
+
+    &__alert-actions {
+        align-self: flex-end;
+        margin-top: 0.25rem;
     }
 
     &__alert-close-button {
-        border: none;
+        border: 1px solid #0c5360;
+        border-radius: 3px;
         background: transparent;
         color: #0c5360;
         padding-left: 0.5rem;

--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -10,7 +10,7 @@ import { HoverMerged } from '../api/client/types/hover'
 import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 import { HoverOverlay, HoverOverlayProps } from './HoverOverlay'
 
-const renderShallow = (element: React.ReactElement<HoverOverlayProps>): React.ReactElement<any> => {
+const renderShallow = (element: React.ReactElement<HoverOverlayProps<string>>): React.ReactElement<any> => {
     const renderer = createRenderer()
     renderer.render(element)
     return renderer.getRenderOutput()
@@ -20,7 +20,7 @@ describe('HoverOverlay', () => {
     const NOOP_EXTENSIONS_CONTROLLER = { executeCommand: async () => void 0 }
     const NOOP_PLATFORM_CONTEXT = { forceUpdateTooltip: () => void 0 }
     const history = H.createMemoryHistory({ keyLength: 0 })
-    const commonProps: HoverOverlayProps = {
+    const commonProps: HoverOverlayProps<string> = {
         location: history.location,
         telemetryService: NOOP_TELEMETRY_SERVICE,
         extensionsController: NOOP_EXTENSIONS_CONTROLLER,

--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -125,7 +125,16 @@ describe('HoverOverlay', () => {
                     actionsOrError={[{ action: { id: 'a', command: 'c' } }]}
                     hoverOrError={{
                         contents: [{ kind: MarkupKind.Markdown, value: 'v' }],
-                        alerts: [{ type: 'a', content: 'b *c* `d`' }],
+                        alerts: [
+                            {
+                                type: 'a' as const,
+                                content: (
+                                    <>
+                                        b <small>c</small> <code>d</code>
+                                    </>
+                                ),
+                            },
+                        ],
                     }}
                 />
             )

--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -117,6 +117,21 @@ describe('HoverOverlay', () => {
         ).toMatchSnapshot()
     })
 
+    test('actions, hover and alert present', () => {
+        expect(
+            renderShallow(
+                <HoverOverlay
+                    {...commonProps}
+                    actionsOrError={[{ action: { id: 'a', command: 'c' } }]}
+                    hoverOrError={{
+                        contents: [{ kind: MarkupKind.Markdown, value: 'v' }],
+                        alerts: [{ type: 'a', content: 'b *c* `d`' }],
+                    }}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
     test('actions present, hover loading', () => {
         expect(
             renderShallow(

--- a/shared/src/hover/HoverOverlay.test.tsx
+++ b/shared/src/hover/HoverOverlay.test.tsx
@@ -20,7 +20,7 @@ describe('HoverOverlay', () => {
     const NOOP_EXTENSIONS_CONTROLLER = { executeCommand: async () => void 0 }
     const NOOP_PLATFORM_CONTEXT = { forceUpdateTooltip: () => void 0 }
     const history = H.createMemoryHistory({ keyLength: 0 })
-    const commonProps: HoverOverlayProps<string> = {
+    const commonProps = {
         location: history.location,
         telemetryService: NOOP_TELEMETRY_SERVICE,
         extensionsController: NOOP_EXTENSIONS_CONTROLLER,

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -37,11 +37,11 @@ export interface HoverOverlayClassProps {
 /**
  * A dismissable alert to be displayed in the hover overlay.
  */
-export interface HoverAlert {
+export interface HoverAlert<T extends string = string> {
     /**
      * The type of the alert, eg. `'nativeTooltips'`
      */
-    type: string
+    type: T
     /**
      * The content of the alert, will be rendered as Markdown.
      */

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -200,23 +200,19 @@ export class HoverOverlay extends React.PureComponent<HoverOverlayProps> {
                 {hoverOrError && hoverOrError !== LOADING && !isErrorLike(hoverOrError) && hoverOrError.alerts && (
                     <div className="hover-overlay__alerts">
                         {hoverOrError.alerts.map(({ content, type }, i) => (
-                            <div
-                                className="hover-overlay__row hover-overlay__content alert-info"
-                                key={i}
-                                onClick={onAlertDismissedCallback(type)}
-                            >
+                            <div className="hover-overlay__row hover-overlay__alert alert-info" key={i}>
+                                <div className="hover-overlay__alert-logo">
+                                    <HelpCircleIcon className="icon-inline" />
+                                </div>
+                                <div className="hover-ovlerlay__alert-content">
+                                    <small dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
+                                </div>
                                 <button
-                                    className={classNames('hover-overlay__close-button')}
+                                    className="hover-overlay__alert-close-button"
                                     onClick={onAlertDismissedCallback(type)}
                                 >
                                     <CloseIcon className="icon-inline" />
                                 </button>
-                                <HelpCircleIcon className="icon-inline" />
-                                &nbsp;
-                                <small
-                                    className="hover-overlay__alert-content"
-                                    dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
-                                ></small>
                             </div>
                         ))}
                     </div>

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -32,6 +32,8 @@ export interface HoverOverlayClassProps {
 
     actionItemClassName?: string
     actionItemPressedClassName?: string
+
+    alertClassName?: string
 }
 
 /**
@@ -106,7 +108,6 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
             className = '',
             actionItemClassName,
             actionItemPressedClassName,
-            onAlertDismissed,
         } = this.props
 
         if (!hoverOrError && (!actionsOrError || isErrorLike(actionsOrError))) {
@@ -199,7 +200,14 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
                 {hoverOrError && hoverOrError !== LOADING && !isErrorLike(hoverOrError) && hoverOrError.alerts && (
                     <div className="hover-overlay__alerts">
                         {hoverOrError.alerts.map(({ content, type }) => (
-                            <div className="hover-overlay__row hover-overlay__alert alert-info" key={type}>
+                            <div
+                                className={classNames(
+                                    'hover-overlay__row',
+                                    'hover-overlay__alert',
+                                    this.props.alertClassName
+                                )}
+                                key={type}
+                            >
                                 <div className="hover-overlay__alert-content">
                                     <HelpCircleIcon className="icon-inline" />
                                     &nbsp;

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -212,14 +212,13 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
                                     <HelpCircleIcon className="icon-inline" />
                                     &nbsp;
                                     <small>{content}</small>
-                                </div>
-                                <div className="hover-overlay__alert-actions">
-                                    <button
-                                        className="hover-overlay__alert-close-button"
+                                    <a
+                                        className="hover-overlay__alert-close"
+                                        href=""
                                         onClick={this.onAlertDismissedCallback(type)}
                                     >
                                         <small>Dismiss</small>
-                                    </button>
+                                    </a>
                                 </div>
                             </div>
                         ))}
@@ -257,8 +256,9 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
         )
     }
 
-    private onAlertDismissedCallback(alertType: A): () => void {
-        return () => {
+    private onAlertDismissedCallback(alertType: A): (e: React.MouseEvent<HTMLAnchorElement>) => void {
+        return e => {
+            e.preventDefault()
             if (this.props.onAlertDismissed) {
                 this.props.onAlertDismissed(alertType)
             }

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -108,7 +108,6 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
             actionItemPressedClassName,
             onAlertDismissed,
         } = this.props
-        const onAlertDismissedCallback = (alertType: A) => () => onAlertDismissed && onAlertDismissed(alertType)
 
         if (!hoverOrError && (!actionsOrError || isErrorLike(actionsOrError))) {
             return null
@@ -209,7 +208,7 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
                                 <div className="hover-overlay__alert-actions">
                                     <button
                                         className="hover-overlay__alert-close-button"
-                                        onClick={onAlertDismissedCallback(type)}
+                                        onClick={this.onAlertDismissedCallback(type)}
                                     >
                                         <small>Dismiss</small>
                                     </button>
@@ -248,6 +247,14 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
                     )}
             </div>
         )
+    }
+
+    private onAlertDismissedCallback(alertType: A): () => void {
+        return () => {
+            if (this.props.onAlertDismissed) {
+                this.props.onAlertDismissed(alertType)
+            }
+        }
     }
 
     private logTelemetryEvent(): void {

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -205,6 +205,12 @@ export class HoverOverlay extends React.PureComponent<HoverOverlayProps> {
                                 key={i}
                                 onClick={onAlertDismissedCallback(type)}
                             >
+                                <button
+                                    className={classNames('hover-overlay__close-button')}
+                                    onClick={onAlertDismissedCallback(type)}
+                                >
+                                    <CloseIcon className="icon-inline" />
+                                </button>
                                 <HelpCircleIcon className="icon-inline" />
                                 &nbsp;
                                 <small

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -201,18 +201,19 @@ export class HoverOverlay extends React.PureComponent<HoverOverlayProps> {
                     <div className="hover-overlay__alerts">
                         {hoverOrError.alerts.map(({ content, type }, i) => (
                             <div className="hover-overlay__row hover-overlay__alert alert-info" key={i}>
-                                <div className="hover-overlay__alert-logo">
+                                <div className="hover-overlay__alert-content">
                                     <HelpCircleIcon className="icon-inline" />
-                                </div>
-                                <div className="hover-ovlerlay__alert-content">
+                                    &nbsp;
                                     <small dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
                                 </div>
-                                <button
-                                    className="hover-overlay__alert-close-button"
-                                    onClick={onAlertDismissedCallback(type)}
-                                >
-                                    <CloseIcon className="icon-inline" />
-                                </button>
+                                <div className="hover-overlay__alert-actions">
+                                    <button
+                                        className="hover-overlay__alert-close-button"
+                                        onClick={onAlertDismissedCallback(type)}
+                                    >
+                                        <small>Dismiss</small>
+                                    </button>
+                                </div>
                             </div>
                         ))}
                     </div>

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -43,9 +43,9 @@ export interface HoverAlert<T extends string> {
      */
     type: T
     /**
-     * The content of the alert, will be rendered as Markdown.
+     * The content of the alert
      */
-    content: string
+    content: React.ReactElement
 }
 
 /**
@@ -204,7 +204,7 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
                                 <div className="hover-overlay__alert-content">
                                     <HelpCircleIcon className="icon-inline" />
                                     &nbsp;
-                                    <small dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
+                                    <small>{content}</small>
                                 </div>
                                 <div className="hover-overlay__alert-actions">
                                     <button

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -368,35 +368,40 @@ exports[`HoverOverlay actions, hover and alert present 1`] = `
     className="hover-overlay__alerts"
   >
     <div
-      className="hover-overlay__row hover-overlay__alert alert-info"
+      className="hover-overlay__row hover-overlay__alert"
     >
       <div
-        className="hover-overlay__alert-logo"
+        className="hover-overlay__alert-content"
       >
         <Memo(HelpCircleIcon)
           className="icon-inline"
         />
+         
+        <small>
+          <React.Fragment>
+            b 
+            <small>
+              c
+            </small>
+             
+            <code>
+              d
+            </code>
+          </React.Fragment>
+        </small>
       </div>
       <div
-        className="hover-ovlerlay__alert-content"
+        className="hover-overlay__alert-actions"
       >
-        <small
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>b <em>c</em> <code>d</code></p>
-",
-            }
-          }
-        />
+        <button
+          className="hover-overlay__alert-close-button"
+          onClick={[Function]}
+        >
+          <small>
+            Dismiss
+          </small>
+        </button>
       </div>
-      <button
-        className="hover-overlay__alert-close-button"
-        onClick={[Function]}
-      >
-        <Memo(CloseIcon)
-          className="icon-inline"
-        />
-      </button>
     </div>
   </div>
   <div

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -339,6 +339,97 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
 </div>
 `;
 
+exports[`HoverOverlay actions, hover and alert present 1`] = `
+<div
+  className="hover-overlay card "
+  style={
+    Object {
+      "left": "0px",
+      "opacity": 1,
+      "top": "0px",
+      "visibility": "visible",
+    }
+  }
+>
+  <div
+    className="hover-overlay__contents"
+  >
+    <div
+      className="hover-overlay__content hover-overlay__row e2e-tooltip-content"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>v</p>
+",
+        }
+      }
+    />
+  </div>
+  <div
+    className="hover-overlay__alerts"
+  >
+    <div
+      className="hover-overlay__row hover-overlay__content alert-info"
+      onClick={[Function]}
+    >
+      <Memo(HelpCircleIcon)
+        className="icon-inline"
+      />
+       
+      <small
+        className="hover-overlay__alert-content"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>b <em>c</em> <code>d</code></p>
+",
+          }
+        }
+      />
+    </div>
+  </div>
+  <div
+    className="hover-overlay__actions hover-overlay__row"
+  >
+    <ActionItem
+      action={
+        Object {
+          "command": "c",
+          "id": "a",
+        }
+      }
+      className="hover-overlay__action e2e-tooltip-untitled"
+      disabledDuringExecution={true}
+      extensionsController={
+        Object {
+          "executeCommand": [Function],
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "key": undefined,
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      platformContext={
+        Object {
+          "forceUpdateTooltip": [Function],
+        }
+      }
+      showInlineError={true}
+      showLoadingSpinnerDuringExecution={true}
+      telemetryService={
+        Object {
+          "log": [Function],
+        }
+      }
+      variant="actionItem"
+    />
+  </div>
+</div>
+`;
+
 exports[`HoverOverlay hover empty 1`] = `null`;
 
 exports[`HoverOverlay hover error 1`] = `

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -368,22 +368,35 @@ exports[`HoverOverlay actions, hover and alert present 1`] = `
     className="hover-overlay__alerts"
   >
     <div
-      className="hover-overlay__row hover-overlay__content alert-info"
-      onClick={[Function]}
+      className="hover-overlay__row hover-overlay__alert alert-info"
     >
-      <Memo(HelpCircleIcon)
-        className="icon-inline"
-      />
-       
-      <small
-        className="hover-overlay__alert-content"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>b <em>c</em> <code>d</code></p>
+      <div
+        className="hover-overlay__alert-logo"
+      >
+        <Memo(HelpCircleIcon)
+          className="icon-inline"
+        />
+      </div>
+      <div
+        className="hover-ovlerlay__alert-content"
+      >
+        <small
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>b <em>c</em> <code>d</code></p>
 ",
+            }
           }
-        }
-      />
+        />
+      </div>
+      <button
+        className="hover-overlay__alert-close-button"
+        onClick={[Function]}
+      >
+        <Memo(CloseIcon)
+          className="icon-inline"
+        />
+      </button>
     </div>
   </div>
   <div

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -389,18 +389,15 @@ exports[`HoverOverlay actions, hover and alert present 1`] = `
             </code>
           </React.Fragment>
         </small>
-      </div>
-      <div
-        className="hover-overlay__alert-actions"
-      >
-        <button
-          className="hover-overlay__alert-close-button"
+        <a
+          className="hover-overlay__alert-close"
+          href=""
           onClick={[Function]}
         >
           <small>
             Dismiss
           </small>
-        </button>
+        </a>
       </div>
     </div>
   </div>

--- a/shared/src/util/errors.ts
+++ b/shared/src/util/errors.ts
@@ -3,8 +3,11 @@ export interface ErrorLike {
     code?: string
 }
 
-export const isErrorLike = (val: any): val is ErrorLike =>
-    !!val && typeof val === 'object' && (!!val.stack || ('message' in val || 'code' in val)) && !('__typename' in val)
+export const isErrorLike = (val: unknown): val is ErrorLike =>
+    typeof val === 'object' &&
+    !!val &&
+    ('stack' in val || ('message' in val || 'code' in val)) &&
+    !('__typename' in val)
 
 /**
  * Ensures a value is a proper Error, copying all properties if needed

--- a/shared/src/util/types.ts
+++ b/shared/src/util/types.ts
@@ -4,6 +4,17 @@
 export const isDefined = <T>(val: T): val is NonNullable<T> => val !== undefined && val !== null
 
 /**
+ * Negates a type guard.
+ * Returns a function that returns `true` when the input is **not** the type checked for by the given type guard.
+ * It therefor excludes a type from a union type.
+ *
+ * @param isType The type guard that checks whether the given input value should be excluded.
+ */
+export const isNot = <TInput, TExclude extends TInput>(isType: (val: TInput) => val is TExclude) => (
+    value: TInput
+): value is Exclude<TInput, TExclude> => !isType(value)
+
+/**
  * Returns a function that returns `true` if the given `key` of the object is not `null` or `undefined`.
  *
  * I ❤️ TypeScript.

--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -10,7 +10,7 @@ import { HoverOverlay, HoverOverlayProps } from '../../../shared/src/hover/Hover
 
 // Components from shared with web-styling class names applied
 
-export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps> = props => (
+export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps<string>> = props => (
     <HoverOverlay closeButtonClassName="btn btn-icon" actionItemClassName="btn btn-secondary" {...props} />
 )
 WebHoverOverlay.displayName = 'WebHoverOverlay'

--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -10,7 +10,7 @@ import { HoverOverlay, HoverOverlayProps } from '../../../shared/src/hover/Hover
 
 // Components from shared with web-styling class names applied
 
-export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps<string>> = props => (
+export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps<never>> = props => (
     <HoverOverlay closeButtonClassName="btn btn-icon" actionItemClassName="btn btn-secondary" {...props} />
 )
 WebHoverOverlay.displayName = 'WebHoverOverlay'


### PR DESCRIPTION
Fixes #4479

This avoids conflicts between GitHub's new jump to definition tooltips, and the Sourcegraph tooltips:

![image](https://user-images.githubusercontent.com/1741180/59424520-6c3c8700-8dd4-11e9-9e90-55eba51fb1e3.png)

It introduces a new setting, `codeHost.useNativeTooltips`, and uses it to determine whether to show the code host's hover tooltips, or our own. By default, the browser extension will hide the code host's native tooltips, and display our own. If the user sets `codeHost.useNativeTooltips` to `true` in his settings, only the code host's hovers will be displayed.

The setting can be toggled from the command palette:

![image](https://user-images.githubusercontent.com/1741180/59427449-f5ef5300-8dda-11e9-80dd-308fc9207d31.png)
