### PR TITLE
remove ineffective "Slack webhook" config action and settings schema property

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -482,17 +482,16 @@ type Sentry struct {
 
 // Settings description: Configuration settings for users and organizations on Sourcegraph.
 type Settings struct {
-	AlertsShowPatchUpdates    bool                      `json:"alerts.showPatchUpdates,omitempty"`
-	CodeHostUseNativeTooltips bool                      `json:"codeHost.useNativeTooltips,omitempty"`
-	Extensions                map[string]bool           `json:"extensions,omitempty"`
-	Motd                      []string                  `json:"motd,omitempty"`
-	Notices                   []*Notice                 `json:"notices,omitempty"`
-	NotificationsSlack        *SlackNotificationsConfig `json:"notifications.slack,omitempty"`
-	Quicklinks                []*QuickLink              `json:"quicklinks,omitempty"`
-	SearchContextLines        int                       `json:"search.contextLines,omitempty"`
-	SearchRepositoryGroups    map[string][]string       `json:"search.repositoryGroups,omitempty"`
-	SearchSavedQueries        []*SearchSavedQueries     `json:"search.savedQueries,omitempty"`
-	SearchScopes              []*SearchScope            `json:"search.scopes,omitempty"`
+	AlertsShowPatchUpdates    bool                  `json:"alerts.showPatchUpdates,omitempty"`
+	CodeHostUseNativeTooltips bool                  `json:"codeHost.useNativeTooltips,omitempty"`
+	Extensions                map[string]bool       `json:"extensions,omitempty"`
+	Motd                      []string              `json:"motd,omitempty"`
+	Notices                   []*Notice             `json:"notices,omitempty"`
+	Quicklinks                []*QuickLink          `json:"quicklinks,omitempty"`
+	SearchContextLines        int                   `json:"search.contextLines,omitempty"`
+	SearchRepositoryGroups    map[string][]string   `json:"search.repositoryGroups,omitempty"`
+	SearchSavedQueries        []*SearchSavedQueries `json:"search.savedQueries,omitempty"`
+	SearchScopes              []*SearchScope        `json:"search.scopes,omitempty"`
 }
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.
@@ -521,11 +520,6 @@ type SiteConfiguration struct {
 	RepoListUpdateInterval            int                         `json:"repoListUpdateInterval,omitempty"`
 	SearchIndexEnabled                *bool                       `json:"search.index.enabled,omitempty"`
 	SearchLargeFiles                  []string                    `json:"search.largeFiles,omitempty"`
-}
-
-// SlackNotificationsConfig description: Configuration for sending notifications to Slack.
-type SlackNotificationsConfig struct {
-	WebhookURL string `json:"webhookURL"`
 }
 type UsernameIdentity struct {
 	Type string `json:"type"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -62,9 +62,6 @@
       "minimum": 0,
       "default": 1
     },
-    "notifications.slack": {
-      "$ref": "#/definitions/SlackNotificationsConfig"
-    },
     "quicklinks": {
       "description": "Links that should be accessible quickly from the home and search pages.",
       "type": "array",
@@ -166,19 +163,6 @@
         "description": {
           "type": "string",
           "description": "A description for this quick link"
-        }
-      }
-    },
-    "SlackNotificationsConfig": {
-      "type": "object",
-      "description": "Configuration for sending notifications to Slack.",
-      "additionalProperties": false,
-      "required": ["webhookURL"],
-      "properties": {
-        "webhookURL": {
-          "type": "string",
-          "description": "The Slack webhook URL used to post notification messages to a Slack channel. To obtain this URL, go to: https://YOUR-WORKSPACE-NAME.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks",
-          "format": "uri"
         }
       }
     }

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -67,9 +67,6 @@ const SettingsSchemaJSON = `{
       "minimum": 0,
       "default": 1
     },
-    "notifications.slack": {
-      "$ref": "#/definitions/SlackNotificationsConfig"
-    },
     "quicklinks": {
       "description": "Links that should be accessible quickly from the home and search pages.",
       "type": "array",
@@ -171,19 +168,6 @@ const SettingsSchemaJSON = `{
         "description": {
           "type": "string",
           "description": "A description for this quick link"
-        }
-      }
-    },
-    "SlackNotificationsConfig": {
-      "type": "object",
-      "description": "Configuration for sending notifications to Slack.",
-      "additionalProperties": false,
-      "required": ["webhookURL"],
-      "properties": {
-        "webhookURL": {
-          "type": "string",
-          "description": "The Slack webhook URL used to post notification messages to a Slack channel. To obtain this URL, go to: https://YOUR-WORKSPACE-NAME.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks",
-          "format": "uri"
         }
       }
     }

--- a/web/src/site-admin/configHelpers.ts
+++ b/web/src/site-admin/configHelpers.ts
@@ -1,6 +1,5 @@
 import { FormattingOptions } from '@sqs/jsonc-parser'
 import { setProperty } from '@sqs/jsonc-parser/lib/edit'
-import { SlackNotificationsConfig } from '../schema/settings.schema'
 import { ConfigInsertionFunction } from '../settings/MonacoSettingsEditor'
 
 const defaultFormattingOptions: FormattingOptions = {
@@ -32,14 +31,6 @@ const addQuickLinkToSettings: ConfigInsertionFunction = config => {
     return { edits, selectText: '<name>' }
 }
 
-const addSlackWebhook: ConfigInsertionFunction = config => {
-    const value: SlackNotificationsConfig = {
-        webhookURL: 'get webhook URL at https://YOUR-WORKSPACE-NAME.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks',
-    }
-    const edits = setProperty(config, ['notifications.slack'], value, defaultFormattingOptions)
-    return { edits, selectText: '""', cursorOffset: 1 }
-}
-
 export interface EditorAction {
     id: string
     label: string
@@ -54,7 +45,6 @@ export const settingsActions: EditorAction[] = [
     },
     { id: 'sourcegraph.settings.searchScopes', label: 'Add search scope', run: addSearchScopeToSettings },
     { id: 'sourcegraph.settings.quickLinks', label: 'Add quick link', run: addQuickLinkToSettings },
-    { id: 'sourcegraph.settings.addSlackWebhook', label: 'Add Slack webhook', run: addSlackWebhook },
 ]
 
 export const siteConfigActions: EditorAction[] = []


### PR DESCRIPTION
a00f2fc02a83c4e8710d4dcf696b5b86e7105172 moved saved searches to the database and made Slack webhooks a per-saved-search option. The `notifications.slack` setting is no longer effective (evidence: there were no Go references to the field).

Also removes the config action that set this property.