### PR TITLE
authz: Bitbucket Server Permissions store fixes

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -37,6 +37,8 @@ func BenchmarkStore(b *testing.B) {
 	b.Run("ttl=0", func(b *testing.B) {
 		ttl := time.Duration(0)
 		s := newStore(db, ttl, clock, newCache())
+		s.block = true
+
 		ps := &Permissions{
 			UserID: 99,
 			Perm:   authz.Read,
@@ -54,6 +56,8 @@ func BenchmarkStore(b *testing.B) {
 	b.Run("ttl=60s/no-in-memory-cache", func(b *testing.B) {
 		ttl := 60 * time.Second
 		s := newStore(db, ttl, clock, nil)
+		s.block = true
+
 		ps := &Permissions{
 			UserID: 99,
 			Perm:   authz.Read,
@@ -71,6 +75,8 @@ func BenchmarkStore(b *testing.B) {
 	b.Run("ttl=60s/in-memory-cache", func(b *testing.B) {
 		ttl := 60 * time.Second
 		s := newStore(db, ttl, clock, newCache())
+		s.block = true
+
 		ps := &Permissions{
 			UserID: 99,
 			Perm:   authz.Read,


### PR DESCRIPTION
This PR is a follow up to #5180 that fixes two things:

1. A test flake that manifested when more than one process acquired the
lock (i.e. one after then other, not simultaneously), others
would detect that the first had already updated permissions and would
return early, which resulted in an update being sent to the updates
channel, which wasn't intended.

2. Replacing the cast function with a simple `int32` conversion.

