### PR TITLE
pkg/highlight: add extensive logging & tracing, Prometheus metrics

### DIFF
--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -122,6 +122,10 @@ func (r *gitTreeEntryResolver) Highlight(ctx context.Context, args *struct {
 		DisableTimeout:  args.DisableTimeout,
 		IsLightTheme:    args.IsLightTheme,
 		SimulateTimeout: simulateTimeout,
+		Metadata: highlight.Metadata{
+			RepoName: string(r.commit.repo.repo.Name),
+			Revision: string(r.commit.oid),
+		},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds extensive logging, tracing, and Prometheus metrics to pkg/highlight to determine how often (& if at all) requests are going slowly, panicking on the syntect_server side, or erroring out.

Test plan: manual