### PR TITLE
searcher: multiline search

### DIFF
--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -25,20 +24,13 @@ import (
 )
 
 const (
-	// maxLineSize is the maximum length of a line in bytes.
-	// Lines larger than this are not scanned for results.
-	// (e.g. minified javascript files that are all on one line).
-	maxLineSize = 500
-
-	// maxFileMatches is the limit on number of matching files we return.
-	maxFileMatches = 1000
+	// maxFileAndLineMatches is the limit on number of matching files we return,
+	// and the number of matching lines in a file we return.
+	maxFileAndLineMatches = 1000
 
 	// maxLineMatches is the limit on number of matches to return in a
 	// file.
 	maxLineMatches = 100
-
-	// maxOffsets is the limit on number of matches to return on a line.
-	maxOffsets = 10
 
 	// numWorkers is how many concurrent readerGreps run per
 	// concurrentFind
@@ -211,68 +203,101 @@ func (rg *readerGrep) Find(zf *store.ZipFile, f *store.SrcFile) (matches []proto
 	if !bytes.Contains(fileMatchBuf, rg.literalSubstring) {
 		return nil, false, nil
 	}
-	first := rg.re.FindIndex(fileMatchBuf)
-	if first == nil {
-		return nil, false, nil
+
+	locs := rg.re.FindAllIndex(fileMatchBuf, maxLineMatches)
+	lastStart := 0
+	lastLineNumber := 0
+	lastMatchIndex := 0
+	lastLineStartIndex := 0
+
+	for _, match := range locs {
+		start, end := match[0], match[1]
+		lineStart := lastLineStartIndex
+		if idx := bytes.LastIndex(fileMatchBuf[lastStart:start], []byte{'\n'}); idx >= 0 {
+			lineStart = lastStart + idx + 1
+		}
+		lastLineStartIndex = lineStart
+		lastStart = start
+
+		lineEnd := end
+		endBuf := end
+		if endBuf > 0 {
+			// Subtract 1 from end so that we can detect the proper lineEnd byte for empty new lines.
+			endBuf--
+		}
+		if idx := bytes.Index(fileMatchBuf[endBuf:], []byte{'\n'}); idx >= 0 {
+			lineEnd += idx
+		} else {
+			lineEnd += len(fileMatchBuf[end:])
+		}
+
+		lineNumber, matchIndex := hydrateLineNumbers(fileMatchBuf, lastLineNumber, lastMatchIndex, lineStart, match)
+
+		lastMatchIndex = matchIndex
+		lastLineNumber = lineNumber
+		matches = appendMatches(matches, fileBuf[lineStart:lineEnd], fileMatchBuf[lineStart:lineEnd], lineNumber, start-lineStart, end-lineStart)
+
 	}
-
-	idx := 0
-	for i := 0; len(matches) < maxLineMatches; i++ {
-		advance, lineBuf, err := bufio.ScanLines(fileBuf, true)
-		if err != nil {
-			// ScanLines should never return an err
-			return nil, false, err
-		}
-		if advance == 0 { // EOF
-			break
-		}
-
-		// matchBuf is what we actually match on. We have already done
-		// the transform of fileBuf in fileMatchBuf. lineBuf is a
-		// prefix of fileBuf, so matchBuf is the corresponding prefix.
-		matchBuf := fileMatchBuf[:len(lineBuf)]
-
-		// Advance file bufs in sync
-		fileBuf = fileBuf[advance:]
-		fileMatchBuf = fileMatchBuf[advance:]
-
-		// Check whether we're before the first match.
-		idx += advance
-		if idx < first[0] {
-			continue
-		}
-
-		// Skip lines that are too long.
-		if len(matchBuf) > maxLineSize {
-			continue
-		}
-
-		locs := rg.re.FindAllIndex(matchBuf, maxOffsets)
-		if len(locs) > 0 {
-			lineLimitHit := len(locs) == maxOffsets
-			offsetAndLengths := make([][2]int, len(locs))
-			for i, match := range locs {
-				start, end := match[0], match[1]
-				offset := utf8.RuneCount(lineBuf[:start])
-				length := utf8.RuneCount(lineBuf[start:end])
-				offsetAndLengths[i] = [2]int{offset, length}
-			}
-			matches = append(matches, protocol.LineMatch{
-				// making a copy of lineBuf is intentional.
-				// we are not allowed to use the fileBuf data after the ZipFile has been Closed,
-				// which currently occurs before Preview has been serialized.
-				// TODO: consider moving the call to Close until after we are
-				// done with Preview, and stop making a copy here.
-				// Special care must be taken to call Close on all possible paths, including error paths.
-				Preview:          string(lineBuf),
-				LineNumber:       i,
-				OffsetAndLengths: offsetAndLengths,
-				LimitHit:         lineLimitHit,
-			})
-		}
-	}
-	limitHit = len(matches) == maxLineMatches
+	limitHit = len(matches) >= maxLineMatches
 	return matches, limitHit, nil
+}
+
+func hydrateLineNumbers(fileBuf []byte, lastLineNumber, lastMatchIndex, lineStart int, match []int) (lineNumber, matchIndex int) {
+	lineNumber = lastLineNumber + bytes.Count(fileBuf[lastMatchIndex:match[0]], []byte{'\n'})
+	return lineNumber, lineStart
+}
+
+// TODO document invariants
+// TODO test corner cases, ie start / end containing new lines / being on buf boundaries / etc.
+// matchLineBuf is a byte slice that contains the full line(s) that the match appears on.
+func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []byte, lineNumber, start, end int) []protocol.LineMatch {
+	// If any newlines appear between start and end, we need to append multiple LineMatch.
+	// We assume there are no newlines before start.
+	for len(matchLineBuf) > 0 {
+		var line []byte
+		var eol int
+		if eol = bytes.Index(matchLineBuf[start:], []byte{'\n'}); eol < 0 {
+			line = matchLineBuf
+			matchLineBuf = []byte{}
+		} else {
+			eol += start
+			// start is 0 indexed, so add 1 to include the new line at the end of the line
+			line = matchLineBuf[:eol+1]
+			matchLineBuf = matchLineBuf[eol+1:]
+		}
+
+		e := end
+		if e > len(line) {
+			e = len(line)
+		}
+
+		offset := utf8.RuneCount(line[:start])
+		length := utf8.RuneCount(line[start:e])
+		limit := eol
+		if limit < 0 {
+			limit = len(fileBuf)
+		}
+		matches = append(matches, protocol.LineMatch{
+			// we are not allowed to use the fileBuf data after the ZipFile has been Closed,
+			// which currently occurs before Preview has been serialized.
+			// TODO: consider moving the call to Close until after we are
+			// done with Preview, and stop making a copy here.
+			// Special care must be taken to call Close on all possible paths, including error paths.
+			Preview:          string(fileBuf[:limit]),
+			LineNumber:       lineNumber,
+			OffsetAndLengths: [][2]int{{offset, length}},
+			LimitHit:         false, // We will always return false for this field since we no longer limit the number of offsets per line.
+		})
+
+		if eol >= 0 {
+			fileBuf = fileBuf[eol+1:]
+		}
+
+		lineNumber++
+		start = 0
+		end -= e
+	}
+	return matches
 }
 
 // FindZip is a convenience function to run Find on f.
@@ -305,8 +330,8 @@ func concurrentFind(ctx context.Context, rg *readerGrep, zf *store.ZipFile, file
 		patternMatchesContent = true
 	}
 
-	if fileMatchLimit > maxFileMatches || fileMatchLimit <= 0 {
-		fileMatchLimit = maxFileMatches
+	if fileMatchLimit > maxFileAndLineMatches || fileMatchLimit <= 0 {
+		fileMatchLimit = maxFileAndLineMatches
 	}
 
 	// If we reach fileMatchLimit we use cancel to stop the search

--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -203,7 +203,7 @@ func (rg *readerGrep) Find(zf *store.ZipFile, f *store.SrcFile) (matches []proto
 		return nil, false, nil
 	}
 
-	locs := rg.re.FindAllIndex(fileMatchBuf, maxLineMatches)
+	locs := rg.re.FindAllIndex(fileMatchBuf, maxLineMatches+1)
 	lastStart := 0
 	lastLineNumber := 0
 	lastMatchIndex := 0
@@ -237,11 +237,11 @@ func (rg *readerGrep) Find(zf *store.ZipFile, f *store.SrcFile) (matches []proto
 		matches = appendMatches(matches, fileBuf[lineStart:lineEnd], fileMatchBuf[lineStart:lineEnd], lineNumber, start-lineStart, end-lineStart)
 
 		if len(matches) > maxLineMatches {
+			matches = matches[:maxLineMatches]
+			limitHit = true
 			break
 		}
-
 	}
-	limitHit = len(matches) >= maxLineMatches
 	return matches, limitHit, nil
 }
 

--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -219,16 +219,16 @@ func (rg *readerGrep) Find(zf *store.ZipFile, f *store.SrcFile) (matches []proto
 		lastLineStartIndex = lineStart
 		lastStart = start
 
-		lineEnd := end
-		endBuf := end
-		if endBuf > 0 {
-			// Subtract 1 from end so that we can detect the proper lineEnd byte for empty new lines.
-			endBuf--
-		}
-		if idx := bytes.Index(fileMatchBuf[endBuf:], []byte{'\n'}); idx >= 0 {
-			lineEnd += idx
+		// lineEnd is the index of the next \n. If the last character of our
+		// match is already a newline, then lineEnd instead points end to
+		// include the newline in the match preview.
+		var lineEnd int
+		if end > 0 && fileMatchBuf[end-1] == '\n' {
+			lineEnd = end // Note: fileMatchBuf[lineEnd] may not be a \n
+		} else if idx := bytes.Index(fileMatchBuf[end:], []byte{'\n'}); idx >= 0 {
+			lineEnd = end + idx
 		} else {
-			lineEnd += len(fileMatchBuf[end:])
+			lineEnd = len(fileMatchBuf)
 		}
 
 		lineNumber, matchIndex := hydrateLineNumbers(fileMatchBuf, lastLineNumber, lastMatchIndex, lineStart, match)

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -420,58 +420,13 @@ func TestReadAll(t *testing.T) {
 	}
 }
 
-func TestLineLimit(t *testing.T) {
-	rg, err := compile(&protocol.PatternInfo{Pattern: "a"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		size    int
-		matches bool
-	}{
-		{size: maxLineSize, matches: true},
-		{size: maxLineSize + 1, matches: false},
-	}
-
-	// calculate maximum size in tests,
-	// needed because readerGreps re-use their buffers.
-	maxBuf := 0
-	for _, test := range tests {
-		if test.size > maxBuf {
-			maxBuf = test.size
-		}
-	}
-
-	for i, test := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			fakeZipFile := store.ZipFile{
-				MaxLen: maxBuf,
-				Data:   bytes.Repeat([]byte("A"), test.size),
-			}
-			fakeSrcFile := store.SrcFile{Len: int32(test.size)}
-			matches, limitHit, err := rg.Find(&fakeZipFile, &fakeSrcFile)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if limitHit {
-				t.Fatalf("expected limit to not hit")
-			}
-			hasMatches := len(matches) != 0
-			if hasMatches != test.matches {
-				t.Fatalf("hasMatches=%t test.matches=%t", hasMatches, test.matches)
-			}
-		})
-	}
-}
-
 func TestMaxMatches(t *testing.T) {
 	pattern := "foo"
 
 	// Create a zip archive which contains our limits + 1
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
-	for i := 0; i < maxFileMatches+1; i++ {
+	for i := 0; i < maxFileAndLineMatches+1; i++ {
 		w, err := zw.CreateHeader(&zip.FileHeader{
 			Name:   strconv.Itoa(i),
 			Method: zip.Store,
@@ -480,11 +435,9 @@ func TestMaxMatches(t *testing.T) {
 			t.Fatal(err)
 		}
 		for j := 0; j < maxLineMatches+1; j++ {
-			for k := 0; k < maxOffsets+1; k++ {
-				w.Write([]byte(pattern))
-				w.Write([]byte{' '})
-			}
-			w.Write([]byte{'\n'})
+			_, _ = w.Write([]byte(pattern))
+			_, _ = w.Write([]byte{' '})
+			_, _ = w.Write([]byte{'\n'})
 		}
 	}
 	err := zw.Close()
@@ -500,7 +453,7 @@ func TestMaxMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileMatches, limitHit, err := concurrentFind(context.Background(), rg, zf, 0, true, false)
+	fileMatches, limitHit, err := concurrentFind(context.Background(), rg, zf, maxFileAndLineMatches, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -508,8 +461,8 @@ func TestMaxMatches(t *testing.T) {
 		t.Fatalf("expected limitHit on concurrentFind")
 	}
 
-	if len(fileMatches) != maxFileMatches {
-		t.Fatalf("expected %d file matches, got %d", maxFileMatches, len(fileMatches))
+	if len(fileMatches) != maxFileAndLineMatches {
+		t.Fatalf("expected %d file matches, got %d", maxFileAndLineMatches, len(fileMatches))
 	}
 	for _, fm := range fileMatches {
 		if !fm.LimitHit {
@@ -517,14 +470,6 @@ func TestMaxMatches(t *testing.T) {
 		}
 		if len(fm.LineMatches) != maxLineMatches {
 			t.Fatalf("expected %d line matches, got %d", maxLineMatches, len(fm.LineMatches))
-		}
-		for _, lm := range fm.LineMatches {
-			if !lm.LimitHit {
-				t.Fatalf("expected limitHit on line match")
-			}
-			if len(lm.OffsetAndLengths) != maxOffsets {
-				t.Fatalf("expected %d offsets, got %d", maxOffsets, len(lm.OffsetAndLengths))
-			}
 		}
 	}
 }

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -426,7 +426,7 @@ func TestMaxMatches(t *testing.T) {
 	// Create a zip archive which contains our limits + 1
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
-	for i := 0; i < maxFileAndLineMatches+1; i++ {
+	for i := 0; i < maxFileMatches+1; i++ {
 		w, err := zw.CreateHeader(&zip.FileHeader{
 			Name:   strconv.Itoa(i),
 			Method: zip.Store,
@@ -453,7 +453,7 @@ func TestMaxMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileMatches, limitHit, err := concurrentFind(context.Background(), rg, zf, maxFileAndLineMatches, true, false)
+	fileMatches, limitHit, err := concurrentFind(context.Background(), rg, zf, maxFileMatches, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,8 +461,8 @@ func TestMaxMatches(t *testing.T) {
 		t.Fatalf("expected limitHit on concurrentFind")
 	}
 
-	if len(fileMatches) != maxFileAndLineMatches {
-		t.Fatalf("expected %d file matches, got %d", maxFileAndLineMatches, len(fileMatches))
+	if len(fileMatches) != maxFileMatches {
+		t.Fatalf("expected %d file matches, got %d", maxFileMatches, len(fileMatches))
 	}
 	for _, fm := range fileMatches {
 		if !fm.LimitHit {

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -181,6 +181,8 @@ main.go:5:func main() {
 main.go:6:	fmt.Println("Hello world")
 main.go:7:}
 `},
+
+		{protocol.PatternInfo{Pattern: "^$", IsRegExp: true}, ``},
 	}
 
 	store, cleanup, err := newStore(files)


### PR DESCRIPTION
Multiline search implementation for searcher.

Test plan: Added unit tests

Benchstat output:
```
BytesToLowerASCII/short-8                            10.8ns ± 5%     9.7ns ± 7%  -10.14%  (p=0.000 n=8+10)
BytesToLowerASCII/pangram-8                          6.95ns ± 5%    8.98ns ±37%     ~     (p=0.810 n=10+10)
BytesToLowerASCII/8k-8                                691ns ± 5%     940ns ±52%     ~     (p=0.468 n=10+10)
BytesToLowerASCII/8k-misaligned-8                     707ns ± 6%    1299ns ±38%  +83.68%  (p=0.000 n=10+9)
ConcurrentFind_large_fixed-8                         10.7ms ± 5%    18.0ms ± 6%  +68.46%  (p=0.000 n=10+10)
ConcurrentFind_large_fixed_casesensitive-8           8.38ms ± 2%    7.59ms ± 3%   -9.38%  (p=0.000 n=9+10)
ConcurrentFind_large_re_dotstar-8                    20.9ms ± 3%    19.8ms ± 2%   -5.37%  (p=0.000 n=10+10)
ConcurrentFind_large_re_common-8                     13.0ms ± 3%     5.1ms ±10%  -60.55%  (p=0.000 n=10+10)
ConcurrentFind_large_re_anchor-8                      141ms ± 2%     128ms ± 1%   -9.56%  (p=0.000 n=10+8)
ConcurrentFind_large_path/path_only-8                 527µs ± 5%     506µs ± 6%   -3.91%  (p=0.029 n=10+10)
ConcurrentFind_large_path/content_only-8             7.35ms ± 6%    8.36ms ± 7%  +13.66%  (p=0.000 n=10+10)
ConcurrentFind_large_path/both_path_and_content-8    7.81ms ± 3%    8.74ms ± 3%  +11.90%  (p=0.000 n=9+10)
ConcurrentFind_small_fixed-8                          213µs ± 2%     159µs ± 5%  -25.05%  (p=0.000 n=10+10)
ConcurrentFind_small_fixed_casesensitive-8            127µs ± 5%      82µs ± 3%  -35.41%  (p=0.000 n=10+10)
ConcurrentFind_small_re_dotstar-8                    1.98ms ± 5%    1.62ms ± 2%  -18.13%  (p=0.000 n=10+10)
ConcurrentFind_small_re_common-8                      351µs ± 5%     143µs ± 5%  -59.36%  (p=0.000 n=10+10)
ConcurrentFind_small_re_anchor-8                     2.32ms ± 6%    1.93ms ± 4%  -16.81%  (p=0.000 n=9+10)

name                                               old alloc/op   new alloc/op   delta
BytesToLowerASCII/short-8                             0.00B          0.00B          ~     (all equal)
BytesToLowerASCII/pangram-8                           0.00B          0.00B          ~     (all equal)
BytesToLowerASCII/8k-8                                0.00B          0.00B          ~     (all equal)
BytesToLowerASCII/8k-misaligned-8                     0.00B          0.00B          ~     (all equal)
ConcurrentFind_large_fixed-8                         5.00MB ± 0%    5.01MB ± 0%   +0.35%  (p=0.002 n=10+9)
ConcurrentFind_large_fixed_casesensitive-8           12.7kB ± 5%    11.5kB ± 5%   -9.35%  (p=0.000 n=10+9)
ConcurrentFind_large_re_dotstar-8                    33.2MB ± 0%    22.7MB ± 0%  -31.43%  (p=0.000 n=10+10)
ConcurrentFind_large_re_common-8                     2.69MB ± 0%    1.76MB ± 1%  -34.51%  (p=0.000 n=10+10)
ConcurrentFind_large_re_anchor-8                     2.49MB ± 3%    1.65MB ± 3%  -33.76%  (p=0.000 n=10+10)
ConcurrentFind_large_path/path_only-8                  630B ± 1%      632B ± 1%     ~     (p=0.466 n=10+9)
ConcurrentFind_large_path/content_only-8             93.1kB ± 5%    69.1kB ± 2%  -25.70%  (p=0.000 n=10+10)
ConcurrentFind_large_path/both_path_and_content-8    94.3kB ± 3%    69.2kB ± 6%  -26.55%  (p=0.000 n=9+10)
ConcurrentFind_small_fixed-8                          474kB ± 6%     393kB ±19%  -17.04%  (p=0.000 n=9+10)
ConcurrentFind_small_fixed_casesensitive-8           5.03kB ± 1%    4.45kB ± 0%  -11.54%  (p=0.000 n=10+9)
ConcurrentFind_small_re_dotstar-8                    2.81MB ± 0%    1.96MB ± 0%  -30.38%  (p=0.000 n=10+10)
ConcurrentFind_small_re_common-8                     58.3kB ± 1%    42.4kB ± 1%  -27.32%  (p=0.000 n=10+10)
ConcurrentFind_small_re_anchor-8                     19.7kB ± 2%    18.0kB ± 1%   -8.61%  (p=0.000 n=10+9)

name                                               old allocs/op  new allocs/op  delta
BytesToLowerASCII/short-8                              0.00           0.00          ~     (all equal)
BytesToLowerASCII/pangram-8                            0.00           0.00          ~     (all equal)
BytesToLowerASCII/8k-8                                 0.00           0.00          ~     (all equal)
BytesToLowerASCII/8k-misaligned-8                      0.00           0.00          ~     (all equal)
ConcurrentFind_large_fixed-8                            209 ± 2%       196 ± 1%   -6.56%  (p=0.000 n=10+9)
ConcurrentFind_large_fixed_casesensitive-8              116 ± 0%       103 ± 0%  -11.21%  (p=0.000 n=10+10)
ConcurrentFind_large_re_dotstar-8                      278k ± 0%      215k ± 0%  -22.65%  (p=0.000 n=10+9)
ConcurrentFind_large_re_common-8                      23.9k ± 0%     19.0k ± 0%  -20.70%  (p=0.000 n=10+10)
ConcurrentFind_large_re_anchor-8                      22.7k ± 0%     18.1k ± 0%  -20.45%  (p=0.000 n=9+9)
ConcurrentFind_large_path/path_only-8                  16.0 ± 0%      16.0 ± 0%     ~     (all equal)
ConcurrentFind_large_path/content_only-8                640 ± 0%       513 ± 0%  -19.91%  (p=0.000 n=10+10)
ConcurrentFind_large_path/both_path_and_content-8       640 ± 0%       513 ± 0%  -19.95%  (p=0.000 n=10+10)
ConcurrentFind_small_fixed-8                           85.8 ± 1%      77.3 ± 3%   -9.88%  (p=0.000 n=9+10)
ConcurrentFind_small_fixed_casesensitive-8             60.0 ± 0%      56.0 ± 0%   -6.67%  (p=0.000 n=10+10)
ConcurrentFind_small_re_dotstar-8                     21.7k ± 0%     16.9k ± 0%  -22.20%  (p=0.000 n=10+10)
ConcurrentFind_small_re_common-8                        485 ± 0%       395 ± 0%  -18.51%  (p=0.000 n=10+10)
ConcurrentFind_small_re_anchor-8                        208 ± 0%       179 ± 0%  -13.94%  (p=0.000 n=10+10)
```