### PR TITLE
Add errors for invalid usage of repohasfile filter

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1131,6 +1131,7 @@ func regexpPatternMatchingExprsInOrder(patterns []string) string {
 func validateRepoHasFileUsage(q *query.Query) error {
 	// Validate usage of `repohasfile` filter
 	rawQuery := q.Syntax.Input
+
 	// Query contains "type:repo" and "repohasfile:"
 	if strings.Contains(rawQuery, "type:repo") && strings.Contains(rawQuery, "repohasfile:") {
 		return errors.New("repohasfile does not currently return repository results. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1128,19 +1128,21 @@ func regexpPatternMatchingExprsInOrder(patterns []string) string {
 	return "(" + strings.Join(patterns, ").*?(") + ")" // "?" makes it prefer shorter matches
 }
 
+// Validates usage of the `repohasfile` filter
 func validateRepoHasFileUsage(q *query.Query) error {
-	// Validate usage of `repohasfile` filter
-	rawQuery := q.Syntax.Input
-
-	// Query contains "type:repo" and "repohasfile:"
-	if strings.Contains(rawQuery, "type:repo") && strings.Contains(rawQuery, "repohasfile:") {
-		return errors.New("repohasfile does not currently return repository results. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")
-	}
 	syntax := q.Syntax
 
 	// Query only contains "repohasfile:"
 	if len(syntax.Expr) == 1 && syntax.Expr[0].Field == "repohasfile" {
 		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
+	}
+
+	rawQuery := q.Syntax.Input
+
+	// Query contains "type:repo" and "repohasfile:"
+	// TODO: check q.Fields["type"] here instead of using string containment (requires checking list of type values in query).
+	if strings.Contains(rawQuery, "type:repo") && q.Fields["type"] != nil && q.Fields["repohasfile"] != nil {
+		return errors.New("repohasfile does not currently return repository results. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")
 	}
 
 	// Query only contains "repohasfile:" and "type:path"

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1141,6 +1141,7 @@ func validateRepoHasFileUsage(q *query.Query) error {
 	if len(syntax.Expr) == 1 && syntax.Expr[0].Field == "repohasfile" {
 		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
 	}
+
 	// Query only contains "repohasfile:" and "type:path"
 	if len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "path" {
 		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1132,7 +1132,7 @@ func validateRepoHasFileUsage(q *query.Query) error {
 	// Validate usage of `repohasfile` filter
 	rawQuery := q.Syntax.Input
 	if strings.Contains(rawQuery, "type:repo") && strings.Contains(rawQuery, "repohasfile:") {
-		return errors.New("repohasfile does not currently return repository results. Support for repository results is in progress. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")
+		return errors.New("repohasfile does not currently return repository results. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")
 	}
 	syntax := q.Syntax
 	rawQueryContainsOnlyRepoHasFileTerm := len(syntax.Expr) == 1 && syntax.Expr[0].Field == "repohasfile"

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1139,5 +1139,15 @@ func validateRepoHasFileUsage(q *query.Query) error {
 	if rawQueryContainsOnlyRepoHasFileTerm {
 		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
 	}
+
+	rawQueryOnlyContainsTypePathAndRepoHasFileTerm := len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "path"
+	if rawQueryOnlyContainsTypePathAndRepoHasFileTerm {
+		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
+	}
+
+	rawQueryOnlyContainsTypeSymbolAndRepoHasFileTerm := len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "symbol"
+	if rawQueryOnlyContainsTypeSymbolAndRepoHasFileTerm {
+		return errors.New("repohasfile does not currently return symbol results. Support for symbol results is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4610 for updates")
+	}
 	return nil
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1137,6 +1137,7 @@ func validateRepoHasFileUsage(q *query.Query) error {
 		return errors.New("repohasfile does not currently return repository results. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")
 	}
 	syntax := q.Syntax
+
 	// Query only contains "repohasfile:"
 	if len(syntax.Expr) == 1 && syntax.Expr[0].Field == "repohasfile" {
 		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -797,6 +797,19 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return nil, &badRequestError{err}
 	}
 
+	// Validate usage of `repohasfile` filter
+	rawQuery := r.query.Syntax.Input
+	if strings.Contains(rawQuery, "type:repo") && strings.Contains(rawQuery, "repohasfile:") {
+		return nil, errors.New("repohasfile does not currently return repository results. Support for repository results is in progress. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")
+	}
+	rawQueryContainsOnlyRepoHasFileTerm, err := regexp.MatchString(`^[\s]*repohasfile:[\S]*[\s]*$`, rawQuery)
+	if err != nil {
+		return nil, err
+	}
+	if rawQueryContainsOnlyRepoHasFileTerm {
+		return nil, errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is in progress. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
+	}
+
 	// Determine which types of results to return.
 	var resultTypes []string
 	if forceOnlyResultType != "" {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1137,7 +1137,7 @@ func validateRepoHasFileUsage(q *query.Query) error {
 	syntax := q.Syntax
 	rawQueryContainsOnlyRepoHasFileTerm := len(syntax.Expr) == 1 && syntax.Expr[0].Field == "repohasfile"
 	if rawQueryContainsOnlyRepoHasFileTerm {
-		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is in progress. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
+		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
 	}
 	return nil
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1131,22 +1131,22 @@ func regexpPatternMatchingExprsInOrder(patterns []string) string {
 func validateRepoHasFileUsage(q *query.Query) error {
 	// Validate usage of `repohasfile` filter
 	rawQuery := q.Syntax.Input
+	// Query contains "type:repo" and "repohasfile:"
 	if strings.Contains(rawQuery, "type:repo") && strings.Contains(rawQuery, "repohasfile:") {
 		return errors.New("repohasfile does not currently return repository results. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4584 for updates")
 	}
 	syntax := q.Syntax
-	rawQueryContainsOnlyRepoHasFileTerm := len(syntax.Expr) == 1 && syntax.Expr[0].Field == "repohasfile"
-	if rawQueryContainsOnlyRepoHasFileTerm {
+	// Query only contains "repohasfile:"
+	if len(syntax.Expr) == 1 && syntax.Expr[0].Field == "repohasfile" {
+		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
+	}
+	// Query only contains "repohasfile:" and "type:path"
+	if len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "path" {
 		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
 	}
 
-	rawQueryOnlyContainsTypePathAndRepoHasFileTerm := len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "path"
-	if rawQueryOnlyContainsTypePathAndRepoHasFileTerm {
-		return errors.New("repohasfile must be used with at least one other search term in the query. Support for usage on its own is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4608 for updates")
-	}
-
-	rawQueryOnlyContainsTypeSymbolAndRepoHasFileTerm := len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "symbol"
-	if rawQueryOnlyContainsTypeSymbolAndRepoHasFileTerm {
+	// Query only contains "repohasfile:" and "type:symbol"
+	if len(q.Fields) == 2 && q.Fields["repohasfile"] != nil && q.Fields["type"] != nil && len(q.Fields["type"]) == 1 && q.Fields["type"][0].Value() == "symbol" {
 		return errors.New("repohasfile does not currently return symbol results. Support for symbol results is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4610 for updates")
 	}
 	return nil

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -661,6 +661,7 @@ func TestValidateRepoHasFileUsage(t *testing.T) {
 	}
 
 	validQueries := []string{
+		"repohasfile:go error",
 		"type:repo",
 		"repohasfile",
 		"foo bar type:repo",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -622,3 +622,42 @@ func Test_roundStr(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRepoHasFileUsage(t *testing.T) {
+	q, err := query.ParseAndCheck("repohasfile:test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateRepoHasFileUsage(q)
+	if err == nil {
+		t.Errorf("Expected error but got nil")
+	}
+
+	q, err = query.ParseAndCheck("repohasfile:test type:repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateRepoHasFileUsage(q)
+	if err == nil {
+		t.Errorf("Expected error but got nil")
+	}
+
+	validQueries := []string{
+		"type:repo",
+		"repohasfile",
+		"foo bar type:repo",
+		"foo",
+		"bar",
+		"\"repohasfile\"",
+	}
+	for _, validQuery := range validQueries {
+		q, err = query.ParseAndCheck(validQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = validateRepoHasFileUsage(q)
+		if err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+	}
+}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -642,10 +642,30 @@ func TestValidateRepoHasFileUsage(t *testing.T) {
 		t.Errorf("Expected error but got nil")
 	}
 
+	q, err = query.ParseAndCheck("repohasfile:test type:path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateRepoHasFileUsage(q)
+	if err == nil {
+		t.Errorf("Expected error but got nil")
+	}
+
+	q, err = query.ParseAndCheck("repohasfile:test type:symbol")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateRepoHasFileUsage(q)
+	if err == nil {
+		t.Errorf("Expected error but got nil")
+	}
+
 	validQueries := []string{
 		"type:repo",
 		"repohasfile",
 		"foo bar type:repo",
+		"repohasfile:test type:path .",
+		"repohasfile:test type:symbol .",
 		"foo",
 		"bar",
 		"\"repohasfile\"",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -642,6 +642,15 @@ func TestValidateRepoHasFileUsage(t *testing.T) {
 		t.Errorf("Expected error but got nil")
 	}
 
+	q, err = query.ParseAndCheck("repohasfile:test type:repo .")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateRepoHasFileUsage(q)
+	if err == nil {
+		t.Errorf("Expected error but got nil")
+	}
+
 	q, err = query.ParseAndCheck("repohasfile:test type:path")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR makes it so that we will return informative error messages for currently invalid usages of the `repohasfile` filter.

Test plan: <!-- Required: What is the test plan for this change? -->
