### PR TITLE
Benchmark in-memory, index-only search

### DIFF
--- a/cmd/frontend/db/repos_mock.go
+++ b/cmd/frontend/db/repos_mock.go
@@ -44,7 +44,7 @@ func (s *MockRepos) MockGet_Return(t *testing.T, returns *types.Repo) (called *b
 	return
 }
 
-func (s *MockRepos) MockGetByName(t *testing.T, want api.RepoName, repo api.RepoID) (called *bool) {
+func (s *MockRepos) MockGetByName(t testing.TB, want api.RepoName, repo api.RepoID) (called *bool) {
 	called = new(bool)
 	s.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
 		*called = true
@@ -57,7 +57,7 @@ func (s *MockRepos) MockGetByName(t *testing.T, want api.RepoName, repo api.Repo
 	return
 }
 
-func (s *MockRepos) MockList(t *testing.T, wantRepos ...api.RepoName) (called *bool) {
+func (s *MockRepos) MockList(t testing.TB, wantRepos ...api.RepoName) (called *bool) {
 	called = new(bool)
 	s.List = func(ctx context.Context, opt ReposListOptions) ([]*types.Repo, error) {
 		*called = true

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -70,6 +70,7 @@ func (r *schemaResolver) Search(args *struct {
 	}
 	return &searchResolver{
 		query: q,
+		zoekt: IndexedSearch(),
 	}, nil
 }
 
@@ -94,6 +95,8 @@ type searchResolver struct {
 	repoResults               []*searchSuggestionResolver
 	repoOverLimit             bool
 	repoErr                   error
+
+	zoekt *searchbackend.Zoekt
 }
 
 // rawQuery returns the original query string input.
@@ -568,6 +571,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		Repos:           repos,
 		Query:           r.query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
+		Zoekt:           r.zoekt,
 	}
 	if err := args.Pattern.Validate(); err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -92,7 +92,6 @@ type searchResolver struct {
 	// Cached resolveRepositories results.
 	reposMu                   sync.Mutex
 	repoRevs, missingRepoRevs []*search.RepositoryRevisions
-	repoResults               []*searchSuggestionResolver
 	repoOverLimit             bool
 	repoErr                   error
 
@@ -200,22 +199,22 @@ func getSampleRepos(ctx context.Context) ([]*types.Repo, error) {
 
 // resolveRepositories calls doResolveRepositories, caching the result for the common
 // case where effectiveRepoFieldValues == nil.
-func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, repoResults []*searchSuggestionResolver, overLimit bool, err error) {
+func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, overLimit bool, err error) {
 	tr, ctx := trace.New(ctx, "graphql.resolveRepositories", fmt.Sprintf("effectiveRepoFieldValues: %v", effectiveRepoFieldValues))
 	defer func() {
 		if err != nil {
 			tr.SetError(err)
 		} else {
-			tr.LazyPrintf("numRepoRevs: %d, numMissingRepoRevs: %d, numRepoResults: %d, overLimit: %v", len(repoRevs), len(missingRepoRevs), len(repoResults), overLimit)
+			tr.LazyPrintf("numRepoRevs: %d, numMissingRepoRevs: %d, overLimit: %v", len(repoRevs), len(missingRepoRevs), overLimit)
 		}
 		tr.Finish()
 	}()
 	if effectiveRepoFieldValues == nil {
 		r.reposMu.Lock()
 		defer r.reposMu.Unlock()
-		if r.repoRevs != nil || r.missingRepoRevs != nil || r.repoResults != nil || r.repoErr != nil {
+		if r.repoRevs != nil || r.missingRepoRevs != nil || r.repoErr != nil {
 			tr.LazyPrintf("cached")
-			return r.repoRevs, r.missingRepoRevs, r.repoResults, r.repoOverLimit, r.repoErr
+			return r.repoRevs, r.missingRepoRevs, r.repoOverLimit, r.repoErr
 		}
 	}
 
@@ -234,7 +233,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 	commitAfter, _ := r.query.StringValue(query.FieldRepoHasCommitAfter)
 
 	tr.LazyPrintf("resolveRepositories - start")
-	repoRevs, missingRepoRevs, repoResults, overLimit, err = resolveRepositories(ctx, resolveRepoOp{
+	repoRevs, missingRepoRevs, overLimit, err = resolveRepositories(ctx, resolveRepoOp{
 		repoFilters:      repoFilters,
 		minusRepoFilters: minusRepoFilters,
 		repoGroupFilters: repoGroupFilters,
@@ -248,11 +247,10 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 	if effectiveRepoFieldValues == nil {
 		r.repoRevs = repoRevs
 		r.missingRepoRevs = missingRepoRevs
-		r.repoResults = repoResults
 		r.repoOverLimit = overLimit
 		r.repoErr = err
 	}
-	return repoRevs, missingRepoRevs, repoResults, overLimit, err
+	return repoRevs, missingRepoRevs, overLimit, err
 }
 
 // a patternRevspec maps an include pattern to a list of revisions
@@ -359,7 +357,7 @@ type resolveRepoOp struct {
 	commitAfter      string
 }
 
-func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, missingRepoRevisions []*search.RepositoryRevisions, repoResolvers []*searchSuggestionResolver, overLimit bool, err error) {
+func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, missingRepoRevisions []*search.RepositoryRevisions, overLimit bool, err error) {
 	tr, ctx := trace.New(ctx, "resolveRepositories", fmt.Sprintf("%+v", op))
 	defer func() {
 		tr.SetError(err)
@@ -381,7 +379,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	if groupNames := op.repoGroupFilters; len(groupNames) > 0 {
 		groups, err := resolveRepoGroups(ctx)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		var patterns []string
 		for _, groupName := range groupNames {
@@ -401,7 +399,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	// revision specs, if they had any.
 	includePatternRevs, err := findPatternRevs(includePatterns)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	tr.LazyPrintf("Repos.List - start")
@@ -418,7 +416,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	})
 	tr.LazyPrintf("Repos.List - done")
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 	overLimit = len(repos) >= maxRepoListSize
 
@@ -481,7 +479,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		repoRevisions, err = filterRepoHasCommitAfter(ctx, repoRevisions, op.commitAfter)
 	}
 
-	return repoRevisions, missingRepoRevisions, repoResolvers, overLimit, err
+	return repoRevisions, missingRepoRevisions, overLimit, err
 }
 
 func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.RepositoryRevisions, after string) ([]*search.RepositoryRevisions, error) {
@@ -544,7 +542,7 @@ func optimizeRepoPatternWithHeuristics(repoPattern string) string {
 }
 
 func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*searchSuggestionResolver, error) {
-	repos, _, _, overLimit, err := r.resolveRepositories(ctx, nil)
+	repos, _, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -232,7 +232,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAler
 	//
 	// TODO(sqs): this logic can be significantly improved, but it's better than
 	// nothing for now.
-	repos, _, _, _, err := r.resolveRepositories(ctx, nil, false)
+	repos, _, _, _, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ outer:
 		repoFieldValues = append(repoFieldValues, repoParentPattern)
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
-		_, _, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues, false)
+		_, _, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
 		if ctx.Err() != nil {
 			continue
 		} else if err != nil {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -80,7 +80,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 		a.title = "Expand your repository filters to see results"
 		a.description = fmt.Sprintf("No repositories in repogroup:%s satisfied all of your repo: filters.", repoGroupFilters[0])
 
-		repos1, _, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: repoFilters, minusRepoFilters: minusRepoFilters, onlyForks: onlyForks, noForks: noForks})
+		repos1, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: repoFilters, minusRepoFilters: minusRepoFilters, onlyForks: onlyForks, noForks: noForks})
 		if err != nil {
 			return nil, err
 		}
@@ -92,7 +92,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 		}
 
 		unionRepoFilter := unionRegExps(repoFilters)
-		repos2, _, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: []string{unionRepoFilter}, minusRepoFilters: minusRepoFilters, repoGroupFilters: repoGroupFilters, onlyForks: onlyForks, noForks: noForks})
+		repos2, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: []string{unionRepoFilter}, minusRepoFilters: minusRepoFilters, repoGroupFilters: repoGroupFilters, onlyForks: onlyForks, noForks: noForks})
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 		a.title = "Expand your repository filters to see results"
 		a.description = fmt.Sprintf("No repositories in repogroup:%s satisfied your repo: filter.", repoGroupFilters[0])
 
-		repos1, _, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: repoFilters, minusRepoFilters: minusRepoFilters, noForks: noForks, onlyForks: onlyForks})
+		repos1, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: repoFilters, minusRepoFilters: minusRepoFilters, noForks: noForks, onlyForks: onlyForks})
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +136,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) (*searchAl
 		a.description = fmt.Sprintf("No repositories satisfied all of your repo: filters.")
 
 		unionRepoFilter := unionRegExps(repoFilters)
-		repos2, _, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: []string{unionRepoFilter}, minusRepoFilters: minusRepoFilters, repoGroupFilters: repoGroupFilters, noForks: noForks, onlyForks: onlyForks})
+		repos2, _, _, err := resolveRepositories(ctx, resolveRepoOp{repoFilters: []string{unionRepoFilter}, minusRepoFilters: minusRepoFilters, repoGroupFilters: repoGroupFilters, noForks: noForks, onlyForks: onlyForks})
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +232,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAler
 	//
 	// TODO(sqs): this logic can be significantly improved, but it's better than
 	// nothing for now.
-	repos, _, _, _, err := r.resolveRepositories(ctx, nil)
+	repos, _, _, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ outer:
 		repoFieldValues = append(repoFieldValues, repoParentPattern)
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
-		_, _, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
+		_, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
 		if ctx.Err() != nil {
 			continue
 		} else if err != nil {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -232,7 +232,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) (*searchAler
 	//
 	// TODO(sqs): this logic can be significantly improved, but it's better than
 	// nothing for now.
-	repos, _, _, _, err := r.resolveRepositories(ctx, nil)
+	repos, _, _, _, err := r.resolveRepositories(ctx, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ outer:
 		repoFieldValues = append(repoFieldValues, repoParentPattern)
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
-		_, _, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues)
+		_, _, _, overLimit, err := r.resolveRepositories(ctx, repoFieldValues, false)
 		if ctx.Err() != nil {
 			continue
 		} else if err != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -763,7 +763,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 	defer cancel()
 
-	repos, missingRepoRevs, _, overLimit, err := r.resolveRepositories(ctx, nil)
+	repos, missingRepoRevs, _, overLimit, err := r.resolveRepositories(ctx, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -792,6 +792,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		Repos:           repos,
 		Query:           r.query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
+		Zoekt:           r.zoekt,
 	}
 	if err := args.Pattern.Validate(); err != nil {
 		return nil, &badRequestError{err}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -763,7 +763,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 	defer cancel()
 
-	repos, missingRepoRevs, _, overLimit, err := r.resolveRepositories(ctx, nil, false)
+	repos, missingRepoRevs, _, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -763,7 +763,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 	defer cancel()
 
-	repos, missingRepoRevs, _, overLimit, err := r.resolveRepositories(ctx, nil)
+	repos, missingRepoRevs, overLimit, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -191,11 +191,6 @@ func BenchmarkSearchResults(b *testing.B) {
 	}
 	defer func() { db.Mocks = db.MockStores{} }()
 
-	mockSearchSymbols = func(ctx context.Context, args *search.Args, limit int) (res []*fileMatchResolver, common *searchResultsCommon, err error) {
-		return nil, nil, nil
-	}
-	defer func() { mockSearchSymbols = nil }()
-
 	b.ResetTimer()
 	b.ReportAllocs()
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -161,7 +161,7 @@ func BenchmarkSearchResults(b *testing.B) {
 
 	// File matches in search result by Zoekt
 	var zoektFileMatches []zoekt.FileMatch
-	for i := 1; i <= 300; i++ {
+	for i := 1; i <= 50; i++ {
 		repoName := fmt.Sprintf("repo-%d", i)
 		fileName := fmt.Sprintf("foobar-%d.go", i)
 
@@ -200,14 +200,17 @@ func BenchmarkSearchResults(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		q, err := query.ParseAndCheck(`print index:only`)
+		q, err := query.ParseAndCheck(`print index:only count:350`)
 		if err != nil {
 			b.Fatal(err)
 		}
 		resolver := &searchResolver{query: q, zoekt: z}
-		_, err = resolver.Results(context.Background())
+		results, err := resolver.Results(context.Background())
 		if err != nil {
 			b.Fatal("Results:", err)
+		}
+		if int(results.MatchCount()) != len(zoektFileMatches) {
+			b.Fatalf("wrong results length. want=%d, have=%d\n", len(zoektFileMatches), results.MatchCount())
 		}
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -71,7 +71,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
 
 		if len(effectiveRepoFieldValues) > 0 {
-			repoRevs, _, _, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues)
+			repoRevs, _, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues)
 
 			resolvers := make([]*searchSuggestionResolver, 0, len(repoRevs))
 			for _, rev := range repoRevs {
@@ -103,7 +103,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 	suggesters = append(suggesters, showFileSuggestions)
 
 	showSymbolMatches := func(ctx context.Context) (results []*searchSuggestionResolver, err error) {
-		repoRevs, _, _, _, err := r.resolveRepositories(ctx, nil)
+		repoRevs, _, _, err := r.resolveRepositories(ctx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"sync"
@@ -70,8 +71,17 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
 
 		if len(effectiveRepoFieldValues) > 0 {
-			_, _, repos, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues, true)
-			return repos, err
+			repoRevs, _, _, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues)
+
+			resolvers := make([]*searchSuggestionResolver, 0, len(repoRevs))
+			for _, rev := range repoRevs {
+				resolvers = append(resolvers, newSearchResultResolver(
+					&repositoryResolver{repo: rev.Repo},
+					math.MaxInt32,
+				))
+			}
+
+			return resolvers, err
 		}
 		return nil, nil
 	}
@@ -93,7 +103,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 	suggesters = append(suggesters, showFileSuggestions)
 
 	showSymbolMatches := func(ctx context.Context) (results []*searchSuggestionResolver, err error) {
-		repoRevs, _, _, _, err := r.resolveRepositories(ctx, nil, false)
+		repoRevs, _, _, _, err := r.resolveRepositories(ctx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -70,7 +70,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		effectiveRepoFieldValues = effectiveRepoFieldValues[:i]
 
 		if len(effectiveRepoFieldValues) > 0 {
-			_, _, repos, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues)
+			_, _, repos, _, err := r.resolveRepositories(ctx, effectiveRepoFieldValues, true)
 			return repos, err
 		}
 		return nil, nil
@@ -93,7 +93,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 	suggesters = append(suggesters, showFileSuggestions)
 
 	showSymbolMatches := func(ctx context.Context) (results []*searchSuggestionResolver, err error) {
-		repoRevs, _, _, _, err := r.resolveRepositories(ctx, nil)
+		repoRevs, _, _, _, err := r.resolveRepositories(ctx, nil, false)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -890,6 +890,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		searcherRepos    []*search.RepositoryRevisions = args.Repos
 		indexedRevisions map[*search.RepositoryRevisions]string
 	)
+
 	if args.Zoekt.Enabled() {
 		var err error
 		zoektRepos, searcherRepos, indexedRevisions, err = zoektIndexedRepos(ctx, args.Zoekt, args.Repos)

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -631,12 +631,6 @@ func Test_createNewRepoSetWithRepoHasFileInputs(t *testing.T) {
 	}
 }
 
-type fakeZoektClient struct{ repos *zoekt.RepoList }
-
-func (z *fakeZoektClient) List(ctx context.Context) (*zoekt.RepoList, error) {
-	return z.repos, nil
-}
-
 func Test_zoektIndexedRepos(t *testing.T) {
 	repos := makeRepositoryRevisions(
 		"foo/indexed-one@",

--- a/cmd/frontend/internal/pkg/search/search.go
+++ b/cmd/frontend/internal/pkg/search/search.go
@@ -5,6 +5,7 @@ import (
 	"regexp/syntax"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"
+	searchbackend "github.com/sourcegraph/sourcegraph/pkg/search/backend"
 )
 
 // PatternInfo is the struct used by vscode pass on search queries. Keep it in
@@ -85,4 +86,6 @@ type Args struct {
 	// repository if this field is true. Another example is we set this field
 	// to true if the user requests a specific timeout or maximum result size.
 	UseFullDeadline bool
+
+	Zoekt *searchbackend.Zoekt
 }


### PR DESCRIPTION
This adds a benchmark for `searchResolver.Results()` that uses as few mocks as possible.

In order to make this benchmark possible, we had to change the code to allow for the injection of `*searchbackend.Zoekt` into the resolver. This removes a lot of calls to the global `IndexedSearch()` function and replaces them either with accesses to the injected `r.zoekt` attribute.

It also includes one quick performance improvement that reduces memory allocations by roughly ~30%

Test plan: go test ./...
