### PR TITLE
expose EditorService#{editorsWithModels,observeEditorAndModel}

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.test.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.test.tsx
@@ -224,7 +224,7 @@ describe('code_intelligence', () => {
                     render: RENDER,
                 })
             )
-            const editors = await from(services.editor.editors)
+            const editors = await from(services.editor.editorsAndModels)
                 .pipe(
                     skip(1),
                     take(1)
@@ -541,7 +541,7 @@ describe('code_intelligence', () => {
                     render: RENDER,
                 })
             )
-            let editors = await from(services.editor.editors)
+            let editors = await from(services.editor.editorsAndModels)
                 .pipe(
                     skip(2),
                     take(1)
@@ -577,7 +577,7 @@ describe('code_intelligence', () => {
             // Simulate codeView1 removal
             mutations.next([{ addedNodes: [], removedNodes: [codeView1] }])
             // One editor should have been removed, model should still exist
-            editors = await from(services.editor.editors)
+            editors = await from(services.editor.editorsAndModels)
                 .pipe(
                     skip(1),
                     take(1)
@@ -601,7 +601,7 @@ describe('code_intelligence', () => {
             // Simulate codeView2 removal
             mutations.next([{ addedNodes: [], removedNodes: [codeView2] }])
             // Second editor and model should have been removed
-            editors = await from(services.editor.editors)
+            editors = await from(services.editor.editorsAndModels)
                 .pipe(
                     skip(1),
                     take(1)
@@ -845,12 +845,6 @@ describe('code_intelligence', () => {
                     isActive: true,
                     // Repo name exposed in URIs is the raw repo name
                     resource: 'git://github.com/foo?1#/bar.ts',
-                    model: {
-                        uri: 'git://github.com/foo?1#/bar.ts',
-                        // Text is undefined as BlobContent graphQL requests will error
-                        text: undefined,
-                        languageId: 'typescript',
-                    },
                     selections: [],
                     type: 'CodeEditor',
                 },

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -35,9 +35,8 @@ import {
     withLatestFrom,
 } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../shared/src/actions/ActionItem'
-import { PartialCodeEditor } from '../../../../shared/src/api/client/context/context'
 import { DecorationMapByLine } from '../../../../shared/src/api/client/services/decoration'
-import { CodeEditorData } from '../../../../shared/src/api/client/services/editorService'
+import { CodeEditorData, CodeEditorWithPartialModel } from '../../../../shared/src/api/client/services/editorService'
 import { ERPRIVATEREPOPUBLICSOURCEGRAPHCOM } from '../../../../shared/src/backend/errors'
 import {
     CommandListClassProps,
@@ -629,7 +628,7 @@ export function handleCodeHost({
                 isActive: true,
             }
             const editorId = extensionsController.services.editor.addEditor(editorData)
-            const scope: PartialCodeEditor = {
+            const scope: CodeEditorWithPartialModel = {
                 ...editorData,
                 ...editorId,
                 model,

--- a/browser/src/libs/code_intelligence/text_fields.test.tsx
+++ b/browser/src/libs/code_intelligence/text_fields.test.tsx
@@ -73,11 +73,6 @@ describe('text_fields', () => {
                     editorId: 'editor#0',
                     isActive: true,
                     resource: 'comment://0',
-                    model: {
-                        uri: 'comment://0',
-                        text: 'abc',
-                        languageId: 'plaintext',
-                    },
                     selections: [
                         {
                             anchor: { line: 0, character: 2 },

--- a/go.sum
+++ b/go.sum
@@ -712,6 +712,7 @@ golang.org/x/sys v0.0.0-20190606212808-7fc4e5ec1444 h1:gmKy/SaqFWnWO0RM/E9ox+LZ3
 golang.org/x/sys v0.0.0-20190606212808-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190608051445-5b15430b70e3 h1:OX5dSAHHPYz8i/jcJD/k6HqRZZHhFzGrIAxdOC5or44=
 golang.org/x/sys v0.0.0-20190608051445-5b15430b70e3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190701071227-04f50cda93cb h1:Lg1hzdbqYD5SXgexpVrmRiyybANxq2at3ALUbcfxsfM=
 golang.org/x/sys v0.0.0-20190701071227-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -1,6 +1,7 @@
 import { Selection } from '@sourcegraph/extension-api-types'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { getComputedContextProperty, PartialCodeEditor } from './context'
+import { CodeEditorWithPartialModel } from '../services/editorService'
+import { getComputedContextProperty } from './context'
 
 describe('getComputedContextProperty', () => {
     test('provides config', () => {
@@ -19,15 +20,12 @@ describe('getComputedContextProperty', () => {
     })
 
     describe('with code editors', () => {
-        const editors: PartialCodeEditor[] = [
+        const editors: CodeEditorWithPartialModel[] = [
             {
                 editorId: 'editor1',
                 type: 'CodeEditor',
                 resource: 'file:///inactive',
-                model: {
-                    uri: 'file:///inactive',
-                    languageId: 'inactive',
-                },
+                model: { languageId: 'inactive' },
                 selections: [
                     {
                         start: { line: 11, character: 22 },
@@ -43,10 +41,7 @@ describe('getComputedContextProperty', () => {
                 editorId: 'editor2',
                 type: 'CodeEditor',
                 resource: 'file:///a/b.c',
-                model: {
-                    uri: 'file:///a/b.c',
-                    languageId: 'l',
-                },
+                model: { languageId: 'l' },
                 selections: [
                     {
                         start: { line: 1, character: 2 },
@@ -95,7 +90,7 @@ describe('getComputedContextProperty', () => {
             test('returns null when there are no code editors', () =>
                 expect(getComputedContextProperty([], EMPTY_SETTINGS_CASCADE, {}, 'component.type')).toBe(null))
 
-            function assertSelection(editors: PartialCodeEditor[], expr: string, expected: Selection): void {
+            function assertSelection(editors: CodeEditorWithPartialModel[], expr: string, expected: Selection): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, expr)).toEqual(expected)
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, `${expr}.start`)).toEqual(
                     expected.start
@@ -139,7 +134,7 @@ describe('getComputedContextProperty', () => {
                     ]
                 ))
 
-            function assertNoSelection(editors: PartialCodeEditor[]): void {
+            function assertNoSelection(editors: CodeEditorWithPartialModel[]): void {
                 expect(getComputedContextProperty(editors, EMPTY_SETTINGS_CASCADE, {}, 'component.selection')).toBe(
                     null
                 )
@@ -174,10 +169,7 @@ describe('getComputedContextProperty', () => {
                         editorId: 'editor1',
                         type: 'CodeEditor' as const,
                         resource: 'file:///a/b.c',
-                        model: {
-                            uri: 'file:///a/b.c',
-                            languageId: 'l',
-                        },
+                        model: { languageId: 'l' },
                         selections: [],
                         isActive: true,
                     },

--- a/shared/src/api/client/context/context.ts
+++ b/shared/src/api/client/context/context.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname } from 'path'
 import { isSettingsValid, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditor } from '../services/editorService'
+import { CodeEditorWithPartialModel } from '../services/editorService'
 
 /**
  * Context is an arbitrary, immutable set of key-value pairs. Its value can be any JSON object.
@@ -15,12 +15,8 @@ export interface Context<T = never>
         string | number | boolean | null | Context | T | (string | number | boolean | null | Context | T)[]
     > {}
 
-export type PartialCodeEditor = Pick<CodeEditor, 'editorId' | 'type' | 'resource' | 'selections' | 'isActive'> & {
-    model: Pick<CodeEditor['model'], 'uri' | 'languageId'>
-}
-
 export type ContributionScope =
-    | PartialCodeEditor
+    | CodeEditorWithPartialModel
     | {
           type: 'panelView'
           id: string
@@ -35,7 +31,7 @@ export type ContributionScope =
  * @param scope the user interface component in whose scope this computation should occur
  */
 export function getComputedContextProperty(
-    editors: readonly PartialCodeEditor[],
+    editors: readonly CodeEditorWithPartialModel[],
     settings: SettingsCascadeOrError,
     context: Context<any>,
     key: string,

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -13,7 +13,7 @@ import {
     mergeContributions,
     parseContributionExpressions,
 } from './contribution'
-import { CodeEditor } from './editorService'
+import { CodeEditorWithPartialModel } from './editorService'
 import { createTestEditorService } from './editorService.test'
 
 const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
@@ -183,7 +183,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editors: cold<readonly CodeEditor[]>('-a-b-|', {
+                                editorsAndModels: cold<readonly CodeEditorWithPartialModel[]>('-a-b-|', {
                                     a: [],
                                     b: [],
                                 }),
@@ -228,7 +228,7 @@ describe('ContributionRegistry', () => {
                     public constructor() {
                         super(
                             {
-                                editors: cold<readonly CodeEditor[]>('a', {
+                                editorsAndModels: cold<readonly CodeEditorWithPartialModel[]>('a', {
                                     a: [],
                                 }),
                             },

--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -34,7 +34,7 @@ export class ContributionRegistry {
     private _entries = new BehaviorSubject<ContributionsEntry[]>([])
 
     public constructor(
-        private editorService: Pick<EditorService, 'editors'>,
+        private editorService: Pick<EditorService, 'editorsAndModels'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private context: Subscribable<Context<any>>
     ) {}
@@ -110,7 +110,7 @@ export class ContributionRegistry {
                     )
                 )
             ),
-            this.editorService.editors,
+            this.editorService.editorsAndModels,
             this.settingsService.data,
             this.context
         ).pipe(

--- a/shared/src/api/client/services/extensionsService.test.ts
+++ b/shared/src/api/client/services/extensionsService.test.ts
@@ -2,7 +2,7 @@ import { from, of, Subscribable, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { ConfiguredExtension } from '../../../extensions/extension'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
-import { CodeEditor, EditorService } from './editorService'
+import { CodeEditorWithPartialModel, EditorService } from './editorService'
 import { createTestEditorService } from './editorService.test'
 import { ExecutableExtension, ExtensionsService } from './extensionsService'
 import { SettingsService } from './settings'
@@ -12,11 +12,11 @@ const scheduler = () => new TestScheduler((a, b) => expect(a).toEqual(b))
 class TestExtensionsService extends ExtensionsService {
     constructor(
         mockConfiguredExtensions: ConfiguredExtension[],
-        editorService: Pick<EditorService, 'editors'>,
+        editorService: Pick<EditorService, 'editorsAndModels'>,
         settingsService: Pick<SettingsService, 'data'>,
         extensionActivationFilter: (
             enabledExtensions: ConfiguredExtension[],
-            editors: readonly CodeEditor[]
+            editors: readonly CodeEditorWithPartialModel[]
         ) => ConfiguredExtension[],
         sideloadedExtensionURL: Subscribable<string | null>,
         fetchSideloadedExtension: (baseUrl: string) => Subscribable<ConfiguredExtension | null>
@@ -46,7 +46,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [],
                         createTestEditorService(
-                            cold<readonly CodeEditor[]>('-a-|', {
+                            cold<readonly CodeEditorWithPartialModel[]>('-a-|', {
                                 a: [],
                             })
                         ),
@@ -69,13 +69,13 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'x', manifest, rawManifest: null }, { id: 'y', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditor[]>('-a-b-|', {
+                            cold<readonly CodeEditorWithPartialModel[]>('-a-b-|', {
                                 a: [
                                     {
                                         type: 'CodeEditor',
                                         editorId: 'editor#0',
                                         resource: 'u',
-                                        model: { languageId: 'x', text: '', uri: 'u' },
+                                        model: { languageId: 'x' },
                                         selections: [],
                                         isActive: true,
                                     },
@@ -85,7 +85,7 @@ describe('activeExtensions', () => {
                                         type: 'CodeEditor',
                                         editorId: 'editor#1',
                                         resource: 'u2',
-                                        model: { languageId: 'y', text: '', uri: 'u2' },
+                                        model: { languageId: 'y' },
                                         selections: [],
                                         isActive: true,
                                     },
@@ -119,7 +119,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditor[]>('a-|', {
+                            cold<readonly CodeEditorWithPartialModel[]>('a-|', {
                                 a: [],
                             })
                         ),
@@ -164,7 +164,7 @@ describe('activeExtensions', () => {
                     new TestExtensionsService(
                         [{ id: 'foo', manifest, rawManifest: null }],
                         createTestEditorService(
-                            cold<readonly CodeEditor[]>('a-|', {
+                            cold<readonly CodeEditorWithPartialModel[]>('a-|', {
                                 a: [],
                             })
                         ),

--- a/shared/src/api/client/services/extensionsService.ts
+++ b/shared/src/api/client/services/extensionsService.ts
@@ -13,7 +13,7 @@ import { isErrorLike } from '../../../util/errors'
 import { memoizeObservable } from '../../../util/memoizeObservable'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
 import { isDefined } from '../../../util/types'
-import { CodeEditor, EditorService } from './editorService'
+import { CodeEditorWithPartialModel, EditorService } from './editorService'
 import { SettingsService } from './settings'
 
 /**
@@ -56,7 +56,7 @@ interface PartialContext extends Pick<PlatformContext, 'requestGraphQL' | 'getSc
 export class ExtensionsService {
     public constructor(
         private platformContext: PartialContext,
-        private editorService: Pick<EditorService, 'editors'>,
+        private editorService: Pick<EditorService, 'editorsAndModels'>,
         private settingsService: Pick<SettingsService, 'data'>,
         private extensionActivationFilter = extensionsWithMatchedActivationEvent,
         private fetchSideloadedExtension: (
@@ -120,7 +120,7 @@ export class ExtensionsService {
         // Extensions that have been activated (including extensions with zero "activationEvents" that evaluate to
         // true currently).
         const activatedExtensionIDs = new Set<string>()
-        return combineLatest(from(this.editorService.editors), this.enabledExtensions).pipe(
+        return combineLatest(from(this.editorService.editorsAndModels), this.enabledExtensions).pipe(
             tap(([editors, enabledExtensions]) => {
                 const activeExtensions = this.extensionActivationFilter(enabledExtensions, editors)
                 for (const x of activeExtensions) {
@@ -171,7 +171,7 @@ function asObservable(input: string | ObservableInput<string>): Observable<strin
 
 function extensionsWithMatchedActivationEvent(
     enabledExtensions: ConfiguredExtension[],
-    editors: readonly CodeEditor[]
+    editors: readonly CodeEditorWithPartialModel[]
 ): ConfiguredExtension[] {
     return enabledExtensions.filter(x => {
         try {

--- a/shared/src/api/client/services/location.test.ts
+++ b/shared/src/api/client/services/location.test.ts
@@ -61,7 +61,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                             type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
                             resource: 'u',
-                            model: { uri: 'u', languageId: 'l', text: 't' },
+                            model: { languageId: 'l' },
                         },
                     ])
                 ).toBe('a', {
@@ -85,7 +85,7 @@ describe('TextDocumentLocationProviderRegistry', () => {
                             type: 'CodeEditor' as const,
                             selections: [new Selection(1, 2, 3, 4).toPlain()],
                             resource: 'u',
-                            model: { uri: 'u', languageId: 'l', text: 't' },
+                            model: { languageId: 'l' },
                         },
                     ])
                 ).toBe('a', {

--- a/shared/src/api/client/services/location.ts
+++ b/shared/src/api/client/services/location.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators'
 import { combineLatestOrDefault } from '../../../util/rxjs/combineLatestOrDefault'
 import { TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
 import { match, TextDocumentIdentifier } from '../types/textDocument'
-import { CodeEditor } from './editorService'
+import { CodeEditorWithPartialModel } from './editorService'
 import { DocumentFeatureProviderRegistry } from './registry'
 import { flattenAndCompact } from './util'
 
@@ -45,7 +45,7 @@ export class TextDocumentLocationProviderRegistry<
      *
      * @param editors The code editors in {@link EditorService}.
      */
-    public hasProvidersForActiveTextDocument(editors: readonly CodeEditor[]): Observable<boolean> {
+    public hasProvidersForActiveTextDocument(editors: readonly CodeEditorWithPartialModel[]): Observable<boolean> {
         return this.entries.pipe(
             map(entries => {
                 const activeEditor = editors.find(({ isActive }) => isActive)
@@ -54,7 +54,10 @@ export class TextDocumentLocationProviderRegistry<
                 }
                 return (
                     entries.filter(({ registrationOptions }) =>
-                        match(registrationOptions.documentSelector, activeEditor.model)
+                        match(registrationOptions.documentSelector, {
+                            uri: activeEditor.resource,
+                            languageId: activeEditor.model.languageId,
+                        })
                     ).length > 0
                 )
             })

--- a/shared/src/components/editorTextField/EditorTextField.test.tsx
+++ b/shared/src/components/editorTextField/EditorTextField.test.tsx
@@ -1,5 +1,5 @@
 import { of } from 'rxjs'
-import { CodeEditor } from '../../api/client/services/editorService'
+import { CodeEditorWithModel } from '../../api/client/services/editorService'
 import { EditorTextFieldUtils } from './EditorTextField'
 
 describe('EditorTextFieldUtils', () => {
@@ -94,8 +94,8 @@ describe('EditorTextFieldUtils', () => {
             const setValue = jest.fn()
             const subscription = EditorTextFieldUtils.updateElementOnEditorOrModelChanges(
                 {
-                    editors: of<readonly CodeEditor[]>([
-                        {
+                    observeEditorAndModel: () =>
+                        of<CodeEditorWithModel>({
                             editorId: 'e',
                             type: 'CodeEditor',
                             resource: 'u',
@@ -110,8 +110,7 @@ describe('EditorTextFieldUtils', () => {
                                 },
                             ],
                             isActive: true,
-                        },
-                    ]),
+                        }),
                 },
                 { editorId: 'e' },
                 setValue,
@@ -130,8 +129,8 @@ describe('EditorTextFieldUtils', () => {
             const setValue = jest.fn()
             const subscription = EditorTextFieldUtils.updateElementOnEditorOrModelChanges(
                 {
-                    editors: of<readonly CodeEditor[]>([
-                        {
+                    observeEditorAndModel: () =>
+                        of<CodeEditorWithModel>({
                             editorId: 'e',
                             type: 'CodeEditor',
                             resource: 'u',
@@ -146,8 +145,7 @@ describe('EditorTextFieldUtils', () => {
                                 },
                             ],
                             isActive: true,
-                        },
-                    ]),
+                        }),
                 },
                 { editorId: 'e' },
                 setValue,

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -95,7 +95,7 @@ export class BlobPanel extends React.PureComponent<Props> {
             extraParams?: Pick<P, Exclude<keyof P, keyof TextDocumentPositionParams>>
         ): Entry<ViewProviderRegistrationOptions, ProvideViewSignature> => ({
             registrationOptions: { id, container: ContributableViewContainer.Panel },
-            provider: from(this.props.extensionsController.services.editor.editors).pipe(
+            provider: from(this.props.extensionsController.services.editor.editorsAndModels).pipe(
                 switchMap(editors =>
                     registry.hasProvidersForActiveTextDocument(editors).pipe(
                         map(hasProviders => {

--- a/web/src/snippets/SnippetsPage.tsx
+++ b/web/src/snippets/SnippetsPage.tsx
@@ -2,7 +2,7 @@ import H from 'history'
 import { uniqueId } from 'lodash'
 import React, { createRef, useEffect, useLayoutEffect, useState } from 'react'
 import { from } from 'rxjs'
-import { filter, map } from 'rxjs/operators'
+import { map } from 'rxjs/operators'
 import { EditorId } from '../../../shared/src/api/client/services/editorService'
 import { TextModel } from '../../../shared/src/api/client/services/modelService'
 import { PanelViewWithComponent } from '../../../shared/src/api/client/services/view'
@@ -14,7 +14,6 @@ import { Markdown } from '../../../shared/src/components/Markdown'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { createLinkClickHandler } from '../../../shared/src/util/linkClickHandler'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
-import { isDefined } from '../../../shared/src/util/types'
 import { LINK_PREVIEW_CLASS } from '../components/linkPreviews/styles'
 import { WebEditorCompletionWidget } from '../components/shared'
 import { setElementTooltip } from '../components/tooltip/Tooltip'
@@ -85,15 +84,11 @@ export const SnippetsPage: React.FunctionComponent<Props> = ({ location, extensi
         if (!editorId) {
             return () => void 0
         }
-        const subscription = from(extensionsController.services.editor.editors)
-            .pipe(
-                map(editors => editors.find(e => e.editorId === editorId.editorId)),
-                filter(isDefined),
-                map(editor => editor.model.text)
-            )
+        const subscription = from(extensionsController.services.editor.observeEditorAndModel(editorId))
+            .pipe(map(editor => editor.model.text))
             .subscribe(text => setModelText(text || null))
         return () => subscription.unsubscribe()
-    }, [editorId, initialModelLanguageId, extensionsController.services.editor.editors])
+    }, [editorId, initialModelLanguageId, extensionsController.services.editor])
     const allPanelViews: PanelViewWithComponent[] | null =
         initialModelLanguageId === 'markdown' && modelText !== null
             ? [...(panelViews || []), { title: 'Preview', content: modelText, priority: 0 }]


### PR DESCRIPTION
Common use case for components are to listen for changes to:

- *all* editors and model languages, or
- a single editor and its model text

This commit adds these new APIs. In doing so, it also fixes #4072 ("Experimental text field completion" interaction with code host text inputs).

fix #4072

cc @slimsag @christinaforney who had expressed interest in getting this fixed