### PR TITLE
Hide new status indicator by default through feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The `orgs` setting in [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github) allows admins to select all repositories from the specified organizations to be synced.
 - The `authorization` setting in the [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#permissions) enables Sourcegraph to enforce the repository permissions defined in Bitbucket Server.
-- A new status icon in the navigation bar allows admins to quickly see whether the configured repositories are up to date or how many are currently being updated in the background
+- A new, experimental status indicator in the navigation bar allows admins to quickly see whether the configured repositories are up to date or how many are currently being updated in the background. You can enable the status indicator with the following site configuration: `"experimentalFeatures": { "statusIndicator": "enabled" }`.
 
 ### Changed
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -78,6 +78,8 @@ type JSContext struct {
 	AuthProviders []authProviderInfo `json:"authProviders"`
 
 	Branding *schema.Branding `json:"branding"`
+
+	ShowStatusIndicator bool `json:"showStatusIndicator"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -172,6 +174,8 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		AuthProviders: authProviders,
 
 		Branding: conf.Branding(),
+
+		ShowStatusIndicator: conf.ShowStatusIndicator(),
 	}
 }
 

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -278,3 +278,7 @@ func IsBuiltinSignupAllowed() bool {
 func Branding() *schema.Branding {
 	return Get().Branding
 }
+
+func ShowStatusIndicator() bool {
+	return Get().ExperimentalFeatures.StatusIndicator == "enabled"
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -223,7 +223,8 @@ type ExcludedGitoliteRepo struct {
 
 // ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 type ExperimentalFeatures struct {
-	Discussions string `json:"discussions,omitempty"`
+	Discussions     string `json:"discussions,omitempty"`
+	StatusIndicator string `json:"statusIndicator,omitempty"`
 }
 
 // Extensions description: Configures Sourcegraph extensions.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -42,6 +42,12 @@
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
+        },
+        "statusIndicator": {
+          "description": "Enables the external service status indicator in the navigation bar.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
         }
       },
       "group": "Experimental",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -47,6 +47,12 @@ const SiteSchemaJSON = `{
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
+        },
+        "statusIndicator": {
+          "description": "Enables the external service status indicator in the navigation bar.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
         }
       },
       "group": "Experimental",

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -121,6 +121,9 @@ interface SourcegraphContext {
         /** Override style for dark themes */
         dark?: BrandAssets
     }
+
+    /** Whether new external service status indicator is shown in navbar or not. */
+    showStatusIndicator?: boolean
 }
 
 interface BrandAssets {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -128,7 +128,13 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                         )}
                     </>
                 )}
-                {!this.state.authRequired && <NavLinks {...this.props} showDotComMarketing={showDotComMarketing} />}
+                {!this.state.authRequired && (
+                    <NavLinks
+                        {...this.props}
+                        showStatusIndicator={!!window.context.showStatusIndicator}
+                        showDotComMarketing={showDotComMarketing}
+                    />
+                )}
             </div>
         )
     }

--- a/web/src/nav/NavLinks.test.tsx
+++ b/web/src/nav/NavLinks.test.tsx
@@ -62,6 +62,7 @@ describe('NavLinks', () => {
         settingsCascade: SETTINGS_CASCADE,
         history,
         isSourcegraphDotCom: false,
+        showStatusIndicator: false,
     }
 
     // The 3 main props that affect the desired contents of NavLinks are whether the user is signed

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -31,6 +31,7 @@ interface Props
     authenticatedUser: GQL.IUser | null
     showDotComMarketing: boolean
     isSourcegraphDotCom: boolean
+    showStatusIndicator: boolean
 }
 
 export class NavLinks extends React.PureComponent<Props> {
@@ -113,6 +114,7 @@ export class NavLinks extends React.PureComponent<Props> {
                     </>
                 )}
                 {!this.props.isSourcegraphDotCom &&
+                    this.props.showStatusIndicator &&
                     this.props.authenticatedUser &&
                     this.props.authenticatedUser.siteAdmin && (
                         <li className="nav-item">


### PR DESCRIPTION
After discovering that on instances with multiple thousands of repositories the new status indicator (#4120) is nearly always active, we decided to hide this feature before branch cut to not confuse users.

In the meantime, I'll start work on figuring out how we can only show "cloning" progress. If that turns out to be "easy", we can cherry-pick into release branch or ship with point release.

Regarding the implementation of the _feature flag itself_, @dadlerj and @felixfbecker noted [in Slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1560437428108600) that it could also be implemented as a per-user feature flag through localStorage. That would mean it's not exposed to the user and not documented. I'm hoping for your input here, @christinaforney :)


