### PR TITLE
repo-updater: Fix not-cloned count by comparing lowercase repo names

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -468,9 +468,10 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 
-	clonedRepos := make(map[api.RepoName]bool, len(names))
+	clonedRepos := make(map[string]bool, len(names))
 	for _, n := range names {
-		clonedRepos[n] = false
+		lower := strings.ToLower(string(n))
+		clonedRepos[lower] = false
 	}
 
 	cloned, err := s.GitserverClient.ListCloned(ctx)
@@ -479,9 +480,10 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 	}
 
 	for _, c := range cloned {
-		if _, ok := clonedRepos[api.RepoName(c)]; ok {
-			clonedRepos[api.RepoName(c)] = true
+		if _, ok := clonedRepos[c]; ok {
+			clonedRepos[c] = true
 		}
+
 	}
 
 	var notCloned uint64

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -605,6 +605,14 @@ func TestServer_StatusMessages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:            "case insensitivity",
+			gitserverCloned: []string{"foobar"},
+			stored:          []*repos.Repo{{Name: "FOOBar"}},
+			res: &protocol.StatusMessagesResponse{
+				Messages: []protocol.StatusMessage{},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
`gitserver`'s `list?cloned` endpoint only returns lowercase repository names. In order for the computation of the not-cloned count in the status indicator to work properly, we need to lowercase the repository names we load from the database before comparing them to gitservers.

Discovered this by accident when cloning the complete `github.com/sourcegraph` organization and seeing the not-cloned count not going down after a certain point.

Test plan: `go test`
