### PR TITLE
change a string func to be unicode safe

### DIFF
--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
@@ -25,7 +25,7 @@ func (r *didYouMeanQuotedResolver) Results(context.Context) (*searchResultsResol
 		case *rxsyntax.Error:
 			srr := &searchResultsResolver{
 				alert: &searchAlert{
-					title:           makeTitle(e.Error()),
+					title:           capFirst(e.Error()),
 					description:     "Quoting the query may help if you want a literal match instead of a regular expression match.",
 					proposedQueries: sqds,
 				},
@@ -37,7 +37,7 @@ func (r *didYouMeanQuotedResolver) Results(context.Context) (*searchResultsResol
 	case *syntax.ParseError:
 		srr := &searchResultsResolver{
 			alert: &searchAlert{
-				title:           makeTitle(e.Msg),
+				title:           capFirst(e.Msg),
 				description:     "Quoting the query may help if you want a literal match.",
 				proposedQueries: sqds,
 			},
@@ -83,7 +83,9 @@ func proposedQuotedQueries(rawQuery string) []*searchQueryDescription {
 	return sqds
 }
 
-func makeTitle(s string) string {
+// capFirst capitalizes the first rune in the given string. It can be safely
+// used with UTF-8 strings.
+func capFirst(s string) string {
 	i := 0
 	return strings.Map(func(r rune) rune {
 		i++

--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted.go
@@ -6,6 +6,7 @@ import (
 	rxsyntax "regexp/syntax"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query/types"
@@ -83,8 +84,12 @@ func proposedQuotedQueries(rawQuery string) []*searchQueryDescription {
 }
 
 func makeTitle(s string) string {
-	if len(s) == 0 {
-		return s
-	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	i := 0
+	return strings.Map(func(r rune) rune {
+		i++
+		if i == 1 {
+			return unicode.ToTitle(r)
+		}
+		return r
+	}, s)
 }

--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
@@ -131,6 +131,7 @@ func Test_makeTitle(t *testing.T) {
 		{name: "empty", in: "", want: ""},
 		{name: "a", in: "a", want: "A"},
 		{name: "ab", in: "ab", want: "Ab"},
+		{name: "хлеб", in: "хлеб", want: "Хлеб"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
@@ -122,7 +122,7 @@ func Test_didYouMeanQuotedResolver_Results(t *testing.T) {
 	})
 }
 
-func Test_makeTitle(t *testing.T) {
+func Test_capFirst(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
@@ -135,7 +135,7 @@ func Test_makeTitle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := makeTitle(tt.in); got != tt.want {
+			if got := capFirst(tt.in); got != tt.want {
 				t.Errorf("makeTitle() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This is in response to [Keegan's feedback](https://github.com/sourcegraph/sourcegraph/pull/4563#discussion_r296163796) on my earlier PR. 

Test plan: unit test
