### PR TITLE
fix "show more" button not showing bug

### DIFF
--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -1,14 +1,77 @@
 import { createBrowserHistory } from 'history'
+import { range } from 'lodash'
 import * as React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { cleanup, getAllByTestId, getByTestId, queryByTestId, render } from 'react-testing-library'
+import _VisibilitySensor from 'react-visibility-sensor'
 import sinon from 'sinon'
 import { setLinkComponent } from '../../../../shared/src/components/Link'
-import { HIGHLIGHTED_FILE_LINES_REQUEST, MULTIPLE_SEARCH_REQUEST, SEARCH_REQUEST } from '../testHelpers'
+import * as GQL from '../../../../shared/src/graphql/schema'
+import { HIGHLIGHTED_FILE_LINES_REQUEST, MULTIPLE_SEARCH_REQUEST, RESULT, SEARCH_REQUEST } from '../testHelpers'
 import { SearchResultsList, SearchResultsListProps } from './SearchResultsList'
+
+let VISIBILITY_CHANGED_CALLBACKS: ((isVisible: boolean) => void)[] = []
+
+class MockVisibilitySensor extends React.Component<{ onChange?: (isVisible: boolean) => void }> {
+    constructor(props: { onChange?: (isVisible: boolean) => void }) {
+        super(props)
+        if (props.onChange) {
+            VISIBILITY_CHANGED_CALLBACKS.push(props.onChange)
+        }
+    }
+
+    public render(): JSX.Element {
+        return <>{this.props.children}</>
+    }
+
+    public componentWillUnmount(): void {
+        if (this.props.onChange) {
+            VISIBILITY_CHANGED_CALLBACKS.splice(VISIBILITY_CHANGED_CALLBACKS.indexOf(this.props.onChange), 1)
+        }
+    }
+}
+
+jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children, onChange }) => (
+    <MockVisibilitySensor onChange={onChange} children={children} />
+))
 
 describe('SearchResultsList', () => {
     setLinkComponent((props: any) => <a {...props} />)
+
+    /**
+     * Simulates "scrolling" to the end of the search results,
+     * by triggering all the visibility changed callbacks with
+     * visibility: `true`.
+     */
+    const scrollToBottom = (): void => {
+        for (const onChange of VISIBILITY_CHANGED_CALLBACKS) {
+            onChange(true)
+        }
+    }
+
+    const mockResults = ({
+        resultCount,
+        limitHit,
+    }: {
+        resultCount: number
+        limitHit: boolean
+    }): GQL.ISearchResults => ({
+        ...MULTIPLE_SEARCH_REQUEST(),
+        limitHit,
+        resultCount,
+        approximateResultCount: `${resultCount}`,
+        results: range(resultCount).map(i => ({
+            ...RESULT,
+            file: {
+                ...RESULT.file,
+                url: `${i}`,
+            },
+        })),
+    })
+
+    afterEach(() => {
+        VISIBILITY_CHANGED_CALLBACKS = []
+    })
 
     afterAll(() => {
         setLinkComponent(null as any)
@@ -103,5 +166,90 @@ describe('SearchResultsList', () => {
         )
         expect(getByTestId(container, 'result-container')).toBeTruthy()
         expect(getAllByTestId(container, 'result-container').length).toBe(3)
+    })
+
+    it('displays "Show More" when the limit is hit', () => {
+        const props = {
+            ...defaultProps,
+            resultsOrError: mockResults({ resultCount: 31, limitHit: true }),
+        }
+        const { container, rerender } = render(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+        scrollToBottom()
+        rerender(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+        expect(getByTestId(container, 'search-show-more-button')).toBeTruthy()
+    })
+
+    it('does not display "Show More" if the limit isn\'t hit', () => {
+        const props = {
+            ...defaultProps,
+            resultsOrError: mockResults({ resultCount: 40, limitHit: false }),
+        }
+        const { container, rerender } = render(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+        scrollToBottom()
+        rerender(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+        expect(queryByTestId(container, 'search-show-more-button')).toBe(null)
+    })
+
+    it('shows "show more" when new results with limitHit=true are received, even if it previously received results with limitHit=false', () => {
+        // Rel: https://github.com/sourcegraph/sourcegraph/issues/4564
+        // Display search results with the limit hit, simulate scrolling and click 'show more'.
+        const showMore = sinon.spy()
+        const props = {
+            ...defaultProps,
+            resultsOrError: mockResults({ resultCount: 31, limitHit: true }),
+            onShowMoreResultsClick: showMore,
+        }
+        const { container, rerender } = render(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+        scrollToBottom()
+        rerender(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+        getByTestId(container, 'search-show-more-button').click()
+        sinon.assert.calledOnce(showMore)
+
+        // Render new results without a limit.
+        // Simulate scrolling and verify show more button isn't present.
+        rerender(
+            <BrowserRouter>
+                <SearchResultsList
+                    {...defaultProps}
+                    resultsOrError={mockResults({ resultCount: 1001, limitHit: false })}
+                />
+            </BrowserRouter>
+        )
+        scrollToBottom()
+        expect(queryByTestId(container, 'search-show-more-button')).toBe(null)
+
+        // Re-render with original props and simulate scrolling,
+        // Expect "show more" button to be present.
+        rerender(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+        scrollToBottom()
+        expect(getByTestId(container, 'search-show-more-button')).toBeTruthy()
     })
 })

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -233,9 +233,8 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     filter(isDefined),
                     filter((resultsOrError): resultsOrError is GQL.ISearchResults => !isErrorLike(resultsOrError)),
                     map(({ results }) => results),
-                    map(
-                        (results): GQL.IFileMatch[] =>
-                            results.filter((res): res is GQL.IFileMatch => res.__typename === 'FileMatch')
+                    map((results): GQL.IFileMatch[] =>
+                        results.filter((res): res is GQL.IFileMatch => res.__typename === 'FileMatch')
                     )
                 )
                 .subscribe(fileMatches => {
@@ -376,6 +375,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                     {results.limitHit && this.state.resultsShown >= results.results.length && (
                                         <button
                                             className="btn btn-secondary btn-block"
+                                            data-testid="search-show-more-button"
                                             onClick={this.props.onShowMoreResultsClick}
                                         >
                                             Show more

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -233,8 +233,9 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     filter(isDefined),
                     filter((resultsOrError): resultsOrError is GQL.ISearchResults => !isErrorLike(resultsOrError)),
                     map(({ results }) => results),
-                    map((results): GQL.IFileMatch[] =>
-                        results.filter((res): res is GQL.IFileMatch => res.__typename === 'FileMatch')
+                    map(
+                        (results): GQL.IFileMatch[] =>
+                            results.filter((res): res is GQL.IFileMatch => res.__typename === 'FileMatch')
                     )
                 )
                 .subscribe(fileMatches => {
@@ -359,8 +360,20 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         onRef={this.nextVirtualListContainerElement}
                                     />
 
-                                    {/* Show more button */}
-                                    {results.limitHit && results.results.length === this.state.resultsShown && (
+                                    {/*
+                                        Show more button
+
+                                        We only show this button at the bottom of the page when the
+                                        user has scrolled completely to the bottom of the virtual
+                                        list (i.e. when resultsShown is results.length).
+
+                                        Note however that when the bottom is hit, this.onBottomHit
+                                        is called to asynchronously update resultsShown to add 10
+                                        which means there is a race condition in which e.g.
+                                        results.length == 30 && resultsShown == 40 so we use >=
+                                        comparison below.
+                                    */}
+                                    {results.limitHit && this.state.resultsShown >= results.results.length && (
                                         <button
                                             className="btn btn-secondary btn-block"
                                             onClick={this.props.onShowMoreResultsClick}


### PR DESCRIPTION
This fixes a P1 customer issue and release blocker https://github.com/sourcegraph/sourcegraph/issues/4564 so I'd like to get this merged ASAP.

Open questions:

1. Can this be tested somehow with sinon or something? It is unclear to me how I would do this because of the interaction with `setState` here.
2. This is clearly an example of code where rxjs would help avoid setState race conditions -- so I feel like the correct fix here would be refactoring this code to use rxjs or maybe maintaining a separate state for whether or not `show more` should be shown -- but I am uncertain about the best path forward with this. Help?

<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
