### PR TITLE
schema: Include example of corsOrigin in description

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -54,7 +54,7 @@
       "hide": true
     },
     "corsOrigin": {
-      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration.",
+      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration. eg \"https://my-phabricator.example.com\"",
       "type": "string",
       "examples": ["https://my-phabricator.example.com"],
       "group": "Security"

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -59,7 +59,7 @@ const SiteSchemaJSON = `{
       "hide": true
     },
     "corsOrigin": {
-      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration.",
+      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration. eg \"https://my-phabricator.example.com\"",
       "type": "string",
       "examples": ["https://my-phabricator.example.com"],
       "group": "Security"


### PR DESCRIPTION
When setting corsOrigin in the configuration editor, it is easier to access the
description in than the examples. This would of helped prevent me making a
mistake, where I set the corsOrigin to `phabricator.sgdev.org` instead of
`https://phabricator.sgdev.org`.