### PR TITLE
show focus ring when using keyboard to focus, hide otherwise

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "d3-shape": "^1.3.5",
     "date-fns": "^2.0.0-alpha.31",
     "downshift": "^3.2.10",
+    "focus-visible": "^5.0.2",
     "graphiql": "^0.13.0",
     "he": "^1.2.0",
     "highlight.js": "^9.15.8",

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -231,6 +231,16 @@ body,
     border-radius: $border-radius;
 }
 
+// Show a focus ring when performing keyboard navigation. Uses the polyfill at
+// https://github.com/WICG/focus-visible because few browsers support :focus-visible.
+.js-focus-visible :focus:not(.focus-visible) {
+    outline: none;
+}
+.js-focus-visible .focus-visible {
+    outline: 0;
+    box-shadow: $btn-focus-box-shadow;
+}
+
 // Pages
 @import './Layout';
 @import './api/APIConsole';

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -1,4 +1,5 @@
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
+import 'focus-visible'
 import ServerIcon from 'mdi-react/ServerIcon'
 import * as React from 'react'
 import { hot } from 'react-hot-loader/root'

--- a/web/src/global-styles/buttons.scss
+++ b/web/src/global-styles/buttons.scss
@@ -26,7 +26,7 @@
         @extend .icon-inline;
     }
 
-    &:focus:not(:disabled):not(.disabled) {
+    &.focus-visible:not(:disabled):not(.disabled) {
         box-shadow: 0 0 0 2px rgba($primary, 0.5);
     }
 

--- a/web/src/global-styles/nav.scss
+++ b/web/src/global-styles/nav.scss
@@ -8,24 +8,6 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
 @import 'bootstrap/scss/nav';
 @import 'bootstrap/scss/navbar';
 
-// Remove focus ring around nav links during mousedown.
-//
-// The focus ring on nav links is usually undesirable. It shows up when you click on a nav link and remains until
-// you click elsewhere. Because many of our nav links are toolbar buttons, this means that (1) the focus ring
-// remains visible even when it is not useful anymore (after you've clicked the button) and (2) the focus ring is
-// chopped off on the top and bottom by the toolbar boundaries.
-//
-// But the focus ring is important when using the keyboard to focus and for accessibility. In the future, the CSS
-// :focus-visible pseudo-selector will solve our problems (and we could consider using the polyfill
-// https://github.com/wicg/focus-visible).
-//
-// For now, we only remove the focus ring during mousedown. This lets elements that want to eliminate the focus
-// ring for mouse focus (without affecting it for keyboard focus or a11y) do so by calling HTMLElement#blur in an
-// onclick handler.
-.nav-link:active {
-    box-shadow: none !important;
-}
-
 // Ensure that tabs are all the same height, regardless of whether they have an icon. Without this,
 // tabs with an icon are 38px and tabs without an icon are 37.5px, which causes tabs without an icon
 // to have an undesirable bottom border when active.

--- a/web/src/global-styles/type.scss
+++ b/web/src/global-styles/type.scss
@@ -57,37 +57,3 @@ h5 {
 small {
     font-size: 12px;
 }
-
-// Apply the same focus outline to links as to buttons
-a {
-    &:focus,
-    &.focus {
-        border-radius: $border-radius;
-        outline: 0;
-        box-shadow: $btn-focus-box-shadow;
-    }
-
-    // Disabled comes first so active can properly restyle
-    &.disabled,
-    &:disabled {
-        opacity: $btn-disabled-opacity;
-
-        @include box-shadow(none);
-    }
-
-    // Opinionated: add "hand" cursor to non-disabled .btn elements
-    &:not(:disabled):not(.disabled) {
-        cursor: pointer;
-    }
-
-    &:not(:disabled):not(.disabled):active,
-    &:not(:disabled):not(.disabled).active {
-        background-image: none;
-
-        @include box-shadow($btn-active-box-shadow);
-
-        &:focus {
-            @include box-shadow($btn-focus-box-shadow, $btn-active-box-shadow);
-        }
-    }
-}

--- a/web/src/tree/Tree.scss
+++ b/web/src/tree/Tree.scss
@@ -8,10 +8,6 @@
 
     user-select: none;
 
-    &:focus {
-        outline: none;
-    }
-
     table {
         border-spacing: 0;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,7 +1599,8 @@
   integrity sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.0.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.1":
   version "3.0.1"
@@ -7701,6 +7702,11 @@ focus-lock@^0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.3.tgz#ef0e82ebac0023f841039d60bf329725d6438028"
   integrity sha512-EU6ePgEauhWrzJEN5RtG1d1ayrWXhEnfzTjnieHj+jG9tNHDEhKTAnCn1TN3gs9h6XWCDH6cpeX1VXY/lzLwZg==
+
+focus-visible@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/focus-visible/-/focus-visible-5.0.2.tgz#4fae9cf40458b73c10701c9774c462e3ccd53caf"
+  integrity sha512-zT2fj/bmOgEBjqGbURGlowTmCwsIs3bRDMr/sFZz8Ly7VkEiwuCn9swNTL3pPuf8Oua2de7CLuKdnuNajWdDsQ==
 
 follow-redirects@1.0.0:
   version "1.0.0"
@@ -15256,7 +15262,8 @@ source-map@^0.7.2, source-map@^0.7.3:
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "23.0.1"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
This cleans up focus rings in our app.

- The :focus-visible CSS pseudoselector is intended for "elements whose focused state should be indicated visibly". This includes elements that are keyboard-focused (eg by pressing tab) but not, eg, buttons that were just clicked. Technically those buttons retain focus after the click, but it's not usually helpful to show the focus ring on them. :focus-visible is not widely supported by browsers yet, so we polyfill it. This means that all focus rings in our application look the same way (before this commit, some were the OS default and some were Bootstrap).
- Remove the focus ring around non-:focus-visible elements. Before this commit, we did show it on buttons that were just clicked, etc.