### PR TITLE
remove unused browser extension CSS for extension cards

### DIFF
--- a/browser/src/shared.scss
+++ b/browser/src/shared.scss
@@ -16,9 +16,7 @@ $body-color-dark: #f2f4f8;
     --text-muted: #{$color-light-text-2};
     --link-color: #566e9f;
     --link-hover-color: #1d2535;
-    --primary-opacity-2: #{transparentize($primary, 0.8)};
     --dropdown-bg: #{$color-light-bg-1};
-    --extension-card-bg: #{lighten($color-light-bg-2, 2.5%)};
     --dropdown-border-color: #{$color-light-border};
 }
 
@@ -58,47 +56,6 @@ $body-color-dark: #f2f4f8;
     right: 0;
     bottom: 0;
     background-color: var(--body-bg);
-}
-
-.configured-extensions-list {
-    h1 {
-        font-size: 32px;
-        line-height: 40px;
-        font-weight: 600;
-        margin: 0 0 1rem;
-    }
-    h2 {
-        font-size: 24px;
-        line-height: 32px;
-        font-weight: 600;
-    }
-    h3 {
-        font-size: 16px;
-        line-height: 24px;
-        font-weight: 600;
-    }
-    h4 {
-        font-size: 14px;
-        line-height: 20px;
-        font-weight: 600;
-    }
-    h5 {
-        font-size: 12px;
-        letter-spacing: 1px;
-        font-weight: 500;
-        text-transform: uppercase;
-        margin: 0;
-    }
-    .btn.btn-sm {
-        font-size: 12px;
-    }
-    .extension-card {
-        .dropdown {
-            button {
-                margin: 0.25rem 0;
-            }
-        }
-    }
 }
 
 .toggle--off::-webkit-slider-runnable-track {


### PR DESCRIPTION
The browser extension used to show the extension registry UI in the browser extension itself. It no longer does, so these styles are not needed.