### PR TITLE
repo-updater: Get rid of global repos.Scheduler instance

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -112,7 +112,8 @@ func main() {
 		}
 	}
 
-	server := repoupdater.Server{Store: store, Scheduler: repos.Scheduler}
+	scheduler := repos.NewUpdateScheduler()
+	server := repoupdater.Server{Store: store, Scheduler: scheduler}
 
 	var handler http.Handler
 	{
@@ -162,7 +163,7 @@ func main() {
 			if !envvar.SourcegraphDotComMode() {
 				rs := diff.Repos()
 				if !conf.Get().DisableAutoGitUpdates {
-					repos.Scheduler.Update(rs...)
+					scheduler.Update(rs...)
 				}
 
 				go func() {
@@ -182,7 +183,7 @@ func main() {
 	}
 
 	// Git fetches scheduler
-	go repos.RunScheduler(ctx)
+	go repos.RunScheduler(ctx, scheduler)
 
 	host := ""
 	if env.InsecureDev {
@@ -198,7 +199,7 @@ func main() {
 		Name: "Repo Updater State",
 		Path: "/repo-updater-state",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			d, err := json.MarshalIndent(repos.Scheduler.DebugDump(), "", "  ")
+			d, err := json.MarshalIndent(scheduler.DebugDump(), "", "  ")
 			if err != nil {
 				http.Error(w, "failed to marshal snapshot: "+err.Error(), http.StatusInternalServerError)
 				return

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -16,9 +16,6 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-// Scheduler schedules repo updates.
-var Scheduler = newUpdateScheduler()
-
 // schedulerConfig tracks the active scheduler configuration.
 type schedulerConfig struct {
 	running               bool
@@ -26,7 +23,7 @@ type schedulerConfig struct {
 }
 
 // RunScheduler runs the worker that schedules git fetches of synced repositories in git-server.
-func RunScheduler(ctx context.Context) {
+func RunScheduler(ctx context.Context, scheduler *updateScheduler) {
 	var (
 		have schedulerConfig
 		stop context.CancelFunc
@@ -56,9 +53,9 @@ func RunScheduler(ctx context.Context) {
 		var ctx2 context.Context
 		ctx2, stop = context.WithCancel(ctx)
 
-		go Scheduler.runUpdateLoop(ctx2)
+		go scheduler.runUpdateLoop(ctx2)
 		if want.autoGitUpdatesEnabled {
-			go Scheduler.runScheduleLoop(ctx2)
+			go scheduler.runScheduleLoop(ctx2)
 		}
 
 		log15.Debug(
@@ -127,7 +124,7 @@ type sourceRepoMap map[api.RepoName]*configuredRepo2
 const notifyChanBuffer = 1
 
 // newUpdateScheduler returns a new scheduler.
-func newUpdateScheduler() *updateScheduler {
+func NewUpdateScheduler() *updateScheduler {
 	return &updateScheduler{
 		sourceRepos: make(map[string]sourceRepoMap),
 		updateQueue: &updateQueue{

--- a/cmd/repo-updater/repos/scheduler_test.go
+++ b/cmd/repo-updater/repos/scheduler_test.go
@@ -271,7 +271,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 
 			for _, call := range test.calls {
 				s.updateQueue.enqueue(&call.repo, call.priority)
@@ -437,7 +437,7 @@ func TestUpdateQueue_remove(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 			setupInitialQueue(s, test.initialQueue)
 
 			// Perform the removals.
@@ -509,7 +509,7 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 			setupInitialQueue(s, test.initialQueue)
 
 			// Test aquireNext.
@@ -685,7 +685,7 @@ func TestSchedule_upsert(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.upsertCalls {
@@ -863,7 +863,7 @@ func TestSchedule_updateInterval(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.updateCalls {
@@ -961,7 +961,7 @@ func TestSchedule_remove(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.removeCalls {
@@ -1123,7 +1123,7 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 
 			setupInitialSchedule(s, test.initialSchedule)
 
@@ -1254,7 +1254,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 			}
 			defer func() { requestRepoUpdate = nil }()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 
 			// unbuffer the channel
 			s.updateQueue.notifyEnqueue = make(chan struct{})
@@ -1608,7 +1608,7 @@ func TestUpdateScheduler_updateSource(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := newUpdateScheduler()
+			s := NewUpdateScheduler()
 			s.sourceRepos = test.initialSourceRepos
 			setupInitialSchedule(s, test.initialSchedule)
 			setupInitialQueue(s, test.initialQueue)


### PR DESCRIPTION
This is something I noticed as a possible refactoring when injecting a `Scheduler` into the `repoupdater.Server`. What do you think?

Test plan: go test
