### PR TITLE
repo-updater: Exclude Phabricator when listing external services for sync

### DIFF
--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -120,11 +120,11 @@ func (s *PhabricatorSource) makeRepo(repo *phabricator.Repo) (*Repo, error) {
 	}
 
 	if cloneURL == "" {
-		return nil, errors.Errorf("no clone URL available for repo with id=%v", repo.ID)
+		log15.Warn("unable to construct clone URL for repo", "name", name, "phabricator_id", repo.PHID)
 	}
 
 	if name == "" {
-		return nil, errors.Errorf("no canonical name available for repo with id=%v", repo.ID)
+		return nil, errors.Errorf("no canonical name available for repo with id=%v", repo.PHID)
 	}
 
 	serviceID, err := urlx.NormalizeString(s.conn.Url)

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -187,6 +187,12 @@ func listExternalServicesQuery(args StoreListExternalServicesArgs) paginatedQuer
 		}
 		preds = append(preds,
 			sqlf.Sprintf("LOWER(kind) IN (%s)", sqlf.Join(ks, ",")))
+	} else {
+		// HACK(tsenart): The syncer and all other places that load all external
+		// services do not want phabricator instances. These are handled separately
+		// by RunPhabricatorRepositorySyncWorker.
+		preds = append(preds,
+			sqlf.Sprintf("LOWER(kind) != 'phabricator'"))
 	}
 
 	preds = append(preds, sqlf.Sprintf("deleted_at IS NULL"))

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -134,8 +134,10 @@ func (s FakeStore) ListExternalServices(ctx context.Context, args StoreListExter
 	set := make(map[*ExternalService]bool, len(s.svcByID))
 	svcs := make(ExternalServices, 0, len(s.svcByID))
 	for _, svc := range s.svcByID {
+		k := strings.ToLower(svc.Kind)
+
 		if !set[svc] &&
-			(len(kinds) == 0 || kinds[strings.ToLower(svc.Kind)]) &&
+			((len(kinds) == 0 && k != "phabricator") || kinds[k]) &&
 			(len(ids) == 0 || ids[svc.ID]) &&
 			!svc.IsDeleted() {
 


### PR DESCRIPTION
:tada: 👯‍♂️ Co-authored with @tsenart 👯‍♂️ 🎉 

A customer reported that syncing external services failed after
upgrading from 3.4 to 3.5 with the following error message:

    no clone URL available for repo with id=XYZ

After investigating the issue we found out that with 3.5 we changed the
Phabricator source to construct clone URLs for every repo it lists. That
fails on the customer instance.

And that happens every time repo-updater syncs.

But since Phabricator is not a _real_ external service and shouldn't be
used to sync repos and clone them, it shouldn't be synced when the
repo-updater Syncer runs.

This commit changes the existing behavior of `ListExternalServices` to
_never_ return Phabricator external services, except when it's
specifically specified (which is what we need for the
gitolite-Phabricator-sync worker).
