### PR TITLE
repo-updater: Make cloned-count ignore gitserver case-sensitivity

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -480,10 +480,10 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 	}
 
 	for _, c := range cloned {
-		if _, ok := clonedRepos[c]; ok {
-			clonedRepos[c] = true
+		lower := strings.ToLower(c)
+		if _, ok := clonedRepos[lower]; ok {
+			clonedRepos[lower] = true
 		}
-
 	}
 
 	var notCloned uint64

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -613,6 +613,14 @@ func TestServer_StatusMessages(t *testing.T) {
 				Messages: []protocol.StatusMessage{},
 			},
 		},
+		{
+			name:            "case insensitivity to gitserver names",
+			gitserverCloned: []string{"FOOBar"},
+			stored:          []*repos.Repo{{Name: "FOOBar"}},
+			res: &protocol.StatusMessagesResponse{
+				Messages: []protocol.StatusMessage{},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This fixes #4894 by only comparing lower-cased names when calculating the number of not cloned repositories.

The previous fix in #4859 was not enough since now gitserver apparently does return mixed-case repository names.

For me this raises a few questions:
1. Why does gitserver now respond with mixed-case repository names?
2. Why was this change of behaviour triggered when @keegancsmith changed the GHE external service config?
3. Does this break any other setups by making the comparison case-insensitive?

Test plan: go test
