### PR TITLE
Increase nginx proxy_buffers size

### DIFF
--- a/cmd/server/shared/assets/nginx.conf
+++ b/cmd/server/shared/assets/nginx.conf
@@ -15,6 +15,10 @@ events {
 http {
     server_tokens off;
 
+    # SAML redirect response headers are sometimes large
+    proxy_buffers         8 16k;  # Buffer pool = 8 buffers of 16k
+    proxy_buffer_size     16k;    # 16k of buffers from pool used for headers
+
     # Do not remove. The contents of sourcegraph_http.conf can change between
     # versions and may include improvements to the configuration.
     include nginx/sourcegraph_http.conf;

--- a/cmd/server/shared/assets/nginx.conf
+++ b/cmd/server/shared/assets/nginx.conf
@@ -16,8 +16,9 @@ http {
     server_tokens off;
 
     # SAML redirect response headers are sometimes large
-    proxy_buffers         8 16k;  # Buffer pool = 8 buffers of 16k
-    proxy_buffer_size     16k;    # 16k of buffers from pool used for headers
+    proxy_buffer_size     128k;
+    proxy_buffers         8 256k;
+    proxy_busy_buffers_size    256k;
 
     # Do not remove. The contents of sourcegraph_http.conf can change between
     # versions and may include improvements to the configuration.
@@ -41,6 +42,11 @@ http {
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # SAML redirect response headers are sometimes large
+            proxy_buffer_size     128k;
+            proxy_buffers         8 256k;
+            proxy_busy_buffers_size    256k;
         }
     }
 }

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -7,6 +7,10 @@ events {
 http {
     server_tokens off;
 
+    # large_client_header_buffers 4 16k;
+    proxy_buffers         8 16k;  # Buffer pool = 8 buffers of 16k
+    proxy_buffer_size     16k;    # 16k of buffers from pool used for headers
+
     # We can upload large extensions
     client_max_body_size 150M;
 

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -7,7 +7,6 @@ events {
 http {
     server_tokens off;
 
-    # large_client_header_buffers 4 16k;
     proxy_buffers         8 16k;  # Buffer pool = 8 buffers of 16k
     proxy_buffer_size     16k;    # 16k of buffers from pool used for headers
 

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -37,10 +37,6 @@ func ComputeConfig() Config {
 
 	taggedRelease := true // true if this is a tagged release
 	switch {
-	case strings.HasPrefix(branch, "docker-images-debug/"):
-		// A branch like "docker-images-debug/foobar" will produce Docker images
-		// tagged as "debug-foobar-$COMMIT".
-		version = fmt.Sprintf("debug-%s-%s", strings.TrimPrefix(branch, "docker-images-debug/"), commit)
 	case strings.HasPrefix(version, "v"):
 		// The Git tag "v1.2.3" should map to the Docker image "1.2.3" (without v prefix).
 		version = strings.TrimPrefix(version, "v")

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -267,7 +267,7 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 			bk.Cmd(getBuildScript()),
 		)
 
-		if app != "server" || c.taggedRelease {
+		if app != "server" || c.taggedRelease || c.patch || c.patchNoTest {
 			cmds = append(cmds,
 				bk.Cmd(fmt.Sprintf("docker push %s:%s", image, c.version)),
 			)

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -41,9 +41,16 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}
 	case c.patchNoTest:
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
-		pipelineOperations = []func(*bk.Pipeline){
-			addDockerImage(c, c.branch[27:], false),
+		app := c.branch[27:]
+		var pipelineOperations []func(*bk.Pipeline)
+		if app == "server" {
+			pipelineOperations = append(pipelineOperations, addServerDockerImageCandidate(c))
 		}
+		pipelineOperations = append(pipelineOperations, addDockerImage(c, app, false))
+		if app == "server" {
+			pipelineOperations = append(pipelineOperations, addCleanUpServerDockerImageCandidate(c))
+		}
+
 	case c.isBextReleaseBranch:
 		// If this is a browser extension release branch, run the browser-extension tests and
 		// builds.

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -42,13 +42,18 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case c.patchNoTest:
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
 		app := c.branch[27:]
-		var pipelineOperations []func(*bk.Pipeline)
 		if app == "server" {
-			pipelineOperations = append(pipelineOperations, addServerDockerImageCandidate(c))
+			pipelineOperations = append(pipelineOperations,
+				addServerDockerImageCandidate(c),
+				wait,
+			)
 		}
 		pipelineOperations = append(pipelineOperations, addDockerImage(c, app, false))
 		if app == "server" {
-			pipelineOperations = append(pipelineOperations, addCleanUpServerDockerImageCandidate(c))
+			pipelineOperations = append(pipelineOperations,
+				wait,
+				addCleanUpServerDockerImageCandidate(c),
+			)
 		}
 
 	case c.isBextReleaseBranch:

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -9,7 +9,8 @@ import (
 )
 
 func main() {
-	pipeline, err := ci.GeneratePipeline(ci.ComputeConfig())
+	config := ci.ComputeConfig()
+	pipeline, err := ci.GeneratePipeline(config)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Increase the nginx proxy buffers, which effectively limit the size of a HTTP response from Sourcegraph. This fixes an issue where SAML login would fail, because the HTTP redirect, which included the URL-encoded SAML assertion, exceeded the proxy buffer size.

[$CUSTOMER](https://app.hubspot.com/contacts/2762526/company/554338610) ran into this after configuring SAML login with encryption (via the `serviceProviderCertificate` and `serviceProviderPrivateKey` fields).

This PR also includes some changes to CI to fix bugs in the `docker-images-patch-notest/server` case.

**Post-merge TODO:**
- [ ] Cherry-pick this into 3.5
- [ ] Update deploy-sourcegraph nginx ConfigMap