### PR TITLE
Unrevert instrumentation for Bitbucket Server ACLs

### DIFF
--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -172,7 +172,7 @@
         "ttl": {
           "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
-          "default": "30m"
+          "default": "3h"
         }
       }
     }

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -177,7 +177,7 @@ const BitbucketServerSchemaJSON = `{
         "ttl": {
           "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
-          "default": "30m"
+          "default": "3h"
         }
       }
     }

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -404,7 +404,7 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
                             consumerKey: '<consumer key>',
                             signingKey: '<signing key>',
                         },
-                        ttl: '30m',
+                        ttl: '3h',
                     }
                     const comment = `// Follow setup instructions in https://docs.sourcegraph.com/admin/repo/permissions#bitbucket_server`
                     const edit = editWithComment(config, ['authorization'], value, comment)


### PR DESCRIPTION
We add back this PR, but exclude the changes to nginx.conf.

Revert "Revert "authz: Instrument Bitbucket Server ACLs code paths with tracing (#4642)" (#4678)"

This reverts commit 511fe1eabfacf5bf57aba7ca69ddc297841e6485.