### PR TITLE
bitbucket_server: fix ServiceID inconsistency in tests

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -29,18 +29,18 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 			Token: "secret",
 		},
 		"ssh": {
-			Url:                         "bitbucket.example.com",
+			Url:                         "https://bitbucket.example.com",
 			Token:                       "secret",
 			InitialRepositoryEnablement: true,
 			GitURLType:                  "ssh",
 		},
 		"path-pattern": {
-			Url:                   "bitbucket.example.com",
+			Url:                   "https://bitbucket.example.com",
 			Token:                 "secret",
 			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
 		},
 		"username": {
-			Url:                   "bitbucket.example.com",
+			Url:                   "https://bitbucket.example.com",
 			Username:              "foo",
 			Token:                 "secret",
 			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
@@ -100,11 +100,11 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 
 	cases := map[string]*schema.BitbucketServerConnection{
 		"none": {
-			Url:   "bitbucket.example.com",
+			Url:   "https://bitbucket.example.com",
 			Token: "secret",
 		},
 		"name": {
-			Url:   "bitbucket.example.com",
+			Url:   "https://bitbucket.example.com",
 			Token: "secret",
 			Exclude: []*schema.ExcludedBitbucketServerRepo{{
 				Name: "SG/python-langserver-fork",
@@ -113,12 +113,12 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 			}},
 		},
 		"id": {
-			Url:     "bitbucket.example.com",
+			Url:     "https://bitbucket.example.com",
 			Token:   "secret",
 			Exclude: []*schema.ExcludedBitbucketServerRepo{{Id: 4}},
 		},
 		"pattern": {
-			Url:   "bitbucket.example.com",
+			Url:   "https://bitbucket.example.com",
 			Token: "secret",
 			Exclude: []*schema.ExcludedBitbucketServerRepo{{
 				Pattern: "SG/python.*",
@@ -127,7 +127,7 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 			}},
 		},
 		"both": {
-			Url:   "bitbucket.example.com",
+			Url:   "https://bitbucket.example.com",
 			Token: "secret",
 			// We match on the bitbucket server repo name, not the repository path pattern.
 			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-path-pattern.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-path-pattern.golden
@@ -2,7 +2,7 @@
   {
     "ID": 0,
     "Name": "bb/SG/go-langserver",
-    "URI": "/SG/go-langserver",
+    "URI": "bitbucket.example.com/SG/go-langserver",
     "Description": "go-langserver",
     "Language": "",
     "Fork": false,
@@ -14,7 +14,7 @@
     "ExternalRepo": {
       "ID": "1",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -68,7 +68,7 @@
   {
     "ID": 0,
     "Name": "bb/SG/python-langserver",
-    "URI": "/SG/python-langserver",
+    "URI": "bitbucket.example.com/SG/python-langserver",
     "Description": "python-langserver",
     "Language": "",
     "Fork": false,
@@ -80,7 +80,7 @@
     "ExternalRepo": {
       "ID": "2",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -134,7 +134,7 @@
   {
     "ID": 0,
     "Name": "bb/SG/python-langserver-fork",
-    "URI": "/SG/python-langserver-fork",
+    "URI": "bitbucket.example.com/SG/python-langserver-fork",
     "Description": "python-langserver-fork",
     "Language": "",
     "Fork": true,
@@ -146,7 +146,7 @@
     "ExternalRepo": {
       "ID": "5",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -241,7 +241,7 @@
   {
     "ID": 0,
     "Name": "bb/~KEEGAN/rgp",
-    "URI": "/~KEEGAN/rgp",
+    "URI": "bitbucket.example.com/~KEEGAN/rgp",
     "Description": "rgp",
     "Language": "",
     "Fork": false,
@@ -253,7 +253,7 @@
     "ExternalRepo": {
       "ID": "4",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -307,7 +307,7 @@
   {
     "ID": 0,
     "Name": "bb/~KEEGAN/rgp-unavailable",
-    "URI": "/~KEEGAN/rgp-unavailable",
+    "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
     "Description": "rgp-unavailable",
     "Language": "",
     "Fork": false,
@@ -319,7 +319,7 @@
     "ExternalRepo": {
       "ID": "4",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-ssh.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-ssh.golden
@@ -1,8 +1,8 @@
 [
   {
     "ID": 0,
-    "Name": "/SG/go-langserver",
-    "URI": "/SG/go-langserver",
+    "Name": "bitbucket.example.com/SG/go-langserver",
+    "URI": "bitbucket.example.com/SG/go-langserver",
     "Description": "go-langserver",
     "Language": "",
     "Fork": false,
@@ -14,7 +14,7 @@
     "ExternalRepo": {
       "ID": "1",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -67,8 +67,8 @@
   },
   {
     "ID": 0,
-    "Name": "/SG/python-langserver",
-    "URI": "/SG/python-langserver",
+    "Name": "bitbucket.example.com/SG/python-langserver",
+    "URI": "bitbucket.example.com/SG/python-langserver",
     "Description": "python-langserver",
     "Language": "",
     "Fork": false,
@@ -80,7 +80,7 @@
     "ExternalRepo": {
       "ID": "2",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -133,8 +133,8 @@
   },
   {
     "ID": 0,
-    "Name": "/SG/python-langserver-fork",
-    "URI": "/SG/python-langserver-fork",
+    "Name": "bitbucket.example.com/SG/python-langserver-fork",
+    "URI": "bitbucket.example.com/SG/python-langserver-fork",
     "Description": "python-langserver-fork",
     "Language": "",
     "Fork": true,
@@ -146,7 +146,7 @@
     "ExternalRepo": {
       "ID": "5",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -240,8 +240,8 @@
   },
   {
     "ID": 0,
-    "Name": "/~KEEGAN/rgp",
-    "URI": "/~KEEGAN/rgp",
+    "Name": "bitbucket.example.com/~KEEGAN/rgp",
+    "URI": "bitbucket.example.com/~KEEGAN/rgp",
     "Description": "rgp",
     "Language": "",
     "Fork": false,
@@ -253,7 +253,7 @@
     "ExternalRepo": {
       "ID": "4",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -306,8 +306,8 @@
   },
   {
     "ID": 0,
-    "Name": "/~KEEGAN/rgp-unavailable",
-    "URI": "/~KEEGAN/rgp-unavailable",
+    "Name": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
+    "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
     "Description": "rgp-unavailable",
     "Language": "",
     "Fork": false,
@@ -319,7 +319,7 @@
     "ExternalRepo": {
       "ID": "4",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {

--- a/cmd/repo-updater/repos/testdata/bitbucketserver-repos-username.golden
+++ b/cmd/repo-updater/repos/testdata/bitbucketserver-repos-username.golden
@@ -2,7 +2,7 @@
   {
     "ID": 0,
     "Name": "bb/SG/go-langserver",
-    "URI": "/SG/go-langserver",
+    "URI": "bitbucket.example.com/SG/go-langserver",
     "Description": "go-langserver",
     "Language": "",
     "Fork": false,
@@ -14,7 +14,7 @@
     "ExternalRepo": {
       "ID": "1",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -68,7 +68,7 @@
   {
     "ID": 0,
     "Name": "bb/SG/python-langserver",
-    "URI": "/SG/python-langserver",
+    "URI": "bitbucket.example.com/SG/python-langserver",
     "Description": "python-langserver",
     "Language": "",
     "Fork": false,
@@ -80,7 +80,7 @@
     "ExternalRepo": {
       "ID": "2",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -134,7 +134,7 @@
   {
     "ID": 0,
     "Name": "bb/SG/python-langserver-fork",
-    "URI": "/SG/python-langserver-fork",
+    "URI": "bitbucket.example.com/SG/python-langserver-fork",
     "Description": "python-langserver-fork",
     "Language": "",
     "Fork": true,
@@ -146,7 +146,7 @@
     "ExternalRepo": {
       "ID": "5",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -241,7 +241,7 @@
   {
     "ID": 0,
     "Name": "bb/~KEEGAN/rgp",
-    "URI": "/~KEEGAN/rgp",
+    "URI": "bitbucket.example.com/~KEEGAN/rgp",
     "Description": "rgp",
     "Language": "",
     "Fork": false,
@@ -253,7 +253,7 @@
     "ExternalRepo": {
       "ID": "4",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {
@@ -307,7 +307,7 @@
   {
     "ID": 0,
     "Name": "bb/~KEEGAN/rgp-unavailable",
-    "URI": "/~KEEGAN/rgp-unavailable",
+    "URI": "bitbucket.example.com/~KEEGAN/rgp-unavailable",
     "Description": "rgp-unavailable",
     "Language": "",
     "Fork": false,
@@ -319,7 +319,7 @@
     "ExternalRepo": {
       "ID": "4",
       "ServiceType": "bitbucketServer",
-      "ServiceID": "bitbucket.example.com/"
+      "ServiceID": "https://bitbucket.example.com/"
     },
     "Sources": {
       "extsvc:bitbucketserver:1": {


### PR DESCRIPTION
Fix Bitbucket Server ServiceID inconsistency in tests as described in #4846.

TL;DR replace `bitbucket.example.com` with `https://bitbucket.example.com`