### PR TITLE
Reduce number of zoekt RPCs for repohasfile: queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Multi-line search now works for non-indexed search.
-- Sped up searches with `repohasfile:` [#4833](https://github.com/sourcegraph/sourcegraph/issues/4833).
 
 ### Changed
 
 - In the [GitHub external service config](https://docs.sourcegraph.com/admin/external_service/github#configuration) it's now possible to specify `orgs` without specifying `repositoryQuery` or `repos` too.
 - Out-of-the-box TypeScript code intelligence is much better with an updated ctags version with a built-in TypeScript parser.
 - Sourcegraph uses Git protocol version 2 for increased efficiency and performance when fetching data from compatible code hosts.
+- Searches with `repohasfile:` are faster at finding repository matches. [#4833](https://github.com/sourcegraph/sourcegraph/issues/4833).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Multi-line search now works for non-indexed search.
+- Sped up searches with `repohasfile:` [#4833](https://github.com/sourcegraph/sourcegraph/issues/4833).
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -51,7 +51,7 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 	common = &searchResultsCommon{}
 	var results []searchResultResolver
 	if len(args.Pattern.FilePatternsReposMustExclude) > 0 || len(args.Pattern.FilePatternsReposMustInclude) > 0 {
-		rsta, err := reposToAdd(ctx, args.Zoekt, repo, args.Pattern)
+		rsta, err := reposToAdd(ctx, args.Zoekt, args.Repos, args.Pattern)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -92,7 +92,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 				return nil, err
 			}
 			for _, m := range matches {
-				matchingIDs[m.Repo.ID] = true
+				matchingIDs[m.repo.ID] = true
 			}
 		}
 	}
@@ -110,7 +110,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 				return nil, err
 			}
 			for _, m := range matches {
-				matchingIDs[m.Repo.ID] = false
+				matchingIDs[m.repo.ID] = false
 			}
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -81,7 +81,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 	matchingIDs := make(map[api.RepoID]bool)
 	if len(pattern.FilePatternsReposMustInclude) > 0 {
 		for _, pattern := range pattern.FilePatternsReposMustInclude {
-			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: int32(len(repos)), IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {
 				return nil, err
@@ -99,7 +99,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 
 	if len(pattern.FilePatternsReposMustExclude) > 0 {
 		for _, pattern := range pattern.FilePatternsReposMustExclude {
-			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: int32(len(repos)), IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {
 				return nil, err

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -58,7 +58,9 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 		}
 
 		for _, r := range rsta {
-			results = append(results, &repositoryResolver{repo: r.Repo, icon: repoIcon})
+			if pattern.MatchString(string(r.Repo.Name)) {
+				results = append(results, &repositoryResolver{repo: r.Repo, icon: repoIcon})
+			}
 		}
 	} else {
 		for _, r := range args.Repos {

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -82,7 +82,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 	matchingIDs := make(map[api.RepoID]bool)
 	if len(pattern.FilePatternsReposMustInclude) > 0 {
 		for _, pattern := range pattern.FilePatternsReposMustInclude {
-			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: int32(len(repos)), IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {
 				return nil, err

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -86,6 +86,9 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 	matchingIDs := make(map[api.RepoID]bool)
 	if len(pattern.FilePatternsReposMustInclude) > 0 {
 		for _, pattern := range pattern.FilePatternsReposMustInclude {
+			// The high FileMatchLimit here is to make sure we get all the repo matches we can. Setting it to
+			// len(repos) could mean we miss some repos since there could be for example len(repos) file matches in
+			// the first repo and some more in other repos.
 			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: math.MaxInt32, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -2,8 +2,9 @@ package graphqlbackend
 
 import (
 	"context"
-	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/pkg/api"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/search/query"

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -82,7 +82,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 	matchingIDs := make(map[api.RepoID]bool)
 	if len(pattern.FilePatternsReposMustInclude) > 0 {
 		for _, pattern := range pattern.FilePatternsReposMustInclude {
-			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: int32(len(repos)), IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {
 				return nil, err

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"math"
 	"regexp"
 
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -85,7 +86,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 	matchingIDs := make(map[api.RepoID]bool)
 	if len(pattern.FilePatternsReposMustInclude) > 0 {
 		for _, pattern := range pattern.FilePatternsReposMustInclude {
-			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: int32(len(repos)), IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: math.MaxInt32, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {
 				return nil, err
@@ -108,7 +109,7 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 
 	if len(pattern.FilePatternsReposMustExclude) > 0 {
 		for _, pattern := range pattern.FilePatternsReposMustExclude {
-			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: int32(len(repos)), IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
+			p := search.PatternInfo{IsRegExp: true, FileMatchLimit: math.MaxInt32, IncludePatterns: []string{pattern}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 			q, err := query.ParseAndCheck("file:" + pattern)
 			if err != nil {
 				return nil, err

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -95,6 +95,11 @@ func reposToAdd(ctx context.Context, zoekt *searchbackend.Zoekt, repos []*search
 				matchingIDs[m.repo.ID] = true
 			}
 		}
+	} else {
+		// Default to including all the repos, then excluding some of them below.
+		for _, r := range repos {
+			matchingIDs[r.Repo.ID] = true
+		}
 	}
 
 	if len(pattern.FilePatternsReposMustExclude) > 0 {

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -197,3 +197,13 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		}
 	})
 }
+
+// repoShouldBeAdded determines whether a repository should be included in the result set based on whether the repository fits in the subset
+// of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
+func repoShouldBeAdded(ctx context.Context, zoekt *searchbackend.Zoekt, repo *search.RepositoryRevisions, pattern *search.PatternInfo) (bool, error) {
+	rsta, err := reposToAdd(ctx, zoekt, repos, pattern)
+	if err != nil {
+		return false, err
+	}
+	return len(rsta) == 1, nil
+}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSearchRepositories(t *testing.T) {
 	repositories := []*search.RepositoryRevisions{
-		{Repo: &types.Repo{Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
-		{Repo: &types.Repo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: &types.Repo{ID: 456, Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
 	}
 
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
@@ -25,7 +25,8 @@ func TestSearchRepositories(t *testing.T) {
 		case "foo/one":
 			return []*fileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
+					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
+					repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		case "foo/no-match":
@@ -117,7 +118,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		case "foo/one":
 			return []*fileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
+					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
+					repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		case "foo/no-match":
@@ -130,11 +132,12 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: &types.Repo{Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
 			return []*fileMatchResolver{
 				{
-					uri: "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+					repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		}
@@ -164,11 +167,12 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	})
 
 	t.Run("repo shouldn't be included in results, query has -repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: &types.Repo{Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.Args) (matches []*fileMatchResolver, common *searchResultsCommon, err error) {
 			return []*fileMatchResolver{
 				{
-					uri: "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+					repo: &types.Repo{ID: 123},
 				},
 			}, &searchResultsCommon{}, nil
 		}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -65,13 +65,13 @@ func TestSearchRepositories(t *testing.T) {
 
 	})
 
-	t.Run("search for all repositories where the repo name includes 'one'", func(t *testing.T) {
-		q, err := query.ParseAndCheck("type:repo one")
+	t.Run("search for all repositories where the repo name includes 'foo/one'", func(t *testing.T) {
+		q, err := query.ParseAndCheck("type:repo foo/one")
 		if err != nil {
 			t.Fatal(err)
 		}
 		args := search.Args{
-			Pattern: &search.PatternInfo{Pattern: "one", IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
+			Pattern: &search.PatternInfo{Pattern: "foo/one", IsRegExp: true, FileMatchLimit: 1, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
 			Repos:   repositories,
 			Query:   q,
 			Zoekt:   zoekt,

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -201,6 +201,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 // repoShouldBeAdded determines whether a repository should be included in the result set based on whether the repository fits in the subset
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
 func repoShouldBeAdded(ctx context.Context, zoekt *searchbackend.Zoekt, repo *search.RepositoryRevisions, pattern *search.PatternInfo) (bool, error) {
+	repos := []*search.RepositoryRevisions{repo}
 	rsta, err := reposToAdd(ctx, zoekt, repos, pattern)
 	if err != nil {
 		return false, err

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -221,4 +221,3 @@ func repoShouldBeAdded(ctx context.Context, zoekt *searchbackend.Zoekt, repo *se
 	}
 	return len(rsta) == 1, nil
 }
-

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -15,6 +15,7 @@ func TestSearchRepositories(t *testing.T) {
 	repositories := []*search.RepositoryRevisions{
 		{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
 		{Repo: &types.Repo{ID: 456, Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: &types.Repo{ID: 789, Name: "bar/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
 	}
 
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
@@ -25,8 +26,15 @@ func TestSearchRepositories(t *testing.T) {
 		case "foo/one":
 			return []*fileMatchResolver{
 				{
-					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
+					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					repo: &types.Repo{ID: 123},
+				},
+			}, &searchResultsCommon{}, nil
+		case "bar/one":
+			return []*fileMatchResolver{
+				{
+					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
+					repo: &types.Repo{ID: 789},
 				},
 			}, &searchResultsCommon{}, nil
 		case "foo/no-match":
@@ -35,6 +43,7 @@ func TestSearchRepositories(t *testing.T) {
 			return nil, &searchResultsCommon{}, errors.New("Unexpected repo")
 		}
 	}
+
 	t.Run("search for all repositories", func(t *testing.T) {
 		q, err := query.ParseAndCheck("type:repo")
 		if err != nil {
@@ -83,13 +92,13 @@ func TestSearchRepositories(t *testing.T) {
 		}
 	})
 
-	t.Run("search for all repositories where the repo name includes 'foo' and the repo has a file path matching 'one'", func(t *testing.T) {
-		q, err := query.ParseAndCheck("foo type:repo repohasfile:one")
+	t.Run("search for all repositories where the repo name includes 'foo' and the repo has a file path matching 'f.go'", func(t *testing.T) {
+		q, err := query.ParseAndCheck("foo type:repo repohasfile:f.go")
 		if err != nil {
 			t.Fatal(err)
 		}
 		args := search.Args{
-			Pattern: &search.PatternInfo{Pattern: "foo", IsRegExp: true, FileMatchLimit: 1, FilePatternsReposMustInclude: []string{"foo"}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
+			Pattern: &search.PatternInfo{Pattern: "foo", IsRegExp: true, FileMatchLimit: 1, FilePatternsReposMustInclude: []string{"f.go"}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true},
 			Repos:   repositories,
 			Query:   q,
 			Zoekt:   zoekt,
@@ -212,3 +221,4 @@ func repoShouldBeAdded(ctx context.Context, zoekt *searchbackend.Zoekt, repo *se
 	}
 	return len(rsta) == 1, nil
 }
+

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -861,7 +861,9 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 
 		for _, branch := range repo.Branches {
 			if branch.Name == "HEAD" {
+				rev.Lock()
 				rev.IndexedHEADCommit = api.CommitID(branch.Version)
+				rev.Unlock()
 				break
 			}
 		}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -631,7 +631,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 			}
 		}
 		repoRev := repoMap[api.RepoName(strings.ToLower(string(file.Repository)))]
-		repoRev.Lock()
+		repoRev.RLock()
 		matches[i] = &fileMatchResolver{
 			JPath:        file.FileName,
 			JLineMatches: lines,
@@ -640,7 +640,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 			repo:         repoRev.Repo,
 			commitID:     repoRev.IndexedHEADCommit,
 		}
-		repoRev.Unlock()
+		repoRev.RUnlock()
 	}
 
 	return matches, limitHit, reposLimitHit, nil

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -631,6 +631,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 			}
 		}
 		repoRev := repoMap[api.RepoName(strings.ToLower(string(file.Repository)))]
+		repoRev.Lock()
 		matches[i] = &fileMatchResolver{
 			JPath:        file.FileName,
 			JLineMatches: lines,
@@ -639,6 +640,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 			repo:         repoRev.Repo,
 			commitID:     repoRev.IndexedHEADCommit,
 		}
+		repoRev.Unlock()
 	}
 
 	return matches, limitHit, reposLimitHit, nil

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -631,16 +631,14 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 			}
 		}
 		repoRev := repoMap[api.RepoName(strings.ToLower(string(file.Repository)))]
-		repoRev.RLock()
 		matches[i] = &fileMatchResolver{
 			JPath:        file.FileName,
 			JLineMatches: lines,
 			JLimitHit:    fileLimitHit,
 			uri:          fileMatchURI(repoRev.Repo.Name, "", file.FileName),
 			repo:         repoRev.Repo,
-			commitID:     repoRev.IndexedHEADCommit,
+			commitID:     repoRev.IndexedHEADCommit(),
 		}
-		repoRev.RUnlock()
 	}
 
 	return matches, limitHit, reposLimitHit, nil
@@ -863,9 +861,7 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 
 		for _, branch := range repo.Branches {
 			if branch.Name == "HEAD" {
-				rev.Lock()
-				rev.IndexedHEADCommit = api.CommitID(branch.Version)
-				rev.Unlock()
+				rev.SetIndexedHEADCommit(api.CommitID(branch.Version))
 				break
 			}
 		}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -377,6 +377,10 @@ func (ss *fakeSearcher) List(ctx context.Context, q zoektquery.Q) (*zoekt.RepoLi
 	return ss.repos, nil
 }
 
+func (ss *fakeSearcher) String() string {
+	return fmt.Sprintf("fakeSearcher(result = %v, repos = %v)", ss.result, ss.repos)
+}
+
 type errorSearcher struct {
 	err error
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -405,12 +405,9 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		since           func(time.Time) time.Duration
 	}
 
-	singleRepositoryRevisions := []*search.RepositoryRevisions{
-		{
-			Repo:              &types.Repo{},
-			IndexedHEADCommit: "abc",
-		},
-	}
+	rr := &search.RepositoryRevisions{Repo:&types.Repo{}}
+	rr.SetIndexedHEADCommit("abc")
+	singleRepositoryRevisions := []*search.RepositoryRevisions{ rr }
 
 	tests := []struct {
 		name              string
@@ -686,7 +683,7 @@ func Test_zoektIndexedRepos(t *testing.T) {
 		var indexed []*search.RepositoryRevisions
 		for _, r := range repos {
 			rev := *r
-			rev.IndexedHEADCommit = "deadbeef"
+			rev.SetIndexedHEADCommit("deadbeef")
 			indexed = append(indexed, &rev)
 		}
 		return indexed

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -405,9 +405,9 @@ func Test_zoektSearchHEAD(t *testing.T) {
 		since           func(time.Time) time.Duration
 	}
 
-	rr := &search.RepositoryRevisions{Repo:&types.Repo{}}
+	rr := &search.RepositoryRevisions{Repo: &types.Repo{}}
 	rr.SetIndexedHEADCommit("abc")
-	singleRepositoryRevisions := []*search.RepositoryRevisions{ rr }
+	singleRepositoryRevisions := []*search.RepositoryRevisions{rr}
 
 	tests := []struct {
 		name              string

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/search/query"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // RevisionSpecifier represents either a revspec or a ref glob. At most one
@@ -62,14 +63,19 @@ type RepositoryRevisions struct {
 	// It is written to by zoektIndexedRepos and read later by zoektSearchHEAD.
 	// See https://github.com/sourcegraph/sourcegraph/pull/4702 for the performance
 	// rationale.
+	mu sync.Mutex
 	indexedHEADCommit api.CommitID
 }
 
 func (r *RepositoryRevisions) IndexedHEADCommit() api.CommitID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.indexedHEADCommit
 }
 
 func (r *RepositoryRevisions) SetIndexedHEADCommit(ihc api.CommitID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.indexedHEADCommit = ihc
 }
 

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -3,6 +3,7 @@ package search
 import (
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	dbquery "github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
@@ -57,6 +58,8 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
+	sync.Mutex
+
 	Repo *types.Repo
 	Revs []RevisionSpecifier
 	// IndexedHEADCommit contains the HEAD Git commit indexed by Zoekt.

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -58,7 +58,7 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
-	sync.Mutex
+	sync.RWMutex
 
 	Repo *types.Repo
 	Revs []RevisionSpecifier

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -1,16 +1,14 @@
 package search
 
 import (
-	"regexp"
-	"strings"
-	"sync"
-
 	"github.com/pkg/errors"
 	dbquery "github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"github.com/sourcegraph/sourcegraph/pkg/search/query"
+	"regexp"
+	"strings"
 )
 
 // RevisionSpecifier represents either a revspec or a ref glob. At most one
@@ -58,15 +56,21 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
-	sync.RWMutex
-
 	Repo *types.Repo
 	Revs []RevisionSpecifier
 	// IndexedHEADCommit contains the HEAD Git commit indexed by Zoekt.
 	// It is written to by zoektIndexedRepos and read later by zoektSearchHEAD.
 	// See https://github.com/sourcegraph/sourcegraph/pull/4702 for the performance
 	// rationale.
-	IndexedHEADCommit api.CommitID
+	indexedHEADCommit api.CommitID
+}
+
+func (r *RepositoryRevisions) IndexedHEADCommit() api.CommitID {
+	return r.indexedHEADCommit
+}
+
+func (r *RepositoryRevisions) SetIndexedHEADCommit(ihc api.CommitID) {
+	r.indexedHEADCommit = ihc
 }
 
 // ParseRepositoryRevisions parses strings that refer to a repository and 0

--- a/cmd/frontend/internal/pkg/search/repo_revs.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs.go
@@ -1,15 +1,16 @@
 package search
 
 import (
+	"regexp"
+	"strings"
+	"sync"
+
 	"github.com/pkg/errors"
 	dbquery "github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/gitserver"
 	"github.com/sourcegraph/sourcegraph/pkg/search/query"
-	"regexp"
-	"strings"
-	"sync"
 )
 
 // RevisionSpecifier represents either a revspec or a ref glob. At most one
@@ -63,7 +64,7 @@ type RepositoryRevisions struct {
 	// It is written to by zoektIndexedRepos and read later by zoektSearchHEAD.
 	// See https://github.com/sourcegraph/sourcegraph/pull/4702 for the performance
 	// rationale.
-	mu sync.Mutex
+	mu                sync.Mutex
 	indexedHEADCommit api.CommitID
 }
 

--- a/cmd/frontend/internal/pkg/search/repo_revs_test.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs_test.go
@@ -176,6 +176,8 @@ func TestRepoQuery(t *testing.T) {
 }
 
 func TestRepositoryRevisions(t *testing.T) {
+
+	// This test has to be run with -race to be effective.
 	t.Run("concurrent access to indexedHEADCommit", func(t *testing.T) {
 		rr := &RepositoryRevisions{}
 		var wg sync.WaitGroup

--- a/cmd/frontend/internal/pkg/search/repo_revs_test.go
+++ b/cmd/frontend/internal/pkg/search/repo_revs_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	dbquery "github.com/sourcegraph/sourcegraph/cmd/frontend/db/query"
@@ -172,4 +173,21 @@ func TestRepoQuery(t *testing.T) {
 			t.Errorf("RepoQuery(%q):\ngot  %s\nwant %s", qStr, got, want)
 		}
 	}
+}
+
+func TestRepositoryRevisions(t *testing.T) {
+	t.Run("concurrent access to indexedHEADCommit", func(t *testing.T) {
+		rr := &RepositoryRevisions{}
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			rr.SetIndexedHEADCommit("")
+		}()
+		go func() {
+			defer wg.Done()
+			_ = rr.IndexedHEADCommit()
+		}()
+		wg.Wait()
+	})
 }

--- a/web/src/e2e/regression.test.tsx
+++ b/web/src/e2e/regression.test.tsx
@@ -187,12 +187,9 @@ describe('regression test suite', () => {
             },
             5 * 1000
         )
-        test(
-            'Perform global text search for "repohasfile:copying", expect many results.',
-            async () => {
-                await driver.page.goto(baseURL + '/search?q=repohasfile:copying')
-                await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 10)
-            }
-        )
+        test('Perform global text search for "repohasfile:copying", expect many results.', async () => {
+            await driver.page.goto(baseURL + '/search?q=repohasfile:copying')
+            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 10)
+        })
     })
 })

--- a/web/src/e2e/regression.test.tsx
+++ b/web/src/e2e/regression.test.tsx
@@ -187,5 +187,12 @@ describe('regression test suite', () => {
             },
             5 * 1000
         )
+        test(
+            'Perform global text search for "repohasfile:copying", expect many results.',
+            async () => {
+                await driver.page.goto(baseURL + '/search?q=repohasfile:copying')
+                await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 10)
+            }
+        )
     })
 })

--- a/web/src/e2e/regression.test.tsx
+++ b/web/src/e2e/regression.test.tsx
@@ -187,9 +187,13 @@ describe('regression test suite', () => {
             },
             5 * 1000
         )
-        test('Perform global text search for "repohasfile:copying", expect many results.', async () => {
-            await driver.page.goto(baseURL + '/search?q=repohasfile:copying')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 10)
-        })
+        test(
+            'Perform global text search for "repohasfile:copying", expect many results.',
+            async () => {
+                await driver.page.goto(baseURL + '/search?q=repohasfile:copying')
+                await driver.page.waitForFunction(() => document.querySelectorAll('.e2e-search-result').length > 10)
+            },
+            5 * 1000
+        )
     })
 })


### PR DESCRIPTION
Fixes #4833, reducing latency for queries with `repohasfile:`.

Before this change, the frontend was making one RPC to zoekt per repo to check if it had a file matching the `repohasfile:` pattern. After this change, the frontend makes a single RPC to find all the repos with files matching the pattern. 

Test plan: reuse existing unit tests for `repoShouldBeAdded` by retrofitting.

The images here show a 7x speedup on this query running on a local instance with 60 repositories:

Before:
<img width="449" alt="Screen Shot 2019-08-13 at 7 40 56 PM" src="https://user-images.githubusercontent.com/15530/62990865-5d894500-be02-11e9-811a-05d2d54553fb.png">

After:
<img width="471" alt="Screen Shot 2019-08-13 at 7 39 27 PM" src="https://user-images.githubusercontent.com/15530/62990859-5a8e5480-be02-11e9-83f1-3cf565e7f807.png">


