### PR TITLE
simplify ResultContainer and FileMatchChildren

### DIFF
--- a/shared/src/components/FileMatchChildren.scss
+++ b/shared/src/components/FileMatchChildren.scss
@@ -9,34 +9,22 @@
         padding: 0.25rem 0.5rem;
         overflow-x: auto;
         overflow-y: hidden;
-        background-color: #0e121b;
 
         &-clickable {
             cursor: pointer;
         }
 
         &:hover {
-            background-color: #151d28;
             text-decoration: none;
         }
 
         &:not(:first-child) {
-            border-top: 1px solid #2a3a51;
-        }
-
-        .theme-light & {
-            background-color: $color-light-bg-1;
-            border-color: $color-light-border;
-
-            &:hover {
-                background-color: $color-light-bg-4;
-                text-decoration: none;
-            }
+            border-top: 1px solid var(--border-color);
         }
     }
 
     &__code {
-        border-bottom: solid 1px #2a3a51;
+        border-bottom: solid 1px var(--border-color);
         font-size: 12px;
         padding: 0.5rem 1.25rem;
         margin-bottom: 0;
@@ -51,9 +39,6 @@
                 padding-right: 0.325rem;
                 display: inline-block;
             }
-        }
-        .theme-light & {
-            border-bottom-color: $color-light-border;
         }
     }
 }

--- a/shared/src/components/ResultContainer.scss
+++ b/shared/src/components/ResultContainer.scss
@@ -3,7 +3,7 @@
 
     border-width: 0 0 1px 0;
     border-style: solid;
-    border-color: #2b3750;
+    border-color: var(--border-color);
     &:first-child {
         border-top-width: 1px;
     }
@@ -18,7 +18,7 @@
         display: flex;
         align-items: center;
         white-space: nowrap;
-        $background-color: #1c2736;
+        $background-color: $card-cap-bg;
 
         background-color: $background-color;
 
@@ -34,21 +34,12 @@
             overflow: hidden;
         }
 
-        &:hover {
-            background-color: darken($background-color, 0.05);
-        }
-
         p {
             margin-bottom: 0;
         }
 
         &:not(:only-of-type) {
-            border-bottom: 1px solid #2a3a51;
-        }
-
-        .theme-light & {
-            background-color: $color-light-bg-1;
-            border-color: $color-light-border;
+            border-bottom: 1px solid var(--border-color);
         }
     }
 
@@ -62,17 +53,6 @@
 }
 
 .theme-light {
-    .result-container {
-        border-color: $color-light-border;
-        &__header {
-            background-color: $color-light-bg-2;
-
-            &:hover {
-                background-color: $color-light-bg-4;
-            }
-        }
-    }
-
     .icon-inline__filtered {
         filter: brightness(0%);
     }

--- a/shared/src/components/ResultContainer.scss
+++ b/shared/src/components/ResultContainer.scss
@@ -22,8 +22,6 @@
 
         background-color: $background-color;
 
-        z-index: 99;
-
         &--collapsible {
             cursor: pointer;
         }


### PR DESCRIPTION
This uses CSS custom properties instead of Bootstrap variables in some cases, and eliminates an unneeded alternate background color for code results (they just use the page BG now, which is fine because they are visually delimited).

### after (changes are imperceptible)

![t4](https://user-images.githubusercontent.com/1976/59735604-0c4a4400-920b-11e9-8324-f692f3b2de1b.png)
![t3](https://user-images.githubusercontent.com/1976/59735605-0ce2da80-920b-11e9-8054-238b82eb719e.png)
![t2](https://user-images.githubusercontent.com/1976/59735606-0ce2da80-920b-11e9-92e5-8b05fdb0afe5.png)
![t1](https://user-images.githubusercontent.com/1976/59735607-0ce2da80-920b-11e9-944a-8d49bd300f05.png)
