### PR TITLE
remove unneeded div in ExtensionAreaHeader

### DIFF
--- a/web/src/extensions/ExtensionToggle.tsx
+++ b/web/src/extensions/ExtensionToggle.tsx
@@ -13,6 +13,8 @@ import { isExtensionAdded } from './extension/extension'
 interface Props extends SettingsCascadeProps, PlatformContextProps<'updateSettings'> {
     /** The extension that this element is for. */
     extension: Pick<ConfiguredRegistryExtension, 'id'>
+
+    className?: string
 }
 
 /**
@@ -89,6 +91,7 @@ export class ExtensionToggle extends React.PureComponent<Props> {
                 value={isExtensionEnabled(this.props.settingsCascade.final, this.props.extension.id)}
                 onToggle={this.onToggle}
                 title={title}
+                className={this.props.className}
             />
         )
     }

--- a/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -86,13 +86,12 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                         </div>
                         <div className="d-flex align-items-center mt-3 mb-2">
                             {props.authenticatedUser && (
-                                <div className="mr-2">
-                                    <ExtensionToggle
-                                        extension={props.extension}
-                                        settingsCascade={props.settingsCascade}
-                                        platformContext={props.platformContext}
-                                    />
-                                </div>
+                                <ExtensionToggle
+                                    extension={props.extension}
+                                    settingsCascade={props.settingsCascade}
+                                    platformContext={props.platformContext}
+                                    className="mr-2"
+                                />
                             )}
                             <ExtensionConfigurationState
                                 className="mr-2"


### PR DESCRIPTION
This also improves the vertical alignment of the toggle with its label.