### PR TITLE
prevent a panic in search

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -844,9 +844,6 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 		return nil, nil, err
 	}
 
-	indexed = make([]*search.RepositoryRevisions, 0, len(set))
-	unindexed = make([]*search.RepositoryRevisions, 0, len(revs)-len(set))
-
 	for _, rev := range revs {
 		repo, ok := set[strings.ToLower(string(rev.Repo.Name))]
 		if !ok {


### PR DESCRIPTION
Fixes #4759. This is a quick fix to buy us time so we can investigate whether there is a deeper issue.

The key change here is the deletion of two lines in `cmd/frontend/graphqlbackend/textsearch.go`, so the slices `indexed` and `unindexed` are initialized as nil instead of having a precomputed capacity. In the case of `unindexed`, this eliminates the possibility of getting a negative capacity that could cause a panic. It's unlikely that this will make any real difference in performance, but if there are worries I can add a benchmark, preferably in a follow-up PR.

Test plan: Reproduced the issue with a unit test.

