### PR TITLE
use GraphQL DateTime scalar type for dates

### DIFF
--- a/cmd/frontend/graphqlbackend/access_token.go
+++ b/cmd/frontend/graphqlbackend/access_token.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -60,14 +59,8 @@ func (r *accessTokenResolver) Creator(ctx context.Context) (*UserResolver, error
 	return UserByIDInt32(ctx, r.accessToken.CreatorUserID)
 }
 
-func (r *accessTokenResolver) CreatedAt() string {
-	return r.accessToken.CreatedAt.Format(time.RFC3339)
-}
+func (r *accessTokenResolver) CreatedAt() DateTime { return DateTime{Time: r.accessToken.CreatedAt} }
 
-func (r *accessTokenResolver) LastUsedAt() *string {
-	if r.accessToken.LastUsedAt == nil {
-		return nil
-	}
-	t := r.accessToken.LastUsedAt.Format(time.RFC3339)
-	return &t
+func (r *accessTokenResolver) LastUsedAt() *DateTime {
+	return DateTimeOrNil(r.accessToken.LastUsedAt)
 }

--- a/cmd/frontend/graphqlbackend/datetime.go
+++ b/cmd/frontend/graphqlbackend/datetime.go
@@ -1,0 +1,40 @@
+package graphqlbackend
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// DateTime implements the DateTime GraphQL scalar type.
+type DateTime struct{ time.Time }
+
+// DateTimeOrNil is a helper function that returns nil for time == nil and otherwise wraps time in
+// DateTime.
+func DateTimeOrNil(time *time.Time) *DateTime {
+	if time == nil {
+		return nil
+	}
+	return &DateTime{Time: *time}
+}
+
+func (DateTime) ImplementsGraphQLType(name string) bool {
+	return name == "DateTime"
+}
+
+func (v DateTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Time.Format(time.RFC3339))
+}
+
+func (v *DateTime) UnmarshalGraphQL(input interface{}) error {
+	s, ok := input.(string)
+	if !ok {
+		return fmt.Errorf("invalid GraphQL DateTime scalar value input (got %T, expected string)", input)
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return err
+	}
+	*v = DateTime{Time: t}
+	return nil
+}

--- a/cmd/frontend/graphqlbackend/datetime_test.go
+++ b/cmd/frontend/graphqlbackend/datetime_test.go
@@ -1,0 +1,27 @@
+package graphqlbackend
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDateTime(t *testing.T) {
+	t0 := time.Unix(123456789, 0).UTC()
+	t.Run("marshal", func(t *testing.T) {
+		v := DateTime{Time: t0}
+		if got, err := v.MarshalJSON(); err != nil {
+			t.Fatal(err)
+		} else if want := `"1973-11-29T21:33:09Z"`; string(got) != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("unmarshal", func(t *testing.T) {
+		var got DateTime
+		if err := got.UnmarshalGraphQL("1973-11-29T21:33:09Z"); err != nil {
+			t.Fatal(err)
+		}
+		if want := (DateTime{Time: t0}); !got.Time.Equal(want.Time) {
+			t.Errorf("got %v, want %v", got.Time, want.Time)
+		}
+	})
+}

--- a/cmd/frontend/graphqlbackend/discussion_comments.go
+++ b/cmd/frontend/graphqlbackend/discussion_comments.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -104,12 +103,12 @@ func (r *discussionCommentResolver) InlineURL(ctx context.Context) (*string, err
 	return strptr(url.String()), nil
 }
 
-func (r *discussionCommentResolver) CreatedAt(ctx context.Context) string {
-	return r.c.CreatedAt.Format(time.RFC3339)
+func (r *discussionCommentResolver) CreatedAt() DateTime {
+	return DateTime{Time: r.c.CreatedAt}
 }
 
-func (r *discussionCommentResolver) UpdatedAt(ctx context.Context) string {
-	return r.c.UpdatedAt.Format(time.RFC3339)
+func (r *discussionCommentResolver) UpdatedAt() DateTime {
+	return DateTime{Time: r.c.UpdatedAt}
 }
 
 func (r *discussionCommentResolver) Reports(ctx context.Context) []string {

--- a/cmd/frontend/graphqlbackend/discussion_threads.go
+++ b/cmd/frontend/graphqlbackend/discussion_threads.go
@@ -687,19 +687,16 @@ func (d *discussionThreadResolver) InlineURL(ctx context.Context) (*string, erro
 	return strptr(url.String()), nil
 }
 
-func (d *discussionThreadResolver) CreatedAt(ctx context.Context) string {
-	return d.t.CreatedAt.Format(time.RFC3339)
+func (d *discussionThreadResolver) CreatedAt() DateTime {
+	return DateTime{Time: d.t.CreatedAt}
 }
 
-func (d *discussionThreadResolver) UpdatedAt(ctx context.Context) string {
-	return d.t.UpdatedAt.Format(time.RFC3339)
+func (d *discussionThreadResolver) UpdatedAt() DateTime {
+	return DateTime{Time: d.t.UpdatedAt}
 }
 
-func (d *discussionThreadResolver) ArchivedAt(ctx context.Context) *string {
-	if d.t.ArchivedAt == nil {
-		return nil
-	}
-	return strptr(d.t.ArchivedAt.Format(time.RFC3339))
+func (d *discussionThreadResolver) ArchivedAt() *DateTime {
+	return DateTimeOrNil(d.t.ArchivedAt)
 }
 
 func (d *discussionThreadResolver) Comments(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -55,7 +55,7 @@ type ProductSubscription interface {
 	Events(context.Context) ([]ProductSubscriptionEvent, error)
 	ActiveLicense(context.Context) (ProductLicense, error)
 	ProductLicenses(context.Context, *graphqlutil.ConnectionArgs) (ProductLicenseConnection, error)
-	CreatedAt() string
+	CreatedAt() DateTime
 	IsArchived() bool
 	URL(context.Context) (string, error)
 	URLForSiteAdmin(context.Context) *string
@@ -67,7 +67,7 @@ type ProductSubscription interface {
 type ProductSubscriptionInvoiceItem interface {
 	Plan() (ProductPlan, error)
 	UserCount() int32
-	ExpiresAt() string
+	ExpiresAt() DateTime
 }
 
 type SetUserBillingArgs struct {
@@ -162,7 +162,7 @@ type ProductLicense interface {
 	Subscription(context.Context) (ProductSubscription, error)
 	Info() (*ProductLicenseInfo, error)
 	LicenseKey() string
-	CreatedAt() string
+	CreatedAt() DateTime
 }
 
 // ProductLicenseInput implements the GraphQL type ProductLicenseInput.

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -109,9 +109,9 @@ type RegistryExtension interface {
 	Publisher(ctx context.Context) (RegistryPublisher, error)
 	Name() string
 	Manifest(ctx context.Context) (ExtensionManifest, error)
-	CreatedAt() *string
-	UpdatedAt() *string
-	PublishedAt(context.Context) (*string, error)
+	CreatedAt() *DateTime
+	UpdatedAt() *DateTime
+	PublishedAt(context.Context) (*DateTime, error)
 	URL() string
 	RemoteURL() *string
 	RegistryName() (string, error)

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -48,8 +47,8 @@ func (r *externalAccountResolver) ServiceType() string { return r.account.Servic
 func (r *externalAccountResolver) ServiceID() string   { return r.account.ServiceID }
 func (r *externalAccountResolver) ClientID() string    { return r.account.ClientID }
 func (r *externalAccountResolver) AccountID() string   { return r.account.AccountID }
-func (r *externalAccountResolver) CreatedAt() string   { return r.account.CreatedAt.Format(time.RFC3339) }
-func (r *externalAccountResolver) UpdatedAt() string   { return r.account.UpdatedAt.Format(time.RFC3339) }
+func (r *externalAccountResolver) CreatedAt() DateTime { return DateTime{Time: r.account.CreatedAt} }
+func (r *externalAccountResolver) UpdatedAt() DateTime { return DateTime{Time: r.account.UpdatedAt} }
 
 func (r *externalAccountResolver) RefreshURL() *string {
 	// TODO(sqs): Not supported.

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"time"
-
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -68,12 +66,12 @@ func (r *externalServiceResolver) Config() string {
 	return r.externalService.Config
 }
 
-func (r *externalServiceResolver) CreatedAt() string {
-	return r.externalService.CreatedAt.Format(time.RFC3339)
+func (r *externalServiceResolver) CreatedAt() DateTime {
+	return DateTime{Time: r.externalService.CreatedAt}
 }
 
-func (r *externalServiceResolver) UpdatedAt() string {
-	return r.externalService.UpdatedAt.Format(time.RFC3339)
+func (r *externalServiceResolver) UpdatedAt() DateTime {
+	return DateTime{Time: r.externalService.UpdatedAt}
 }
 
 func (r *externalServiceResolver) Warning() *string {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -80,7 +79,7 @@ func (o *OrgResolver) URL() string { return "/organizations/" + o.org.Name }
 
 func (o *OrgResolver) SettingsURL() *string { return strptr(o.URL() + "/settings") }
 
-func (o *OrgResolver) CreatedAt() string { return o.org.CreatedAt.Format(time.RFC3339) }
+func (o *OrgResolver) CreatedAt() DateTime { return DateTime{Time: o.org.CreatedAt} }
 
 func (o *OrgResolver) Members(ctx context.Context) (*staticUserConnectionResolver, error) {
 	// 🚨 SECURITY: Only org members can list the org members.

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -52,21 +51,13 @@ func (r *organizationInvitationResolver) Sender(ctx context.Context) (*UserResol
 func (r *organizationInvitationResolver) Recipient(ctx context.Context) (*UserResolver, error) {
 	return UserByIDInt32(ctx, r.v.RecipientUserID)
 }
-func (r *organizationInvitationResolver) CreatedAt() string { return r.v.CreatedAt.Format(time.RFC3339) }
-func (r *organizationInvitationResolver) NotifiedAt() *string {
-	if r.v.NotifiedAt == nil {
-		return nil
-	}
-	s := r.v.NotifiedAt.Format(time.RFC3339)
-	return &s
+func (r *organizationInvitationResolver) CreatedAt() DateTime { return DateTime{Time: r.v.CreatedAt} }
+func (r *organizationInvitationResolver) NotifiedAt() *DateTime {
+	return DateTimeOrNil(r.v.NotifiedAt)
 }
 
-func (r *organizationInvitationResolver) RespondedAt() *string {
-	if r.v.RespondedAt == nil {
-		return nil
-	}
-	s := r.v.RespondedAt.Format(time.RFC3339)
-	return &s
+func (r *organizationInvitationResolver) RespondedAt() *DateTime {
+	return DateTimeOrNil(r.v.RespondedAt)
 }
 
 func (r *organizationInvitationResolver) ResponseType() *string {
@@ -91,12 +82,8 @@ func (r *organizationInvitationResolver) RespondURL(ctx context.Context) (*strin
 	return nil, nil
 }
 
-func (r *organizationInvitationResolver) RevokedAt() *string {
-	if r.v.RevokedAt == nil {
-		return nil
-	}
-	s := r.v.RevokedAt.Format(time.RFC3339)
-	return &s
+func (r *organizationInvitationResolver) RevokedAt() *DateTime {
+	return DateTimeOrNil(r.v.RevokedAt)
 }
 
 func strptr(s string) *string { return &s }

--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -45,10 +44,10 @@ func (r *organizationMembershipResolver) User(ctx context.Context) (*UserResolve
 	return UserByIDInt32(ctx, r.membership.UserID)
 }
 
-func (r *organizationMembershipResolver) CreatedAt() string {
-	return r.membership.CreatedAt.Format(time.RFC3339)
+func (r *organizationMembershipResolver) CreatedAt() DateTime {
+	return DateTime{Time: r.membership.CreatedAt}
 }
 
-func (r *organizationMembershipResolver) UpdatedAt() string {
-	return r.membership.UpdatedAt.Format(time.RFC3339)
+func (r *organizationMembershipResolver) UpdatedAt() DateTime {
+	return DateTime{Time: r.membership.UpdatedAt}
 }

--- a/cmd/frontend/graphqlbackend/product_license_info.go
+++ b/cmd/frontend/graphqlbackend/product_license_info.go
@@ -1,6 +1,8 @@
 package graphqlbackend
 
-import "time"
+import (
+	"time"
+)
 
 // GetConfiguredProductLicenseInfo is called to obtain the product subscription info when creating
 // the GraphQL resolver for the GraphQL type ProductLicenseInfo.
@@ -30,6 +32,6 @@ func (r ProductLicenseInfo) UserCount() int32 {
 	return int32(r.UserCountValue)
 }
 
-func (r ProductLicenseInfo) ExpiresAt() string {
-	return r.ExpiresAtValue.Format(time.RFC3339)
+func (r ProductLicenseInfo) ExpiresAt() DateTime {
+	return DateTime{Time: r.ExpiresAtValue}
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -186,11 +186,11 @@ func (r *RepositoryResolver) Language(ctx context.Context) string {
 
 func (r *RepositoryResolver) Enabled() bool { return true }
 
-func (r *RepositoryResolver) CreatedAt() string {
-	return time.Now().Format(time.RFC3339)
+func (r *RepositoryResolver) CreatedAt() DateTime {
+	return DateTime{Time: time.Now()}
 }
 
-func (r *RepositoryResolver) UpdatedAt() *string {
+func (r *RepositoryResolver) UpdatedAt() *DateTime {
 	return nil
 }
 

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -107,16 +106,12 @@ func (r *repositoryMirrorInfoResolver) CloneProgress(ctx context.Context) (*stri
 	return strptr(info.CloneProgress), nil
 }
 
-func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*string, error) {
+func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*DateTime, error) {
 	info, err := r.gitserverRepoInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if info.LastFetched == nil {
-		return nil, err
-	}
-	s := info.LastFetched.Format(time.RFC3339)
-	return &s, nil
+	return DateTimeOrNil(info.LastFetched), nil
 }
 
 func (r *repositoryMirrorInfoResolver) UpdateSchedule(ctx context.Context) (*updateScheduleResolver, error) {
@@ -138,8 +133,8 @@ func (r *updateScheduleResolver) IntervalSeconds() int32 {
 	return int32(r.schedule.IntervalSeconds)
 }
 
-func (r *updateScheduleResolver) Due() string {
-	return r.schedule.Due.Format(time.RFC3339)
+func (r *updateScheduleResolver) Due() DateTime {
+	return DateTime{Time: r.schedule.Due}
 }
 
 func (r *updateScheduleResolver) Index() int32 {

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
@@ -68,8 +67,8 @@ type repositoryTextSearchIndexStatus struct {
 	entry zoekt.RepoListEntry
 }
 
-func (r *repositoryTextSearchIndexStatus) UpdatedAt() string {
-	return r.entry.IndexMetadata.IndexTime.Format(time.RFC3339)
+func (r *repositoryTextSearchIndexStatus) UpdatedAt() DateTime {
+	return DateTime{Time: r.entry.IndexMetadata.IndexTime}
 }
 
 func (r *repositoryTextSearchIndexStatus) ContentByteSize() int32 {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1138,9 +1138,9 @@ type ExternalService implements Node {
     # The JSON configuration of the external service.
     config: String!
     # When the external service was created.
-    createdAt: String!
+    createdAt: DateTime!
     # When the external service was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the
     # create/update still succeeded.
@@ -1193,11 +1193,11 @@ type Repository implements Node & GenericSearchResultInterface {
     # DEPRECATED: This field is unused in known clients.
     #
     # The date when this repository was created on Sourcegraph.
-    createdAt: String!
+    createdAt: DateTime!
     # DEPRECATED: This field is unused in known clients.
     #
     # The date when this repository's metadata was last updated on Sourcegraph.
-    updatedAt: String
+    updatedAt: DateTime
     # Returns information about the given commit in the repository, or null if no commit exists with the given rev.
     commit(
         # The Git revision specifier (revspec) for the commit.
@@ -1320,7 +1320,7 @@ type MirrorRepositoryInfo {
     # Whether the repository has ever been successfully cloned.
     cloned: Boolean!
     # When the repository was last successfully updated from the remote source repository..
-    updatedAt: String
+    updatedAt: DateTime
     # The state of this repository in the update schedule.
     updateSchedule: UpdateSchedule
     # The state of this repository in the update queue.
@@ -1332,7 +1332,7 @@ type UpdateSchedule {
     # The interval that was used when scheduling the current due time.
     intervalSeconds: Int!
     # The next time that the repo will be inserted into the update queue.
-    due: String!
+    due: DateTime!
     # The index of the repo in the schedule.
     index: Int!
     # The total number of repos in the schedule.
@@ -1381,7 +1381,7 @@ type RepositoryTextSearchIndex {
 # The status of a repository's text search index.
 type RepositoryTextSearchIndexStatus {
     # The date that the index was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
     # The byte size of the original content.
     contentByteSize: Int!
     # The number of files in the original content.
@@ -2163,9 +2163,9 @@ type User implements Node & SettingsSubject & Namespace {
     # The URL to the user's settings.
     settingsURL: String
     # The date when the user account was created on Sourcegraph.
-    createdAt: String!
+    createdAt: DateTime!
     # The date when the user account was last updated on Sourcegraph.
-    updatedAt: String
+    updatedAt: DateTime
     # Whether the user is a site admin.
     #
     # Only the user and site admins can access this field.
@@ -2254,9 +2254,9 @@ type AccessToken implements Node {
     # was created by the same user) or a site admin (who can create access tokens for any user).
     creator: User!
     # The date when the access token was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The date when the access token was last used to authenticate a request.
-    lastUsedAt: String
+    lastUsedAt: DateTime
 }
 
 # A list of access tokens.
@@ -2325,9 +2325,9 @@ type ExternalAccount implements Node {
     # An identifier for the external account (typically equal to or derived from the ID on the external service).
     accountID: String!
     # The creation date of this external account on Sourcegraph.
-    createdAt: String!
+    createdAt: DateTime!
     # The last-updated date of this external account on Sourcegraph.
-    updatedAt: String!
+    updatedAt: DateTime!
     # A URL that, when visited, re-initiates the authentication process.
     refreshURL: String
     # Provider-specific data about the external account.
@@ -2349,9 +2349,9 @@ type OrganizationMembership {
     # The user.
     user: User!
     # The time when this was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The time when this was updated.
-    updatedAt: String!
+    updatedAt: DateTime!
 }
 
 # A list of organization memberships.
@@ -2398,8 +2398,8 @@ type Org implements Node & SettingsSubject & Namespace {
     name: String!
     # The organization's chosen display name.
     displayName: String
-    # The date when the organization was created, in RFC 3339 format.
-    createdAt: String!
+    # The date when the organization was created.
+    createdAt: DateTime!
     # A list of users who are members of this organization.
     members: UserConnection!
     # The latest settings for the organization.
@@ -2449,17 +2449,17 @@ type OrganizationInvitation implements Node {
     # The user who received the invitation.
     recipient: User!
     # The date when this invitation was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The most recent date when a notification was sent to the recipient about this invitation.
-    notifiedAt: String
+    notifiedAt: DateTime
     # The date when this invitation was responded to by the recipient.
-    respondedAt: String
+    respondedAt: DateTime
     # The recipient's response to this invitation, or no response (null).
     responseType: OrganizationInvitationResponseType
     # The URL where the recipient can respond to the invitation when pending, or null if not pending.
     respondURL: String
     # The date when this invitation was revoked.
-    revokedAt: String
+    revokedAt: DateTime
 }
 
 # The recipient's possible responses to an invitation to join an organization as a member.
@@ -2601,13 +2601,13 @@ type DiscussionThread implements Node {
     inlineURL: String
 
     # The date when the discussion thread was created.
-    createdAt: String!
+    createdAt: DateTime!
 
     # The date when the discussion thread was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
 
     # The date when the discussion thread was archived (or null if it has not).
-    archivedAt: String
+    archivedAt: DateTime
 
     # The comments in the discussion thread.
     comments(
@@ -2651,10 +2651,10 @@ type DiscussionComment implements Node {
     inlineURL: String
 
     # The date when the discussion thread was created.
-    createdAt: String!
+    createdAt: DateTime!
 
     # The date when the discussion thread was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
 
     # Reports filed by users about this comment. Only admins will receive a non
     # empty list of reports.
@@ -2863,7 +2863,7 @@ type UpdateCheck {
     pending: Boolean!
     # When the last update check was completed, or null if no update check has
     # been completed (or performed) yet.
-    checkedAt: String
+    checkedAt: DateTime
     # If an error occurred during the last update check, this message describes
     # the error.
     errorMessage: String
@@ -2941,7 +2941,7 @@ type Settings {
     # The author, or null if there is no author or the authoring user was deleted.
     author: User
     # The time when this was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The stringified JSON contents of the settings. The contents may include "//"-style comments and trailing
     # commas in the JSON.
     contents: String!
@@ -3112,7 +3112,7 @@ type SurveyResponse {
     # The answer to "What can Sourcegraph do to provide a better product"
     better: String
     # The time when this response was created.
-    createdAt: String!
+    createdAt: DateTime!
 }
 
 # Information about this site's product subscription (which enables access to and renewals of a product license).
@@ -3146,7 +3146,7 @@ type ProductLicenseInfo {
     # The number of users allowed by this license.
     userCount: Int!
     # The date when this license expires.
-    expiresAt: String!
+    expiresAt: DateTime!
 }
 
 # An extension registry.
@@ -3304,12 +3304,12 @@ type RegistryExtension implements Node {
     # The extension manifest, or null if none is set.
     manifest: ExtensionManifest
     # The date when this extension was created on the registry.
-    createdAt: String
+    createdAt: DateTime
     # The date when this extension was last updated on the registry (including updates to its metadata only, not
     # publishing new releases).
-    updatedAt: String
+    updatedAt: DateTime
     # The date when a release of this extension was most recently published, or null if there are no releases.
-    publishedAt: String
+    publishedAt: DateTime
     # The URL to the extension on this Sourcegraph site.
     url: String!
     # The URL to the extension on the extension registry where it lives (if this is a remote
@@ -3530,7 +3530,7 @@ type ProductSubscription implements Node {
         first: Int
     ): ProductLicenseConnection!
     # The date when this product subscription was created.
-    createdAt: String!
+    createdAt: DateTime!
     # Whether this product subscription was archived.
     isArchived: Boolean!
     # The URL to view this product subscription.
@@ -3605,7 +3605,7 @@ type ProductLicense implements Node {
     # The license key.
     licenseKey: String!
     # The date when this product license was created.
-    createdAt: String!
+    createdAt: DateTime!
 }
 
 # A list of product licenses.
@@ -3665,7 +3665,7 @@ type ProductSubscriptionInvoiceItem {
     # This subscription's user count.
     userCount: Int!
     # The date when the subscription expires.
-    expiresAt: String!
+    expiresAt: DateTime!
 }
 
 # An input type that describes a product subscription to be purchased. Corresponds to
@@ -3724,4 +3724,9 @@ type StatusMessage {
     # The type.
     type: StatusMessageType!
 }
+
+# An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
+# JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use
+# Date#toISOString.
+scalar DateTime
 `

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1145,9 +1145,9 @@ type ExternalService implements Node {
     # The JSON configuration of the external service.
     config: String!
     # When the external service was created.
-    createdAt: String!
+    createdAt: DateTime!
     # When the external service was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
     # This is an optional field that's populated when we ran into errors on the
     # backend side when trying to create/update an ExternalService, but the
     # create/update still succeeded.
@@ -1200,11 +1200,11 @@ type Repository implements Node & GenericSearchResultInterface {
     # DEPRECATED: This field is unused in known clients.
     #
     # The date when this repository was created on Sourcegraph.
-    createdAt: String!
+    createdAt: DateTime!
     # DEPRECATED: This field is unused in known clients.
     #
     # The date when this repository's metadata was last updated on Sourcegraph.
-    updatedAt: String
+    updatedAt: DateTime
     # Returns information about the given commit in the repository, or null if no commit exists with the given rev.
     commit(
         # The Git revision specifier (revspec) for the commit.
@@ -1327,7 +1327,7 @@ type MirrorRepositoryInfo {
     # Whether the repository has ever been successfully cloned.
     cloned: Boolean!
     # When the repository was last successfully updated from the remote source repository..
-    updatedAt: String
+    updatedAt: DateTime
     # The state of this repository in the update schedule.
     updateSchedule: UpdateSchedule
     # The state of this repository in the update queue.
@@ -1339,7 +1339,7 @@ type UpdateSchedule {
     # The interval that was used when scheduling the current due time.
     intervalSeconds: Int!
     # The next time that the repo will be inserted into the update queue.
-    due: String!
+    due: DateTime!
     # The index of the repo in the schedule.
     index: Int!
     # The total number of repos in the schedule.
@@ -1388,7 +1388,7 @@ type RepositoryTextSearchIndex {
 # The status of a repository's text search index.
 type RepositoryTextSearchIndexStatus {
     # The date that the index was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
     # The byte size of the original content.
     contentByteSize: Int!
     # The number of files in the original content.
@@ -2170,9 +2170,9 @@ type User implements Node & SettingsSubject & Namespace {
     # The URL to the user's settings.
     settingsURL: String
     # The date when the user account was created on Sourcegraph.
-    createdAt: String!
+    createdAt: DateTime!
     # The date when the user account was last updated on Sourcegraph.
-    updatedAt: String
+    updatedAt: DateTime
     # Whether the user is a site admin.
     #
     # Only the user and site admins can access this field.
@@ -2261,9 +2261,9 @@ type AccessToken implements Node {
     # was created by the same user) or a site admin (who can create access tokens for any user).
     creator: User!
     # The date when the access token was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The date when the access token was last used to authenticate a request.
-    lastUsedAt: String
+    lastUsedAt: DateTime
 }
 
 # A list of access tokens.
@@ -2332,9 +2332,9 @@ type ExternalAccount implements Node {
     # An identifier for the external account (typically equal to or derived from the ID on the external service).
     accountID: String!
     # The creation date of this external account on Sourcegraph.
-    createdAt: String!
+    createdAt: DateTime!
     # The last-updated date of this external account on Sourcegraph.
-    updatedAt: String!
+    updatedAt: DateTime!
     # A URL that, when visited, re-initiates the authentication process.
     refreshURL: String
     # Provider-specific data about the external account.
@@ -2356,9 +2356,9 @@ type OrganizationMembership {
     # The user.
     user: User!
     # The time when this was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The time when this was updated.
-    updatedAt: String!
+    updatedAt: DateTime!
 }
 
 # A list of organization memberships.
@@ -2405,8 +2405,8 @@ type Org implements Node & SettingsSubject & Namespace {
     name: String!
     # The organization's chosen display name.
     displayName: String
-    # The date when the organization was created, in RFC 3339 format.
-    createdAt: String!
+    # The date when the organization was created.
+    createdAt: DateTime!
     # A list of users who are members of this organization.
     members: UserConnection!
     # The latest settings for the organization.
@@ -2456,17 +2456,17 @@ type OrganizationInvitation implements Node {
     # The user who received the invitation.
     recipient: User!
     # The date when this invitation was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The most recent date when a notification was sent to the recipient about this invitation.
-    notifiedAt: String
+    notifiedAt: DateTime
     # The date when this invitation was responded to by the recipient.
-    respondedAt: String
+    respondedAt: DateTime
     # The recipient's response to this invitation, or no response (null).
     responseType: OrganizationInvitationResponseType
     # The URL where the recipient can respond to the invitation when pending, or null if not pending.
     respondURL: String
     # The date when this invitation was revoked.
-    revokedAt: String
+    revokedAt: DateTime
 }
 
 # The recipient's possible responses to an invitation to join an organization as a member.
@@ -2608,13 +2608,13 @@ type DiscussionThread implements Node {
     inlineURL: String
 
     # The date when the discussion thread was created.
-    createdAt: String!
+    createdAt: DateTime!
 
     # The date when the discussion thread was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
 
     # The date when the discussion thread was archived (or null if it has not).
-    archivedAt: String
+    archivedAt: DateTime
 
     # The comments in the discussion thread.
     comments(
@@ -2658,10 +2658,10 @@ type DiscussionComment implements Node {
     inlineURL: String
 
     # The date when the discussion thread was created.
-    createdAt: String!
+    createdAt: DateTime!
 
     # The date when the discussion thread was last updated.
-    updatedAt: String!
+    updatedAt: DateTime!
 
     # Reports filed by users about this comment. Only admins will receive a non
     # empty list of reports.
@@ -2870,7 +2870,7 @@ type UpdateCheck {
     pending: Boolean!
     # When the last update check was completed, or null if no update check has
     # been completed (or performed) yet.
-    checkedAt: String
+    checkedAt: DateTime
     # If an error occurred during the last update check, this message describes
     # the error.
     errorMessage: String
@@ -2948,7 +2948,7 @@ type Settings {
     # The author, or null if there is no author or the authoring user was deleted.
     author: User
     # The time when this was created.
-    createdAt: String!
+    createdAt: DateTime!
     # The stringified JSON contents of the settings. The contents may include "//"-style comments and trailing
     # commas in the JSON.
     contents: String!
@@ -3119,7 +3119,7 @@ type SurveyResponse {
     # The answer to "What can Sourcegraph do to provide a better product"
     better: String
     # The time when this response was created.
-    createdAt: String!
+    createdAt: DateTime!
 }
 
 # Information about this site's product subscription (which enables access to and renewals of a product license).
@@ -3153,7 +3153,7 @@ type ProductLicenseInfo {
     # The number of users allowed by this license.
     userCount: Int!
     # The date when this license expires.
-    expiresAt: String!
+    expiresAt: DateTime!
 }
 
 # An extension registry.
@@ -3311,12 +3311,12 @@ type RegistryExtension implements Node {
     # The extension manifest, or null if none is set.
     manifest: ExtensionManifest
     # The date when this extension was created on the registry.
-    createdAt: String
+    createdAt: DateTime
     # The date when this extension was last updated on the registry (including updates to its metadata only, not
     # publishing new releases).
-    updatedAt: String
+    updatedAt: DateTime
     # The date when a release of this extension was most recently published, or null if there are no releases.
-    publishedAt: String
+    publishedAt: DateTime
     # The URL to the extension on this Sourcegraph site.
     url: String!
     # The URL to the extension on the extension registry where it lives (if this is a remote
@@ -3537,7 +3537,7 @@ type ProductSubscription implements Node {
         first: Int
     ): ProductLicenseConnection!
     # The date when this product subscription was created.
-    createdAt: String!
+    createdAt: DateTime!
     # Whether this product subscription was archived.
     isArchived: Boolean!
     # The URL to view this product subscription.
@@ -3612,7 +3612,7 @@ type ProductLicense implements Node {
     # The license key.
     licenseKey: String!
     # The date when this product license was created.
-    createdAt: String!
+    createdAt: DateTime!
 }
 
 # A list of product licenses.
@@ -3672,7 +3672,7 @@ type ProductSubscriptionInvoiceItem {
     # This subscription's user count.
     userCount: Int!
     # The date when the subscription expires.
-    expiresAt: String!
+    expiresAt: DateTime!
 }
 
 # An input type that describes a product subscription to be purchased. Corresponds to
@@ -3731,3 +3731,8 @@ type StatusMessage {
     # The type.
     type: StatusMessageType!
 }
+
+# An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
+# JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use
+# Date#toISOString.
+scalar DateTime

--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -30,8 +29,8 @@ func (o *settingsResolver) Configuration() *configurationResolver {
 
 func (o *settingsResolver) Contents() string { return o.settings.Contents }
 
-func (o *settingsResolver) CreatedAt() string {
-	return o.settings.CreatedAt.Format(time.RFC3339) // ISO
+func (o *settingsResolver) CreatedAt() DateTime {
+	return DateTime{Time: o.settings.CreatedAt}
 }
 
 func (o *settingsResolver) Author(ctx context.Context) (*UserResolver, error) {

--- a/cmd/frontend/graphqlbackend/site_update_check.go
+++ b/cmd/frontend/graphqlbackend/site_update_check.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/pkg/updatecheck"
@@ -26,12 +25,11 @@ type updateCheckResolver struct {
 
 func (r *updateCheckResolver) Pending() bool { return r.pending }
 
-func (r *updateCheckResolver) CheckedAt() *string {
+func (r *updateCheckResolver) CheckedAt() *DateTime {
 	if r.last == nil {
 		return nil
 	}
-	s := r.last.Date.Format(time.RFC3339)
-	return &s
+	return &DateTime{Time: r.last.Date}
 }
 
 func (r *updateCheckResolver) ErrorMessage() *string {

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -46,8 +45,8 @@ func (s *surveyResponseResolver) Better() *string {
 	return s.surveyResponse.Better
 }
 
-func (s *surveyResponseResolver) CreatedAt() string {
-	return s.surveyResponse.CreatedAt.Format(time.RFC3339)
+func (s *surveyResponseResolver) CreatedAt() DateTime {
+	return DateTime{Time: s.surveyResponse.CreatedAt}
 }
 
 // SurveySubmissionInput contains a satisfaction (NPS) survey response.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -124,13 +123,12 @@ func (r *UserResolver) URL() string {
 
 func (r *UserResolver) SettingsURL() *string { return strptr(r.URL() + "/settings") }
 
-func (r *UserResolver) CreatedAt() string {
-	return r.user.CreatedAt.Format(time.RFC3339)
+func (r *UserResolver) CreatedAt() DateTime {
+	return DateTime{Time: r.user.CreatedAt}
 }
 
-func (r *UserResolver) UpdatedAt() *string {
-	t := r.user.UpdatedAt.Format(time.RFC3339) // ISO
-	return &t
+func (r *UserResolver) UpdatedAt() *DateTime {
+	return &DateTime{Time: r.user.UpdatedAt}
 }
 
 func (r *UserResolver) settingsSubject() api.SettingsSubject {

--- a/cmd/frontend/registry/extension_remote_graphql.go
+++ b/cmd/frontend/registry/extension_remote_graphql.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"context"
 	"net/url"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -49,16 +48,16 @@ func (r *registryExtensionRemoteResolver) Manifest(context.Context) (graphqlback
 	return NewExtensionManifest(r.v.Manifest), nil
 }
 
-func (r *registryExtensionRemoteResolver) CreatedAt() *string {
-	return strptr(r.v.CreatedAt.Format(time.RFC3339))
+func (r *registryExtensionRemoteResolver) CreatedAt() *graphqlbackend.DateTime {
+	return &graphqlbackend.DateTime{Time: r.v.CreatedAt}
 }
 
-func (r *registryExtensionRemoteResolver) UpdatedAt() *string {
-	return strptr(r.v.UpdatedAt.Format(time.RFC3339))
+func (r *registryExtensionRemoteResolver) UpdatedAt() *graphqlbackend.DateTime {
+	return &graphqlbackend.DateTime{Time: r.v.UpdatedAt}
 }
 
-func (r *registryExtensionRemoteResolver) PublishedAt(context.Context) (*string, error) {
-	return strptr(r.v.PublishedAt.Format(time.RFC3339)), nil
+func (r *registryExtensionRemoteResolver) PublishedAt(context.Context) (*graphqlbackend.DateTime, error) {
+	return &graphqlbackend.DateTime{Time: r.v.PublishedAt}, nil
 }
 
 func (r *registryExtensionRemoteResolver) URL() string {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -89,8 +89,8 @@ func (r *productLicense) Info() (*graphqlbackend.ProductLicenseInfo, error) {
 
 func (r *productLicense) LicenseKey() string { return r.v.LicenseKey }
 
-func (r *productLicense) CreatedAt() string {
-	return r.v.CreatedAt.Format(time.RFC3339)
+func (r *productLicense) CreatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: r.v.CreatedAt}
 }
 
 func generateProductLicenseForSubscription(ctx context.Context, subscriptionID string, input *graphqlbackend.ProductLicenseInput) (id string, err error) {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscription_invoice_item_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscription_invoice_item_graphql.go
@@ -44,6 +44,6 @@ func (r *productSubscriptionInvoiceItem) UserCount() int32 {
 	return r.userCount
 }
 
-func (r *productSubscriptionInvoiceItem) ExpiresAt() string {
-	return r.expiresAt.Format(time.RFC3339)
+func (r *productSubscriptionInvoiceItem) ExpiresAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: r.expiresAt}
 }

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -136,8 +135,8 @@ func (r *productSubscription) ProductLicenses(ctx context.Context, args *graphql
 	return &productLicenseConnection{opt: opt}, nil
 }
 
-func (r *productSubscription) CreatedAt() string {
-	return r.v.CreatedAt.Format(time.RFC3339)
+func (r *productSubscription) CreatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: r.v.CreatedAt}
 }
 
 func (r *productSubscription) IsArchived() bool { return r.v.ArchivedAt != nil }

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"context"
 	"strings"
-	"time"
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -42,20 +41,20 @@ func (r *extensionDBResolver) Manifest(ctx context.Context) (graphqlbackend.Exte
 	return registry.NewExtensionManifest(manifest), nil
 }
 
-func (r *extensionDBResolver) CreatedAt() *string {
-	return strptr(r.v.CreatedAt.Format(time.RFC3339))
+func (r *extensionDBResolver) CreatedAt() *graphqlbackend.DateTime {
+	return &graphqlbackend.DateTime{Time: r.v.CreatedAt}
 }
 
-func (r *extensionDBResolver) UpdatedAt() *string {
-	return strptr(r.v.UpdatedAt.Format(time.RFC3339))
+func (r *extensionDBResolver) UpdatedAt() *graphqlbackend.DateTime {
+	return &graphqlbackend.DateTime{Time: r.v.UpdatedAt}
 }
 
-func (r *extensionDBResolver) PublishedAt(ctx context.Context) (*string, error) {
+func (r *extensionDBResolver) PublishedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
 	_, publishedAt, err := getExtensionManifestWithBundleURL(ctx, r.v.NonCanonicalExtensionID, r.v.ID, "release")
 	if err != nil {
 		return nil, err
 	}
-	return strptr(publishedAt.Format(time.RFC3339)), nil
+	return &graphqlbackend.DateTime{Time: publishedAt}, nil
 }
 
 func (r *extensionDBResolver) URL() string {


### PR DESCRIPTION
Previously, GraphQL datetime values were `String` and their format was only specified in (inconsistent) docstrings. Now, all datetime values are of the GraphQL scalar type `DateTime`, which is documented in one place as being RFC3339.

There is no change to API consumers (the API responses remain exactly the same for all queries); this is purely an API documentation and organization improvement.