### PR TITLE
Enable status indicator if no config value has been set

### DIFF
--- a/dev/site-config.json
+++ b/dev/site-config.json
@@ -1,8 +1,7 @@
 // The Sourcegraph site configuration for development servers.
 {
   "experimentalFeatures": {
-    "discussions": "enabled",
-    "statusIndicator": "enabled"
+    "discussions": "enabled"
   },
   "disablePublicRepoRedirects": true,
   "repoListUpdateInterval": 1

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -280,5 +280,9 @@ func Branding() *schema.Branding {
 }
 
 func ShowStatusIndicator() bool {
-	return Get().ExperimentalFeatures.StatusIndicator == "enabled"
+	val := Get().ExperimentalFeatures.StatusIndicator
+	if val == "" {
+		return true
+	}
+	return val == "enabled"
 }


### PR DESCRIPTION
This fixes #4914 and also removes the default value from the `dev/site-config.json` so that a dev setup makes use of the computed value.

In summary: I learned a ton of things about feature flags...

Test plan: local testing

cc @christinaforney 