### PR TITLE
Add selected options to 'Selected options' row at the top

### DIFF
--- a/web/src/search/results/SearchResultsFilterBars.scss
+++ b/web/src/search/results/SearchResultsFilterBars.scss
@@ -29,6 +29,10 @@
         &--no-label {
             margin-left: 0;
         }
+
+        &__selected {
+            margin-left: 1.5rem;
+        }
     }
 
     &__quicklinks {

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -33,9 +33,8 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
     <div className="search-results-filter-bars">
         {isSearchResults(results) &&
             results.dynamicFilters.some(filter => isScopeSelected(navbarSearchQuery, filter.value)) && (
-                <div className="search-results-filter-bars__row">
-                    Selected options:
-                    <div className="search-results-filter-bars__filters">
+                <div className="search-results-filter-bars__row global-navbar--bg">
+                    <div className="search-results-filter-bars__filters__selected">
                         {results.dynamicFilters
                             .filter(filter => filter.value !== '')
                             .filter(filter => isScopeSelected(navbarSearchQuery, filter.value))

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -31,13 +31,36 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
     calculateShowMoreResultsCount,
 }) => (
     <div className="search-results-filter-bars">
-        {((isSearchResults(results) && filters.length > 0) || extensionFilters) && (
+        {isSearchResults(results) &&
+            results.dynamicFilters.filter(filter => isScopeSelected(navbarSearchQuery, filter.value)).length > 0 && (
+                <div className="search-results-filter-bars__row">
+                    Selected options:
+                    <div className="search-results-filter-bars__filters">
+                        {results.dynamicFilters
+                            .filter(filter => filter.value !== '')
+                            .filter(filter => isScopeSelected(navbarSearchQuery, filter.value))
+                            .map((filter, i) => (
+                                <FilterChip
+                                    isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
+                                    onFilterChosen={onFilterClick}
+                                    key={filter.label + filter.value}
+                                    value={filter.value}
+                                    name={filter.label}
+                                />
+                            ))}
+                    </div>
+                </div>
+            )}
+        {((isSearchResults(results) &&
+            filters.filter(filter => !isScopeSelected(navbarSearchQuery, filter.value)).length > 0) ||
+            extensionFilters) && (
             <div className="search-results-filter-bars__row" data-testid="filters-bar">
                 Filters:
                 <div className="search-results-filter-bars__filters">
                     {extensionFilters &&
                         extensionFilters
                             .filter(filter => filter.value !== '')
+                            .filter(filter => !isScopeSelected(navbarSearchQuery, filter.value))
                             .map((filter, i) => (
                                 <FilterChip
                                     isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
@@ -49,6 +72,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                             ))}
                     {filters
                         .filter(filter => filter.value !== '')
+                        .filter(filter => !isScopeSelected(navbarSearchQuery, filter.value))
                         .map((filter, i) => (
                             <FilterChip
                                 isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
@@ -61,36 +85,40 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                 </div>
             </div>
         )}
-        {isSearchResults(results) && results.dynamicFilters.filter(filter => filter.kind === 'repo').length > 0 && (
-            <div className="search-results-filter-bars__row" data-testid="repo-filters-bar">
-                Repositories:
-                <div className="search-results-filter-bars__filters">
-                    {results.dynamicFilters
-                        .filter(filter => filter.kind === 'repo' && filter.value !== '')
-                        .map((filter, i) => (
+        {isSearchResults(results) &&
+            results.dynamicFilters
+                .filter(filter => filter.kind === 'repo')
+                .filter(filter => !isScopeSelected(navbarSearchQuery, filter.value)).length > 0 && (
+                <div className="search-results-filter-bars__row" data-testid="repo-filters-bar">
+                    Repositories:
+                    <div className="search-results-filter-bars__filters">
+                        {results.dynamicFilters
+                            .filter(filter => filter.kind === 'repo' && filter.value !== '')
+                            .filter(filter => !isScopeSelected(navbarSearchQuery, filter.value))
+                            .map((filter, i) => (
+                                <FilterChip
+                                    name={filter.label}
+                                    isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
+                                    onFilterChosen={onFilterClick}
+                                    key={filter.value}
+                                    value={filter.value}
+                                    count={filter.count}
+                                    limitHit={filter.limitHit}
+                                />
+                            ))}
+                        {results.limitHit && !/\brepo:/.test(navbarSearchQuery) && (
                             <FilterChip
-                                name={filter.label}
-                                isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
-                                onFilterChosen={onFilterClick}
-                                key={filter.value}
-                                value={filter.value}
-                                count={filter.count}
-                                limitHit={filter.limitHit}
+                                name="Show more"
+                                isSelected={false}
+                                onFilterChosen={onShowMoreResultsClick}
+                                key={`count:${calculateShowMoreResultsCount()}`}
+                                value={`count:${calculateShowMoreResultsCount()}`}
+                                showMore={true}
                             />
-                        ))}
-                    {results.limitHit && !/\brepo:/.test(navbarSearchQuery) && (
-                        <FilterChip
-                            name="Show more"
-                            isSelected={false}
-                            onFilterChosen={onShowMoreResultsClick}
-                            key={`count:${calculateShowMoreResultsCount()}`}
-                            value={`count:${calculateShowMoreResultsCount()}`}
-                            showMore={true}
-                        />
-                    )}
+                        )}
+                    </div>
                 </div>
-            </div>
-        )}
+            )}
         {quickLinks && (
             <div className="search-results-filter-bars__row" data-testid="quicklinks-bar">
                 <div className="search-results-filter-bars__quicklinks">

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -32,16 +32,16 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
 }) => (
     <div className="search-results-filter-bars">
         {isSearchResults(results) &&
-            results.dynamicFilters.filter(filter => isScopeSelected(navbarSearchQuery, filter.value)).length > 0 && (
+            results.dynamicFilters.some(filter => isScopeSelected(navbarSearchQuery, filter.value)) && (
                 <div className="search-results-filter-bars__row">
                     Selected options:
                     <div className="search-results-filter-bars__filters">
                         {results.dynamicFilters
                             .filter(filter => filter.value !== '')
                             .filter(filter => isScopeSelected(navbarSearchQuery, filter.value))
-                            .map((filter, i) => (
+                            .map(filter => (
                                 <FilterChip
-                                    isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
+                                    isSelected={true}
                                     onFilterChosen={onFilterClick}
                                     key={filter.label + filter.value}
                                     value={filter.value}
@@ -52,7 +52,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                 </div>
             )}
         {((isSearchResults(results) &&
-            filters.filter(filter => !isScopeSelected(navbarSearchQuery, filter.value)).length > 0) ||
+            filters.some(filter => !isScopeSelected(navbarSearchQuery, filter.value))) ||
             extensionFilters) && (
             <div className="search-results-filter-bars__row" data-testid="filters-bar">
                 Filters:
@@ -63,7 +63,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                             .filter(filter => !isScopeSelected(navbarSearchQuery, filter.value))
                             .map((filter, i) => (
                                 <FilterChip
-                                    isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
+                                    isSelected={false}
                                     onFilterChosen={onFilterClick}
                                     key={filter.name + filter.value}
                                     value={filter.value}
@@ -75,7 +75,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                         .filter(filter => !isScopeSelected(navbarSearchQuery, filter.value))
                         .map((filter, i) => (
                             <FilterChip
-                                isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
+                                isSelected={false}
                                 onFilterChosen={onFilterClick}
                                 key={filter.name + filter.value}
                                 value={filter.value}
@@ -98,7 +98,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                             .map((filter, i) => (
                                 <FilterChip
                                     name={filter.label}
-                                    isSelected={isScopeSelected(navbarSearchQuery, filter.value)}
+                                    isSelected={false}
                                     onFilterChosen={onFilterClick}
                                     key={filter.value}
                                     value={filter.value}


### PR DESCRIPTION
This prototype demonstrates the UX of the search bar such that selected options move to the 'Selected options' row, and out of their original rows. 

Related: [Search vision](https://docs.google.com/document/d/1oB2i-1iOy3rUGyD2sjSVgRWTUkPFO2q5Pa_zihhur2o/edit#)

![search-filters](https://user-images.githubusercontent.com/1559622/60749547-4d06c480-9f50-11e9-934a-b491c5deca35.gif)

