### PR TITLE
fix quoting suggestions for fields with invalid regexes

### DIFF
--- a/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
+++ b/cmd/frontend/graphqlbackend/search_didyoumeanquoted_test.go
@@ -91,7 +91,7 @@ func Test_didYouMeanQuotedResolver_Results(t *testing.T) {
 		}
 	})
 
-	t.Run("type error that is not a regex error", func(t *testing.T) {
+	t.Run("type error that is not a regex error should show a suggestion", func(t *testing.T) {
 		raw := "-foobar"
 		_, err := query.ParseAndCheck(raw)
 		if err == nil {
@@ -118,6 +118,23 @@ func Test_didYouMeanQuotedResolver_Results(t *testing.T) {
 		}
 		if strings.Contains(alert.description, "regular expression") {
 			t.Errorf("description is '%s', want it not to contain 'regular expression'", alert.description)
+		}
+	})
+
+	t.Run("negated file field with an invalid regex", func(t *testing.T) {
+		raw := "-f:(a"
+		_, err := query.ParseAndCheck(raw)
+		if err == nil {
+			t.Fatal("ParseAndCheck failed to detect the invalid regex in the f: field")
+		}
+		dymqr := didYouMeanQuotedResolver{query: raw, err: err}
+		srr, err := dymqr.Results(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		alert := srr.alert
+		if len(alert.proposedQueries) != 1 {
+			t.Fatalf("got %d proposed queries (%v), want exactly 1", len(alert.proposedQueries), alert.proposedQueries)
 		}
 	})
 }

--- a/cmd/frontend/internal/pkg/search/query/syntax/query.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/query.go
@@ -59,16 +59,21 @@ func (e Expr) String() string {
 // quoting in case of TokenError or an invalid regular expression.
 func (e Expr) WithErrorsQuoted() Expr {
 	e2 := e
+	needsQuoting := false
 	switch e.ValueType {
 	case TokenError:
-		e2.Value = fmt.Sprintf("%q", e.Value)
-		e2.ValueType = TokenQuoted
+		needsQuoting = true
 	case TokenPattern, TokenLiteral:
 		_, err := regexp.Compile(e2.Value)
 		if err != nil {
-			e2.Value = fmt.Sprintf("%q", e.Value)
-			e2.ValueType = TokenQuoted
+			needsQuoting = true
 		}
+	}
+	if needsQuoting {
+		e2.Not = false
+		e2.Field = ""
+		e2.Value = fmt.Sprintf("%q", e.String())
+		e2.ValueType = TokenQuoted
 	}
 	return e2
 }

--- a/cmd/frontend/internal/pkg/search/query/syntax/query_test.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/query_test.go
@@ -66,8 +66,8 @@ func TestQuery_WithErrorsQuoted(t *testing.T) {
 		{in: "f:foo bar", want: `f:foo bar`},
 		{in: "f:foo b(ar", want: `f:foo "b(ar"`},
 		{in: "f:foo b(ar b[az", want: `f:foo "b(ar" "b[az"`},
-		{name: "invalid regex in field", in: `f:(`, want: `"f:("`},
-		{name: "invalid regex in negated field", in: `-f:(`, want: `"-f:("`},
+		{name: "invalid regex in field", in: `f:(a`, want: `"f:(a"`},
+		{name: "invalid regex in negated field", in: `-f:(a`, want: `"-f:(a"`},
 	}
 	for _, c := range cases {
 		name := c.name

--- a/cmd/frontend/internal/pkg/search/query/syntax/query_test.go
+++ b/cmd/frontend/internal/pkg/search/query/syntax/query_test.go
@@ -57,19 +57,22 @@ func TestExpr_String(t *testing.T) {
 
 func TestQuery_WithErrorsQuoted(t *testing.T) {
 	cases := []struct {
+		name string
 		in   string
 		want string
 	}{
-		{in: "", want: ""},
+		{name: "empty", in: "", want: ""},
 		{in: "a", want: "a"},
 		{in: "f:foo bar", want: `f:foo bar`},
 		{in: "f:foo b(ar", want: `f:foo "b(ar"`},
 		{in: "f:foo b(ar b[az", want: `f:foo "b(ar" "b[az"`},
+		{name: "invalid regex in field", in: `f:(`, want: `"f:("`},
+		{name: "invalid regex in negated field", in: `-f:(`, want: `"-f:("`},
 	}
 	for _, c := range cases {
-		name := c.in
-		if c.in == "" {
-			name = "empty"
+		name := c.name
+		if name == "" {
+			name = c.in
 		}
 		t.Run(name, func(t *testing.T) {
 			q := ParseAllowingErrors(c.in)


### PR DESCRIPTION
This is a fix for a corner case with quoting suggestions.

Test plan: unit tests

After:
<img width="677" alt="Screen Shot 2019-06-24 at 13 44 26" src="https://user-images.githubusercontent.com/15530/60050742-3629bd80-9686-11e9-9a82-3ee9d1962911.png">

Before:
<img width="677" alt="Screen Shot 2019-06-24 at 13 43 49" src="https://user-images.githubusercontent.com/15530/60050884-91f44680-9686-11e9-80f5-2700f9bb734c.png">
