### PR TITLE
Revert "repo-updater: Improve performance when calculating notClonedCount (#4801)"

### DIFF
--- a/cmd/gitserver/server/list.go
+++ b/cmd/gitserver/server/list.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -24,13 +23,53 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 		return
 
 	case query("cloned"):
-		err := s.walkCloned(ctx, func(path string) error {
+		err := filepath.Walk(s.ReposDir, func(path string, info os.FileInfo, err error) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			if s.ignorePath(path) {
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			if err != nil {
+				return nil
+			}
+
+			// We only care about directories
+			if !info.IsDir() {
+				return nil
+			}
+
+			// New style git directory layout
+			if filepath.Base(path) == ".git" {
+				name, err := filepath.Rel(s.ReposDir, filepath.Dir(path))
+				if err != nil {
+					return err
+				}
+				repos = append(repos, name)
+				return filepath.SkipDir
+			}
+
+			// For old-style directory layouts we need to do an extra extra
+			// stat to check if this is a repo.
+			if _, err := os.Stat(filepath.Join(path, "HEAD")); os.IsNotExist(err) {
+				// HEAD doesn't exist, so keep recursing
+				return nil
+			} else if err != nil {
+				return err
+			}
+
+			// path is an old style git repo since it contains HEAD
 			name, err := filepath.Rel(s.ReposDir, path)
 			if err != nil {
 				return err
 			}
 			repos = append(repos, name)
-			return nil
+			return filepath.SkipDir
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -45,53 +84,4 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-}
-
-func (s *Server) walkCloned(ctx context.Context, handle func(path string) error) error {
-	return filepath.Walk(s.ReposDir, func(path string, info os.FileInfo, err error) error {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		if s.ignorePath(path) {
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if err != nil {
-			return nil
-		}
-
-		// We only care about directories
-		if !info.IsDir() {
-			return nil
-		}
-
-		// New style git directory layout
-		if filepath.Base(path) == ".git" {
-			err := handle(filepath.Dir(path))
-			if err != nil {
-				return err
-			}
-			return filepath.SkipDir
-		}
-
-		// For old-style directory layouts we need to do an extra extra
-		// stat to check if this is a repo.
-		if _, err := os.Stat(filepath.Join(path, "HEAD")); os.IsNotExist(err) {
-			// HEAD doesn't exist, so keep recursing
-			return nil
-		} else if err != nil {
-			return err
-		}
-
-		// path is an old style git repo since it contains HEAD
-		err = handle(path)
-		if err != nil {
-			return err
-		}
-		return filepath.SkipDir
-	})
 }

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -226,13 +226,13 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/list-gitolite", s.handleListGitolite)
 	mux.HandleFunc("/is-repo-cloneable", s.handleIsRepoCloneable)
 	mux.HandleFunc("/is-repo-cloned", s.handleIsRepoCloned)
+	mux.HandleFunc("/are-repos-cloned", s.handleAreReposCloned)
 	mux.HandleFunc("/repo", s.handleDeprecatedRepoInfo) // TODO(slimsag): Remove this after 3.3 is released.
 	mux.HandleFunc("/repos", s.handleRepoInfo)
 	mux.HandleFunc("/delete", s.handleRepoDelete)
 	mux.HandleFunc("/repo-update", s.handleRepoUpdate)
 	mux.HandleFunc("/getGitolitePhabricatorMetadata", s.handleGetGitolitePhabricatorMetadata)
 	mux.HandleFunc("/create-commit-from-patch", s.handleCreateCommitFromPatch)
-	mux.HandleFunc("/cloned-count", s.handleClonedCount)
 	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -372,6 +372,30 @@ func (s *Server) handleIsRepoCloned(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	} else {
 		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func (s *Server) handleAreReposCloned(w http.ResponseWriter, r *http.Request) {
+	var req protocol.AreReposClonedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp := protocol.AreReposClonedResponse{
+		Results: make(map[api.RepoName]bool, len(req.Repos)),
+	}
+
+	for _, repoName := range req.Repos {
+		normalized := protocol.NormalizeRepo(repoName)
+		dir := path.Join(s.ReposDir, string(normalized))
+
+		resp.Results[repoName] = repoCloned(dir)
+	}
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -1273,25 +1297,6 @@ func (s *Server) ensureRevision(ctx context.Context, repo api.RepoName, url, rev
 	// Revision not found, update before returning.
 	s.doRepoUpdate(ctx, repo, url)
 	return true
-}
-
-func (s *Server) handleClonedCount(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	var resp protocol.ClonedCountResponse
-
-	err := s.walkCloned(ctx, func(path string) error {
-		resp.Count++
-		return nil
-	})
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 }
 
 // quickRevParseHead best-effort mimics the execution of `git rev-parse HEAD`, but doesn't exec a child process.

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -75,7 +75,7 @@ func main() {
 			m.UpsertRepos,
 			m.ListExternalServices,
 			m.UpsertExternalServices,
-			m.CountRepos,
+			m.ListAllRepoNames,
 		} {
 			om.MustRegister(prometheus.DefaultRegisterer)
 		}

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -8,6 +8,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/trace"
 )
 
@@ -142,7 +143,7 @@ type StoreMetrics struct {
 	ListRepos              *OperationMetrics
 	UpsertExternalServices *OperationMetrics
 	ListExternalServices   *OperationMetrics
-	CountRepos             *OperationMetrics
+	ListAllRepoNames       *OperationMetrics
 }
 
 // NewStoreMetrics returns StoreMetrics that need to be registered
@@ -269,7 +270,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help:      "Total number of errors when listing external_services",
 			}, []string{}),
 		},
-		CountRepos: &OperationMetrics{
+		ListAllRepoNames: &OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "src",
 				Subsystem: "repoupdater",
@@ -434,21 +435,23 @@ func (o *ObservedStore) ListRepos(ctx context.Context, args StoreListReposArgs) 
 	return o.store.ListRepos(ctx, args)
 }
 
-// CountRepos calls into the inner Store and registers the observed results.
-func (o *ObservedStore) CountRepos(ctx context.Context) (count int, err error) {
-	tr, ctx := o.trace(ctx, "Store.CountRepos")
+// ListAllRepoNames calls into the inner Store and registers the observed results.
+func (o *ObservedStore) ListAllRepoNames(ctx context.Context) (names []api.RepoName, err error) {
+	tr, ctx := o.trace(ctx, "Store.ListAllRepoNames")
 
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
-		o.metrics.CountRepos.Observe(secs, 1, &err)
-		log(o.log, "store.count-repos", &err, "count", count)
+		count := float64(len(names))
 
-		tr.LogFields(otlog.Int("count", count))
+		o.metrics.ListAllRepoNames.Observe(secs, count, &err)
+		log(o.log, "store.list-all-repo-names", &err, "count", len(names))
+
+		tr.LogFields(otlog.Int("count", len(names)))
 		tr.SetError(err)
 		tr.Finish()
 	}(time.Now())
 
-	return o.store.CountRepos(ctx)
+	return o.store.ListAllRepoNames(ctx)
 }
 
 // UpsertRepos calls into the inner Store and registers the observed results.

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -27,7 +27,7 @@ type Store interface {
 	ListRepos(context.Context, StoreListReposArgs) ([]*Repo, error)
 	UpsertRepos(ctx context.Context, repos ...*Repo) error
 
-	CountRepos(context.Context) (int, error)
+	ListAllRepoNames(context.Context) ([]api.RepoName, error)
 }
 
 // StoreListReposArgs is a query arguments type used by
@@ -369,28 +369,37 @@ func listReposQuery(args StoreListReposArgs) paginatedQuery {
 	}
 }
 
-// CountRepos lists the names of all stored repos
-func (s DBStore) CountRepos(ctx context.Context) (count int, err error) {
-	rows, err := s.db.QueryContext(ctx, countReposQuery)
-	if err != nil {
-		return count, errors.Wrap(err, "CountRepos")
-	}
-
-	defer closeErr(rows, &err)
-
-	rows.Next()
-
-	err = rows.Scan(&count)
-	return count, err
+// ListAllRepoNames lists the names of all stored repos
+func (s DBStore) ListAllRepoNames(ctx context.Context) (names []api.RepoName, _ error) {
+	return names, s.paginate(ctx, 0, 0, listAllRepoNamesQuery,
+		func(sc scanner) (last, count int64, err error) {
+			var (
+				id   int64
+				name api.RepoName
+			)
+			if err = sc.Scan(&id, &name); err != nil {
+				return 0, 0, err
+			}
+			names = append(names, name)
+			return id, 1, nil
+		},
+	)
 }
 
-const countReposQuery = `
--- source: cmd/repo-updater/repos/store.go:DBStore.CountRepos
+const listAllRepoNamesQueryFmtstr = `
+-- source: cmd/repo-updater/repos/store.go:DBStore.ListAllRepoNames
 SELECT
-  COUNT(*)
+  id,
+  name
 FROM repo
-WHERE deleted_at IS NULL
+WHERE id > %s
+AND deleted_at IS NULL
+ORDER BY id ASC LIMIT %s
 `
+
+func listAllRepoNamesQuery(cursor, limit int64) *sqlf.Query {
+	return sqlf.Sprintf(listAllRepoNamesQueryFmtstr, cursor, limit)
+}
 
 // a paginatedQuery returns a query with the given pagination
 // parameters

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -56,7 +56,7 @@ type FakeStore struct {
 	GetRepoByNameError          error // error to be returned in GetRepoByName
 	ListReposError              error // error to be returned in ListRepos
 	UpsertReposError            error // error to be returned in UpsertRepos
-	CountReposError             error // error to be returned in CountRepos
+	ListAllRepoNamesError       error // error to be returned in ListAllRepoNames
 
 	svcIDSeq  int64
 	repoIDSeq uint32
@@ -88,7 +88,7 @@ func (s *FakeStore) Transact(ctx context.Context) (TxStore, error) {
 		GetRepoByNameError:          s.GetRepoByNameError,
 		ListReposError:              s.ListReposError,
 		UpsertReposError:            s.UpsertReposError,
-		CountReposError:             s.CountReposError,
+		ListAllRepoNamesError:       s.ListAllRepoNamesError,
 
 		svcIDSeq:  s.svcIDSeq,
 		svcByID:   svcByID,
@@ -251,13 +251,18 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 	return repos, nil
 }
 
-// CountRepos lists names of all repos in the store
-func (s FakeStore) CountRepos(ctx context.Context) (int, error) {
-	if s.CountReposError != nil {
-		return 0, s.CountReposError
+// ListAllRepoNames lists names of all repos in the store
+func (s FakeStore) ListAllRepoNames(ctx context.Context) ([]api.RepoName, error) {
+	if s.ListAllRepoNamesError != nil {
+		return nil, s.ListAllRepoNamesError
 	}
 
-	return len(s.repoByID), nil
+	names := make([]api.RepoName, 0, len(s.repoByID))
+	for _, r := range s.repoByID {
+		names = append(names, api.RepoName(r.Name))
+	}
+
+	return names, nil
 }
 
 func evalOr(bs ...bool) bool {

--- a/pkg/gitserver/protocol/gitserver.go
+++ b/pkg/gitserver/protocol/gitserver.go
@@ -92,6 +92,19 @@ type IsRepoClonedRequest struct {
 	Repo api.RepoName
 }
 
+// AreReposClonedRequest is a request to determine if multiple repos currently exist on gitserver.
+type AreReposClonedRequest struct {
+	// Repos are the names of the the repositories to check.
+	Repos []api.RepoName
+}
+
+// AreReposClonedResponse is the response when requesting the clone status for
+// multiple repositories at the same time.
+type AreReposClonedResponse struct {
+	// Results mapping from the repository name to the cloned status
+	Results map[api.RepoName]bool
+}
+
 // DeprecatedRepoInfoRequest is a request for information about a repository on gitserver.
 //
 // TODO(slimsag): Remove this after 3.3 is released.
@@ -180,10 +193,4 @@ type PatchCommitInfo struct {
 type CreatePatchFromPatchResponse struct {
 	// Rev is the tag that the staging object can be found at
 	Rev string
-}
-
-// ClonedCountResponse is the response type returned after asking for the
-// number of cloned repositories
-type ClonedCountResponse struct {
-	Count int `json:"count"`
 }


### PR DESCRIPTION
This reverts #4801 due to a bug that it contains. Full description can
be found in this comment: https://github.com/sourcegraph/sourcegraph/pull/4801#issuecomment-508682077
