### PR TITLE
ci: Test node resolvers to remove non-deterministic coverage

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -33,6 +33,81 @@ func TestRepository(t *testing.T) {
 	})
 }
 
+func TestNodeResolverTo(t *testing.T) {
+	// This test exists purely to remove some non determinism in our tests
+	// run. The To* resolvers are stored in a map in our graphql
+	// implementation => the order we call them is non deterministic =>
+	// codecov coverage reports are noisy.
+	nodes := []node{
+		&accessTokenResolver{},
+		&discussionCommentResolver{},
+		&discussionThreadResolver{},
+		&externalAccountResolver{},
+		&externalServiceResolver{},
+		&gitRefResolver{},
+		&repositoryResolver{},
+		&UserResolver{},
+		&OrgResolver{},
+		&organizationInvitationResolver{},
+		&gitCommitResolver{},
+		&savedSearchResolver{},
+		&siteResolver{},
+	}
+
+	for _, n := range nodes {
+		r := &nodeResolver{n}
+		if _, b := r.ToAccessToken(); b {
+			continue
+		}
+		if _, b := r.ToDiscussionComment(); b {
+			continue
+		}
+		if _, b := r.ToDiscussionThread(); b {
+			continue
+		}
+		if _, b := r.ToProductLicense(); b {
+			continue
+		}
+		if _, b := r.ToProductSubscription(); b {
+			continue
+		}
+		if _, b := r.ToExternalAccount(); b {
+			continue
+		}
+		if _, b := r.ToExternalService(); b {
+			continue
+		}
+		if _, b := r.ToGitRef(); b {
+			continue
+		}
+		if _, b := r.ToRepository(); b {
+			continue
+		}
+		if _, b := r.ToUser(); b {
+			continue
+		}
+		if _, b := r.ToOrg(); b {
+			continue
+		}
+		if _, b := r.ToOrganizationInvitation(); b {
+			continue
+		}
+		if _, b := r.ToGitCommit(); b {
+			continue
+		}
+		if _, b := r.ToRegistryExtension(); b {
+			continue
+		}
+		if _, b := r.ToSavedSearch(); b {
+			continue
+		}
+		if _, b := r.ToSite(); b {
+			continue
+		}
+		t.Fatalf("unexpected node %#+v", n)
+	}
+}
+
 func init() {
 	if !testing.Verbose() {
 		log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.Root().GetHandler()))


### PR DESCRIPTION
This test exists purely to remove some non determinism in our tests run. The To* resolvers are stored in a map in our graphql implementation => the order we call them is non deterministic => codecov coverage reports are noisy.