### PR TITLE
repo-updater: Use client factory when saving external services

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -305,7 +305,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 			Kind:        req.ExternalService.Kind,
 			DisplayName: req.ExternalService.DisplayName,
 			Config:      req.ExternalService.Config,
-		}, nil)
+		}, repos.NewHTTPClientFactory())
 		if err != nil {
 			errch <- err
 			return


### PR DESCRIPTION
This fixes #4898 and gets rid of the the nil-pointer panic by always passing in a client factory when creating a new source to test the new external service configuration.