### PR TITLE
fix: remove references to telligentdata.com

### DIFF
--- a/cmd/frontend/internal/httpapi/telemetry.go
+++ b/cmd/frontend/internal/httpapi/telemetry.go
@@ -1,15 +1,12 @@
 package httpapi
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
 
-	"github.com/gorilla/mux"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -24,22 +21,8 @@ func init() {
 	if envvar.SourcegraphDotComMode() {
 		telemetryHandler = &httputil.ReverseProxy{
 			Director: func(req *http.Request) {
-				req.URL.Scheme = "https"
-				req.URL.Host = "sourcegraph-logging.telligentdata.com"
-				req.Host = "sourcegraph-logging.telligentdata.com"
-				req.URL.Path = "/" + mux.Vars(req)["TelemetryPath"]
-
-				var tr eventlogger.TelemetryRequest
-				err := json.NewDecoder(req.Body).Decode(&tr)
-				if err != nil {
-					log15.Error("telemetryHandler: Decode", "error", err)
-				}
-
-				var buf bytes.Buffer
-				if err := json.NewEncoder(&buf).Encode(tr.Payload); err != nil {
-					log15.Error("telemetryHandler: Encode", "error", err)
-				}
-				req.Body = ioutil.NopCloser(&buf)
+				// Removed due to our event logging ETL pipeline sunsetting schedule.
+				// TODO(Dan): update with new logging URL.
 			},
 			ErrorLog: log.New(env.DebugOut, "telemetry proxy: ", log.LstdFlags),
 		}

--- a/web/src/tracking/services/telligentWrapper.tsx
+++ b/web/src/tracking/services/telligentWrapper.tsx
@@ -69,28 +69,8 @@ class TelligentWrapper {
         if (!this.telligent) {
             return
         }
-        const telligentUrl = 'sourcegraph-logging.telligentdata.com'
-        this.telligent('newTracker', 'sg', telligentUrl, {
-            appId: siteID,
-            platform: 'Web',
-            encodeBase64: false,
-            env,
-            configUseCookies: true,
-            useCookies: true,
-            trackUrls: true,
-            /**
-             * NOTE: do not use window.location.hostname (which includes subdomains) as the cookieDomain
-             * on sourcegraph.com subdomains (such as about.sourcegraph.com). Subdomains should be removed
-             * from the cookieDomain property to ensure analytics user profiles sync across all Sourcegraph sites.
-             */
-            cookieDomain: window.location.hostname,
-            metadata: {
-                gaCookies: true,
-                performanceTiming: true,
-                augurIdentityLite: true,
-                webPage: true,
-            },
-        })
+        // Logger initialization removed due to our event logging ETL pipeline sunsetting schedule.
+        // TODO(Dan): update with new logging URL.
     }
 
     private inspectTelligentCookie(): string[] | null {


### PR DESCRIPTION
Does not affect any private/self-hosted instances. Temporary solution to the TLS cert issues on Sourcegraph.com. 

part of https://github.com/sourcegraph/infrastructure/issues/1577
