### PR TITLE
repositoryPathPattern for "Other" external service

### DIFF
--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -87,17 +87,21 @@ func otherRepoCloneURL(base *url.URL, repo string) (*url.URL, error) {
 
 func (s OtherSource) otherRepoFromCloneURL(urn string, u *url.URL) (*Repo, error) {
 	repoURL := u.String()
-	repoName, err := reposource.Other{s.conn}.CloneURLToRepoName(u.String())
+	repoSource := reposource.Other{s.conn}
+	repoName, err := repoSource.CloneURLToRepoName(u.String())
 	if err != nil {
 		return nil, err
 	}
-
+	repoURI, err := repoSource.CloneURLToRepoURI(u.String())
+	if err != nil {
+		return nil, err
+	}
 	u.Path, u.RawQuery = "", ""
 	serviceID := u.String()
 
 	return &Repo{
 		Name: string(repoName),
-		URI:  string(repoName),
+		URI:  repoURI,
 		ExternalRepo: api.ExternalRepoSpec{
 			ID:          string(repoName),
 			ServiceType: "other",

--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -3,10 +3,10 @@ package repos
 import (
 	"context"
 	"net/url"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/pkg/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -38,7 +38,11 @@ func (s OtherSource) ListRepos(ctx context.Context) ([]*Repo, error) {
 	urn := s.svc.URN()
 	repos := make([]*Repo, 0, len(urls))
 	for _, u := range urls {
-		repos = append(repos, otherRepoFromCloneURL(urn, u))
+		r, err := s.otherRepoFromCloneURL(urn, u)
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, r)
 	}
 
 	return repos, nil
@@ -81,26 +85,19 @@ func otherRepoCloneURL(base *url.URL, repo string) (*url.URL, error) {
 	return base.Parse(repo)
 }
 
-var otherRepoNameReplacer = strings.NewReplacer(":", "-", "@", "-", "//", "")
-
-func otherRepoName(cloneURL *url.URL) string {
-	u := *cloneURL
-	u.User = nil
-	u.Scheme = ""
-	u.RawQuery = ""
-	u.Fragment = ""
-	return otherRepoNameReplacer.Replace(u.String())
-}
-
-func otherRepoFromCloneURL(urn string, u *url.URL) *Repo {
+func (s OtherSource) otherRepoFromCloneURL(urn string, u *url.URL) (*Repo, error) {
 	repoURL := u.String()
-	repoName := otherRepoName(u)
+	repoName, err := reposource.Other{s.conn}.CloneURLToRepoName(u.String())
+	if err != nil {
+		return nil, err
+	}
+
 	u.Path, u.RawQuery = "", ""
 	serviceID := u.String()
 
 	return &Repo{
-		Name: repoName,
-		URI:  repoName,
+		Name: string(repoName),
+		URI:  string(repoName),
 		ExternalRepo: api.ExternalRepoSpec{
 			ID:          string(repoName),
 			ServiceType: "other",
@@ -113,5 +110,5 @@ func otherRepoFromCloneURL(urn string, u *url.URL) *Repo {
 				CloneURL: repoURL,
 			},
 		},
-	}
+	}, nil
 }

--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -87,7 +87,7 @@ func otherRepoCloneURL(base *url.URL, repo string) (*url.URL, error) {
 
 func (s OtherSource) otherRepoFromCloneURL(urn string, u *url.URL) (*Repo, error) {
 	repoURL := u.String()
-	repoSource := reposource.Other{s.conn}
+	repoSource := reposource.Other{OtherExternalServiceConnection: s.conn}
 	repoName, err := repoSource.CloneURLToRepoName(u.String())
 	if err != nil {
 		return nil, err

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -29,35 +28,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
-
-func TestOtherRepoName(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		in   string
-		out  string
-	}{
-		{"user and password elided", "https://user:pass@foo.bar/baz", "foo.bar/baz"},
-		{"scheme elided", "https://user@foo.bar/baz", "foo.bar/baz"},
-		{"raw query elided", "https://foo.bar/baz?secret_token=12345", "foo.bar/baz"},
-		{"fragment elided", "https://foo.bar/baz#fragment", "foo.bar/baz"},
-		{": replaced with -", "git://foo.bar/baz:bam", "foo.bar/baz-bam"},
-		{"@ replaced with -", "ssh://foo.bar/baz@bam", "foo.bar/baz-bam"},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			cloneURL, err := url.Parse(tc.in)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if have, want := otherRepoName(cloneURL), tc.out; have != want {
-				t.Errorf("otherRepoName(%q):\nhave: %q\nwant: %q", tc.in, have, want)
-			}
-		})
-	}
-}
 
 func TestNewSourcer(t *testing.T) {
 	now := time.Now()

--- a/pkg/conf/reposource/common_test.go
+++ b/pkg/conf/reposource/common_test.go
@@ -13,6 +13,13 @@ type urlToRepoName struct {
 	repoName string
 }
 
+// urlToRepoNameErr is similar to urlToRepoName, but with an expected error value
+type urlToRepoNameErr struct {
+	cloneURL string
+	repoName string
+	err      error
+}
+
 func TestParseCloneURL(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/pkg/conf/reposource/other.go
+++ b/pkg/conf/reposource/other.go
@@ -1,0 +1,64 @@
+package reposource
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/pkg/api"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type urlMismatchErr struct {
+	cloneURL string
+	hostURL  string
+}
+
+func (e urlMismatchErr) Error() string {
+	return fmt.Sprintf("cloneURL %q did not match git host %q", e.cloneURL, e.hostURL)
+}
+
+type Other struct {
+	*schema.OtherExternalServiceConnection
+}
+
+var _ RepoSource = Other{}
+
+func (c Other) CloneURLToRepoName(cloneURL string) (repoName api.RepoName, err error) {
+	parsedCloneURL, baseURL, match, err := parseURLs(cloneURL, c.Url)
+	if err != nil {
+		return "", err
+	}
+	if !match {
+		return "", urlMismatchErr{cloneURL: cloneURL, hostURL: c.Url}
+	}
+
+	basePrefix := baseURL.Path
+	if !strings.HasSuffix(basePrefix, "/") {
+		basePrefix = basePrefix + "/"
+	}
+	if parsedCloneURL.Path != baseURL.Path && !strings.HasPrefix(parsedCloneURL.Path, basePrefix) {
+		return "", urlMismatchErr{cloneURL: cloneURL, hostURL: c.Url}
+	}
+	relativeRepoPath := strings.TrimPrefix(parsedCloneURL.Path, basePrefix)
+
+	base := url.URL{
+		Host: baseURL.Host,
+		Path: baseURL.Path,
+	}
+	return OtherRepoName(c.RepositoryPathPattern, base.String(), relativeRepoPath), nil
+}
+
+var otherRepoNameReplacer = strings.NewReplacer(":", "-", "@", "-", "//", "")
+
+func OtherRepoName(repositoryPathPattern, base, relativeRepoPath string) api.RepoName {
+	if repositoryPathPattern == "" {
+		repositoryPathPattern = "{base}/{repo}"
+	}
+	return api.RepoName(
+		strings.NewReplacer(
+			"{base}", otherRepoNameReplacer.Replace(strings.TrimSuffix(base, "/")),
+			"{repo}", otherRepoNameReplacer.Replace(strings.TrimSuffix(strings.TrimPrefix(relativeRepoPath, "/"), ".git")),
+		).Replace(repositoryPathPattern),
+	)
+}

--- a/pkg/conf/reposource/other_test.go
+++ b/pkg/conf/reposource/other_test.go
@@ -1,0 +1,85 @@
+package reposource
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestOtherCloneURLToRepoName(t *testing.T) {
+	tests := []struct {
+		conn schema.OtherExternalServiceConnection
+		urls []urlToRepoNameErr
+	}{
+		{
+			conn: schema.OtherExternalServiceConnection{
+				Url:                   "https://github.com",
+				RepositoryPathPattern: "{base}/{repo}",
+				Repos:                 []string{"gorilla/mux"},
+			},
+			urls: []urlToRepoNameErr{
+				{"https://github.com/gorilla/mux", "github.com/gorilla/mux", nil},
+				{"https://github.com/gorilla/mux.git", "github.com/gorilla/mux", nil},
+				{"https://asdf.com/gorilla/mux.git", "", urlMismatchErr{"https://asdf.com/gorilla/mux.git", "https://github.com"}},
+			},
+		},
+		{
+			conn: schema.OtherExternalServiceConnection{
+				Url:                   "https://github.com/?access_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				RepositoryPathPattern: "{base}/{repo}",
+				Repos:                 []string{"gorilla/mux"},
+			},
+			urls: []urlToRepoNameErr{
+				{"https://github.com/gorilla/mux", "github.com/gorilla/mux", nil},
+				{"https://github.com/gorilla/mux.git", "github.com/gorilla/mux", nil},
+			},
+		},
+		{
+			conn: schema.OtherExternalServiceConnection{
+				Url:                   "ssh://thaddeus@gerrit.com:12345",
+				RepositoryPathPattern: "{base}/{repo}",
+				Repos:                 []string{"repos/repo1"},
+			},
+			urls: []urlToRepoNameErr{{"ssh://thaddeus@gerrit.com:12345/repos/repo1", "gerrit.com-12345/repos/repo1", nil}},
+		},
+		{
+			conn: schema.OtherExternalServiceConnection{
+				Url:                   "ssh://thaddeus@gerrit.com:12345",
+				RepositoryPathPattern: "prettyhost/{repo}",
+				Repos:                 []string{"repos/repo1"},
+			},
+			urls: []urlToRepoNameErr{{"ssh://thaddeus@gerrit.com:12345/repos/repo1", "prettyhost/repos/repo1", nil}},
+		},
+		{
+			conn: schema.OtherExternalServiceConnection{
+				Url:                   "ssh://thaddeus@gerrit.com:12345/repos",
+				RepositoryPathPattern: "{repo}",
+				Repos:                 []string{"repo1"},
+			},
+			urls: []urlToRepoNameErr{
+				{"ssh://thaddeus@gerrit.com:12345/repos/repo1", "repo1", nil},
+				{"ssh://thaddeus@asdf.com/repos/repo1", "", urlMismatchErr{"ssh://thaddeus@asdf.com/repos/repo1", "ssh://thaddeus@gerrit.com:12345/repos"}},
+				{"ssh://thaddeus@gerrit.com:12345/asdf/repo1", "", urlMismatchErr{"ssh://thaddeus@gerrit.com:12345/asdf/repo1", "ssh://thaddeus@gerrit.com:12345/repos"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		for _, u := range test.urls {
+			repoName, err := Other{&test.conn}.CloneURLToRepoName(u.cloneURL)
+			if u.err != nil {
+				if !reflect.DeepEqual(u.err, err) {
+					t.Errorf("expected error [%v], but got [%v] for clone URL %q (connection: %+v)", u.err, err, u.cloneURL, test.conn)
+				}
+				continue
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if u.repoName != string(repoName) {
+				t.Errorf("expected %q but got %q for clone URL %q (connection: %+v)", u.repoName, repoName, u.cloneURL, test.conn)
+			}
+		}
+	}
+}

--- a/schema/other_external_service.schema.json
+++ b/schema/other_external_service.schema.json
@@ -28,6 +28,11 @@
         "format": "uri-reference",
         "examples": ["path/to/my/repo", "path/to/my/repo.git/"]
       }
+    },
+    "repositoryPathPattern": {
+      "description": "The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable \"{base}\" is replaced with the Git clone base URL host and path, and \"{repo}\" is replaced with the repository path taken from the `repos` field.\n\nFor example, if your Git clone base URL is https://git.example.com/repos and `repos` contains the value \"my/repo\", then a repositoryPathPattern of \"{base}/{repo}\" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+      "type": "string",
+      "default": "{base}/{repo}"
     }
   }
 }

--- a/schema/other_external_service.schema.json
+++ b/schema/other_external_service.schema.json
@@ -32,7 +32,8 @@
     "repositoryPathPattern": {
       "description": "The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable \"{base}\" is replaced with the Git clone base URL host and path, and \"{repo}\" is replaced with the repository path taken from the `repos` field.\n\nFor example, if your Git clone base URL is https://git.example.com/repos and `repos` contains the value \"my/repo\", then a repositoryPathPattern of \"{base}/{repo}\" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
       "type": "string",
-      "default": "{base}/{repo}"
+      "default": "{base}/{repo}",
+      "examples": ["pretty-host-name/{repo}"]
     }
   }
 }

--- a/schema/other_external_service_stringdata.go
+++ b/schema/other_external_service_stringdata.go
@@ -33,6 +33,11 @@ const OtherExternalServiceSchemaJSON = `{
         "format": "uri-reference",
         "examples": ["path/to/my/repo", "path/to/my/repo.git/"]
       }
+    },
+    "repositoryPathPattern": {
+      "description": "The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable \"{base}\" is replaced with the Git clone base URL host and path, and \"{repo}\" is replaced with the repository path taken from the ` + "`" + `repos` + "`" + ` field.\n\nFor example, if your Git clone base URL is https://git.example.com/repos and ` + "`" + `repos` + "`" + ` contains the value \"my/repo\", then a repositoryPathPattern of \"{base}/{repo}\" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+      "type": "string",
+      "default": "{base}/{repo}"
     }
   }
 }

--- a/schema/other_external_service_stringdata.go
+++ b/schema/other_external_service_stringdata.go
@@ -37,7 +37,8 @@ const OtherExternalServiceSchemaJSON = `{
     "repositoryPathPattern": {
       "description": "The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable \"{base}\" is replaced with the Git clone base URL host and path, and \"{repo}\" is replaced with the repository path taken from the ` + "`" + `repos` + "`" + ` field.\n\nFor example, if your Git clone base URL is https://git.example.com/repos and ` + "`" + `repos` + "`" + ` contains the value \"my/repo\", then a repositoryPathPattern of \"{base}/{repo}\" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
       "type": "string",
-      "default": "{base}/{repo}"
+      "default": "{base}/{repo}",
+      "examples": ["pretty-host-name/{repo}"]
     }
   }
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -403,8 +403,9 @@ type OpenIDConnectAuthProvider struct {
 
 // OtherExternalServiceConnection description: Configuration for a Connection to Git repositories for which an external service integration isn't yet available.
 type OtherExternalServiceConnection struct {
-	Repos []string `json:"repos"`
-	Url   string   `json:"url,omitempty"`
+	Repos                 []string `json:"repos"`
+	RepositoryPathPattern string   `json:"repositoryPathPattern,omitempty"`
+	Url                   string   `json:"url,omitempty"`
 }
 
 // ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"


### PR DESCRIPTION
Adds `repositoryPathPattern` for the "Other" external service type. This resolves a request from https://app.hubspot.com/contacts/2762526/company/554338610.

This is similar to the `repositoryPathPattern` fields for the GitHub, GitLab, and Bitbucket Server external service types. The reference-able components are `{base}` (the base URL of the code host) and `{repo}` (the sub path relative to the base URL that completes the clone URL). The default value is `{base}/{repo}`.