### PR TITLE
Fix browser extension source maps in prod

### DIFF
--- a/browser/config/webpack/prod.config.ts
+++ b/browser/config/webpack/prod.config.ts
@@ -13,6 +13,7 @@ const config: webpack.Configuration = {
         minimize: true,
         minimizer: [
             new TerserPlugin({
+                sourceMap: true,
                 terserOptions: {
                     output: {
                         // Without this, Uglify will change \u0000 to \0 (NULL byte),


### PR DESCRIPTION
This should help with exception grouping on Sentry