### PR TITLE
Do not paste text on macOS in e2e tests

### DIFF
--- a/web/src/e2e/util.ts
+++ b/web/src/e2e/util.ts
@@ -76,6 +76,8 @@ export class Driver {
     }
 
     public async enterText(method: EnterTextMethod = 'type', text: string): Promise<void> {
+        // Pasting does not work on macOS. See:  https://github.com/GoogleChrome/puppeteer/issues/1313
+        method = os.platform() === 'darwin' ? 'type' : method
         switch (method) {
             case 'type':
                 await this.page.keyboard.type(text)


### PR DESCRIPTION
Pasting text was introduced in f2365a5f3e8b729663d83f1158d6d4ccabb28903 and doesn't work on my macOS machine.

Reading through https://github.com/GoogleChrome/puppeteer/issues/1313 (and a ton of other GitHub issues and SO questions/answers) tells me that other people also couldn't get pasting via Meta+V to work on macOS with Puppeteer.

This commit adds an override for macOS while leaving the existing `paste` function as is.