### PR TITLE
support non-100%-width Select component

### DIFF
--- a/web/src/components/Select.scss
+++ b/web/src/components/Select.scss
@@ -1,8 +1,12 @@
+$icon-size: 1.625rem;
+
 .select {
-    position: relative;
+    display: flex;
+    align-items: center;
 
     &__picker {
         appearance: none;
+        padding-right: $icon-size;
 
         &:disabled {
             &,
@@ -15,9 +19,7 @@
     &__icon {
         display: block;
         pointer-events: none;
-        right: 0.5rem;
-        top: 0.25rem;
-        height: 1.625rem;
-        position: absolute;
+        height: $icon-size;
+        margin-left: -1 * $icon-size;
     }
 }


### PR DESCRIPTION
Previously, a non-100%-width `<Select>` would have the caret outside of the form control visually.

Confirmed it does not regress 100%-width `<Select>`s:

![image](https://user-images.githubusercontent.com/1976/63210046-e4a61980-c09d-11e9-89c6-32cc1e221c07.png)
