### PR TITLE
graphqlbackend: Simplify zoektIndexedRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -861,11 +861,7 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 			}
 		}
 
-		if rev.IndexedHEADCommit == "" {
-			unindexed = append(unindexed, rev)
-		} else {
-			indexed = append(indexed, rev)
-		}
+		indexed = append(indexed, rev)
 	}
 
 	return indexed, unindexed, nil

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -648,7 +648,6 @@ func Test_zoektIndexedRepos(t *testing.T) {
 		"foo/indexed-three@",
 		"foo/unindexed-one",
 		"foo/unindexed-two",
-		"foo/unindexed-three@",
 	)
 
 	zoektRepoList := &zoekt.RepoList{
@@ -672,12 +671,6 @@ func Test_zoektIndexedRepos(t *testing.T) {
 						{Name: "HEAD", Version: "deadbeef"},
 						{Name: "foobar", Version: "deadcow"},
 					},
-				},
-			},
-			{
-				Repository: zoekt.Repository{
-					Name:     "foo/unindexed-three",
-					Branches: []zoekt.RepositoryBranch{},
 				},
 			},
 		},


### PR DESCRIPTION
This commit removes code than handles a case that is not possible. Zoekt
always indexes the HEAD branch so each repo returned will contain that branch and
its version.