### PR TITLE
add support for quick links from the homepage & search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The `github.exclude` setting in [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) additionally allows you to specify regular expressions with `{"pattern": "regex"}`.
+- A new [`quicklinks` setting](https://docs.sourcegraph.com/user/quick_links) allows adding links to be displayed on the homepage and search page for all users (or users in an organization).
 
 ### Changed
 
@@ -25,6 +26,12 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 ### Removed
+
+## 3.5.1 (unreleasted)
+
+### Added
+
+- A new [`quicklinks` setting](https://docs.sourcegraph.com/user/quick_links) allows adding links to be displayed on the homepage and search page for all users (or users in an organization).
 
 ## 3.5.0
 

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -116,6 +116,7 @@ var deeplyMergedSettingsFields = map[string]int{
 	"search.scopes":           1,
 	"search.savedQueries":     1,
 	"search.repositoryGroups": 1,
+	"quicklinks":              1,
 	"motd":                    1,
 	"extensions":              1,
 }

--- a/doc/user/index.md
+++ b/doc/user/index.md
@@ -31,6 +31,7 @@ All features:
 - [Usage statistics](usage_statistics.md)
 - [User surveys](user_surveys.md)
 - [Color themes](themes.md)
+- [Quick links](quick_links.md)
 
 ## What is Sourcegraph?
 

--- a/doc/user/quick_links.md
+++ b/doc/user/quick_links.md
@@ -1,0 +1,36 @@
+# Quick links
+
+It is sometimes desirable to display links that are quickly accessible to users on the homepage and search page, e.g. links to:
+
+- Important repositories in your organization
+- Internal documentation you have about Sourcegraph
+- Other links you think your Sourcegraph users would often want quick access to
+
+Sourcegraph supports setting these `quicklinks` at 3 different levels:
+
+- By site admins for all users: in the **Global settings** in the site admin area.
+- By org admins for all org members: in the org profile **Configuration** section
+- By users for themselves only: in the user profile **Configuration** section
+
+You can configure search scopes by setting the `quicklinks` property to a JSON array of `{name, url}` objects. The `url` may be any valid URL or URL path.
+
+For example, this JSON will create two quick links:
+
+```json
+{
+  // ...
+  "quicklinks": [
+    {
+      "name": "ACMECorp main repo",
+      "url": "/github.com/acmecorp/main-repository"
+    },
+    {
+      "name": "ACMECorp Sourcegraph docs",
+      "url": "https://dev.acme.com/docs/sourcegraph"
+    }
+  ]
+  // ...
+}
+```
+
+After editing and saving the configuration settings JSON you can view the new links on the homepage or search results page.

--- a/doc/user/quick_links.md
+++ b/doc/user/quick_links.md
@@ -12,7 +12,7 @@ Sourcegraph supports setting these `quicklinks` at 3 different levels:
 - By org admins for all org members: in the org profile **Configuration** section
 - By users for themselves only: in the user profile **Configuration** section
 
-You can configure search scopes by setting the `quicklinks` property to a JSON array of `{name, url}` objects. The `url` may be any valid URL or URL path.
+You can display these links by setting the `quicklinks` property to a JSON array of `{name, url}` objects. The `url` may be any valid URL or URL path.
 
 For example, this JSON will create two quick links:
 

--- a/doc/user/quick_links.md
+++ b/doc/user/quick_links.md
@@ -33,4 +33,4 @@ For example, this JSON will create two quick links:
 }
 ```
 
-After editing and saving the configuration settings JSON you can view the new links on the homepage or search results page.
+After editing and saving the settings JSON, you can view the new links on the homepage or search results page.

--- a/doc/user/quick_links.md
+++ b/doc/user/quick_links.md
@@ -9,8 +9,8 @@ It is sometimes desirable to display links that are quickly accessible to users 
 Sourcegraph supports setting these `quicklinks` at 3 different levels:
 
 - By site admins for all users: in the **Global settings** in the site admin area.
-- By org admins for all org members: in the org profile **Configuration** section
-- By users for themselves only: in the user profile **Configuration** section
+- By organization admins for all organization members: in the organization profile **Settings** section
+- By users for themselves only: in the user profile **Settings** section
 
 You can display these links by setting the `quicklinks` property to a JSON array of `{name, url}` objects. The `url` may be any valid URL or URL path.
 

--- a/doc/user/search/scopes.md
+++ b/doc/user/search/scopes.md
@@ -11,8 +11,8 @@ A search scope is any valid query. For example, a search scope that defines all 
 Custom search scopes can be specified at 3 different levels:
 
 - By site admins for all users: in the **Global settings** in the site admin area.
-- By org admins for all org members: in the org profile **Configuration** section
-- By users for themselves only: in the user profile **Configuration** section
+- By organization admins for all organization members: in the organization profile **Settings** section
+- By users for themselves only: in the user profile **Settings** section
 
 You can configure search scopes by setting the `search.scopes` to a JSON array of `{name, value}` objects.
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -414,6 +414,11 @@ type PhabricatorConnection struct {
 	Token string   `json:"token,omitempty"`
 	Url   string   `json:"url,omitempty"`
 }
+type QuickLink struct {
+	Description string `json:"description,omitempty"`
+	Name        string `json:"name"`
+	Url         string `json:"url,omitempty"`
+}
 type Repos struct {
 	Callsign string `json:"callsign"`
 	Path     string `json:"path"`
@@ -473,6 +478,7 @@ type Settings struct {
 	Motd                      []string                  `json:"motd,omitempty"`
 	Notices                   []*Notice                 `json:"notices,omitempty"`
 	NotificationsSlack        *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
+	Quicklinks                []*QuickLink              `json:"quicklinks,omitempty"`
 	SearchContextLines        int                       `json:"search.contextLines,omitempty"`
 	SearchRepositoryGroups    map[string][]string       `json:"search.repositoryGroups,omitempty"`
 	SearchSavedQueries        []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -417,7 +417,7 @@ type PhabricatorConnection struct {
 type QuickLink struct {
 	Description string `json:"description,omitempty"`
 	Name        string `json:"name"`
-	Url         string `json:"url,omitempty"`
+	Url         string `json:"url"`
 }
 type Repos struct {
 	Callsign string `json:"callsign"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -65,6 +65,13 @@
     "notifications.slack": {
       "$ref": "#/definitions/SlackNotificationsConfig"
     },
+    "quicklinks": {
+      "description": "Links that should be accessible quickly from the home and search pages.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/QuickLink"
+      }
+    },
     "motd": {
       "description": "DEPRECATED: Use `notices` instead.\n\nAn array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
       "type": "array",
@@ -140,6 +147,25 @@
         "description": {
           "type": "string",
           "description": "A description for this search scope"
+        }
+      }
+    },
+    "QuickLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The human-readable name for this quick link"
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL of this quick link (absolute or relative)"
+        },
+        "description": {
+          "type": "string",
+          "description": "A description for this quick link"
         }
       }
     },

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -153,7 +153,7 @@
     "QuickLink": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "value"],
+      "required": ["name", "url"],
       "properties": {
         "name": {
           "type": "string",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -70,6 +70,13 @@ const SettingsSchemaJSON = `{
     "notifications.slack": {
       "$ref": "#/definitions/SlackNotificationsConfig"
     },
+    "quicklinks": {
+      "description": "Links that should be accessible quickly from the home and search pages.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/QuickLink"
+      }
+    },
     "motd": {
       "description": "DEPRECATED: Use ` + "`" + `notices` + "`" + ` instead.\n\nAn array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
       "type": "array",
@@ -145,6 +152,25 @@ const SettingsSchemaJSON = `{
         "description": {
           "type": "string",
           "description": "A description for this search scope"
+        }
+      }
+    },
+    "QuickLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The human-readable name for this quick link"
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL of this quick link (absolute or relative)"
+        },
+        "description": {
+          "type": "string",
+          "description": "A description for this quick link"
         }
       }
     },

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -158,7 +158,7 @@ const SettingsSchemaJSON = `{
     "QuickLink": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "value"],
+      "required": ["name", "url"],
       "properties": {
         "name": {
           "type": "string",

--- a/shared/src/settings/settings.test.ts
+++ b/shared/src/settings/settings.test.ts
@@ -101,6 +101,29 @@ describe('mergeSettings', () => {
                 { name: 'sourcegraph repos', value: 'repogroup:sourcegraph' },
             ],
         }))
+    test('merges quicklinks property', () =>
+        expect(
+            mergeSettings<
+                {
+                    a?: { [key: string]: { [key: string]: string }[] }
+                    b?: { [key: string]: { [key: string]: string }[] }
+                } & Settings
+            >([
+                { quicklinks: [{ name: 'main repo', value: '/github.com/org/main-repo' }] },
+                { quicklinks: [{ name: 'About Sourcegraph', value: 'https://docs.internal/about-sourcegraph' }] },
+                {
+                    quicklinks: [
+                        { name: 'mycorp extensions', value: 'https://sourcegraph.com/extensions?query=mycorp%2F' },
+                    ],
+                },
+            ])
+        ).toEqual({
+            quicklinks: [
+                { name: 'main repo', value: '/github.com/org/main-repo' },
+                { name: 'About Sourcegraph', value: 'https://docs.internal/about-sourcegraph' },
+                { name: 'mycorp extensions', value: 'https://sourcegraph.com/extensions?query=mycorp%2F' },
+            ],
+        }))
     test('merges search.repositoryGroups property', () =>
         expect(
             mergeSettings<{ a?: { [key: string]: string }; b?: { [key: string]: string } } & Settings>([

--- a/shared/src/settings/settings.ts
+++ b/shared/src/settings/settings.ts
@@ -183,6 +183,7 @@ export function mergeSettings<S extends Settings>(values: S[]): S | null {
         'search.scopes': (base: any, add: any) => [...base, ...add],
         'search.savedQueries': (base: any, add: any) => [...base, ...add],
         'search.repositoryGroups': (base: any, add: any) => ({ ...base, ...add }),
+        quicklinks: (base: any, add: any) => [...base, ...add],
     }
     const target = cloneDeep(values[0])
     for (const value of values.slice(1)) {

--- a/web/src/search/QuickLinks.scss
+++ b/web/src/search/QuickLinks.scss
@@ -1,0 +1,3 @@
+.quicklink {
+    display: inline-block;
+}

--- a/web/src/search/QuickLinks.tsx
+++ b/web/src/search/QuickLinks.tsx
@@ -1,0 +1,25 @@
+import LinkIcon from 'mdi-react/LinkIcon'
+import React from 'react'
+import { Link } from '../../../shared/src/components/Link'
+import { QuickLink } from '../schema/settings.schema'
+
+interface Props {
+    quickLinks: QuickLink[]
+}
+
+export class QuickLinks extends React.PureComponent<Props> {
+    public render(): JSX.Element | null {
+        return this.props.quickLinks.length > 0 ? (
+            <>
+                {this.props.quickLinks.map((quickLink, i) => (
+                    <small className="quicklink text-nowrap mr-2">
+                        <Link to={quickLink.url} data-tooltip={quickLink.description} key={i}>
+                            <LinkIcon className="icon-inline pr-1" />
+                            {quickLink.name}
+                        </Link>
+                    </small>
+                ))}
+            </>
+        ) : null
+    }
+}

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -41,6 +41,10 @@
         display: block;
         margin: 0.5rem 0;
     }
+
+    &__quicklink {
+        display: inline-block;
+    }
 }
 
 .theme-light {

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -1,4 +1,5 @@
 @import '../../nav/GlobalNavbar';
+@import '../QuickLinks';
 @import './SearchFilterChips';
 @import './QueryInput';
 @import './QueryBuilder';
@@ -40,10 +41,6 @@
         width: 100%;
         display: block;
         margin: 0.5rem 0;
-    }
-
-    &__quicklink {
-        display: inline-block;
     }
 }
 

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -1,4 +1,5 @@
 import * as H from 'history'
+import LinkIcon from 'mdi-react/LinkIcon'
 import * as React from 'react'
 import { parseSearchURLQuery } from '..'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
@@ -7,7 +8,7 @@ import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/se
 import { Form } from '../../components/Form'
 import { PageTitle } from '../../components/PageTitle'
 import { Notices } from '../../global/Notices'
-import { Settings } from '../../schema/settings.schema'
+import { QuickLink, Settings } from '../../schema/settings.schema'
 import { ThemePreferenceProps, ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { limitString } from '../../util'
@@ -101,6 +102,7 @@ export class SearchPage extends React.Component<Props, State> {
                                     isSourcegraphDotCom={this.props.isSourcegraphDotCom}
                                 />
                             </div>
+                            {this.renderQuickLinks()}
                             <QueryBuilder
                                 onFieldsQueryChange={this.onBuilderQueryChange}
                                 isSourcegraphDotCom={window.context.sourcegraphDotComMode}
@@ -112,6 +114,7 @@ export class SearchPage extends React.Component<Props, State> {
                                 onFieldsQueryChange={this.onBuilderQueryChange}
                                 isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                             />
+                            {this.renderQuickLinks()}
                             <div className="search-page__input-sub-container">
                                 <SearchFilterChips
                                     location={this.props.location}
@@ -128,6 +131,22 @@ export class SearchPage extends React.Component<Props, State> {
                 </Form>
             </div>
         )
+    }
+
+    private renderQuickLinks(): JSX.Element | null {
+        const quickLinks = this.getQuickLinks()
+        return quickLinks.length > 0 ? (
+            <div className="search-page__input-sub-container">
+                {quickLinks.map((quickLink, i) => (
+                    <small className="text-nowrap mr-2 search-page__quicklink">
+                        <a href={quickLink.url} data-tooltip={quickLink.description} key={i}>
+                            <LinkIcon className="icon-inline pr-1" />
+                            {quickLink.name}
+                        </a>
+                    </small>
+                ))}
+            </div>
+        ) : null
     }
 
     private onUserQueryChange = (userQuery: string) => {
@@ -161,10 +180,16 @@ export class SearchPage extends React.Component<Props, State> {
     }
 
     private getScopes(): ISearchScope[] {
-        const allScopes: ISearchScope[] =
+        return (
             (isSettingsValid<Settings>(this.props.settingsCascade) &&
                 this.props.settingsCascade.final['search.scopes']) ||
             []
-        return allScopes
+        )
+    }
+
+    private getQuickLinks(): QuickLink[] {
+        return (
+            (isSettingsValid<Settings>(this.props.settingsCascade) && this.props.settingsCascade.final.quicklinks) || []
+        )
     }
 }

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -13,6 +13,7 @@ import { ThemePreferenceProps, ThemeProps } from '../../theme'
 import { eventLogger } from '../../tracking/eventLogger'
 import { limitString } from '../../util'
 import { queryIndexOfScope, submitSearch } from '../helpers'
+import { QuickLinks } from '../QuickLinks'
 import { QueryBuilder } from './QueryBuilder'
 import { QueryInput } from './QueryInput'
 import { SearchButton } from './SearchButton'
@@ -75,6 +76,7 @@ export class SearchPage extends React.Component<Props, State> {
             }
         }
         const hasScopes = this.getScopes().length > 0
+        const quickLinks = this.getQuickLinks()
         return (
             <div className="search-page">
                 <PageTitle title={this.getPageTitle()} />
@@ -102,7 +104,11 @@ export class SearchPage extends React.Component<Props, State> {
                                     isSourcegraphDotCom={this.props.isSourcegraphDotCom}
                                 />
                             </div>
-                            {this.renderQuickLinks()}
+                            {quickLinks.length > 0 && (
+                                <div className="search-page__input-sub-container">
+                                    <QuickLinks quickLinks={quickLinks} />
+                                </div>
+                            )}
                             <QueryBuilder
                                 onFieldsQueryChange={this.onBuilderQueryChange}
                                 isSourcegraphDotCom={window.context.sourcegraphDotComMode}
@@ -114,7 +120,11 @@ export class SearchPage extends React.Component<Props, State> {
                                 onFieldsQueryChange={this.onBuilderQueryChange}
                                 isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                             />
-                            {this.renderQuickLinks()}
+                            {quickLinks.length > 0 && (
+                                <div className="search-page__input-sub-container">
+                                    <QuickLinks quickLinks={quickLinks} />
+                                </div>
+                            )}
                             <div className="search-page__input-sub-container">
                                 <SearchFilterChips
                                     location={this.props.location}
@@ -131,22 +141,6 @@ export class SearchPage extends React.Component<Props, State> {
                 </Form>
             </div>
         )
-    }
-
-    private renderQuickLinks(): JSX.Element | null {
-        const quickLinks = this.getQuickLinks()
-        return quickLinks.length > 0 ? (
-            <div className="search-page__input-sub-container">
-                {quickLinks.map((quickLink, i) => (
-                    <small className="text-nowrap mr-2 search-page__quicklink">
-                        <a href={quickLink.url} data-tooltip={quickLink.description} key={i}>
-                            <LinkIcon className="icon-inline pr-1" />
-                            {quickLink.name}
-                        </a>
-                    </small>
-                ))}
-            </div>
-        ) : null
     }
 
     private onUserQueryChange = (userQuery: string) => {

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -1,5 +1,4 @@
 import * as H from 'history'
-import LinkIcon from 'mdi-react/LinkIcon'
 import * as React from 'react'
 import { parseSearchURLQuery } from '..'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -161,6 +161,9 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         const filters = this.getFilters()
         const extensionFilters = this.state.contributions && this.state.contributions.searchFilters
 
+        const quickLinks =
+            (isSettingsValid<Settings>(this.props.settingsCascade) && this.props.settingsCascade.final.quicklinks) || []
+
         return (
             <div className="e2e-search-results search-results d-flex flex-column w-100">
                 <PageTitle key="page-title" title={query} />
@@ -169,6 +172,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                     results={this.state.resultsOrError}
                     filters={filters}
                     extensionFilters={extensionFilters}
+                    quickLinks={quickLinks}
                     onFilterClick={this.onDynamicFilterClicked}
                     onShowMoreResultsClick={this.showMoreResults}
                     calculateShowMoreResultsCount={this.calculateCount}

--- a/web/src/search/results/SearchResultsFilterBars.scss
+++ b/web/src/search/results/SearchResultsFilterBars.scss
@@ -23,5 +23,13 @@
         &::-webkit-scrollbar {
             display: none;
         }
+
+        &--no-label {
+            margin-left: 0;
+        }
+
+        &-quicklink {
+            margin: 0.25rem 0.5rem 0.25rem 0;
+        }
     }
 }

--- a/web/src/search/results/SearchResultsFilterBars.scss
+++ b/web/src/search/results/SearchResultsFilterBars.scss
@@ -1,3 +1,5 @@
+@import '../QuickLinks';
+
 .search-results-filter-bars {
     &__row {
         display: flex;
@@ -27,9 +29,15 @@
         &--no-label {
             margin-left: 0;
         }
+    }
 
-        &-quicklink {
-            margin: 0.25rem 0.5rem 0.25rem 0;
+    &__quicklinks {
+        margin: 0.25rem 0 0.25rem 0;
+        display: flex;
+        overflow-x: auto;
+
+        &::-webkit-scrollbar {
+            display: none;
         }
     }
 }

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -1,6 +1,8 @@
+import LinkIcon from 'mdi-react/LinkIcon'
 import React from 'react'
 import { SearchFilters } from '../../../../shared/src/api/protocol'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { QuickLink } from '../../schema/settings.schema'
 import { FilterChip } from '../FilterChip'
 import { isSearchResults } from '../helpers'
 
@@ -14,6 +16,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
     results?: GQL.ISearchResults
     filters: SearchScopeWithOptionalName[]
     extensionFilters: SearchFilters[] | undefined
+    quickLinks?: QuickLink[] | undefined
     onFilterClick: (value: string) => void
     onShowMoreResultsClick: (value: string) => void
     calculateShowMoreResultsCount: () => number
@@ -22,6 +25,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
     results,
     filters,
     extensionFilters,
+    quickLinks,
     onFilterClick,
     onShowMoreResultsClick,
     calculateShowMoreResultsCount,
@@ -84,6 +88,20 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                             showMore={true}
                         />
                     )}
+                </div>
+            </div>
+        )}
+        {quickLinks && (
+            <div className="search-results-filter-bars__row" data-testid="quicklinks-bar">
+                <div className="search-results-filter-bars__filters search-results-filter-bars__filters--no-label">
+                    {quickLinks.map((quickLink, i) => (
+                        <small className="search-results-filter-bars__filters-quicklink text-nowrap">
+                            <a href={quickLink.url} data-tooltip={quickLink.description} key={i}>
+                                <LinkIcon className="icon-inline pr-1" />
+                                {quickLink.name}
+                            </a>
+                        </small>
+                    ))}
                 </div>
             </div>
         )}

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -1,10 +1,10 @@
-import LinkIcon from 'mdi-react/LinkIcon'
 import React from 'react'
 import { SearchFilters } from '../../../../shared/src/api/protocol'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { QuickLink } from '../../schema/settings.schema'
 import { FilterChip } from '../FilterChip'
 import { isSearchResults } from '../helpers'
+import { QuickLinks } from '../QuickLinks'
 
 export interface SearchScopeWithOptionalName {
     name?: string
@@ -93,15 +93,8 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
         )}
         {quickLinks && (
             <div className="search-results-filter-bars__row" data-testid="quicklinks-bar">
-                <div className="search-results-filter-bars__filters search-results-filter-bars__filters--no-label">
-                    {quickLinks.map((quickLink, i) => (
-                        <small className="search-results-filter-bars__filters-quicklink text-nowrap">
-                            <a href={quickLink.url} data-tooltip={quickLink.description} key={i}>
-                                <LinkIcon className="icon-inline pr-1" />
-                                {quickLink.name}
-                            </a>
-                        </small>
-                    ))}
+                <div className="search-results-filter-bars__quicklinks">
+                    <QuickLinks quickLinks={quickLinks} />
                 </div>
             </div>
         )}

--- a/web/src/site-admin/configHelpers.ts
+++ b/web/src/site-admin/configHelpers.ts
@@ -23,6 +23,15 @@ const addSearchScopeToSettings: ConfigInsertionFunction = config => {
     return { edits, selectText: '<name>' }
 }
 
+const addQuickLinkToSettings: ConfigInsertionFunction = config => {
+    const value: { name: string; url: string } = {
+        name: '<human-readable name>',
+        url: '<URL>',
+    }
+    const edits = setProperty(config, ['quicklinks', -1], value, defaultFormattingOptions)
+    return { edits, selectText: '<name>' }
+}
+
 const addSlackWebhook: ConfigInsertionFunction = config => {
     const value: SlackNotificationsConfig = {
         webhookURL: 'get webhook URL at https://YOUR-WORKSPACE-NAME.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks',
@@ -44,6 +53,7 @@ export const settingsActions: EditorAction[] = [
         run: setSearchContextLines,
     },
     { id: 'sourcegraph.settings.searchScopes', label: 'Add search scope', run: addSearchScopeToSettings },
+    { id: 'sourcegraph.settings.quickLinks', label: 'Add quick link', run: addQuickLinkToSettings },
     { id: 'sourcegraph.settings.addSlackWebhook', label: 'Add Slack webhook', run: addSlackWebhook },
 ]
 


### PR DESCRIPTION
This adds support for a new `quicklinks` property you can set in user/org/global settings which allows adding some links to be quickly accessible from the homepage and search page.

(It is my intent to ship this quickly in a patch release as it is a blocking issue for a major user.)

How it looks:

![image](https://user-images.githubusercontent.com/3173176/60380673-35828580-99fe-11e9-8a60-7160bce68909.png)

![image](https://user-images.githubusercontent.com/3173176/60380742-67e0b280-99ff-11e9-88fc-d8587f84b768.png)

![image](https://user-images.githubusercontent.com/3173176/60380685-5c40bc00-99fe-11e9-9d60-5e0e91440c73.png)

Test plan: Manual & minor unit test & e2e tests / Percy
