### PR TITLE
Opt-in to Git protocol v2 for better perf when fetching references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Out-of-the-box TypeScript code intelligence is much better with an updated ctags version with a built-in TypeScript parser.
+- Sourcegraph uses Git protocol version 2 for increased efficiency and performance when fetching data from compatible code hosts.
 
 ### Fixed
 

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -43,6 +43,10 @@ func (s *Server) runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress 
 	extraArgs := []string{
 		// Unset credential helper because the command is non-interactive.
 		"-c", "credential.helper=",
+
+		// Use Git protocol version 2.
+		// https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html
+		"-c", "protocol.version=2",
 	}
 	cmd.Args = append(cmd.Args[:1], append(extraArgs, cmd.Args[1:]...)...)
 


### PR DESCRIPTION
We were aware of this last year, but it seems like [we misinterpreted the blog post and thought that all we needed to do is update our version of git](https://github.com/sourcegraph/enterprise/issues/11419#issuecomment-407061799).

Taking advantage of the protocol does require [setting a config option on the client to opt-in](https://github.blog/changelog/2018-11-08-git-protocol-v2-support/).

To demonstrate the difference, I started a fresh 3.6 instance of Sourcegraph (single docker image) and ran a git fetch with and without `-c protocol.version=2`.

Using protocol v2 significantly reduces the size of the data fetched from the server.

```
$ docker exec -it 8db280883c5f /bin/sh

/ # git version
git version 2.22.0

/ # git clone https://github.com/sourcegraph/sourcegraph
Cloning into 'sourcegraph'...
remote: Enumerating objects: 1343, done.
remote: Counting objects: 100% (1343/1343), done.
remote: Compressing objects: 100% (1065/1065), done.
remote: Total 357117 (delta 294), reused 591 (delta 222), pack-reused 355774
Receiving objects: 100% (357117/357117), 305.94 MiB | 9.96 MiB/s, done.
Resolving deltas: 100% (244206/244206), done.
/ # export GIT_TRACE_PACKET=1
/ # cd sourcegraph/
/sourcegraph # git fetch --no-tags origin master 2>&1 | wc -l
3391
/sourcegraph # git -c protocol.version=2 fetch --no-tags origin master 2>&1 | wc -l
44
```

Ideally we would set this in the global git config on gitserver on the off chance there are other code paths in the future, but this seems like the simplest change to make now.

cc @ggilmore since this could be related to https://sourcegraph.slack.com/archives/CLZ3BK0Q6/p1565217996012700