### PR TITLE
Reset viewport when launching Chromium for e2e tests

### DIFF
--- a/web/src/e2e/util.ts
+++ b/web/src/e2e/util.ts
@@ -243,6 +243,7 @@ export async function createDriverForTest(): Promise<Driver> {
     const launchOpt: LaunchOptions = {
         args: [...args, '--window-size=1280,1024'],
         headless: readEnvBoolean({ variable: 'HEADLESS', defaultValue: false }),
+        defaultViewport: null,
     }
     const browser = await puppeteer.launch(launchOpt)
     const page = await browser.newPage()


### PR DESCRIPTION
Before this change the viewport didn't match the window size. With this change, the viewport is reset with each launch and then stretches to the window size.

Before:

<img width="1392" alt="Screen Shot 2019-08-05 at 07 02 29" src="https://user-images.githubusercontent.com/1185253/62440236-7aad7c00-b74f-11e9-8ced-57b31d39f136.png">

After:

<img width="1392" alt="Screen Shot 2019-08-05 at 07 03 54" src="https://user-images.githubusercontent.com/1185253/62440243-826d2080-b74f-11e9-8511-3b6996627030.png">
