### PR TITLE
search: Bump background timeout of Zoekt.ListAll to 1min

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -895,7 +895,9 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		if err != nil {
 			// Don't hard fail if index is not available yet.
 			tr.LogFields(otlog.String("indexErr", err.Error()))
-			log15.Warn("zoektIndexedRepos failed", "error", err)
+			if ctx.Err() == nil {
+				log15.Warn("zoektIndexedRepos failed", "error", err)
+			}
 			common.indexUnavailable = true
 			err = nil
 		}

--- a/pkg/search/backend/text.go
+++ b/pkg/search/backend/text.go
@@ -107,7 +107,7 @@ func (c *Zoekt) start() {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		listResp, listErr := c.Client.List(ctx, &zoektquery.Const{Value: true})
 		cancel()
 


### PR DESCRIPTION
Noticed on a large instance lots of context cancelled errors for List. This is
the most likely cause.