### PR TITLE
Stop using aui-dropdown2-trigger on Bitbucket

### DIFF
--- a/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -196,7 +196,7 @@ export const bitbucketServerCodeHost: CodeHost = {
     getCommandPaletteMount,
     commandPaletteClassProps: {
         buttonClassName:
-            'aui-dropdown2-trigger aui-alignment-target aui-alignment-abutted aui-alignment-abutted-left aui-alignment-element-attached-top aui-alignment-element-attached-left aui-alignment-target-attached-bottom aui-alignment-target-attached-left',
+            'command-list-popover-button--bitbucket-server aui-alignment-target aui-alignment-abutted aui-alignment-abutted-left aui-alignment-element-attached-top aui-alignment-element-attached-left aui-alignment-target-attached-bottom aui-alignment-target-attached-left',
         buttonElement: 'a',
         buttonOpenClassName: 'aui-dropdown2-active active aui-alignment-enabled',
         showCaret: false,

--- a/browser/src/libs/bitbucket/style.scss
+++ b/browser/src/libs/bitbucket/style.scss
@@ -43,3 +43,28 @@
         border-left: none !important;
     }
 }
+
+// Bitbucket's style is copied here because adding the aui-dropdown2-trigger class
+// to the command palette causes exceptions in Atlassian's JS.
+.command-list-popover-button--bitbucket-server {
+    padding-right: 24px !important;
+
+    &::after {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        -webkit-text-stroke-width: 0;
+        font-family: 'Adgs Icons';
+        font-weight: normal;
+        font-style: normal;
+        content: '\f15b';
+        font-size: 16px;
+        height: 16px;
+        line-height: 1;
+        margin-top: -8px;
+        position: absolute;
+        right: 4px;
+        top: 50%;
+        text-indent: 0;
+        width: 16px;
+    }
+}


### PR DESCRIPTION
Fixes #4834

Adding the `aui-dropdown2-trigger` class to the command palette causes exceptions in Atlassian's JS.