### PR TITLE
check error in search result resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -465,6 +465,9 @@ loop:
 
 func (r *searchResolver) Results(ctx context.Context) (*searchResultsResolver, error) {
 	rr, err := r.resultsWithTimeoutSuggestion(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// Log the query if not too many have piled up to be logged.
 	select {


### PR DESCRIPTION
`err` isn't checked in the search result resolver and can cause a panic if a non-nil error is returned.

Test plan: None. `err` should be checked.
