### PR TITLE
Hide the search results banner if a repo: field is present on sg.com

### DIFF
--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -31,6 +31,9 @@ interface SearchResultsInfoBarProps {
     didSave: boolean
 
     displayPerformanceWarning: boolean
+
+    // Whether the search query contains a repo: field.
+    hasRepoField: boolean
 }
 
 /**
@@ -149,7 +152,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 </div>
             </small>
         )}
-        {!props.results.alert && props.showDotComMarketing && <ServerBanner />}
+        {!props.results.alert && props.showDotComMarketing && !props.hasRepoField && <ServerBanner />}
         {!props.results.alert && props.displayPerformanceWarning && <PerformanceWarningAlert />}
     </div>
 )

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -33,7 +33,7 @@ interface SearchResultsInfoBarProps {
     displayPerformanceWarning: boolean
 
     // Whether the search query contains a repo: field.
-    hasRepoField: boolean
+    hasRepoishField: boolean
 }
 
 /**
@@ -152,7 +152,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 </div>
             </small>
         )}
-        {!props.results.alert && props.showDotComMarketing && !props.hasRepoField && <ServerBanner />}
+        {!props.results.alert && props.showDotComMarketing && !props.hasRepoishField && <ServerBanner />}
         {!props.results.alert && props.displayPerformanceWarning && <PerformanceWarningAlert />}
     </div>
 )

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -347,8 +347,11 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         displayPerformanceWarning={this.state.displayPerformanceWarning}
                                         // This isn't always correct, but the penalty for a false-positive is
                                         // low.
-                                        hasRepoishField={parsedQuery ? parsedQuery.includes("repo:") ||
-                                            parsedQuery.includes("repogroup:") : false}
+                                        hasRepoishField={
+                                            parsedQuery
+                                                ? parsedQuery.includes('repo:') || parsedQuery.includes('repogroup:')
+                                                : false
+                                        }
                                     />
 
                                     {/* Results */}

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -345,6 +345,9 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         onShowMoreResultsClick={this.props.onShowMoreResultsClick}
                                         showDotComMarketing={this.props.isSourcegraphDotCom}
                                         displayPerformanceWarning={this.state.displayPerformanceWarning}
+                                        // This isn't always correct, but the penalty for a false-positive is
+                                        // low.
+                                        hasRepoField={parsedQuery ? parsedQuery.includes("repo:") : false}
                                     />
 
                                     {/* Results */}

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -347,7 +347,8 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         displayPerformanceWarning={this.state.displayPerformanceWarning}
                                         // This isn't always correct, but the penalty for a false-positive is
                                         // low.
-                                        hasRepoField={parsedQuery ? parsedQuery.includes("repo:") : false}
+                                        hasRepoishField={parsedQuery ? parsedQuery.includes("repo:") ||
+                                            parsedQuery.includes("repogroup:") : false}
                                     />
 
                                     {/* Results */}


### PR DESCRIPTION
Test plan: manually tested by commenting out `&& props.showDotComMarketing` locally
