### PR TITLE
handle repohascommitafter timeouts and errors more appropriately

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -515,7 +515,15 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 			var specifiers []search.RevisionSpecifier
 			for _, rev := range revs.Revs {
 				ok, err := git.HasCommitAfter(ctx, revs.GitserverRepo(), after, rev.RevSpec)
-				if err != nil || ok {
+				if err != nil {
+					if ctx.Error() != nil {
+						run.Error(errors.New("timeout due to repohascommitafter: filter, please try setting a larger timeout: in your query (we are improving this, see https://github.com/sourcegraph/sourcegraph/issues/4614)"))
+						continue
+					}
+					run.Error(err)
+					continue
+				}
+				if ok {
 					specifiers = append(specifiers, rev)
 				}
 			}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -516,7 +516,7 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 			for _, rev := range revs.Revs {
 				ok, err := git.HasCommitAfter(ctx, revs.GitserverRepo(), after, rev.RevSpec)
 				if err != nil {
-					if ctx.Error() != nil {
+					if ctx.Err() != nil {
 						run.Error(errors.New("timeout due to repohascommitafter: filter, please try setting a larger timeout: in your query (we are improving this, see https://github.com/sourcegraph/sourcegraph/issues/4614)"))
 						continue
 					}


### PR DESCRIPTION
This is a last-ditch effort to solve https://github.com/sourcegraph/sourcegraph/issues/4602 for 3.5.

It's a low-risk change because it only affects queries including `repohascommitafter:` which is marked as experimental.