### PR TITLE
Fix broken in-page Chrome search

### DIFF
--- a/pkg/highlight/highlight.go
+++ b/pkg/highlight/highlight.go
@@ -158,10 +158,11 @@ func preSpansToTable(h string) (string, error) {
 		tdLineNumber.Attr = append(tdLineNumber.Attr, html.Attribute{Key: "class", Val: "line"})
 		tdLineNumber.Attr = append(tdLineNumber.Attr, html.Attribute{Key: "data-line", Val: fmt.Sprint(rows)})
 		tr.AppendChild(tdLineNumber)
-
-		codeCell = &html.Node{Type: html.ElementNode, DataAtom: atom.Td, Data: atom.Td.String()}
-		codeCell.Attr = append(codeCell.Attr, html.Attribute{Key: "class", Val: "code"})
-		tr.AppendChild(codeCell)
+		codeTd := &html.Node{Type: html.ElementNode, DataAtom: atom.Td, Data: atom.Td.String()}
+		tr.AppendChild(codeTd)
+		codeCell = &html.Node{Type: html.ElementNode, DataAtom: atom.Div, Data: atom.Div.String()}
+		codeTd.AppendChild(codeCell)
+		codeTd.Attr = append(codeCell.Attr, html.Attribute{Key: "class", Val: "code"})
 	}
 	newRow()
 	for next != nil {

--- a/pkg/highlight/highlight_test.go
+++ b/pkg/highlight/highlight_test.go
@@ -11,7 +11,7 @@ func TestPreSpansToTable_Simple(t *testing.T) {
 </pre>
 
 `
-	want := `<table><tr><td class="line" data-line="1"></td><td class="code"><span>package</span></td></tr><tr><td class="line" data-line="2"></td><td class="code"></td></tr></table>`
+	want := `<table><tr><td class="line" data-line="1"></td><td class="code"><div><span>package</span></div></td></tr><tr><td class="line" data-line="2"></td><td class="code"><div></div></td></tr></table>`
 	got, err := preSpansToTable(input)
 	if err != nil {
 		t.Fatal(err)
@@ -34,15 +34,15 @@ func TestPreSpansToTable_Complex(t *testing.T) {
 </span></pre>
 `
 
-	want := `<table><tr><td class="line" data-line="1"></td><td class="code"><span style="font-weight:bold;color:#a71d5d;">package</span><span style="color:#323232;"> errcode
-</span></td></tr><tr><td class="line" data-line="2"></td><td class="code"><span style="color:#323232;">
-</span></td></tr><tr><td class="line" data-line="3"></td><td class="code"><span style="font-weight:bold;color:#a71d5d;">import </span><span style="color:#323232;">(
-</span></td></tr><tr><td class="line" data-line="4"></td><td class="code"><span style="color:#323232;">	</span><span style="color:#183691;">&#34;net/http&#34;
-</span></td></tr><tr><td class="line" data-line="5"></td><td class="code"><span style="color:#323232;">	</span><span style="color:#183691;">&#34;github.com/sourcegraph/sourcegraph/pkg/api/legacyerr&#34;
-</span></td></tr><tr><td class="line" data-line="6"></td><td class="code"><span style="color:#323232;">)
-</span></td></tr><tr><td class="line" data-line="7"></td><td class="code"><span style="color:#323232;">
-</span></td></tr><tr><td class="line" data-line="8"></td><td class="code"><span style="color:#323232;">
-</span></td></tr><tr><td class="line" data-line="9"></td><td class="code"></td></tr></table>`
+	want := `<table><tr><td class="line" data-line="1"></td><td class="code"><div><span style="font-weight:bold;color:#a71d5d;">package</span><span style="color:#323232;"> errcode
+</span></div></td></tr><tr><td class="line" data-line="2"></td><td class="code"><div><span style="color:#323232;">
+</span></div></td></tr><tr><td class="line" data-line="3"></td><td class="code"><div><span style="font-weight:bold;color:#a71d5d;">import </span><span style="color:#323232;">(
+</span></div></td></tr><tr><td class="line" data-line="4"></td><td class="code"><div><span style="color:#323232;">	</span><span style="color:#183691;">&#34;net/http&#34;
+</span></div></td></tr><tr><td class="line" data-line="5"></td><td class="code"><div><span style="color:#323232;">	</span><span style="color:#183691;">&#34;github.com/sourcegraph/sourcegraph/pkg/api/legacyerr&#34;
+</span></div></td></tr><tr><td class="line" data-line="6"></td><td class="code"><div><span style="color:#323232;">)
+</span></div></td></tr><tr><td class="line" data-line="7"></td><td class="code"><div><span style="color:#323232;">
+</span></div></td></tr><tr><td class="line" data-line="8"></td><td class="code"><div><span style="color:#323232;">
+</span></div></td></tr><tr><td class="line" data-line="9"></td><td class="code"><div></div></td></tr></table>`
 	got, err := preSpansToTable(input)
 	if err != nil {
 		t.Fatal(err)
@@ -91,8 +91,8 @@ func TestIssue6892(t *testing.T) {
 
 <span style="color:#9b9b9b;">import</span>
 </pre>`
-	want := `<table><tr><td class="line" data-line="1"></td><td class="code"><span>
-</span></td></tr><tr><td class="line" data-line="2"></td><td class="code"><span style="color:#9b9b9b;">import</span></td></tr><tr><td class="line" data-line="3"></td><td class="code"></td></tr></table>`
+	want := `<table><tr><td class="line" data-line="1"></td><td class="code"><div><span>
+</span></div></td></tr><tr><td class="line" data-line="2"></td><td class="code"><div><span style="color:#9b9b9b;">import</span></div></td></tr><tr><td class="line" data-line="3"></td><td class="code"><div></div></td></tr></table>`
 	got, err := preSpansToTable(input)
 	if err != nil {
 		t.Fatal(err)

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -180,7 +180,7 @@ describe('e2e test suite', function(this: any): void {
          * @param spanOffset 1-indexed index of the span that's to be clicked
          */
         const clickToken = async (line: number, spanOffset: number): Promise<void> => {
-            const selector = `${blobTableSelector} tr:nth-child(${line}) > td.code > span:nth-child(${spanOffset})`
+            const selector = `${blobTableSelector} tr:nth-child(${line}) > td.code > div:nth-child(1) > span:nth-child(${spanOffset})`
             await driver.page.waitForSelector(selector, { visible: true })
             await driver.page.click(selector)
         }

--- a/web/src/repo/blob/Blob.scss
+++ b/web/src/repo/blob/Blob.scss
@@ -57,15 +57,11 @@
             padding-left: 1rem;
             white-space: pre;
 
-            // Possibly not needed. Without this, empty lines with line-decoration-attachment-portals wrap
-            // incorrectly.
-            span {
+            div {
                 display: inline-block;
             }
 
             .line-decoration-attachment-portal {
-                display: inline-block;
-
                 span::before {
                     content: attr(data-contents);
                 }

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -454,7 +454,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
         if (codeCell.querySelector('.line-decoration-attachment-portal')) {
             return
         }
-        const portalNode = document.createElement('span')
+        const portalNode = document.createElement('div')
 
         const id = toPortalID(line)
         portalNode.id = id


### PR DESCRIPTION
Fixes #3160

I found while trying to build a minimal repro case for #3160 that what broke in-page Chrome search was displaying all tokenized `<span>` elements in a code line as `inline-block`. This was done to ensure that after-line decorations were displayed correctly (cf comment added in https://github.com/sourcegraph/sourcegraph/commit/7c74b041e5436e780b804c039f5d5949fae2ef17). It would cause the browser to stop considering the content of consecutive spans (eg. `<span>Errors</span><span>.</span><span>New</span>`) as part of the same string when running an in-page search.

This PR fixes it by wrapping each line's code spans in a `<div>`, and displaying the `line-decoration-attachment-portal` as a `<div>` as well. Both are set to display as `inline-block`, but individual tokenized spans keep their default display value, `inline`.
