### PR TITLE
dev: Fix `notest` docker build branches

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -74,6 +74,67 @@ func main() {
 		}
 	}
 
+	// addDockerImageStep adds a build step for a given app.
+	// If the app is not in the cmd directory, it is assumed to be from the open source repo.
+	addDockerImageStep := func(app string, insiders bool) {
+		cmds := []bk.StepOpt{
+			bk.Cmd(fmt.Sprintf(`echo "Building %s..."`, app)),
+		}
+
+		cmdDir := "cmd/" + app
+		if _, err := os.Stat(filepath.Join("enterprise", cmdDir)); err != nil {
+			fmt.Fprintf(os.Stderr, "github.com/sourcegraph/sourcegraph/enterprise/cmd/%s does not exist so building github.com/sourcegraph/sourcegraph/cmd/%s instead\n", app, app)
+		} else {
+			cmds = append(cmds, bk.Cmd("pushd enterprise"))
+		}
+
+		preBuildScript := cmdDir + "/pre-build.sh"
+		if _, err := os.Stat(preBuildScript); err == nil {
+			cmds = append(cmds, bk.Cmd(preBuildScript))
+		}
+
+		image := "sourcegraph/" + app
+
+		getBuildScript := func() string {
+			buildScriptByApp := map[string]string{
+				"symbols": "env BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImage",
+				// The server image was built prior to e2e tests in a previous step.
+				"server": fmt.Sprintf("docker tag %s:%s_candidate %s:%s", image, version, image, version),
+			}
+			if buildScript, ok := buildScriptByApp[app]; ok {
+				return buildScript
+			}
+			return cmdDir + "/build.sh"
+		}
+
+		cmds = append(cmds,
+			bk.Env("IMAGE", image+":"+version),
+			bk.Env("VERSION", version),
+			bk.Cmd(getBuildScript()),
+		)
+
+		if app != "server" || taggedRelease {
+			cmds = append(cmds,
+				bk.Cmd(fmt.Sprintf("docker push %s:%s", image, version)),
+			)
+		}
+
+		if app == "server" && releaseBranch {
+			cmds = append(cmds,
+				bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s-insiders", image, version, image, branch)),
+				bk.Cmd(fmt.Sprintf("docker push %s:%s-insiders", image, branch)),
+			)
+		}
+
+		if insiders {
+			cmds = append(cmds,
+				bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:insiders", image, version, image)),
+				bk.Cmd(fmt.Sprintf("docker push %s:insiders", image)),
+			)
+		}
+		pipeline.AddStep(":docker:", cmds...)
+	}
+
 	isPR := !isBextReleaseBranch &&
 		!releaseBranch &&
 		!taggedRelease &&
@@ -100,6 +161,12 @@ func main() {
 				bk.Cmd("./dev/check/docsite.sh"))
 			return
 		}
+	}
+
+	if strings.HasPrefix(branch, "docker-images-patch-notest/") {
+		version = version + "_patch"
+		addDockerImageStep(branch[27:], false)
+		return
 	}
 
 	if !isBextReleaseBranch {
@@ -195,73 +262,6 @@ func main() {
 		bk.Cmd("buildkite-agent artifact download 'coverage.txt' . || true"), // ignore error when no report exists
 		bk.Cmd("buildkite-agent artifact download '*/coverage-final.json' . || true"),
 		bk.Cmd("bash <(curl -s https://codecov.io/bash) -X gcov -X coveragepy -X xcode"))
-
-	// addDockerImageStep adds a build step for a given app.
-	// If the app is not in the cmd directory, it is assumed to be from the open source repo.
-	addDockerImageStep := func(app string, insiders bool) {
-		cmds := []bk.StepOpt{
-			bk.Cmd(fmt.Sprintf(`echo "Building %s..."`, app)),
-		}
-
-		cmdDir := "cmd/" + app
-		if _, err := os.Stat(filepath.Join("enterprise", cmdDir)); err != nil {
-			fmt.Fprintf(os.Stderr, "github.com/sourcegraph/sourcegraph/enterprise/cmd/%s does not exist so building github.com/sourcegraph/sourcegraph/cmd/%s instead\n", app, app)
-		} else {
-			cmds = append(cmds, bk.Cmd("pushd enterprise"))
-		}
-
-		preBuildScript := cmdDir + "/pre-build.sh"
-		if _, err := os.Stat(preBuildScript); err == nil {
-			cmds = append(cmds, bk.Cmd(preBuildScript))
-		}
-
-		image := "sourcegraph/" + app
-
-		getBuildScript := func() string {
-			buildScriptByApp := map[string]string{
-				"symbols": "env BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImage",
-				// The server image was built prior to e2e tests in a previous step.
-				"server": fmt.Sprintf("docker tag %s:%s_candidate %s:%s", image, version, image, version),
-			}
-			if buildScript, ok := buildScriptByApp[app]; ok {
-				return buildScript
-			}
-			return cmdDir + "/build.sh"
-		}
-
-		cmds = append(cmds,
-			bk.Env("IMAGE", image+":"+version),
-			bk.Env("VERSION", version),
-			bk.Cmd(getBuildScript()),
-		)
-
-		if app != "server" || taggedRelease {
-			cmds = append(cmds,
-				bk.Cmd(fmt.Sprintf("docker push %s:%s", image, version)),
-			)
-		}
-
-		if app == "server" && releaseBranch {
-			cmds = append(cmds,
-				bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s-insiders", image, version, image, branch)),
-				bk.Cmd(fmt.Sprintf("docker push %s:%s-insiders", image, branch)),
-			)
-		}
-
-		if insiders {
-			cmds = append(cmds,
-				bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:insiders", image, version, image)),
-				bk.Cmd(fmt.Sprintf("docker push %s:insiders", image)),
-			)
-		}
-		pipeline.AddStep(":docker:", cmds...)
-	}
-
-	if strings.HasPrefix(branch, "docker-images-patch-notest/") {
-		version = version + "_patch"
-		addDockerImageStep(branch[27:], false)
-		return
-	}
 
 	addBrowserExtensionReleaseSteps := func() {
 		for _, browser := range []string{"chrome", "firefox"} {


### PR DESCRIPTION
The idea behind the `docker-images-patch-notest/<IMAGE>` branches was that you could push to them to build a Docker image on CI without running through the test suite (hence the `notest` in the name).

All this change here does is move the existing code around so that the check for the branch name results in the early exit that we want.

To test I pushed this branch here to the a notest-branch:

```
$ git push origin docker/fix-notest-branches:docker-images-patch-notest/frontend --force
```

The resulting build only generates a pipeline and runs a Docker image build. See here: https://buildkite.com/sourcegraph/sourcegraph/builds/38666#efe8245a-872f-44ad-98cc-a2a71e61c853

**Question:** is that correct or should we run more steps?
