### PR TITLE
remove .btn-outline-* variants

### DIFF
--- a/browser/src/app.scss
+++ b/browser/src/app.scss
@@ -102,11 +102,6 @@ $theme-colors-light: (
             border-right-color: #e4e9f1 !important;
         }
     }
-    // A .btn-outline-link button class that displays an unsaturated outline around a link.
-    .btn.btn-outline-link {
-        color: $link-color !important;
-        @include button-outline-variant(#ced4da);
-    }
     .input-group {
         .form-control {
             margin-right: 1rem;

--- a/web/src/enterprise/extensions/extension/RegistryExtensionDeleteButton.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionDeleteButton.tsx
@@ -69,7 +69,7 @@ export class RegistryExtensionDeleteButton extends React.PureComponent<
         return (
             <div className="btn-group" role="group">
                 <button
-                    className="btn btn-outline-danger"
+                    className="btn btn-danger"
                     onClick={this.deleteExtension}
                     disabled={this.props.disabled || this.state.deletionOrError === undefined}
                     title={this.props.compact ? 'Delete extension' : ''}

--- a/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -106,7 +106,7 @@ class RegistryExtensionNodeSiteAdminRow extends React.PureComponent<
                         )}
                         {this.props.node.viewerCanAdminister && (
                             <button
-                                className="btn btn-outline-danger btn-sm ml-1"
+                                className="btn btn-danger btn-sm ml-1"
                                 onClick={this.deleteExtension}
                                 disabled={loading}
                                 title="Delete extension"
@@ -170,7 +170,7 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
                 <div className="d-flex justify-content-between align-items-center mt-3 mb-3">
                     <h2 className="mb-0">Registry extensions</h2>
                     <div>
-                        <Link className="btn btn-outline-link mr-sm-2" to="/extensions">
+                        <Link className="btn btn-link mr-sm-2" to="/extensions">
                             View extensions
                         </Link>
                         <Link className="btn btn-primary" to="/extensions/registry/new">

--- a/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -148,7 +148,7 @@ export class SiteAdminProductSubscriptionPage extends React.Component<Props, Sta
             <div className="site-admin-product-subscription-page">
                 <PageTitle title="Product subscription" />
                 <div className="mb-2">
-                    <Link to="/site-admin/dotcom/product/subscriptions" className="btn btn-outline-link btn-sm">
+                    <Link to="/site-admin/dotcom/product/subscriptions" className="btn btn-link btn-sm">
                         <ArrowLeftIcon className="icon-inline" /> All subscriptions
                     </Link>
                 </div>
@@ -163,7 +163,7 @@ export class SiteAdminProductSubscriptionPage extends React.Component<Props, Sta
                         <h2>Product subscription {this.state.productSubscriptionOrError.name}</h2>
                         <div className="mb-3">
                             <button
-                                className="btn btn-outline-danger"
+                                className="btn btn-danger"
                                 onClick={this.archiveProductSubscription}
                                 disabled={this.state.archivalOrError === null}
                             >
@@ -236,10 +236,7 @@ export class SiteAdminProductSubscriptionPage extends React.Component<Props, Sta
                                         Dismiss new license form
                                     </button>
                                 ) : (
-                                    <button
-                                        className="btn btn-outline-primary btn-sm"
-                                        onClick={this.toggleShowGenerate}
-                                    >
+                                    <button className="btn btn-primary btn-sm" onClick={this.toggleShowGenerate}>
                                         <AddIcon className="icon-inline" /> Generate new license manually
                                     </button>
                                 )}

--- a/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
+++ b/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
@@ -6,7 +6,7 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 export const BackToAllSubscriptionsLink: React.FunctionComponent<{ user: Pick<GQL.IUser, 'settingsURL'> }> = ({
     user,
 }) => (
-    <Link to={`${user.settingsURL!}/subscriptions`} className="btn btn-outline-link btn-sm mb-3">
+    <Link to={`${user.settingsURL!}/subscriptions`} className="btn btn-link btn-sm mb-3">
         <ArrowLeftIcon className="icon-inline" /> All subscriptions
     </Link>
 )

--- a/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -130,10 +130,7 @@ export class UserSubscriptionsEditProductSubscriptionPage extends React.Componen
                     </div>
                 ) : (
                     <>
-                        <Link
-                            to={this.state.productSubscriptionOrError.url}
-                            className="btn btn-outline-link btn-sm mb-3"
-                        >
+                        <Link to={this.state.productSubscriptionOrError.url} className="btn btn-link btn-sm mb-3">
                             <ArrowLeftIcon className="icon-inline" /> Subscription
                         </Link>
                         <h2>Upgrade or change subscription {this.state.productSubscriptionOrError.name}</h2>

--- a/web/src/global-styles/buttons.scss
+++ b/web/src/global-styles/buttons.scss
@@ -8,12 +8,6 @@
             @include button-variant($value, $value);
         }
     }
-
-    @each $color, $value in $theme-colors-light {
-        .btn-outline-#{$color} {
-            @include button-outline-variant($value);
-        }
-    }
 }
 
 // This class is meant for clickable icons
@@ -47,20 +41,4 @@
 
 .btn.btn-sm {
     @extend small;
-}
-
-// A .btn-outline-link button class that displays an unsaturated outline around a link.
-.btn.btn-outline-link {
-    color: $link-color !important;
-}
-.theme-dark {
-    .btn.btn-outline-link {
-        @include button-outline-variant($secondary);
-    }
-}
-// stylelint-disable-next-line no-duplicate-selectors
-.theme-light {
-    .btn.btn-outline-link {
-        @include button-outline-variant($secondary-light);
-    }
 }

--- a/web/src/org/area/OrgInvitationPage.tsx
+++ b/web/src/org/area/OrgInvitationPage.tsx
@@ -139,7 +139,7 @@ export const OrgInvitationPage = withAuthenticatedUser(
                                     >
                                         Join {this.props.org.name}
                                     </button>
-                                    <Link className="btn btn-outline-link" to={orgURL(this.props.org.name)}>
+                                    <Link className="btn btn-link" to={orgURL(this.props.org.name)}>
                                         Go to {this.props.org.name}'s profile
                                     </Link>
                                 </div>


### PR DESCRIPTION
They are not consistently used, and they are not worth the complexity burden and custom code needed to make them work on both light and dark themes (and other themes in the future).