### PR TITLE
fix tooltip positioning

### DIFF
--- a/web/src/components/tooltip/Tooltip.tsx
+++ b/web/src/components/tooltip/Tooltip.tsx
@@ -64,7 +64,6 @@ export class Tooltip extends React.PureComponent<Props, State> {
                 // Set key prop to work around a bug where quickly mousing between 2 elements with tooltips
                 // displays the 2nd element's tooltip as still pointing to the first.
                 key={this.state.subjectSeq}
-                className="tooltip"
                 isOpen={true}
                 target={this.state.subject}
                 placement="auto"


### PR DESCRIPTION
fix #4585

For some reason, upgrading reactstrap in #4545 caused the tooltip element to be in a `.tooltip > .tooltip`, which meant that the tooltip was positioned relative to the parent `.tooltip`, not relative to the page.