### PR TITLE
prefer using the Prisma GraphQL VS Code extension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -241,6 +241,7 @@ README.md @sqs
 /dev/fakehub @ijt
 /dev/repogen @ijt
 /.vscode @felixfbecker
+/.graphqlconfig @felixfbecker
 
 # Misc and special overrides
 /LICENSE* @sqs @beyang @slimsag

--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,0 +1,3 @@
+{
+  "schemaPath": "./cmd/frontend/graphqlbackend/schema.graphql"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,7 @@
     "EditorConfig.editorconfig",
     "ms-vscode.vscode-typescript-tslint-plugin",
     "esbenp.prettier-vscode",
-    "kumar-harsh.graphql-for-vscode",
+    "prisma.vscode-graphql",
     "ms-vscode.Go",
     "shinnn.stylelint",
     "exiasr.hadolint",


### PR DESCRIPTION
It is much easier to configure, just requiring a single `.graphqlconfig` file (also added in this commit). This gives us go-to-definition in the `schema.graphql` file.

The VS Code extension is https://github.com/prisma/vscode-graphql.