### PR TITLE
Enable JSON schema embeds to support linking to a specific key

### DIFF
--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -585,6 +585,23 @@ a:hover {
 .markdown-body hr {
     border-bottom-color: #eee;
 }
+
+/* Display hash  on hover for schema doc key */
+
+.markdown-body .json-schema-doc-heading {
+    margin-bottom: -1rem;
+}
+.schema-doc-key {
+    position: relative;
+}
+.schema-doc-key:hover::before {
+    content: '#';
+    position: absolute;
+    top: -2px;
+    left: -15px;
+    padding-right: 20px;
+    font-size: 1rem;
+}
 /*
 
 Visibility classes:

--- a/doc/_resources/assets/docs.js
+++ b/doc/_resources/assets/docs.js
@@ -127,12 +127,6 @@ window.sgdocs = (() => {
    * Check the URL to see if navigation to a schema key is desired
    */
   function schemaLinkCheck() {
-    function onKeyActive(targetKey) {
-      targetKey.style.fontWeight = '700' // Bold, then un-bold text to draw attention
-      setTimeout(() => targetKey.style.fontWeight = 400, 1000)
-      scrollToElement(targetKey, offsetTop)
-    }
-
     const schemaDocSelector = '.json-schema-doc'
     const offsetTop = document.querySelector('.global-navbar').clientHeight + 20
     const schemaDocs = document.querySelectorAll(schemaDocSelector)
@@ -147,6 +141,7 @@ window.sgdocs = (() => {
           return
         }
 
+        // Add a named anchor to get the hover functionality we need
         const keyText = keyNameMatch[1]
         const id = keyText.replace('.', '-')
         const anchor = document
@@ -157,8 +152,12 @@ window.sgdocs = (() => {
         anchor.style.color = el.style.color
         el.replaceWith(anchor)
 
+        // Temporarily change the id of the anchor to prevent the browser
+        // from scrolling to the element
         anchor.addEventListener('click', e => {
-          setTimeout(() => onKeyActive(e.target), 0)
+          let originalId = e.target.id
+          e.target.id = `${originalId}-id-miss`
+          setTimeout(() => e.target.id = originalId, 1000)
         })
       })
     })
@@ -166,7 +165,7 @@ window.sgdocs = (() => {
     // If URL hash is set and matches a schema key, scroll to it
     let targetKey = document.querySelector(`${schemaDocSelector} ${window.location.hash}`)
     if (window.location.hash && targetKey) {
-      onKeyActive(targetKey)
+      scrollToElement(targetKey, offsetTop)
     }
   }
 })()

--- a/doc/_resources/assets/docs.js
+++ b/doc/_resources/assets/docs.js
@@ -27,7 +27,26 @@ window.sgdocs = (() => {
       mobileNavInit()
       navInit()
       breadcrumbsInit()
+      setTimeout(schemaLinkCheck, 0) // Browser scrolls straight to element without this
     },
+  }
+
+  /**
+   * Smoothly scroll to an element
+   *
+   * @param {*} element Element to scroll to
+   * @param {*} elementOffsetTop Optionally reduce vertical scroll distance
+   */
+  function scrollToElement(element, elementOffsetTop=0) {
+    if (!element) {
+      return
+    }
+
+    document.body.scrollTo({
+      top: element.offsetTop - elementOffsetTop,
+      left: 0,
+      behavior: 'smooth',
+    })
   }
 
   function searchInit() {
@@ -91,7 +110,6 @@ window.sgdocs = (() => {
       el.addEventListener('click', e => e.srcElement.closest('.content-nav-section').classList.toggle('expanded'))
     })
 
-    // TODO(ryan): Link titles should be auto-generated
     document.querySelectorAll('.content-nav a').forEach(el => (el.title = el.text.trim()))
   }
 
@@ -103,5 +121,52 @@ window.sgdocs = (() => {
         el.text = text
       }
     })
+  }
+
+  /**
+   * Check the URL to see if navigation to a schema key is desired
+   */
+  function schemaLinkCheck() {
+    function onKeyActive(targetKey) {
+      targetKey.style.fontWeight = '700' // Bold, then un-bold text to draw attention
+      setTimeout(() => targetKey.style.fontWeight = 400, 1000)
+      scrollToElement(targetKey, offsetTop)
+    }
+
+    const schemaDocSelector = '.json-schema-doc'
+    const offsetTop = document.querySelector('.global-navbar').clientHeight + 20
+    const schemaDocs = document.querySelectorAll(schemaDocSelector)
+
+    // Find spans that contain a key and swap them for anchors for hover functionality
+    schemaDocs.forEach(schemaDoc => {
+      schemaDoc.querySelectorAll(`span`).forEach(el => {
+        const keyNameMatch = el.innerText.match(/^"(.*)"/)
+        const isKey = el.nextSibling && el.nextSibling.textContent.includes(':') ? true : false
+
+        if (!isKey || !keyNameMatch) {
+          return
+        }
+
+        const keyText = keyNameMatch[1]
+        const id = keyText.replace('.', '-')
+        const anchor = document
+          .createRange()
+          .createContextualFragment(
+            `<a id="${id}" class="schema-doc-key" href="#${id}" rel="nofollow" aria-hidden="true">"${keyText}"</a>`
+          ).firstElementChild
+        anchor.style.color = el.style.color
+        el.replaceWith(anchor)
+
+        anchor.addEventListener('click', e => {
+          setTimeout(() => onKeyActive(e.target), 0)
+        })
+      })
+    })
+
+    // If URL hash is set and matches a schema key, scroll to it
+    let targetKey = document.querySelector(`${schemaDocSelector} ${window.location.hash}`)
+    if (window.location.hash && targetKey) {
+      onKeyActive(targetKey)
+    }
   }
 })()

--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -1203,3 +1203,4 @@ li.content-nav-no-hover:hover {
 .version-dropdown .dropdown-item {
     padding: 0.5rem 1rem;
 }
+


### PR DESCRIPTION
Fixes #5002. Needs https://github.com/sourcegraph/docsite/pull/23 for this to work but fails gracefully if not present.

 - Scrolls to the schema doc key if hash in URL exists and a match is found
 - Keys in schema doc are clickable to make getting the path to link to a specific key easy

![ScreenFlow](https://user-images.githubusercontent.com/133014/62673810-acdbfb00-b954-11e9-8450-42f1864b14ff.gif)
