### PR TITLE
Vary info bar banner based on repo field

### DIFF
--- a/web/src/marketing/ServerBanner.tsx
+++ b/web/src/marketing/ServerBanner.tsx
@@ -4,9 +4,20 @@ import { eventLogger } from '../tracking/eventLogger'
 
 const onClickInstall = (): void => {
     eventLogger.log('InstallSourcegraphServerCTAClicked', { location_on_page: 'banner' })
-}
+};
 
 export const ServerBanner: React.FunctionComponent = () => (
+    <DismissibleAlert partialStorageKey="set-up-self-hosted" className="alert alert-info">
+        <span>
+            Search your private and internal code.{' '}
+            <a href="https://docs.sourcegraph.com/#quickstart" onClick={onClickInstall}>
+                Set up a self-hosted Sourcegraph instance.
+            </a>
+        </span>
+    </DismissibleAlert>
+);
+
+export const ServerBannerNoRepo: React.FunctionComponent = () => (
     <DismissibleAlert partialStorageKey="set-up-self-hosted" className="alert alert-info">
         <span>
             Sourcegraph.com searches over the top 10k GitHub repositories by default. You can search over other public
@@ -16,4 +27,4 @@ export const ServerBanner: React.FunctionComponent = () => (
             </a>
         </span>
     </DismissibleAlert>
-)
+);

--- a/web/src/marketing/ServerBanner.tsx
+++ b/web/src/marketing/ServerBanner.tsx
@@ -4,7 +4,7 @@ import { eventLogger } from '../tracking/eventLogger'
 
 const onClickInstall = (): void => {
     eventLogger.log('InstallSourcegraphServerCTAClicked', { location_on_page: 'banner' })
-};
+}
 
 export const ServerBanner: React.FunctionComponent = () => (
     <DismissibleAlert partialStorageKey="set-up-self-hosted" className="alert alert-info">
@@ -15,7 +15,7 @@ export const ServerBanner: React.FunctionComponent = () => (
             </a>
         </span>
     </DismissibleAlert>
-);
+)
 
 export const ServerBannerNoRepo: React.FunctionComponent = () => (
     <DismissibleAlert partialStorageKey="set-up-self-hosted" className="alert alert-info">
@@ -27,4 +27,4 @@ export const ServerBannerNoRepo: React.FunctionComponent = () => (
             </a>
         </span>
     </DismissibleAlert>
-);
+)

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -9,7 +9,7 @@ import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import * as React from 'react'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { pluralize } from '../../../../shared/src/util/strings'
-import {ServerBanner, ServerBannerNoRepo} from '../../marketing/ServerBanner'
+import { ServerBanner, ServerBannerNoRepo } from '../../marketing/ServerBanner'
 import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
 
 interface SearchResultsInfoBarProps {
@@ -152,8 +152,9 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 </div>
             </small>
         )}
-        {!props.results.alert && props.showDotComMarketing &&
-        (props.hasRepoishField ? <ServerBanner/> : <ServerBannerNoRepo/>)}
+        {!props.results.alert &&
+            props.showDotComMarketing &&
+            (props.hasRepoishField ? <ServerBanner /> : <ServerBannerNoRepo />)}
         {!props.results.alert && props.displayPerformanceWarning && <PerformanceWarningAlert />}
     </div>
-);
+)

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -9,7 +9,7 @@ import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import * as React from 'react'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { pluralize } from '../../../../shared/src/util/strings'
-import { ServerBanner } from '../../marketing/ServerBanner'
+import {ServerBanner, ServerBannerNoRepo} from '../../marketing/ServerBanner'
 import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
 
 interface SearchResultsInfoBarProps {
@@ -152,7 +152,8 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 </div>
             </small>
         )}
-        {!props.results.alert && props.showDotComMarketing && !props.hasRepoishField && <ServerBanner />}
+        {!props.results.alert && props.showDotComMarketing &&
+        (props.hasRepoishField ? <ServerBanner/> : <ServerBannerNoRepo/>)}
         {!props.results.alert && props.displayPerformanceWarning && <PerformanceWarningAlert />}
     </div>
-)
+);


### PR DESCRIPTION
This is in response to https://github.com/sourcegraph/sourcegraph/pull/5142#discussion_r312594332.

Test plan: manually tested by commenting out `props.showDotComMarketing &&` locally and trying the query with `repo:bar`, `repogroup:baz` and no filter.
