### PR TITLE
Restore tsx symbols

### DIFF
--- a/cmd/symbols/.ctags.d/tsx.ctags
+++ b/cmd/symbols/.ctags.d/tsx.ctags
@@ -1,0 +1,20 @@
+# See additional-language.ctags for maintaining this file
+
+# To avoid the warning:
+#
+#     Don't reuse the kind letter `c' in a language typescript (old: "classes", new: "modules")
+#
+# Make sure there's a 1-1 correspondence between kind letters and kind names.
+
+--langdef=tsx
+--langmap=tsx:.tsx
+--regex-tsx=/^[ \t]*(export[ \t]+([a-z]+[ \t]+)?)?class[ \t]+([a-zA-Z0-9_$]+)/\3/c,class/
+--regex-tsx=/^[ \t]*(declare[ \t]+)?namespace[ \t]+([a-zA-Z0-9_$]+)/\2/n,module/
+--regex-tsx=/^[ \t]*(export[ \t]+)?module[ \t]+([a-zA-Z0-9_$]+)/\2/n,module/
+--regex-tsx=/^[ \t]*(export[ \t]+)?(default[ \t]+)?(async[ \t]+)?function[ \t]+([a-zA-Z0-9_$]+)/\4/f,function/
+--regex-tsx=/^[ \t]*export[ \t]+(var|let|const)[ \t]+([a-zA-Z0-9_$]+)/\2/v,variable/
+--regex-tsx=/^[ \t]*(var|let|const)[ \t]+([a-zA-Z0-9_$]+)[ \t]*=[ \t]*function[ \t]*[*]?[ \t]*\(\)/\2/v,variable/
+--regex-tsx=/^[ \t]*(export[ \t]+)?(public|protected|private)[ \t]+(static[ \t]+)?(abstract[ \t]+)?(((get|set)[ \t]+)|(async[ \t]+[*]*[ \t]*))?([a-zA-Z1-9_$]+)/\9/m,member/
+--regex-tsx=/^[ \t]*(export[ \t]+)?interface[ \t]+([a-zA-Z0-9_$]+)/\2/i,interface/
+--regex-tsx=/^[ \t]*(export[ \t]+)?type[ \t]+([a-zA-Z0-9_$]+)/\2/t,type/
+--regex-tsx=/^[ \t]*(export[ \t]+)?enum[ \t]+([a-zA-Z0-9_$]+)/\2/e,enum/

--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -68,7 +68,7 @@ func NewParser(ctagsCommand string) (Parser, error) {
 	// }
 
 	cmd := exec.Command(ctagsCommand, "--_interactive="+opt, "--fields=*",
-		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,Tcl,typescript,Verilog,Vim",
+		"--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,haskell,Java,JavaScript,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Perl,Perl6,PHP,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,Tcl,typescript,tsx,Verilog,Vim",
 		"--map-CSS=+.scss", "--map-CSS=+.less", "--map-CSS=+.sass",
 	)
 	in, err := cmd.StdinPipe()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/5063

Closes https://github.com/sourcegraph/sourcegraph/pull/5064

No need to update the changelog or docs because the PR that broke this #4987 hasn't been released.

Test plan: manual
