### PR TITLE
Add e2e test for highlighting correct line on symbol navigation.

### DIFF
--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -596,16 +596,16 @@ describe('e2e test suite', () => {
                 },
             ]
 
-            for (const highlightSymbolTest of highlightSymbolTests) {
-                test(highlightSymbolTest.name, async () => {
-                    await driver.page.goto(baseURL + highlightSymbolTest.filePath)
+            for (const { name, filePath } of highlightSymbolTests) {
+                test(name, async () => {
+                    await driver.page.goto(baseURL + filePath)
 
                     await (await driver.page.waitForSelector('[data-e2e-tab="symbols"]')).click()
 
                     await driver.page.waitForSelector('.e2e-symbol-name', { visible: true })
 
                     let evaluated = false
-                    for await (const selector of await driver.page.$$('.e2e-symbol-link')) {
+                    for (const selector of await driver.page.$$('.e2e-symbol-link')) {
                         const href = await (await selector.getProperty('href')).jsonValue()
                         const line = href.match(/#L(\d+):\d+-\d+:\d+$/)[1]
                         await selector.click()

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -611,11 +611,7 @@ describe('e2e test suite', () => {
                     await driver.page.waitForSelector('.e2e-blob .selected .line')
                     const selectedLineNumber = await driver.page.evaluate(() => {
                         const elem = document.querySelector<HTMLElement>('.e2e-blob .selected .line')
-                        if (!elem || !elem.dataset.line) {
-                            return 0
-                        }
-
-                        return parseInt(elem.dataset.line, 10)
+                        return elem && elem.dataset.line && parseInt(elem.dataset.line, 10)
                     })
 
                     expect(selectedLineNumber).toEqual(line)

--- a/web/src/e2e/index.e2e.test.tsx
+++ b/web/src/e2e/index.e2e.test.tsx
@@ -606,11 +606,16 @@ describe('e2e test suite', () => {
                     await (await driver.page.waitForSelector('[data-e2e-tab="symbols"]')).click()
                     await driver.page.waitForSelector('.e2e-symbol-name', { visible: true })
                     await driver.page.click(`.filtered-connection__nodes li:nth-child(${index + 1}) a`)
-                    const selectedLine = await driver.page.waitForSelector('.e2e-blob .selected .line')
-                    const selectedLineNumber = await driver.page.evaluate(
-                        e => parseInt(e.getAttribute('data-line')),
-                        selectedLine
-                    )
+
+                    await driver.page.waitForSelector('.e2e-blob .selected .line')
+                    const selectedLineNumber = await driver.page.evaluate(() => {
+                        const elem = document.querySelector<HTMLElement>('.e2e-blob .selected .line')
+                        if (!elem || !elem.dataset.line) {
+                            return 0
+                        }
+
+                        return parseInt(elem.dataset.line, 10)
+                    })
 
                     expect(selectedLineNumber).toEqual(line)
                 })


### PR DESCRIPTION
Covers a superset of 7.4.2 on the test grid.