### PR TITLE
Extracting isScopeSelected action from FilterChip

### DIFF
--- a/web/src/search/FilterChip.tsx
+++ b/web/src/search/FilterChip.tsx
@@ -1,11 +1,10 @@
 import { truncate } from 'lodash'
 import * as React from 'react'
-import { queryIndexOfScope } from './helpers'
 
 interface Props {
     name?: string
     value: string
-    query: string
+    isSelected?: boolean
     count?: number
     limitHit?: boolean
     showMore?: boolean
@@ -20,7 +19,7 @@ export class FilterChip extends React.PureComponent<Props> {
                 type="button"
                 className={
                     `btn btn-sm text-nowrap filter-chip ${this.props.count ? 'filter-chip-repo' : ''}` +
-                    (this.isScopeSelected(this.props.query, this.props.value) ? ' filter-chip--selected' : '')
+                    (this.props.isSelected ? ' filter-chip--selected' : '')
                 }
                 data-testid="filter-chip"
                 value={this.props.value}
@@ -33,9 +32,7 @@ export class FilterChip extends React.PureComponent<Props> {
                     {!!this.props.count && (
                         <span
                             className={`filter-chip__count ${
-                                this.isScopeSelected(this.props.query, this.props.value)
-                                    ? ' filter-chip__count--selected'
-                                    : ''
+                                this.props.isSelected ? ' filter-chip__count--selected' : ''
                             }`}
                         >
                             {this.props.count}
@@ -48,7 +45,7 @@ export class FilterChip extends React.PureComponent<Props> {
     }
 
     private renderTooltip(valueIsTruncated: boolean): string | undefined {
-        if (this.isScopeSelected(this.props.query, this.props.value)) {
+        if (this.props.isSelected) {
             return 'Already added to query'
         }
         // Show filter value in tooltip if chip shows truncated value or scope name
@@ -56,10 +53,6 @@ export class FilterChip extends React.PureComponent<Props> {
             return this.props.value
         }
         return undefined
-    }
-
-    private isScopeSelected(query: string, scope: string): boolean {
-        return queryIndexOfScope(query, scope) !== -1
     }
 
     private onMouseDown: React.MouseEventHandler<HTMLButtonElement> = event => {

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -56,6 +56,16 @@ export function queryIndexOfScope(query: string, scope: string): number {
 }
 
 /**
+ * For a given query, identifies if the scope specified is present
+ *
+ * @param query the current user query
+ * @param scope the scope to look for presence of, indicating it is currently selected.
+ */
+export function isScopeSelected(query: string, scope: string): boolean {
+    return queryIndexOfScope(query, scope) !== -1
+}
+
+/**
  * Toggles the given search scope by adding or removing it from the current
  * user query string.
  *

--- a/web/src/search/input/SearchFilterChips.tsx
+++ b/web/src/search/input/SearchFilterChips.tsx
@@ -14,7 +14,7 @@ import { Settings } from '../../schema/settings.schema'
 import { eventLogger } from '../../tracking/eventLogger'
 import { FilterChip } from '../FilterChip'
 import {
-    queryIndexOfScope,
+    isScopeSelected,
     submitSearch,
     toggleSearchFilter,
     toggleSearchFilterAndReplaceSampleRepogroup,
@@ -178,8 +178,4 @@ function scopeForRepo(repoName: string): ISearchScope {
     return {
         value: `repo:^${escapeRegExp(repoName)}$`,
     }
-}
-
-function isScopeSelected(query: string, scope: string): boolean {
-    return queryIndexOfScope(query, scope) !== -1
 }

--- a/web/src/search/input/SearchFilterChips.tsx
+++ b/web/src/search/input/SearchFilterChips.tsx
@@ -13,7 +13,12 @@ import { routes } from '../../routes'
 import { Settings } from '../../schema/settings.schema'
 import { eventLogger } from '../../tracking/eventLogger'
 import { FilterChip } from '../FilterChip'
-import { submitSearch, toggleSearchFilter, toggleSearchFilterAndReplaceSampleRepogroup } from '../helpers'
+import {
+    queryIndexOfScope,
+    submitSearch,
+    toggleSearchFilter,
+    toggleSearchFilterAndReplaceSampleRepogroup,
+} from '../helpers'
 
 interface Props extends SettingsCascadeProps {
     location: H.Location
@@ -63,7 +68,7 @@ export class SearchFilterChips extends React.PureComponent<Props> {
                     .filter(scope => scope.value !== '')
                     .map((scope, i) => (
                         <FilterChip
-                            query={this.props.query}
+                            isSelected={isScopeSelected(this.props.query, scope.value)}
                             onFilterChosen={this.onSearchScopeClicked}
                             key={i}
                             value={scope.value}
@@ -173,4 +178,8 @@ function scopeForRepo(repoName: string): ISearchScope {
     return {
         value: `repo:^${escapeRegExp(repoName)}$`,
     }
+}
+
+function isScopeSelected(query: string, scope: string): boolean {
+    return queryIndexOfScope(query, scope) !== -1
 }

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -3,7 +3,7 @@ import { SearchFilters } from '../../../../shared/src/api/protocol'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { QuickLink } from '../../schema/settings.schema'
 import { FilterChip } from '../FilterChip'
-import { isSearchResults } from '../helpers'
+import { isSearchResults, queryIndexOfScope } from '../helpers'
 import { QuickLinks } from '../QuickLinks'
 
 export interface SearchScopeWithOptionalName {
@@ -40,7 +40,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                             .filter(filter => filter.value !== '')
                             .map((filter, i) => (
                                 <FilterChip
-                                    query={navbarSearchQuery}
+                                    isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
                                     onFilterChosen={onFilterClick}
                                     key={filter.name + filter.value}
                                     value={filter.value}
@@ -51,7 +51,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                         .filter(filter => filter.value !== '')
                         .map((filter, i) => (
                             <FilterChip
-                                query={navbarSearchQuery}
+                                isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
                                 onFilterChosen={onFilterClick}
                                 key={filter.name + filter.value}
                                 value={filter.value}
@@ -70,7 +70,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                         .map((filter, i) => (
                             <FilterChip
                                 name={filter.label}
-                                query={navbarSearchQuery}
+                                isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
                                 onFilterChosen={onFilterClick}
                                 key={filter.value}
                                 value={filter.value}
@@ -81,7 +81,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                     {results.limitHit && !/\brepo:/.test(navbarSearchQuery) && (
                         <FilterChip
                             name="Show more"
-                            query={navbarSearchQuery}
+                            isSelected={false}
                             onFilterChosen={onShowMoreResultsClick}
                             key={`count:${calculateShowMoreResultsCount()}`}
                             value={`count:${calculateShowMoreResultsCount()}`}
@@ -100,3 +100,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
         )}
     </div>
 )
+
+function isScopeSelected(query: string, scope: string): boolean {
+    return queryIndexOfScope(query, scope) !== -1
+}

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -3,7 +3,7 @@ import { SearchFilters } from '../../../../shared/src/api/protocol'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { QuickLink } from '../../schema/settings.schema'
 import { FilterChip } from '../FilterChip'
-import { isSearchResults, queryIndexOfScope } from '../helpers'
+import { isScopeSelected, isSearchResults } from '../helpers'
 import { QuickLinks } from '../QuickLinks'
 
 export interface SearchScopeWithOptionalName {
@@ -100,7 +100,3 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
         )}
     </div>
 )
-
-function isScopeSelected(query: string, scope: string): boolean {
-    return queryIndexOfScope(query, scope) !== -1
-}


### PR DESCRIPTION
Move selected state computation up a layer to the SearchResultsFilterBars and SearchFilterChips. This is necessary as we move in a direction that brings search options out of the search bar, and captures them in the filters section as selected or de-selected toggles. Ultimately extracting the selected filters from the search query will be done up-front, rather that checking if a filter is in the query.

Related: [Search vision](https://docs.google.com/document/d/1oB2i-1iOy3rUGyD2sjSVgRWTUkPFO2q5Pa_zihhur2o/edit#)
