### PR TITLE
graphqlbackend: Use an interface for searchResultResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -182,6 +182,20 @@ func (r *repositoryResolver) Matches() []*searchResultMatchResolver {
 	return r.matches
 }
 
+func (r *repositoryResolver) ToRepository() (*repositoryResolver, bool) { return r, true }
+func (r *repositoryResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
+func (r *repositoryResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+	return nil, false
+}
+
+func (r *repositoryResolver) searchResultURIs() (string, string) {
+	return string(r.repo.Name), ""
+}
+
+func (r *repositoryResolver) resultCount() int32 {
+	return 1
+}
+
 func (*schemaResolver) AddPhabricatorRepo(ctx context.Context, args *struct {
 	Callsign string
 	Name     *string

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -61,6 +61,22 @@ func (r *commitSearchResultResolver) Matches() []*searchResultMatchResolver {
 	return r.matches
 }
 
+func (r *commitSearchResultResolver) ToRepository() (*repositoryResolver, bool) { return nil, false }
+func (r *commitSearchResultResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
+func (r *commitSearchResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+	return r, true
+}
+
+func (r *commitSearchResultResolver) searchResultURIs() (string, string) {
+	// Diffs aren't going to be returned with other types of results
+	// and are already ordered in the desired order, so we'll just leave them in place.
+	return "~", "~" // lexicographically last in ASCII
+}
+
+func (r *commitSearchResultResolver) resultCount() int32 {
+	return 1
+}
+
 var mockSearchCommitDiffsInRepo func(ctx context.Context, repoRevs search.RepositoryRevisions, info *search.PatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error)
 
 func searchCommitDiffsInRepo(ctx context.Context, repoRevs search.RepositoryRevisions, info *search.PatternInfo, query *query.Query) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
@@ -416,10 +432,10 @@ func highlightMatches(pattern *regexp.Regexp, data []byte) *highlightedString {
 	}
 }
 
-var mockSearchCommitDiffsInRepos func(args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error)
+var mockSearchCommitDiffsInRepos func(args *search.Args) ([]searchResultResolver, *searchResultsCommon, error)
 
 // searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error) {
+func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]searchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitDiffsInRepos != nil {
 		return mockSearchCommitDiffsInRepos(args)
 	}
@@ -477,10 +493,10 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.Args) ([]*search
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-var mockSearchCommitLogInRepos func(args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error)
+var mockSearchCommitLogInRepos func(args *search.Args) ([]searchResultResolver, *searchResultsCommon, error)
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error) {
+func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]searchResultResolver, *searchResultsCommon, error) {
 	if mockSearchCommitLogInRepos != nil {
 		return mockSearchCommitLogInRepos(args)
 	}
@@ -538,15 +554,15 @@ func searchCommitLogInRepos(ctx context.Context, args *search.Args) ([]*searchRe
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-func commitSearchResultsToSearchResults(results []*commitSearchResultResolver) []*searchResultResolver {
+func commitSearchResultsToSearchResults(results []*commitSearchResultResolver) []searchResultResolver {
 	// Show most recent commits first.
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].commit.author.Date() > results[j].commit.author.Date()
 	})
 
-	results2 := make([]*searchResultResolver, len(results))
+	results2 := make([]searchResultResolver, len(results))
 	for i, result := range results {
-		results2[i] = &searchResultResolver{diff: result}
+		results2[i] = result
 	}
 	return results2
 }

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -9,14 +9,14 @@ import (
 	searchbackend "github.com/sourcegraph/sourcegraph/pkg/search/backend"
 )
 
-var mockSearchRepositories func(args *search.Args) ([]*searchResultResolver, *searchResultsCommon, error)
+var mockSearchRepositories func(args *search.Args) ([]searchResultResolver, *searchResultsCommon, error)
 var repoIcon = "data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K"
 
 // searchRepositories searches for repositories by name.
 //
 // For a repository to match a query, the repository's name must match all of the repo: patterns AND the
 // default patterns (i.e., the patterns that are not prefixed with any search field).
-func searchRepositories(ctx context.Context, args *search.Args, limit int32) (res []*searchResultResolver, common *searchResultsCommon, err error) {
+func searchRepositories(ctx context.Context, args *search.Args, limit int32) (res []searchResultResolver, common *searchResultsCommon, err error) {
 	if mockSearchRepositories != nil {
 		return mockSearchRepositories(args)
 	}
@@ -48,7 +48,7 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 	}
 
 	common = &searchResultsCommon{}
-	var results []*searchResultResolver
+	var results []searchResultResolver
 	for _, repo := range args.Repos {
 		if len(results) == int(limit) {
 			common.limitHit = true
@@ -63,10 +63,10 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 				}
 
 				if shouldBeAdded {
-					results = append(results, &searchResultResolver{repo: &repositoryResolver{repo: repo.Repo, icon: repoIcon}})
+					results = append(results, &repositoryResolver{repo: repo.Repo, icon: repoIcon})
 				}
 			} else {
-				results = append(results, &searchResultResolver{repo: &repositoryResolver{repo: repo.Repo, icon: repoIcon}})
+				results = append(results, &repositoryResolver{repo: repo.Repo, icon: repoIcon})
 			}
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -73,7 +73,11 @@ func TestSearchRepositories(t *testing.T) {
 		if len(res) != 1 {
 			t.Errorf("expected only one repository result `foo/one`, but got %v", len(res))
 		}
-		if res[0].repo.repo.Name != "foo/one" {
+		r, ok := res[0].ToRepository()
+		if !ok {
+			t.Fatalf("expected repo result")
+		}
+		if r.repo.Name != "foo/one" {
 			t.Errorf("expected the repository result to be `foo/one`, but got another repo")
 		}
 	})
@@ -96,7 +100,11 @@ func TestSearchRepositories(t *testing.T) {
 		if len(res) != 1 {
 			t.Errorf("expected only one repository result `foo/one`, but got %v", len(res))
 		}
-		if res[0].repo.repo.Name != "foo/one" {
+		r, ok := res[0].ToRepository()
+		if !ok {
+			t.Fatalf("expected repo result")
+		}
+		if r.repo.Name != "foo/one" {
 			t.Errorf("expected the repository result to be `foo/one`, but got another repo")
 		}
 	})

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -148,13 +148,13 @@ func (c *searchResultsCommon) update(other searchResultsCommon) {
 
 // searchResultsResolver is a resolver for the GraphQL type `SearchResults`
 type searchResultsResolver struct {
-	results []*searchResultResolver
+	results []searchResultResolver
 	searchResultsCommon
 	alert *searchAlert
 	start time.Time // when the results started being computed
 }
 
-func (sr *searchResultsResolver) Results() []*searchResultResolver {
+func (sr *searchResultsResolver) Results() []searchResultResolver {
 	return sr.results
 }
 
@@ -266,25 +266,23 @@ func (sr *searchResultsResolver) DynamicFilters() []*searchFilterResolver {
 	}
 
 	for _, result := range sr.results {
-		if result.fileMatch != nil {
+		if fm, ok := result.ToFileMatch(); ok {
 			rev := ""
-			if result.fileMatch.inputRev != nil {
-				rev = *result.fileMatch.inputRev
+			if fm.inputRev != nil {
+				rev = *fm.inputRev
 			}
-			addRepoFilter(string(result.fileMatch.repo.Name), rev, len(result.fileMatch.LineMatches()))
-			addLangFilter(result.fileMatch.JPath, len(result.fileMatch.LineMatches()), result.fileMatch.JLimitHit)
-			addFileFilter(result.fileMatch.JPath, len(result.fileMatch.LineMatches()), result.fileMatch.JLimitHit)
+			addRepoFilter(string(fm.repo.Name), rev, len(fm.LineMatches()))
+			addLangFilter(fm.JPath, len(fm.LineMatches()), fm.JLimitHit)
+			addFileFilter(fm.JPath, len(fm.LineMatches()), fm.JLimitHit)
 
-			if len(result.fileMatch.symbols) > 0 {
-				add("type:symbol", "type:symbol", 1, result.fileMatch.JLimitHit, "symbol")
+			if len(fm.symbols) > 0 {
+				add("type:symbol", "type:symbol", 1, fm.JLimitHit, "symbol")
 			}
-		}
-
-		if result.repo != nil {
+		} else if r, ok := result.ToRepository(); ok {
 			// It should be fine to leave this blank since revision specifiers
 			// can only be used with the 'repo:' scope. In that case,
 			// we shouldn't be getting any repositoy name matches back.
-			addRepoFilter(result.repo.Name(), "", 1)
+			addRepoFilter(r.Name(), "", 1)
 		}
 		// Add `case:yes` filter to offer easier access to search results matching with case sensitive set to yes
 		// We use count == 0 and limitHit == false since we can't determine that information without
@@ -423,14 +421,14 @@ func (sr *searchResultsResolver) Sparkline(ctx context.Context) (sparkline []int
 loop:
 	for _, r := range sr.results {
 		r := r // shadow so it doesn't change in the goroutine
-		switch {
-		case r.repo != nil:
+		switch m := r.(type) {
+		case *repositoryResolver:
 			// We don't care about repo results here.
 			continue
-		case r.diff != nil:
+		case *commitSearchResultResolver:
 			// Diff searches are cheap, because we implicitly have author date info.
-			addPoint(r.diff.commit.author.date)
-		case r.fileMatch != nil:
+			addPoint(m.commit.author.date)
+		case *fileMatchResolver:
 			// File match searches are more expensive, because we must blame the
 			// (first) line in order to know its placement in our sparkline.
 			blameOps++
@@ -447,7 +445,7 @@ loop:
 
 				// Blame the file match in order to retrieve date informatino.
 				var err error
-				t, err := sr.blameFileMatch(ctx, r.fileMatch)
+				t, err := sr.blameFileMatch(ctx, m)
 				if err != nil {
 					log15.Warn("failed to blame fileMatch during sparkline generation", "error", err)
 					return
@@ -826,7 +824,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	var (
 		requiredWg sync.WaitGroup
 		optionalWg sync.WaitGroup
-		results    []*searchResultResolver
+		results    []searchResultResolver
 		resultsMu  sync.Mutex
 		common     = searchResultsCommon{maxResultsCount: r.maxResults()}
 		commonMu   sync.Mutex
@@ -903,7 +901,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 					} else {
 						fileMatches[key] = symbolFileMatch
 						resultsMu.Lock()
-						results = append(results, &searchResultResolver{fileMatch: symbolFileMatch})
+						results = append(results, symbolFileMatch)
 						resultsMu.Unlock()
 					}
 					fileMatchesMu.Unlock()
@@ -943,7 +941,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 					} else {
 						fileMatches[key] = r
 						resultsMu.Lock()
-						results = append(results, &searchResultResolver{fileMatch: r})
+						results = append(results, r)
 						resultsMu.Unlock()
 					}
 					fileMatchesMu.Unlock()
@@ -1052,33 +1050,30 @@ func isContextError(ctx context.Context, err error) bool {
 	return ctx.Err() != nil || err == context.Canceled || err == context.DeadlineExceeded
 }
 
-// searchResultResolver is a resolver for the GraphQL union type `SearchResult`
+// searchResultResolver is a resolver for the GraphQL union type `SearchResult`.
+//
+// Supported types:
+//
+//   - *repositoryResolver         // repo name match
+//   - *fileMatchResolver          // text match
+//   - *commitSearchResultResolver // diff or commit match
 //
 // Note: Any new result types added here also need to be handled properly in search_results.go:301 (sparklines)
-type searchResultResolver struct {
-	repo      *repositoryResolver         // repo name match
-	fileMatch *fileMatchResolver          // text match
-	diff      *commitSearchResultResolver // diff or commit match
-}
+type searchResultResolver interface {
+	ToRepository() (*repositoryResolver, bool)
+	ToFileMatch() (*fileMatchResolver, bool)
+	ToCommitSearchResult() (*commitSearchResultResolver, bool)
 
-// getSearchResultURIs returns the repo name and file uri respectiveley
-func getSearchResultURIs(c *searchResultResolver) (string, string) {
-	if c.fileMatch != nil {
-		return string(c.fileMatch.repo.Name), c.fileMatch.JPath
-	}
-	if c.repo != nil {
-		return string(c.repo.repo.Name), ""
-	}
-	// Diffs aren't going to be returned with other types of results
-	// and are already ordered in the desired order, so we'll just leave them in place.
-	return "~", "~" // lexicographically last in ASCII
+	// SearchResultURIs returns the repo name and file uri respectiveley
+	searchResultURIs() (string, string)
+	resultCount() int32
 }
 
 // compareSearchResults checks to see if a is less than b.
 // It is implemented separately for easier testing.
-func compareSearchResults(a, b *searchResultResolver) bool {
-	arepo, afile := getSearchResultURIs(a)
-	brepo, bfile := getSearchResultURIs(b)
+func compareSearchResults(a, b searchResultResolver) bool {
+	arepo, afile := a.searchResultURIs()
+	brepo, bfile := b.searchResultURIs()
 
 	if arepo == brepo {
 		return afile < bfile
@@ -1087,34 +1082,8 @@ func compareSearchResults(a, b *searchResultResolver) bool {
 	return arepo < brepo
 }
 
-func sortResults(r []*searchResultResolver) {
+func sortResults(r []searchResultResolver) {
 	sort.Slice(r, func(i, j int) bool { return compareSearchResults(r[i], r[j]) })
-}
-
-func (g *searchResultResolver) ToRepository() (*repositoryResolver, bool) {
-	return g.repo, g.repo != nil
-}
-
-func (g *searchResultResolver) ToFileMatch() (*fileMatchResolver, bool) {
-	return g.fileMatch, g.fileMatch != nil
-}
-
-func (g *searchResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
-	return g.diff, g.diff != nil
-}
-
-func (g *searchResultResolver) resultCount() int32 {
-	switch {
-	case g.fileMatch != nil:
-		if l := len(g.fileMatch.LineMatches()); l > 0 {
-			return int32(l)
-		}
-		return 1 // 1 to count "empty" results like type:path results
-	case g.diff != nil:
-		return 1
-	default:
-		return 1
-	}
 }
 
 // regexpPatternMatchingExprsInOrder returns a regexp that matches lines that contain

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -175,9 +175,12 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 				if len(results.results) > int(*args.First) {
 					results.results = results.results[:*args.First]
 				}
+				suggestions = make([]*searchSuggestionResolver, 0, len(results.results))
 				for i, res := range results.results {
-					entryResolver := res.fileMatch.File()
-					suggestions = append(suggestions, newSearchResultResolver(entryResolver, len(results.results)-i))
+					if fm, ok := res.ToFileMatch(); ok {
+						entryResolver := fm.File()
+						suggestions = append(suggestions, newSearchResultResolver(entryResolver, len(results.results)-i))
+					}
 				}
 			}
 			return suggestions, err

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -113,6 +113,23 @@ func (fm *fileMatchResolver) LimitHit() bool {
 	return fm.JLimitHit
 }
 
+func (fm *fileMatchResolver) ToRepository() (*repositoryResolver, bool) { return nil, false }
+func (fm *fileMatchResolver) ToFileMatch() (*fileMatchResolver, bool)   { return fm, true }
+func (fm *fileMatchResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+	return nil, false
+}
+
+func (fm *fileMatchResolver) searchResultURIs() (string, string) {
+	return string(fm.repo.Name), fm.JPath
+}
+
+func (fm *fileMatchResolver) resultCount() int32 {
+	if l := len(fm.LineMatches()); l > 0 {
+		return int32(l)
+	}
+	return 1 // 1 to count "empty" results like type:path results
+}
+
 // LineMatch is the struct used by vscode to receive search results for a line
 type lineMatch struct {
 	JPreview          string     `json:"Preview"`


### PR DESCRIPTION
By just making each result type implement the To* methods, we can use
interfaces instead of our own "tagged union type". This generally leads to
much nicer code and a minor reduction in memory usage for large result sets.