### PR TITLE
PROTOTYPE: Remove search bar from TreePage and replace with button

### DIFF
--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -274,11 +274,11 @@ export class TreePage extends React.PureComponent<Props, State> {
                             )}
                             <section className="tree-page__section">
                                 <Link
-                                    className="btn btn-primary d-inline-flex align-items-center"
+                                    className="btn btn-secondary d-inline-flex align-items-center"
                                     to={`/search?${buildSearchURLQuery(this.getQueryPrefix())}`}
                                 >
                                     <SearchIcon className="icon-inline"></SearchIcon>
-                                    Search in this {this.props.filePath ? 'tree' : 'repository'}
+                                    Search in this {this.props.filePath ? 'directory' : 'repository'}
                                 </Link>
                             </section>
                             <TreeEntriesSection

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -141,16 +141,9 @@ interface Props
 interface State {
     /** This tree, or an error. Undefined while loading. */
     treeOrError?: GQL.IGitTree | ErrorLike
-
-    /**
-     * The value of the search query input field.
-     */
-    query: string
 }
 
 export class TreePage extends React.PureComponent<Props, State> {
-    public state: State = { query: '' }
-
     private componentUpdates = new Subject<Props>()
     private subscriptions = new Subscription()
 

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -3,6 +3,7 @@ import * as H from 'history'
 import { escapeRegExp, upperFirst } from 'lodash'
 import FolderIcon from 'mdi-react/FolderIcon'
 import HistoryIcon from 'mdi-react/HistoryIcon'
+import SearchIcon from 'mdi-react/SearchIcon'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import TagIcon from 'mdi-react/TagIcon'
@@ -24,16 +25,13 @@ import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { memoizeObservable } from '../../../shared/src/util/memoizeObservable'
+import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { queryGraphQL } from '../backend/graphql'
 import { FilteredConnection } from '../components/FilteredConnection'
-import { Form } from '../components/Form'
 import { PageTitle } from '../components/PageTitle'
 import { isDiscussionsEnabled } from '../discussions'
 import { DiscussionsList } from '../discussions/DiscussionsList'
 import { searchQueryForRepoRev } from '../search'
-import { submitSearch } from '../search/helpers'
-import { QueryInput } from '../search/input/QueryInput'
-import { SearchButton } from '../search/input/SearchButton'
 import { ThemeProps } from '../theme'
 import { eventLogger, EventLoggerProps } from '../tracking/eventLogger'
 import { basename } from '../util/path'
@@ -275,20 +273,13 @@ export class TreePage extends React.PureComponent<Props, State> {
                                 </header>
                             )}
                             <section className="tree-page__section">
-                                <h3 className="tree-page__section-header">
+                                <Link
+                                    className="btn btn-primary d-inline-flex align-items-center"
+                                    to={`/search?${buildSearchURLQuery(this.getQueryPrefix())}`}
+                                >
+                                    <SearchIcon className="icon-inline"></SearchIcon>
                                     Search in this {this.props.filePath ? 'tree' : 'repository'}
-                                </h3>
-                                <Form className="tree-page__section-search" onSubmit={this.onSubmit}>
-                                    <QueryInput
-                                        {...this.props}
-                                        value={this.state.query}
-                                        onChange={this.onQueryChange}
-                                        prependQueryForSuggestions={this.getQueryPrefix()}
-                                        autoFocus={true}
-                                        placeholder=""
-                                    />
-                                    <SearchButton />
-                                </Form>
+                                </Link>
                             </section>
                             <TreeEntriesSection
                                 title="Files and directories"
@@ -364,18 +355,6 @@ export class TreePage extends React.PureComponent<Props, State> {
                         </>
                     ))}
             </div>
-        )
-    }
-
-    private onQueryChange = (query: string) => this.setState({ query })
-
-    private onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
-        event.preventDefault()
-        submitSearch(
-            this.props.history,
-            this.getQueryPrefix() + this.state.query,
-            this.props.filePath ? 'tree' : 'repo',
-            this.props.activation
         )
     }
 


### PR DESCRIPTION
To make sure we can provide a consistent experience with the search bar, we are going to get rid of the in-page search bar for page trees and blobs. To keep the local search functionality, we will change the in-page search bar to be a button instead, which will populate the search bar with the proper query parameters.

![image](https://user-images.githubusercontent.com/1559622/60748727-d1077f00-9f45-11e9-8ec2-f08556e50e77.png)

![image](https://user-images.githubusercontent.com/1559622/60748734-dfee3180-9f45-11e9-8d0f-0fb1283117bd.png)

This prototype just redirects to a search page, and populates the appropriate relative filters. The next step will be to make this add the query to the top search bar, and add focus, without the redirection.