### PR TITLE
Fix: reactstrap tooltips causing browser tab to freeze

### DIFF
--- a/web/src/components/tooltip/Tooltip.tsx
+++ b/web/src/components/tooltip/Tooltip.tsx
@@ -66,10 +66,10 @@ export class Tooltip extends React.PureComponent<Props, State> {
                 key={this.state.subjectSeq}
                 isOpen={true}
                 target={this.state.subject}
-                placement="bottom"
+                placement="auto"
                 modifiers={{
                     flip: {
-                        behavior: ['bottom'],
+                        enabled: false,
                     },
                 }}
             >

--- a/web/src/components/tooltip/Tooltip.tsx
+++ b/web/src/components/tooltip/Tooltip.tsx
@@ -66,7 +66,12 @@ export class Tooltip extends React.PureComponent<Props, State> {
                 key={this.state.subjectSeq}
                 isOpen={true}
                 target={this.state.subject}
-                placement="auto"
+                placement="bottom"
+                modifiers={{
+                    flip: {
+                        behavior: ['bottom'],
+                    },
+                }}
             >
                 {this.state.content}
             </BootstrapTooltip>


### PR DESCRIPTION
Fixes #4853. 

The commit https://github.com/sourcegraph/sourcegraph/commit/d9e6207cb7790db2a5fa13e90af4423c5cb47299 resulted in a bug that would cause the entire page to freeze if the tooltip popovers that appear when hovering on some buttons had too much content, which is a [bug in the upgraded version of reactstrap](https://github.com/reactstrap/reactstrap/issues/1482). This PR implements a [workaround mentioned in the issue, which disables the `flip` modifier of the tooltip](https://github.com/reactstrap/reactstrap/issues/1482#issuecomment-499729774).