### PR TITLE
Add e2e test to ensure repositoryPathPattern works

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -45,7 +45,7 @@ describe('e2e test suite', function(this: any): void {
                 repos: repoSlugs,
                 repositoryQuery: ['none'],
             }),
-            ensureRepos: repoSlugs,
+            ensureRepos: repoSlugs.map(slug => `github.com/${slug}`),
         })
     }
 
@@ -134,19 +134,10 @@ describe('e2e test suite', function(this: any): void {
                     repos: [repo],
                     repositoryPathPattern,
                 }),
+                // Make sure repository is named according to path pattern
+                ensureRepos: [pathPatternSlug],
             }
             await driver.ensureHasExternalService(config)
-
-            await driver.page.goto(baseURL + '/site-admin/external-services')
-            await (await driver.page.waitForSelector(
-                `[data-e2e-external-service-name="${config.displayName}"] .e2e-edit-external-service-button`
-            )).click()
-
-            // Make sure repository is named according to path pattern
-            await driver.page.goto(baseURL + `/site-admin/repositories?query=${encodeURIComponent(pathPatternSlug)}`)
-            await driver.page.waitForSelector(`.repository-node[data-e2e-repository='${pathPatternSlug}']`, {
-                visible: true,
-            })
 
             // Make sure repository slug without path pattern redirects to path pattern
             await driver.page.goto(baseURL + '/' + slug)

--- a/web/src/e2e/util.ts
+++ b/web/src/e2e/util.ts
@@ -162,7 +162,7 @@ export class Driver {
             // Clone the repositories
             for (const slug of ensureRepos) {
                 await this.page.goto(baseURL + `/site-admin/repositories?query=${encodeURIComponent(slug)}`)
-                await this.page.waitForSelector(`.repository-node[data-e2e-repository='github.com/${slug}']`, {
+                await this.page.waitForSelector(`.repository-node[data-e2e-repository='${slug}']`, {
                     visible: true,
                 })
             }


### PR DESCRIPTION
This automates release test grid item [15.1 When `repositoryPathPattern` is configured, paths from the full long name will redirect to the configured name. Extensions will function with the configured name.](https://docs.google.com/document/d/10QryO5cvEEVw6m5VI6D7JY-oYcD1yJbwUp_uqNFdySg/edit#heading=h.aq6zejp6wvsn), except for the "Extensions" part.

This was fun 🙂

@nicksnyder What do you think about this for automating the release testing? This test certainly has a cost (new (although tiny) repo to clone, lots of page loads, etc.), but it's still a ton faster than what I did for 2 times now 😉
