### PR TITLE
web: Poll if admin repo list is empty

### DIFF
--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -17,7 +17,7 @@ import {
 import { PageTitle } from '../components/PageTitle'
 import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
-import { fetchAllRepositoriesAndPollIfAnyCloning } from './backend'
+import { fetchAllRepositoriesAndPollIfEmptyOrAnyCloning } from './backend'
 
 interface RepositoryNodeProps extends ActivationProps {
     node: GQL.IRepository
@@ -178,7 +178,7 @@ export class SiteAdminRepositoriesPage extends React.PureComponent<Props> {
     }
 
     private queryRepositories = (args: FilteredConnectionQueryArgs) =>
-        fetchAllRepositoriesAndPollIfAnyCloning({ ...args })
+        fetchAllRepositoriesAndPollIfEmptyOrAnyCloning({ ...args })
 
     private onDidUpdateRepository = () => this.repositoryUpdates.next()
 }

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -148,8 +148,10 @@ function fetchAllRepositories(args: RepositoryArgs): Observable<GQL.IRepositoryC
     )
 }
 
-export function fetchAllRepositoriesAndPollIfAnyCloning(args: RepositoryArgs): Observable<GQL.IRepositoryConnection> {
-    // Poll if there are repositories that are being cloned.
+export function fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(
+    args: RepositoryArgs
+): Observable<GQL.IRepositoryConnection> {
+    // Poll if there are repositories that are being cloned or the list is empty.
     //
     // TODO(sqs): This is hacky, but I couldn't figure out a better way.
     const subject = new Subject<null>()
@@ -157,7 +159,7 @@ export function fetchAllRepositoriesAndPollIfAnyCloning(args: RepositoryArgs): O
         startWith(null),
         mergeMap(() => fetchAllRepositories(args)),
         tap(result => {
-            if (result.nodes && result.nodes.some(n => !n.mirrorInfo.cloned)) {
+            if (!result.nodes || result.nodes.some(n => !n.mirrorInfo.cloned)) {
                 setTimeout(() => subject.next(), 5000)
             }
         })


### PR DESCRIPTION
If a user has added an external service, the repo table will be empty until the
first sync has run. In this case we can refresh so the repos appear. Our e2e
tests also rely on this behaviour.