### PR TITLE
perf: Use godirwalk in gitserver to speed up listing cloned repos

### DIFF
--- a/cmd/gitserver/server/list.go
+++ b/cmd/gitserver/server/list.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/karrick/godirwalk"
 )
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
@@ -48,50 +50,53 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) walkCloned(ctx context.Context, handle func(path string) error) error {
-	return filepath.Walk(s.ReposDir, func(path string, info os.FileInfo, err error) error {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
+	return godirwalk.Walk(s.ReposDir, &godirwalk.Options{
+		Callback: func(path string, de *godirwalk.Dirent) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 
-		if s.ignorePath(path) {
-			if info.IsDir() {
+			if s.ignorePath(path) {
+				if de.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			// We only care about directories
+			if !de.IsDir() {
+				return nil
+			}
+
+			// New style git directory layout
+			if filepath.Base(path) == ".git" {
+				err := handle(filepath.Dir(path))
+				if err != nil {
+					return err
+				}
 				return filepath.SkipDir
 			}
-			return nil
-		}
 
-		if err != nil {
-			return nil
-		}
+			// For old-style directory layouts we need to do an extra extra
+			// stat to check if this is a repo.
+			if _, err := os.Stat(filepath.Join(path, "HEAD")); os.IsNotExist(err) {
+				// HEAD doesn't exist, so keep recursing
+				return nil
+			} else if err != nil {
+				return err
+			}
 
-		// We only care about directories
-		if !info.IsDir() {
-			return nil
-		}
-
-		// New style git directory layout
-		if filepath.Base(path) == ".git" {
-			err := handle(filepath.Dir(path))
+			// path is an old style git repo since it contains HEAD
+			err := handle(path)
 			if err != nil {
 				return err
 			}
 			return filepath.SkipDir
-		}
-
-		// For old-style directory layouts we need to do an extra extra
-		// stat to check if this is a repo.
-		if _, err := os.Stat(filepath.Join(path, "HEAD")); os.IsNotExist(err) {
-			// HEAD doesn't exist, so keep recursing
-			return nil
-		} else if err != nil {
-			return err
-		}
-
-		// path is an old style git repo since it contains HEAD
-		err = handle(path)
-		if err != nil {
-			return err
-		}
-		return filepath.SkipDir
+		},
+		ErrorCallback: func(path string, err error) godirwalk.ErrorAction {
+			// Ignore errors and simply continue with other nodes
+			return godirwalk.SkipNode
+		},
+		Unsorted: true,
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
 	github.com/karlseguin/expect v1.0.1 // indirect
 	github.com/karlseguin/typed v1.1.7 // indirect
+	github.com/karrick/godirwalk v1.10.12
 	github.com/karrick/tparse v2.4.2+incompatible
 	github.com/keegancsmith/rpc v1.1.0
 	github.com/keegancsmith/sqlf v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8
 github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/karlseguin/typed v1.1.7 h1:R8JGxdS0PNWWPKnHg4zh/n8NDFTEa6oIUcxjrMO4c6w=
 github.com/karlseguin/typed v1.1.7/go.mod h1:329jL66F7EH9O3xIBv2GAIFnMHIxH55NCQ78LUbZoJM=
+github.com/karrick/godirwalk v1.10.12 h1:BqUm+LuJcXjGv1d2mj3gBiQyrQ57a0rYoAmhvJQ7RDU=
+github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/tparse v2.4.2+incompatible h1:+cW306qKAzrASC5XieHkgN7/vPaGKIuK62Q7nI7DIRc=
 github.com/karrick/tparse v2.4.2+incompatible/go.mod h1:ASPA+vrIcN1uEW6BZg8vfWbzm69ODPSYZPU6qJyfdK0=
 github.com/keegancsmith/rpc v1.1.0 h1:bXVRk3EzbtrEegTGKxNTc+St1lR7t/Z1PAO8misBnCc=


### PR DESCRIPTION
Inspired by @keegancsmith's [comment in the previous PR](https://github.com/sourcegraph/sourcegraph/pull/4801#pullrequestreview-257979392) I decided to look for a faster `filepath.Walk` implementation. For our use case (we don't rely on the order of the list of cloned repos, we only need the `IsDir()` info per path), [godirwalk](https://github.com/karrick/godirwalk) seems to be the fastest.

In this change I replaced the existing `filepath.Walk` call with `godirwalk`.

Deployed to k8s.sgdev.org and ran the vegeta test again. Result: max latency is down again, by `400ms`, down from `~1.2s` to `~800ms`:

```
Requests      [total, rate]            290, 1.00
Duration      [total, attack, wait]    4m49.156038676s, 4m49.000915525s, 155.123151ms
Latencies     [mean, 50, 95, 99, max]  201.288068ms, 138.438191ms, 444.46946ms, 731.865021ms, 882.493109ms
Bytes In      [total, mean]            29000, 100.00
Bytes Out     [total, mean]            48430, 167.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:290
Error Set:
```

Test plan: `go test` & deploy and test on k8s.sgdev.org
