### PR TITLE
Revert "authz: Instrument Bitbucket Server ACLs code paths with tracing (#4642)"

### DIFF
--- a/cmd/frontend/db/external_accounts.go
+++ b/cmd/frontend/db/external_accounts.go
@@ -7,10 +7,8 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
-	"github.com/sourcegraph/sourcegraph/pkg/trace"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -201,21 +199,7 @@ type ExternalAccountsListOptions struct {
 	*LimitOffset
 }
 
-func (s *userExternalAccounts) List(ctx context.Context, opt ExternalAccountsListOptions) (acct []*extsvc.ExternalAccount, err error) {
-	tr, ctx := trace.New(ctx, "userExternalAccounts.List", "")
-	defer func() {
-		if err != nil {
-			tr.SetError(err)
-		}
-
-		tr.LogFields(
-			otlog.Object("opt", opt),
-			otlog.Int("accounts.count", len(acct)),
-		)
-
-		tr.Finish()
-	}()
-
+func (s *userExternalAccounts) List(ctx context.Context, opt ExternalAccountsListOptions) ([]*extsvc.ExternalAccount, error) {
 	if Mocks.ExternalAccounts.List != nil {
 		return Mocks.ExternalAccounts.List(opt)
 	}

--- a/cmd/frontend/db/repos_perm.go
+++ b/cmd/frontend/db/repos_perm.go
@@ -3,13 +3,11 @@ package db
 import (
 	"context"
 
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
-	"github.com/sourcegraph/sourcegraph/pkg/trace"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -37,15 +35,7 @@ var mockAuthzFilter func(ctx context.Context, repos []*types.Repo, p authz.Perm)
 //
 // - If no authz providers match the repository, consult `authzAllowByDefault`. If true, then return
 //   the repository; otherwise, do not.
-func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perm) (rs []*types.Repo, err error) {
-	tr, ctx := trace.New(ctx, "authzFilter", "")
-	defer func() {
-		if err != nil {
-			tr.SetError(err)
-		}
-		tr.Finish()
-	}()
-
+func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perm) ([]*types.Repo, error) {
 	if mockAuthzFilter != nil {
 		return mockAuthzFilter(ctx, repos, p)
 	}
@@ -93,27 +83,6 @@ func isInternalActor(ctx context.Context) bool {
 }
 
 func getFilteredRepoNames(ctx context.Context, currentUser *types.User, repos map[authz.Repo]struct{}, p authz.Perm) (accepted map[api.RepoName]struct{}, err error) {
-	tr, ctx := trace.New(ctx, "getFilteredRepoNames", "")
-	defer func() {
-		if err != nil {
-			tr.SetError(err)
-		}
-
-		fields := []otlog.Field{
-			otlog.String("permission", string(p)),
-			otlog.Int("repos.count", len(repos)),
-			otlog.Int("authorized.count", len(accepted)),
-		}
-
-		if currentUser != nil {
-			fields = append(fields, otlog.Object("user", currentUser))
-		}
-
-		tr.LogFields(fields...)
-
-		tr.Finish()
-	}()
-
 	var accts []*extsvc.ExternalAccount
 	authzAllowByDefault, authzProviders := authz.GetProviders()
 	if len(authzProviders) > 0 && currentUser != nil {

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -1,13 +1,7 @@
 error_log stderr;
 pid dev/nginx.pid;
 
-worker_processes auto;
-worker_rlimit_nofile 100000;
-
 events {
-    worker_connections 4000;
-    use epoll;
-    multi_accept on;
 }
 
 http {
@@ -37,6 +31,4 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
-
-    keepalive_requests 100000;
 }

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -8,14 +8,12 @@ import (
 	"strconv"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/bitbucketserver"
-	"github.com/sourcegraph/sourcegraph/pkg/trace"
 )
 
 // Provider is an implementation of AuthzProvider that provides repository permissions as
@@ -73,27 +71,11 @@ func (p *Provider) Repos(ctx context.Context, repos map[authz.Repo]struct{}) (mi
 // RepoPerms returns the permissions the given external account has in relation to the given set of repos.
 // It performs a single HTTP request against the Bitbucket Server API which returns all repositories
 // the authenticated user has permissions to read.
-func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (authorized map[api.RepoName]map[authz.Perm]bool, err error) {
+func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, repos map[authz.Repo]struct{}) (map[api.RepoName]map[authz.Perm]bool, error) {
 	var (
 		userName string
 		userID   int32
 	)
-
-	tr, ctx := trace.New(ctx, "bitbucket.authz.provider.RepoPerms", "")
-	defer func() {
-		tr.LogFields(
-			otlog.String("user.name", userName),
-			otlog.Int32("user.id", userID),
-			otlog.Int("repos.count", len(repos)),
-			otlog.Int("authorized.count", len(authorized)),
-		)
-
-		if err != nil {
-			tr.SetError(err)
-		}
-
-		tr.Finish()
-	}()
 
 	if acct != nil && acct.ServiceID == p.codeHost.ServiceID && acct.ServiceType == p.codeHost.ServiceType {
 		var user bitbucketserver.User
@@ -134,7 +116,7 @@ func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, 
 		Type:   "repos",
 	}
 
-	err = p.store.LoadPermissions(ctx, &ps, update)
+	err := p.store.LoadPermissions(ctx, &ps, update)
 	if err != nil {
 		return nil, err
 	}
@@ -143,24 +125,10 @@ func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, 
 }
 
 // FetchAccount satisfies the authz.Provider interface.
-func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*extsvc.ExternalAccount) (acct *extsvc.ExternalAccount, err error) {
+func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*extsvc.ExternalAccount) (*extsvc.ExternalAccount, error) {
 	if user == nil {
 		return nil, nil
 	}
-
-	tr, ctx := trace.New(ctx, "bitbucket.authz.provider.FetchAccount", "")
-	defer func() {
-		tr.LogFields(
-			otlog.String("user.name", user.Username),
-			otlog.Int32("user.id", user.ID),
-		)
-
-		if err != nil {
-			tr.SetError(err)
-		}
-
-		tr.Finish()
-	}()
 
 	bitbucketUser, err := p.user(ctx, user.Username)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/keegancsmith/sqlf"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
-	"github.com/sourcegraph/sourcegraph/pkg/trace"
 )
 
 // A store of Permissions with in-memory caching, safe for concurrent use.
@@ -69,9 +67,6 @@ func (s *store) LoadPermissions(
 	p **Permissions,
 	update func() (objectIDs []uint32, _ error),
 ) (err error) {
-	ctx, save := s.observe(ctx, "LoadPermissions", "")
-	defer func() { save(*p, &err) }()
-
 	if s == nil {
 		return nil
 	}
@@ -93,7 +88,7 @@ func (s *store) LoadPermissions(
 	}
 
 	// Load the permissions with a read lock.
-	if err = s.load(ctx, stored, "SHARE"); err != nil {
+	if err = s.load(ctx, stored, false); err != nil {
 		return err
 	}
 
@@ -115,14 +110,10 @@ func (s *store) LoadPermissions(
 	return nil
 }
 
-func (s *store) load(ctx context.Context, p *Permissions, lock string) (err error) {
-	ctx, save := s.observe(ctx, "load", lock)
-	defer save(p, &err)
+func (s *store) load(ctx context.Context, p *Permissions, update bool) error {
+	q := s.loadQuery(p, update)
 
-	q := s.loadQuery(p, lock)
-
-	var rows *sql.Rows
-	rows, err = s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return err
 	}
@@ -149,7 +140,14 @@ func (s *store) load(ctx context.Context, p *Permissions, lock string) (err erro
 	return p.IDs.UnmarshalBinary(ids)
 }
 
-func (s *store) loadQuery(p *Permissions, lock string) *sqlf.Query {
+func (s *store) loadQuery(p *Permissions, update bool) *sqlf.Query {
+	var lock string
+	if update {
+		lock = "FOR UPDATE" // Exclusive write lock (one writer)
+	} else {
+		lock = "FOR SHARE" // Shared read lock (many readers)
+	}
+
 	return sqlf.Sprintf(
 		loadQueryFmtStr+lock,
 		p.UserID,
@@ -163,15 +161,12 @@ const loadQueryFmtStr = `
 SELECT object_ids, updated_at
 FROM user_permissions
 WHERE user_id = %s AND permission = %s AND object_type = %s
-FOR `
+`
 
 func (s *store) update(ctx context.Context, p *Permissions, update func() ([]uint32, error)) (err error) {
-	ctx, save := s.observe(ctx, "update", "")
-	defer save(p, &err)
-
 	// Open a transaction for concurrency control.
-	var tx *sql.Tx
-	if tx, err = s.tx(ctx); err != nil {
+	tx, err := s.tx(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -194,7 +189,7 @@ func (s *store) update(ctx context.Context, p *Permissions, update func() ([]uin
 	//
 	// This means other processes will block until the cache fill succeeds,
 	// which is the desired behaviour.
-	if err = txs.load(ctx, p, "UPDATE"); err != nil {
+	if err = txs.load(ctx, p, true); err != nil {
 		return err
 	}
 
@@ -231,17 +226,13 @@ func (s *store) tx(ctx context.Context) (*sql.Tx, error) {
 	}
 }
 
-func (s *store) upsert(ctx context.Context, p *Permissions) (err error) {
-	ctx, save := s.observe(ctx, "upsert", "")
-	defer save(p, &err)
-
-	var q *sqlf.Query
-	if q, err = s.upsertQuery(p); err != nil {
+func (s *store) upsert(ctx context.Context, p *Permissions) error {
+	q, err := s.upsertQuery(p)
+	if err != nil {
 		return err
 	}
 
-	var rows *sql.Rows
-	rows, err = s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return err
 	}
@@ -281,39 +272,6 @@ DO UPDATE SET
   object_ids = excluded.object_ids,
   updated_at = excluded.updated_at
 `
-
-func (s *store) observe(ctx context.Context, family, title string) (context.Context, func(*Permissions, *error)) {
-	began := s.clock()
-	tr, ctx := trace.New(ctx, "bitbucket.authz.store."+family, title)
-
-	return ctx, func(ps *Permissions, err *error) {
-		now := s.clock()
-		took := now.Sub(began)
-
-		fields := []otlog.Field{
-			otlog.String("Duration", took.String()),
-			otlog.Int32("Permissions.UserID", ps.UserID),
-			otlog.String("Permissions.Perm", string(ps.Perm)),
-			otlog.String("Permissions.Type", ps.Type),
-		}
-
-		if ps.IDs != nil {
-			fields = append(fields,
-				otlog.Uint64("Permissions.IDs.Count", ps.IDs.GetCardinality()),
-				otlog.String("Permissions.UpdatedAt", ps.UpdatedAt.String()),
-			)
-		}
-
-		tr.LogFields(fields...)
-
-		success := err == nil || *err == nil
-		if !success {
-			tr.SetError(*err)
-		}
-
-		tr.Finish()
-	}
-}
 
 // A store's in-memory read-through cache used in LoadPermissions.
 type cache struct {

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -172,7 +172,7 @@
         "ttl": {
           "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
-          "default": "3h"
+          "default": "30m"
         }
       }
     }

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -177,7 +177,7 @@ const BitbucketServerSchemaJSON = `{
         "ttl": {
           "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
-          "default": "3h"
+          "default": "30m"
         }
       }
     }

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -404,7 +404,7 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
                             consumerKey: '<consumer key>',
                             signingKey: '<signing key>',
                         },
-                        ttl: '3h',
+                        ttl: '30m',
                     }
                     const comment = `// Follow setup instructions in https://docs.sourcegraph.com/admin/repo/permissions#bitbucket_server`
                     const edit = editWithComment(config, ['authorization'], value, comment)


### PR DESCRIPTION
This reverts commit 09c8a1b8cbfa7cf695fdd589c50122461124b340.

`epoll` is not supported in Mac.

