### PR TITLE
Separate "steps" into separate lines

### DIFF
--- a/doc/extensions/authoring/development_environment.md
+++ b/doc/extensions/authoring/development_environment.md
@@ -22,5 +22,5 @@ Bring your extension's features for code viewed on GitHub, GitLab and other code
 
 ## Next steps
 
-[Creating a Sourcegraph extension](creating.md)
-[Local development](local_development.md)
+* [Creating a Sourcegraph extension](creating.md)
+* [Developing Sourcegraph extensions locally](local_development.md)


### PR DESCRIPTION
Right now the site comes out reading "Creating a Sourcegraph extension Local development" in one line so adding bullet points improves readability and changing verbs for consistency?



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
