### PR TITLE
DRY entrypoints

### DIFF
--- a/browser/src/extension/scripts/inject.tsx
+++ b/browser/src/extension/scripts/inject.tsx
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
 
     // Check if a native integration is already running on the page,
     // and abort execution if it's the case.
-    // Note: we should not need this check. Integration scripts are run as
+    // Note: this is just a sanity check. Integration scripts are run as
     // script tags with `defer`, they will be fetched and executed before
     // DOMContentLoaded fires. Meanwhile, the content script is set to run at document_end,
     // meaning that it will only execute after DOMContentLoaded has fired.

--- a/browser/src/integration/integration.tsx
+++ b/browser/src/integration/integration.tsx
@@ -2,34 +2,11 @@ import '../config/polyfill'
 
 import * as H from 'history'
 import React from 'react'
-import { Observable } from 'rxjs'
-import { startWith } from 'rxjs/operators'
 import { setLinkComponent } from '../../../shared/src/components/Link'
-import { determineCodeHost, injectCodeIntelligenceToCodeHost } from '../libs/code_intelligence'
-import { MutationRecordLike, observeMutations } from '../shared/util/dom'
+import { injectCodeIntelligence } from '../libs/code_intelligence/inject'
+import { injectExtensionMarker } from '../libs/sourcegraph/inject'
 
 const IS_EXTENSION = false
-
-// NOT idempotent.
-async function injectModules(): Promise<void> {
-    // This is added so that the browser extension doesn't
-    // interfere with the native integration.
-    // TODO this is racy because the script is loaded async
-    const extensionMarker = document.createElement('div')
-    extensionMarker.id = 'sourcegraph-app-background'
-    extensionMarker.style.display = 'none'
-    document.body.appendChild(extensionMarker)
-
-    // TODO handle subscription
-    const codeHost = await determineCodeHost()
-    if (codeHost) {
-        const mutations: Observable<MutationRecordLike[]> = observeMutations(document.body, {
-            childList: true,
-            subtree: true,
-        }).pipe(startWith([{ addedNodes: [document.body], removedNodes: [] }]))
-        await injectCodeIntelligenceToCodeHost(mutations, codeHost, IS_EXTENSION)
-    }
-}
 
 setLinkComponent(({ to, children, ...props }) => (
     <a href={to && typeof to !== 'string' ? H.createPath(to) : to} {...props}>
@@ -50,7 +27,9 @@ async function init(): Promise<void> {
     document.getElementsByTagName('head')[0].appendChild(link)
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL
-    await injectModules()
+    injectExtensionMarker()
+    // TODO handle subscription
+    await injectCodeIntelligence(IS_EXTENSION)
 }
 
 init().catch(err => {

--- a/browser/src/libs/code_intelligence/inject.ts
+++ b/browser/src/libs/code_intelligence/inject.ts
@@ -1,0 +1,24 @@
+import { Observable, Subscription } from 'rxjs'
+import { startWith } from 'rxjs/operators'
+import { MutationRecordLike, observeMutations } from '../../shared/util/dom'
+import { determineCodeHost, injectCodeIntelligenceToCodeHost } from './code_intelligence'
+
+/**
+ * Checks if the current page is a known code host. If it is,
+ * injects features for the lifetime of the script in reaction to DOM mutations.
+ *
+ * @param isExtension `true` when executing in the browser extension.
+ */
+export async function injectCodeIntelligence(isExtension: boolean): Promise<Subscription> {
+    const subscriptions = new Subscription()
+    const codeHost = await determineCodeHost()
+    if (codeHost) {
+        console.log('Detected code host:', codeHost.type)
+        const mutations: Observable<MutationRecordLike[]> = observeMutations(document.body, {
+            childList: true,
+            subtree: true,
+        }).pipe(startWith([{ addedNodes: [document.body], removedNodes: [] }]))
+        subscriptions.add(await injectCodeIntelligenceToCodeHost(mutations, codeHost, isExtension))
+    }
+    return subscriptions
+}

--- a/browser/src/libs/phabricator/extension.tsx
+++ b/browser/src/libs/phabricator/extension.tsx
@@ -47,7 +47,7 @@ async function init(): Promise<void> {
     style.setAttribute('type', 'text/css')
     style.id = 'sourcegraph-styles'
     style.textContent = css
-    document.getElementsByTagName('head')[0].appendChild(style)
+    document.head.appendChild(style)
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL
     metaClickOverride()

--- a/browser/src/libs/phabricator/extension.tsx
+++ b/browser/src/libs/phabricator/extension.tsx
@@ -19,46 +19,40 @@ setLinkComponent(({ to, children, ...props }) => (
     </a>
 ))
 
-function init(): void {
+async function init(): Promise<void> {
     /**
      * This is the main entry point for the phabricator in-page JavaScript plugin.
      */
-    if (window.localStorage && window.localStorage.getItem('SOURCEGRAPH_DISABLED') !== 'true') {
-        // Backwards compat: Support Legacy Phabricator extension. Check that the Phabricator integration
-        // passed the bundle url. Legacy Phabricator extensions inject CSS via the loader.js script
-        // so we do not need to do this here.
-        if (!window.SOURCEGRAPH_BUNDLE_URL && !window.localStorage.getItem('SOURCEGRAPH_BUNDLE_URL')) {
-            injectExtensionMarker()
-            injectCodeIntelligence(IS_EXTENSION).catch(err => console.error('Unable to inject code intelligence', err))
-            metaClickOverride()
-            return
-        }
-
-        getSourcegraphURLFromConduit()
-            .then(sourcegraphURL =>
-                getPhabricatorCSS(sourcegraphURL).then(css => {
-                    const style = document.createElement('style')
-                    style.setAttribute('type', 'text/css')
-                    style.id = 'sourcegraph-styles'
-                    style.textContent = css
-                    document.getElementsByTagName('head')[0].appendChild(style)
-                    window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
-                    window.SOURCEGRAPH_URL = sourcegraphURL
-                    metaClickOverride()
-                    injectExtensionMarker()
-                    injectCodeIntelligence(IS_EXTENSION).catch(err =>
-                        console.error('Unable to inject code intelligence', err)
-                    )
-                })
-            )
-            .catch(e => console.error(e))
-    } else {
+    if (window.localStorage && window.localStorage.getItem('SOURCEGRAPH_DISABLED') === 'true') {
         console.log(
             `Sourcegraph on Phabricator is disabled because window.localStorage.getItem('SOURCEGRAPH_DISABLED') is set to ${window.localStorage.getItem(
                 'SOURCEGRAPH_DISABLED'
             )}.`
         )
+        return
     }
+    // Backwards compat: Support Legacy Phabricator extension. Check that the Phabricator integration
+    // passed the bundle url. Legacy Phabricator extensions inject CSS via the loader.js script
+    // so we do not need to do this here.
+    if (!window.SOURCEGRAPH_BUNDLE_URL && !window.localStorage.getItem('SOURCEGRAPH_BUNDLE_URL')) {
+        injectExtensionMarker()
+        await injectCodeIntelligence(IS_EXTENSION)
+        metaClickOverride()
+        return
+    }
+
+    const sourcegraphURL = await getSourcegraphURLFromConduit()
+    const css = await getPhabricatorCSS(sourcegraphURL)
+    const style = document.createElement('style')
+    style.setAttribute('type', 'text/css')
+    style.id = 'sourcegraph-styles'
+    style.textContent = css
+    document.getElementsByTagName('head')[0].appendChild(style)
+    window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
+    window.SOURCEGRAPH_URL = sourcegraphURL
+    metaClickOverride()
+    injectExtensionMarker()
+    await injectCodeIntelligence(IS_EXTENSION)
 }
 
-init()
+init().catch(err => console.error(`Error initializing Phabricator integration`, err))

--- a/browser/src/libs/sourcegraph/inject.tsx
+++ b/browser/src/libs/sourcegraph/inject.tsx
@@ -1,13 +1,37 @@
+export const EXTENSION_MARKER_ID = 'sourcegraph-app-background'
+
 /**
+ * Injects a `#sourcegraph-app-background` hidden element.
+ *
+ * This element is checked for in the webapp to know if the browser extension
+ * is installed, and in the browser extension to determine whether a native integration
+ * is already running on the page.
+ *
  * Not idempotent.
  */
-export function injectSourcegraphApp(marker: HTMLElement): void {
-    // Generate and insert DOM element, in case this code executes first.
-    document.body.appendChild(marker)
+export function injectExtensionMarker(): void {
+    const extensionMarker = document.createElement('div')
+    extensionMarker.id = EXTENSION_MARKER_ID
+    extensionMarker.style.display = 'none'
+    document.body.appendChild(extensionMarker)
+}
 
-    window.addEventListener('load', () => {
-        dispatchSourcegraphEvents()
-    })
+/**
+ * Injects the extension marker and dispatches a custom event
+ * to signal to Sourcegraph web app that the browser extension is installed.
+ *
+ *  Not idempotent.
+ */
+export function signalBrowserExtensionInstalled(): void {
+    injectExtensionMarker()
+
+    window.addEventListener(
+        'load',
+        () => {
+            dispatchSourcegraphEvents()
+        },
+        { once: true }
+    )
 
     if (document.readyState === 'complete' || document.readyState === 'interactive') {
         dispatchSourcegraphEvents()

--- a/browser/src/libs/sourcegraph/inject.tsx
+++ b/browser/src/libs/sourcegraph/inject.tsx
@@ -28,13 +28,7 @@ export function signalBrowserExtensionInstalled(): void {
     if (document.readyState === 'complete' || document.readyState === 'interactive') {
         dispatchSourcegraphEvents()
     } else {
-        window.addEventListener(
-            'load',
-            () => {
-                dispatchSourcegraphEvents()
-            },
-            { once: true }
-        )
+        window.addEventListener('load', dispatchSourcegraphEvents, { once: true })
     }
 }
 

--- a/browser/src/libs/sourcegraph/inject.tsx
+++ b/browser/src/libs/sourcegraph/inject.tsx
@@ -25,16 +25,16 @@ export function injectExtensionMarker(): void {
 export function signalBrowserExtensionInstalled(): void {
     injectExtensionMarker()
 
-    window.addEventListener(
-        'load',
-        () => {
-            dispatchSourcegraphEvents()
-        },
-        { once: true }
-    )
-
     if (document.readyState === 'complete' || document.readyState === 'interactive') {
         dispatchSourcegraphEvents()
+    } else {
+        window.addEventListener(
+            'load',
+            () => {
+                dispatchSourcegraphEvents()
+            },
+            { once: true }
+        )
     }
 }
 


### PR DESCRIPTION
Deduplicates code around extension marker and code intelligence injection in phabricator, integrations & injected script entrypoints.

Also removes comments about extension marker injection being racy in Phabricator and integration entry points: `<script>` tags with the `defer` attribute are executed after the document has been parsed, but before `DOMContentLoaded` fires. Meanwhile, browser extension content scripts are set to run at `document_end`, after `DOMContentLoaded` has fired.

#### Test Plan

- [x] Browser extension
- [x] Bitbucket integration
- [x] Phabricator integration