### PR TITLE
Bitbucket: use AJS.contextPath() to build API URLs

### DIFF
--- a/browser/src/libs/bitbucket/api.ts
+++ b/browser/src/libs/bitbucket/api.ts
@@ -11,7 +11,12 @@ import { BitbucketRepoInfo } from './scrape'
 // PR API /rest/api/1.0/projects/SG/repos/go-langserver/pull-requests/1
 
 const buildURL = (project: string, repoSlug: string, path: string) =>
-    `${window.location.origin}/rest/api/1.0/projects/${encodeURIComponent(project)}/repos/${repoSlug}${path}`
+    // If possible, use the global `AJS.contextPath()` to reliably construct an absolute URL.
+    // This is possible in the native integration only - browser extension content scripts cannot
+    // access the page's global scope.
+    `${AJS ? AJS.contextPath() : window.location.origin}/rest/api/1.0/projects/${encodeURIComponent(
+        project
+    )}/repos/${repoSlug}${path}`
 
 const get = <T>(url: string): Observable<T> => ajax.get(url).pipe(map(({ response }) => response as T))
 

--- a/browser/src/libs/bitbucket/api.ts
+++ b/browser/src/libs/bitbucket/api.ts
@@ -10,11 +10,17 @@ import { BitbucketRepoInfo } from './scrape'
 //
 // PR API /rest/api/1.0/projects/SG/repos/go-langserver/pull-requests/1
 
+/**
+ * Builds the URL to the Bitbucket Server REST API endpoint for the given project/repo/path.
+ *
+ * `path` should have a leading slash.
+ * `project` and `repoSlug` should have neither a leading nor a traling slash.
+ */
 const buildURL = (project: string, repoSlug: string, path: string) =>
     // If possible, use the global `AJS.contextPath()` to reliably construct an absolute URL.
     // This is possible in the native integration only - browser extension content scripts cannot
     // access the page's global scope.
-    `${AJS ? AJS.contextPath() : window.location.origin}/rest/api/1.0/projects/${encodeURIComponent(
+    `${window.AJS ? window.AJS.contextPath() : window.location.origin}/rest/api/1.0/projects/${encodeURIComponent(
         project
     )}/repos/${repoSlug}${path}`
 

--- a/browser/src/types/ajs/index.d.ts
+++ b/browser/src/types/ajs/index.d.ts
@@ -6,9 +6,11 @@ interface AJS {
     contextPath(): string
 }
 
-/**
- * The `AJS` global object provides helper methods to interact with
- * the UI of Atlassian products. It is only defined when executing in the
- * Bitbucket Server native integration.
- */
-declare var AJS: AJS | undefined
+interface Window {
+    /**
+     * The `AJS` global object provides helper methods to interact with
+     * the UI of Atlassian products. It is only defined when executing in the
+     * Bitbucket Server native integration.
+     */
+    AJS?: AJS
+}

--- a/browser/src/types/ajs/index.d.ts
+++ b/browser/src/types/ajs/index.d.ts
@@ -1,9 +1,14 @@
-declare var AJS:
-    | {
-          /**
-           * The AJS.contextPath() function returns the "path" to the application,
-           * which is needed when creating absolute urls within the application.
-           */
-          contextPath(): string
-      }
-    | undefined
+interface AJS {
+    /**
+     * The AJS.contextPath() function returns the "path" to the application,
+     * which is needed when creating absolute urls within the application.
+     */
+    contextPath(): string
+}
+
+/**
+ * The `AJS` global object provides helper methods to interact with
+ * the UI of Atlassian products. It is only defined when executing in the
+ * Bitbucket Server native integration.
+ */
+declare var AJS: AJS | undefined

--- a/browser/src/types/ajs/index.d.ts
+++ b/browser/src/types/ajs/index.d.ts
@@ -1,0 +1,9 @@
+declare var AJS:
+    | {
+          /**
+           * The AJS.contextPath() function returns the "path" to the application,
+           * which is needed when creating absolute urls within the application.
+           */
+          contextPath(): string
+      }
+    | undefined


### PR DESCRIPTION
When using a context path (https://confluence.atlassian.com/kb/set-a-context-path-for-atlassian-applications-836601189.html), the assumption that the bitbucket API is at `${window.location.origin}/rest/api` is broken.

This introduces a fix by using the global `AJS.contextPath()` when available.

Since browser extension content scripts cannot access the page's global scope, this currently only works in the native integration. I'm a bit reluctant to use the "usual hacks" to access `AJS.contextPath()` from the browser extension content script (eg. script tag injection + communicating the value through data attributes or custom events), and have left the `window.location.origin` fallback in place when `AJS` is undefined. Thoughts?
