### PR TITLE
frontend: Do not re-create services in EXTSVC_CONFIG_FILE

### DIFF
--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -243,7 +243,7 @@ type ExternalServiceUpdate struct {
 // Update updates a external service.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Update(ctx context.Context, id int64, update *ExternalServiceUpdate) error {
+func (c *ExternalServicesStore) Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error {
 	if update.Config != nil {
 		// Query to get the kind (which is immutable) so we can validate the new config.
 		externalService, err := c.GetByID(ctx, id)
@@ -251,7 +251,6 @@ func (c *ExternalServicesStore) Update(ctx context.Context, id int64, update *Ex
 			return err
 		}
 
-		ps := conf.Get().Critical.AuthProviders
 		if err := c.ValidateConfig(externalService.Kind, *update.Config, ps); err != nil {
 			return err
 		}

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -75,11 +75,12 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *struct {
 		return nil, fmt.Errorf("blank external service configuration is invalid (must be valid JSONC)")
 	}
 
+	ps := conf.Get().Critical.AuthProviders
 	update := &db.ExternalServiceUpdate{
 		DisplayName: args.Input.DisplayName,
 		Config:      args.Input.Config,
 	}
-	if err := db.ExternalServices.Update(ctx, externalServiceID, update); err != nil {
+	if err := db.ExternalServices.Update(ctx, ps, externalServiceID, update); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -90,41 +90,96 @@ func handleConfigOverrides() error {
 			}
 			confGet := func() *conf.Unified { return parsed }
 
-			existing, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{})
-			if err != nil {
-				return errors.Wrap(err, "ExternalServices.List")
-			}
-			for _, existing := range existing {
-				err := db.ExternalServices.Delete(ctx, existing.ID)
-				if err != nil {
-					return errors.Wrap(err, "ExternalServices.Delete")
-				}
-			}
-
 			extsvc, err := ioutil.ReadFile(overrideExtSvcConfig)
 			if err != nil {
 				return errors.Wrap(err, "reading EXTSVC_CONFIG_FILE")
 			}
-			var configs map[string][]*json.RawMessage
-			if err := jsonc.Unmarshal(string(extsvc), &configs); err != nil {
+			var rawConfigs map[string][]*json.RawMessage
+			if err := jsonc.Unmarshal(string(extsvc), &rawConfigs); err != nil {
 				return errors.Wrap(err, "parsing EXTSVC_CONFIG_FILE")
 			}
-			if len(configs) == 0 {
+			if len(rawConfigs) == 0 {
 				log15.Warn("EXTSVC_CONFIG_FILE contains zero external service configurations")
 			}
-			for key, cfgs := range configs {
+
+			existing, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{})
+			if err != nil {
+				return errors.Wrap(err, "ExternalServices.List")
+			}
+
+			// Perform delta update for external services. We don't want to
+			// just delete all external services and re-add all of them,
+			// because that would cause repo-updater to need to update
+			// repositories and reassociate them with external services each
+			// time the frontend restarts.
+			//
+			// Start out by assuming we will remove all and re-add all.
+			var (
+				toAdd    = make(map[*types.ExternalService]bool)
+				toRemove = make(map[*types.ExternalService]bool)
+				toUpdate = make(map[int64]*types.ExternalService)
+			)
+			for _, existing := range existing {
+				toRemove[existing] = true
+			}
+			for key, cfgs := range rawConfigs {
 				for i, cfg := range cfgs {
 					marshaledCfg, err := json.MarshalIndent(cfg, "", "  ")
 					if err != nil {
 						return errors.Wrap(err, fmt.Sprintf("marshaling extsvc config ([%v][%v])", key, i))
 					}
-					if err := db.ExternalServices.Create(ctx, confGet, &types.ExternalService{
+					toAdd[&types.ExternalService{
 						Kind:        key,
 						DisplayName: fmt.Sprintf("%s #%d", key, i+1),
 						Config:      string(marshaledCfg),
-					}); err != nil {
-						return errors.Wrap(err, "ExternalServices.Create")
+					}] = true
+				}
+			}
+			// Now eliminate operations from toAdd/toRemove where the config
+			// file and DB describe an equivalent external service.
+			isEquiv := func(a, b *types.ExternalService) bool {
+				return a.Kind == b.Kind && a.DisplayName == b.DisplayName && a.Config == b.Config
+			}
+			shouldUpdate := func(a, b *types.ExternalService) bool {
+				return a.Kind == b.Kind && a.DisplayName == b.DisplayName && a.Config != b.Config
+			}
+			for a := range toAdd {
+				for b := range toRemove {
+					if isEquiv(a, b) {
+						delete(toAdd, a)
+						delete(toRemove, b)
+					} else {
+						if shouldUpdate(a, b) {
+							delete(toAdd, a)
+							delete(toRemove, b)
+							toUpdate[b.ID] = a
+						}
 					}
+				}
+			}
+
+			// Apply the delta update.
+			for extSvc := range toRemove {
+				log15.Debug("Deleting external service", "id", extSvc.ID, "displayName", extSvc.DisplayName)
+				err := db.ExternalServices.Delete(ctx, extSvc.ID)
+				if err != nil {
+					return errors.Wrap(err, "ExternalServices.Delete")
+				}
+			}
+			for extSvc := range toAdd {
+				log15.Debug("Adding external service", "displayName", extSvc.DisplayName)
+				if err := db.ExternalServices.Create(ctx, confGet, extSvc); err != nil {
+					return errors.Wrap(err, "ExternalServices.Create")
+				}
+			}
+
+			ps := confGet().Critical.AuthProviders
+			for id, extSvc := range toUpdate {
+				log15.Debug("Updating external service", "id", id, "displayName", extSvc.DisplayName)
+
+				update := &db.ExternalServiceUpdate{DisplayName: &extSvc.DisplayName, Config: &extSvc.Config}
+				if err := db.ExternalServices.Update(ctx, ps, id, update); err != nil {
+					return errors.Wrap(err, "ExternalServices.Update")
 				}
 			}
 		}

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -145,15 +145,13 @@ func handleConfigOverrides() error {
 			}
 			for a := range toAdd {
 				for b := range toRemove {
-					if isEquiv(a, b) {
+					if isEquiv(a, b) { // Nothing changed
 						delete(toAdd, a)
 						delete(toRemove, b)
-					} else {
-						if shouldUpdate(a, b) {
-							delete(toAdd, a)
-							delete(toRemove, b)
-							toUpdate[b.ID] = a
-						}
+					} else if shouldUpdate(a, b) {
+						delete(toAdd, a)
+						delete(toRemove, b)
+						toUpdate[b.ID] = a
 					}
 				}
 			}


### PR DESCRIPTION
This fixes #5134 by using the suggested changes and extending them to
also allow the in-place modification of external services in case they
have the same display name.

I tested this with 3 GitHub external services and 1 AWS CC external
service in `external-services-config.json` defined and then booted up
`frontend` with debug log messages enabled:

    msg="Adding external service" displayName="AWSCODECOMMIT #1"
    msg="Adding external service" displayName="GITHUB #1"
    msg="Adding external service" displayName="GITHUB #2"
    msg="Adding external service" displayName="GITHUB #3"

After updating `GITHUB #2` in the JSON and restarting:

    msg="Updating external service" id=3 displayName="GITHUB #2"

Without changing the JSON and restarting:

    <no changes>

After updating `GITHUB #1` in the JSON and restarting:

    msg="Updating external service" id=2 displayName="GITHUB #1"

After removing `GITHUB #3` from JSON and restarting:

    msg="Deleting external service" id=4 displayName="GITHUB #3"

After re-adding `GITHUB #3` to JSON and restarting:

    msg="Adding external service" displayName="GITHUB #3"
