### PR TITLE
repo-updater: Migrate a repo without external and different name

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -272,7 +272,7 @@ func NewDiff(sourced, stored []*Repo) (diff Diff) {
 	for _, old := range stored {
 		src := byID[old.ExternalRepo]
 		if src == nil && old.ExternalRepo.ID == "" && !seenName[old.Name] {
-			src = byName[old.Name]
+			src = byName[strings.ToLower(old.Name)]
 		}
 
 		if src == nil {

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -965,6 +965,21 @@ func TestDiff(t *testing.T) {
 			},
 		},
 		{
+			name: "conflict on case insensitive name no external",
+			store: repos.Repos{
+				{Name: "fOO"},
+			},
+			source: repos.Repos{
+				{Name: "fOO", ExternalRepo: eid("fOO")},
+				{Name: "Foo", ExternalRepo: eid("Foo")},
+			},
+			diff: repos.Diff{
+				Modified: repos.Repos{
+					{Name: "Foo", ExternalRepo: eid("Foo")},
+				},
+			},
+		},
+		{
 			name: "conflict on case insensitive name exists 1",
 			store: repos.Repos{
 				{Name: "foo", ExternalRepo: eid("1")},

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -604,10 +604,6 @@ func (r *Repo) IsDeleted() bool { return !r.DeletedAt.IsZero() }
 // Update updates Repo r with the fields from the given newer Repo n,
 // returning true if modified.
 func (r *Repo) Update(n *Repo) (modified bool) {
-	if !r.ExternalRepo.Equal(&n.ExternalRepo) && r.Name != n.Name {
-		return false
-	}
-
 	if r.Name != n.Name {
 		r.Name, modified = n.Name, true
 	}


### PR DESCRIPTION
We special case repositories that do not have an external repo set in our sync
algorithm. We make an attempt to associate them with an existing
repository. However, our algorithm had two short-comings resolved in this
commit.

In the case that we associated it with a repository with a name in a different
case the Update call would fail. So we remove the unneccessary in Update
ensuring the name is the same. We could change this to using
string.EqualFold. However, in every case we call Update we really do want to
merge the two repositories. So the guard is unneccessary.

The other important change is that when we try to associate the repository we
need to look up byName case insensitively. This bug has likely saved us
before, since things would "just work" if the name in stored is already lower
cased. In the case of a customer running into this issue, they likely had the
byName lookup work, but the Update call fail.

This change will need to be cherry-picked to the 3.4, 3.5 and 3.6 release branches. However, we only know of one customer running into this issue. In that case we can not cherry-pick this everywhere to prevent unnecessary patch releases on older versions.