### PR TITLE
Update references to oauth2_proxy

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -273,7 +273,7 @@ https://sourcegraph.example.com/.auth/saml/metadata
 
 ## HTTP authentication proxies
 
-You can wrap Sourcegraph in an authentication proxy that authenticates the user and passes the user's username to Sourcegraph via HTTP headers. The most popular such authentication proxy is [bitly/oauth2_proxy](https://github.com/bitly/oauth2_proxy). Another example is [Google Identity-Aware Proxy (IAP)](https://cloud.google.com/iap/). Both work well with Sourcegraph.
+You can wrap Sourcegraph in an authentication proxy that authenticates the user and passes the user's username to Sourcegraph via HTTP headers. The most popular such authentication proxy is [pusher/oauth2_proxy](https://github.com/pusher/oauth2_proxy). Another example is [Google Identity-Aware Proxy (IAP)](https://cloud.google.com/iap/). Both work well with Sourcegraph.
 
 To use an authentication proxy to authenticate users to Sourcegraph, add the following lines to your critical configuration:
 
@@ -293,7 +293,7 @@ Replace `X-Forwarded-User` with the name of the HTTP header added by the authent
 
 Ensure that the HTTP proxy is not setting its own `Authorization` header on the request. Sourcegraph rejects requests with unrecognized `Authorization` headers and prints the error log `lvl=eror msg="Invalid Authorization header." err="unrecognized HTTP Authorization request header scheme (supported values: token, token-sudo)"`.
 
-For bitly/oauth2_proxy, use the `-pass-basic-auth false` option to prevent it from sending the `Authorization` header.
+For pusher/oauth2_proxy, use the `-pass-basic-auth false` option to prevent it from sending the `Authorization` header.
 
 ### Username header prefixes
 


### PR DESCRIPTION
The custodian of the project has been shifted from [bitly] to [pusher].
So this diff updates these references.

[bitly]: https://github.com/bitly/oauth2_proxy
[pusher]: https://github.com/pusher/oauth2_proxy



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
