### PR TITLE
fix flash of unstyled content in browser extension

### DIFF
--- a/browser/src/extension/scripts/inject.tsx
+++ b/browser/src/extension/scripts/inject.tsx
@@ -73,19 +73,17 @@ async function main(): Promise<void> {
 
     // Add style sheet and wait for it to load to avoid rendering unstyled elements (which causes an
     // annoying flash/jitter when the stylesheet loads shortly thereafter).
-    await new Promise(resolve => {
-        if (!isSourcegraphServer && !document.getElementById('ext-style-sheet')) {
-            const styleSheet = document.createElement('link')
-            styleSheet.id = 'ext-style-sheet'
-            styleSheet.rel = 'stylesheet'
-            styleSheet.type = 'text/css'
-            styleSheet.href = browser.extension.getURL('css/style.bundle.css')
-            styleSheet.onload = () => resolve()
+    if (!isSourcegraphServer && !document.getElementById('ext-style-sheet')) {
+        const styleSheet = document.createElement('link')
+        styleSheet.id = 'ext-style-sheet'
+        styleSheet.rel = 'stylesheet'
+        styleSheet.type = 'text/css'
+        styleSheet.href = browser.extension.getURL('css/style.bundle.css')
+        await new Promise(resolve => {
+            styleSheet.onload = resolve
             document.head.appendChild(styleSheet)
-        } else {
-            resolve()
-        }
-    })
+        })
+    }
 
     // Add a marker to the DOM that the extension is loaded
     injectSourcegraphApp(extensionMarker)


### PR DESCRIPTION
The elements were being injected before the stylesheet finished loading (even though it is a local stylesheet, it still takes a brief moment to load). This fixes it so that the injection waits until the styles are loaded.

fix #4033

### before and after videos

- [BEFORE (video)](https://drive.google.com/file/d/19Vf-mX12DSUbgSxhJaXH_UE4HORsIrdM/view?usp=sharing): Watch for the jitter in the top navbar of Bitbucket Server and GitHub.
- [AFTER (video)](https://drive.google.com/file/d/1GfLz0y43BCIEMlUSPnyV2jtoxSisRiWA/view?usp=sharing): No jitter!