### PR TITLE
Add e2e tests for symbol table to ensure symbols change with file

### DIFF
--- a/shared/src/components/Tabs.tsx
+++ b/shared/src/components/Tabs.tsx
@@ -215,6 +215,7 @@ export class TabsWithLocalStorageViewStatePersistence<ID extends string, T exten
         <button
             type="button"
             className={className}
+            data-e2e-tab={tab.id}
             // tslint:disable-next-line:jsx-no-lambda
             onClick={() => this.onSelectTab(tab.id)}
         >

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -460,6 +460,26 @@ describe('e2e test suite', function(this: any): void {
                     expect(symbolTypes).toEqual(test.symbolTypes)
                 }
             })
+
+            test('navigates to file on symbol click', async () => {
+                const repoBaseURL =
+                    baseURL + '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-'
+                const symbolPath = '/blob/cmd/go-diff/go-diff.go#L19:2-19:10'
+
+                await driver.page.goto(repoBaseURL + '/tree/cmd')
+
+                await (await driver.page.waitForSelector('.tab-bar__tab[data-e2e-tab="symbols"]')).click()
+
+                await driver.page.waitForSelector('.repo-rev-sidebar-symbols-node__name', { visible: true })
+
+                await (await driver.page.waitForSelector(
+                    `.repo-rev-sidebar-symbols-node__link[href*="${symbolPath}"]`,
+                    {
+                        visible: true,
+                    }
+                )).click()
+                await driver.assertWindowLocation(repoBaseURL + symbolPath, true)
+            })
         })
 
         describe('directory page', () => {

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -77,6 +77,15 @@ describe('e2e test suite', function(this: any): void {
         () => driver.page
     )
 
+    // Clear local storage to reset sidebar selection (files or tabs) for each test
+    beforeEach(async () => {
+        if (driver) {
+            await driver.page.evaluate(() => {
+                localStorage.setItem('repo-rev-sidebar-last-tab', 'files')
+            })
+        }
+    })
+
     describe('External services', () => {
         test('External service add, edit, delete', async () => {
             const displayName = 'e2e-github-test-2'

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -367,79 +367,75 @@ describe('e2e test suite', function(this: any): void {
             })
         })
         describe('symbol sidebar', () => {
-            test('lists symbols in current file', async () => {
-                const tests = [
-                    {
-                        filePath:
-                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/cmd/go-diff/go-diff.go',
-                        symbolNames: ['main', 'stdin', 'diffPath', 'fileIdx', 'main'],
-                        symbolTypes: ['package', 'constant', 'variable', 'variable', 'function'],
-                    },
-                    {
-                        filePath:
-                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/diff.go',
-                        symbolNames: [
-                            'diff',
-                            'Stat',
-                            'Stat',
-                            'hunkPrefix',
-                            'hunkHeader',
-                            'diffTimeParseLayout',
-                            'diffTimeFormatLayout',
-                            'add',
-                        ],
-                        symbolTypes: [
-                            'package',
-                            'function',
-                            'function',
-                            'variable',
-                            'constant',
-                            'constant',
-                            'constant',
-                            'function',
-                        ],
-                    },
-                    {
-                        filePath:
-                            '/github.com/sourcegraph/appdash@ebfcffb1b5c00031ce797183546746715a3cfe87/-/blob/python/appdash/sockcollector.py',
-                        symbolNames: [
-                            'RemoteCollector',
-                            'sock',
-                            '_debug',
-                            '__init__',
-                            '_log',
-                            'connect',
-                            'collect',
-                            'close',
-                        ],
-                        symbolTypes: ['class', 'variable', 'variable', 'field', 'field', 'field', 'field', 'field'],
-                    },
-                    {
-                        filePath:
-                            '/github.com/sourcegraph/sourcegraph-typescript@a7b7a61e31af76dad3543adec359fa68737a58a1/-/blob/server/src/cancellation.ts',
-                        symbolNames: [
-                            'createAbortError',
-                            'Object',
-                            'isAbortError',
-                            'throwIfCancelled',
-                            'tryCancel',
-                            'toAxiosCancelToken',
-                            'source',
-                        ],
-                        symbolTypes: [
-                            'constant',
-                            'constant',
-                            'constant',
-                            'function',
-                            'function',
-                            'function',
-                            'constant',
-                        ],
-                    },
-                ]
+            const listSymbolsTests = [
+                {
+                    name: 'lists symbols in file for Go',
+                    filePath:
+                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/cmd/go-diff/go-diff.go',
+                    symbolNames: ['main', 'stdin', 'diffPath', 'fileIdx', 'main'],
+                    symbolTypes: ['package', 'constant', 'variable', 'variable', 'function'],
+                },
+                {
+                    name: 'lists symbols in another file for Go',
+                    filePath:
+                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/diff.go',
+                    symbolNames: [
+                        'diff',
+                        'Stat',
+                        'Stat',
+                        'hunkPrefix',
+                        'hunkHeader',
+                        'diffTimeParseLayout',
+                        'diffTimeFormatLayout',
+                        'add',
+                    ],
+                    symbolTypes: [
+                        'package',
+                        'function',
+                        'function',
+                        'variable',
+                        'constant',
+                        'constant',
+                        'constant',
+                        'function',
+                    ],
+                },
+                {
+                    name: 'lists symbols in file for Python',
+                    filePath:
+                        '/github.com/sourcegraph/appdash@ebfcffb1b5c00031ce797183546746715a3cfe87/-/blob/python/appdash/sockcollector.py',
+                    symbolNames: [
+                        'RemoteCollector',
+                        'sock',
+                        '_debug',
+                        '__init__',
+                        '_log',
+                        'connect',
+                        'collect',
+                        'close',
+                    ],
+                    symbolTypes: ['class', 'variable', 'variable', 'field', 'field', 'field', 'field', 'field'],
+                },
+                {
+                    name: 'lists symbols in file for TypeScript',
+                    filePath:
+                        '/github.com/sourcegraph/sourcegraph-typescript@a7b7a61e31af76dad3543adec359fa68737a58a1/-/blob/server/src/cancellation.ts',
+                    symbolNames: [
+                        'createAbortError',
+                        'Object',
+                        'isAbortError',
+                        'throwIfCancelled',
+                        'tryCancel',
+                        'toAxiosCancelToken',
+                        'source',
+                    ],
+                    symbolTypes: ['constant', 'constant', 'constant', 'function', 'function', 'function', 'constant'],
+                },
+            ]
 
-                for (const test of tests) {
-                    await driver.page.goto(baseURL + test.filePath)
+            for (const symbolTest of listSymbolsTests) {
+                test(symbolTest.name, async () => {
+                    await driver.page.goto(baseURL + symbolTest.filePath)
 
                     await (await driver.page.waitForSelector('.tab-bar__tab[data-e2e-tab="symbols"]')).click()
 
@@ -456,10 +452,10 @@ describe('e2e test suite', function(this: any): void {
                         )
                     )
 
-                    expect(symbolNames).toEqual(test.symbolNames)
-                    expect(symbolTypes).toEqual(test.symbolTypes)
-                }
-            })
+                    expect(symbolNames).toEqual(symbolTest.symbolNames)
+                    expect(symbolTypes).toEqual(symbolTest.symbolTypes)
+                })
+            }
 
             test('navigates to file on symbol click', async () => {
                 const repoBaseURL =

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -446,17 +446,15 @@ describe('e2e test suite', function(this: any): void {
                 test(symbolTest.name, async () => {
                     await driver.page.goto(baseURL + symbolTest.filePath)
 
-                    await (await driver.page.waitForSelector('.tab-bar__tab[data-e2e-tab="symbols"]')).click()
+                    await (await driver.page.waitForSelector('[data-e2e-tab="symbols"]')).click()
 
-                    await driver.page.waitForSelector('.repo-rev-sidebar-symbols-node__name', { visible: true })
+                    await driver.page.waitForSelector('.e2e-symbol-name', { visible: true })
 
                     const symbolNames = await driver.page.evaluate(() =>
-                        Array.from(document.querySelectorAll('.repo-rev-sidebar-symbols-node__name')).map(
-                            t => t.textContent || ''
-                        )
+                        Array.from(document.querySelectorAll('.e2e-symbol-name')).map(t => t.textContent || '')
                     )
                     const symbolTypes = await driver.page.evaluate(() =>
-                        Array.from(document.querySelectorAll('.repo-rev-sidebar-symbols-node__link .symbol-icon')).map(
+                        Array.from(document.querySelectorAll('.e2e-symbol-icon')).map(
                             t => t.getAttribute('data-tooltip') || ''
                         )
                     )
@@ -473,16 +471,13 @@ describe('e2e test suite', function(this: any): void {
 
                 await driver.page.goto(repoBaseURL + '/tree/cmd')
 
-                await (await driver.page.waitForSelector('.tab-bar__tab[data-e2e-tab="symbols"]')).click()
+                await (await driver.page.waitForSelector('[data-e2e-tab="symbols"]')).click()
 
-                await driver.page.waitForSelector('.repo-rev-sidebar-symbols-node__name', { visible: true })
+                await driver.page.waitForSelector('.e2e-symbol-name', { visible: true })
 
-                await (await driver.page.waitForSelector(
-                    `.repo-rev-sidebar-symbols-node__link[href*="${symbolPath}"]`,
-                    {
-                        visible: true,
-                    }
-                )).click()
+                await (await driver.page.waitForSelector(`.e2e-symbol-link[href*="${symbolPath}"]`, {
+                    visible: true,
+                })).click()
                 await driver.assertWindowLocation(repoBaseURL + symbolPath, true)
             })
         })

--- a/web/src/e2e/util.ts
+++ b/web/src/e2e/util.ts
@@ -250,6 +250,9 @@ export async function createDriverForTest(): Promise<Driver> {
         if (message.text().indexOf('Download the React DevTools') !== -1) {
             return
         }
+        if (message.text().indexOf('[HMR]') !== -1 || message.text().indexOf('[WDS]') !== -1) {
+            return
+        }
         console.log(
             'Browser console message:',
             util.inspect(message, { colors: true, depth: 2, breakLength: Infinity })

--- a/web/src/repo/RepoRevSidebarSymbols.tsx
+++ b/web/src/repo/RepoRevSidebarSymbols.tsx
@@ -36,11 +36,11 @@ const SymbolNode: React.FunctionComponent<SymbolNodeProps> = ({ node, location }
             <NavLink
                 to={node.url}
                 isActive={isActiveFunc}
-                className="repo-rev-sidebar-symbols-node__link"
+                className="repo-rev-sidebar-symbols-node__link e2e-symbol-link"
                 activeClassName="repo-rev-sidebar-symbols-node__link--active"
             >
-                <SymbolIcon kind={node.kind} className="icon-inline mr-1" />
-                <span className="repo-rev-sidebar-symbols-node__name">{node.name}</span>
+                <SymbolIcon kind={node.kind} className="icon-inline mr-1 e2e-symbol-icon" />
+                <span className="repo-rev-sidebar-symbols-node__name e2e-symbol-name">{node.name}</span>
                 {node.containerName && (
                     <span className="repo-rev-sidebar-symbols-node__container-name">
                         <small>{node.containerName}</small>


### PR DESCRIPTION
This implements E2E tests for the following 3 items in the [release testing grid](https://docs.google.com/spreadsheets/d/1y7JPkq_KucroiI1Eet2Cd53pt7F7Cx_2NStg8qqUvow/edit#gid=900645919&fvid=1166985493):

* `7.4.1 Verify the symbol sidebar works in each of the following languages: Go` ([Test plan](https://docs.google.com/document/d/10QryO5cvEEVw6m5VI6D7JY-oYcD1yJbwUp_uqNFdySg/edit#heading=h.lcju821jp6u))
* `7.4.2 Verify the symbol sidebar works in each of the following languages: TypeScript` ([Test plan](https://docs.google.com/document/d/1gUPvD0QtMScX-1j5hA417OJpH4kLtzecJEjIs84HLdk/edit))
* `7.4.3 Verify the symbol sidebar works in each of the following languages: Python` ([Test plan](https://docs.google.com/document/d/10QryO5cvEEVw6m5VI6D7JY-oYcD1yJbwUp_uqNFdySg/edit#heading=h.ebmuahy9zzjo))

The added cost are the two new repos, `appdash` and `sourcegraph-typescript`. But those are necessary to have so we can test that the symbol bar works for Go, TypeScript and Python.

Regarding the tests themselves: I'm not sure how welcome "table-driven tests" such as these are in the TypeScript world, but since we want to test the same thing for multiple files in different languages I think this is the most readable and extendable version.

I also want to add a separate test in a separate PR that tests that clicking on a symbol navigates to its definition.

**Note**: the TypeScript test will fail if precise code intelligence is enabled, since `Object` and `source` are not in the list of symbols then.
