### PR TITLE
Rename methods on types.RepoIdentifier

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -159,7 +159,7 @@ func (s *repos) GetInventory(ctx context.Context, repo types.RepoIdentifier, com
 		return Mocks.Repos.GetInventory(ctx, repo, commitID)
 	}
 
-	ctx, done := trace(ctx, "Repos", "GetInventory", map[string]interface{}{"repo": repo.GetName(), "commitID": commitID}, &err)
+	ctx, done := trace(ctx, "Repos", "GetInventory", map[string]interface{}{"repo": repo.RepoName(), "commitID": commitID}, &err)
 	defer done()
 
 	// Cap GetInventory operation to some reasonable time.
@@ -171,13 +171,13 @@ func (s *repos) GetInventory(ctx context.Context, repo types.RepoIdentifier, com
 	}
 
 	// Try cache first
-	cacheKey := fmt.Sprintf("%s:%s", repo.GetName(), commitID)
+	cacheKey := fmt.Sprintf("%s:%s", repo.RepoName(), commitID)
 	if b, ok := inventoryCache.Get(cacheKey); ok {
 		var inv inventory.Inventory
 		if err := json.Unmarshal(b, &inv); err == nil {
 			return &inv, nil
 		}
-		log15.Warn("Repos.GetInventory failed to unmarshal cached JSON inventory", "repo", repo.GetName(), "commitID", commitID, "err", err)
+		log15.Warn("Repos.GetInventory failed to unmarshal cached JSON inventory", "repo", repo.RepoName(), "commitID", commitID, "err", err)
 	}
 
 	// Not found in the cache, so compute it.
@@ -201,7 +201,7 @@ func (s *repos) GetInventoryUncached(ctx context.Context, repo types.RepoIdentif
 		return Mocks.Repos.GetInventoryUncached(ctx, repo, commitID)
 	}
 
-	ctx, done := trace(ctx, "Repos", "GetInventoryUncached", map[string]interface{}{"repo": repo.GetName(), "commitID": commitID}, &err)
+	ctx, done := trace(ctx, "Repos", "GetInventoryUncached", map[string]interface{}{"repo": repo.RepoName(), "commitID": commitID}, &err)
 	defer done()
 
 	cachedRepo, err := CachedGitRepo(ctx, repo)

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -98,13 +98,13 @@ func (s *MockRepos) MockResolveRev_NotFound(t *testing.T, wantRepo api.RepoID, w
 	called = new(bool)
 	s.ResolveRev = func(ctx context.Context, repo types.RepoIdentifier, rev string) (api.CommitID, error) {
 		*called = true
-		if repo.GetID() != wantRepo {
-			t.Errorf("got repo %v, want %v", repo.GetID(), wantRepo)
+		if repo.RepoID() != wantRepo {
+			t.Errorf("got repo %v, want %v", repo.RepoID(), wantRepo)
 		}
 		if rev != wantRev {
 			t.Errorf("got rev %v, want %v", rev, wantRev)
 		}
-		return "", &git.RevisionNotFoundError{Repo: repo.GetName(), Spec: rev}
+		return "", &git.RevisionNotFoundError{Repo: repo.RepoName(), Spec: rev}
 	}
 	return
 }

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -22,7 +22,7 @@ func TestGitTree(t *testing.T) {
 	}
 	db.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo types.RepoIdentifier, rev string) (api.CommitID, error) {
-		if repo.GetID() != 2 || rev != exampleCommitSHA1 {
+		if repo.RepoID() != 2 || rev != exampleCommitSHA1 {
 			t.Error("wrong arguments to Repos.ResolveRev")
 		}
 		return exampleCommitSHA1, nil

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -19,7 +19,7 @@ func TestRepository_Commit(t *testing.T) {
 	resetMocks()
 	db.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo types.RepoIdentifier, rev string) (api.CommitID, error) {
-		if repo.GetID() != 2 || rev != "abc" {
+		if repo.RepoID() != 2 || rev != "abc" {
 			t.Error("wrong arguments to ResolveRev")
 		}
 		return exampleCommitSHA1, nil

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -225,7 +225,7 @@ func TestQueryToZoektFileOnlyQueries(t *testing.T) {
 
 func TestSearchFilesInRepos(t *testing.T) {
 	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoIdentifier, gitserverRepo gitserver.Repo, rev string, info *search.PatternInfo, fetchTimeout time.Duration) (matches []*fileMatchResolver, limitHit bool, err error) {
-		repoName := repo.GetName()
+		repoName := repo.RepoName()
 		switch repoName {
 		case "foo/one":
 			return []*fileMatchResolver{

--- a/cmd/frontend/internal/httpapi/repo_refresh_test.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh_test.go
@@ -43,7 +43,7 @@ func TestRepoRefresh(t *testing.T) {
 		}
 	}
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo types.RepoIdentifier, rev string) (api.CommitID, error) {
-		if repo.GetID() != 2 || rev != "master" {
+		if repo.RepoID() != 2 || rev != "master" {
 			t.Error("wrong arguments to ResolveRev")
 		}
 		return "aed", nil

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -46,7 +46,7 @@ func TestRepoShield(t *testing.T) {
 		}
 	}
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo types.RepoIdentifier, rev string) (api.CommitID, error) {
-		if repo.GetID() != 2 || rev != "master" {
+		if repo.RepoID() != 2 || rev != "master" {
 			t.Error("wrong arguments to ResolveRev")
 		}
 		return "aed", nil

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -10,9 +10,9 @@ import (
 // RepoIdentifier identifies a single repository by providing ID, Name and the
 // ExternalRepo
 type RepoIdentifier interface {
-	GetID() api.RepoID
-	GetExternalRepo() *api.ExternalRepoSpec
-	GetName() api.RepoName
+	RepoID() api.RepoID
+	RepoName() api.RepoName
+	ExternalRepoSpec() *api.ExternalRepoSpec
 }
 
 // Repo represents a source code repository.
@@ -43,9 +43,9 @@ type Repo struct {
 	Fork bool
 }
 
-func (r *Repo) GetID() api.RepoID                      { return r.ID }
-func (r *Repo) GetName() api.RepoName                  { return r.Name }
-func (r *Repo) GetExternalRepo() *api.ExternalRepoSpec { return r.ExternalRepo }
+func (r *Repo) RepoID() api.RepoID                      { return r.ID }
+func (r *Repo) RepoName() api.RepoName                  { return r.Name }
+func (r *Repo) ExternalRepoSpec() *api.ExternalRepoSpec { return r.ExternalRepo }
 
 // ExternalService is a connection to an external service.
 type ExternalService struct {


### PR DESCRIPTION
After the extraction in https://github.com/sourcegraph/sourcegraph/pull/4765 this is the missing part, the renaming of the interface methods.

Test plan: `go test`