### PR TITLE
graphqlbackend: Ensure we use a non-negative capacity in zoektIndexedRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -844,11 +844,6 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 		return nil, nil, err
 	}
 
-	unindexedCap := len(revs) - len(set)
-	if unindexedCap < 0 {
-		unindexedCap = 0
-	}
-
 	indexed = make([]*search.RepositoryRevisions, 0, count)
 	unindexed = make([]*search.RepositoryRevisions, 0, len(revs)-count)
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -849,8 +849,8 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 		unindexedCap = 0
 	}
 
-	indexed = make([]*search.RepositoryRevisions, 0, len(set))
-	unindexed = make([]*search.RepositoryRevisions, 0, unindexedCap)
+	indexed = make([]*search.RepositoryRevisions, 0, count)
+	unindexed = make([]*search.RepositoryRevisions, 0, len(revs)-count)
 
 	for _, rev := range revs {
 		repo, ok := set[strings.ToLower(string(rev.Repo.Name))]

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -844,8 +844,13 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 		return nil, nil, err
 	}
 
+	unindexedCap := len(revs) - len(set)
+	if unindexedCap < 0 {
+		unindexedCap = 0
+	}
+
 	indexed = make([]*search.RepositoryRevisions, 0, len(set))
-	unindexed = make([]*search.RepositoryRevisions, 0, len(revs)-len(set))
+	unindexed = make([]*search.RepositoryRevisions, 0, unindexedCap)
 
 	for _, rev := range revs {
 		repo, ok := set[strings.ToLower(string(rev.Repo.Name))]

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -686,29 +686,44 @@ func Test_zoektIndexedRepos(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{repos: zoektRepoList}}
 	ctx := context.Background()
 
-	indexed, unindexed, err := zoektIndexedRepos(ctx, zoekt, repos)
-	if err != nil {
-		t.Fatal(err)
+	makeIndexed := func(repos []*search.RepositoryRevisions) []*search.RepositoryRevisions {
+		var indexed []*search.RepositoryRevisions
+		for _, r := range repos {
+			rev := *r
+			rev.IndexedHEADCommit = "deadbeef"
+			indexed = append(indexed, &rev)
+		}
+		return indexed
 	}
 
-	for _, tc := range []struct {
-		name       string
-		have, want []*search.RepositoryRevisions
-	}{
-		{"indexed", indexed, func() (want []*search.RepositoryRevisions) {
-			for i := 0; i < 3; i++ {
-				rev := *repos[i]
-				rev.IndexedHEADCommit = "deadbeef"
-				want = append(want, &rev)
+	cases := []struct {
+		name      string
+		repos     []*search.RepositoryRevisions
+		indexed   []*search.RepositoryRevisions
+		unindexed []*search.RepositoryRevisions
+	}{{
+		name:      "all",
+		repos:     repos,
+		indexed:   makeIndexed(repos[:3]),
+		unindexed: repos[3:],
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexed, unindexed, err := zoektIndexedRepos(ctx, zoekt, tc.repos)
+			if err != nil {
+				t.Fatal(err)
 			}
-			return
-		}()},
-		{"unindexed", unindexed, repos[3:]},
-	} {
-		if !reflect.DeepEqual(tc.have, tc.want) {
-			diff := cmp.Diff(tc.have, tc.want)
-			t.Fatalf("%s has wrong repo revs. diff=%s", tc.name, diff)
-		}
+
+			if !reflect.DeepEqual(tc.indexed, indexed) {
+				diff := cmp.Diff(tc.indexed, indexed)
+				t.Error("unexpected indexed:", diff)
+			}
+			if !reflect.DeepEqual(tc.unindexed, unindexed) {
+				diff := cmp.Diff(tc.unindexed, unindexed)
+				t.Error("unexpected unindexed:", diff)
+			}
+		})
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -706,6 +706,16 @@ func Test_zoektIndexedRepos(t *testing.T) {
 		repos:     repos,
 		indexed:   makeIndexed(repos[:3]),
 		unindexed: repos[3:],
+	}, {
+		name:      "one unindexed",
+		repos:     repos[3:4],
+		indexed:   repos[:0],
+		unindexed: repos[3:4],
+	}, {
+		name:      "one indexed",
+		repos:     repos[:1],
+		indexed:   makeIndexed(repos[:1]),
+		unindexed: repos[:0],
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This is currently causing panics on our dogfood instances.

Test plan: Added a unit test which reproduces the panic. Unit test now passes.

Supersedes #4761 

Fixes #4759 