### PR TITLE
Add repohasfile flag to searcher code path

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -341,7 +341,7 @@ func searchFilesInRepo(ctx context.Context, repo *types.Repo, gitserverRepo gits
 	if repoHasFileFlagIsInQuery {
 		// search for file in repo, if file is in repo, actually search through it.
 		for _, pattern := range info.FilePatternsReposMustInclude {
-			repoHasFileOnlyPattern := search.PatternInfo{IsRegExp: true, FileMatchLimit: 30, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			repoHasFileOnlyPattern := search.PatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			matches, limitHit, err := textSearch(ctx, gitserverRepo, commit, &repoHasFileOnlyPattern, fetchTimeout)
 			if err != nil {
 				return nil, false, err
@@ -355,7 +355,7 @@ func searchFilesInRepo(ctx context.Context, repo *types.Repo, gitserverRepo gits
 	negatedRepoHasFileFlagIsInQuery := len(info.FilePatternsReposMustExclude) > 0
 	if negatedRepoHasFileFlagIsInQuery {
 		for _, pattern := range info.FilePatternsReposMustExclude {
-			repoHasFileOnlyPattern := search.PatternInfo{IsRegExp: true, FileMatchLimit: 30, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			repoHasFileOnlyPattern := search.PatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			matches, limitHit, err := textSearch(ctx, gitserverRepo, commit, &repoHasFileOnlyPattern, fetchTimeout)
 			if err != nil {
 				return nil, false, err

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -337,7 +337,6 @@ func searchFilesInRepo(ctx context.Context, repo *types.Repo, gitserverRepo gits
 	}
 
 	repoHasFileFlagIsInQuery := len(info.FilePatternsReposMustInclude) > 0
-
 	if repoHasFileFlagIsInQuery {
 		// search for file in repo, if file is in repo, actually search through it.
 		for _, pattern := range info.FilePatternsReposMustInclude {
@@ -361,7 +360,7 @@ func searchFilesInRepo(ctx context.Context, repo *types.Repo, gitserverRepo gits
 				return nil, false, err
 			}
 			if len(matches) > 0 {
-				// Return with no matches if the repo does match the patterns in `-repohasfile`.
+				// Return with no matches if the repo has matches for the patterns in `-repohasfile`.
 				return []*fileMatchResolver{}, limitHit, err
 			}
 		}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -342,7 +342,7 @@ func searchFilesInRepo(ctx context.Context, repo *types.Repo, gitserverRepo gits
 		return nil, false, err
 	}
 
-	shouldBeSearched, err := repoShouldBeSearched(ctx, info, gitserverRepo, commit, fetchTimeout)
+	shouldBeSearched, err := shouldRepoBeSearched(ctx, info, gitserverRepo, commit, fetchTimeout)
 	if err != nil {
 		return nil, false, err
 	}
@@ -363,9 +363,9 @@ func searchFilesInRepo(ctx context.Context, repo *types.Repo, gitserverRepo gits
 	return matches, limitHit, err
 }
 
-// repoShouldBeSearched determines whether a repository should be searched in, based on whether the repository
+// shouldRepoBeSearched determines whether a repository should be searched in, based on whether the repository
 // fits in the subset of repositories specified in the query's `repohasfile` and `-repohasfile` flags if they exist.
-func repoShouldBeSearched(ctx context.Context, info *search.PatternInfo, gitserverRepo gitserver.Repo, commit api.CommitID, fetchTimeout time.Duration) (bool, error) {
+func shouldRepoBeSearched(ctx context.Context, info *search.PatternInfo, gitserverRepo gitserver.Repo, commit api.CommitID, fetchTimeout time.Duration) (bool, error) {
 	shouldBeSearched := true
 	repoHasFileFlagIsInQuery := len(info.FilePatternsReposMustInclude) > 0
 	if repoHasFileFlagIsInQuery {
@@ -379,7 +379,10 @@ func repoShouldBeSearched(ctx context.Context, info *search.PatternInfo, gitserv
 			if len(matches) <= 0 {
 				// repo shouldn't be searched if it doesn't match the patterns in `repohasfile`.
 				shouldBeSearched = false
+			} else {
+				fmt.Println("SHOULD BE SEARCHED", matches[0].JPath)
 			}
+
 		}
 	}
 	negatedRepoHasFileFlagIsInQuery := len(info.FilePatternsReposMustExclude) > 0

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -379,8 +379,6 @@ func shouldRepoBeSearched(ctx context.Context, info *search.PatternInfo, gitserv
 			if len(matches) <= 0 {
 				// repo shouldn't be searched if it doesn't match the patterns in `repohasfile`.
 				shouldBeSearched = false
-			} else {
-				fmt.Println("SHOULD BE SEARCHED", matches[0].JPath)
 			}
 
 		}


### PR DESCRIPTION
Adds `repohasfile` flag handling to the searcher codepath. 

Fixes #4501.

Test plan: Unit test.
