### PR TITLE
tracer: Remove debug logs from automaxprocs

### DIFF
--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -49,10 +49,7 @@ func init() {
 	// TODO it is surprising that we do this here. We should create a standard
 	// import for sourcegraph binaries which would have less surprising
 	// behaviour.
-	_, err := maxprocs.Set(maxprocs.Logger(func(format string, a ...interface{}) {
-		log15.Debug("automaxprocs", "msg", fmt.Sprintf(format, a...))
-	}))
-	if err != nil {
+	if _, err := maxprocs.Set(); err != nil {
 		log15.Error("automaxprocs failed", "error", err)
 	}
 }


### PR DESCRIPTION
These log statements will run before we have had a chance to set our log
level. They are also not that useful. So we remove them. Note: We will still
log in the case of error.