### PR TITLE
Improve style of activated extension toggle

### DIFF
--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -7,6 +7,9 @@
     &--variant-action-item &__content {
         justify-content: center;
     }
+    border-left: 1px solid $color-light-bg-1;
+    margin-left: 2px;
+    border-right: 1px solid $color-light-bg-1;
 
     // Show loader on top of the action's content. This avoids changing the element's width when loading, which
     // looks bad.

--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -7,9 +7,6 @@
     &--variant-action-item &__content {
         justify-content: center;
     }
-    border-left: 1px solid $color-light-bg-1;
-    margin-left: 2px;
-    border-right: 1px solid $color-light-bg-1;
 
     // Show loader on top of the action's content. This avoids changing the element's width when loading, which
     // looks bad.
@@ -25,5 +22,18 @@
         top: 50%;
         left: 50%;
         transform: translateX(-50%) translateY(-50%);
+    }
+}
+.theme-dark {
+    .action-item {
+        border-left: 1px solid $black;
+        border-right: 1px solid $black;
+    }
+}
+
+.theme-light {
+    .action-item {
+        border-left: 1px solid $color-light-border-3;
+        border-right: 1px solid $color-light-border-3;
     }
 }

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -281,4 +281,3 @@ body,
 @import '~@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
 
 @import '../../shared/src/index';
-@import '../../shared/src/actions/ActionItem.scss';

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -281,3 +281,4 @@ body,
 @import '~@sourcegraph/react-loading-spinner/lib/LoadingSpinner.css';
 
 @import '../../shared/src/index';
+@import '../../shared/src/actions/ActionItem.scss';

--- a/web/src/global-styles/colors.scss
+++ b/web/src/global-styles/colors.scss
@@ -62,3 +62,4 @@ $color-light-text-6: #1d2535;
 
 $color-light-border: #cad2e2;
 $color-light-border-2: #e4e9f1;
+$color-light-border-3: #ffffff;

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -52,12 +52,18 @@
 
 .theme-dark {
     .repo-header {
-        border-color: #233043;
+        border-color: $color-border;
     }
     .action-item--pressed {
-        background-color: $color-bg-3;
-        border-color: $color-border;
         height: 100%;
+        background: linear-gradient(
+                    to bottom,
+                    transparent 55%,
+                    rgba($color-border-hover, 1) 100%
+                );
+        border-color: $color-border!important;
+        color: $color-text-3;
+        text-shadow: 1px 1px 1px rgba($color-text-3, 0.15);
     }
 }
 
@@ -66,16 +72,14 @@
         border-color: $color-light-border;
     }
     .action-item--pressed {
+        height: 100%;
         background: linear-gradient(
                     to bottom,
-                    rgba($color-light-bg-3, 0.75) 0%,
-                    transparent 45%,
-                    // transparent 55%,
-                    // rgba($color-light-bg-3, 0.75) 100%
+                    transparent 55%,
+                    rgba($color-light-bg-3, 0.75) 100%
                 );
-        border-color: $color-light-border;
-        height: 100%;
+        border-color: $color-light-border!important;
+        color: $color-light-text-6;
         text-shadow: 1px 1px 1px rgba($color-light-text-5, 0.15);
-        color: $color-light-text-5;
     }
 }

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -56,6 +56,8 @@
     }
     .action-item--pressed {
         background-color: $color-bg-3;
+        border-color: $color-border;
+        height: 100%;
     }
 }
 
@@ -64,6 +66,16 @@
         border-color: $color-light-border;
     }
     .action-item--pressed {
-        background-color: $color-light-bg-3;
+        background: linear-gradient(
+                    to bottom,
+                    rgba($color-light-bg-3, 0.75) 0%,
+                    transparent 45%,
+                    // transparent 55%,
+                    // rgba($color-light-bg-3, 0.75) 100%
+                );
+        border-color: $color-light-border;
+        height: 100%;
+        text-shadow: 1px 1px 1px rgba($color-light-text-5, 0.15);
+        color: $color-light-text-5;
     }
 }

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -56,12 +56,8 @@
     }
     .action-item--pressed {
         height: 100%;
-        background: linear-gradient(
-                    to bottom,
-                    transparent 55%,
-                    rgba($color-border-hover, 1) 100%
-                );
-        border-color: $color-border!important;
+        background: linear-gradient(to bottom, transparent 55%, rgba($color-border-hover, 1) 100%);
+        border-color: $color-border !important;
         color: $color-text-3;
         text-shadow: 1px 1px 1px rgba($color-text-3, 0.15);
     }
@@ -73,12 +69,8 @@
     }
     .action-item--pressed {
         height: 100%;
-        background: linear-gradient(
-                    to bottom,
-                    transparent 55%,
-                    rgba($color-light-bg-3, 0.75) 100%
-                );
-        border-color: $color-light-border!important;
+        background: linear-gradient(to bottom, transparent 55%, rgba($color-light-bg-3, 0.75) 100%);
+        border-color: $color-light-border !important;
         color: $color-light-text-6;
         text-shadow: 1px 1px 1px rgba($color-light-text-5, 0.15);
     }


### PR DESCRIPTION
This PR will improve the styling of the activated extension toggle button located in the navigation above the code view (`repo header`).

Current view of an activated extension toggle.
![image](https://user-images.githubusercontent.com/9110008/60975727-49bd6100-a2e1-11e9-84c0-cf233e39e862.png)

![image](https://user-images.githubusercontent.com/9110008/60975773-59d54080-a2e1-11e9-820c-6887ff9ec13d.png)

Change through this PR:
![image](https://user-images.githubusercontent.com/9110008/60975812-68235c80-a2e1-11e9-9dc6-aae96039575e.png)

![image](https://user-images.githubusercontent.com/9110008/60975840-75404b80-a2e1-11e9-9951-79c47a35ee43.png)

