### PR TITLE
graphql: return correct, non-empty language for repositories

### DIFF
--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -37,8 +37,13 @@ type Repo struct {
 
 	// Description is a brief description of the repository.
 	Description string
+
+	// DEPRECATED: this field is always empty for new repositories as of
+	// https://github.com/sourcegraph/sourcegraph/issues/2586. Do not use it.
+	//
 	// Language is the primary programming language used in this repository.
 	Language string
+
 	// Fork is whether this repository is a fork of another repository.
 	Fork bool
 }


### PR DESCRIPTION
Related issue: https://github.com/sourcegraph/sourcegraph/issues/2586

**Post-merge TODO:**
- [ ] Cherry-pick this onto 3.4 and 3.5.
- [ ] Cut new 3.4 and 3.5 releases for $CUSTOMER.
