### PR TITLE
fix corsOrigin wildcard handling regression in Sourcegraph 3.3.8

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -138,6 +138,15 @@ func secureHeadersMiddleware(next http.Handler) http.Handler {
 		// CORS
 		// If the headerOrigin is the development or production Chrome Extension explicitly set the Allow-Control-Allow-Origin
 		// to the incoming header URL. Otherwise use the configured CORS origin.
+		//
+		// Note: API users also rely on this codepath handling wildcards
+		// properly. For example, if Sourcegraph is behind a corporate VPN an
+		// admin may choose to set the CORS origin to "*" and would expect
+		// Sourcegraph to respond appropriately to any Origin request header:
+		//
+		// 	"Origin: *" -> "Access-Control-Allow-Origin: *"
+		// 	"Origin: https://foobar.com" -> "Access-Control-Allow-Origin: https://foobar.com"
+		//
 		headerOrigin := r.Header.Get("Origin")
 		isExtensionRequest := headerOrigin == devExtension || headerOrigin == prodExtension
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -273,11 +273,8 @@ func (s *httpServers) Wait() {
 }
 
 func isAllowedOrigin(origin string, allowedOrigins []string) bool {
-	if origin == "*" {
-		return true
-	}
 	for _, o := range allowedOrigins {
-		if o == origin {
+		if o == "*" || o == origin {
 			return true
 		}
 	}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -273,6 +273,9 @@ func (s *httpServers) Wait() {
 }
 
 func isAllowedOrigin(origin string, allowedOrigins []string) bool {
+	if origin == "*" {
+		return true
+	}
 	for _, o := range allowedOrigins {
 		if o == origin {
 			return true


### PR DESCRIPTION
Prior to 34caedf364b18559ce62f7cba036d6cd890de179 it was the case that:

> ```json
> "corsOrigin": "*"
> ```
>
> Request header: `Origin: *`

or:

> ```json
> "corsOrigin": "*"
> ```
>
> Request header: `Origin: https://www.google.com`

Would always respond with:

> Access-Control-Allow-Credentials: true
> Access-Control-Allow-Origin: *
> ...

However, that change introduced a regression breaking anyone relying on that
behavior, for example in the context of making API requests from a web
browser or other API client that respects CORS when Sourcegraph is deployed
behind a corporate VPN. The wildcard was no longer respected.

This PR fixes this appropriately by ensuring that when those two requests are
made we correctly respond the following (for each request, respectively):

> Access-Control-Allow-Credentials: true
> Access-Control-Allow-Origin: *
> ...

> Access-Control-Allow-Credentials: true
> Access-Control-Allow-Origin: https://www.google.com
> ...

Which is the correct and logical way to respect wildcard CORS origins.

Fixes #4424



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
