### PR TITLE
Don't use git protocol v2 for ls-remote

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -808,7 +808,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, url string, o
 		defer pw.Close()
 		go readCloneProgress(repo, url, lock, pr)
 
-		if output, err := s.runWithRemoteOpts(ctx, cmd, pw); err != nil {
+		if output, err := runWithRemoteOpts(ctx, cmd, pw); err != nil {
 			return errors.Wrapf(err, "clone failed. Output: %s", string(output))
 		}
 
@@ -965,7 +965,7 @@ func (s *Server) isCloneable(ctx context.Context, url string) error {
 	}
 
 	cmd := exec.CommandContext(ctx, "git", args...)
-	out, err := s.runWithRemoteOpts(ctx, cmd, nil)
+	out, err := runWithRemoteOpts(ctx, cmd, nil)
 	if err != nil {
 		if ctxerr := ctx.Err(); ctxerr != nil {
 			err = ctxerr
@@ -1255,7 +1255,7 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 	// when the cleanup happens, just that it does.
 	defer s.cleanTmpFiles(dir)
 
-	if output, err := s.runWithRemoteOpts(ctx, cmd, nil); err != nil {
+	if output, err := runWithRemoteOpts(ctx, cmd, nil); err != nil {
 		log15.Error("Failed to update", "repo", repo, "error", err, "output", string(output))
 		return errors.Wrap(err, "failed to update")
 	}
@@ -1270,7 +1270,7 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 	// try to fetch HEAD from origin
 	cmd = exec.CommandContext(ctx, "git", "remote", "show", url)
 	cmd.Dir = path.Join(s.ReposDir, string(repo))
-	output, err := s.runWithRemoteOpts(ctx, cmd, nil)
+	output, err := runWithRemoteOpts(ctx, cmd, nil)
 	if err != nil {
 		log15.Error("Failed to fetch remote info", "repo", repo, "error", err, "output", string(output))
 		return errors.Wrap(err, "failed to fetch remote info")

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -31,24 +31,8 @@ func checkSpecArgSafety(spec string) error {
 
 // runWithRemoteOpts runs the command after applying the remote options.
 // If progress is not nil, all output is written to it in a separate goroutine.
-func (s *Server) runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress io.Writer) ([]byte, error) {
-	cmd.Env = append(cmd.Env, "GIT_ASKPASS=true") // disable password prompt
-
-	// Suppress asking to add SSH host key to known_hosts (which will hang because
-	// the command is non-interactive).
-	//
-	// And set a timeout to avoid indefinite hangs if the server is unreachable.
-	cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30")
-
-	extraArgs := []string{
-		// Unset credential helper because the command is non-interactive.
-		"-c", "credential.helper=",
-
-		// Use Git protocol version 2.
-		// https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html
-		"-c", "protocol.version=2",
-	}
-	cmd.Args = append(cmd.Args[:1], append(extraArgs, cmd.Args[1:]...)...)
+func runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress io.Writer) ([]byte, error) {
+	configureGitCommand(cmd)
 
 	var b interface {
 		Bytes() []byte
@@ -76,6 +60,33 @@ func (s *Server) runWithRemoteOpts(ctx context.Context, cmd *exec.Cmd, progress 
 
 	_, err := runCommand(ctx, cmd)
 	return b.Bytes(), err
+}
+
+func configureGitCommand(cmd *exec.Cmd) {
+	if cmd.Args[0] != "git" {
+		panic("Only git commands are supported")
+	}
+
+	cmd.Env = append(cmd.Env, "GIT_ASKPASS=true") // disable password prompt
+
+	// Suppress asking to add SSH host key to known_hosts (which will hang because
+	// the command is non-interactive).
+	//
+	// And set a timeout to avoid indefinite hangs if the server is unreachable.
+	cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30")
+
+	extraArgs := []string{
+		// Unset credential helper because the command is non-interactive.
+		"-c", "credential.helper=",
+	}
+
+	if cmd.Args[1] != "ls-remote" {
+		// Use Git protocol version 2 for all commands except for ls-remote.
+		// https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html
+		extraArgs = append(extraArgs, "-c", "protocol.version=2")
+	}
+
+	cmd.Args = append(cmd.Args[:1], append(extraArgs, cmd.Args[1:]...)...)
 }
 
 // repoCloned checks if dir or `${dir}/.git` is a valid GIT_DIR.

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -81,7 +81,7 @@ func configureGitCommand(cmd *exec.Cmd) {
 	}
 
 	if len(cmd.Args) > 1 && cmd.Args[1] != "ls-remote" {
-		// Use Git protocol version 2 for all commands except for ls-remote.
+		// Use Git protocol version 2 for all commands except for ls-remote because it actually decreases the performance of ls-remote.
 		// https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html
 		extraArgs = append(extraArgs, "-c", "protocol.version=2")
 	}

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -80,7 +80,7 @@ func configureGitCommand(cmd *exec.Cmd) {
 		"-c", "credential.helper=",
 	}
 
-	if cmd.Args[1] != "ls-remote" {
+	if len(cmd.Args) > 1 && cmd.Args[1] != "ls-remote" {
 		// Use Git protocol version 2 for all commands except for ls-remote.
 		// https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html
 		extraArgs = append(extraArgs, "-c", "protocol.version=2")


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/757 added support for Git protocol v2.

https://github.com/sourcegraph/sourcegraph/pull/4350 removed support for Git protocol v2 because it impacted the performance of ls-remote.

https://github.com/sourcegraph/sourcegraph/pull/5155 added back support for Git protocol v2 without knowledge that it had been removed for that reason.

Instead of reverting https://github.com/sourcegraph/sourcegraph/pull/5155, this PR adds Git protocol v2 support for all git commands except ls-remote and it enforces this behavior with tests.