### PR TITLE
LSIF: fix JSON header in response

### DIFF
--- a/lsif/server/src/http-server.ts
+++ b/lsif/server/src/http-server.ts
@@ -265,7 +265,7 @@ function main(): void {
                         default:
                             throw new Error(`Unknown method ${method}`)
                     }
-                    res.json(result)
+                    res.json(result || null)
                 })
             } catch (e) {
                 if ('code' in e && e.code === 'ENOENT') {

--- a/lsif/server/src/http-server.ts
+++ b/lsif/server/src/http-server.ts
@@ -265,7 +265,7 @@ function main(): void {
                         default:
                             throw new Error(`Unknown method ${method}`)
                     }
-                    res.send(result).json()
+                    res.json(result)
                 })
             } catch (e) {
                 if ('code' in e && e.code === 'ENOENT') {


### PR DESCRIPTION
I noticed some of these errors from lsif-server on my test cluster:

> cannot set headers after they are sent to the client

It turns out I was using `.json()` incorrectly https://expressjs.com/en/api.html#res.json

There are no other uses of `.json()` in the file, nor `.header()`.

Test plan: I deployed to a test cluster to verify it works