### PR TITLE
Optimize browser extension bundle size

### DIFF
--- a/browser/config/webpack/base.config.ts
+++ b/browser/config/webpack/base.config.ts
@@ -27,6 +27,7 @@ const config: webpack.Configuration = {
         filename: '[name].bundle.js',
         chunkFilename: '[id].chunk.js',
     },
+    devtool: 'inline-cheap-module-source-map',
 
     plugins: [
         new MiniCssExtractPlugin({ filename: '../css/[name].bundle.css' }),

--- a/browser/config/webpack/dev.config.ts
+++ b/browser/config/webpack/dev.config.ts
@@ -16,7 +16,6 @@ const config: webpack.Configuration = {
     ...base,
     entry: process.env.AUTO_RELOAD === 'false' ? entries : entriesWithAutoReload,
     mode: 'development',
-    devtool: 'inline-cheap-module-source-map',
     plugins: (plugins || []).concat(
         ...[
             new webpack.DefinePlugin({

--- a/browser/config/webpack/prod.config.ts
+++ b/browser/config/webpack/prod.config.ts
@@ -8,7 +8,6 @@ const { plugins, ...base } = baseConfig
 const config: webpack.Configuration = {
     ...base,
     mode: 'production',
-    devtool: 'inline-source-map',
     optimization: {
         minimize: true,
         minimizer: [

--- a/browser/src/extension/scripts/inject.tsx
+++ b/browser/src/extension/scripts/inject.tsx
@@ -6,6 +6,7 @@ import { fromEvent, Subscription } from 'rxjs'
 import { first } from 'rxjs/operators'
 import { setLinkComponent } from '../../../../shared/src/components/Link'
 import { storage } from '../../browser/storage'
+import { determineCodeHost } from '../../libs/code_intelligence'
 import { injectCodeIntelligence } from '../../libs/code_intelligence/inject'
 import { initSentry } from '../../libs/sentry'
 import {
@@ -24,7 +25,8 @@ window.addEventListener('unload', () => subscriptions.unsubscribe(), { once: tru
 
 assertEnv('CONTENT')
 
-initSentry('content')
+const codeHost = determineCodeHost()
+initSentry('content', codeHost && codeHost.type)
 
 setLinkComponent(({ to, children, ...props }) => (
     <a href={to && typeof to !== 'string' ? H.createPath(to) : to} {...props}>

--- a/browser/src/libs/sentry/index.ts
+++ b/browser/src/libs/sentry/index.ts
@@ -4,7 +4,6 @@ import { observeStorageKey } from '../../browser/storage'
 import { featureFlagDefaults } from '../../browser/types'
 import { isInPage } from '../../context'
 import { DEFAULT_SOURCEGRAPH_URL, getExtensionVersion } from '../../shared/util/context'
-import { determineCodeHost } from '../code_intelligence'
 
 const isExtensionStackTrace = (stacktrace: Sentry.Stacktrace, extensionID: string): boolean =>
     !!(stacktrace.frames && stacktrace.frames.some(({ filename }) => !!(filename && filename.includes(extensionID))))
@@ -29,7 +28,7 @@ const callSentryInit = once((extensionID: string) => {
 })
 
 /** Initialize Sentry for error reporting. */
-export function initSentry(script: 'content' | 'options' | 'background'): void {
+export function initSentry(script: 'content' | 'options' | 'background', codeHost?: string): void {
     if (process.env.NODE_ENV !== 'production') {
         return
     }
@@ -51,9 +50,8 @@ export function initSentry(script: 'content' | 'options' | 'background'): void {
         Sentry.configureScope(async scope => {
             scope.setTag('script', script)
             scope.setTag('extension_version', getExtensionVersion())
-            const codeHost = determineCodeHost()
             if (codeHost) {
-                scope.setTag('code_host', codeHost.type)
+                scope.setTag('code_host', codeHost)
             }
         })
     })


### PR DESCRIPTION
I noticed the latest browser extension deployment failed on Firefox: https://buildkite.com/sourcegraph/sourcegraph/builds/39979#abea95e4-23f5-4e06-8a55-9513f485cd6e

This is due to Mozilla's requirement that no single non-binary file be larger than 4mb. From [validation results](https://addons.mozilla.org/en-US/developers/upload/befc4fd513b74a1ab12dc7a9fd06cdc0):

![image](https://user-images.githubusercontent.com/1741180/61626845-a5430380-ac7e-11e9-905f-8a015a2a05a6.png)

I took a look at our built bundle sizes, and noticed they were very large:

```
11M background.bundle.js
7.2M inject.bundle.js
7.2M options.bundle.js
```

This was mostly a side-effect of re-enabling source maps using `inline-source-map`, but there were some other interesting things happening, notably all of `code_intelligence.tsx` and its dependencies (react-dom, highlight.js, popper...) being pulled into the background page and options bundles 🤔 

I made two main changes:
- A slight refactor in `sentry/index.ts`, to avoid calling `determineCodeHost()` in the background and options pages, which is pointless anyway and leads to a bunch of content script-specific stuff being bundled in.
- Switching to `inline-cheap-module-source-map` for prod as well. This yields much smaller bundle sizes than inline-source-map, will still allow for correct stacktrace mapping in Sentry, and doesn't degrade the debugging experience (this is already what we used in dev mode).

Bundle sizes following these changes:

```
1.1M background.bundle.js
1.4M inject.bundle.js
681K options.bundle.js
```

This gets us under the 4mb limit, but there are further opportunities to optimize:
- The bulk of the size of the background page bundle is the inlined extension host worker. Since we anyway use it as a separate bundle in the integrations, we could do the same thing in the background page (instantiating it as `new Worker(browser.runtime.getURL('js/extensionHostWorker.bundle.js'))` and avoid not only bundling it, but also compiling it multiple times, for the background, phabricator and integrations entry points.
- The bulk of the size of the injected JS bundle is dependencies. Maybe there's some fat-trimming we could do there.