### PR TITLE
dev: Use watchman for watching go files changes

### DIFF
--- a/dev/changewatch.sh
+++ b/dev/changewatch.sh
@@ -4,18 +4,18 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 GO_DIRS="$(./dev/watchdirs.sh) ${ADDITIONAL_GO_DIRS}"
 
 dirs_starstar() {
-	for i; do echo "'$i/**/*.go'"; done
+    for i; do echo "'$i/**/*.go'"; done
 }
 
 dirs_path() {
-	for i; do echo "-path $i"; done
+    for i; do echo "-path $i"; done
 }
 
 useChokidar() {
-	echo >&2 "Using chokidar."
-	# eval so the expansion can produce quoted things, and eval can eat the
-	# quotes, so it doesn't try to expand wildcards.
-	eval exec chokidar --silent \
+    echo >&2 "Using chokidar."
+    # eval so the expansion can produce quoted things, and eval can eat the
+    # quotes, so it doesn't try to expand wildcards.
+    eval exec chokidar --silent \
         $(dirs_starstar $GO_DIRS) \
         cmd/frontend/graphqlbackend/schema.graphql \
         "'schema/*.json'" \
@@ -25,22 +25,27 @@ useChokidar() {
 }
 
 useInotifywrapper() {
-	echo >&2 "Using inotifywrapper."
-	exec dev/inotifywrapper/inotifywrapper $(dirs_path $GO_DIRS) \
-		-match '\.go$' \
-		-match 'cmd/frontend/graphqlbackend/schema\.graphql' \
-		-match 'schema/.*.json' \
-		-cmd './dev/handle-change.sh'
+    echo >&2 "Using inotifywrapper."
+    exec dev/inotifywrapper/inotifywrapper $(dirs_path $GO_DIRS) \
+        -match '\.go$' \
+        -match 'cmd/frontend/graphqlbackend/schema\.graphql' \
+        -match 'schema/.*.json' \
+        -cmd './dev/handle-change.sh'
 }
 
 case $(which inotifywait 2>/dev/null) in
-"")	useChokidar
-	;;
-*)	if ( cd dev/inotifywrapper; go build ); then
-		useInotifywrapper
-	else
-		echo >&2 "Can't build inotifywrapper: Falling back on chokidar."
-		useChokidar
-	fi
-	;;
+"")
+    useChokidar
+    ;;
+*)
+    if (
+        cd dev/inotifywrapper
+        go build
+    ); then
+        useInotifywrapper
+    else
+        echo >&2 "Can't build inotifywrapper: Falling back on chokidar."
+        useChokidar
+    fi
+    ;;
 esac

--- a/dev/watchmanwrapper/.gitignore
+++ b/dev/watchmanwrapper/.gitignore
@@ -1,0 +1,1 @@
+/watchmanwrapper

--- a/dev/watchmanwrapper/main.go
+++ b/dev/watchmanwrapper/main.go
@@ -1,3 +1,6 @@
+// Command watchmanwrapper runs watchman subscribe and parses its output to
+// trigger another command with the files that have changed. See
+// dev/changewatch for how it is invocated.
 package main
 
 import (
@@ -41,14 +44,14 @@ func main() {
 			cmd := exec.Command(os.Args[1], r.Files...)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
-			err := cmd.Run()
+			err = cmd.Run()
 			if err != nil {
-				log.Println("%s failed to run: %v", os.Args[1], err)
+				log.Printf("%s failed to run: %v", os.Args[1], err)
 			}
 		}
 	}()
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/dev/watchmanwrapper/main.go
+++ b/dev/watchmanwrapper/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+)
+
+type Response struct {
+	IsFreshInstance bool     `json:"is_fresh_instance"`
+	Files           []string `json:"files"`
+}
+
+func main() {
+	cmd := exec.Command("watchman", "-j", "--server-encoding=json", "-p")
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		dec := json.NewDecoder(stdout)
+		for {
+			var r Response
+			err := dec.Decode(&r)
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				log.Fatal(err)
+			}
+			if r.IsFreshInstance || len(r.Files) == 0 {
+				continue
+			}
+
+			cmd := exec.Command(os.Args[1], r.Files...)
+			cmd.Stderr = os.Stderr
+			cmd.Stdout = os.Stdout
+			cmd.Run()
+		}
+	}()
+
+	cmd.Run()
+}

--- a/dev/watchmanwrapper/main.go
+++ b/dev/watchmanwrapper/main.go
@@ -41,9 +41,15 @@ func main() {
 			cmd := exec.Command(os.Args[1], r.Files...)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
-			cmd.Run()
+			err := cmd.Run()
+			if err != nil {
+				log.Println("%s failed to run: %v", os.Args[1], err)
+			}
 		}
 	}()
 
-	cmd.Run()
+	err := cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Chokidar would open too many files on my laptop. Additionally I already use
watchman to speed up my git operations. Watchman is also fast enough to watch
all go files, instead of relying on our "godirs" hacks.