### PR TITLE
fix command palette styling on Bitbucket Server

### DIFF
--- a/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -194,7 +194,16 @@ export const bitbucketServerCodeHost: CodeHost = {
     codeViewResolvers: [codeViewResolver],
     getCommandPaletteMount,
     commandPaletteClassProps: {
-        popoverClassName: 'searchable-selector command-palette-popover--bitbucket-server',
+        buttonClassName:
+            'aui-dropdown2-trigger aui-alignment-target aui-alignment-abutted aui-alignment-abutted-left aui-alignment-element-attached-top aui-alignment-element-attached-left aui-alignment-target-attached-bottom aui-alignment-target-attached-left',
+        buttonElement: 'a',
+        buttonOpenClassName: 'aui-dropdown2-active active aui-alignment-enabled',
+        showCaret: false,
+        popoverClassName:
+            'command-palette-popover--bitbucket-server aui-dropdown2 aui-style-default aui-layer aui-dropdown2-in-header aui-alignment-element aui-alignment-side-bottom aui-alignment-snap-left aui-alignment-enabled aui-alignment-abutted aui-alignment-abutted-left aui-alignment-element-attached-top aui-alignment-element-attached-left aui-alignment-target-attached-bottom aui-alignment-target-attached-left',
+        popoverInnerClassName: 'aui-dropdown2-section',
+        formClassName: 'aui',
+        inputClassName: 'text',
         resultsContainerClassName: 'results',
         listClassName: 'results-list',
         listItemClassName: 'result',

--- a/browser/src/libs/bitbucket/style.scss
+++ b/browser/src/libs/bitbucket/style.scss
@@ -1,7 +1,26 @@
 // Command palette
 .command-palette-button--bitbucket-server {
-    position: relative;
-    top: 5px;
+    z-index: 3000;
+    font-size: 13px;
+    svg {
+        // The icon we use is taller than the other items' font size, so make it a bit shorter.
+        height: 13px;
+    }
+}
+
+.command-palette-popover--bitbucket-server {
+    display: block !important;
+    max-width: unset !important;
+
+    header {
+        padding: 8px;
+    }
+    input {
+        max-width: unset !important;
+    }
+    .no-results {
+        padding: 10px;
+    }
 }
 
 // Open on Sourcegraph button

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -29,7 +29,10 @@ import { PartialCodeEditor } from '../../../../shared/src/api/client/context/con
 import { DecorationMapByLine } from '../../../../shared/src/api/client/services/decoration'
 import { CodeEditorData } from '../../../../shared/src/api/client/services/editorService'
 import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
-import { CommandListClassProps } from '../../../../shared/src/commandPalette/CommandList'
+import {
+    CommandListClassProps,
+    CommandListPopoverButtonClassProps,
+} from '../../../../shared/src/commandPalette/CommandList'
 import { CompletionWidgetClassProps } from '../../../../shared/src/components/completion/CompletionWidget'
 import { ApplyLinkPreviewOptions } from '../../../../shared/src/components/linkPreviews/linkPreviews'
 import { Controller } from '../../../../shared/src/extensions/controller'
@@ -170,7 +173,7 @@ export interface CodeHost extends ApplyLinkPreviewOptions {
     /**
      * CSS classes for the command palette to customize styling
      */
-    commandPaletteClassProps?: CommandListClassProps
+    commandPaletteClassProps?: CommandListPopoverButtonClassProps & CommandListClassProps
 
     /**
      * CSS classes for the code view toolbar to customize styling

--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -20,14 +20,23 @@ import { PlatformContextProps } from '../platform/context'
 import { TelemetryProps } from '../telemetry/telemetryService'
 
 /**
- * Customizable CSS classes for elements of the the command list
+ * Customizable CSS classes for elements of the the command list button.
  */
-export interface CommandListClassProps {
+export interface CommandListPopoverButtonClassProps {
     /** The class name for the root button element of {@link CommandListPopoverButton}. */
     buttonClassName?: string
+    buttonElement?: 'span' | 'a'
+    buttonOpenClassName?: string
 
+    showCaret?: boolean
     popoverClassName?: string
     popoverInnerClassName?: string
+}
+
+/**
+ * Customizable CSS classes for elements of the the command list.
+ */
+export interface CommandListClassProps {
     inputClassName?: string
     formClassName?: string
     listItemClassName?: string
@@ -40,10 +49,7 @@ export interface CommandListClassProps {
 }
 
 export interface CommandListProps
-    extends Pick<
-            CommandListClassProps,
-            Exclude<keyof CommandListClassProps, 'buttonClassName' | 'popoverClassName' | 'popoverInnerClassName'>
-        >,
+    extends CommandListClassProps,
         ExtensionsControllerProps<'services' | 'executeCommand'>,
         PlatformContextProps<'forceUpdateTooltip'>,
         TelemetryProps {
@@ -300,12 +306,18 @@ export function filterAndRankItems(
     return sortBy(scoredItems, 'recentIndex', 'score', ({ item }) => item.action.id).map(({ item }) => item)
 }
 
-export interface CommandListPopoverButtonProps extends CommandListProps, CommandListClassProps {
+export interface CommandListPopoverButtonProps
+    extends CommandListProps,
+        CommandListPopoverButtonClassProps,
+        CommandListClassProps {
     toggleVisibilityKeybinding?: Pick<ShortcutProps, 'held' | 'ordered'>[]
 }
 
 export const CommandListPopoverButton: React.FunctionComponent<CommandListPopoverButtonProps> = ({
     buttonClassName = '',
+    buttonElement: ButtonElement = 'span',
+    buttonOpenClassName = '',
+    showCaret = true,
     popoverClassName = '',
     popoverInnerClassName = '',
     toggleVisibilityKeybinding,
@@ -318,9 +330,14 @@ export const CommandListPopoverButton: React.FunctionComponent<CommandListPopove
     const id = useMemo(() => uniqueId('command-list-popover-button-'), [])
 
     return (
-        <span role="button" className={`command-list-popover-button ${buttonClassName}`} id={id} onClick={toggleIsOpen}>
+        <ButtonElement
+            role="button"
+            className={`command-list-popover-button ${buttonClassName} ${isOpen ? buttonOpenClassName : ''}`}
+            id={id}
+            onClick={toggleIsOpen}
+        >
             <MenuIcon className="icon-inline" />
-            {isOpen ? <MenuUpIcon className="icon-inline" /> : <MenuDownIcon className="icon-inline" />}
+            {showCaret && (isOpen ? <MenuUpIcon className="icon-inline" /> : <MenuDownIcon className="icon-inline" />)}
             {/* Need to use TooltipPopoverWrapper to apply classNames to inner element, see https://github.com/reactstrap/reactstrap/issues/1484 */}
             <TooltipPopoverWrapper
                 isOpen={isOpen}
@@ -339,6 +356,6 @@ export const CommandListPopoverButton: React.FunctionComponent<CommandListPopove
                 toggleVisibilityKeybinding.map((keybinding, i) => (
                     <Shortcut key={i} {...keybinding} onMatch={toggleIsOpen} />
                 ))}
-        </span>
+        </ButtonElement>
     )
 }


### PR DESCRIPTION
fix #3381

Known issues:

- Up/down arrow keys do not work on Bitbucket Server (probably due to other listeners on the page not set by us). They did not work before, either, so this is not a regression.

cc @slimsag 

### after

![image](https://user-images.githubusercontent.com/1976/59584046-df265600-9091-11e9-9a5b-824b1a559ccc.png)
![image](https://user-images.githubusercontent.com/1976/59584057-e64d6400-9091-11e9-8ac1-7a7a5481b6b9.png)
![image](https://user-images.githubusercontent.com/1976/59584075-eea59f00-9091-11e9-890b-8847512de820.png)

