### PR TITLE
Prevent native integration & bext conflict

### DIFF
--- a/browser/src/extension/scripts/inject.tsx
+++ b/browser/src/extension/scripts/inject.tsx
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
     }
     // If the extension marker isn't present, listen for a custom event sent by the native
     // integration to signal its activation.
-    const nativeIntegrationActivationEventReceived = new Promise<boolean>(resolve =>
+    const nativeIntegrationActivationEventReceived = new Promise<void>(resolve =>
         document.addEventListener(
             NATIVE_INTEGRATION_ACTIVATED,
             () => {

--- a/browser/src/integration/integration.tsx
+++ b/browser/src/integration/integration.tsx
@@ -4,7 +4,7 @@ import * as H from 'history'
 import React from 'react'
 import { setLinkComponent } from '../../../shared/src/components/Link'
 import { injectCodeIntelligence } from '../libs/code_intelligence/inject'
-import { injectExtensionMarker, NATIVE_INTEGRATION_ACTIVATED } from '../libs/sourcegraph/inject'
+import { EXTENSION_MARKER_ID, injectExtensionMarker, NATIVE_INTEGRATION_ACTIVATED } from '../libs/sourcegraph/inject'
 
 const IS_EXTENSION = false
 
@@ -20,6 +20,13 @@ async function init(): Promise<void> {
     if (!sourcegraphURL) {
         throw new Error('window.SOURCEGRAPH_URL is undefined')
     }
+    if (document.getElementById(EXTENSION_MARKER_ID) !== null) {
+        // If the extension marker already exists, it means the browser extension is currently executing.
+        // Dispatch a custom event to signal that browser extension resources should be cleaned up.
+        document.dispatchEvent(new CustomEvent<{}>(NATIVE_INTEGRATION_ACTIVATED))
+    } else {
+        injectExtensionMarker()
+    }
     const link = document.createElement('link')
     link.setAttribute('rel', 'stylesheet')
     link.setAttribute('type', 'text/css')
@@ -28,10 +35,8 @@ async function init(): Promise<void> {
     document.getElementsByTagName('head')[0].appendChild(link)
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL
-    injectExtensionMarker()
     // TODO handle subscription
     await injectCodeIntelligence(IS_EXTENSION)
-    document.dispatchEvent(new CustomEvent<{}>(NATIVE_INTEGRATION_ACTIVATED))
 }
 
 init().catch(err => {

--- a/browser/src/integration/integration.tsx
+++ b/browser/src/integration/integration.tsx
@@ -4,7 +4,7 @@ import * as H from 'history'
 import React from 'react'
 import { setLinkComponent } from '../../../shared/src/components/Link'
 import { injectCodeIntelligence } from '../libs/code_intelligence/inject'
-import { injectExtensionMarker } from '../libs/sourcegraph/inject'
+import { injectExtensionMarker, NATIVE_INTEGRATION_ACTIVATED } from '../libs/sourcegraph/inject'
 
 const IS_EXTENSION = false
 
@@ -15,6 +15,7 @@ setLinkComponent(({ to, children, ...props }) => (
 ))
 
 async function init(): Promise<void> {
+    console.log('Sourcegraph native integration is running')
     const sourcegraphURL = window.SOURCEGRAPH_URL
     if (!sourcegraphURL) {
         throw new Error('window.SOURCEGRAPH_URL is undefined')
@@ -30,6 +31,7 @@ async function init(): Promise<void> {
     injectExtensionMarker()
     // TODO handle subscription
     await injectCodeIntelligence(IS_EXTENSION)
+    document.dispatchEvent(new CustomEvent<{}>(NATIVE_INTEGRATION_ACTIVATED))
 }
 
 init().catch(err => {

--- a/browser/src/libs/sourcegraph/inject.tsx
+++ b/browser/src/libs/sourcegraph/inject.tsx
@@ -1,6 +1,13 @@
 export const EXTENSION_MARKER_ID = 'sourcegraph-app-background'
 
 /**
+ * A custom native integration <-> browser extension event used to free
+ * browser extension subscriptions when the native integration gets activated
+ * on the page, so as to avoid conflicts such as duplicate UI elements.
+ */
+export const NATIVE_INTEGRATION_ACTIVATED = 'sourcegraph:native-integration-activated'
+
+/**
  * Injects a `#sourcegraph-app-background` hidden element.
  *
  * This element is checked for in the webapp to know if the browser extension

--- a/browser/src/libs/sourcegraph/inject.tsx
+++ b/browser/src/libs/sourcegraph/inject.tsx
@@ -24,14 +24,10 @@ export function injectExtensionMarker(): void {
 }
 
 /**
- * Injects the extension marker and dispatches a custom event
- * to signal to Sourcegraph web app that the browser extension is installed.
- *
- *  Not idempotent.
+ * Dispatches a custom event to signal to Sourcegraph web app
+ * that the browser extension is installed.
  */
 export function signalBrowserExtensionInstalled(): void {
-    injectExtensionMarker()
-
     if (document.readyState === 'complete' || document.readyState === 'interactive') {
         dispatchSourcegraphEvents()
     } else {


### PR DESCRIPTION
Fixes #4900 (release bocker for 3.6)

The execution order of the [callback passed to `AJS.toInit()`](https://sourcegraph.com/github.com/sourcegraph/bitbucket-server-plugin/-/blob/src/main/resources/js/sourcegraph-bitbucket.js#L1-25) by the Bitbucket Server plugin and the browser extension content script can be racy, leading to conflicts between the browser extension and the Bitbucket Server native integration.

This fixes these conflicts by introducing a custom event sent by the native integration upon activation, signaling that browser extension resources should be cleaned up.

**Test plan**: I verified that there were no conflicts when:
- The native integration is activated before the browser extension.
- The native integration is activated later during the lifetime of the content script.