### PR TITLE
Update the sourcegraph.com results banner to say 10k default repos instead of 500

### DIFF
--- a/web/src/marketing/ServerBanner.tsx
+++ b/web/src/marketing/ServerBanner.tsx
@@ -9,7 +9,7 @@ const onClickInstall = (): void => {
 export const ServerBanner: React.FunctionComponent = () => (
     <DismissibleAlert partialStorageKey="set-up-self-hosted" className="alert alert-info">
         <span>
-            Sourcegraph.com searches over the top 500 GitHub repositories by default. You can search over other public
+            Sourcegraph.com searches over the top 10k GitHub repositories by default. You can search over other public
             repositories by providing a repo: filter or you can search all of your own private code by{' '}
             <a href="https://docs.sourcegraph.com/#quickstart" onClick={onClickInstall}>
                 setting up a self-hosted Sourcegraph instance.


### PR DESCRIPTION
Test plan: None.