### PR TITLE
update latestReleaseDockerServerImageBuild + latestReleaseKubernetesBuild for 3.5.0

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -24,12 +24,12 @@ var (
 	// non-cluster installations what the latest version is. The version here _must_ be
 	// available at https://hub.docker.com/r/sourcegraph/server/tags/ before
 	// landing in master.
-	latestReleaseDockerServerImageBuild = newBuild("3.4.4")
+	latestReleaseDockerServerImageBuild = newBuild("3.5.0")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newBuild("3.4.4")
+	latestReleaseKubernetesBuild = newBuild("3.5.0")
 )
 
 func getLatestRelease(deployType string) build {


### PR DESCRIPTION
@christinaforney @ryan-blunden please merge this PR when you are ready to announce 3.5.0's release.