### PR TITLE
server: redirect Grafana + Prometheus output to seperate logfile

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -150,8 +150,8 @@ func Main() {
 		`github-proxy: github-proxy`,
 		`repo-updater: repo-updater`,
 		`syntect_server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,
-		`prometheus: prometheus -config.file=/etc/prometheus/prometheus_local.yml  -storage.local.path=/var/opt/sourcegraph/prometheus -web.console.libraries=/etc/prometheus/console_libraries  -web.console.templates=/etc/prometheus/consoles`,
-		`grafana: env GF_AUTH_ANONYMOUS_ENABLED=true GF_AUTH_ANONYMOUS_ORG_NAME=Sourcegraph GF_AUTH_ANONYMOUS_ORG_ROLE=Editor GF_USERS_ALLOW_SIGN_UP=false GF_USERS_AUTO_ASSIGN_ORG=true GF_USERS_AUTO_ASSIGN_ORG_ROLE=Editor /usr/share/grafana/bin/grafana-server -config /etc/grafana/grafana-single-container.ini -homepath /usr/share/grafana`,
+		`prometheus: prometheus -config.file=/etc/prometheus/prometheus_local.yml  -storage.local.path=/var/opt/sourcegraph/prometheus -web.console.libraries=/etc/prometheus/console_libraries  -web.console.templates=/etc/prometheus/consoles >> /var/opt/sourcegraph/prometheus.log 2>&1`,
+		`grafana: env GF_AUTH_ANONYMOUS_ENABLED=true GF_AUTH_ANONYMOUS_ORG_NAME=Sourcegraph GF_AUTH_ANONYMOUS_ORG_ROLE=Editor GF_USERS_ALLOW_SIGN_UP=false GF_USERS_AUTO_ASSIGN_ORG=true GF_USERS_AUTO_ASSIGN_ORG_ROLE=Editor /usr/share/grafana/bin/grafana-server -config /etc/grafana/grafana-single-container.ini -homepath /usr/share/grafana >> /var/opt/sourcegraph/grafana.log 2>&1`,
 	}
 	procfile = append(procfile, ProcfileAdditions...)
 


### PR DESCRIPTION
This redirects Grafana and Prometheus log output to a seperate logfile,
located at (host / container):

- `~/.sourcegraph/data/grafana.log` / `/var/opt/sourcegraph/grafana.log`
- `~/.sourcegraph/data/prometheus.log` / `/var/opt/sourcegraph/prometheus.log`

The main benefit of doing this is that we separate auxiliary service logs
(which are verbose, and won't usually be helpful to us/customers) from app logs
(which customers should look at / inspect, etc.)

Fixes #5221



<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: <!-- Required: What is the test plan for this change? -->
