### PR TITLE
export GraphQL JSONValue scalar type for use in other packages

### DIFF
--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -64,7 +64,7 @@ func (r *externalAccountResolver) AccountData(ctx context.Context) (*JSONValue, 
 	}
 
 	if r.account.AccountData != nil {
-		return &JSONValue{value: r.account.AccountData}, nil
+		return &JSONValue{r.account.AccountData}, nil
 	}
 	return nil, nil
 }

--- a/cmd/frontend/graphqlbackend/json.go
+++ b/cmd/frontend/graphqlbackend/json.go
@@ -4,17 +4,17 @@ import "encoding/json"
 
 // JSONValue implements the JSONValue scalar type. In GraphQL queries, it is represented the JSON
 // representation of its Go value.
-type JSONValue struct{ value interface{} }
+type JSONValue struct{ Value interface{} }
 
 func (JSONValue) ImplementsGraphQLType(name string) bool {
 	return name == "JSONValue"
 }
 
 func (v *JSONValue) UnmarshalGraphQL(input interface{}) error {
-	*v = JSONValue{value: input}
+	*v = JSONValue{Value: input}
 	return nil
 }
 
 func (v JSONValue) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	return json.Marshal(v.Value)
 }

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -117,7 +117,7 @@ func (r *settingsMutation) EditSettings(ctx context.Context, args *struct {
 	remove := args.Edit.Value == nil
 	var value interface{}
 	if args.Edit.Value != nil {
-		value = args.Edit.Value.value
+		value = args.Edit.Value.Value
 	}
 	if args.Edit.ValueIsJSONCEncodedString {
 		s, ok := value.(string)


### PR DESCRIPTION
This helps us as we split apart the monolithic graphqlbackend package.