### PR TITLE
feat: allow admins to prevent the icon in the top left corner from sp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The `authorization` setting in the [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#permissions) enables Sourcegraph to enforce the repository permissions defined in Bitbucket Server.
 - A new, experimental status indicator in the navigation bar allows admins to quickly see whether the configured repositories are up to date or how many are currently being updated in the background. You can enable the status indicator with the following site configuration: `"experimentalFeatures": { "statusIndicator": "enabled" }`.
 - A new search filter `repohasfile` allows users to filter results to just repositories containing a matching file. For example `ubuntu file:Dockerfile repohasfile:\.py$` would find Dockerfiles mentioning Ubuntu in repositories that contain Python files. [#4501](https://github.com/sourcegraph/sourcegraph/pull/4501)
+- Site admins can prevent the icon in the top-left corner of the screen from spinning on hovers by setting `"branding": { "disableSymbolSpin": true }` in their site configuration.
 
 ### Changed
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -157,9 +157,10 @@ type BrandAssets struct {
 //
 // Only available in Sourcegraph Enterprise.
 type Branding struct {
-	Dark    *BrandAssets `json:"dark,omitempty"`
-	Favicon string       `json:"favicon,omitempty"`
-	Light   *BrandAssets `json:"light,omitempty"`
+	Dark              *BrandAssets `json:"dark,omitempty"`
+	DisableSymbolSpin bool         `json:"disableSymbolSpin,omitempty"`
+	Favicon           string       `json:"favicon,omitempty"`
+	Light             *BrandAssets `json:"light,omitempty"`
 }
 
 // BuiltinAuthProvider description: Configures the builtin username-password authentication provider.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -172,6 +172,11 @@
           "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
           "type": "string",
           "format": "uri"
+        },
+        "disableSymbolSpin": {
+          "description": "Prevents the icon in the top-left corner of the screen from spinning on hover.",
+          "type": "boolean",
+          "default": false
         }
       },
       "examples": [

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -177,6 +177,11 @@ const SiteSchemaJSON = `{
           "description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
           "type": "string",
           "format": "uri"
+        },
+        "disableSymbolSpin": {
+          "description": "Prevents the icon in the top-left corner of the screen from spinning on hover.",
+          "type": "boolean",
+          "default": false
         }
       },
       "examples": [

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -120,6 +120,9 @@ interface SourcegraphContext {
         light?: BrandAssets
         /** Override style for dark themes */
         dark?: BrandAssets
+
+        /** Prevent the icon in the top-left corner of the screen from spinning */
+        disableSymbolSpin?: boolean
     }
 
     /** Whether new external service status indicator is shown in navbar or not. */

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -121,7 +121,7 @@ interface SourcegraphContext {
         /** Override style for dark themes */
         dark?: BrandAssets
 
-        /** Prevent the icon in the top-left corner of the screen from spinning */
+        /** Prevents the icon in the top-left corner of the screen from spinning. */
         disableSymbolSpin?: boolean
     }
 

--- a/web/src/nav/GlobalNavbar.scss
+++ b/web/src/nav/GlobalNavbar.scss
@@ -22,6 +22,9 @@
         height: 1.5rem;
 
         width: 1.5rem;
+    }
+
+    &__logo-animated {
         &:hover {
             animation: spin 0.5s ease-in-out 1;
 

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -81,6 +81,8 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         let logoSrc = '/.assets/img/sourcegraph-mark.svg'
+        let logoLinkClassName = 'global-navbar__logo-link global-navbar__logo-animated'
+
         const { branding } = window.context
         if (branding) {
             if (this.props.isLightTheme) {
@@ -89,6 +91,9 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                 }
             } else if (branding.dark && branding.dark.symbol) {
                 logoSrc = branding.dark.symbol
+            }
+            if (branding.disableSymbolSpin) {
+                logoLinkClassName = 'global-navbar__logo-link'
             }
         }
 
@@ -101,9 +106,9 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                 ) : (
                     <>
                         {this.state.authRequired ? (
-                            <div className="global-navbar__logo-link">{logo}</div>
+                            <div className={logoLinkClassName}>{logo}</div>
                         ) : (
-                            <Link to="/search" className="global-navbar__logo-link">
+                            <Link to="/search" className={logoLinkClassName}>
                                 {logo}
                             </Link>
                         )}


### PR DESCRIPTION
…inning on hovers

fixes https://github.com/sourcegraph/sourcegraph/issues/4574

![logo-spin](https://user-images.githubusercontent.com/5589410/59785717-63d3c880-927a-11e9-9f31-9243d56bdb26.gif)

You can't see it in my gif, but I'm hovering over the icon both BEFORE I update the config and AFTER. It spins before, doesn't after.