### PR TITLE
remove hover translateY effects

### DIFF
--- a/web/src/enterprise/extensions/explore/ExtensionsExploreSection.scss
+++ b/web/src/enterprise/extensions/explore/ExtensionsExploreSection.scss
@@ -22,9 +22,6 @@
         &:first-of-type {
             margin-top: 0;
         }
-        &:hover {
-            transform: translateY(-2px);
-        }
         &__content {
             display: block;
             height: 100%;

--- a/web/src/integrations/explore/IntegrationsExploreSection.scss
+++ b/web/src/integrations/explore/IntegrationsExploreSection.scss
@@ -22,9 +22,6 @@
         &:first-of-type {
             margin-top: 0;
         }
-        &:hover {
-            transform: translateY(-2px);
-        }
         &__content {
             display: block;
             height: 100%;


### PR DESCRIPTION
Removes the effect where when you hover something, it moves in the y-axis by a few pixels. This was inconsistently applied and always felt like a glitch to me.