### PR TITLE
add Alt+t keybinding for cycling the color theme

### DIFF
--- a/web/src/keybindings.ts
+++ b/web/src/keybindings.ts
@@ -1,25 +1,24 @@
 import { Key, ModifierKey } from '@slimsag/react-shortcuts'
 
-/**
- * A map of action names to the keys that trigger them. The actions are their own namespace for now, but it will be
- * merged with extension actions/commands in the future.
- */
-export interface Keybindings extends Record<'commandPalette', Keybinding[]> {}
-
 interface Keybinding {
     held?: ModifierKey[]
     ordered: Key[]
 }
 
+type Action = 'commandPalette' | 'switchTheme'
+
 /**
- * Global keybinding actions.
+ * Global keybinding actions. This is a map of action names to the keys that trigger them. The
+ * actions are their own namespace for now, but it will be merged with extension actions/commands in
+ * the future.
  */
-export const keybindings: Keybindings = {
+export const keybindings: Record<Action, Keybinding[]> = {
     commandPalette: [{ held: ['Control'], ordered: ['p'] }, { ordered: ['F1'] }, { held: ['Alt'], ordered: ['x'] }],
+    switchTheme: [{ held: ['Alt'], ordered: ['t'] }],
 }
 
 /** A partial React props type for components that use or propagate keybindings. */
 export interface KeybindingsProps {
     /** The global map of keybindings and their associated actions. */
-    keybindings: Readonly<Keybindings>
+    keybindings: Readonly<typeof keybindings>
 }

--- a/web/src/nav/NavLinks.test.tsx
+++ b/web/src/nav/NavLinks.test.tsx
@@ -46,7 +46,7 @@ describe('NavLinks', () => {
         'executeCommand' | 'services'
     >['extensionsController'] = { executeCommand: async () => void 0, services: {} as any }
     const NOOP_PLATFORM_CONTEXT = { forceUpdateTooltip: () => void 0 }
-    const KEYBINDINGS: KeybindingsProps['keybindings'] = { commandPalette: [] }
+    const KEYBINDINGS: KeybindingsProps['keybindings'] = { commandPalette: [], switchTheme: [] }
     const SETTINGS_CASCADE: SettingsCascadeProps['settingsCascade'] = { final: null, subjects: null }
     // tslint:disable-next-line:no-object-literal-type-assertion
     const USER = { username: 'u' } as GQL.IUser

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -119,6 +119,7 @@ export class NavLinks extends React.PureComponent<Props> {
                             authenticatedUser={this.props.authenticatedUser}
                             showDotComMarketing={this.props.showDotComMarketing}
                             showDiscussions={isDiscussionsEnabled(this.props.settingsCascade)}
+                            switchThemeKeybinding={this.props.keybindings.switchTheme}
                         />
                     </li>
                 )}

--- a/web/src/nav/UserNavItem.tsx
+++ b/web/src/nav/UserNavItem.tsx
@@ -1,3 +1,4 @@
+import { Shortcut, ShortcutProps } from '@slimsag/react-shortcuts'
 import * as H from 'history'
 import React from 'react'
 import { Link } from 'react-router-dom'
@@ -11,6 +12,7 @@ interface Props extends ThemeProps, ThemePreferenceProps {
     authenticatedUser: GQL.IUser
     showDotComMarketing: boolean
     showDiscussions: boolean
+    switchThemeKeybinding?: Pick<ShortcutProps, 'held' | 'ordered'>[]
 }
 
 interface State {
@@ -95,6 +97,10 @@ export class UserNavItem extends React.PureComponent<Props, State> {
                                 </small>
                             </div>
                         )}
+                        {this.props.switchThemeKeybinding &&
+                            this.props.switchThemeKeybinding.map((keybinding, i) => (
+                                <Shortcut key={i} {...keybinding} onMatch={this.onThemeCycle} />
+                            ))}
                     </div>
                     {this.props.authenticatedUser.organizations.nodes.length > 0 && (
                         <>
@@ -144,5 +150,11 @@ export class UserNavItem extends React.PureComponent<Props, State> {
 
     private onThemeChange: React.ChangeEventHandler<HTMLSelectElement> = event => {
         this.props.onThemePreferenceChange(event.target.value as ThemePreference)
+    }
+
+    private onThemeCycle = () => {
+        this.props.onThemePreferenceChange(
+            this.props.themePreference === ThemePreference.Dark ? ThemePreference.Light : ThemePreference.Dark
+        )
     }
 }


### PR DESCRIPTION
This is not documented anywhere yet. It will be documented in an upcoming keyboard shortcuts in-app help modal (triggered by <kbd>?</kbd>) that I will add in hackweek.