### PR TITLE
lsif: GZIP compression of index file before upload

### DIFF
--- a/lsif/master-upload.sh
+++ b/lsif/master-upload.sh
@@ -22,8 +22,11 @@ if [[ -z "$SRC_ACCESS_TOKEN" || -z "$REPOSITORY" || -z "$COMMIT" || -z "$file" ]
   exit 1
 fi
 
+gzip -k -c "$file" > "$file.gz"
+
 curl \
   -H "Authorization: token $SRC_ACCESS_TOKEN" \
   -H "Content-Type: application/x-ndjson+lsif" \
+  -H "Content-Encoding: gzip" \
   "$SRC_ENDPOINT/.api/lsif/upload?repository=$(urlencode "$REPOSITORY")&commit=$(urlencode "$COMMIT")" \
-  --data-binary "@$file"
+  --data-binary "@$file.gz"

--- a/lsif/upload.sh
+++ b/lsif/upload.sh
@@ -22,7 +22,10 @@ if [[ -z "$SRC_LSIF_UPLOAD_TOKEN" || -z "$REPOSITORY" || -z "$COMMIT" || -z "$fi
   exit 1
 fi
 
+gzip -k -c "$file" > "$file.gz"
+
 curl \
   -H "Content-Type: application/x-ndjson+lsif" \
+  -H "Content-Encoding: gzip" \
   "$SRC_ENDPOINT/.api/lsif/upload?repository=$(urlencode "$REPOSITORY")&commit=$(urlencode "$COMMIT")&upload_token=$(urlencode "$SRC_LSIF_UPLOAD_TOKEN")" \
-  --data-binary "@$file"
+  --data-binary "@$file.gz"


### PR DESCRIPTION
This commit makes the LSIF upload scripts send a GZIP compressed index
file, to reduce network transfer time.