### PR TITLE
use sinon 7.4.1 because 7.4.0 was force-unpublished from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "shelljs": "^0.8.3",
     "signale": "^1.4.0",
     "simmerjs": "^0.5.6",
-    "sinon": "^7.4.0",
+    "sinon": "^7.4.1",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
     "style-loader": "^0.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15482,10 +15482,10 @@ simplebar@^4.0.0:
     resize-observer-polyfill "^1.5.1"
     scrollbarwidth "^0.1.3"
 
-sinon@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.npmjs.org/sinon/-/sinon-7.4.0.tgz#1e0c12538aa2170a3a98467d112cf361c7ade8a8"
-  integrity sha512-Els0KRgijhuHz9qEyzUFmZtpS1kuj6CMwyKdyWyPW1dnYGOcwqdqFp95u7fcLJbuga/SrVYGxaqCY3JPWMOJAQ==
+sinon@^7.4.1:
+  version "7.4.1"
+  resolved "https://registry.npmjs.org/sinon/-/sinon-7.4.1.tgz#bcd0c63953893e87fa0cc502f52489c32a83d4d9"
+  integrity sha512-7s9buHGHN/jqoy/v4bJgmt0m1XEkCEd/tqdHXumpBp0JSujaT4Ng84JU5wDdK4E85ZMq78NuDe0I3NAqXY8TFg==
   dependencies:
     "@sinonjs/commons" "^1.4.0"
     "@sinonjs/formatio" "^3.2.1"


### PR DESCRIPTION
Fixes the following error when running `yarn`:

```
error An unexpected error occurred: "https://registry.npmjs.org/sinon/-/sinon-7.4.0.tgz: Request failed \"404 Not Found\"".
```

I see no 7.4.0 at https://github.com/sinonjs/sinon/releases, and it was confirmed unpublished at https://github.com/sinonjs/sinon/issues/2071#issuecomment-518213768.