### PR TITLE
Improve repo-updater tracing

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -44,10 +44,10 @@ func main() {
 	if err := api.InternalClient.WaitForFrontend(ctx); err != nil {
 		log.Fatalf("sourcegraph-frontend not reachable: %v", err)
 	}
-	log15.Info("detected frontend ready")
+	log15.Debug("detected frontend ready")
 
 	gitserver.DefaultClient.WaitForGitServers(ctx)
-	log15.Info("detected gitservers ready")
+	log15.Debug("detected gitservers ready")
 
 	dsn := conf.Get().ServiceConnections.PostgresDSN
 	conf.Watch(func() {
@@ -113,7 +113,7 @@ func main() {
 			log.Fatalf("failed to run migration: %s", err)
 		}
 	}
-	log15.Info("ran migrations")
+	log15.Debug("ran migrations")
 
 	scheduler := repos.NewUpdateScheduler()
 	server := repoupdater.Server{Store: store, Scheduler: scheduler}
@@ -177,7 +177,7 @@ func main() {
 			}
 		}
 	}()
-	log15.Info("started new repo syncer updates scheduler relay thread")
+	log15.Debug("started new repo syncer updates scheduler relay thread")
 
 	go repos.RunPhabricatorRepositorySyncWorker(ctx, store)
 
@@ -188,7 +188,7 @@ func main() {
 
 	// Git fetches scheduler
 	go repos.RunScheduler(ctx, scheduler)
-	log15.Info("started scheduler")
+	log15.Debug("started scheduler")
 
 	host := ""
 	if env.InsecureDev {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -245,7 +245,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 func (s *Server) enqueueRepoUpdate(ctx context.Context, req *protocol.RepoUpdateRequest) (resp *protocol.RepoUpdateResponse, httpStatus int, err error) {
 	tr, ctx := trace.New(ctx, "enqueueRepoUpdate", req.String())
 	defer func() {
-		log15.Debug("enqueueRepoUpdate", "resp", resp, "error", err)
+		log15.Debug("enqueueRepoUpdate", "httpStatus", httpStatus, "resp", resp, "error", err)
 		if resp != nil {
 			tr.LazyPrintf("response: %s", resp)
 		}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -211,7 +210,6 @@ func (s *Server) handleRepoLookup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t := time.Now()
 	result, err := s.repoLookup(r.Context(), args)
 	if err != nil {
 		if err == context.Canceled {
@@ -222,7 +220,6 @@ func (s *Server) handleRepoLookup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	log15.Debug("TRACE repoLookup", "args", &args, "result", result, "duration", time.Since(t))
 
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -236,14 +233,12 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 		respond(w, http.StatusBadRequest, err)
 		return
 	}
-	t := time.Now()
 	result, status, err := s.enqueueRepoUpdate(r.Context(), &req)
 	if err != nil {
 		log15.Error("enqueueRepoUpdate failed", "req", req, "error", err)
 		respond(w, status, err)
 		return
 	}
-	log15.Debug("TRACE enqueueRepoUpdate", "req", &req, "res", result, "duration", time.Since(t))
 	respond(w, status, result)
 }
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/awscodecommit"
@@ -238,6 +237,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	t := time.Now()
 	args := repos.StoreListReposArgs{Names: []string{string(req.Repo)}}
 	rs, err := s.Store.ListRepos(r.Context(), args)
 	if err != nil {
@@ -260,11 +260,13 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 
 	s.Scheduler.UpdateOnce(repo.ID, req.Repo, req.URL)
 
-	respond(w, http.StatusOK, &protocol.RepoUpdateResponse{
+	result := &protocol.RepoUpdateResponse{
 		ID:   repo.ID,
 		Name: repo.Name,
 		URL:  req.URL,
-	})
+	}
+	log15.Debug("TRACE enqueueRepoUpdate", "args", &args, "result", result, "duration", time.Since(t))
+	respond(w, http.StatusOK, result)
 }
 
 func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Request) {

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -145,6 +145,10 @@ type RepoUpdateRequest struct {
 	URL string `json:"url"`
 }
 
+func (a *RepoUpdateRequest) String() string {
+	return fmt.Sprintf("RepoUpdateRequest{%s, %s}", a.Repo, a.URL)
+}
+
 // RepoUpdateResponse is a response type to a RepoUpdateRequest.
 type RepoUpdateResponse struct {
 	// ID of the repo that got an update request.


### PR DESCRIPTION
This adds additional tracing to debug 2 issues experienced by a customer:
* `enqueue-repo-update` requests would fail with HTTP 500 statuses. Adding additional logging resolved the issue unexpectedly, suggesting a race condition.
* repo-updater was observed to hang on startup (it never reached this line: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7bdaddd1bfed9c2b2a6395084cb8e543d0b11fd5/-/blob/cmd/repo-updater/main.go?suggestion#L195)

Post-merge TODO
- [ ] Cherry-pick onto 3.4 and cut a patch release.