### PR TITLE
more compact ExtensionCard

### DIFF
--- a/shared/src/components/Toggle.scss
+++ b/shared/src/components/Toggle.scss
@@ -6,8 +6,7 @@
     outline: none !important;
     padding: 0;
     position: relative;
-    width: 2rem;
-    z-index: 0;
+    width: 2.125rem;
 }
 
 .toggle__bar {
@@ -25,7 +24,6 @@
     width: 100%;
 
     position: absolute;
-    z-index: 0;
 }
 
 .toggle__bar--active {
@@ -44,7 +42,6 @@
     margin-top: 2px;
 
     position: relative;
-    z-index: 1;
 }
 
 .toggle__knob--active {

--- a/web/src/extensions/ExtensionCard.scss
+++ b/web/src/extensions/ExtensionCard.scss
@@ -1,5 +1,6 @@
 .extension-card {
     flex: 1;
+    position: relative;
 
     &__body-title {
         color: var(--body-color) !important;
@@ -10,8 +11,8 @@
         height: 6rem;
     }
 
-    &__spacer {
-        flex: 1;
+    &__toggle {
+        z-index: 1;
     }
 
     &__footer {

--- a/web/src/extensions/ExtensionCard.tsx
+++ b/web/src/extensions/ExtensionCard.tsx
@@ -1,6 +1,5 @@
 import WarningIcon from 'mdi-react/WarningIcon'
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import { LinkOrSpan } from '../../../shared/src/components/LinkOrSpan'
 import { Path } from '../../../shared/src/components/Path'
 import { ConfiguredRegistryExtension, isExtensionEnabled } from '../../../shared/src/extensions/extension'
@@ -27,6 +26,10 @@ interface Props extends SettingsCascadeProps, PlatformContextProps<'updateSettin
     subject: Pick<GQL.SettingsSubject, 'id' | 'viewerCanAdminister'>
 }
 
+const stopPropagation: React.MouseEventHandler<HTMLElement> = e => {
+    e.stopPropagation()
+}
+
 /** Displays an extension as a card. */
 export class ExtensionCard extends React.PureComponent<Props> {
     public render(): JSX.Element | null {
@@ -45,9 +48,11 @@ export class ExtensionCard extends React.PureComponent<Props> {
         return (
             <div className="d-flex">
                 <div className="extension-card card">
-                    <LinkOrSpan
-                        to={node.registryExtension && node.registryExtension.url}
-                        className="card-body extension-card__body d-flex flex-column"
+                    <div
+                        className="card-body extension-card__body d-flex flex-column position-relative"
+                        // Prevent toggle clicks from propagating to the stretched-link (and
+                        // navigating to the extension detail page).
+                        onClick={stopPropagation}
                     >
                         <div className="d-flex">
                             {manifest &&
@@ -57,22 +62,43 @@ export class ExtensionCard extends React.PureComponent<Props> {
                                 /^data:image\/png(;base64)?,/.test(manifest.icon) && (
                                     <img className="extension-card__icon mr-2" src={manifest.icon} />
                                 )}
-                            <div className="text-truncate">
+                            <div className="text-truncate w-100">
                                 <div className="d-flex align-items-center">
-                                    <h4 className="card-title extension-card__body-title mb-0 mr-1 text-truncate font-weight-normal">
-                                        <Path
-                                            path={
-                                                node.registryExtension
-                                                    ? node.registryExtension.extensionIDWithoutRegistry
-                                                    : node.id
-                                            }
-                                        />
+                                    <h4 className="card-title extension-card__body-title mb-0 mr-1 text-truncate font-weight-normal flex-1">
+                                        <LinkOrSpan
+                                            to={node.registryExtension && node.registryExtension.url}
+                                            className="stretched-link"
+                                        >
+                                            <Path
+                                                path={
+                                                    node.registryExtension
+                                                        ? node.registryExtension.extensionIDWithoutRegistry
+                                                        : node.id
+                                                }
+                                            />
+                                        </LinkOrSpan>
                                     </h4>
                                     {node.registryExtension && node.registryExtension.isWorkInProgress && (
                                         <WorkInProgressBadge
                                             viewerCanAdminister={node.registryExtension.viewerCanAdminister}
                                         />
                                     )}
+                                    {props.subject &&
+                                        (props.subject.viewerCanAdminister ? (
+                                            <ExtensionToggle
+                                                extension={node}
+                                                settingsCascade={this.props.settingsCascade}
+                                                platformContext={this.props.platformContext}
+                                                className="extension-card__toggle"
+                                            />
+                                        ) : (
+                                            <ExtensionConfigurationState
+                                                isAdded={isExtensionAdded(props.settingsCascade.final, node.id)}
+                                                isEnabled={isExtensionEnabled(props.settingsCascade.final, node.id)}
+                                                enabledIconOnly={true}
+                                                className="small"
+                                            />
+                                        ))}
                                 </div>
                                 <div className="mt-1">
                                     {node.manifest ? (
@@ -95,33 +121,6 @@ export class ExtensionCard extends React.PureComponent<Props> {
                                 </div>
                             </div>
                         </div>
-                    </LinkOrSpan>
-                    <div className="card-footer extension-card__footer py-0 pl-0">
-                        <ul className="nav align-items-center">
-                            {node.registryExtension && node.registryExtension.url && (
-                                <li className="nav-item">
-                                    <Link to={node.registryExtension.url} className="nav-link px-2" tabIndex={-1}>
-                                        Details
-                                    </Link>
-                                </li>
-                            )}
-                            <li className="extension-card__spacer" />
-                            {props.subject &&
-                                (props.subject.viewerCanAdminister ? (
-                                    <ExtensionToggle
-                                        extension={node}
-                                        settingsCascade={this.props.settingsCascade}
-                                        platformContext={this.props.platformContext}
-                                    />
-                                ) : (
-                                    <li className="nav-item">
-                                        <ExtensionConfigurationState
-                                            isAdded={isExtensionAdded(props.settingsCascade.final, node.id)}
-                                            isEnabled={isExtensionEnabled(props.settingsCascade.final, node.id)}
-                                        />
-                                    </li>
-                                ))}
-                        </ul>
                     </div>
                 </div>
             </div>

--- a/web/src/extensions/ExtensionsList.scss
+++ b/web/src/extensions/ExtensionsList.scss
@@ -2,7 +2,7 @@
     &__cards {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
-        grid-auto-rows: minmax(7rem, auto);
+        grid-auto-rows: minmax(4rem, auto);
         gap: $spacer * 0.75;
     }
 }

--- a/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
+++ b/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
@@ -7,9 +7,9 @@ exports[`ExtensionCard renders 1`] = `
   <div
     className="extension-card card"
   >
-    <a
-      className="card-body extension-card__body d-flex flex-column"
-      to="extensions/x/y"
+    <div
+      className="card-body extension-card__body d-flex flex-column position-relative"
+      onClick={[Function]}
     >
       <div
         className="d-flex"
@@ -19,24 +19,34 @@ exports[`ExtensionCard renders 1`] = `
           src="data:image/png,abcd"
         />
         <div
-          className="text-truncate"
+          className="text-truncate w-100"
         >
           <div
             className="d-flex align-items-center"
           >
             <h4
-              className="card-title extension-card__body-title mb-0 mr-1 text-truncate font-weight-normal"
+              className="card-title extension-card__body-title mb-0 mr-1 text-truncate font-weight-normal flex-1"
             >
-              <span
-                className="text-muted"
+              <a
+                className="stretched-link"
+                to="extensions/x/y"
               >
-                x
-                /
-              </span>
-              <strong>
-                y
-              </strong>
+                <span
+                  className="text-muted"
+                >
+                  x
+                  /
+                </span>
+                <strong>
+                  y
+                </strong>
+              </a>
             </h4>
+            <span
+              className="text-muted small"
+            >
+              Disabled
+            </span>
           </div>
           <div
             className="mt-1"
@@ -49,38 +59,6 @@ exports[`ExtensionCard renders 1`] = `
           </div>
         </div>
       </div>
-    </a>
-    <div
-      className="card-footer extension-card__footer py-0 pl-0"
-    >
-      <ul
-        className="nav align-items-center"
-      >
-        <li
-          className="nav-item"
-        >
-          <a
-            className="nav-link px-2"
-            href="/extensions/x/y"
-            onClick={[Function]}
-            tabIndex={-1}
-          >
-            Details
-          </a>
-        </li>
-        <li
-          className="extension-card__spacer"
-        />
-        <li
-          className="nav-item"
-        >
-          <span
-            className="text-muted "
-          >
-            Disabled
-          </span>
-        </li>
-      </ul>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This makes them look cleaner and tighter. It also may slightly help with the user confusion from last week where they didn't know how to enable an extension, because it simplifies the cards.

- Remove "Details" link
- Moves enable toggle slider to top right
- Reduce height

### for authed users (both themes)

![ext2](https://user-images.githubusercontent.com/1976/59590178-4fd46f00-90a0-11e9-9f1f-21ebb3bc9263.png)
![ext1](https://user-images.githubusercontent.com/1976/59590180-4fd46f00-90a0-11e9-92a1-1f83310d730f.png)

### for unauthed users

![ext3](https://user-images.githubusercontent.com/1976/59590177-4f3bd880-90a0-11e9-964f-43008ac1301f.png)
