### PR TITLE
docs: added bitbucket cloud integration page plus other fixes

### DIFF
--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -124,13 +124,14 @@
                             <li><a href="/admin/external_service">External services</a></li>
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">
-                                    <li><a href="/admin/external_service/aws_codecommit">AWS CodeCommit</a></li>
-                                    <li><a href="/admin/external_service/bitbucket_server">Bitbucket Server</a></li>
-                                    <li><a href="/admin/external_service/github">GitHub external service</a></li>
+                                    <li><a href="/admin/external_service/github">GitHub</a></li>
                                     <li><a href="/admin/external_service/gitlab">GitLab</a></li>
-                                    <li><a href="/admin/external_service/gitolite">Gitolite</a></li>
-                                    <li><a href="/admin/external_service/other">Other Git repository hosts</a></li>
+                                    <li><a href="/admin/external_service/bitbucket_cloud">Bitbucket Cloud</a></li>
+                                    <li><a href="/admin/external_service/bitbucket_server">Bitbucket Server</a></li>
                                     <li><a href="/admin/external_service/phabricator">Phabricator</a></li>
+                                    <li><a href="/admin/external_service/gitolite">Gitolite</a></li>
+                                    <li><a href="/admin/external_service/aws_codecommit">AWS CodeCommit</a></li>
+                                    <li><a href="/admin/external_service/other">Other Git repository hosts</a></li>
                                 </ul>
                             </li>
                             <li><a href="/admin/federation">Federation</a></li>
@@ -208,17 +209,19 @@
                     <li class="content-nav-no-hover">
                         <a class="content-nav-section-header" href="/integration">Integrations</a>
                         <ul class="content-nav-section-group">
-                            <li><a href="/integration/aws_codecommit">AWS CodeCommit integration with Sourcegraph</a></li>
-                            <li><a href="/integration/bitbucket_server">Bitbucket Server integration with Sourcegraph</a></li>
-                            <li><a href="/integration/browser_search_engine">Browser search engine shortcuts</a></li>
-                            <li><a href="/integration/editor">Editor integrations</a></li>
-                            <li><a href="/integration/google_gsuite">G Suite and Chrome Enterprise integration</a></li>
-                            <li><a href="/integration/github">GitHub integration with Sourcegraph</a></li>
-                            <li><a href="/integration/gitlab">GitLab integration with Sourcegraph</a></li>
-                            <li><a href="/integration/gitolite">Gitolite integration with Sourcegraph</a></li>
-                            <li><a href="/integration/lightstep">LightStep integration with Sourcegraph</a></li>
-                            <li><a href="/integration/phabricator">Phabricator integration with Sourcegraph</a></li>
-                            <li><a href="/integration/browser_extension">Sourcegraph browser extension</a></li>
+                                <li><a href="/integration/github">GitHub</a></li>
+                                <li><a href="/integration/gitlab">GitLab</a></li>                                
+                                <li><a href="/integration/bitbucket_cloud">Bitbucket Cloud</a></li>
+                                <li><a href="/integration/bitbucket_server">Bitbucket Server</a></li>
+                                <li><a href="/integration/phabricator">Phabricator</a></li>
+                                <li><a href="/integration/aws_codecommit">AWS CodeCommit</a></li>
+                                <li><a href="/integration/gitolite">Gitolite</a></li>                                
+                                <hr />
+                                <li><a href="/integration/browser_extension">Browser extension</a></li>
+                                <li><a href="/integration/browser_search_engine">Browser search engine shortcuts</a></li>
+                                <li><a href="/integration/editor">Editor integrations</a></li>
+                                <li><a href="/integration/google_gsuite">G Suite and Chrome Enterprise integration</a></li>        
+                                <li><a href="/integration/lightstep">LightStep</a></li>
                         </ul>
                     </li>
                 </ul>

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -1,7 +1,5 @@
 # Site administration documentation
 
-> NOTE: Upgrading to `3.0.1+`? Read our [migration guide](migration/3_0.md) for `2.x` and `3.0.0`.
-
 Site administrators are the admins responsible for deploying, managing, and configuring Sourcegraph for regular users.
 
 - [Install Sourcegraph](install.md)

--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -1,9 +1,5 @@
 # Upgrading Sourcegraph
 
-## Upgrading to 3.0.1+
-
-Read our [migration guide](migration/3_0.md) for `2.x` and `3.0.0`.
-
 ## For single-node deployments (`sourcegraph/server`)
 
 A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates.

--- a/doc/integration/bitbucket_cloud.md
+++ b/doc/integration/bitbucket_cloud.md
@@ -1,0 +1,14 @@
+# Bitbucket Cloud integration with Sourcegraph
+
+You can use Sourcegraph with Git repositories hosted on [Bitbucket Cloud](https://bitbucket.org).
+
+Feature | Supported?
+------- | ----------
+[Repository syncing](../admin/external_service/bitbucket_cloud.md) | ✅
+Repository permissions | Coming soon
+Browser extension | Coming soon
+Native extension | ❌ Not supported on Bitbucket.org
+
+## Repository syncing
+
+Site admins can [add Bitbucket Cloud repositories to Sourcegraph](../admin/external_service/bitbucket_cloud.md).

--- a/doc/integration/index.md
+++ b/doc/integration/index.md
@@ -7,6 +7,7 @@ Sourcegraph integrates with your other tools to help you search, navigate, and r
 - Code hosts
   - [GitHub](github.md)
   - [GitLab](gitlab.md)
+  - [Bitbucket Cloud](bitbucket_cloud.md)
   - [Bitbucket Server](bitbucket_server.md)
   - [Phabricator](phabricator.md)
   - [AWS CodeCommit](aws_codecommit.md)


### PR DESCRIPTION
Other changes:
 - Changed order of nav items in external services and intetgrations to match the orderr on the index pages
 - Shortened some of the nav link text
 - Removed 2.x to 3.0.1 not
 - Added nav link to Bitbucket Cloud external service

Fixes #4891 