### PR TITLE
frontend: Do not expose repo created_at and updated_at timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Updating or creating an external service will no longer block until the service is synced.
+- The GraphQL fields `Repository.createdAt` and `Repository.updatedAt` are deprecated and will be removed in 3.8. Now `createdAt` is always the current time and updatedAt is always null.
 
 ### Fixed
 

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -116,8 +116,8 @@ func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
 }
 
 const getRepoByQueryFmtstr = `
-SELECT id, name, COALESCE(uri, ''), description, language, created_at,
-  updated_at, external_id, external_service_type, external_service_id
+SELECT id, name, COALESCE(uri, ''), description, language,
+  external_id, external_service_type, external_service_id
 FROM repo
 WHERE deleted_at IS NULL AND enabled = true AND %s`
 
@@ -140,8 +140,6 @@ func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types
 			&repo.URI,
 			&repo.Description,
 			&repo.Language,
-			&repo.CreatedAt,
-			&repo.UpdatedAt,
 			&spec.id, &spec.serviceType, &spec.serviceID,
 		); err != nil {
 			return nil, err

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -582,14 +582,18 @@ func TestRepos_Create(t *testing.T) {
 	ctx := dbtesting.TestContext(t)
 
 	// Add a repo.
-	createRepo(ctx, t, &types.Repo{Name: "a/b"})
+	createRepo(ctx, t, &types.Repo{Name: "a/b", Description: "test"})
 
 	repo, err := Repos.GetByName(ctx, "a/b")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if repo.CreatedAt.IsZero() {
-		t.Fatal("got CreatedAt.IsZero()")
+
+	if got, want := repo.Name, api.RepoName("a/b"); got != want {
+		t.Fatalf("got Name %q, want %q", got, want)
+	}
+	if got, want := repo.Description, "test"; got != want {
+		t.Fatalf("got Description %q, want %q", got, want)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -152,14 +152,10 @@ func (r *repositoryResolver) Language() string {
 func (r *repositoryResolver) Enabled() bool { return true }
 
 func (r *repositoryResolver) CreatedAt() string {
-	return r.repo.CreatedAt.Format(time.RFC3339)
+	return time.Now().Format(time.RFC3339)
 }
 
 func (r *repositoryResolver) UpdatedAt() *string {
-	if r.repo.UpdatedAt != nil {
-		t := r.repo.UpdatedAt.Format(time.RFC3339)
-		return &t
-	}
 	return nil
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1166,8 +1166,12 @@ type Repository implements Node & GenericSearchResultInterface {
     # NOTE: Disabling a repository does not provide any additional security. This field is merely a
     # guideline to UI implementations.
     enabled: Boolean! @deprecated(reason: "Always true. All repositories are enabled.")
+    # DEPRECATED: This field is unused in known clients.
+    #
     # The date when this repository was created on Sourcegraph.
     createdAt: String!
+    # DEPRECATED: This field is unused in known clients.
+    #
     # The date when this repository's metadata was last updated on Sourcegraph.
     updatedAt: String
     # Returns information about the given commit in the repository, or null if no commit exists with the given rev.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1173,8 +1173,12 @@ type Repository implements Node & GenericSearchResultInterface {
     # NOTE: Disabling a repository does not provide any additional security. This field is merely a
     # guideline to UI implementations.
     enabled: Boolean! @deprecated(reason: "Always true. All repositories are enabled.")
+    # DEPRECATED: This field is unused in known clients.
+    #
     # The date when this repository was created on Sourcegraph.
     createdAt: String!
+    # DEPRECATED: This field is unused in known clients.
+    #
     # The date when this repository's metadata was last updated on Sourcegraph.
     updatedAt: String
     # Returns information about the given commit in the repository, or null if no commit exists with the given rev.

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -33,10 +33,6 @@ type Repo struct {
 	Language string
 	// Fork is whether this repository is a fork of another repository.
 	Fork bool
-	// CreatedAt is when this repository was created on Sourcegraph.
-	CreatedAt time.Time
-	// UpdatedAt is when this repository's metadata was last updated on Sourcegraph.
-	UpdatedAt *time.Time
 }
 
 // ExternalService is a connection to an external service.


### PR DESCRIPTION
No clients that we know of read this field. Additionally on performance profiles
the marshalling of timestamps is significant in our postgres client. So we
deprecate the fields and return fake data for created_at.
