### PR TITLE
fix absolute link to contact page from perf alert

### DIFF
--- a/web/src/site/PerformanceWarningAlert.tsx
+++ b/web/src/site/PerformanceWarningAlert.tsx
@@ -25,9 +25,9 @@ export const PerformanceWarningAlert: React.FunctionComponent = () => (
                 deploy to a cluster
             </Link>
             &nbsp;for optimal performance.&nbsp;
-            <Link className="site-alert__link" to="https://about.sourcegraph.com/contact">
+            <a className="site-alert__link" href="https://about.sourcegraph.com/contact">
                 Contact us
-            </Link>
+            </a>
             &nbsp;for support or to learn more.
         </div>
     </DismissibleAlert>


### PR DESCRIPTION
Fixes #4928 

Test plan: manually tested locally (see repro description in #4928)

After (result of clicking on Contact link):
<img width="716" alt="Screen Shot 2019-07-17 at 18 50 38" src="https://user-images.githubusercontent.com/15530/61424011-dca06180-a8c6-11e9-9364-15f0f7374612.png">

Before:
<img width="719" alt="Screen Shot 2019-07-17 at 18 49 39" src="https://user-images.githubusercontent.com/15530/61424016-e5913300-a8c6-11e9-8fa8-b32002585da0.png">
