### PR TITLE
Fix result container overlapping notifications 

### DIFF
--- a/shared/src/notifications/Notifications.scss
+++ b/shared/src/notifications/Notifications.scss
@@ -3,5 +3,5 @@
     width: 28rem;
     top: 82px;
     right: 0;
-    z-index: 90;
+    z-index: 100;
 }


### PR DESCRIPTION
z-index for result [container is 99](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/shared/src/components/ResultContainer.scss#L25), and [90 for notifications](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/shared/src/notifications/Notifications.scss#L6) (like those coming from extensions). This causes an undesired overlapping.


Before:
<img width="461" alt="Screen Shot 2019-06-17 at 5 33 13 PM" src="https://user-images.githubusercontent.com/888624/59638701-ffecbb00-9126-11e9-96c4-18d61bd9accd.png">

After:

<img width="457" alt="Screen Shot 2019-06-17 at 5 41 10 PM" src="https://user-images.githubusercontent.com/888624/59638736-1dba2000-9127-11e9-8596-83d7f6903a52.png">

Test plan: I looked at it visually.