### PR TITLE
refactor: export more things from graphqlbackend to support separating into multiple packages

### DIFF
--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -42,7 +42,7 @@ type args struct {
 
 // codemodResultResolver is a resolver for the GraphQL type `CodemodResult`
 type codemodResultResolver struct {
-	commit  *gitCommitResolver
+	commit  *GitCommitResolver
 	path    string
 	fileURL string
 	diff    string
@@ -306,7 +306,7 @@ func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions
 			return nil, err
 		}
 		result := codemodResultResolver{
-			commit: &gitCommitResolver{
+			commit: &GitCommitResolver{
 				repo:     &repositoryResolver{repo: repoRevs.Repo},
 				inputRev: &repoRevs.Revs[0].RevSpec,
 			},

--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -49,7 +49,7 @@ type codemodResultResolver struct {
 	matches []*searchResultMatchResolver
 }
 
-func (r *codemodResultResolver) ToRepository() (*repositoryResolver, bool) { return nil, false }
+func (r *codemodResultResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
 func (r *codemodResultResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
 func (r *codemodResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
@@ -307,7 +307,7 @@ func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions
 		}
 		result := codemodResultResolver{
 			commit: &GitCommitResolver{
-				repo:     &repositoryResolver{repo: repoRevs.Repo},
+				repo:     &RepositoryResolver{repo: repoRevs.Repo},
 				inputRev: &repoRevs.Revs[0].RevSpec,
 			},
 			path:    raw.URI,

--- a/cmd/frontend/graphqlbackend/discussion_threads.go
+++ b/cmd/frontend/graphqlbackend/discussion_threads.go
@@ -465,7 +465,7 @@ func (r *discussionThreadTargetRepoResolver) RelativePath(ctx context.Context, a
 	} else if r.t.Branch != nil {
 		rev = *r.t.Branch
 	}
-	comparison, err := repo.Comparison(ctx, &repositoryComparisonInput{
+	comparison, err := repo.Comparison(ctx, &RepositoryComparisonInput{
 		Base: &rev,
 		Head: &args.Rev,
 	})

--- a/cmd/frontend/graphqlbackend/discussion_threads.go
+++ b/cmd/frontend/graphqlbackend/discussion_threads.go
@@ -38,7 +38,7 @@ type discussionThreadTargetRepoSelectionInput struct {
 
 // discussionsResolveRepository resolves the repository given an ID, name, or
 // git clone URL. Only one must be specified, or else this function will panic.
-func discussionsResolveRepository(ctx context.Context, id *graphql.ID, name, gitCloneURL *string) (*repositoryResolver, error) {
+func discussionsResolveRepository(ctx context.Context, id *graphql.ID, name, gitCloneURL *string) (*RepositoryResolver, error) {
 	switch {
 	case id != nil:
 		return repositoryByID(ctx, *id)
@@ -145,7 +145,7 @@ func (d *discussionThreadTargetRepoInput) validate() error {
 // d.LinesAfter fields by pulling the information directly from the repository.
 //
 // Precondition: d.Selection != nil && d.validate() == nil
-func (d *discussionThreadTargetRepoInput) populateLinesFromRepository(ctx context.Context, repo *repositoryResolver) error {
+func (d *discussionThreadTargetRepoInput) populateLinesFromRepository(ctx context.Context, repo *RepositoryResolver) error {
 	if d.Selection == nil {
 		panic("precondition failed")
 	}
@@ -401,7 +401,7 @@ type discussionThreadTargetRepoResolver struct {
 	t *types.DiscussionThreadTargetRepo
 }
 
-func (r *discussionThreadTargetRepoResolver) Repository(ctx context.Context) (*repositoryResolver, error) {
+func (r *discussionThreadTargetRepoResolver) Repository(ctx context.Context) (*RepositoryResolver, error) {
 	return repositoryByIDInt32(ctx, r.t.RepoID)
 }
 

--- a/cmd/frontend/graphqlbackend/discussion_threads.go
+++ b/cmd/frontend/graphqlbackend/discussion_threads.go
@@ -407,15 +407,15 @@ func (r *discussionThreadTargetRepoResolver) Repository(ctx context.Context) (*r
 
 func (r *discussionThreadTargetRepoResolver) Path() *string { return r.t.Path }
 
-func (r *discussionThreadTargetRepoResolver) Branch(ctx context.Context) (*gitRefResolver, error) {
+func (r *discussionThreadTargetRepoResolver) Branch(ctx context.Context) (*GitRefResolver, error) {
 	return r.branchOrRevision(ctx, r.t.Branch)
 }
 
-func (r *discussionThreadTargetRepoResolver) Revision(ctx context.Context) (*gitRefResolver, error) {
+func (r *discussionThreadTargetRepoResolver) Revision(ctx context.Context) (*GitRefResolver, error) {
 	return r.branchOrRevision(ctx, r.t.Revision)
 }
 
-func (r *discussionThreadTargetRepoResolver) branchOrRevision(ctx context.Context, rev *string) (*gitRefResolver, error) {
+func (r *discussionThreadTargetRepoResolver) branchOrRevision(ctx context.Context, rev *string) (*GitRefResolver, error) {
 	if rev == nil {
 		return nil, nil
 	}
@@ -423,7 +423,7 @@ func (r *discussionThreadTargetRepoResolver) branchOrRevision(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	return &gitRefResolver{repo: repo, name: *rev}, nil
+	return &GitRefResolver{repo: repo, name: *rev}, nil
 }
 
 func (r *discussionThreadTargetRepoResolver) Selection() *discussionThreadTargetRepoSelectionResolver {

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -56,7 +56,7 @@ func (r *externalAccountResolver) RefreshURL() *string {
 	return nil
 }
 
-func (r *externalAccountResolver) AccountData(ctx context.Context) (*jsonValue, error) {
+func (r *externalAccountResolver) AccountData(ctx context.Context) (*JSONValue, error) {
 	// 🚨 SECURITY: Only the site admins can view this information, because the auth provider might
 	// provide sensitive information that is not known to the user.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
@@ -64,7 +64,7 @@ func (r *externalAccountResolver) AccountData(ctx context.Context) (*jsonValue, 
 	}
 
 	if r.account.AccountData != nil {
-		return &jsonValue{value: r.account.AccountData}, nil
+		return &JSONValue{value: r.account.AccountData}, nil
 	}
 	return nil, nil
 }

--- a/cmd/frontend/graphqlbackend/git.go
+++ b/cmd/frontend/graphqlbackend/git.go
@@ -26,7 +26,7 @@ type GitResolver interface {
 type GitCreateRefFromPatchInput struct {
 	Repository graphql.ID
 	Name       string
-	BaseCommit gitObjectID
+	BaseCommit GitObjectID
 	Patch      string
 }
 

--- a/cmd/frontend/graphqlbackend/git.go
+++ b/cmd/frontend/graphqlbackend/git.go
@@ -1,0 +1,35 @@
+package graphqlbackend
+
+import (
+	"context"
+	"errors"
+
+	graphql "github.com/graph-gophers/graphql-go"
+)
+
+// Git is the implementation of the GraphQL type GitMutation. If it is not set at runtime, a "not
+// implemented" error is returned to API clients who invoke it.
+var Git GitResolver
+
+func (schemaResolver) Git() (GitResolver, error) {
+	if Git == nil {
+		return nil, errors.New("git is not implemented")
+	}
+	return Git, nil
+}
+
+// GitResolver is the interface for the GraphQL type GitMutation.
+type GitResolver interface {
+	CreateRefFromPatch(context.Context, *struct{ Input GitCreateRefFromPatchInput }) (GitCreateRefFromPatchPayload, error)
+}
+
+type GitCreateRefFromPatchInput struct {
+	Repository graphql.ID
+	Name       string
+	BaseCommit gitObjectID
+	Patch      string
+}
+
+type GitCreateRefFromPatchPayload interface {
+	Ref(ctx context.Context) (*GitRefResolver, error)
+}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -28,7 +28,7 @@ func gitCommitByID(ctx context.Context, id graphql.ID) (*GitCommitResolver, erro
 }
 
 type GitCommitResolver struct {
-	repo *repositoryResolver
+	repo *RepositoryResolver
 
 	// inputRev is the Git revspec that the user originally requested that resolved to this Git commit. It is used
 	// to avoid redirecting a user browsing a revision "mybranch" to the absolute commit ID as they follow links in the UI.
@@ -43,7 +43,7 @@ type GitCommitResolver struct {
 	parents   []api.CommitID
 }
 
-func toGitCommitResolver(repo *repositoryResolver, commit *git.Commit) *GitCommitResolver {
+func toGitCommitResolver(repo *RepositoryResolver, commit *git.Commit) *GitCommitResolver {
 	authorResolver := toSignatureResolver(&commit.Author)
 	return &GitCommitResolver{
 		repo: repo,
@@ -78,7 +78,7 @@ func (r *GitCommitResolver) ID() graphql.ID {
 	return marshalGitCommitID(r.repo.ID(), r.oid)
 }
 
-func (r *GitCommitResolver) Repository() *repositoryResolver { return r.repo }
+func (r *GitCommitResolver) Repository() *RepositoryResolver { return r.repo }
 
 func (r *GitCommitResolver) OID() GitObjectID { return r.oid }
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -35,7 +35,7 @@ type gitCommitResolver struct {
 	inputRev *string
 
 	// oid MUST be specified and a 40-character Git SHA.
-	oid gitObjectID
+	oid GitObjectID
 
 	author    signatureResolver
 	committer *signatureResolver
@@ -48,7 +48,7 @@ func toGitCommitResolver(repo *repositoryResolver, commit *git.Commit) *gitCommi
 	return &gitCommitResolver{
 		repo: repo,
 
-		oid: gitObjectID(commit.ID),
+		oid: GitObjectID(commit.ID),
 
 		author:    *authorResolver,
 		committer: toSignatureResolver(commit.Committer),
@@ -61,14 +61,14 @@ func toGitCommitResolver(repo *repositoryResolver, commit *git.Commit) *gitCommi
 // GraphQL ID.
 type gitCommitGQLID struct {
 	Repository graphql.ID  `json:"r"`
-	CommitID   gitObjectID `json:"c"`
+	CommitID   GitObjectID `json:"c"`
 }
 
-func marshalGitCommitID(repo graphql.ID, commitID gitObjectID) graphql.ID {
+func marshalGitCommitID(repo graphql.ID, commitID GitObjectID) graphql.ID {
 	return relay.MarshalID("GitCommit", gitCommitGQLID{Repository: repo, CommitID: commitID})
 }
 
-func unmarshalGitCommitID(id graphql.ID) (repoID graphql.ID, commitID gitObjectID, err error) {
+func unmarshalGitCommitID(id graphql.ID) (repoID graphql.ID, commitID GitObjectID, err error) {
 	var spec gitCommitGQLID
 	err = relay.UnmarshalSpec(id, &spec)
 	return spec.Repository, spec.CommitID, err
@@ -80,7 +80,7 @@ func (r *gitCommitResolver) ID() graphql.ID {
 
 func (r *gitCommitResolver) Repository() *repositoryResolver { return r.repo }
 
-func (r *gitCommitResolver) OID() gitObjectID { return r.oid }
+func (r *gitCommitResolver) OID() GitObjectID { return r.oid }
 
 func (r *gitCommitResolver) AbbreviatedOID() string {
 	return string(r.oid)[:7]

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -67,7 +67,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*git.Commi
 	return r.commits, r.err
 }
 
-func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*gitCommitResolver, error) {
+func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*GitCommitResolver, error) {
 	commits, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*gitCommitRe
 		commits = commits[:*r.first]
 	}
 
-	resolvers := make([]*gitCommitResolver, len(commits))
+	resolvers := make([]*GitCommitResolver, len(commits))
 	for i, commit := range commits {
 		resolvers[i] = toGitCommitResolver(r.repo, commit)
 	}

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -18,7 +18,7 @@ type gitCommitConnectionResolver struct {
 	author *string
 	after  *string
 
-	repo *repositoryResolver
+	repo *RepositoryResolver
 
 	// cache results because it is used by multiple fields
 	once    sync.Once

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -60,7 +60,7 @@ func (o *gitObject) AbbreviatedOID(ctx context.Context) (string, error) {
 	return string(o.oid[:7]), nil
 }
 
-func (o *gitObject) Commit(ctx context.Context) (*gitCommitResolver, error) {
+func (o *gitObject) Commit(ctx context.Context) (*GitCommitResolver, error) {
 	return o.repo.Commit(ctx, &repositoryCommitArgs{Rev: string(o.oid)})
 }
 func (o *gitObject) Type(context.Context) (gitObjectType, error) { return o.typ, nil }
@@ -106,7 +106,7 @@ func (o *gitObjectResolver) AbbreviatedOID(ctx context.Context) (string, error) 
 	return string(oid[:7]), nil
 }
 
-func (o *gitObjectResolver) Commit(ctx context.Context) (*gitCommitResolver, error) {
+func (o *gitObjectResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
 	oid, _, err := o.resolve(ctx)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -35,15 +35,15 @@ func toGitObjectType(t git.ObjectType) gitObjectType {
 	return gitObjectTypeUnknown
 }
 
-type gitObjectID string
+type GitObjectID string
 
-func (gitObjectID) ImplementsGraphQLType(name string) bool {
+func (GitObjectID) ImplementsGraphQLType(name string) bool {
 	return name == "GitObjectID"
 }
 
-func (id *gitObjectID) UnmarshalGraphQL(input interface{}) error {
+func (id *GitObjectID) UnmarshalGraphQL(input interface{}) error {
 	if input, ok := input.(string); ok && git.IsAbsoluteRevision(input) {
-		*id = gitObjectID(input)
+		*id = GitObjectID(input)
 		return nil
 	}
 	return errors.New("GitObjectID: expected 40-character string (SHA-1 hash)")
@@ -51,11 +51,11 @@ func (id *gitObjectID) UnmarshalGraphQL(input interface{}) error {
 
 type gitObject struct {
 	repo *repositoryResolver
-	oid  gitObjectID
+	oid  GitObjectID
 	typ  gitObjectType
 }
 
-func (o *gitObject) OID(ctx context.Context) (gitObjectID, error) { return o.oid, nil }
+func (o *gitObject) OID(ctx context.Context) (GitObjectID, error) { return o.oid, nil }
 func (o *gitObject) AbbreviatedOID(ctx context.Context) (string, error) {
 	return string(o.oid[:7]), nil
 }
@@ -70,12 +70,12 @@ type gitObjectResolver struct {
 	revspec string
 
 	once sync.Once
-	oid  gitObjectID
+	oid  GitObjectID
 	typ  gitObjectType
 	err  error
 }
 
-func (o *gitObjectResolver) resolve(ctx context.Context) (gitObjectID, gitObjectType, error) {
+func (o *gitObjectResolver) resolve(ctx context.Context) (GitObjectID, gitObjectType, error) {
 	o.once.Do(func() {
 		cachedRepo, err := backend.CachedGitRepo(ctx, o.repo.repo)
 		if err != nil {
@@ -87,13 +87,13 @@ func (o *gitObjectResolver) resolve(ctx context.Context) (gitObjectID, gitObject
 			o.err = err
 			return
 		}
-		o.oid = gitObjectID(oid.String())
+		o.oid = GitObjectID(oid.String())
 		o.typ = toGitObjectType(objectType)
 	})
 	return o.oid, o.typ, o.err
 }
 
-func (o *gitObjectResolver) OID(ctx context.Context) (gitObjectID, error) {
+func (o *gitObjectResolver) OID(ctx context.Context) (GitObjectID, error) {
 	oid, _, err := o.resolve(ctx)
 	return oid, err
 }

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -50,7 +50,7 @@ func (id *GitObjectID) UnmarshalGraphQL(input interface{}) error {
 }
 
 type gitObject struct {
-	repo *repositoryResolver
+	repo *RepositoryResolver
 	oid  GitObjectID
 	typ  gitObjectType
 }
@@ -66,7 +66,7 @@ func (o *gitObject) Commit(ctx context.Context) (*GitCommitResolver, error) {
 func (o *gitObject) Type(context.Context) (gitObjectType, error) { return o.typ, nil }
 
 type gitObjectResolver struct {
-	repo    *repositoryResolver
+	repo    *RepositoryResolver
 	revspec string
 
 	once sync.Once

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -113,7 +113,7 @@ func (r *GitRefResolver) Target() interface {
 	//lint:ignore U1000 is used by graphql via reflection
 	AbbreviatedOID(context.Context) (string, error)
 	//lint:ignore U1000 is used by graphql via reflection
-	Commit(context.Context) (*gitCommitResolver, error)
+	Commit(context.Context) (*GitCommitResolver, error)
 	//lint:ignore U1000 is used by graphql via reflection
 	Type(context.Context) (gitObjectType, error)
 } {

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -74,12 +74,12 @@ func gitRefByID(ctx context.Context, id graphql.ID) (*GitRefResolver, error) {
 	}, nil
 }
 
-func NewGitRefResolver(repo *repositoryResolver, name string, target GitObjectID) *GitRefResolver {
+func NewGitRefResolver(repo *RepositoryResolver, name string, target GitObjectID) *GitRefResolver {
 	return &GitRefResolver{repo: repo, name: name, target: target}
 }
 
 type GitRefResolver struct {
-	repo *repositoryResolver
+	repo *RepositoryResolver
 	name string
 
 	target GitObjectID // the target's OID, if known (otherwise computed on demand)
@@ -122,6 +122,6 @@ func (r *GitRefResolver) Target() interface {
 	}
 	return &gitObjectResolver{repo: r.repo, revspec: r.name}
 }
-func (r *GitRefResolver) Repository() *repositoryResolver { return r.repo }
+func (r *GitRefResolver) Repository() *RepositoryResolver { return r.repo }
 
 func (r *GitRefResolver) URL() string { return r.repo.URL() + "@" + escapeRevspecForURL(r.AbbrevName()) }

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -59,7 +59,7 @@ func gitRefDisplayName(ref string) string {
 	return strings.TrimPrefix(ref, prefix)
 }
 
-func gitRefByID(ctx context.Context, id graphql.ID) (*gitRefResolver, error) {
+func gitRefByID(ctx context.Context, id graphql.ID) (*GitRefResolver, error) {
 	repoID, rev, err := unmarshalGitRefID(id)
 	if err != nil {
 		return nil, err
@@ -68,13 +68,13 @@ func gitRefByID(ctx context.Context, id graphql.ID) (*gitRefResolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &gitRefResolver{
+	return &GitRefResolver{
 		repo: repo,
 		name: rev,
 	}, nil
 }
 
-type gitRefResolver struct {
+type GitRefResolver struct {
 	repo *repositoryResolver
 	name string
 
@@ -98,13 +98,13 @@ func unmarshalGitRefID(id graphql.ID) (repoID graphql.ID, rev string, err error)
 	return spec.Repository, spec.Rev, err
 }
 
-func (r *gitRefResolver) ID() graphql.ID      { return marshalGitRefID(r.repo.ID(), r.name) }
-func (r *gitRefResolver) Name() string        { return r.name }
-func (r *gitRefResolver) AbbrevName() string  { return strings.TrimPrefix(r.name, gitRefPrefix(r.name)) }
-func (r *gitRefResolver) DisplayName() string { return gitRefDisplayName(r.name) }
-func (r *gitRefResolver) Prefix() string      { return gitRefPrefix(r.name) }
-func (r *gitRefResolver) Type() string        { return gitRefType(r.name) }
-func (r *gitRefResolver) Target() interface {
+func (r *GitRefResolver) ID() graphql.ID      { return marshalGitRefID(r.repo.ID(), r.name) }
+func (r *GitRefResolver) Name() string        { return r.name }
+func (r *GitRefResolver) AbbrevName() string  { return strings.TrimPrefix(r.name, gitRefPrefix(r.name)) }
+func (r *GitRefResolver) DisplayName() string { return gitRefDisplayName(r.name) }
+func (r *GitRefResolver) Prefix() string      { return gitRefPrefix(r.name) }
+func (r *GitRefResolver) Type() string        { return gitRefType(r.name) }
+func (r *GitRefResolver) Target() interface {
 	OID(context.Context) (gitObjectID, error)
 	//lint:ignore U1000 is used by graphql via reflection
 	AbbreviatedOID(context.Context) (string, error)
@@ -118,6 +118,6 @@ func (r *gitRefResolver) Target() interface {
 	}
 	return &gitObjectResolver{repo: r.repo, revspec: r.name}
 }
-func (r *gitRefResolver) Repository() *repositoryResolver { return r.repo }
+func (r *GitRefResolver) Repository() *repositoryResolver { return r.repo }
 
-func (r *gitRefResolver) URL() string { return r.repo.URL() + "@" + escapeRevspecForURL(r.AbbrevName()) }
+func (r *GitRefResolver) URL() string { return r.repo.URL() + "@" + escapeRevspecForURL(r.AbbrevName()) }

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -78,7 +78,7 @@ type GitRefResolver struct {
 	repo *repositoryResolver
 	name string
 
-	target gitObjectID // the target's OID, if known (otherwise computed on demand)
+	target GitObjectID // the target's OID, if known (otherwise computed on demand)
 }
 
 // gitRefGQLID is a type used for marshaling and unmarshaling a Git ref's
@@ -105,7 +105,7 @@ func (r *GitRefResolver) DisplayName() string { return gitRefDisplayName(r.name)
 func (r *GitRefResolver) Prefix() string      { return gitRefPrefix(r.name) }
 func (r *GitRefResolver) Type() string        { return gitRefType(r.name) }
 func (r *GitRefResolver) Target() interface {
-	OID(context.Context) (gitObjectID, error)
+	OID(context.Context) (GitObjectID, error)
 	//lint:ignore U1000 is used by graphql via reflection
 	AbbreviatedOID(context.Context) (string, error)
 	//lint:ignore U1000 is used by graphql via reflection

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -74,6 +74,10 @@ func gitRefByID(ctx context.Context, id graphql.ID) (*GitRefResolver, error) {
 	}, nil
 }
 
+func NewGitRefResolver(repo *repositoryResolver, name string, target GitObjectID) *GitRefResolver {
+	return &GitRefResolver{repo: repo, name: name, target: target}
+}
+
 type GitRefResolver struct {
 	repo *repositoryResolver
 	name string

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -26,7 +26,7 @@ func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
 		return nil, err
 	}
 	return &gitObject{
-		oid:  gitObjectID(oid),
+		oid:  GitObjectID(oid),
 		repo: r.repo,
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -32,12 +32,12 @@ func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
 }
 
 type gitRevSpec struct {
-	ref    *gitRefResolver
+	ref    *GitRefResolver
 	expr   *gitRevSpecExpr
 	object *gitObject
 }
 
-func (r *gitRevSpec) ToGitRef() (*gitRefResolver, bool)         { return r.ref, r.ref != nil }
+func (r *gitRevSpec) ToGitRef() (*GitRefResolver, bool)         { return r.ref, r.ref != nil }
 func (r *gitRevSpec) ToGitRevSpecExpr() (*gitRevSpecExpr, bool) { return r.expr, r.expr != nil }
 func (r *gitRevSpec) ToGitObject() (*gitObject, bool)           { return r.object, r.object != nil }
 

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -11,7 +11,7 @@ import (
 
 type gitRevSpecExpr struct {
 	expr string
-	repo *repositoryResolver
+	repo *RepositoryResolver
 }
 
 func (r *gitRevSpecExpr) Expr() string { return r.expr }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -38,7 +38,7 @@ func (r *gitTreeEntryResolver) ToGitBlob() (*gitTreeEntryResolver, bool) { retur
 
 func (r *gitTreeEntryResolver) Commit() *GitCommitResolver { return r.commit }
 
-func (r *gitTreeEntryResolver) Repository() *repositoryResolver { return r.commit.repo }
+func (r *gitTreeEntryResolver) Repository() *RepositoryResolver { return r.commit.repo }
 
 func (r *gitTreeEntryResolver) IsRecursive() bool { return r.isRecursive }
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -22,7 +22,7 @@ import (
 // gitTreeEntryResolver resolves an entry in a Git tree in a repository. The entry can be any Git
 // object type that is valid in a tree.
 type gitTreeEntryResolver struct {
-	commit *gitCommitResolver
+	commit *GitCommitResolver
 
 	path string      // this tree entry's path (relative to the root)
 	stat os.FileInfo // this tree entry's file info
@@ -36,7 +36,7 @@ func (r *gitTreeEntryResolver) Name() string { return path.Base(r.path) }
 func (r *gitTreeEntryResolver) ToGitTree() (*gitTreeEntryResolver, bool) { return r, true }
 func (r *gitTreeEntryResolver) ToGitBlob() (*gitTreeEntryResolver, bool) { return r, true }
 
-func (r *gitTreeEntryResolver) Commit() *gitCommitResolver { return r.commit }
+func (r *gitTreeEntryResolver) Commit() *GitCommitResolver { return r.commit }
 
 func (r *gitTreeEntryResolver) Repository() *repositoryResolver { return r.commit.repo }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -70,88 +70,88 @@ type Node interface {
 	ID() graphql.ID
 }
 
-type nodeResolver struct {
+type NodeResolver struct {
 	Node
 }
 
-func (r *nodeResolver) ToAccessToken() (*accessTokenResolver, bool) {
+func (r *NodeResolver) ToAccessToken() (*accessTokenResolver, bool) {
 	n, ok := r.Node.(*accessTokenResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToDiscussionComment() (*discussionCommentResolver, bool) {
+func (r *NodeResolver) ToDiscussionComment() (*discussionCommentResolver, bool) {
 	n, ok := r.Node.(*discussionCommentResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToDiscussionThread() (*discussionThreadResolver, bool) {
+func (r *NodeResolver) ToDiscussionThread() (*discussionThreadResolver, bool) {
 	n, ok := r.Node.(*discussionThreadResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToProductLicense() (ProductLicense, bool) {
+func (r *NodeResolver) ToProductLicense() (ProductLicense, bool) {
 	n, ok := r.Node.(ProductLicense)
 	return n, ok
 }
 
-func (r *nodeResolver) ToProductSubscription() (ProductSubscription, bool) {
+func (r *NodeResolver) ToProductSubscription() (ProductSubscription, bool) {
 	n, ok := r.Node.(ProductSubscription)
 	return n, ok
 }
 
-func (r *nodeResolver) ToExternalAccount() (*externalAccountResolver, bool) {
+func (r *NodeResolver) ToExternalAccount() (*externalAccountResolver, bool) {
 	n, ok := r.Node.(*externalAccountResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToExternalService() (*externalServiceResolver, bool) {
+func (r *NodeResolver) ToExternalService() (*externalServiceResolver, bool) {
 	n, ok := r.Node.(*externalServiceResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToGitRef() (*gitRefResolver, bool) {
+func (r *NodeResolver) ToGitRef() (*gitRefResolver, bool) {
 	n, ok := r.Node.(*gitRefResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToRepository() (*repositoryResolver, bool) {
+func (r *NodeResolver) ToRepository() (*repositoryResolver, bool) {
 	n, ok := r.Node.(*repositoryResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToUser() (*UserResolver, bool) {
+func (r *NodeResolver) ToUser() (*UserResolver, bool) {
 	n, ok := r.Node.(*UserResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToOrg() (*OrgResolver, bool) {
+func (r *NodeResolver) ToOrg() (*OrgResolver, bool) {
 	n, ok := r.Node.(*OrgResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToOrganizationInvitation() (*organizationInvitationResolver, bool) {
+func (r *NodeResolver) ToOrganizationInvitation() (*organizationInvitationResolver, bool) {
 	n, ok := r.Node.(*organizationInvitationResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToGitCommit() (*gitCommitResolver, bool) {
+func (r *NodeResolver) ToGitCommit() (*gitCommitResolver, bool) {
 	n, ok := r.Node.(*gitCommitResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToRegistryExtension() (RegistryExtension, bool) {
+func (r *NodeResolver) ToRegistryExtension() (RegistryExtension, bool) {
 	if NodeToRegistryExtension == nil {
 		return nil, false
 	}
 	return NodeToRegistryExtension(r.Node)
 }
 
-func (r *nodeResolver) ToSavedSearch() (*savedSearchResolver, bool) {
+func (r *NodeResolver) ToSavedSearch() (*savedSearchResolver, bool) {
 	n, ok := r.Node.(*savedSearchResolver)
 	return n, ok
 }
 
-func (r *nodeResolver) ToSite() (*siteResolver, bool) {
+func (r *NodeResolver) ToSite() (*siteResolver, bool) {
 	n, ok := r.Node.(*siteResolver)
 	return n, ok
 }
@@ -180,12 +180,12 @@ func (r *schemaResolver) Root() *schemaResolver {
 	return &schemaResolver{}
 }
 
-func (r *schemaResolver) Node(ctx context.Context, args *struct{ ID graphql.ID }) (*nodeResolver, error) {
+func (r *schemaResolver) Node(ctx context.Context, args *struct{ ID graphql.ID }) (*NodeResolver, error) {
 	n, err := nodeByID(ctx, args.ID)
 	if err != nil {
 		return nil, err
 	}
-	return &nodeResolver{n}, nil
+	return &NodeResolver{n}, nil
 }
 
 func nodeByID(ctx context.Context, id graphql.ID) (Node, error) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -66,76 +66,76 @@ func (er *EmptyResponse) AlwaysNil() *string {
 	return nil
 }
 
-type node interface {
+type Node interface {
 	ID() graphql.ID
 }
 
 type nodeResolver struct {
-	node
+	Node
 }
 
 func (r *nodeResolver) ToAccessToken() (*accessTokenResolver, bool) {
-	n, ok := r.node.(*accessTokenResolver)
+	n, ok := r.Node.(*accessTokenResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToDiscussionComment() (*discussionCommentResolver, bool) {
-	n, ok := r.node.(*discussionCommentResolver)
+	n, ok := r.Node.(*discussionCommentResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToDiscussionThread() (*discussionThreadResolver, bool) {
-	n, ok := r.node.(*discussionThreadResolver)
+	n, ok := r.Node.(*discussionThreadResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToProductLicense() (ProductLicense, bool) {
-	n, ok := r.node.(ProductLicense)
+	n, ok := r.Node.(ProductLicense)
 	return n, ok
 }
 
 func (r *nodeResolver) ToProductSubscription() (ProductSubscription, bool) {
-	n, ok := r.node.(ProductSubscription)
+	n, ok := r.Node.(ProductSubscription)
 	return n, ok
 }
 
 func (r *nodeResolver) ToExternalAccount() (*externalAccountResolver, bool) {
-	n, ok := r.node.(*externalAccountResolver)
+	n, ok := r.Node.(*externalAccountResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToExternalService() (*externalServiceResolver, bool) {
-	n, ok := r.node.(*externalServiceResolver)
+	n, ok := r.Node.(*externalServiceResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToGitRef() (*gitRefResolver, bool) {
-	n, ok := r.node.(*gitRefResolver)
+	n, ok := r.Node.(*gitRefResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToRepository() (*repositoryResolver, bool) {
-	n, ok := r.node.(*repositoryResolver)
+	n, ok := r.Node.(*repositoryResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToUser() (*UserResolver, bool) {
-	n, ok := r.node.(*UserResolver)
+	n, ok := r.Node.(*UserResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToOrg() (*OrgResolver, bool) {
-	n, ok := r.node.(*OrgResolver)
+	n, ok := r.Node.(*OrgResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToOrganizationInvitation() (*organizationInvitationResolver, bool) {
-	n, ok := r.node.(*organizationInvitationResolver)
+	n, ok := r.Node.(*organizationInvitationResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToGitCommit() (*gitCommitResolver, bool) {
-	n, ok := r.node.(*gitCommitResolver)
+	n, ok := r.Node.(*gitCommitResolver)
 	return n, ok
 }
 
@@ -143,16 +143,16 @@ func (r *nodeResolver) ToRegistryExtension() (RegistryExtension, bool) {
 	if NodeToRegistryExtension == nil {
 		return nil, false
 	}
-	return NodeToRegistryExtension(r.node)
+	return NodeToRegistryExtension(r.Node)
 }
 
 func (r *nodeResolver) ToSavedSearch() (*savedSearchResolver, bool) {
-	n, ok := r.node.(*savedSearchResolver)
+	n, ok := r.Node.(*savedSearchResolver)
 	return n, ok
 }
 
 func (r *nodeResolver) ToSite() (*siteResolver, bool) {
-	n, ok := r.node.(*siteResolver)
+	n, ok := r.Node.(*siteResolver)
 	return n, ok
 }
 
@@ -188,7 +188,7 @@ func (r *schemaResolver) Node(ctx context.Context, args *struct{ ID graphql.ID }
 	return &nodeResolver{n}, nil
 }
 
-func nodeByID(ctx context.Context, id graphql.ID) (node, error) {
+func nodeByID(ctx context.Context, id graphql.ID) (Node, error) {
 	switch relay.UnmarshalKind(id) {
 	case "AccessToken":
 		return accessTokenByID(ctx, id)

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -181,14 +181,14 @@ func (r *schemaResolver) Root() *schemaResolver {
 }
 
 func (r *schemaResolver) Node(ctx context.Context, args *struct{ ID graphql.ID }) (*NodeResolver, error) {
-	n, err := nodeByID(ctx, args.ID)
+	n, err := NodeByID(ctx, args.ID)
 	if err != nil {
 		return nil, err
 	}
 	return &NodeResolver{n}, nil
 }
 
-func nodeByID(ctx context.Context, id graphql.ID) (Node, error) {
+func NodeByID(ctx context.Context, id graphql.ID) (Node, error) {
 	switch relay.UnmarshalKind(id) {
 	case "AccessToken":
 		return accessTokenByID(ctx, id)

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -109,8 +109,8 @@ func (r *NodeResolver) ToExternalService() (*externalServiceResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToGitRef() (*gitRefResolver, bool) {
-	n, ok := r.Node.(*gitRefResolver)
+func (r *NodeResolver) ToGitRef() (*GitRefResolver, bool) {
+	n, ok := r.Node.(*GitRefResolver)
 	return n, ok
 }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -134,8 +134,8 @@ func (r *NodeResolver) ToOrganizationInvitation() (*organizationInvitationResolv
 	return n, ok
 }
 
-func (r *NodeResolver) ToGitCommit() (*gitCommitResolver, bool) {
-	n, ok := r.Node.(*gitCommitResolver)
+func (r *NodeResolver) ToGitCommit() (*GitCommitResolver, bool) {
+	n, ok := r.Node.(*GitCommitResolver)
 	return n, ok
 }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -114,8 +114,8 @@ func (r *NodeResolver) ToGitRef() (*GitRefResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToRepository() (*repositoryResolver, bool) {
-	n, ok := r.Node.(*repositoryResolver)
+func (r *NodeResolver) ToRepository() (*RepositoryResolver, bool) {
+	n, ok := r.Node.(*RepositoryResolver)
 	return n, ok
 }
 
@@ -238,7 +238,7 @@ func (r *schemaResolver) Repository(ctx context.Context, args *struct {
 	CloneURL *string
 	// TODO(chris): Remove URI in favor of Name.
 	URI *string
-}) (*repositoryResolver, error) {
+}) (*RepositoryResolver, error) {
 	var name api.RepoName
 	if args.URI != nil {
 		// Deprecated query by "URI"
@@ -264,14 +264,14 @@ func (r *schemaResolver) Repository(ctx context.Context, args *struct {
 	repo, err := backend.Repos.GetByName(ctx, name)
 	if err != nil {
 		if err, ok := err.(backend.ErrRepoSeeOther); ok {
-			return &repositoryResolver{repo: &types.Repo{}, redirectURL: &err.RedirectURL}, nil
+			return &RepositoryResolver{repo: &types.Repo{}, redirectURL: &err.RedirectURL}, nil
 		}
 		if errcode.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return &repositoryResolver{repo: repo}, nil
+	return &RepositoryResolver{repo: repo}, nil
 }
 
 func (r *schemaResolver) PhabricatorRepo(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -217,7 +217,7 @@ func NodeByID(ctx context.Context, id graphql.ID) (Node, error) {
 	case "User":
 		return UserByID(ctx, id)
 	case "Org":
-		return orgByID(ctx, id)
+		return OrgByID(ctx, id)
 	case "OrganizationInvitation":
 		return orgInvitationByID(ctx, id)
 	case "GitCommit":

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -45,7 +45,7 @@ func TestNodeResolverTo(t *testing.T) {
 		&externalAccountResolver{},
 		&externalServiceResolver{},
 		&GitRefResolver{},
-		&repositoryResolver{},
+		&RepositoryResolver{},
 		&UserResolver{},
 		&OrgResolver{},
 		&organizationInvitationResolver{},

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -55,7 +55,7 @@ func TestNodeResolverTo(t *testing.T) {
 	}
 
 	for _, n := range nodes {
-		r := &nodeResolver{n}
+		r := &NodeResolver{n}
 		if _, b := r.ToAccessToken(); b {
 			continue
 		}

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -38,7 +38,7 @@ func TestNodeResolverTo(t *testing.T) {
 	// run. The To* resolvers are stored in a map in our graphql
 	// implementation => the order we call them is non deterministic =>
 	// codecov coverage reports are noisy.
-	nodes := []node{
+	nodes := []Node{
 		&accessTokenResolver{},
 		&discussionCommentResolver{},
 		&discussionThreadResolver{},

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -44,7 +44,7 @@ func TestNodeResolverTo(t *testing.T) {
 		&discussionThreadResolver{},
 		&externalAccountResolver{},
 		&externalServiceResolver{},
-		&gitRefResolver{},
+		&GitRefResolver{},
 		&repositoryResolver{},
 		&UserResolver{},
 		&OrgResolver{},

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -49,7 +49,7 @@ func TestNodeResolverTo(t *testing.T) {
 		&UserResolver{},
 		&OrgResolver{},
 		&organizationInvitationResolver{},
-		&gitCommitResolver{},
+		&GitCommitResolver{},
 		&savedSearchResolver{},
 		&siteResolver{},
 	}

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -8,7 +8,7 @@ import (
 )
 
 type hunkResolver struct {
-	repo *repositoryResolver
+	repo *RepositoryResolver
 	hunk *git.Hunk
 }
 

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -46,7 +46,7 @@ func (r *hunkResolver) Message() string {
 	return r.hunk.Message
 }
 
-func (r *hunkResolver) Commit(ctx context.Context) (*gitCommitResolver, error) {
+func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo.repo)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/json.go
+++ b/cmd/frontend/graphqlbackend/json.go
@@ -2,19 +2,19 @@ package graphqlbackend
 
 import "encoding/json"
 
-// jsonValue implements the JSONValue scalar type. In GraphQL queries, it is represented the JSON
+// JSONValue implements the JSONValue scalar type. In GraphQL queries, it is represented the JSON
 // representation of its Go value.
-type jsonValue struct{ value interface{} }
+type JSONValue struct{ value interface{} }
 
-func (jsonValue) ImplementsGraphQLType(name string) bool {
+func (JSONValue) ImplementsGraphQLType(name string) bool {
 	return name == "JSONValue"
 }
 
-func (v *jsonValue) UnmarshalGraphQL(input interface{}) error {
-	*v = jsonValue{value: input}
+func (v *JSONValue) UnmarshalGraphQL(input interface{}) error {
+	*v = JSONValue{value: input}
 	return nil
 }
 
-func (v jsonValue) MarshalJSON() ([]byte, error) {
+func (v JSONValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.value)
 }

--- a/cmd/frontend/graphqlbackend/namespaces.go
+++ b/cmd/frontend/graphqlbackend/namespaces.go
@@ -28,7 +28,7 @@ func NamespaceByID(ctx context.Context, id graphql.ID) (Namespace, error) {
 	case "User":
 		return UserByID(ctx, id)
 	case "Org":
-		return orgByID(ctx, id)
+		return OrgByID(ctx, id)
 	default:
 		return nil, errors.New("invalid ID for namespace")
 	}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -30,10 +30,10 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 func (r *schemaResolver) Org(ctx context.Context, args *struct {
 	ID graphql.ID
 }) (*OrgResolver, error) {
-	return orgByID(ctx, args.ID)
+	return OrgByID(ctx, args.ID)
 }
 
-func orgByID(ctx context.Context, id graphql.ID) (*OrgResolver, error) {
+func OrgByID(ctx context.Context, id graphql.ID) (*OrgResolver, error) {
 	orgID, err := UnmarshalOrgID(id)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -198,18 +198,18 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 	return r.repos, r.err
 }
 
-func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*repositoryResolver, error) {
+func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*RepositoryResolver, error) {
 	repos, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
 	}
-	resolvers := make([]*repositoryResolver, 0, len(repos))
+	resolvers := make([]*RepositoryResolver, 0, len(repos))
 	for i, repo := range repos {
 		if r.opt.LimitOffset != nil && i == r.opt.Limit {
 			break
 		}
 
-		resolvers = append(resolvers, &repositoryResolver{repo: repo})
+		resolvers = append(resolvers, &RepositoryResolver{repo: repo})
 	}
 	return resolvers, nil
 }
@@ -377,14 +377,14 @@ func repoNamesToStrings(repoNames []api.RepoName) []string {
 	return strings
 }
 
-func toRepositoryResolvers(repos []*types.Repo) []*repositoryResolver {
+func toRepositoryResolvers(repos []*types.Repo) []*RepositoryResolver {
 	if len(repos) == 0 {
-		return []*repositoryResolver{}
+		return []*RepositoryResolver{}
 	}
 
-	resolvers := make([]*repositoryResolver, len(repos))
+	resolvers := make([]*RepositoryResolver, len(repos))
 	for i := range repos {
-		resolvers[i] = &repositoryResolver{repo: repos[i]}
+		resolvers[i] = &RepositoryResolver{repo: repos[i]}
 	}
 
 	return resolvers

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -23,7 +23,7 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-type repositoryResolver struct {
+type RepositoryResolver struct {
 	hydration sync.Once
 	err       error
 
@@ -33,7 +33,13 @@ type repositoryResolver struct {
 	matches     []*searchResultMatchResolver
 }
 
-func repositoryByID(ctx context.Context, id graphql.ID) (*repositoryResolver, error) {
+func NewRepositoryResolver(repo *types.Repo) *RepositoryResolver {
+	return &RepositoryResolver{repo: repo}
+}
+
+var RepositoryByID = repositoryByID
+
+func repositoryByID(ctx context.Context, id graphql.ID) (*RepositoryResolver, error) {
 	var repoID api.RepoID
 	if err := relay.UnmarshalSpec(id, &repoID); err != nil {
 		return nil, err
@@ -42,18 +48,18 @@ func repositoryByID(ctx context.Context, id graphql.ID) (*repositoryResolver, er
 	if err != nil {
 		return nil, err
 	}
-	return &repositoryResolver{repo: repo}, nil
+	return &RepositoryResolver{repo: repo}, nil
 }
 
-func repositoryByIDInt32(ctx context.Context, repoID api.RepoID) (*repositoryResolver, error) {
+func repositoryByIDInt32(ctx context.Context, repoID api.RepoID) (*RepositoryResolver, error) {
 	repo, err := db.Repos.Get(ctx, repoID)
 	if err != nil {
 		return nil, err
 	}
-	return &repositoryResolver{repo: repo}, nil
+	return &RepositoryResolver{repo: repo}, nil
 }
 
-func (r *repositoryResolver) ID() graphql.ID {
+func (r *RepositoryResolver) ID() graphql.ID {
 	return marshalRepositoryID(r.repo.ID)
 }
 
@@ -64,11 +70,11 @@ func unmarshalRepositoryID(id graphql.ID) (repo api.RepoID, err error) {
 	return
 }
 
-func (r *repositoryResolver) Name() string {
+func (r *RepositoryResolver) Name() string {
 	return string(r.repo.Name)
 }
 
-func (r *repositoryResolver) URI(ctx context.Context) (string, error) {
+func (r *RepositoryResolver) URI(ctx context.Context) (string, error) {
 	err := r.hydrate(ctx)
 	if err != nil {
 		return "", err
@@ -77,7 +83,7 @@ func (r *repositoryResolver) URI(ctx context.Context) (string, error) {
 	return r.repo.URI, nil
 }
 
-func (r *repositoryResolver) Description(ctx context.Context) (string, error) {
+func (r *RepositoryResolver) Description(ctx context.Context) (string, error) {
 	err := r.hydrate(ctx)
 	if err != nil {
 		return "", err
@@ -86,11 +92,11 @@ func (r *repositoryResolver) Description(ctx context.Context) (string, error) {
 	return r.repo.Description, nil
 }
 
-func (r *repositoryResolver) RedirectURL() *string {
+func (r *RepositoryResolver) RedirectURL() *string {
 	return r.redirectURL
 }
 
-func (r *repositoryResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
+func (r *RepositoryResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		if err == backend.ErrMustBeSiteAdmin || err == backend.ErrNotAuthenticated {
 			return false, nil // not an error
@@ -100,7 +106,7 @@ func (r *repositoryResolver) ViewerCanAdminister(ctx context.Context) (bool, err
 	return true, nil
 }
 
-func (r *repositoryResolver) CloneInProgress(ctx context.Context) (bool, error) {
+func (r *RepositoryResolver) CloneInProgress(ctx context.Context) (bool, error) {
 	return r.MirrorInfo().CloneInProgress(ctx)
 }
 
@@ -109,7 +115,7 @@ type repositoryCommitArgs struct {
 	InputRevspec *string
 }
 
-func (r *repositoryResolver) Commit(ctx context.Context, args *repositoryCommitArgs) (*GitCommitResolver, error) {
+func (r *RepositoryResolver) Commit(ctx context.Context, args *repositoryCommitArgs) (*GitCommitResolver, error) {
 	commitID, err := backend.Repos.ResolveRev(ctx, r.repo, args.Rev)
 	if err != nil {
 		if gitserver.IsRevisionNotFound(err) {
@@ -132,7 +138,7 @@ func (r *repositoryResolver) Commit(ctx context.Context, args *repositoryCommitA
 	return resolver, nil
 }
 
-func (r *repositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver, error) {
+func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo)
 	if err != nil {
 		return nil, err
@@ -157,7 +163,7 @@ func (r *repositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver
 	return &GitRefResolver{repo: r, name: refName}, nil
 }
 
-func (r *repositoryResolver) Language(ctx context.Context) string {
+func (r *RepositoryResolver) Language(ctx context.Context) string {
 	// The repository language is the most common language at the HEAD commit of the repository.
 	// Note: the repository database field is no longer updated as of
 	// https://github.com/sourcegraph/sourcegraph/issues/2586, so we do not use it anymore and
@@ -178,63 +184,63 @@ func (r *repositoryResolver) Language(ctx context.Context) string {
 	return inventory.Languages[0].Name
 }
 
-func (r *repositoryResolver) Enabled() bool { return true }
+func (r *RepositoryResolver) Enabled() bool { return true }
 
-func (r *repositoryResolver) CreatedAt() string {
+func (r *RepositoryResolver) CreatedAt() string {
 	return time.Now().Format(time.RFC3339)
 }
 
-func (r *repositoryResolver) UpdatedAt() *string {
+func (r *RepositoryResolver) UpdatedAt() *string {
 	return nil
 }
 
-func (r *repositoryResolver) URL() string { return "/" + string(r.repo.Name) }
+func (r *RepositoryResolver) URL() string { return "/" + string(r.repo.Name) }
 
-func (r *repositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
+func (r *RepositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
 	return externallink.Repository(ctx, r.repo)
 }
 
-func (r *repositoryResolver) Icon() string {
+func (r *RepositoryResolver) Icon() string {
 	return r.icon
 }
 
-func (r *repositoryResolver) Label() (*markdownResolver, error) {
+func (r *RepositoryResolver) Label() (*markdownResolver, error) {
 	text := "[" + string(r.repo.Name) + "](/" + string(r.repo.Name) + ")"
 	return &markdownResolver{text: text}, nil
 }
 
-func (r *repositoryResolver) Detail() *markdownResolver {
+func (r *RepositoryResolver) Detail() *markdownResolver {
 	return &markdownResolver{text: "Repository name match"}
 }
 
-func (r *repositoryResolver) Matches() []*searchResultMatchResolver {
+func (r *RepositoryResolver) Matches() []*searchResultMatchResolver {
 	return r.matches
 }
 
-func (r *repositoryResolver) ToRepository() (*repositoryResolver, bool) { return r, true }
-func (r *repositoryResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
-func (r *repositoryResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+func (r *RepositoryResolver) ToRepository() (*RepositoryResolver, bool) { return r, true }
+func (r *RepositoryResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
+func (r *RepositoryResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
 }
-func (r *repositoryResolver) ToCodemodResult() (*codemodResultResolver, bool) {
+func (r *RepositoryResolver) ToCodemodResult() (*codemodResultResolver, bool) {
 	return nil, false
 }
 
-func (r *repositoryResolver) searchResultURIs() (string, string) {
+func (r *RepositoryResolver) searchResultURIs() (string, string) {
 	return string(r.repo.Name), ""
 }
 
-func (r *repositoryResolver) resultCount() int32 {
+func (r *RepositoryResolver) resultCount() int32 {
 	return 1
 }
 
-func (r *repositoryResolver) hydrate(ctx context.Context) error {
+func (r *RepositoryResolver) hydrate(ctx context.Context) error {
 	r.hydration.Do(func() {
 		if r.repo.RepoFields != nil {
 			return
 		}
 
-		log15.Debug("repositoryResolver.hydrate", "repo.ID", r.repo.ID)
+		log15.Debug("RepositoryResolver.hydrate", "repo.ID", r.repo.ID)
 
 		var repo *types.Repo
 		repo, r.err = db.Repos.Get(ctx, r.repo.ID)
@@ -281,7 +287,7 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 	targetRef := fmt.Sprintf("phabricator/diff/%d", args.DiffID)
 	getCommit := func() (*GitCommitResolver, error) {
 		// We first check via the vcsrepo api so that we can toggle
-		// NoEnsureRevision. We do this, otherwise repositoryResolver.Commit
+		// NoEnsureRevision. We do this, otherwise RepositoryResolver.Commit
 		// will try and fetch it from the remote host. However, this is not on
 		// the remote host since we created it.
 		cachedRepo, err := backend.CachedGitRepo(ctx, repo)
@@ -294,7 +300,7 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 		if err != nil {
 			return nil, err
 		}
-		r := &repositoryResolver{repo: repo}
+		r := &RepositoryResolver{repo: repo}
 		return r.Commit(ctx, &repositoryCommitArgs{Rev: targetRef})
 	}
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -132,7 +132,7 @@ func (r *repositoryResolver) Commit(ctx context.Context, args *repositoryCommitA
 	return resolver, nil
 }
 
-func (r *repositoryResolver) DefaultBranch(ctx context.Context) (*gitRefResolver, error) {
+func (r *repositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo)
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func (r *repositoryResolver) DefaultBranch(ctx context.Context) (*gitRefResolver
 		return nil, err
 	}
 
-	return &gitRefResolver{repo: r, name: refName}, nil
+	return &GitRefResolver{repo: r, name: refName}, nil
 }
 
 func (r *repositoryResolver) Language(ctx context.Context) string {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -109,7 +109,7 @@ type repositoryCommitArgs struct {
 	InputRevspec *string
 }
 
-func (r *repositoryResolver) Commit(ctx context.Context, args *repositoryCommitArgs) (*gitCommitResolver, error) {
+func (r *repositoryResolver) Commit(ctx context.Context, args *repositoryCommitArgs) (*GitCommitResolver, error) {
 	commitID, err := backend.Repos.ResolveRev(ctx, r.repo, args.Rev)
 	if err != nil {
 		if gitserver.IsRevisionNotFound(err) {
@@ -273,13 +273,13 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 	AuthorEmail *string
 	Description *string
 	Date        *string
-}) (*gitCommitResolver, error) {
+}) (*GitCommitResolver, error) {
 	repo, err := db.Repos.GetByName(ctx, api.RepoName(args.RepoName))
 	if err != nil {
 		return nil, err
 	}
 	targetRef := fmt.Sprintf("phabricator/diff/%d", args.DiffID)
-	getCommit := func() (*gitCommitResolver, error) {
+	getCommit := func() (*GitCommitResolver, error) {
 		// We first check via the vcsrepo api so that we can toggle
 		// NoEnsureRevision. We do this, otherwise repositoryResolver.Commit
 		// will try and fetch it from the remote host. However, this is not on

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -38,7 +38,7 @@ func NewRepositoryComparison(ctx context.Context, r *repositoryResolver, args *R
 		headRevspec = *args.Head
 	}
 
-	getCommit := func(ctx context.Context, repo gitserver.Repo, revspec string) (*gitCommitResolver, error) {
+	getCommit := func(ctx context.Context, repo gitserver.Repo, revspec string) (*GitCommitResolver, error) {
 		if revspec == devNullSHA {
 			return nil, nil
 		}
@@ -85,7 +85,7 @@ func (r *repositoryResolver) Comparison(ctx context.Context, args *RepositoryCom
 
 type RepositoryComparisonResolver struct {
 	baseRevspec, headRevspec string
-	base, head               *gitCommitResolver
+	base, head               *GitCommitResolver
 	repo                     *repositoryResolver
 }
 

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -20,12 +20,12 @@ import (
 // when computing the `git diff` of the root commit.
 const devNullSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-type repositoryComparisonInput struct {
+type RepositoryComparisonInput struct {
 	Base *string
 	Head *string
 }
 
-func (r *repositoryResolver) Comparison(ctx context.Context, args *repositoryComparisonInput) (*repositoryComparisonResolver, error) {
+func (r *repositoryResolver) Comparison(ctx context.Context, args *RepositoryComparisonInput) (*repositoryComparisonResolver, error) {
 	var baseRevspec, headRevspec string
 	if args.Base == nil {
 		baseRevspec = "HEAD"

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -25,7 +25,7 @@ type RepositoryComparisonInput struct {
 	Head *string
 }
 
-func NewRepositoryComparison(ctx context.Context, r *repositoryResolver, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
+func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
 	var baseRevspec, headRevspec string
 	if args.Base == nil {
 		baseRevspec = "HEAD"
@@ -79,15 +79,19 @@ func NewRepositoryComparison(ctx context.Context, r *repositoryResolver, args *R
 	}, nil
 }
 
-func (r *repositoryResolver) Comparison(ctx context.Context, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
+func (r *RepositoryResolver) Comparison(ctx context.Context, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
 	return NewRepositoryComparison(ctx, r, args)
 }
 
 type RepositoryComparisonResolver struct {
 	baseRevspec, headRevspec string
 	base, head               *GitCommitResolver
-	repo                     *repositoryResolver
+	repo                     *RepositoryResolver
 }
+
+func (r *RepositoryComparisonResolver) BaseRepository() *RepositoryResolver { return r.repo }
+
+func (r *RepositoryComparisonResolver) HeadRepository() *RepositoryResolver { return r.repo }
 
 func (r *RepositoryComparisonResolver) Range() *gitRevisionRange {
 	return &gitRevisionRange{

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -5,7 +5,7 @@ type repositoryContributorResolver struct {
 	email string
 	count int32
 
-	repo *repositoryResolver
+	repo *RepositoryResolver
 	args repositoryContributorsArgs
 }
 
@@ -15,7 +15,7 @@ func (r *repositoryContributorResolver) Person() *personResolver {
 
 func (r *repositoryContributorResolver) Count() int32 { return r.count }
 
-func (r *repositoryContributorResolver) Repository() *repositoryResolver { return r.repo }
+func (r *repositoryContributorResolver) Repository() *RepositoryResolver { return r.repo }
 
 func (r *repositoryContributorResolver) Commits(args *struct {
 	First *int32

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -15,7 +15,7 @@ type repositoryContributorsArgs struct {
 	Path          *string
 }
 
-func (r *repositoryResolver) Contributors(args *struct {
+func (r *RepositoryResolver) Contributors(args *struct {
 	repositoryContributorsArgs
 	First *int32
 }) *repositoryContributorConnectionResolver {
@@ -30,7 +30,7 @@ type repositoryContributorConnectionResolver struct {
 	args  repositoryContributorsArgs
 	first *int32
 
-	repo *repositoryResolver
+	repo *RepositoryResolver
 
 	// cache result because it is used by multiple fields
 	once    sync.Once

--- a/cmd/frontend/graphqlbackend/repository_external.go
+++ b/cmd/frontend/graphqlbackend/repository_external.go
@@ -10,12 +10,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/repoupdater"
 )
 
-func (r *repositoryResolver) ExternalRepository() *externalRepositoryResolver {
+func (r *RepositoryResolver) ExternalRepository() *externalRepositoryResolver {
 	return &externalRepositoryResolver{repository: r}
 }
 
 type externalRepositoryResolver struct {
-	repository *repositoryResolver
+	repository *RepositoryResolver
 }
 
 func (r *externalRepositoryResolver) ID() string { return r.repository.repo.ExternalRepo.ID }
@@ -27,7 +27,7 @@ func (r *externalRepositoryResolver) ServiceID() string {
 	return r.repository.repo.ExternalRepo.ServiceID
 }
 
-func (r *repositoryResolver) ExternalServices(ctx context.Context, args *struct {
+func (r *RepositoryResolver) ExternalServices(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 }) (*computedExternalServiceConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins may read external services (they have secrets).

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -107,12 +107,12 @@ func (r *repositoryResolver) GitRefs(ctx context.Context, args *struct {
 	}
 
 	// Combine branches and tags.
-	refs := make([]*gitRefResolver, len(branches)+len(tags))
+	refs := make([]*GitRefResolver, len(branches)+len(tags))
 	for i, b := range branches {
-		refs[i] = &gitRefResolver{name: "refs/heads/" + b.Name, repo: r, target: gitObjectID(b.Head)}
+		refs[i] = &GitRefResolver{name: "refs/heads/" + b.Name, repo: r, target: gitObjectID(b.Head)}
 	}
 	for i, t := range tags {
-		refs[i+len(branches)] = &gitRefResolver{name: "refs/tags/" + t.Name, repo: r, target: gitObjectID(t.CommitID)}
+		refs[i+len(branches)] = &GitRefResolver{name: "refs/tags/" + t.Name, repo: r, target: gitObjectID(t.CommitID)}
 	}
 
 	if args.Query != nil {
@@ -137,13 +137,13 @@ func (r *repositoryResolver) GitRefs(ctx context.Context, args *struct {
 
 type gitRefConnectionResolver struct {
 	first *int32
-	refs  []*gitRefResolver
+	refs  []*GitRefResolver
 
 	repo *repositoryResolver
 }
 
-func (r *gitRefConnectionResolver) Nodes() []*gitRefResolver {
-	var nodes []*gitRefResolver
+func (r *gitRefConnectionResolver) Nodes() []*GitRefResolver {
+	var nodes []*GitRefResolver
 
 	// Paginate.
 	if r.first != nil && len(r.refs) > int(*r.first) {

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -109,10 +109,10 @@ func (r *repositoryResolver) GitRefs(ctx context.Context, args *struct {
 	// Combine branches and tags.
 	refs := make([]*GitRefResolver, len(branches)+len(tags))
 	for i, b := range branches {
-		refs[i] = &GitRefResolver{name: "refs/heads/" + b.Name, repo: r, target: gitObjectID(b.Head)}
+		refs[i] = &GitRefResolver{name: "refs/heads/" + b.Name, repo: r, target: GitObjectID(b.Head)}
 	}
 	for i, t := range tags {
-		refs[i+len(branches)] = &GitRefResolver{name: "refs/tags/" + t.Name, repo: r, target: gitObjectID(t.CommitID)}
+		refs[i+len(branches)] = &GitRefResolver{name: "refs/tags/" + t.Name, repo: r, target: GitObjectID(t.CommitID)}
 	}
 
 	if args.Query != nil {

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/vcs/git"
 )
 
-func (r *repositoryResolver) Branches(ctx context.Context, args *struct {
+func (r *RepositoryResolver) Branches(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 	Query   *string
 	OrderBy *string
@@ -25,7 +25,7 @@ func (r *repositoryResolver) Branches(ctx context.Context, args *struct {
 	}{ConnectionArgs: args.ConnectionArgs, Query: args.Query, Type: &gitRefTypeBranch, OrderBy: args.OrderBy})
 }
 
-func (r *repositoryResolver) Tags(ctx context.Context, args *struct {
+func (r *RepositoryResolver) Tags(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 	Query *string
 }) (*gitRefConnectionResolver, error) {
@@ -38,7 +38,7 @@ func (r *repositoryResolver) Tags(ctx context.Context, args *struct {
 	}{ConnectionArgs: args.ConnectionArgs, Query: args.Query, Type: &gitRefTypeTag})
 }
 
-func (r *repositoryResolver) GitRefs(ctx context.Context, args *struct {
+func (r *RepositoryResolver) GitRefs(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 	Query   *string
 	Type    *string
@@ -139,7 +139,7 @@ type gitRefConnectionResolver struct {
 	first *int32
 	refs  []*GitRefResolver
 
-	repo *repositoryResolver
+	repo *RepositoryResolver
 }
 
 func (r *gitRefConnectionResolver) Nodes() []*GitRefResolver {

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -18,12 +18,12 @@ import (
 	repoupdaterprotocol "github.com/sourcegraph/sourcegraph/pkg/repoupdater/protocol"
 )
 
-func (r *repositoryResolver) MirrorInfo() *repositoryMirrorInfoResolver {
+func (r *RepositoryResolver) MirrorInfo() *repositoryMirrorInfoResolver {
 	return &repositoryMirrorInfoResolver{repository: r}
 }
 
 type repositoryMirrorInfoResolver struct {
-	repository *repositoryResolver
+	repository *RepositoryResolver
 
 	// memoize the repo-updater RepoUpdateSchedulerInfo call
 	repoUpdateSchedulerInfoOnce   sync.Once

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -88,7 +88,7 @@ func TestRepositoryHydration(t *testing.T) {
 		}
 		defer func() { db.Mocks = db.MockStores{} }()
 
-		repoResolver := &repositoryResolver{repo: minimalRepo}
+		repoResolver := &RepositoryResolver{repo: minimalRepo}
 		assertRepoResolverHydrated(ctx, t, repoResolver, hydratedRepo)
 	})
 
@@ -102,7 +102,7 @@ func TestRepositoryHydration(t *testing.T) {
 		}
 		defer func() { db.Mocks = db.MockStores{} }()
 
-		repoResolver := &repositoryResolver{repo: minimalRepo}
+		repoResolver := &RepositoryResolver{repo: minimalRepo}
 		_, err := repoResolver.Description(ctx)
 		if err == nil {
 			t.Fatal("err is unexpected nil")
@@ -124,7 +124,7 @@ func TestRepositoryHydration(t *testing.T) {
 	})
 }
 
-func assertRepoResolverHydrated(ctx context.Context, t *testing.T, r *repositoryResolver, hydrated *types.Repo) {
+func assertRepoResolverHydrated(ctx context.Context, t *testing.T, r *RepositoryResolver, hydrated *types.Repo) {
 	t.Helper()
 
 	description, err := r.Description(ctx)

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -103,7 +103,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 
 	refs := make([]*repositoryTextSearchIndexedRef, len(refNames))
 	for i, refName := range refNames {
-		refs[i] = &repositoryTextSearchIndexedRef{ref: &gitRefResolver{name: refName, repo: r.repo}}
+		refs[i] = &repositoryTextSearchIndexedRef{ref: &GitRefResolver{name: refName, repo: r.repo}}
 	}
 	refByName := func(refName string) *repositoryTextSearchIndexedRef {
 		for _, ref := range refs {
@@ -113,7 +113,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 		}
 
 		// If Zoekt reports it has another indexed branch, include that.
-		newRef := &repositoryTextSearchIndexedRef{ref: &gitRefResolver{name: refName, repo: r.repo}}
+		newRef := &repositoryTextSearchIndexedRef{ref: &GitRefResolver{name: refName, repo: r.repo}}
 		refs = append(refs, newRef)
 		return newRef
 	}
@@ -136,11 +136,11 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 }
 
 type repositoryTextSearchIndexedRef struct {
-	ref           *gitRefResolver
+	ref           *GitRefResolver
 	indexedCommit gitObjectID
 }
 
-func (r *repositoryTextSearchIndexedRef) Ref() *gitRefResolver { return r.ref }
+func (r *repositoryTextSearchIndexedRef) Ref() *GitRefResolver { return r.ref }
 func (r *repositoryTextSearchIndexedRef) Indexed() bool        { return r.indexedCommit != "" }
 
 func (r *repositoryTextSearchIndexedRef) Current(ctx context.Context) (bool, error) {

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -129,7 +129,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 				name = defaultBranchRef.name
 			}
 			ref := refByName(name)
-			ref.indexedCommit = gitObjectID(branch.Version)
+			ref.indexedCommit = GitObjectID(branch.Version)
 		}
 	}
 	return refs, nil
@@ -137,7 +137,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 
 type repositoryTextSearchIndexedRef struct {
 	ref           *GitRefResolver
-	indexedCommit gitObjectID
+	indexedCommit GitObjectID
 }
 
 func (r *repositoryTextSearchIndexedRef) Ref() *GitRefResolver { return r.ref }

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -10,7 +10,7 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 )
 
-func (r *repositoryResolver) TextSearchIndex() *repositoryTextSearchIndexResolver {
+func (r *RepositoryResolver) TextSearchIndex() *repositoryTextSearchIndexResolver {
 	if !IndexedSearch().Enabled() {
 		return nil
 	}
@@ -21,7 +21,7 @@ func (r *repositoryResolver) TextSearchIndex() *repositoryTextSearchIndexResolve
 }
 
 type repositoryTextSearchIndexResolver struct {
-	repo   *repositoryResolver
+	repo   *RepositoryResolver
 	client repoLister
 
 	once  sync.Once
@@ -51,7 +51,7 @@ func (r *repositoryTextSearchIndexResolver) resolve(ctx context.Context) (*zoekt
 	return r.entry, r.err
 }
 
-func (r *repositoryTextSearchIndexResolver) Repository() *repositoryResolver { return r.repo }
+func (r *repositoryTextSearchIndexResolver) Repository() *RepositoryResolver { return r.repo }
 
 func (r *repositoryTextSearchIndexResolver) Status(ctx context.Context) (*repositoryTextSearchIndexStatus, error) {
 	entry, err := r.resolve(ctx)

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -646,7 +646,7 @@ func (e *badRequestError) Cause() error {
 
 // searchSuggestionResolver is a resolver for the GraphQL union type `SearchSuggestion`
 type searchSuggestionResolver struct {
-	// result is either a repositoryResolver or a gitTreeEntryResolver
+	// result is either a RepositoryResolver or a gitTreeEntryResolver
 	result interface{}
 	// score defines how well this item matches the query for sorting purposes
 	score int
@@ -656,8 +656,8 @@ type searchSuggestionResolver struct {
 	label string
 }
 
-func (r *searchSuggestionResolver) ToRepository() (*repositoryResolver, bool) {
-	res, ok := r.result.(*repositoryResolver)
+func (r *searchSuggestionResolver) ToRepository() (*RepositoryResolver, bool) {
+	res, ok := r.result.(*RepositoryResolver)
 	return res, ok
 }
 
@@ -687,11 +687,11 @@ func (r *searchSuggestionResolver) ToSymbol() (*symbolResolver, bool) {
 // newSearchResultResolver returns a new searchResultResolver wrapping the
 // given result.
 //
-// A panic occurs if the type of result is not a *repositoryResolver or
+// A panic occurs if the type of result is not a *RepositoryResolver or
 // *gitTreeEntryResolver.
 func newSearchResultResolver(result interface{}, score int) *searchSuggestionResolver {
 	switch r := result.(type) {
-	case *repositoryResolver:
+	case *RepositoryResolver:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.repo.Name), label: string(r.repo.Name)}
 
 	case *gitTreeEntryResolver:

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -26,8 +26,8 @@ import (
 // commitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
 type commitSearchResultResolver struct {
 	commit         *gitCommitResolver
-	refs           []*gitRefResolver
-	sourceRefs     []*gitRefResolver
+	refs           []*GitRefResolver
+	sourceRefs     []*GitRefResolver
 	messagePreview *highlightedString
 	diffPreview    *highlightedString
 	icon           string
@@ -38,8 +38,8 @@ type commitSearchResultResolver struct {
 }
 
 func (r *commitSearchResultResolver) Commit() *gitCommitResolver         { return r.commit }
-func (r *commitSearchResultResolver) Refs() []*gitRefResolver            { return r.refs }
-func (r *commitSearchResultResolver) SourceRefs() []*gitRefResolver      { return r.sourceRefs }
+func (r *commitSearchResultResolver) Refs() []*GitRefResolver            { return r.refs }
+func (r *commitSearchResultResolver) SourceRefs() []*GitRefResolver      { return r.sourceRefs }
 func (r *commitSearchResultResolver) MessagePreview() *highlightedString { return r.messagePreview }
 func (r *commitSearchResultResolver) DiffPreview() *highlightedString    { return r.diffPreview }
 func (r *commitSearchResultResolver) Icon() string {
@@ -275,9 +275,9 @@ func searchCommitsInRepo(ctx context.Context, op commitSearchOp) (results []*com
 		commitResolver := toGitCommitResolver(repoResolver, &commit)
 		results[i] = &commitSearchResultResolver{commit: commitResolver}
 
-		addRefs := func(dst *[]*gitRefResolver, src []string) {
+		addRefs := func(dst *[]*GitRefResolver, src []string) {
 			for _, ref := range src {
-				*dst = append(*dst, &gitRefResolver{
+				*dst = append(*dst, &GitRefResolver{
 					repo: repoResolver,
 					name: ref,
 				})

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -25,7 +25,7 @@ import (
 
 // commitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
 type commitSearchResultResolver struct {
-	commit         *gitCommitResolver
+	commit         *GitCommitResolver
 	refs           []*GitRefResolver
 	sourceRefs     []*GitRefResolver
 	messagePreview *highlightedString
@@ -37,7 +37,7 @@ type commitSearchResultResolver struct {
 	matches        []*searchResultMatchResolver
 }
 
-func (r *commitSearchResultResolver) Commit() *gitCommitResolver         { return r.commit }
+func (r *commitSearchResultResolver) Commit() *GitCommitResolver         { return r.commit }
 func (r *commitSearchResultResolver) Refs() []*GitRefResolver            { return r.refs }
 func (r *commitSearchResultResolver) SourceRefs() []*GitRefResolver      { return r.sourceRefs }
 func (r *commitSearchResultResolver) MessagePreview() *highlightedString { return r.messagePreview }
@@ -389,7 +389,7 @@ func cleanDiffPreview(highlights []*highlightedRange, rawDiffResult string) (str
 	return body, highlights
 }
 
-func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *gitCommitResolver) (string, error) {
+func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *GitCommitResolver) (string, error) {
 	message := commitSubject(rawResult.Commit.Message)
 	author := rawResult.Commit.Author.Name
 	repoName := displayRepoName(commitResolver.Repository().Name())

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -62,7 +62,7 @@ func (r *commitSearchResultResolver) Matches() []*searchResultMatchResolver {
 	return r.matches
 }
 
-func (r *commitSearchResultResolver) ToRepository() (*repositoryResolver, bool) { return nil, false }
+func (r *commitSearchResultResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
 func (r *commitSearchResultResolver) ToFileMatch() (*fileMatchResolver, bool)   { return nil, false }
 func (r *commitSearchResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return r, true
@@ -268,7 +268,7 @@ func searchCommitsInRepo(ctx context.Context, op commitSearchOp) (results []*com
 		rawResults = rawResults[:maxResults]
 	}
 
-	repoResolver := &repositoryResolver{repo: repo}
+	repoResolver := &RepositoryResolver{repo: repo}
 	results = make([]*commitSearchResultResolver, len(rawResults))
 	for i, rawResult := range rawResults {
 		commit := rawResult.Commit

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -67,7 +67,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantCommit := gitCommitResolver{
+	wantCommit := GitCommitResolver{
 		repo:   &repositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
 		oid:    "c1",
 		author: *toSignatureResolver(&gitSignatureWithDate),

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -68,7 +68,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 
 	wantCommit := GitCommitResolver{
-		repo:   &repositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
+		repo:   &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
 		oid:    "c1",
 		author: *toSignatureResolver(&gitSignatureWithDate),
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -67,14 +67,14 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 		}
 	}
 
-	// Convert the repos to repositoryResolvers.
+	// Convert the repos to RepositoryResolvers.
 	results := make([]searchResultResolver, 0, len(repos))
 	for _, r := range repos {
 		if len(results) == int(limit) {
 			common.limitHit = true
 			break
 		}
-		results = append(results, &repositoryResolver{repo: r.Repo, icon: repoIcon})
+		results = append(results, &RepositoryResolver{repo: r.Repo, icon: repoIcon})
 	}
 
 	return results, common, nil

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -62,35 +62,35 @@ func (c *searchResultsCommon) LimitHit() bool {
 	return c.limitHit || c.resultCount > c.maxResultsCount
 }
 
-func (c *searchResultsCommon) Repositories() []*repositoryResolver {
-	return repositoryResolvers(c.repos)
+func (c *searchResultsCommon) Repositories() []*RepositoryResolver {
+	return RepositoryResolvers(c.repos)
 }
 
-func (c *searchResultsCommon) RepositoriesSearched() []*repositoryResolver {
-	return repositoryResolvers(c.searched)
+func (c *searchResultsCommon) RepositoriesSearched() []*RepositoryResolver {
+	return RepositoryResolvers(c.searched)
 }
 
-func (c *searchResultsCommon) IndexedRepositoriesSearched() []*repositoryResolver {
-	return repositoryResolvers(c.indexed)
+func (c *searchResultsCommon) IndexedRepositoriesSearched() []*RepositoryResolver {
+	return RepositoryResolvers(c.indexed)
 }
 
-func (c *searchResultsCommon) Cloning() []*repositoryResolver {
-	return repositoryResolvers(c.cloning)
+func (c *searchResultsCommon) Cloning() []*RepositoryResolver {
+	return RepositoryResolvers(c.cloning)
 }
 
-func (c *searchResultsCommon) Missing() []*repositoryResolver {
-	return repositoryResolvers(c.missing)
+func (c *searchResultsCommon) Missing() []*RepositoryResolver {
+	return RepositoryResolvers(c.missing)
 }
 
-func (c *searchResultsCommon) Timedout() []*repositoryResolver {
-	return repositoryResolvers(c.timedout)
+func (c *searchResultsCommon) Timedout() []*RepositoryResolver {
+	return RepositoryResolvers(c.timedout)
 }
 
 func (c *searchResultsCommon) IndexUnavailable() bool {
 	return c.indexUnavailable
 }
 
-func repositoryResolvers(repos types.Repos) []*repositoryResolver {
+func RepositoryResolvers(repos types.Repos) []*RepositoryResolver {
 	dedupSort(&repos)
 	return toRepositoryResolvers(repos)
 }
@@ -414,7 +414,7 @@ loop:
 	for _, r := range sr.results {
 		r := r // shadow so it doesn't change in the goroutine
 		switch m := r.(type) {
-		case *repositoryResolver:
+		case *RepositoryResolver:
 			// We don't care about repo results here.
 			continue
 		case *commitSearchResultResolver:
@@ -1074,14 +1074,14 @@ func isContextError(ctx context.Context, err error) bool {
 //
 // Supported types:
 //
-//   - *repositoryResolver         // repo name match
+//   - *RepositoryResolver         // repo name match
 //   - *fileMatchResolver          // text match
 //   - *commitSearchResultResolver // diff or commit match
 //   - *codemodResultResolver      // code modification
 //
 // Note: Any new result types added here also need to be handled properly in search_results.go:301 (sparklines)
 type searchResultResolver interface {
-	ToRepository() (*repositoryResolver, bool)
+	ToRepository() (*RepositoryResolver, bool)
 	ToFileMatch() (*fileMatchResolver, bool)
 	ToCommitSearchResult() (*commitSearchResultResolver, bool)
 	ToCodemodResult() (*codemodResultResolver, bool)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -41,7 +41,7 @@ func TestSearchResults(t *testing.T) {
 			// NOTE: Only supports one match per line. If we need to test other cases,
 			// just remove that assumption in the following line of code.
 			switch m := result.(type) {
-			case *repositoryResolver:
+			case *RepositoryResolver:
 				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.repo.Name)
 			case *fileMatchResolver:
 				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.JPath, m.JLineMatches[0].JLineNumber)
@@ -461,7 +461,7 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 func TestSearchResolver_DynamicFilters(t *testing.T) {
 	repo := &types.Repo{Name: "testRepo"}
 
-	repoMatch := &repositoryResolver{
+	repoMatch := &RepositoryResolver{
 		repo: repo,
 	}
 
@@ -682,10 +682,10 @@ func TestCompareSearchResults(t *testing.T) {
 
 	tests := []testCase{{
 		// Different repo matches
-		a: &repositoryResolver{
+		a: &RepositoryResolver{
 			repo: &types.Repo{Name: api.RepoName("a")},
 		},
-		b: &repositoryResolver{
+		b: &RepositoryResolver{
 			repo: &types.Repo{Name: api.RepoName("b")},
 		},
 		aIsLess: true,
@@ -696,7 +696,7 @@ func TestCompareSearchResults(t *testing.T) {
 
 			JPath: "a",
 		},
-		b: &repositoryResolver{
+		b: &RepositoryResolver{
 			repo: &types.Repo{Name: api.RepoName("a")},
 		},
 		aIsLess: false,
@@ -908,7 +908,7 @@ func TestSearchResultsHydration(t *testing.T) {
 		case *fileMatchResolver:
 			assertRepoResolverHydrated(ctx, t, r.Repository(), hydratedRepo)
 
-		case *repositoryResolver:
+		case *RepositoryResolver:
 			assertRepoResolverHydrated(ctx, t, r, hydratedRepo)
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -244,7 +244,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			k.repoName = s.repo.Name
 		case *gitTreeEntryResolver:
 			k.repoName = s.commit.repo.repo.Name
-			// We explicitely do not use gitCommitResolver.OID() to get the OID here
+			// We explicitely do not use GitCommitResolver.OID() to get the OID here
 			// because it could significantly slow down search suggestions from zoekt as
 			// it doesn't specify the commit the default branch is on. This result would in
 			// computing this commit for each suggestion, which could be heavy.

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -76,7 +76,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			resolvers := make([]*searchSuggestionResolver, 0, len(repoRevs))
 			for _, rev := range repoRevs {
 				resolvers = append(resolvers, newSearchResultResolver(
-					&repositoryResolver{repo: rev.Repo},
+					&RepositoryResolver{repo: rev.Repo},
 					math.MaxInt32,
 				))
 			}
@@ -240,7 +240,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 	for _, s := range allSuggestions {
 		var k key
 		switch s := s.result.(type) {
-		case *repositoryResolver:
+		case *RepositoryResolver:
 			k.repoName = s.repo.Name
 		case *gitTreeEntryResolver:
 			k.repoName = s.commit.repo.repo.Name

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -35,7 +35,7 @@ type searchSymbolResult struct {
 	symbol  protocol.Symbol
 	baseURI *gituri.URI
 	lang    string
-	commit  *gitCommitResolver // TODO: change to utility type we create to remove git resolvers from search.
+	commit  *GitCommitResolver // TODO: change to utility type we create to remove git resolvers from search.
 }
 
 func (s *searchSymbolResult) uri() *gituri.URI {
@@ -284,7 +284,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 	fileMatchesByURI := make(map[string]*fileMatchResolver)
 	fileMatches := make([]*fileMatchResolver, 0)
 	for _, symbol := range symbols {
-		commit := &gitCommitResolver{
+		commit := &GitCommitResolver{
 			repo:     &repositoryResolver{repo: repoRevs.Repo},
 			oid:      GitObjectID(commitID),
 			inputRev: &inputRev,
@@ -308,7 +308,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 				symbols: []*searchSymbolResult{symbolRes},
 				uri:     uri,
 				repo:    symbolRes.commit.repo.repo,
-				// Don't get commit from gitCommitResolver.OID() because we don't want to
+				// Don't get commit from GitCommitResolver.OID() because we don't want to
 				// slow search results down when they are coming from zoekt.
 				commitID: api.CommitID(symbolRes.commit.oid),
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -285,7 +285,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 	fileMatches := make([]*fileMatchResolver, 0)
 	for _, symbol := range symbols {
 		commit := &GitCommitResolver{
-			repo:     &repositoryResolver{repo: repoRevs.Repo},
+			repo:     &RepositoryResolver{repo: repoRevs.Repo},
 			oid:      GitObjectID(commitID),
 			inputRev: &inputRev,
 			// NOTE: Not all fields are set, for performance.

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -286,7 +286,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 	for _, symbol := range symbols {
 		commit := &gitCommitResolver{
 			repo:     &repositoryResolver{repo: repoRevs.Repo},
-			oid:      gitObjectID(commitID),
+			oid:      GitObjectID(commitID),
 			inputRev: &inputRev,
 			// NOTE: Not all fields are set, for performance.
 		}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -23,7 +23,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
 	commit := &GitCommitResolver{
-		repo:   &repositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
+		repo:   &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
 		oid:    "c1",
 		author: *toSignatureResolver(&gitSignatureWithDate),
 	}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -22,7 +22,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	}
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
-	commit := &gitCommitResolver{
+	commit := &GitCommitResolver{
 		repo:   &repositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
 		oid:    "c1",
 		author: *toSignatureResolver(&gitSignatureWithDate),

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -233,7 +233,7 @@ var testSearchGQLQuery = `
 func testStringResult(result *searchSuggestionResolver) string {
 	var name string
 	switch r := result.result.(type) {
-	case *repositoryResolver:
+	case *RepositoryResolver:
 		name = "repo:" + string(r.repo.Name)
 	case *gitTreeEntryResolver:
 		name = "file:" + r.path

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -78,7 +78,7 @@ func (updateSettingsPayload) Empty() *EmptyResponse { return nil }
 
 type settingsEdit struct {
 	KeyPath                   []*keyPathSegment
-	Value                     *jsonValue
+	Value                     *JSONValue
 	ValueIsJSONCEncodedString bool
 }
 

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -28,7 +28,7 @@ type settingsSubject struct {
 // settingsSubjectByID fetches the settings subject with the given ID. If the ID refers to a node
 // that is not a valid settings subject, an error is returned.
 func settingsSubjectByID(ctx context.Context, id graphql.ID) (*settingsSubject, error) {
-	resolver, err := nodeByID(ctx, id)
+	resolver, err := NodeByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -24,7 +24,7 @@ import (
 
 const singletonSiteGQLID = "site"
 
-func siteByGQLID(ctx context.Context, id graphql.ID) (node, error) {
+func siteByGQLID(ctx context.Context, id graphql.ID) (Node, error) {
 	siteGQLID, err := unmarshalSiteGQLID(id)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -27,7 +27,7 @@ func (r *gitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (
 	return &symbolConnectionResolver{symbols: symbols, first: args.First}, nil
 }
 
-func (r *gitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
+func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
 	symbols, err := computeSymbols(ctx, r, args.Query, args.First, args.IncludePatterns)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
@@ -47,7 +47,7 @@ func limitOrDefault(first *int32) int {
 	return int(*first)
 }
 
-func computeSymbols(ctx context.Context, commit *gitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
+func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
 	ctx, done := context.WithTimeout(ctx, 5*time.Second)
 	defer done()
 	defer func() {
@@ -87,7 +87,7 @@ func computeSymbols(ctx context.Context, commit *gitCommitResolver, query *strin
 	return resolvers, err
 }
 
-func toSymbolResolver(symbol protocol.Symbol, baseURI *gituri.URI, lang string, commitResolver *gitCommitResolver) *symbolResolver {
+func toSymbolResolver(symbol protocol.Symbol, baseURI *gituri.URI, lang string, commitResolver *GitCommitResolver) *symbolResolver {
 	resolver := &symbolResolver{
 		symbol:   symbol,
 		language: lang,

--- a/cmd/frontend/graphqlbackend/tags.go
+++ b/cmd/frontend/graphqlbackend/tags.go
@@ -19,7 +19,7 @@ func (r *schemaResolver) SetTag(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	node, err := nodeByID(ctx, args.Node)
+	node, err := NodeByID(ctx, args.Node)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -83,7 +83,7 @@ func (fm *fileMatchResolver) File() *gitTreeEntryResolver {
 	return &gitTreeEntryResolver{
 		commit: &gitCommitResolver{
 			repo:     &repositoryResolver{repo: fm.repo},
-			oid:      gitObjectID(fm.commitID),
+			oid:      GitObjectID(fm.commitID),
 			inputRev: fm.inputRev,
 		},
 		path: fm.JPath,
@@ -632,7 +632,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 					if isSymbol && m.SymbolInfo != nil {
 						commit := &gitCommitResolver{
 							repo:     &repositoryResolver{repo: repoRev.Repo},
-							oid:      gitObjectID(repoRev.IndexedHEADCommit()),
+							oid:      GitObjectID(repoRev.IndexedHEADCommit()),
 							inputRev: &inputRev,
 						}
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -82,7 +82,7 @@ func (fm *fileMatchResolver) File() *gitTreeEntryResolver {
 	// values for all other fields.
 	return &gitTreeEntryResolver{
 		commit: &GitCommitResolver{
-			repo:     &repositoryResolver{repo: fm.repo},
+			repo:     &RepositoryResolver{repo: fm.repo},
 			oid:      GitObjectID(fm.commitID),
 			inputRev: fm.inputRev,
 		},
@@ -91,8 +91,8 @@ func (fm *fileMatchResolver) File() *gitTreeEntryResolver {
 	}
 }
 
-func (fm *fileMatchResolver) Repository() *repositoryResolver {
-	return &repositoryResolver{repo: fm.repo}
+func (fm *fileMatchResolver) Repository() *RepositoryResolver {
+	return &RepositoryResolver{repo: fm.repo}
 }
 
 func (fm *fileMatchResolver) Resource() string {
@@ -115,7 +115,7 @@ func (fm *fileMatchResolver) LimitHit() bool {
 	return fm.JLimitHit
 }
 
-func (fm *fileMatchResolver) ToRepository() (*repositoryResolver, bool) { return nil, false }
+func (fm *fileMatchResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
 func (fm *fileMatchResolver) ToFileMatch() (*fileMatchResolver, bool)   { return fm, true }
 func (fm *fileMatchResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
 	return nil, false
@@ -631,7 +631,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 					offsets[k] = [2]int32{int32(offset), int32(length)}
 					if isSymbol && m.SymbolInfo != nil {
 						commit := &GitCommitResolver{
-							repo:     &repositoryResolver{repo: repoRev.Repo},
+							repo:     &RepositoryResolver{repo: repoRev.Repo},
 							oid:      GitObjectID(repoRev.IndexedHEADCommit()),
 							inputRev: &inputRev,
 						}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -78,10 +78,10 @@ func (fm *fileMatchResolver) Key() string {
 
 func (fm *fileMatchResolver) File() *gitTreeEntryResolver {
 	// NOTE(sqs): Omits other commit fields to avoid needing to fetch them
-	// (which would make it slow). This gitCommitResolver will return empty
+	// (which would make it slow). This GitCommitResolver will return empty
 	// values for all other fields.
 	return &gitTreeEntryResolver{
-		commit: &gitCommitResolver{
+		commit: &GitCommitResolver{
 			repo:     &repositoryResolver{repo: fm.repo},
 			oid:      GitObjectID(fm.commitID),
 			inputRev: fm.inputRev,
@@ -630,7 +630,7 @@ func zoektSearchHEAD(ctx context.Context, query *search.PatternInfo, repos []*se
 					length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 					offsets[k] = [2]int32{int32(offset), int32(length)}
 					if isSymbol && m.SymbolInfo != nil {
-						commit := &gitCommitResolver{
+						commit := &GitCommitResolver{
 							repo:     &repositoryResolver{repo: repoRev.Repo},
 							oid:      GitObjectID(repoRev.IndexedHEADCommit()),
 							inputRev: &inputRev,


### PR DESCRIPTION
The graphqlbackend is a huge package right now. We are trying to extract more things from it (such as `./enterprise/cmd/frontend/internal/{licensing,registry,dotcom/{billing,productsubscription}}`, all of which contribute GraphQL resolvers but are in separate, well encapsulated packages). The extracted packages do need to access certain definitions in the graphqlbackend package, so it is necessary to export some more things from it.

This commit is entirely automated codemods.