### PR TITLE
Reduce icon size so all cards are same size

### DIFF
--- a/web/src/extensions/ExtensionCard.scss
+++ b/web/src/extensions/ExtensionCard.scss
@@ -7,8 +7,8 @@
     }
 
     &__icon {
-        width: 6rem;
-        height: 6rem;
+        width: 3rem;
+        height: 3rem;
         object-fit: contain;
     }
 


### PR DESCRIPTION
This makes it so that icons in the extension registry fit within the standard size of the extension cards, and all cards are the same. 

Before:
![image](https://user-images.githubusercontent.com/1559622/62987622-8eaf4880-bdf5-11e9-819d-ccd46132bc7b.png)

After:
![image](https://user-images.githubusercontent.com/1559622/62987646-a38bdc00-bdf5-11e9-9ce3-ff726c359499.png)
