### PR TITLE
server: Remove log-spam seen at startup

### DIFF
--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -93,7 +93,7 @@ func maybePostgresProcFile() (string, error) {
 	SetDefaultEnv("PGDATABASE", "sourcegraph")
 	SetDefaultEnv("PGSSLMODE", "disable")
 
-	return "postgres: su-exec postgres sh -c 'postgres -c listen_addresses=127.0.0.1 -D " + path + "' 2>&1 | grep -v 'database system was shut down' | grep -v 'MultiXact member wraparound' | grep -v 'database system is ready' | grep -v 'autovacuum launcher started' | grep -v 'the database system is starting up'", nil
+	return "postgres: su-exec postgres sh -c 'postgres -c listen_addresses=127.0.0.1 -D " + path + "' 2>&1 | grep -v 'database system was shut down' | grep -v 'MultiXact member wraparound' | grep -v 'database system is ready' | grep -v 'autovacuum launcher started' | grep -v 'the database system is starting up' | grep -v 'listening on IPv4 address'", nil
 }
 
 // maybeUpgradePostgres upgrades the Postgres data files in path to the given version

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -144,7 +144,7 @@ func Main() {
 		`gitserver: gitserver`,
 		`query-runner: query-runner`,
 		`symbols: symbols`,
-		`lsif-server: node /lsif-server.js`,
+		`lsif-server: node /lsif-server.js | grep -v 'Listening for HTTP requests'`,
 		`management-console: management-console`,
 		`searcher: searcher`,
 		`github-proxy: github-proxy`,

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -149,7 +149,7 @@ func Main() {
 		`searcher: searcher`,
 		`github-proxy: github-proxy`,
 		`repo-updater: repo-updater`,
-		`syntect_server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"'`,
+		`syntect_server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,
 	}
 	procfile = append(procfile, ProcfileAdditions...)
 	if line, err := maybeRedisProcFile(); err != nil {

--- a/dev/ci/db-backcompat.sh
+++ b/dev/ci/db-backcompat.sh
@@ -27,6 +27,7 @@ if [ -z "$OLD" ]; then
 fi
 
 if [ ! -z "$(git status --porcelain)" ]; then
+    git status
     echo 'Work tree is dirty, aborting.'
     exit 1
 fi

--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20190712184556-51c44e6be086
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20190718092054-9cdf2d3e8edb
 	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20180929065141-c790ffc3c46a
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab

--- a/go.sum
+++ b/go.sum
@@ -560,6 +560,8 @@ github.com/sourcegraph/zoekt v0.0.0-20190614204709-c84cd1977f24 h1:XMSPEwhlzcbJj
 github.com/sourcegraph/zoekt v0.0.0-20190614204709-c84cd1977f24/go.mod h1:Sa1TO1+Y/kM0jA9AISpwx6islOvLy7tsnEUKIFwOb7I=
 github.com/sourcegraph/zoekt v0.0.0-20190712184556-51c44e6be086 h1:n6m5cZjD5KFvIbq+2oC8Zjp+Psalxuk4RHqqkmwwcc0=
 github.com/sourcegraph/zoekt v0.0.0-20190712184556-51c44e6be086/go.mod h1:tDAyQ+Ui8gE8QxzLA1Gl8KTu+EM5rjerL4GQ6nnFYM8=
+github.com/sourcegraph/zoekt v0.0.0-20190718092054-9cdf2d3e8edb h1:CcRIAIQC9bYIPZt5JlA7wgdlCkLhmXyU5UvtcSnVM5c=
+github.com/sourcegraph/zoekt v0.0.0-20190718092054-9cdf2d3e8edb/go.mod h1:tDAyQ+Ui8gE8QxzLA1Gl8KTu+EM5rjerL4GQ6nnFYM8=
 github.com/spf13/afero v1.1.0 h1:bopulORc2JeYaxfHLvJa5NzxviA9PoWhpiiJkru7Ji4=
 github.com/spf13/afero v1.1.0/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.2.0 h1:HHl1DSRbEQN2i8tJmtS6ViPyHx35+p51amrdsiTCrkg=

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -49,9 +49,12 @@ func init() {
 	// TODO it is surprising that we do this here. We should create a standard
 	// import for sourcegraph binaries which would have less surprising
 	// behaviour.
-	maxprocs.Set(maxprocs.Logger(func(format string, a ...interface{}) {
+	_, err := maxprocs.Set(maxprocs.Logger(func(format string, a ...interface{}) {
 		log15.Debug("automaxprocs", "msg", fmt.Sprintf(format, a...))
 	}))
+	if err != nil {
+		log15.Error("automaxprocs failed", "error", err)
+	}
 }
 
 func condensedFormat(r *log15.Record) []byte {


### PR DESCRIPTION
We aim to have minimal log output when starting sourcegraph server. The only log output should be from frontend (announcing its listening address and ascii art) and management console (announcing its listening address)

Fixes https://github.com/sourcegraph/sourcegraph/issues/4569