### PR TITLE
Fix nil panic in concurrentFind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Added a check to prevent a nil panic. [#5246](https://github.com/sourcegraph/sourcegraph/issues/5246)
+- Fix some logic to prevent a nil panic. [#5246](https://github.com/sourcegraph/sourcegraph/issues/5246)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Added a check to prevent a nil panic. [#5246](https://github.com/sourcegraph/sourcegraph/issues/5246)
+
 ### Removed
 
 ## 3.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Fix some logic to prevent a nil panic. [#5246](https://github.com/sourcegraph/sourcegraph/issues/5246)
+- Fixed an issue where search would sometimes crash with a panic due to a nil pointer. [#5246](https://github.com/sourcegraph/sourcegraph/issues/5246)
 
 ### Removed
 

--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -354,7 +354,7 @@ func concurrentFind(ctx context.Context, rg *readerGrep, zf *store.ZipFile, file
 		matches   = []protocol.FileMatch{}
 	)
 
-	if rg.re == nil || patternMatchesPaths || !patternMatchesContent {
+	if rg.re == nil || (patternMatchesPaths && !patternMatchesContent) {
 		// Fast path for only matching file paths (or with a nil pattern, which matches all files,
 		// so is effectively matching only on file paths).
 		for _, f := range files {

--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -354,7 +354,7 @@ func concurrentFind(ctx context.Context, rg *readerGrep, zf *store.ZipFile, file
 		matches   = []protocol.FileMatch{}
 	)
 
-	if patternMatchesPaths && (!patternMatchesContent || rg.re == nil) {
+	if rg.re == nil || patternMatchesPaths || !patternMatchesContent {
 		// Fast path for only matching file paths (or with a nil pattern, which matches all files,
 		// so is effectively matching only on file paths).
 		for _, f := range files {

--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/pathmatch"
 	"github.com/sourcegraph/sourcegraph/pkg/store"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 )
@@ -303,6 +303,12 @@ func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []
 
 // FindZip is a convenience function to run Find on f.
 func (rg *readerGrep) FindZip(zf *store.ZipFile, f *store.SrcFile) (protocol.FileMatch, error) {
+	if rg.re == nil {
+		return protocol.FileMatch{
+			Path:     f.Name,
+			LimitHit: false,
+		}, nil
+	}
 	lm, limitHit, err := rg.Find(zf, f)
 	return protocol.FileMatch{
 		Path:        f.Name,

--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/pathmatch"
 	"github.com/sourcegraph/sourcegraph/pkg/store"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 )
@@ -303,12 +303,6 @@ func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []
 
 // FindZip is a convenience function to run Find on f.
 func (rg *readerGrep) FindZip(zf *store.ZipFile, f *store.SrcFile) (protocol.FileMatch, error) {
-	if rg.re == nil {
-		return protocol.FileMatch{
-			Path:     f.Name,
-			LimitHit: false,
-		}, nil
-	}
 	lm, limitHit, err := rg.Find(zf, f)
 	return protocol.FileMatch{
 		Path:        f.Name,

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -586,7 +586,9 @@ func Test_readerGrep_FindZip(t *testing.T) {
 				},
 				zf: &store.ZipFile{},
 			},
-			want: protocol.FileMatch{},
+			want: protocol.FileMatch{
+				Path: "foo.go",
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -14,9 +14,8 @@ import (
 	"testing/iotest"
 	"testing/quick"
 
-	"github.com/sourcegraph/sourcegraph/pkg/pathmatch"
-
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
+	"github.com/sourcegraph/sourcegraph/pkg/pathmatch"
 	"github.com/sourcegraph/sourcegraph/pkg/store"
 	"github.com/sourcegraph/sourcegraph/pkg/testutil"
 )

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -590,7 +590,7 @@ func Test_concurrentFind(t *testing.T) {
 						},
 					},
 				},
-				patternMatchesPaths: false,
+				patternMatchesPaths:   false,
 				patternMatchesContent: true,
 			},
 			wantFm: []protocol.FileMatch{
@@ -616,4 +616,3 @@ func Test_concurrentFind(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -584,7 +584,6 @@ func Test_concurrentFind(t *testing.T) {
 					matchPath: match,
 				},
 				zf: &store.ZipFile{
-					Data: []byte("the quick brown fox"),
 					Files: []store.SrcFile{
 						{
 							Name: "a.go",

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"github.com/sourcegraph/sourcegraph/pkg/pathmatch"
 	"os"
 	"reflect"
 	"regexp"
@@ -14,6 +13,8 @@ import (
 	"testing"
 	"testing/iotest"
 	"testing/quick"
+
+	"github.com/sourcegraph/sourcegraph/pkg/pathmatch"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/pkg/store"

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -609,3 +609,68 @@ func Test_readerGrep_FindZip(t *testing.T) {
 		})
 	}
 }
+
+func Test_concurrentFind(t *testing.T) {
+	match, err := pathmatch.CompilePathPatterns([]string{`a\.go`}, `README\.md`, pathmatch.CompileOptions{RegExp: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	type args struct {
+		ctx                   context.Context
+		rg                    *readerGrep
+		zf                    *store.ZipFile
+		fileMatchLimit        int
+		patternMatchesContent bool
+		patternMatchesPaths   bool
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantFm       []protocol.FileMatch
+		wantLimitHit bool
+		wantErr      bool
+	}{
+		{
+			name: "nil re returns a FileMatch with no LineMatches",
+			args: args{
+				ctx: context.Background(),
+				rg: &readerGrep{
+					// Check this case specifically.
+					re:        nil,
+					matchPath: match,
+				},
+				zf: &store.ZipFile{
+					Data: []byte("the quick brown fox"),
+					Files: []store.SrcFile{
+						{
+							Name: "a.go",
+						},
+					},
+				},
+				patternMatchesPaths: false,
+				patternMatchesContent: true,
+			},
+			wantFm: []protocol.FileMatch{
+				{
+					Path: "a.go",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFm, gotLimitHit, err := concurrentFind(tt.args.ctx, tt.args.rg, tt.args.zf, tt.args.fileMatchLimit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("concurrentFind() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotFm, tt.wantFm) {
+				t.Errorf("concurrentFind() gotFm = %v, want %v", gotFm, tt.wantFm)
+			}
+			if gotLimitHit != tt.wantLimitHit {
+				t.Errorf("concurrentFind() gotLimitHit = %v, want %v", gotLimitHit, tt.wantLimitHit)
+			}
+		})
+	}
+}
+

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -554,62 +554,6 @@ func init() {
 	os.RemoveAll(githubStore.Path)
 }
 
-func Test_readerGrep_FindZip(t *testing.T) {
-	type fields struct {
-		re               *regexp.Regexp
-		ignoreCase       bool
-		transformBuf     []byte
-		matchPath        pathmatch.PathMatcher
-		literalSubstring []byte
-	}
-	type args struct {
-		zf *store.ZipFile
-		f  *store.SrcFile
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    protocol.FileMatch
-		wantErr bool
-	}{
-		{
-			name: "nil re returns a FileMatch with no LineMatches",
-			fields: fields{
-				// Just calling this out explicitly.
-				// This field can be nil.
-				re: nil,
-			},
-			args: args{
-				f: &store.SrcFile{
-					Name: "foo.go",
-				},
-				zf: &store.ZipFile{},
-			},
-			want: protocol.FileMatch{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rg := &readerGrep{
-				re:               tt.fields.re,
-				ignoreCase:       tt.fields.ignoreCase,
-				transformBuf:     tt.fields.transformBuf,
-				matchPath:        tt.fields.matchPath,
-				literalSubstring: tt.fields.literalSubstring,
-			}
-			got, err := rg.FindZip(tt.args.zf, tt.args.f)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("FindZip() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FindZip() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_concurrentFind(t *testing.T) {
 	match, err := pathmatch.CompilePathPatterns([]string{`a\.go`}, `README\.md`, pathmatch.CompileOptions{RegExp: true})
 	if err != nil {

--- a/cmd/searcher/search/matcher_test.go
+++ b/cmd/searcher/search/matcher_test.go
@@ -586,9 +586,7 @@ func Test_readerGrep_FindZip(t *testing.T) {
 				},
 				zf: &store.ZipFile{},
 			},
-			want: protocol.FileMatch{
-				Path: "foo.go",
-			},
+			want: protocol.FileMatch{},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #5246 

This PR makes sure that if the `re` field of the `readerGrep` is `nil` in `concurrentFind` then `FindZip` will not be called, preventing the nil panic reported in the issue.

Test plan: Added a unit test that reproduces the nil panic.
