### PR TITLE
add config-via-file documentation

### DIFF
--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -92,7 +92,7 @@ When you upgrade Sourcegraph versions, you should do the following to ensure you
 1. Upgrade Sourcegraph to the new version
 2. Visit each configuration page in the web UI (management console, site configuration, each external service)
 3. Copy the (now migrated) configuration from those pages into your JSON files.
-
+It is important to follow the above steps after *every* Sourcegraph version update, because we only guarantee migrations remain valid across two minor versions. If you fail to apply a migration and later upgrade Sourcegraph twice more, you may effectively "skip" an important migration.
 We're planning to improve this by having Sourcegraph notify you as a site admin when you should do the above, since today it is not actually required in most upgrades. See https://github.com/sourcegraph/sourcegraph/issues/4650 for details.
 
 ## Kubernetes ConfigMap

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -85,7 +85,7 @@ You can find a full list of [valid top-level keys here](https://sourcegraph.com/
 
 As mentioned earlier, when configuration is loaded via this manner Sourcegraph can no longer persist the automatic migrations to configuration it sometimes performs on upgrades.
 
-It will still perform such migrations on the configuration loaded from file, it just cannot persist such migrations _back to file_ and we only guarantee such migrations stick around for two minor versions.
+It will still perform such migrations on the configuration loaded from file, it just cannot persist such migrations _back to file_.
 
 When you upgrade Sourcegraph versions, to ensure your configurations do not become invalid, you should:
 

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -52,7 +52,7 @@ Set the environment variable below on all `frontend` containers (cluster deploym
 EXTSVC_CONFIG_FILE=extsvc.json
 ```
 
-Where `extsvc.json` is _all_ of your external services in a single JSONC file like so:
+`extsvc.json` contains a JSON object that specifies _all_ of your external services in a single JSONC file:
 
 ```jsonc
 

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -87,7 +87,7 @@ As mentioned earlier, when configuration is loaded via this manner Sourcegraph c
 
 It will still perform such migrations on the configuration loaded from file, it just cannot persist such migrations _back to file_.
 
-When you upgrade Sourcegraph versions, to ensure your configurations do not become invalid, you should:
+When you upgrade Sourcegraph versions, you should do the following to ensure your configurations do not become invalid:
 
 1. Upgrade Sourcegraph to the new version
 2. Visit each configuration page in the web UI (management console, site configuration, each external service)

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -7,7 +7,7 @@ As of Sourcegraph v3.4+, this is possible for [site configuration](site_config.m
 ## Benefits
 
 1. Configuration can be checked into version control (e.g. Git).
-2. Edits through the web UI cannot be saved (good for enforcing configuration organization-wide).
+2. Configuration is enforced across the entire instance and edits cannot be made from the web UI.
 
 ## Drawbacks
 

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -42,7 +42,7 @@ Set the environment variable below on all `frontend` containers (cluster deploym
 SITE_CONFIG_FILE=site.json
 ```
 
-Where `site.json` is literally the [site configuration](site_config.md) from the in-app editor.
+`site.json` contains the [site configuration](site_config.md), which you would otherwise edit through the in-app site configuration editor.
 
 #### External service configuration
 

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -18,13 +18,15 @@ Loading configuration in this manner has two important drawbacks:
 
 ## Getting started
 
-Simply add the relevant environment variable below to all `frontend` containers (cluster deployment) or to the `server` container (single-container Docker deployment):
+#### Critical configuration
+
+Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):
 
 ```sh
 CRITICAL_CONFIG_FILE=critical.json
-SITE_CONFIG_FILE=site.json
-EXTSVC_CONFIG_FILE=extsvc.json
 ```
+
+Where `critical.json` is literally the [management console](../management_console.md) configuration.
 
 You should also add to the `management-console` container (cluster deployment) or to the `server` container (single-container Docker deployment) the following:
 
@@ -32,32 +34,46 @@ You should also add to the `management-console` container (cluster deployment) o
 DISABLE_CONFIG_UPDATES=true
 ```
 
-- `critical.json` is literally the [management console](../management_console.md) configuration.
-- `site.json` is literally the [site configuration](site_config.md)
-- `extsvc.json` is _all_ of your external services in a single JSONC file like so:
+#### Site configuration
+
+Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):
+
+```sh
+SITE_CONFIG_FILE=site.json
+```
+
+Where `site.json` is literally the [site configuration](site_config.md) from the in-app editor.
+
+#### External service configuration
+
+Set the environment variable below on all `frontend` containers (cluster deployment) or on the `server` container (single-container Docker deployment):
+
+```sh
+EXTSVC_CONFIG_FILE=extsvc.json
+```
+
+Where `extsvc.json` is _all_ of your external services in a single JSONC file like so:
 
 ```jsonc
 
 {
   "GITHUB": [
     {
-      // First GitHub external service configuration
+      // First GitHub external service configuration: literally the JSON object from the external service config editor.
       "authorization": {},
       "url": "https://github.com",
       "token": "...",
       "repositoryQuery": ["affiliated"]
     },
     {
-      // Second GitHub external service configuration
-      "authorization": {},
-      "url": "https://github.com",
-      "token": "...",
-      "repositoryQuery": ["affiliated"]
+      // Second GitHub external service configuration: literally the JSON object from the external service config editor.
+      ...
     },
   ],
   "PHABRICATOR": [
     {
-      // First Phabricator external service configuration
+      // First Phabricator external service configuration: literally the JSON object from the external service config editor.
+      ...
     },
   ]
 }

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -97,6 +97,6 @@ We're planning to improve this by having Sourcegraph notify you as a site admin 
 
 ## Kubernetes ConfigMap
 
-Currently, site admins are responsible for creating the ConfigMap resource that maps the above environment variables to refer to the ConfigMap'd files on disk.
+Currently, site admins are responsible for creating the ConfigMap resource that maps the above environment variables to files on the container disk.
 
 (If you need assistance with this, please contact us.)

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -26,7 +26,7 @@ Set the environment variable below on all `frontend` containers (cluster deploym
 CRITICAL_CONFIG_FILE=critical.json
 ```
 
-Where `critical.json` is literally the [management console](../management_console.md) configuration.
+`critical.json` should contain the [management console](../management_console.md) configuration that you would otherwise enter through the management console UI.
 
 You should also add to the `management-console` container (cluster deployment) or to the `server` container (single-container Docker deployment) the following:
 

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -1,0 +1,86 @@
+# (advanced) Loading configuration via the file system or Kubernetes ConfigMap
+
+In teams where Sourcegraph is a critical piece of infrastructure, it can often be desirable to check the Sourcegraph configuration into version control.
+
+As of Sourcegraph v3.4+, this is possible for [site configuration](site_config.md), [critical configuration](critical_config.md), and [external services configuration]()
+
+## Benefits
+
+1. Configuration can be checked into version control (e.g. Git).
+2. Edits through the web UI cannot be saved (good for enforcing configuration organization-wide).
+
+## Drawbacks
+
+Loading configuration in this manner has two important drawbacks:
+
+1. You will no longer be able to save configuration edits through the web UI (you can use the web UI as scratch space, though).
+2. Sourcegraph sometimes performs automatic migrations of configuration when upgrading versions. This process will now be more manual for you (see below).
+
+## Getting started
+
+Simply add the relevant environment variable below to all `frontend` containers (cluster deployment) or to the `server` container (single-container Docker deployment):
+
+```sh
+CRITICAL_CONFIG_FILE=critical.json
+SITE_CONFIG_FILE=site.json
+EXTSVC_CONFIG_FILE=extsvc.json
+```
+
+You should also add to the `management-console` container (cluster deployment) or to the `server` container (single-container Docker deployment) the following:
+
+```sh
+DISABLE_CONFIG_UPDATES=true
+```
+
+- `critical.json` is literally the [management console](../management_console.md) configuration.
+- `site.json` is literally the [site configuration](site_config.md)
+- `extsvc.json` is _all_ of your external services in a single JSONC file like so:
+
+```jsonc
+
+{
+  "GITHUB": [
+    {
+      // First GitHub external service configuration
+      "authorization": {},
+      "url": "https://github.com",
+      "token": "...",
+      "repositoryQuery": ["affiliated"]
+    },
+    {
+      // Second GitHub external service configuration
+      "authorization": {},
+      "url": "https://github.com",
+      "token": "...",
+      "repositoryQuery": ["affiliated"]
+    },
+  ],
+  "PHABRICATOR": [
+    {
+      // First Phabricator external service configuration
+    },
+  ]
+}
+```
+
+You can find a full list of [valid top-level keys here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@b7ebb9024e3a95109fdedfb8057795b9a7c638bc/-/blob/cmd/frontend/graphqlbackend/schema.graphql#L1104-1110).
+
+## Upgrades & Migrations
+
+As mentioned earlier, when configuration is loaded via this manner Sourcegraph can no longer persist the automatic migrations to configuration it sometimes performs on upgrades.
+
+It will still perform such migrations on the configuration loaded from file, it just cannot persist such migrations _back to file_ and we only guarantee such migrations stick around for two minor versions.
+
+When you upgrade Sourcegraph versions, to ensure your configurations do not become invalid, you should:
+
+1. Upgrade Sourcegraph to the new version
+2. Visit each configuration page in the web UI (management console, site configuration, each external service)
+3. Copy the (now migrated) configuration from those pages into your JSON files.
+
+We're planning to improve this by having Sourcegraph notify you as a site admin when you should do the above, since today it is not actually required in most upgrades. See https://github.com/sourcegraph/sourcegraph/issues/4650 for details.
+
+## Kubernetes ConfigMap
+
+Currently, site admins are responsible for creating the ConfigMap resource that maps the above environment variables to refer to the ConfigMap'd files on disk.
+
+(If you need assistance with this, please contact us.)

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -1,8 +1,8 @@
-# (advanced) Loading configuration via the file system or Kubernetes ConfigMap
+# (advanced) Loading configuration via the file system
 
 In teams where Sourcegraph is a critical piece of infrastructure, it can often be desirable to check the Sourcegraph configuration into version control.
 
-As of Sourcegraph v3.4+, this is possible for [site configuration](site_config.md), [critical configuration](critical_config.md), and [external services configuration]()
+As of Sourcegraph v3.4+, this is possible for [site configuration](site_config.md), [critical configuration](critical_config.md), and [external services configuration](../external_service/index.md)
 
 ## Benefits
 

--- a/doc/admin/config/index.md
+++ b/doc/admin/config/index.md
@@ -17,3 +17,7 @@ There are 2 types of site configuration for a Sourcegraph instance:
 - [Set up HTTPS](../nginx.md)
 - [Use a custom domain](../url.md)
 - [Update Sourcegraph](../updates.md)
+
+## Advanced tasks
+
+- [Loading configuration via the file system](advanced_config_file.md)


### PR DESCRIPTION
This was added in Sourcegraph 3.4 for a customer but not documented well. Here is the proper documentation for it.