### PR TITLE
graphqlbackend: Use pointers to zoekt.Repository instead of copying

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -835,9 +835,9 @@ func zoektIndexedRepos(ctx context.Context, repos []*search.RepositoryRevisions)
 
 	// Everything currently in indexed is at HEAD. Filter out repos which
 	// zoekt hasn't indexed yet.
-	zoektIndexed := map[string]zoekt.Repository{}
+	zoektIndexed := make(map[string]*zoekt.Repository, len(resp.Repos))
 	for _, repo := range resp.Repos {
-		zoektIndexed[repo.Repository.Name] = repo.Repository
+		zoektIndexed[repo.Repository.Name] = &repo.Repository
 	}
 	head := indexed
 	indexed = indexed[:0]

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -640,19 +640,19 @@ func Test_zoektIndexedRepos(t *testing.T) {
 			{
 				Repository: zoekt.Repository{
 					Name:     "foo/indexed-one",
-					Branches: []zoekt.RepositoryBranch{{"HEAD", "deadbeef"}},
+					Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 				},
 			},
 			{
 				Repository: zoekt.Repository{
 					Name:     "foo/indexed-two",
-					Branches: []zoekt.RepositoryBranch{{"HEAD", "deadbeef"}},
+					Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 				},
 			},
 			{
 				Repository: zoekt.Repository{
 					Name:     "foo/indexed-three-no-HEAD",
-					Branches: []zoekt.RepositoryBranch{{"foobar", "deadbeef"}},
+					Branches: []zoekt.RepositoryBranch{{Name: "foobar", Version: "deadbeef"}},
 				},
 			},
 		},
@@ -710,7 +710,7 @@ func Benchmark_zoektIndexedRepos(b *testing.B) {
 		zoektRepos = append(zoektRepos, &zoekt.RepoListEntry{
 			Repository: zoekt.Repository{
 				Name:     indexedName,
-				Branches: []zoekt.RepositoryBranch{{"HEAD", "deadbeef"}},
+				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 			},
 		})
 	}
@@ -723,7 +723,7 @@ func Benchmark_zoektIndexedRepos(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		zoektIndexedRepos(ctx, zoekt, repos)
+		_, _, _, _ = zoektIndexedRepos(ctx, zoekt, repos)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/pkg/errors"
@@ -616,6 +617,87 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeZoektBackend struct{ repos *zoekt.RepoList }
+
+func (z *fakeZoektBackend) ListAll(ctx context.Context) (*zoekt.RepoList, error) {
+	return z.repos, nil
+}
+
+func Test_zoektIndexedRepos(t *testing.T) {
+	repos := makeRepositoryRevisions(
+		"foo/indexed-one@",
+		"foo/indexed-two@",
+		"foo/indexed-three-no-HEAD@",
+		"foo/unindexed-one",
+		"foo/unindexed-two",
+	)
+
+	zoektRepoList := &zoekt.RepoList{
+		Repos: []*zoekt.RepoListEntry{
+			{
+				Repository: zoekt.Repository{
+					Name:     "foo/indexed-one",
+					Branches: []zoekt.RepositoryBranch{{"HEAD", "deadbeef"}},
+				},
+			},
+			{
+				Repository: zoekt.Repository{
+					Name:     "foo/indexed-two",
+					Branches: []zoekt.RepositoryBranch{{"HEAD", "deadbeef"}},
+				},
+			},
+			{
+				Repository: zoekt.Repository{
+					Name:     "foo/indexed-three-no-HEAD",
+					Branches: []zoekt.RepositoryBranch{{"foobar", "deadbeef"}},
+				},
+			},
+		},
+	}
+
+	zoekt := &fakeZoektBackend{repos: zoektRepoList}
+	ctx := context.Background()
+
+	indexed, unindexed, indexedRevisions, err := zoektIndexedRepos(ctx, zoekt, repos)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, assertion := range []struct {
+		name       string
+		have, want []*search.RepositoryRevisions
+	}{
+		{"indexed", indexed, makeRepositoryRevisions("foo/indexed-one@", "foo/indexed-two@", "foo/indexed-three-no-HEAD@")},
+		{"unindexed", unindexed, makeRepositoryRevisions("foo/unindexed-one", "foo/unindexed-two")},
+	} {
+		if len(assertion.have) != len(assertion.want) {
+			t.Fatalf("%s has wrong length: %d", assertion.name, len(assertion.have))
+		}
+
+		sort.Slice(assertion.have, sortRepoRevsByName(assertion.have))
+		sort.Slice(assertion.want, sortRepoRevsByName(assertion.want))
+
+		if !reflect.DeepEqual(assertion.have, assertion.want) {
+			diff := cmp.Diff(assertion.have, assertion.want)
+			t.Fatalf("%s has wrong repo revs. diff=%s", assertion.name, diff)
+		}
+	}
+
+	wantIndexedRevisions := map[*search.RepositoryRevisions]string{
+		repos[0]: "deadbeef",
+		repos[1]: "deadbeef",
+	}
+
+	if !reflect.DeepEqual(indexedRevisions, wantIndexedRevisions) {
+		diff := cmp.Diff(indexedRevisions, wantIndexedRevisions)
+		t.Fatalf("indexedRevisions has wrong revisions. diff=%s", diff)
+	}
+}
+
+func sortRepoRevsByName(repoRevs []*search.RepositoryRevisions) func(int, int) bool {
+	return func(i, j int) bool { return repoRevs[i].Repo.Name < repoRevs[j].Repo.Name }
 }
 
 func init() {


### PR DESCRIPTION
With large numbers of repositories, this map can grow really big and put
a lot of pressure on the GC. Instead of copying the structs, use
pointers.

Test plan: go test ./...
