### PR TITLE
Bump server startup timeout in CI from 30s to 60s

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -44,13 +44,13 @@ docker exec "$CONTAINER" apk add --no-cache socat
 socat tcp-listen:7080,reuseaddr,fork system:"docker exec -i $CONTAINER socat stdio 'tcp:localhost:7080'" &
 
 set +e
-timeout 30s bash -c "until curl --output /dev/null --silent --head --fail $URL; do
+timeout 60s bash -c "until curl --output /dev/null --silent --head --fail $URL; do
     echo Waiting 5s for $URL...
     sleep 5
 done"
 if [ $? -ne 0 ]; then
     echo "^^^ +++"
-    echo "$URL was not accessible within 30s. Here's the output of docker inspect and docker logs:"
+    echo "$URL was not accessible within 60s. Here's the output of docker inspect and docker logs:"
     docker inspect "$CONTAINER"
     docker logs --timestamps "$CONTAINER"
     exit 1


### PR DESCRIPTION
@kevin noticed CI was consistently failing for him on https://github.com/sourcegraph/sourcegraph/pull/5192

It looks like other PRs are also hitting the 30s timeout: https://buildkite.com/sourcegraph/sourcegraph/builds/41048#596d2110-90b6-43ea-942c-4221a022b633/77-109

And when the timeout is not exceeded, it usually takes ~20s

I'm recommending we bump the timeout to 1 minute now, and investigate what's taking so long in the future when the 1 minute timeout starts getting exceeded

See https://sourcegraph.slack.com/archives/C07KZF47K/p1565820787198000