### PR TITLE
all: go test skip on missing tools

### DIFF
--- a/cmd/replacer/replace/replace_test.go
+++ b/cmd/replacer/replace/replace_test.go
@@ -23,6 +23,11 @@ import (
 )
 
 func TestReplace(t *testing.T) {
+	// If we are not on CI skip the test if comby is not installed.
+	if _, err := exec.LookPath("comby"); os.Getenv("CI") == "" && err != nil {
+		t.Skip("comby is not installed on the PATH. Try running 'bash <(curl -sL get.comby.dev)'.")
+	}
+
 	files := map[string]string{
 
 		"README.md": `# Hello World

--- a/cmd/symbols/internal/pkg/ctags/parser.go
+++ b/cmd/symbols/internal/pkg/ctags/parser.go
@@ -4,13 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
 
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/env"
 )
 
@@ -97,6 +97,11 @@ func NewParser(ctagsCommand string) (Parser, error) {
 	if err := proc.read(&init); err != nil {
 		proc.Close()
 		return nil, err
+	}
+
+	if init.Typ == "error" {
+		proc.Close()
+		return nil, errors.Errorf("starting %s failed with: %s", ctagsCommand, init.Message)
 	}
 
 	return &proc, nil

--- a/cmd/symbols/internal/pkg/ctags/parser_test.go
+++ b/cmd/symbols/internal/pkg/ctags/parser_test.go
@@ -1,6 +1,7 @@
 package ctags
 
 import (
+	"os"
 	"os/exec"
 	"reflect"
 	"testing"
@@ -15,6 +16,9 @@ func TestParser(t *testing.T) {
 
 	p, err := NewParser(command)
 	if err != nil {
+		if os.Getenv("CI") == "" {
+			t.Skipf("failed to start universal-ctags. Assuming it is due to our custom build of universal-ctags not being installed. Reason: %v", err)
+		}
 		t.Fatal(err)
 	}
 	defer p.Close()


### PR DESCRIPTION
A good property we used to have (and should keep) is that `go test -short ./...` just
works, and `go test ./...` works if you have our important services running
(redis/postgres). This PR fixes up some cases where this could fail.

In particular if you don't have comby on your path the test skips (we use the
same pattern for other tool dependencies). We also use a custom build of
universal-ctags for symbols, so if you have the normal version on your path we
don't fail tests due to it failing to start.

In both cases we do fail if we are on CI, to ensure we don't regress.



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
