### PR TITLE
schema: Allow specifying only `orgs` in Github ext svc config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- In the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) it's now possible to specify `orgs` without specifying `repositoryQuery` or `repos` too.
 - Out-of-the-box TypeScript code intelligence is much better with an updated ctags version with a built-in TypeScript parser.
 
 ### Fixed

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -181,8 +181,8 @@ func (e *ExternalServicesStore) validateGithubConnection(c *schema.GitHubConnect
 		err = multierror.Append(err, validate(c))
 	}
 
-	if c.Repos == nil && c.RepositoryQuery == nil {
-		err = multierror.Append(err, errors.New("at least one of repositoryQuery or repos must be set"))
+	if c.Repos == nil && c.RepositoryQuery == nil && c.Orgs == nil {
+		err = multierror.Append(err, errors.New("at least one of repositoryQuery, repos or orgs must be set"))
 	}
 
 	return err.ErrorOrNil()

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -597,12 +597,12 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "GITHUB",
-			desc:   "without url, token, repositoryQuery nor repos",
+			desc:   "without url, token, repositoryQuery, repos nor orgs",
 			config: `{}`,
 			assert: includes(
 				"url: url is required",
 				"token: token is required",
-				"at least one of repositoryQuery or repos must be set",
+				"at least one of repositoryQuery, repos or orgs must be set",
 			),
 		},
 		{
@@ -624,6 +624,17 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				"url": "https://github.corp.com",
 				"token": "very-secret-token",
 				"repos": ["sourcegraph/sourcegraph"],
+			}`,
+			assert: equals(`<nil>`),
+		},
+		{
+			kind: "GITHUB",
+			desc: "with url, token, orgs",
+			config: `
+			{
+				"url": "https://github.corp.com",
+				"token": "very-secret-token",
+				"orgs": ["sourcegraph"],
 			}`,
 			assert: equals(`<nil>`),
 		},


### PR DESCRIPTION
This fixes the re-opened #4322
