### PR TITLE
SELECT name, change a switch to if/else, make a JSON struct more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
-- Repos with greatest `updated_at - created_at` are prioritized for indexing, to support `repo:`-free queries on sourcegraph.com. [#4958](https://github.com/sourcegraph/sourcegraph/issues/4958).
-
 ### Changed
 
 ### Fixed

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -322,7 +322,7 @@ func (s *repos) List(ctx context.Context, opt ReposListOptions) (results []*type
 // experience for people trying out search.
 func (s *repos) ListWithLongestInterval(ctx context.Context, lim int) (URIs []string, err error) {
 	query := fmt.Sprintf(`
-		SELECT uri
+		SELECT name
 		FROM repo
 		WHERE deleted_at IS NULL
 		AND enabled = true

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -209,18 +209,19 @@ func serveReposList(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "listing repos")
 	}
 
-	// BACKCOMPAT: Add a "URI" field because zoekt-sourcegraph-indexserver expects one to exist
-	// (with the repository name). This is a legacy of the rename from "repo URI" to "repo name".
+	// BACKCOMPAT: Add a Name field that serializes to `URI` because
+	// zoekt-sourcegraph-indexserver expects one to exist (with the
+	// repository name). This is a legacy of the rename from "repo URI" to
+	// "repo name".
 	type repoWithBackcompatURIField struct {
-		URI string
-		*types.Repo
+		Name string `json:URI`
+		// The Repo field has been removed because the only caller of this handler
+		// (zoekt-sourcegraph-indexserver) wasn't using it.
 	}
-	res2 := make([]*repoWithBackcompatURIField, len(res))
+	res2 := make([]repoWithBackcompatURIField, len(res))
 	for i, repo := range res {
-		res2[i] = &repoWithBackcompatURIField{
-			URI: string(repo.Name),
-			// The setting of the Repo field has been removed because the only caller of this handler
-			// wasn't using it: zoekt-sourcegraph-indexserver.
+		res2[i] = repoWithBackcompatURIField{
+			Name: string(repo.Name),
 		}
 	}
 

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,11 +39,7 @@ func Test_serveReposList(t *testing.T) {
 			URI string
 		}
 		var repos []repo
-		bod, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = json.Unmarshal(bod, &repos)
+		err = json.NewDecoder(resp.Body).Decode(&repos)
 		if err != nil {
 			t.Fatalf("json decoding response: %v", err)
 		}


### PR DESCRIPTION
The original PR chooses a set of repositories to index on sourcegraph.com.

Test plan: The changes are covered by existing tests.