### PR TITLE
doc: add Bitbucket Cloud docs

### DIFF
--- a/doc/admin/external_service/bitbucket_cloud.md
+++ b/doc/admin/external_service/bitbucket_cloud.md
@@ -1,0 +1,31 @@
+# Bitbucket Cloud
+
+Site admins can sync Git repositories hosted on [Bitbucket Cloud](https://bitbucket.org) with Sourcegraph so that users can search and navigate the repositories.
+
+To set this up, add Bitbucket Cloud as an external service to Sourcegraph:
+
+1. Go to **User menu > Site admin**.
+1. Open the **External services** page.
+1. Press **+ Add external service**.
+1. In the list, select **Bitbucket.org repositories**.
+1. Enter a **Display name** (using "Bitbucket Cloud" is OK).
+1. Configure the connection to Bitbucket Cloud in the JSON editor. Use Cmd/Ctrl+Space for completion, and [see configuration documentation below](#configuration).
+1. Press **Add external service**.
+
+## Repository syncing
+
+Currently, all repositories belonging the user configured will be synced.
+
+In addition, there is one more field for configuring which repositories are mirrored:
+
+- [`teams`](bitbucket_cloud.md#configuration)<br>A list of teams whose repositories should be selected.
+
+### HTTPS cloning
+
+Sourcegraph by default clones repositories from your Bitbucket Cloud via HTTP(S), using the username and app password you provide in the configuration. The [`username`](bitbucket_cloud.md#configuration) and [`appPassword`](bitbucket_cloud.md#configuration) fields are always used when cloning, so they are required.
+
+## Configuration
+
+Bitbucket Cloud external service connections support the following configuration options, which are specified in the JSON editor in the site admin external services area.
+
+<div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/bitbucket_cloud.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/bitbucket_cloud) to see rendered content.</div>

--- a/doc/admin/external_service/bitbucket_cloud.md
+++ b/doc/admin/external_service/bitbucket_cloud.md
@@ -18,11 +18,11 @@ Currently, all repositories belonging the user configured will be synced.
 
 In addition, there is one more field for configuring which repositories are mirrored:
 
-- [`teams`](bitbucket_cloud.md#configuration)<br>A list of teams whose repositories should be selected.
+- [`teams`](bitbucket_cloud.md#configuration)<br>A list of teams that the configured user has access to whose repositories should be synced.
 
 ### HTTPS cloning
 
-Sourcegraph by default clones repositories from your Bitbucket Cloud via HTTP(S), using the username and app password you provide in the configuration. The [`username`](bitbucket_cloud.md#configuration) and [`appPassword`](bitbucket_cloud.md#configuration) fields are always used when cloning, so they are required.
+Sourcegraph clones repositories from your Bitbucket Cloud via HTTP(S), using the [`username`](bitbucket_cloud.md#configuration) and [`appPassword`](bitbucket_cloud.md#configuration) required fields you provide in the configuration.
 
 ## Configuration
 

--- a/doc/admin/external_service/bitbucket_cloud.schema.json
+++ b/doc/admin/external_service/bitbucket_cloud.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "bitbucket_cloud.schema.json#",
+  "title": "BitbucketCloudConnection",
+  "description": "Configuration for a connection to Bitbucket Cloud.",
+  "allowComments": true,
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["url", "username", "appPassword"],
+  "properties": {
+    "url": {
+      "description": "URL of Bitbucket Cloud, such as https://bitbucket.org.",
+      "type": "string",
+      "not": {
+        "type": "string",
+        "pattern": "example\\.com"
+      },
+      "pattern": "^https?://",
+      "format": "uri",
+      "examples": ["https://bitbucket.org"]
+    },
+    "username": {
+      "description": "The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"appPassword\" field.",
+      "type": "string"
+    },
+    "appPassword": {
+      "description": "The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"username\" field.",
+      "type": "string"
+    },
+    "gitURLType": {
+      "description": "The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Cloud.\n\nIf \"http\", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form https://bitbucket.org/myteam/myproject.git.\n\nIf \"ssh\", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form git@bitbucket.org:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
+      "type": "string",
+      "enum": ["http", "ssh"],
+      "default": "http",
+      "examples": ["ssh"]
+    },
+    "repositoryPathPattern": {
+      "description": "The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Cloud repository.\n\n - \"{host}\" is replaced with the Bitbucket Cloud URL's host (such as bitbucket.org),  and \"{nameWithOwner}\" is replaced with the GitHub repository's \"owner/path\" (such as \"myorg/myrepo\").\n\nFor example, if your Bitbucket Cloud is https://bitbucket.org and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{nameWithOwner}\" would mean that a Bitbucket Cloud repository at https://bitbucket.org/alice/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.org/alice/my-repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+      "type": "string",
+      "default": "{host}/{nameWithOwner}"
+    },
+    "teams": {
+      "description": "An array of team names identifying Bitbucket Cloud teams whose repositories should be mirrored on Sourcegraph.",
+      "type": "array",
+      "items": { "type": "string", "pattern": "^\\w+$" },
+      "examples": [["name"], ["kubernetes", "golang", "facebook"]]
+    }
+  }
+}

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -4,6 +4,7 @@ Sourcegraph can sync repositories from code hosts and other similar external ser
 
 - [GitHub](github.md)
 - [GitLab](gitlab.md)
+- [Bitbucket Cloud](bitbucket_cloud.md)
 - [Bitbucket Server](bitbucket_server.md)
 - [Phabricator](phabricator.md)
 - [Gitolite](gitolite.md)


### PR DESCRIPTION
Add documentation about new Bitbucket Cloud native integration.

Matches PR https://github.com/sourcegraph/sourcegraph/pull/4825.
