### PR TITLE
Bitbucket Server plugin: CHANGELOG & docs changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
+++ b/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
@@ -11,6 +11,7 @@
 - [ ] Phabricator
 - [ ] Phabricator integration
 - [ ] Bitbucket
+- [ ] Bitbucket integration
 - [ ] Gitlab
 
 ##### Browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The `github.exclude` setting in [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) additionally allows you to specify regular expressions with `{"pattern": "regex"}`.
 - A new [`quicklinks` setting](https://docs.sourcegraph.com/user/quick_links) allows adding links to be displayed on the homepage and search page for all users (or users in an organization).
+- Compatibility with the [Sourcegraph for Bitbucket Server](https://github.com/sourcegraph/bitbucket-server-plugin) plugin.
 
 ### Changed
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -43,7 +43,7 @@ Bitbucket Server external service connections support the following configuratio
 
 ## Native extension
 
-For production usage, we recommend installing the Sourcegraph Bitbucket Server plugin for all users (so that each user doesn't need to install the browser extension individually). This involves adding a new extension to the extension directory of your Phabricator instance.
+For production usage, we recommend installing the Sourcegraph Bitbucket Server plugin for all users (so that each user doesn't need to install and configure the browser extension individually). This involves adding a new add-on to  your Bitbucket Server instance.
 
 See the [bitbucket-server-plugin](https://github.com/sourcegraph/bitbucket-server-plugin) repository for installation instructions and configuration settings.
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -40,3 +40,20 @@ Sourcegraph by default clones repositories from your Bitbucket Server via HTTP(S
 Bitbucket Server external service connections support the following configuration options, which are specified in the JSON editor in the site admin external services area.
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/bitbucket_server.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/bitbucket_server) to see rendered content.</div>
+
+## Native extension
+
+For production usage, we recommend installing the Sourcegraph Bitbucket Server plugin for all users (so that each user doesn't need to install the browser extension individually). This involves adding a new extension to the extension directory of your Phabricator instance.
+
+See the [bitbucket-server-plugin](https://github.com/sourcegraph/bitbucket-server-plugin) repository for installation instructions and configuration settings.
+
+The Sourcegraph instance's site admin must [update the `corsOrigin` site config property](../config/site_config.md) to allow the Bitbucket Server plugin to communicate with the Sourcegraph instance. For example:
+
+```json
+{
+  // ...
+  "corsOrigin":
+    "https://my-bitbucket.example.com"
+  // ...
+}
+```

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -7,6 +7,7 @@ Feature | Supported?
 [Repository syncing](../admin/external_service/bitbucket_server.md) | ✅
 [Repository permissions](../admin/external_service/bitbucket_server.md#repository-permissions) | ✅
 [Browser extension](#browser-extension) | ✅
+[Native extension](../admin/external_service/bitbucket_server.md#native-extension) | ✅
 
 ## Repository syncing
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -54,9 +54,9 @@
       "hide": true
     },
     "corsOrigin": {
-      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration. eg \"https://my-phabricator.example.com\"",
+      "description": "Only required when using the Phabricator integration or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com\"",
       "type": "string",
-      "examples": ["https://my-phabricator.example.com"],
+      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com"],
       "group": "Security"
     },
     "disableAutoGitUpdates": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -59,9 +59,9 @@ const SiteSchemaJSON = `{
       "hide": true
     },
     "corsOrigin": {
-      "description": "Only required when using the Phabricator integration for Sourcegraph (https://docs.sourcegraph.com/integration/phabricator). This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration. eg \"https://my-phabricator.example.com\"",
+      "description": "Only required when using the Phabricator integration or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com\"",
       "type": "string",
-      "examples": ["https://my-phabricator.example.com"],
+      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com"],
       "group": "Security"
     },
     "disableAutoGitUpdates": {


### PR DESCRIPTION
- Add CHANGELOG entry mentioning compatibility with the Bitbucket Server plugin.
- Edit Bitbucket Server integration, external service docs.
- Edit `corsOrigin` schema.
- Edit browser extension pull request template to add Bitbucket Server integration to test plan.