### PR TITLE
search: Fix data race in searchSymbolsInRepo()

### DIFF
--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -54,6 +54,7 @@ func (r *codemodResultResolver) ToFileMatch() (*fileMatchResolver, bool)   { ret
 func (r *codemodResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
 }
+
 func (r *codemodResultResolver) ToCodemodResult() (*codemodResultResolver, bool) {
 	return r, true
 }
@@ -61,6 +62,7 @@ func (r *codemodResultResolver) ToCodemodResult() (*codemodResultResolver, bool)
 func (r *codemodResultResolver) searchResultURIs() (string, string) {
 	return string(r.commit.repo.repo.Name), r.path
 }
+
 func (r *codemodResultResolver) resultCount() int32 {
 	return int32(len(r.matches))
 }
@@ -119,7 +121,7 @@ func validateQuery(q *query.Query) (*args, error) {
 	if len(includeFileFilter) > 0 {
 		includeFileFilterText = includeFileFilter[0]
 		// only file names or files with extensions in the following characterset are allowed
-		var IsAlphanumericWithPeriod = regexp.MustCompile(`^[a-zA-Z0-9_.]+$`).MatchString
+		IsAlphanumericWithPeriod := regexp.MustCompile(`^[a-zA-Z0-9_.]+$`).MatchString
 		if !IsAlphanumericWithPeriod(includeFileFilterText) {
 			return nil, errors.New("the 'file:' filter cannot contain regex when using the 'replace:' filter currently. Only alphanumeric characters or '.'")
 		}
@@ -128,7 +130,7 @@ func validateQuery(q *query.Query) (*args, error) {
 	var excludeFileFilterText string
 	if len(excludeFileFilter) > 0 {
 		excludeFileFilterText = excludeFileFilter[0]
-		var IsAlphanumericWithPeriod = regexp.MustCompile(`^[a-zA-Z_.]+$`).MatchString
+		IsAlphanumericWithPeriod := regexp.MustCompile(`^[a-zA-Z_.]+$`).MatchString
 		if !IsAlphanumericWithPeriod(includeFileFilterText) {
 			return nil, errors.New("the '-file:' filter cannot contain regex when using the 'replace:' filter currently. Only alphanumeric characters or '.'")
 		}
@@ -178,7 +180,7 @@ func performCodemod(ctx context.Context, args *search.Args) ([]searchResultResol
 			mu.Lock()
 			defer mu.Unlock()
 			if fatalErr := handleRepoSearchResult(common, repoRev, false, repoTimedOut, searchErr); fatalErr != nil {
-				err = errors.Wrapf(searchErr, "failed to call codemod %s", repoRev)
+				err = errors.Wrapf(searchErr, "failed to call codemod %s", &repoRev)
 				cancel()
 			}
 			if len(results) > 0 {

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -121,11 +121,11 @@ func parseRev(spec string) RevisionSpecifier {
 
 // GitserverRepo is a convenience function to return the gitserver.Repo for
 // r.Repo. The returned Repo will not have the URL set, only the name.
-func (r RepositoryRevisions) GitserverRepo() gitserver.Repo {
+func (r *RepositoryRevisions) GitserverRepo() gitserver.Repo {
 	return gitserver.Repo{Name: r.Repo.Name}
 }
 
-func (r RepositoryRevisions) String() string {
+func (r *RepositoryRevisions) String() string {
 	if len(r.Revs) == 0 {
 		return string(r.Repo.Name)
 	}


### PR DESCRIPTION
Fixes #5006

```
Read at 0x00c000940320 by goroutine 104:
  github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.searchSymbolsInRepo()
      /Users/issactrotts/sg/sourcegraph/cmd/frontend/graphqlbackend/search_symbols.go:157 +0x303
  github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.searchSymbols.func2()
      /Users/issactrotts/sg/sourcegraph/cmd/frontend/graphqlbackend/search_symbols.go:81 +0x1a2
  github.com/sourcegraph/sourcegraph/cmd/frontend/internal/goroutine.Go.func1()
      /Users/issactrotts/sg/sourcegraph/cmd/frontend/internal/goroutine/goroutine.go:24 +0x50
Previous write at 0x00c000940320 by goroutine 108:
  github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.zoektIndexedRepos()
      /Users/issactrotts/sg/sourcegraph/cmd/frontend/graphqlbackend/textsearch.go:863 +0x634
  github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.searchFilesInRepos()
      /Users/issactrotts/sg/sourcegraph/cmd/frontend/graphqlbackend/textsearch.go:899 +0x2316
  github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.(*searchResolver).doResults.func5()
      /Users/issactrotts/sg/sourcegraph/cmd/frontend/graphqlbackend/search_results.go:922 +0x12e
  github.com/sourcegraph/sourcegraph/cmd/frontend/internal/goroutine.Go.func1()
      /Users/issactrotts/sg/sourcegraph/cmd/frontend/internal/goroutine/goroutine.go:24 +0x50
```


<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
