### PR TITLE
Fit icons

### DIFF
--- a/web/src/extensions/ExtensionCard.scss
+++ b/web/src/extensions/ExtensionCard.scss
@@ -9,6 +9,7 @@
     &__icon {
         width: 6rem;
         height: 6rem;
+        object-fit: contain;
     }
 
     &__toggle {

--- a/web/src/extensions/extension/ExtensionAreaHeader.scss
+++ b/web/src/extensions/extension/ExtensionAreaHeader.scss
@@ -5,5 +5,6 @@
         display: block;
         width: 8rem;
         height: 8rem;
+        object-fit: contain;
     }
 }


### PR DESCRIPTION
This sets `object-fit: contain;` on the extension registry icons.

Before:

![image](https://user-images.githubusercontent.com/1387653/62838609-15202a80-bc3c-11e9-8e39-4d176b2d10bb.png)

After:

![image](https://user-images.githubusercontent.com/1387653/62838852-e8214700-bc3e-11e9-9b12-b2c17b43908e.png)

Test plan: manual
