### PR TITLE
CHANGELOG: move dots in usernames to 3.5.2 as it should be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Updating or creating an external service will no longer block until the service is synced.
 - The GraphQL fields `Repository.createdAt` and `Repository.updatedAt` are deprecated and will be removed in 3.8. Now `createdAt` is always the current time and updatedAt is always null.
 - In the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) and [Bitbucket Server external service config](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#permissions) `repositoryQuery` is now only required if `repos` is not set.
-- Usernames can now contain the `.` character (#4690).
 - Log messages from query-runner when saved searches fail now include the raw query as part of the message.
 - The status indicator in the navigation bar is now enabled by default
 
@@ -44,6 +43,10 @@ All notable changes to Sourcegraph are documented in this file.
 - Symbol searches with truncated results now show a `+` on the results page to signal that some results have been omitted. [#4579](https://github.com/sourcegraph/sourcegraph/issues/4579)
 
 ## 3.5.2
+
+### Changed
+
+- Usernames can now contain the `.` character (#4690).
 
 ### Added
 


### PR DESCRIPTION
This was released in 3.5.2 but accidentally not moved in the changelog.