### PR TITLE
graphqlbackend: Reduce allocations in zoektIndexedRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -848,7 +848,7 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 	unindexed = make([]*search.RepositoryRevisions, 0, len(revs)-len(set))
 
 	for _, rev := range revs {
-		repo, ok := set[string(rev.Repo.Name)]
+		repo, ok := set[strings.ToLower(string(rev.Repo.Name))]
 		if !ok {
 			unindexed = append(unindexed, rev)
 			continue

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -393,20 +393,20 @@ func Test_zoektSearchHEAD(t *testing.T) {
 	zeroTimeoutCtx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 	type args struct {
-		ctx              context.Context
-		query            *search.PatternInfo
-		indexedRevisions map[*search.RepositoryRevisions]string
-		repos            []*search.RepositoryRevisions
-		useFullDeadline  bool
-		searcher         zoekt.Searcher
-		opts             zoekt.SearchOptions
-		since            func(time.Time) time.Duration
+		ctx             context.Context
+		query           *search.PatternInfo
+		indexedCommits  map[*search.RepositoryRevisions]string
+		repos           []*search.RepositoryRevisions
+		useFullDeadline bool
+		searcher        zoekt.Searcher
+		opts            zoekt.SearchOptions
+		since           func(time.Time) time.Duration
 	}
 
 	singleRepositoryRevisions := []*search.RepositoryRevisions{
 		{Repo: &types.Repo{}},
 	}
-	singleIndexedRevisions := map[*search.RepositoryRevisions]string{
+	singleIndexedCommits := map[*search.RepositoryRevisions]string{
 		singleRepositoryRevisions[0]: "abc",
 	}
 
@@ -421,14 +421,14 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		{
 			name: "returns no error if search completed with no matches before timeout",
 			args: args{
-				ctx:              context.Background(),
-				query:            &search.PatternInfo{PathPatternsAreRegExps: true},
-				indexedRevisions: singleIndexedRevisions,
-				repos:            singleRepositoryRevisions,
-				useFullDeadline:  false,
-				searcher:         &fakeSearcher{result: &zoekt.SearchResult{}},
-				opts:             zoekt.SearchOptions{MaxWallTime: time.Second},
-				since:            func(time.Time) time.Duration { return time.Second - time.Millisecond },
+				ctx:             context.Background(),
+				query:           &search.PatternInfo{PathPatternsAreRegExps: true},
+				indexedCommits:  singleIndexedCommits,
+				repos:           singleRepositoryRevisions,
+				useFullDeadline: false,
+				searcher:        &fakeSearcher{result: &zoekt.SearchResult{}},
+				opts:            zoekt.SearchOptions{MaxWallTime: time.Second},
+				since:           func(time.Time) time.Duration { return time.Second - time.Millisecond },
 			},
 			wantFm:            nil,
 			wantLimitHit:      false,
@@ -438,14 +438,14 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		{
 			name: "returns error if max wall time is exceeded but no matches have been found yet",
 			args: args{
-				ctx:              context.Background(),
-				query:            &search.PatternInfo{PathPatternsAreRegExps: true},
-				indexedRevisions: singleIndexedRevisions,
-				repos:            singleRepositoryRevisions,
-				useFullDeadline:  false,
-				searcher:         &fakeSearcher{result: &zoekt.SearchResult{}},
-				opts:             zoekt.SearchOptions{MaxWallTime: time.Second},
-				since:            func(time.Time) time.Duration { return time.Second },
+				ctx:             context.Background(),
+				query:           &search.PatternInfo{PathPatternsAreRegExps: true},
+				indexedCommits:  singleIndexedCommits,
+				repos:           singleRepositoryRevisions,
+				useFullDeadline: false,
+				searcher:        &fakeSearcher{result: &zoekt.SearchResult{}},
+				opts:            zoekt.SearchOptions{MaxWallTime: time.Second},
+				since:           func(time.Time) time.Duration { return time.Second },
 			},
 			wantFm:            nil,
 			wantLimitHit:      false,
@@ -455,14 +455,14 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		{
 			name: "returns error if context timeout already passed",
 			args: args{
-				ctx:              zeroTimeoutCtx,
-				query:            &search.PatternInfo{PathPatternsAreRegExps: true},
-				indexedRevisions: singleIndexedRevisions,
-				repos:            singleRepositoryRevisions,
-				useFullDeadline:  true,
-				searcher:         &fakeSearcher{result: &zoekt.SearchResult{}},
-				opts:             zoekt.SearchOptions{},
-				since:            func(time.Time) time.Duration { return 0 },
+				ctx:             zeroTimeoutCtx,
+				query:           &search.PatternInfo{PathPatternsAreRegExps: true},
+				indexedCommits:  singleIndexedCommits,
+				repos:           singleRepositoryRevisions,
+				useFullDeadline: true,
+				searcher:        &fakeSearcher{result: &zoekt.SearchResult{}},
+				opts:            zoekt.SearchOptions{},
+				since:           func(time.Time) time.Duration { return 0 },
 			},
 			wantFm:            nil,
 			wantLimitHit:      false,
@@ -472,14 +472,14 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		{
 			name: "returns error if searcher returns an error",
 			args: args{
-				ctx:              context.Background(),
-				query:            &search.PatternInfo{PathPatternsAreRegExps: true},
-				indexedRevisions: singleIndexedRevisions,
-				repos:            singleRepositoryRevisions,
-				useFullDeadline:  true,
-				searcher:         &errorSearcher{err: errors.New("womp womp")},
-				opts:             zoekt.SearchOptions{},
-				since:            func(time.Time) time.Duration { return 0 },
+				ctx:             context.Background(),
+				query:           &search.PatternInfo{PathPatternsAreRegExps: true},
+				indexedCommits:  singleIndexedCommits,
+				repos:           singleRepositoryRevisions,
+				useFullDeadline: true,
+				searcher:        &errorSearcher{err: errors.New("womp womp")},
+				opts:            zoekt.SearchOptions{},
+				since:           func(time.Time) time.Duration { return 0 },
 			},
 			wantFm:            nil,
 			wantLimitHit:      false,
@@ -489,7 +489,7 @@ func Test_zoektSearchHEAD(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFm, gotLimitHit, gotReposLimitHit, err := zoektSearchHEAD(tt.args.ctx, tt.args.query, tt.args.repos, tt.args.indexedRevisions, tt.args.useFullDeadline, tt.args.searcher, tt.args.opts, tt.args.since)
+			gotFm, gotLimitHit, gotReposLimitHit, err := zoektSearchHEAD(tt.args.ctx, tt.args.query, tt.args.repos, tt.args.indexedCommits, tt.args.useFullDeadline, tt.args.searcher, tt.args.opts, tt.args.since)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return
@@ -666,7 +666,7 @@ func Test_zoektIndexedRepos(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{repos: zoektRepoList}}
 	ctx := context.Background()
 
-	indexed, unindexed, indexedRevisions, err := zoektIndexedRepos(ctx, zoekt, repos)
+	indexed, unindexed, indexedCommits, err := zoektIndexedRepos(ctx, zoekt, repos)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,10 +678,6 @@ func Test_zoektIndexedRepos(t *testing.T) {
 		{"indexed", indexed, makeRepositoryRevisions("foo/indexed-one@", "foo/indexed-two@", "foo/indexed-three-no-HEAD@")},
 		{"unindexed", unindexed, makeRepositoryRevisions("foo/unindexed-one", "foo/unindexed-two")},
 	} {
-		if len(assertion.have) != len(assertion.want) {
-			t.Fatalf("%s has wrong length: %d", assertion.name, len(assertion.have))
-		}
-
 		sort.Slice(assertion.have, sortRepoRevsByName(assertion.have))
 		sort.Slice(assertion.want, sortRepoRevsByName(assertion.want))
 
@@ -691,14 +687,14 @@ func Test_zoektIndexedRepos(t *testing.T) {
 		}
 	}
 
-	wantIndexedRevisions := map[*search.RepositoryRevisions]string{
+	wantIndexedCommits := map[*search.RepositoryRevisions]string{
 		repos[0]: "deadbeef",
 		repos[1]: "deadbeef",
 	}
 
-	if !reflect.DeepEqual(indexedRevisions, wantIndexedRevisions) {
-		diff := cmp.Diff(indexedRevisions, wantIndexedRevisions)
-		t.Fatalf("indexedRevisions has wrong revisions. diff=%s", diff)
+	if !reflect.DeepEqual(indexedCommits, wantIndexedCommits) {
+		diff := cmp.Diff(indexedCommits, wantIndexedCommits)
+		t.Fatalf("indexedCommits has wrong revisions. diff=%s", diff)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -723,7 +724,7 @@ func Benchmark_zoektIndexedRepos(b *testing.B) {
 
 		zoektRepos = append(zoektRepos, &zoekt.RepoListEntry{
 			Repository: zoekt.Repository{
-				Name:     indexedName,
+				Name:     strings.TrimSuffix(indexedName, "@"),
 				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 			},
 		})

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -57,8 +57,9 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
-	Repo *types.Repo
-	Revs []RevisionSpecifier
+	Repo              *types.Repo
+	Revs              []RevisionSpecifier
+	IndexedHEADCommit api.CommitID
 }
 
 // ParseRepositoryRevisions parses strings that refer to a repository and 0

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -57,8 +57,12 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
-	Repo              *types.Repo
-	Revs              []RevisionSpecifier
+	Repo *types.Repo
+	Revs []RevisionSpecifier
+	// IndexedHEADCommit contains the HEAD Git commit indexed by Zoekt.
+	// It is written to by zoektIndexedRepos and read later by zoektSearchHEAD.
+	// See https://github.com/sourcegraph/sourcegraph/pull/4702 for the performance
+	// rationale.
 	IndexedHEADCommit api.CommitID
 }
 

--- a/pkg/search/backend/text.go
+++ b/pkg/search/backend/text.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,10 +23,10 @@ type Zoekt struct {
 	// tests.
 	DisableCache bool
 
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	state    int32 // 0 not running, 1 running, 2 stopped
-	listResp *zoekt.RepoList
-	listErr  error
+	set      map[string]*zoekt.Repository
+	err      error
 	disabled bool
 }
 
@@ -41,26 +42,26 @@ func (c *Zoekt) String() string {
 }
 
 // ListAll returns the response of List without any restrictions.
-func (c *Zoekt) ListAll(ctx context.Context) (*zoekt.RepoList, error) {
+func (c *Zoekt) ListAll(ctx context.Context) (map[string]*zoekt.Repository, error) {
 	if !c.Enabled() {
 		// By returning an empty list Text.Search won't send any queries to
 		// Zoekt.
-		return &zoekt.RepoList{}, nil
+		return map[string]*zoekt.Repository{}, nil
 	}
 
-	c.mu.Lock()
-	r, err := c.listResp, c.listErr
-	c.mu.Unlock()
+	c.mu.RLock()
+	set, err := c.set, c.err
+	c.mu.RUnlock()
 
 	// No cached responses, start up and just do uncached query.
-	if r == nil && err == nil {
+	if set == nil && err == nil {
 		if !c.DisableCache {
 			go c.start()
 		}
-		r, err = c.Client.List(ctx, &zoektquery.Const{Value: true})
+		set, err = c.list(ctx)
 	}
 
-	return r, err
+	return set, err
 }
 
 // SetEnabled will disable zoekt if b is false.
@@ -77,6 +78,20 @@ func (c *Zoekt) Enabled() bool {
 	b := c.disabled
 	c.mu.Unlock()
 	return c.Client != nil && !b
+}
+
+func (c *Zoekt) list(ctx context.Context) (map[string]*zoekt.Repository, error) {
+	resp, err := c.Client.List(ctx, &zoektquery.Const{Value: true})
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]*zoekt.Repository, len(resp.Repos))
+	for _, r := range resp.Repos {
+		set[strings.ToLower(r.Repository.Name)] = &r.Repository
+	}
+
+	return set, nil
 }
 
 // start starts a goroutine that keeps the listResp and listErr fields updated
@@ -101,33 +116,28 @@ func (c *Zoekt) start() {
 			c.mu.Lock()
 			defer c.mu.Unlock()
 			if c.state == 1 {
-				c.state = 0
-				c.listResp, c.listErr = nil, nil
+				c.state, c.set, c.err = 0, nil, nil
 			}
 			return
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		listResp, listErr := c.Client.List(ctx, &zoektquery.Const{Value: true})
+		set, err := c.list(ctx)
 		cancel()
 
-		// Only update on error once it has happened 3 times in a row. This is
-		// to prevent us caching transient errors, and instead fallback on the
-		// old list.
-		update := true
-		if listErr != nil {
+		if err != nil {
 			errorCount++
-			if errorCount <= 3 {
-				update = false
-			}
 		} else {
 			errorCount = 0
 		}
 
 		c.mu.Lock()
 		state = c.state
-		if update {
-			c.listResp, c.listErr = listResp, listErr
+		// Only update on error once it has happened 3 times in a row. This is
+		// to prevent us caching transient errors, and instead fallback on the
+		// old list.
+		if errorCount == 0 || errorCount > 3 {
+			c.set, c.err = set, err
 		}
 		c.mu.Unlock()
 


### PR DESCRIPTION
### Original delta
```
name                   old time/op    new time/op    delta
SearchResults-16         6.13ms ±22%    6.04ms ±19%     ~     (p=0.912 n=10+10)
_zoektIndexedRepos-16    1.83ms ± 4%    1.30ms ± 2%  -29.02%  (p=0.000 n=9+9)

name                   old alloc/op   new alloc/op   delta
SearchResults-16         2.32MB ± 0%    2.39MB ± 0%   +2.84%  (p=0.000 n=10+10)
_zoektIndexedRepos-16    2.50MB ± 0%    1.16MB ± 0%  -53.82%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
SearchResults-16          20.7k ± 0%     15.8k ± 0%  -23.57%  (p=0.000 n=8+10)
_zoektIndexedRepos-16     20.1k ± 0%      0.0k ± 0%  -99.96%  (p=0.000 n=10+10)
```

### Updated delta

```
name                   old time/op    new time/op    delta
SearchResults-16         5.37ms ±13%    4.79ms ±11%  -10.73%  (p=0.004 n=10+10)
_zoektIndexedRepos-16    2.41ms ± 3%    0.58ms ± 4%  -76.02%  (p=0.000 n=10+10)

name                   old alloc/op   new alloc/op   delta
SearchResults-16         2.32MB ± 0%    1.97MB ± 0%  -14.88%  (p=0.000 n=10+10)
_zoektIndexedRepos-16    2.49MB ± 0%    0.17MB ± 1%  -93.36%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
SearchResults-16          20.7k ± 0%     15.6k ± 0%  -24.28%  (p=0.000 n=8+10)
_zoektIndexedRepos-16     20.1k ± 0%      0.0k ± 0%  -99.97%  (p=0.000 n=10+10)

```