### PR TITLE
Improve style of activated extension toggle

### DIFF
--- a/shared/src/actions/ActionItem.scss
+++ b/shared/src/actions/ActionItem.scss
@@ -1,4 +1,5 @@
 .action-item {
+    height: 100%;
     &__content {
         display: flex;
         align-items: center;

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -56,6 +56,8 @@
     }
     .action-item--pressed {
         background-color: $color-bg-3;
+        height: 100%;
+        color: $color-text-3;
     }
 }
 
@@ -66,6 +68,6 @@
     .action-item--pressed {
         background-color: $color-light-bg-3;
         height: 100%;
-        color: $color-light-text-1;
+        color: $color-light-text-5;
     }
 }

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -56,7 +56,6 @@
     }
     .action-item--pressed {
         background-color: $color-bg-3;
-        height: 100%;
         color: $color-text-3;
     }
 }
@@ -67,7 +66,6 @@
     }
     .action-item--pressed {
         background-color: $color-light-bg-3;
-        height: 100%;
-        color: $color-light-text-5;
+        color: $color-light-text-1;
     }
 }

--- a/web/src/repo/RepoHeader.scss
+++ b/web/src/repo/RepoHeader.scss
@@ -65,5 +65,7 @@
     }
     .action-item--pressed {
         background-color: $color-light-bg-3;
+        height: 100%;
+        color: $color-light-text-1;
     }
 }


### PR DESCRIPTION
This PR will improve the styling of the activated extension toggle button located in the navigation above the code view (repo header).

Current view of an activated extension toggle:
![image](https://user-images.githubusercontent.com/9110008/60975727-49bd6100-a2e1-11e9-84c0-cf233e39e862.png)

![image](https://user-images.githubusercontent.com/9110008/60975773-59d54080-a2e1-11e9-820c-6887ff9ec13d.png)

Change through this PR:
![image](https://user-images.githubusercontent.com/9110008/61234258-727d9600-a6e7-11e9-8862-a34124fe1d71.png)

![image](https://user-images.githubusercontent.com/9110008/60980270-036c0000-a2e9-11e9-8f56-ee7e8138e04e.png)

