### PR TITLE
search: parallelize repositories resolver gitserver requests

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -489,12 +489,14 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 }
 
 func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.RepositoryRevisions, after string) []*search.RepositoryRevisions {
-	var mut sync.Mutex
-	pass := []*search.RepositoryRevisions{}
-	res := make(chan *search.RepositoryRevisions)
+	var (
+		mut  sync.Mutex
+		pass = []*search.RepositoryRevisions{}
+		res  = make(chan *search.RepositoryRevisions)
 
-	repoRun := parallel.NewRun(1000)
-	revRun := parallel.NewRun(1000)
+		repoRun = parallel.NewRun(1000)
+		revRun  = parallel.NewRun(1000)
+	)
 
 	go func() {
 		for rev := range res {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -483,13 +483,13 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	tr.LazyPrintf("Associate/validate revs - done")
 
 	if op.commitAfter != "" {
-		repoRevisions = filterRepoHasCommitAfter(ctx, repoRevisions, op.commitAfter)
+		repoRevisions, err = filterRepoHasCommitAfter(ctx, repoRevisions, op.commitAfter)
 	}
 
-	return repoRevisions, missingRepoRevisions, repoResolvers, overLimit, nil
+	return repoRevisions, missingRepoRevisions, repoResolvers, overLimit, err
 }
 
-func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.RepositoryRevisions, after string) []*search.RepositoryRevisions {
+func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.RepositoryRevisions, after string) ([]*search.RepositoryRevisions, error) {
 	var (
 		mut  sync.Mutex
 		pass = []*search.RepositoryRevisions{}
@@ -524,10 +524,10 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 		})
 	}
 
-	run.Wait()
+	err := run.Wait()
 	close(res)
 
-	return pass
+	return pass, err
 }
 
 func optimizeRepoPatternWithHeuristics(repoPattern string) string {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -484,7 +484,7 @@ func resolveRepository(ctx context.Context, repo *types.Repo, op resolveRepoOp, 
 		wg.Add(1)
 
 		var x interface{}
-		for x != nil {
+		for x == nil {
 			x = pool.Get()
 		}
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -14,7 +14,6 @@ import (
 	zoektrpc "github.com/google/zoekt/rpc"
 	"github.com/neelance/parallel"
 	"github.com/pkg/errors"
-	"gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -442,11 +442,11 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		run.Acquire()
 		go resolveRepository(ctx, repo, op, includePatternRevs, resolverPool, results)
 	}
-	run.Wait()
+	err = run.Wait()
 	close(results)
 
 	tr.LazyPrintf("Associate/validate revs - done")
-	return repoRevisions, missingRepoRevisions, repoResolvers, overLimit, nil
+	return repoRevisions, missingRepoRevisions, repoResolvers, overLimit, err
 }
 
 type repositoryResult struct {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -430,9 +430,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 			mut.Lock()
 			repoRevisions = append(repoRevisions, res.revisions)
 			repoResolvers = append(repoResolvers, res.resolver)
-			for _, missing := range res.missingRepoRevisions {
-				missingRepoRevisions = append(missingRepoRevisions, missing)
-			}
+			missingRepoRevisions = append(missingRepoRevisions, res.missingRepoRevisions...)
 			mut.Unlock()
 			run.Release()
 		}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -416,25 +416,82 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	}
 	overLimit = len(repos) >= maxRepoListSize
 
+	resolverPool := sync.Pool{}
+	for i := 0; i < 100; i++ {
+		resolverPool.Put(struct{}{})
+	}
+
+	var mut sync.Mutex
+	var wg sync.WaitGroup
+	results := make(chan *repositoryResult)
+
 	repoRevisions = make([]*search.RepositoryRevisions, 0, len(repos))
 	repoResolvers = make([]*searchSuggestionResolver, 0, len(repos))
-	tr.LazyPrintf("Associate/validate revs - start")
 	for _, repo := range repos {
-		repoRev := &search.RepositoryRevisions{Repo: repo}
+		wg.Add(1)
+		go resolveRepository(ctx, repo, op, includePatternRevs, resolverPool, results)
+	}
 
-		revs, clashingRevs := getRevsForMatchedRepo(repo.Name, includePatternRevs)
-
-		repoResolver := &repositoryResolver{repo: repo}
-
-		// if multiple specified revisions clash, report this usefully:
-		if len(revs) == 0 && clashingRevs != nil {
-			missingRepoRevisions = append(missingRepoRevisions, &search.RepositoryRevisions{
-				Repo: repo,
-				Revs: clashingRevs,
-			})
+	go func() {
+		for res := range results {
+			mut.Lock()
+			repoRevisions = append(repoRevisions, res.revisions)
+			repoResolvers = append(repoResolvers, res.resolver)
+			for _, missing := range res.missingRepoRevisions {
+				missingRepoRevisions = append(missingRepoRevisions, missing)
+			}
+			mut.Unlock()
+			wg.Done()
 		}
-		// Check if the repository actually has the revisions that the user specified.
-		for _, rev := range revs {
+	}()
+	wg.Wait()
+	close(results)
+
+	tr.LazyPrintf("Associate/validate revs - done")
+	return repoRevisions, missingRepoRevisions, repoResolvers, overLimit, nil
+}
+
+type repositoryResult struct {
+	revisions            *search.RepositoryRevisions
+	resolver             *searchSuggestionResolver
+	missingRepoRevisions []*search.RepositoryRevisions
+}
+
+func resolveRepository(ctx context.Context, repo *types.Repo, op resolveRepoOp, includePatternRevs []patternRevspec, pool sync.Pool, results chan<- *repositoryResult) {
+	repoRev := &search.RepositoryRevisions{Repo: repo}
+	revs, clashingRevs := getRevsForMatchedRepo(repo.Name, includePatternRevs)
+	repoResolver := &repositoryResolver{repo: repo}
+
+	var mut sync.Mutex
+	res := &repositoryResult{
+		resolver: newSearchResultResolver(
+			repoResolver,
+			math.MaxInt32,
+		),
+		revisions: repoRev,
+	}
+
+	// if multiple specified revisions clash, report this usefully:
+	if len(revs) == 0 && clashingRevs != nil {
+		res.missingRepoRevisions = append(res.missingRepoRevisions, &search.RepositoryRevisions{
+			Repo: repo,
+			Revs: clashingRevs,
+		})
+	}
+
+	var wg sync.WaitGroup
+	for _, rev := range revs {
+		wg.Add(1)
+
+		var x interface{}
+		for x != nil {
+			x = pool.Get()
+		}
+
+		go func(rev search.RevisionSpecifier) {
+			defer wg.Done()
+			defer pool.Put(x)
+
 			if rev.RefGlob != "" || rev.ExcludeRefGlob != "" {
 				// Do not validate ref patterns. A ref pattern matching 0 refs is not necessarily
 				// invalid, so it's not clear what validation would even mean.
@@ -453,39 +510,33 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 				if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), nil, rev.RevSpec, &git.ResolveRevisionOptions{NoEnsureRevision: true}); git.IsRevisionNotFound(err) || err == context.DeadlineExceeded {
 					// The revspec does not exist, so don't include it, and report that it's missing.
 					if rev.RevSpec == "" {
-						// Report as HEAD not "" (empty string) to avoid user confusion.
 						rev.RevSpec = "HEAD"
 					}
-					missingRepoRevisions = append(missingRepoRevisions, &search.RepositoryRevisions{
+					mut.Lock()
+					res.missingRepoRevisions = append(res.missingRepoRevisions, &search.RepositoryRevisions{
 						Repo: repo,
 						Revs: []search.RevisionSpecifier{{RevSpec: rev.RevSpec}},
 					})
-					continue
+					mut.Unlock()
+					return
 				}
-				// If err != nil and is not one of the err values checked for above, cloning and other errors will be handled later, so just ignore an error
-				// if there is one.
 			}
 
 			if op.commitAfter != "" {
 				ok, err := git.HasCommitAfter(ctx, repoRev.GitserverRepo(), op.commitAfter, rev.RevSpec)
 				if err == nil && !ok {
-					continue
+					return
 				}
 			}
 
+			mut.Lock()
 			repoRev.Revs = append(repoRev.Revs, rev)
-		}
-
-		repoResolvers = append(repoResolvers, newSearchResultResolver(
-			repoResolver,
-			math.MaxInt32,
-		))
-
-		repoRevisions = append(repoRevisions, repoRev)
+			mut.Unlock()
+		}(rev)
 	}
-	tr.LazyPrintf("Associate/validate revs - done")
+	wg.Wait()
 
-	return repoRevisions, missingRepoRevisions, repoResolvers, overLimit, nil
+	results <- res
 }
 
 func optimizeRepoPatternWithHeuristics(repoPattern string) string {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -494,7 +494,7 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 		mut  sync.Mutex
 		pass = []*search.RepositoryRevisions{}
 		res  = make(chan *search.RepositoryRevisions, 100)
-		run  = parallel.NewRun(1000)
+		run  = parallel.NewRun(128)
 	)
 
 	goroutine.Go(func() {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -492,7 +492,7 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 	var (
 		mut  sync.Mutex
 		pass = []*search.RepositoryRevisions{}
-		res  = make(chan *search.RepositoryRevisions)
+		res  = make(chan *search.RepositoryRevisions, 100)
 		run  = parallel.NewRun(1000)
 	)
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"sync"
 
+	zoektrpc "github.com/google/zoekt/rpc"
 	"github.com/neelance/parallel"
 	"github.com/pkg/errors"
 	"gopkg.in/inconshreveable/log15.v2"
 
-	zoektrpc "github.com/google/zoekt/rpc"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -493,8 +493,7 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 		mut  sync.Mutex
 		pass = []*search.RepositoryRevisions{}
 		res  = make(chan *search.RepositoryRevisions)
-
-		repoRun = parallel.NewRun(1000)
+		run  = parallel.NewRun(1000)
 	)
 
 	go func() {
@@ -504,12 +503,12 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 				pass = append(pass, rev)
 				mut.Unlock()
 			}
-			repoRun.Release()
+			run.Release()
 		}
 	}()
 
 	for _, revs := range revisions {
-		repoRun.Acquire()
+		run.Acquire()
 
 		go func(revs *search.RepositoryRevisions) {
 			var specifiers []search.RevisionSpecifier
@@ -523,7 +522,7 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 		}(revs)
 	}
 
-	repoRun.Wait()
+	run.Wait()
 	close(res)
 
 	return pass


### PR DESCRIPTION
This PR aims to improve the speed of the repositories resolver to accompany the addition of the `repohascommitafter` filter. It switches to concurrent gitserver requests.

The current `repohascommitafter` implementation (synchronous) times out (when searching over all repos) on the large test sourcegraph instance. This PR should provide a fix for that issue.

Fixes #4567