### PR TITLE
Bext e2e: launch puppeteer with headless: false

### DIFF
--- a/browser/src/e2e/e2e.test.ts
+++ b/browser/src/e2e/e2e.test.ts
@@ -80,7 +80,7 @@ describe(`Sourcegraph ${startCase(BROWSER)} extension`, () => {
                     console.warn('Running as root, disabling sandbox')
                     args = [...args, '--no-sandbox', '--disable-setuid-sandbox']
                 }
-                browser = await puppeteer.launch({ args })
+                browser = await puppeteer.launch({ args, headless: false })
             } else {
                 // Make sure CSP is disabled in FF preferences,
                 // because Puppeteer uses new Function() to evaluate code


### PR DESCRIPTION
`headless:false` was removed in https://github.com/sourcegraph/sourcegraph/commit/69fab829fb3efd6ccc0abac2466d80eb5c4e5219, but it appears to break e2e tests: https://buildkite.com/sourcegraph/sourcegraph/builds/38641#f60d5b4b-e544-4f46-89da-7fa16fcd4b41 (I also reproduced this locally).
