### PR TITLE
Revert "Bump ctags to get the new TypeScript parser (#4987)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Out-of-the-box TypeScript code intelligence is much better with an updated ctags version with a built-in TypeScript parser.
-
 ### Fixed
 
 ### Removed

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache add --virtual build-deps curl jansson-dev \
     libseccomp-dev linux-headers autoconf pkgconfig make automake \
     gcc g++ binutils
 
-ENV CTAGS_VERSION=1a94658c2cb47304d0e9811d49e0a5f48bdb3a0a
+ENV CTAGS_VERSION=5b4865cc2d4831db9d638a647ff2f5a0dced2133
 
 # hadolint ignore=DL3003
 RUN curl -fsSL -o ctags.tar.gz "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" && \

--- a/cmd/symbols/.ctags.d/typescript.ctags
+++ b/cmd/symbols/.ctags.d/typescript.ctags
@@ -1,0 +1,20 @@
+# See additional-language.ctags for maintaining this file
+
+# To avoid the warning:
+#
+#     Don't reuse the kind letter `c' in a language typescript (old: "classes", new: "modules")
+#
+# Make sure there's a 1-1 correspondence between kind letters and kind names.
+
+--langdef=typescript
+--langmap=typescript:.ts.tsx
+--regex-typescript=/^[ \t]*(export[ \t]+([a-z]+[ \t]+)?)?class[ \t]+([a-zA-Z0-9_$]+)/\3/c,class/
+--regex-typescript=/^[ \t]*(declare[ \t]+)?namespace[ \t]+([a-zA-Z0-9_$]+)/\2/n,module/
+--regex-typescript=/^[ \t]*(export[ \t]+)?module[ \t]+([a-zA-Z0-9_$]+)/\2/n,module/
+--regex-typescript=/^[ \t]*(export[ \t]+)?(default[ \t]+)?(async[ \t]+)?function[ \t]+([a-zA-Z0-9_$]+)/\4/f,function/
+--regex-typescript=/^[ \t]*export[ \t]+(var|let|const)[ \t]+([a-zA-Z0-9_$]+)/\2/v,variable/
+--regex-typescript=/^[ \t]*(var|let|const)[ \t]+([a-zA-Z0-9_$]+)[ \t]*=[ \t]*function[ \t]*[*]?[ \t]*\(\)/\2/v,variable/
+--regex-typescript=/^[ \t]*(export[ \t]+)?(public|protected|private)[ \t]+(static[ \t]+)?(abstract[ \t]+)?(((get|set)[ \t]+)|(async[ \t]+[*]*[ \t]*))?([a-zA-Z1-9_$]+)/\9/m,member/
+--regex-typescript=/^[ \t]*(export[ \t]+)?interface[ \t]+([a-zA-Z0-9_$]+)/\2/i,interface/
+--regex-typescript=/^[ \t]*(export[ \t]+)?type[ \t]+([a-zA-Z0-9_$]+)/\2/t,type/
+--regex-typescript=/^[ \t]*(export[ \t]+)?enum[ \t]+([a-zA-Z0-9_$]+)/\2/e,enum/

--- a/cmd/symbols/internal/pkg/ctags/Dockerfile
+++ b/cmd/symbols/internal/pkg/ctags/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9@sha256:644fcb1a676b5165371437feaa922943aaf7afcfa8bfee4472f6860aad1ef2a0 AS ctags
 
-ENV CTAGS_VERSION=1a94658c2cb47304d0e9811d49e0a5f48bdb3a0a
+ENV CTAGS_VERSION=5b4865cc2d4831db9d638a647ff2f5a0dced2133
 
 # hadolint ignore=DL3003,DL3018,DL4006
 RUN apk --no-cache add --virtual build-deps curl jansson-dev libseccomp-dev linux-headers autoconf pkgconfig make automake gcc g++ binutils && \


### PR DESCRIPTION
This reverts commit bf40d9e36920b62fc7fb6c8ed2e8f4365525d504. https://github.com/sourcegraph/sourcegraph/issues/4987 broke the build.



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
