### PR TITLE
graphqlbackend: Pass RepositoryRevisions by reference

### DIFF
--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -164,7 +164,7 @@ func performCodemod(ctx context.Context, args *search.Args) ([]searchResultResol
 	)
 	for _, repoRev := range args.Repos {
 		wg.Add(1)
-		repoRev := *repoRev // shadow variable so it doesn't change while goroutine is running
+		repoRev := repoRev // shadow variable so it doesn't change while goroutine is running
 		goroutine.Go(func() {
 			defer wg.Done()
 			results, searchErr := callCodemodInRepo(ctx, repoRev, cmodArgs)
@@ -180,7 +180,7 @@ func performCodemod(ctx context.Context, args *search.Args) ([]searchResultResol
 			mu.Lock()
 			defer mu.Unlock()
 			if fatalErr := handleRepoSearchResult(common, repoRev, false, repoTimedOut, searchErr); fatalErr != nil {
-				err = errors.Wrapf(searchErr, "failed to call codemod %s", &repoRev)
+				err = errors.Wrapf(searchErr, "failed to call codemod %s", repoRev)
 				cancel()
 			}
 			if len(results) > 0 {
@@ -221,7 +221,7 @@ func toMatchResolver(fileURL string, raw *rawCodemodResult) ([]*searchResultMatc
 		nil
 }
 
-func callCodemodInRepo(ctx context.Context, repoRevs search.RepositoryRevisions, args *args) (results []codemodResultResolver, err error) {
+func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, args *args) (results []codemodResultResolver, err error) {
 	tr, ctx := trace.New(ctx, "callCodemodInRepo", fmt.Sprintf("repoRevs: %v, pattern %+v, replace: %+v", repoRevs, args.matchTemplate, args.rewriteTemplate))
 	defer func() {
 		tr.LazyPrintf("%d results", len(results))

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -771,7 +771,7 @@ func langIncludeExcludePatterns(values, negatedValues []string) (includePatterns
 // updating common as to reflect that new information. If searchErr is a fatal error,
 // it returns a non-nil error; otherwise, if searchErr == nil or a non-fatal error, it returns a
 // nil error.
-func handleRepoSearchResult(common *searchResultsCommon, repoRev search.RepositoryRevisions, limitHit, timedOut bool, searchErr error) (fatalErr error) {
+func handleRepoSearchResult(common *searchResultsCommon, repoRev *search.RepositoryRevisions, limitHit, timedOut bool, searchErr error) (fatalErr error) {
 	common.limitHit = common.limitHit || limitHit
 	if vcs.IsRepoNotExist(searchErr) {
 		if vcs.IsCloneInProgress(searchErr) {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -52,7 +52,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repoRevs := search.RepositoryRevisions{
+	repoRevs := &search.RepositoryRevisions{
 		Repo: &types.Repo{ID: 1, Name: "repo"},
 		Revs: []search.RevisionSpecifier{{RevSpec: "rev"}},
 	}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -85,7 +85,7 @@ func searchSymbols(ctx context.Context, args *search.Args, limit int) (res []*fi
 			mu.Lock()
 			defer mu.Unlock()
 			limitHit := symbolCount(res) > limit
-			repoErr = handleRepoSearchResult(common, *repoRevs, limitHit, false, repoErr)
+			repoErr = handleRepoSearchResult(common, repoRevs, limitHit, false, repoErr)
 			if repoErr != nil {
 				if ctx.Err() == nil || errors.Cause(repoErr) != ctx.Err() {
 					// Only record error if it's not directly caused by a context error.

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -118,6 +118,7 @@ func (fm *fileMatchResolver) ToFileMatch() (*fileMatchResolver, bool)   { return
 func (fm *fileMatchResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
 }
+
 func (r *fileMatchResolver) ToCodemodResult() (*codemodResultResolver, bool) {
 	return nil, false
 }
@@ -1057,7 +1058,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 		}
 
 		wg.Add(1)
-		go func(ctx context.Context, done context.CancelFunc, repoRev search.RepositoryRevisions) {
+		go func(ctx context.Context, done context.CancelFunc, repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
 			defer done()
 
@@ -1091,7 +1092,7 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 				cancel()
 			}
 			addMatches(matches)
-		}(limitCtx, limitDone, *repoRev)
+		}(limitCtx, limitDone, repoRev)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
This commit is a follow up to #5137 that prevents other possible race
conditions that could occur when concurrently copying (i.e. reading) the
`search.RepositoryRevisions` struct that has its `IndexedHEADCommit`
concurrently hydrated.
