### PR TITLE
fix background color on ref/def results snippets

### DIFF
--- a/shared/src/components/FileMatchChildren.scss
+++ b/shared/src/components/FileMatchChildren.scss
@@ -42,3 +42,19 @@
         }
     }
 }
+
+.theme-dark {
+    .file-match-children {
+        &__item {
+            background-color: $color-bg-4;
+        }
+    }
+}
+
+.theme-light {
+    .file-match-children {
+        &__item {
+            background-color: $color-light-bg-1;
+        }
+    }
+}


### PR DESCRIPTION
#4588 made the background color (in the light theme) gray, which was the same background color as the header and had poor visual contrast.
