### PR TITLE
ci: Improve performance of go build for server

### DIFF
--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -40,7 +40,6 @@ for pkg in $server_pkg \
     github.com/google/zoekt/cmd/zoekt-webserver $additional_images; do
 
     go build \
-      -a \
       -ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=$VERSION"  \
       -buildmode exe \
       -installsuffix netgo \

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -4,9 +4,13 @@ set -ex
 cd $(dirname "${BASH_SOURCE[0]}")/../..
 
 pushd ..
+echo "--- yarn root"
 yarn --frozen-lockfile --network-timeout 60000
+echo "--- yarn browser"
 (pushd browser && TARGETS=phabricator yarn build && popd)
+echo "--- yarn web"
 (pushd web && NODE_ENV=production yarn -s run build --color && popd)
 popd
 
+echo "--- generate"
 dev/generate.sh


### PR DESCRIPTION
Demo video: https://www.loom.com/share/db21ed115d3e4e78ba8eddab7c6b52a0

Older versions of go may have been more unreliable. But in this case we should be able to rely on the build cache. Additionally this was the only image we set -a. An example CI job had the building of go images take 3m15s. After this change a go build took 28s.