### PR TITLE
Fix bitbucket isCommitsView and isPullRequestView

### DIFF
--- a/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -137,14 +137,14 @@ const codeViewResolver: ViewResolver<CodeView> = {
         if (isCompareView()) {
             return { element, ...compareDiffCodeView }
         }
-        if (isCommitsView()) {
+        if (isCommitsView(window.location)) {
             return { element, ...commitDiffCodeView }
         }
         if (isSingleFileView(element)) {
             const isDiff = contentView.classList.contains('diff-view')
             return isDiff ? { element, ...singleFileDiffCodeView } : { element, ...singleFileSourceCodeView }
         }
-        if (isPullRequestView()) {
+        if (isPullRequestView(window.location)) {
             return { element, ...pullRequestDiffCodeView }
         }
         console.error('Unknown code view', element)

--- a/browser/src/libs/bitbucket/scrape.test.ts
+++ b/browser/src/libs/bitbucket/scrape.test.ts
@@ -155,7 +155,7 @@ describe('Bitbucket scrape.ts', () => {
             expect(
                 isCommitsView(
                     new URL(
-                        'https://atlassian.company.org/bitbucket//bitbucket/projects/SOUR/repos/mux/commits/8eaa9f13091105874ef3e20c65922e382cef3c64'
+                        'https://atlassian.company.org/bitbucket/projects/SOUR/repos/mux/commits/8eaa9f13091105874ef3e20c65922e382cef3c64'
                     )
                 )
             ).toBe(true)

--- a/browser/src/libs/bitbucket/scrape.test.ts
+++ b/browser/src/libs/bitbucket/scrape.test.ts
@@ -1,6 +1,11 @@
 import { readFile } from 'mz/fs'
 import { getFixtureBody } from '../code_intelligence/code_intelligence_test_utils'
-import { getFileInfoFromSingleFileSourceCodeView, getFileInfoWithoutCommitIDsFromMultiFileDiffCodeView } from './scrape'
+import {
+    getFileInfoFromSingleFileSourceCodeView,
+    getFileInfoWithoutCommitIDsFromMultiFileDiffCodeView,
+    isCommitsView,
+    isPullRequestView,
+} from './scrape'
 
 describe('Bitbucket scrape.ts', () => {
     describe('getFileInfoFromSingleFileSourceCodeView()', () => {
@@ -132,6 +137,46 @@ describe('Bitbucket scrape.ts', () => {
                 repoSlug: 'mux',
                 rawRepoName: 'bitbucket.test/SOURCEGRAPH/mux',
             })
+        })
+    })
+
+    describe('isCommitView()', () => {
+        it('detects a commit view when there is no context path', () => {
+            expect(
+                isCommitsView(
+                    new URL(
+                        'https://bitbucket.sgdev.org/projects/SOUR/repos/vegeta/commits/e827e02858e8d5d581bac4d57b31fbd275da39c5'
+                    )
+                )
+            ).toBe(true)
+        })
+
+        it('detects a commit view when there is a context path', () => {
+            expect(
+                isCommitsView(
+                    new URL(
+                        'https://atlassian.company.org/bitbucket//bitbucket/projects/SOUR/repos/mux/commits/8eaa9f13091105874ef3e20c65922e382cef3c64'
+                    )
+                )
+            ).toBe(true)
+        })
+    })
+
+    describe('isPullRequestView()', () => {
+        it('detects a pull request view when there is no context path', () => {
+            expect(
+                isPullRequestView(
+                    new URL('https://bitbucket.sgdev.org/projects/SOUR/repos/mux/pull-requests/1/overview')
+                )
+            ).toBe(true)
+        })
+
+        it('detects a pull request view when there is a context path', () => {
+            expect(
+                isPullRequestView(
+                    new URL('https://atlassian.company.org/bitbucket/projects/SOUR/repos/mux/pull-requests/1/overview')
+                )
+            ).toBe(true)
         })
     })
 })

--- a/browser/src/libs/bitbucket/scrape.ts
+++ b/browser/src/libs/bitbucket/scrape.ts
@@ -129,13 +129,14 @@ export const isCompareView = () => !!document.querySelector('#branch-compare')
 /**
  * Returns true if the active page is a commit view.
  */
-export const isCommitsView = () => /^\/projects\/[^\/]+\/repos\/[^\/]+\/commits\/\w+$/.test(window.location.pathname)
+export const isCommitsView = ({ pathname }: Pick<Location, 'pathname'>): boolean =>
+    /\/projects\/[^\/]+\/repos\/[^\/]+\/commits\/\w+$/.test(pathname)
 
 /**
  * Returns true if the active page is a pull request view.
  */
-export const isPullRequestView = () =>
-    /^\/projects\/[^\/]+\/repos\/[^\/]+\/pull-requests\/\d+/.test(window.location.pathname)
+export const isPullRequestView = ({ pathname }: Pick<Location, 'pathname'>): boolean =>
+    /\/projects\/[^\/]+\/repos\/[^\/]+\/pull-requests\/\d+/.test(pathname)
 
 /**
  * Returns true if the given code view is a single file source or "diff to previous" view.


### PR DESCRIPTION
It's quite common for Atlassian applications to be deployed with a context path (https://confluence.atlassian.com/kb/set-a-context-path-for-atlassian-applications-836601189.html) - the URL of the bitbucket instance then becomes `https://altassian.company.org/<contextpath>`, and the pathname of a PR view doesn't start with `/projects`, which both of these functions previously assumed.
