### PR TITLE
redis: only warn about eviction if cache/store are separated

### DIFF
--- a/cmd/frontend/internal/bg/check_redis_cache_eviction_policy.go
+++ b/cmd/frontend/internal/bg/check_redis_cache_eviction_policy.go
@@ -1,7 +1,9 @@
 package bg
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/garyburd/redigo/redis"
 	"github.com/sourcegraph/sourcegraph/pkg/redispool"
@@ -11,10 +13,33 @@ import (
 const recommendedPolicy = "allkeys-lru"
 
 func CheckRedisCacheEvictionPolicy() {
-	c := redispool.Cache.Get()
-	defer c.Close()
+	cacheConn := redispool.Cache.Get()
+	defer cacheConn.Close()
 
-	vals, err := redis.Strings(c.Do("CONFIG", "GET", "maxmemory-policy"))
+	storeConn := redispool.Store.Get()
+	defer storeConn.Close()
+
+	storeRunID, err := getRunID(storeConn)
+	if err != nil {
+		log15.Error("Reading run_id from redis-store failed", "error", err)
+		return
+	}
+
+	cacheRunID, err := getRunID(cacheConn)
+	if err != nil {
+		log15.Error("Reading run_id from redis-cache failed", "error", err)
+		return
+	}
+
+	if cacheRunID == storeRunID {
+		// If users use the same instance for redis-store and redis-cache we
+		// don't want to recommend an LRU policy, because that could interfere
+		// with the functionality of redis-store, which expects to store items
+		// for longer term usage
+		return
+	}
+
+	vals, err := redis.Strings(cacheConn.Do("CONFIG", "GET", "maxmemory-policy"))
 	if err != nil {
 		log15.Error("Reading `maxmemory-policy` from Redis failed", "error", err)
 		return
@@ -26,4 +51,19 @@ func CheckRedisCacheEvictionPolicy() {
 		log15.Warn(msg)
 		log15.Warn("****************************")
 	}
+}
+
+func getRunID(c redis.Conn) (string, error) {
+	infos, err := redis.String(c.Do("INFO", "server"))
+	if err != nil {
+		return "", err
+	}
+
+	for _, l := range strings.Split(infos, "\n") {
+		if strings.HasPrefix(l, "run_id:") {
+			s := strings.Split(l, ":")
+			return s[1], nil
+		}
+	}
+	return "", errors.New("no run_id found")
 }


### PR DESCRIPTION
This is a follow-up to #5040 and corrects the printing of the warning message with the motivation that we don't want to recommend `allkeys-lru` when the users has a single Redis instance that's used for `redis-store` (longer term storage) and `redis-cache` (ephemeral data)

cc @nicksnyder 
