### PR TITLE
Integrations CSS: use a link instead of fetch()

### DIFF
--- a/browser/src/integration/integration.tsx
+++ b/browser/src/integration/integration.tsx
@@ -37,25 +37,16 @@ setLinkComponent(({ to, children, ...props }) => (
     </a>
 ))
 
-async function fetchCSS(sourcegraphURL: string): Promise<string> {
-    const resp = await fetch(sourcegraphURL + `/.assets/extension/css/style.bundle.css`, {
-        method: 'GET',
-        credentials: 'include',
-        headers: new Headers({ Accept: 'text/html' }),
-    })
-    return resp.text()
-}
-
 async function init(): Promise<void> {
     const sourcegraphURL = window.SOURCEGRAPH_URL
     if (!sourcegraphURL) {
         throw new Error('window.SOURCEGRAPH_URL is undefined')
     }
-    const css = await fetchCSS(sourcegraphURL)
-    const style = document.createElement('style')
+    const style = document.createElement('link')
+    style.setAttribute('rel', 'stylesheet')
     style.setAttribute('type', 'text/css')
+    style.setAttribute('href', sourcegraphURL + `/.assets/extension/css/style.bundle.css`)
     style.id = 'sourcegraph-styles'
-    style.textContent = css
     document.getElementsByTagName('head')[0].appendChild(style)
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL

--- a/browser/src/integration/integration.tsx
+++ b/browser/src/integration/integration.tsx
@@ -42,12 +42,12 @@ async function init(): Promise<void> {
     if (!sourcegraphURL) {
         throw new Error('window.SOURCEGRAPH_URL is undefined')
     }
-    const style = document.createElement('link')
-    style.setAttribute('rel', 'stylesheet')
-    style.setAttribute('type', 'text/css')
-    style.setAttribute('href', sourcegraphURL + `/.assets/extension/css/style.bundle.css`)
-    style.id = 'sourcegraph-styles'
-    document.getElementsByTagName('head')[0].appendChild(style)
+    const link = document.createElement('link')
+    link.setAttribute('rel', 'stylesheet')
+    link.setAttribute('type', 'text/css')
+    link.setAttribute('href', sourcegraphURL + `/.assets/extension/css/style.bundle.css`)
+    link.id = 'sourcegraph-styles'
+    document.getElementsByTagName('head')[0].appendChild(link)
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL
     await injectModules()


### PR DESCRIPTION
`fetch()` was likely used in Phabricator code because of a restrictive `style-src` directive, but there is no reason not to use a `<link>` element for Bitbucket/Gitlab.

