### PR TITLE
frontend: Remove references to sgdev and umami in asset caching

### DIFF
--- a/cmd/frontend/internal/app/assetsutil/handler.go
+++ b/cmd/frontend/internal/app/assetsutil/handler.go
@@ -76,11 +76,5 @@ func isPhabricatorAsset(path string) bool {
 	if strings.Contains(path, "phabricator.bundle.js") {
 		return true
 	}
-	if strings.Contains(path, "sgdev.bundle.sj") {
-		return true
-	}
-	if strings.Contains(path, "umami.bundle.sj") {
-		return true
-	}
 	return false
 }


### PR DESCRIPTION
These assets no longer exist.

Fixes https://github.com/sourcegraph/sourcegraph/issues/4631