### PR TITLE
Add regex pattern for corsOrigin setting

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -57,6 +57,7 @@
       "description": "Only required when using the Phabricator integration or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com\"",
       "type": "string",
       "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com"],
+      "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },
     "lsifVerificationGithubToken": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -62,6 +62,7 @@ const SiteSchemaJSON = `{
       "description": "Only required when using the Phabricator integration or Bitbucket Server plugin. This value is the space-separated list of allowed origins for cross-origin HTTP requests to Sourcegraph. Usually it contains the base URL for your Phabricator or Bitbucket Server instance.\n\nPreviously, this value was also used for the GitHub, GitLab, etc., integrations using the browser extension. It is no longer necessary for those. You may remove this setting if you are not using the Phabricator integration or Bitbucket Server plugin. eg \"https://my-phabricator.example.com https://my-bitbucket.example.com\"",
       "type": "string",
       "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com"],
+      "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },
     "lsifVerificationGithubToken": {


### PR DESCRIPTION
This would have caught https://github.com/sourcegraph/infrastructure/issues/1574.

The goal of this regex is to ensure the value is a space-delimited list of [origins](https://developer.mozilla.org/en-US/docs/Glossary/origin).

It enforces
- providing at least one element
- delimiting with exactly one space
- including `http://` or `https://`
- not including any path segment or trailing `/`
- or providing `*`

It does not enforce perfectly valid domain names.

It does not allow `null` origins or special origins like `chrome-extension://...`.

If the pattern does not match, afaik all that happens is that a hint is shown in the config UI, so no backcompat concerns.