### PR TITLE
on dotcom, index repos from default_repos table instead of ones with longest interval

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -153,8 +153,8 @@ func (s *repos) List(ctx context.Context, opt db.ReposListOptions) (repos []*typ
 }
 
 // ListDefault calls db.DefaultRepos.List, with tracing.
-func (s *repos) ListDefault(ctx context.Context, lim int) (repos []*types.Repo, err error) {
-	ctx, done := trace(ctx, "Repos", "ListDefault", map[string]interface{}{"lim": lim}, &err)
+func (s *repos) ListDefault(ctx context.Context) (repos []*types.Repo, err error) {
+	ctx, done := trace(ctx, "Repos", "ListDefault", nil, &err)
 	defer func() {
 		if err == nil {
 			span := opentracing.SpanFromContext(ctx)

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -152,22 +152,17 @@ func (s *repos) List(ctx context.Context, opt db.ReposListOptions) (repos []*typ
 	return db.Repos.List(ctx, opt)
 }
 
-// ListWithLongestInterval calls db.Repos.ListWithLongestInterval, with tracing.
-func (s *repos) ListWithLongestInterval(ctx context.Context, lim int) (URIs []string, err error) {
-	if Mocks.Repos.List != nil {
-		return Mocks.Repos.ListWithLongestInterval(ctx, lim)
-	}
-
-	ctx, done := trace(ctx, "Repos", "ListWithLongestInterval", map[string]interface{}{"lim": lim}, &err)
+// ListDefault calls db.DefaultRepos.List, with tracing.
+func (s *repos) ListDefault(ctx context.Context, lim int) (repos []*types.Repo, err error) {
+	ctx, done := trace(ctx, "Repos", "ListDefault", map[string]interface{}{"lim": lim}, &err)
 	defer func() {
 		if err == nil {
 			span := opentracing.SpanFromContext(ctx)
-			span.LogFields(otlog.Int("result.len", len(URIs)))
+			span.LogFields(otlog.Int("result.len", len(repos)))
 		}
 		done()
 	}()
-
-	return db.Repos.ListWithLongestInterval(ctx, lim)
+	return db.DefaultRepos.List(ctx)
 }
 
 var inventoryCache = rcache.New("inv")

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -20,7 +20,6 @@ type MockRepos struct {
 	GetByName                 func(v0 context.Context, name api.RepoName) (*types.Repo, error)
 	AddGitHubDotComRepository func(name api.RepoName) error
 	List                      func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
-	ListWithLongestInterval   func(v0 context.Context, v1 int) ([]string, error)
 	GetCommit                 func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*git.Commit, error)
 	ResolveRev                func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
 	GetInventory              func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)

--- a/cmd/frontend/db/default_repos.go
+++ b/cmd/frontend/db/default_repos.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
@@ -18,19 +19,19 @@ ON default_repos.repo_id = repo.id
 `
 	rows, err := dbconn.Global.QueryContext(ctx, q)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "querying default_repos table")
 	}
 	defer rows.Close()
 	var repos []*types.Repo
 	for rows.Next() {
 		var r types.Repo
 		if err := rows.Scan(&r.ID, &r.Name); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "scanning row from default_repos table")
 		}
 		repos = append(repos, &r)
 	}
 	if err = rows.Err(); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "scanning rows from default_repos table")
 	}
 	return repos, nil
 }

--- a/cmd/frontend/db/default_repos.go
+++ b/cmd/frontend/db/default_repos.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -2,8 +2,9 @@ package httpapi
 
 import (
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -247,12 +247,9 @@ func listReposForSgDotCom(ctx context.Context) (res []*types.Repo, err error) {
 	}
 	// Grab a bunch of repos that are likely to be fairly popular,
 	// to demo Sourcegraph search.
-	URIs, err := backend.Repos.ListWithLongestInterval(ctx, lim)
+	res, err = backend.Repos.ListDefault(ctx, lim)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing repos with longest interval")
-	}
-	for _, u := range URIs {
-		res = append(res, &types.Repo{Name: api.RepoName(u)})
 	}
 	return res, nil
 }

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -249,7 +249,7 @@ func listReposForSgDotCom(ctx context.Context) (res []*types.Repo, err error) {
 	// to demo Sourcegraph search.
 	res, err = backend.Repos.ListDefault(ctx, lim)
 	if err != nil {
-		return nil, errors.Wrap(err, "listing repos with longest interval")
+		return nil, errors.Wrap(err, "listing default repos for sourcegraph.com")
 	}
 	return res, nil
 }

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -58,8 +58,8 @@ func Test_serveReposList(t *testing.T) {
 	t.Run("all repos are returned for non-sourcegraph.com", func(t *testing.T) {
 		ctx := dbtesting.TestContext(t)
 		qs := []string{
-			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/quickhack', 'github.com/quickhack', '2015-01-01', '2016-01-01', '', '')`,
-			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/vim', 'github.com/vim', '2001-01-01', '2019-01-01', '', '')`,
+			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/alice/rabbitmq', 'github.com/alice/rabbitmq', '2015-01-01', '2016-01-01', '', '')`,
+			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/bob/jabberd', 'github.com/bob/jabberd', '2001-01-01', '2019-01-01', '', '')`,
 		}
 		for _, q := range qs {
 			if _, err := dbconn.Global.ExecContext(ctx, q); err != nil {
@@ -71,7 +71,7 @@ func Test_serveReposList(t *testing.T) {
 		}
 		defer func() { db.MockAuthzFilter = nil }()
 		URIs := getRepoURIsViaHTTP(t)
-		wantURIs := []string{"github.com/vim/vim", "github.com/torvalds/linux"}
+		wantURIs := []string{"github.com/alice/rabbitmq", "github.com/bob/jabberd"}
 		if !reflect.DeepEqual(URIs, wantURIs) {
 			t.Errorf("got %v, want %v", URIs, wantURIs)
 		}

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -54,46 +54,36 @@ func Test_serveReposList(t *testing.T) {
 		return URIs
 	}
 
-	t.Run("all repos are returned for non-sourcegraph.com", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
-		qs := []string{
-			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/quickhack', 'github.com/quickhack', '2015-01-01', '2016-01-01', '', '')`,
-			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/vim', 'github.com/vim', '2001-01-01', '2019-01-01', '', '')`,
+	ctx := dbtesting.TestContext(t)
+	qs := []string{
+		`INSERT INTO repo(id, name) VALUES (1, 'github.com/vim/vim')`,
+		`INSERT INTO repo(id, name) VALUES (2, 'github.com/torvalds/linux')`,
+		`INSERT INTO default_repos(repo_id) VALUES (2)`,
+	}
+	for _, q := range qs {
+		if _, err := dbconn.Global.ExecContext(ctx, q); err != nil {
+			t.Fatal(err)
 		}
-		for _, q := range qs {
-			if _, err := dbconn.Global.ExecContext(ctx, q); err != nil {
-				t.Fatal(err)
-			}
-		}
+	}
 
+	t.Run("all repos are returned for non-sourcegraph.com", func(t *testing.T) {
 		db.MockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perms) ([]*types.Repo, error) {
 			return repos, nil
 		}
 		defer func() { db.MockAuthzFilter = nil }()
 		URIs := getRepoURIsViaHTTP()
-		wantURIs := []string{"github.com/quickhack", "github.com/vim"}
+		wantURIs := []string{"github.com/vim/vim", "github.com/torvalds/linux"}
 		if !reflect.DeepEqual(URIs, wantURIs) {
 			t.Errorf("got %v, want %v", URIs, wantURIs)
 		}
 	})
 
-	t.Run("long-interval repos are returned for sourcegraph.com when limit is set", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
-		qs := []string{
-			`INSERT INTO repo(uri, name, created_at, updated_at) VALUES ('github.com/quickhack', 'github.com/quickhack', '2015-01-01', '2016-01-01')`,
-			`INSERT INTO repo(uri, name, created_at, updated_at) VALUES ('github.com/vim', 'github.com/vim', '2001-01-01', '2019-01-01')`,
-		}
-		for _, q := range qs {
-			if _, err := dbconn.Global.ExecContext(ctx, q); err != nil {
-				t.Fatal(err)
-			}
-		}
-
+	t.Run("only default repos are returned for sourcegraph.com", func(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(false)
 		withEnv("SOURCEGRAPH_REPOS_TO_INDEX_LIMIT", "1", func() {
 			URIs := getRepoURIsViaHTTP()
-			wantURIs := []string{"github.com/vim"}
+			wantURIs := []string{"github.com/torvalds/linux"}
 			if !reflect.DeepEqual(URIs, wantURIs) {
 				t.Errorf("got %v, want %v", URIs, wantURIs)
 			}

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -27,7 +27,7 @@ func Test_serveReposList(t *testing.T) {
 		t.Helper()
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if err := serveReposList(w, r); err != nil {
-				t.Fatalf("calling serveReposList: %v", err)
+				t.Errorf("calling serveReposList: %v", err)
 			}
 		}))
 		defer ts.Close()

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -91,13 +91,11 @@ func Test_serveReposList(t *testing.T) {
 		}
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(false)
-		withEnv("SOURCEGRAPH_REPOS_TO_INDEX_LIMIT", "1", func() {
-			URIs := getRepoURIsViaHTTP(t)
-			wantURIs := []string{"github.com/torvalds/linux"}
-			if !reflect.DeepEqual(URIs, wantURIs) {
-				t.Errorf("got %v, want %v", URIs, wantURIs)
-			}
-		})
+		URIs := getRepoURIsViaHTTP(t)
+		wantURIs := []string{"github.com/torvalds/linux"}
+		if !reflect.DeepEqual(URIs, wantURIs) {
+			t.Errorf("got %v, want %v", URIs, wantURIs)
+		}
 	})
 }
 

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
-	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
 )
 
@@ -23,7 +23,8 @@ func Test_serveReposList(t *testing.T) {
 		t.Skip()
 	}
 
-	getRepoURIsViaHTTP := func() []string {
+	getRepoURIsViaHTTP := func(t *testing.T) []string {
+		t.Helper()
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if err := serveReposList(w, r); err != nil {
 				t.Fatalf("calling serveReposList: %v", err)
@@ -54,24 +55,27 @@ func Test_serveReposList(t *testing.T) {
 		return URIs
 	}
 
-	ctx := dbtesting.TestContext(t)
-	qs := []string{
-		`INSERT INTO repo(id, name) VALUES (1, 'github.com/vim/vim')`,
-		`INSERT INTO repo(id, name) VALUES (2, 'github.com/torvalds/linux')`,
-		`INSERT INTO default_repos(repo_id) VALUES (2)`,
-	}
-	for _, q := range qs {
-		if _, err := dbconn.Global.ExecContext(ctx, q); err != nil {
-			t.Fatal(err)
+	addTestDataToDb := func(ctx context.Context) {
+		qs := []string{
+			`INSERT INTO repo(id, name) VALUES (1, 'github.com/vim/vim')`,
+			`INSERT INTO repo(id, name) VALUES (2, 'github.com/torvalds/linux')`,
+			`INSERT INTO default_repos(repo_id) VALUES (2)`,
+		}
+		for _, q := range qs {
+			if _, err := dbconn.Global.ExecContext(ctx, q); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 
 	t.Run("all repos are returned for non-sourcegraph.com", func(t *testing.T) {
+		ctx := dbtesting.TestContext(t)
+		addTestDataToDb(ctx)
 		db.MockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perms) ([]*types.Repo, error) {
 			return repos, nil
 		}
 		defer func() { db.MockAuthzFilter = nil }()
-		URIs := getRepoURIsViaHTTP()
+		URIs := getRepoURIsViaHTTP(t)
 		wantURIs := []string{"github.com/vim/vim", "github.com/torvalds/linux"}
 		if !reflect.DeepEqual(URIs, wantURIs) {
 			t.Errorf("got %v, want %v", URIs, wantURIs)
@@ -79,10 +83,12 @@ func Test_serveReposList(t *testing.T) {
 	})
 
 	t.Run("only default repos are returned for sourcegraph.com", func(t *testing.T) {
+		ctx := dbtesting.TestContext(t)
+		addTestDataToDb(ctx)
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(false)
 		withEnv("SOURCEGRAPH_REPOS_TO_INDEX_LIMIT", "1", func() {
-			URIs := getRepoURIsViaHTTP()
+			URIs := getRepoURIsViaHTTP(t)
 			wantURIs := []string{"github.com/torvalds/linux"}
 			if !reflect.DeepEqual(URIs, wantURIs) {
 				t.Errorf("got %v, want %v", URIs, wantURIs)


### PR DESCRIPTION
This is intended to fix https://github.com/sourcegraph/sourcegraph/issues/5094.

Test plan: manual