### PR TITLE
emit React hot loader wrappers for Area components

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -127,7 +127,7 @@ const config: webpack.Configuration = {
                                     '@sourcegraph/babel-plugin-transform-react-hot-loader-wrapper',
                                     {
                                         modulePattern: 'web/src/.*\\.tsx$',
-                                        componentNamePattern: 'Page$',
+                                        componentNamePattern: '(Page|Area)$',
                                     },
                                 ],
                             ],


### PR DESCRIPTION
For React hot loading (which is when, after saving a `.ts`/`.tsx` file in your editor, your browser loads new React components and inserts them into the page in place of the old components), each code splitting entrypoint must have the wrapper applied. The most common level at which we perform code splitting is the "Area" (ie user area, settings area, etc.). This change makes it so that more changes in local dev can be hot-reloaded.