### PR TITLE
Enable clone status indicator by default and remove feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - In the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) and [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#permissions) `repositoryQuery` is now only required if `repos` is not set.
 - Usernames can now contain the `.` character (#4690).
 - Log messages from query-runner when saved searches fail now include the raw query as part of the message.
+- The status indicator in the navigation bar is now enabled by default
 
 ### Fixed
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -47,7 +47,7 @@
           "description": "Enables the external service status indicator in the navigation bar.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "disabled"
+          "default": "enabled"
         }
       },
       "group": "Experimental",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -52,7 +52,7 @@ const SiteSchemaJSON = `{
           "description": "Enables the external service status indicator in the navigation bar.",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "disabled"
+          "default": "enabled"
         }
       },
       "group": "Experimental",


### PR DESCRIPTION
The original reason for putting the status indicator behind a feature flag was that on large instances it was always in an active state, indicating that repositories are being cloned, when in fact they were only enqueued for updates. See PR #4497 for more details on this.

With the improvements made in the following PRs, I think it's safe to enable the status indicator by default now:

- #4591 - status-indicator: Show actual cloning state
- #4810 - perf: Improve performance of computing number of not-cloned repos
- #4859 - Fix not-cloned count by comparing lowercase repo names

The number is now accurate and it's reasonably fast to compute (3.3s on an instance with 33k repositories, calculated every 30s).

**Question**: is it okay to remove a feature-flag like this or will that invalidate customer's configurations if they have enabled it?

(cc @nicksnyder)