### PR TITLE
Symbols: escape file path for use in regex

### DIFF
--- a/web/src/repo/RepoRevSidebarSymbols.tsx
+++ b/web/src/repo/RepoRevSidebarSymbols.tsx
@@ -98,6 +98,8 @@ export class RepoRevSidebarSymbols extends React.PureComponent<Props> {
             switchMap(props =>
                 fetchSymbols(props.repoID, props.rev || '', {
                     ...args,
+                    // `includePatterns` expects regexes, so first escape the
+                    // path.
                     includePatterns: [escapeRegExp(props.activePath)],
                 })
             )

--- a/web/src/repo/RepoRevSidebarSymbols.tsx
+++ b/web/src/repo/RepoRevSidebarSymbols.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import { isEqual } from 'lodash'
+import { escapeRegExp, isEqual } from 'lodash'
 import * as React from 'react'
 import { NavLink } from 'react-router-dom'
 import { Observable, Subject } from 'rxjs'
@@ -98,7 +98,7 @@ export class RepoRevSidebarSymbols extends React.PureComponent<Props> {
             switchMap(props =>
                 fetchSymbols(props.repoID, props.rev || '', {
                     ...args,
-                    includePatterns: [props.activePath],
+                    includePatterns: [escapeRegExp(props.activePath)],
                 })
             )
         )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/4687

Test plan: manual