### PR TITLE
support extensions contributing actions to the search results info bar

### DIFF
--- a/shared/src/actions/ActionsNavItems.tsx
+++ b/shared/src/actions/ActionsNavItems.tsx
@@ -4,7 +4,7 @@ import { switchMap } from 'rxjs/operators'
 import { ContributionScope } from '../api/client/context/context'
 import { getContributedActionItems } from '../contributions/contributions'
 import { TelemetryProps } from '../telemetry/telemetryService'
-import { ActionItem } from './ActionItem'
+import { ActionItem, ActionItemProps } from './ActionItem'
 import { ActionsState } from './actions'
 import { ActionsProps } from './ActionsContainer'
 
@@ -27,7 +27,11 @@ export interface ActionNavItemsClassProps {
     listItemClass?: string
 }
 
-export interface ActionsNavItemsProps extends ActionsProps, ActionNavItemsClassProps, TelemetryProps {
+export interface ActionsNavItemsProps
+    extends ActionsProps,
+        ActionNavItemsClassProps,
+        TelemetryProps,
+        Pick<ActionItemProps, 'showLoadingSpinnerDuringExecution'> {
     /**
      * If true, it renders a `<ul className="nav">...</ul>` around the items. If there are no items, it renders `null`.
      *

--- a/shared/src/api/protocol/contribution.ts
+++ b/shared/src/api/protocol/contribution.ts
@@ -234,6 +234,9 @@ export enum ContributableMenu {
     /** The panel toolbar. */
     PanelToolbar = 'panel/toolbar',
 
+    /** The search results toolbar. */
+    SearchResultsToolbar = 'search/results/toolbar',
+
     /** The help menu in the application. */
     Help = 'help',
 }

--- a/shared/src/schema/extension.schema.json
+++ b/shared/src/schema/extension.schema.json
@@ -184,6 +184,12 @@
               },
               "type": "array"
             },
+            "search/results/toolbar": {
+              "items": {
+                "$ref": "#/properties/contributes/definitions/MenuItemContribution"
+              },
+              "type": "array"
+            },
             "help": {
               "items": {
                 "$ref": "#/properties/contributes/definitions/MenuItemContribution"

--- a/web/src/search/results/SearchResults.test.tsx
+++ b/web/src/search/results/SearchResults.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { cleanup, getAllByTestId, getByTestId, render, waitForElement } from 'react-testing-library'
 import { noop } from 'rxjs'
+import sinon from 'sinon'
 import { setLinkComponent } from '../../../../shared/src/components/Link'
 import {
     extensionsController,
@@ -34,6 +35,7 @@ describe('SearchResults', () => {
         settingsCascade: NOOP_SETTINGS_CASCADE,
         extensionsController,
         isSourcegraphDotCom: false,
+        platformContext: { forceUpdateTooltip: sinon.spy() },
         telemetryService: { log: noop, logViewEvent: noop },
         deployType: 'dev',
     }

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -8,7 +8,9 @@ import { Contributions, Evaluated } from '../../../../shared/src/api/protocol'
 import { FetchFileCtx } from '../../../../shared/src/components/CodeExcerpt'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { isSettingsValid, SettingsCascadeProps } from '../../../../shared/src/settings/settings'
+import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { PageTitle } from '../../components/PageTitle'
 import { Settings } from '../../schema/settings.schema'
@@ -24,7 +26,12 @@ import { queryTelemetryData } from '../queryTelemetry'
 import { SearchResultsFilterBars, SearchScopeWithOptionalName } from './SearchResultsFilterBars'
 import { SearchResultsList } from './SearchResultsList'
 
-export interface SearchResultsProps extends ExtensionsControllerProps<'services'>, SettingsCascadeProps, ThemeProps {
+export interface SearchResultsProps
+    extends ExtensionsControllerProps<'executeCommand' | 'services'>,
+        PlatformContextProps<'forceUpdateTooltip'>,
+        SettingsCascadeProps,
+        TelemetryProps,
+        ThemeProps {
     authenticatedUser: GQL.IUser | null
     location: H.Location
     history: H.History
@@ -173,6 +180,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                     calculateShowMoreResultsCount={this.calculateCount}
                 />
                 <SearchResultsList
+                    {...this.props}
                     resultsOrError={this.state.resultsOrError}
                     onShowMoreResultsClick={this.showMoreResults}
                     onExpandAllResultsToggle={this.onExpandAllResultsToggle}
@@ -182,14 +190,6 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                     onSavedQueryModalClose={this.onModalClose}
                     onDidCreateSavedQuery={this.onDidCreateSavedQuery}
                     didSave={this.state.didSaveQuery}
-                    location={this.props.location}
-                    history={this.props.history}
-                    authenticatedUser={this.props.authenticatedUser}
-                    settingsCascade={this.props.settingsCascade}
-                    isLightTheme={this.props.isLightTheme}
-                    isSourcegraphDotCom={this.props.isSourcegraphDotCom}
-                    fetchHighlightedFileLines={this.props.fetchHighlightedFileLines}
-                    deployType={this.props.deployType}
                 />
             </div>
         )

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -1,3 +1,4 @@
+import H from 'history'
 import ArrowCollapseVerticalIcon from 'mdi-react/ArrowCollapseVerticalIcon'
 import ArrowExpandVerticalIcon from 'mdi-react/ArrowExpandVerticalIcon'
 import CalculatorIcon from 'mdi-react/CalculatorIcon'
@@ -7,12 +8,20 @@ import DownloadIcon from 'mdi-react/DownloadIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import * as React from 'react'
+import { ContributableMenu } from '../../../../shared/src/api/protocol'
+import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { PlatformContextProps } from '../../../../shared/src/platform/context'
+import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { pluralize } from '../../../../shared/src/util/strings'
+import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { ServerBanner, ServerBannerNoRepo } from '../../marketing/ServerBanner'
 import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
 
-interface SearchResultsInfoBarProps {
+interface SearchResultsInfoBarProps
+    extends ExtensionsControllerProps<'executeCommand' | 'services'>,
+        PlatformContextProps<'forceUpdateTooltip'>,
+        TelemetryProps {
     /** The currently authenticated user or null */
     authenticatedUser: GQL.IUser | null
 
@@ -34,6 +43,8 @@ interface SearchResultsInfoBarProps {
 
     // Whether the search query contains a repo: field.
     hasRepoishField: boolean
+
+    location: H.Location
 }
 
 /**
@@ -110,46 +121,57 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         </div>
                     )}
                 </div>
-                <div className="search-results-info-bar__row-right">
+                <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end">
+                    <ActionsNavItems
+                        {...props}
+                        menu={ContributableMenu.SearchResultsToolbar}
+                        wrapInList={false}
+                        showLoadingSpinnerDuringExecution={true}
+                        actionItemClass="btn btn-link nav-link text-decoration-none"
+                    />
                     {/* Expand all feature */}
                     {props.results.results.length > 0 && (
-                        <button
-                            type="button"
-                            onClick={props.onExpandAllResultsToggle}
-                            className="btn btn-link"
-                            data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
-                        >
-                            {props.allExpanded ? (
-                                <>
-                                    <ArrowCollapseVerticalIcon className="icon-inline" /> Collapse all
-                                </>
-                            ) : (
-                                <>
-                                    <ArrowExpandVerticalIcon className="icon-inline" /> Expand all
-                                </>
-                            )}
-                        </button>
+                        <li className="nav-item">
+                            <button
+                                type="button"
+                                onClick={props.onExpandAllResultsToggle}
+                                className="btn btn-link nav-link text-decoration-none"
+                                data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
+                            >
+                                {props.allExpanded ? (
+                                    <>
+                                        <ArrowCollapseVerticalIcon className="icon-inline" /> Collapse all
+                                    </>
+                                ) : (
+                                    <>
+                                        <ArrowExpandVerticalIcon className="icon-inline" /> Expand all
+                                    </>
+                                )}
+                            </button>
+                        </li>
                     )}
                     {/* Saved Queries */}
                     {props.authenticatedUser && (
-                        <button
-                            type="button"
-                            onClick={props.onSaveQueryClick}
-                            className="btn btn-link"
-                            disabled={props.didSave}
-                        >
-                            {props.didSave ? (
-                                <>
-                                    <CheckIcon className="icon-inline" /> Query saved
-                                </>
-                            ) : (
-                                <>
-                                    <DownloadIcon className="icon-inline" /> Save this search query
-                                </>
-                            )}
-                        </button>
+                        <li className="nav-item">
+                            <button
+                                type="button"
+                                onClick={props.onSaveQueryClick}
+                                className="btn btn-link nav-link text-decoration-none"
+                                disabled={props.didSave}
+                            >
+                                {props.didSave ? (
+                                    <>
+                                        <CheckIcon className="icon-inline" /> Query saved
+                                    </>
+                                ) : (
+                                    <>
+                                        <DownloadIcon className="icon-inline" /> Save this search query
+                                    </>
+                                )}
+                            </button>
+                        </li>
                     )}
-                </div>
+                </ul>
             </small>
         )}
         {!props.results.alert &&

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -7,7 +7,14 @@ import _VisibilitySensor from 'react-visibility-sensor'
 import sinon from 'sinon'
 import { setLinkComponent } from '../../../../shared/src/components/Link'
 import * as GQL from '../../../../shared/src/graphql/schema'
-import { HIGHLIGHTED_FILE_LINES_REQUEST, MULTIPLE_SEARCH_REQUEST, RESULT, SEARCH_REQUEST } from '../testHelpers'
+import { NOOP_TELEMETRY_SERVICE } from '../../../../shared/src/telemetry/telemetryService'
+import {
+    extensionsController,
+    HIGHLIGHTED_FILE_LINES_REQUEST,
+    MULTIPLE_SEARCH_REQUEST,
+    RESULT,
+    SEARCH_REQUEST,
+} from '../testHelpers'
 import { SearchResultsList, SearchResultsListProps } from './SearchResultsList'
 
 let VISIBILITY_CHANGED_CALLBACKS: ((isVisible: boolean) => void)[] = []
@@ -107,6 +114,9 @@ describe('SearchResultsList', () => {
             subjects: null,
             final: null,
         },
+        extensionsController: { executeCommand: sinon.spy(), services: extensionsController.services },
+        platformContext: { forceUpdateTooltip: sinon.spy() },
+        telemetryService: NOOP_TELEMETRY_SERVICE,
     }
 
     it('displays loading text when results is undefined', () => {

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -15,8 +15,11 @@ import { FileMatch } from '../../../../shared/src/components/FileMatch'
 import { RepositoryIcon } from '../../../../shared/src/components/icons' // TODO: Switch to mdi icon
 import { displayRepoName } from '../../../../shared/src/components/RepoFileLink'
 import { VirtualList } from '../../../../shared/src/components/VirtualList'
+import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import * as GQL from '../../../../shared/src/graphql/schema'
+import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
+import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { isDefined } from '../../../../shared/src/util/types'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
@@ -30,7 +33,12 @@ import { SearchResultsInfoBar } from './SearchResultsInfoBar'
 
 const isSearchResults = (val: any): val is GQL.ISearchResults => val && val.__typename === 'SearchResults'
 
-export interface SearchResultsListProps extends SettingsCascadeProps, ThemeProps {
+export interface SearchResultsListProps
+    extends ExtensionsControllerProps<'executeCommand' | 'services'>,
+        PlatformContextProps<'forceUpdateTooltip'>,
+        TelemetryProps,
+        SettingsCascadeProps,
+        ThemeProps {
     location: H.Location
     history: H.History
     authenticatedUser: GQL.IUser | null
@@ -335,14 +343,8 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                 <>
                                     {/* Info Bar */}
                                     <SearchResultsInfoBar
-                                        authenticatedUser={this.props.authenticatedUser}
+                                        {...this.props}
                                         results={results}
-                                        allExpanded={this.props.allExpanded}
-                                        didSave={this.props.didSave}
-                                        onDidCreateSavedQuery={this.props.onDidCreateSavedQuery}
-                                        onExpandAllResultsToggle={this.props.onExpandAllResultsToggle}
-                                        onSaveQueryClick={this.props.onSaveQueryClick}
-                                        onShowMoreResultsClick={this.props.onShowMoreResultsClick}
                                         showDotComMarketing={this.props.isSourcegraphDotCom}
                                         displayPerformanceWarning={this.state.displayPerformanceWarning}
                                         // This isn't always correct, but the penalty for a false-positive is

--- a/web/src/search/testHelpers.ts
+++ b/web/src/search/testHelpers.ts
@@ -202,6 +202,7 @@ const services = {
     },
 }
 
-export const extensionsController: Pick<Controller, 'services'> = {
+export const extensionsController: Pick<Controller, 'executeCommand' | 'services'> = {
+    executeCommand: () => Promise.resolve(),
     services: services as any,
 }


### PR DESCRIPTION
This lets extensions and other encapsulated code add buttons or information-display actions right above the search results. Example use cases:

- "Replace" for codemod
- "Statistics" for language statistics

Sample screenshot (this PR just adds the capability to add things like the **Replace** button, it doesn't actually add that button):

![image](https://user-images.githubusercontent.com/1976/63230686-00580f80-c1c5-11e9-9abb-15a03e09cf0a.png)

Example code to add that (you can also do this in an extension):

<details>

```diff
diff --git a/web/src/Layout.tsx b/web/src/Layout.tsx
index 7c419c624..99931fd55 100644
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -1,5 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import React, { Suspense } from 'react'
+import React, { Suspense, useEffect } from 'react'
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 import { Observable } from 'rxjs'
 import { ActivationProps } from '../../shared/src/components/activation/Activation'
@@ -41,6 +41,7 @@ import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
 import { parseBrowserRepoURL } from './util/url'
+import { registerCodemodSearchContributions } from './enterprise/codemod/contributions/search'
 
 export interface LayoutProps
     extends RouteComponentProps<any>,
@@ -101,6 +102,11 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const needsSiteInit = window.context.showOnboarding
     const isSiteInit = props.location.pathname === '/site-admin/init'
 
+    useEffect(() => {
+        const sub = registerCodemodSearchContributions(props)
+        return () => sub.unsubscribe()
+    }, [])
+
     useScrollToLocationHash(props.location)
     // Remove trailing slash (which is never valid in any of our URLs).
     if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {
diff --git a/web/src/enterprise/codemod/contributions/search.ts b/web/src/enterprise/codemod/contributions/search.ts
new file mode 100644
index 000000000..d0b9b1ab0
--- /dev/null
+++ b/web/src/enterprise/codemod/contributions/search.ts
@@ -0,0 +1,61 @@
+import H from 'history'
+import { Subscription, Unsubscribable } from 'rxjs'
+import { parseContributionExpressions } from '../../../../../shared/src/api/client/services/contribution'
+import { ContributableMenu } from '../../../../../shared/src/api/protocol'
+import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
+
+export const CODEMOD_PANEL_VIEW_ID = 'codemod'
+
+export function registerCodemodSearchContributions({
+    history,
+    extensionsController,
+}: {
+    history: H.History
+} & ExtensionsControllerProps<'services'>): Unsubscribable {
+    const subscriptions = new Subscription()
+
+    const REPLACE_ID = 'codemod.search.replace'
+    subscriptions.add(
+        extensionsController.services.commands.registerCommand({
+            command: REPLACE_ID,
+            run: () => {
+                const text = prompt('Enter replacement text:')
+                if (text !== null) {
+                    const params = new URLSearchParams(history.location.search)
+                    history.push({
+                        // TODO!(sqs):why is this commented out/necessary?
+                        //
+                        // ...TabsWithURLViewStatePersistence.urlForTabID(history.location, CODEMOD_PANEL_VIEW_ID),
+                        search: `${params}`,
+                    })
+                }
+                return Promise.resolve()
+            },
+        })
+    )
+    subscriptions.add(
+        extensionsController.services.contribution.registerContributions({
+            contributions: parseContributionExpressions({
+                actions: [
+                    {
+                        id: REPLACE_ID,
+                        title: 'Replace',
+                        category: 'Codemod',
+                        command: REPLACE_ID,
+                        actionItem: {
+                            label: 'Replace...',
+                            // TODO!(sqs): icon theme color doesn't update
+                            iconURL:
+                                "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%23a2b0cd' d='M11,6C12.38,6 13.63,6.56 14.54,7.46L12,10H18V4L15.95,6.05C14.68,4.78 12.93,4 11,4C7.47,4 4.57,6.61 4.08,10H6.1C6.56,7.72 8.58,6 11,6M16.64,15.14C17.3,14.24 17.76,13.17 17.92,12H15.9C15.44,14.28 13.42,16 11,16C9.62,16 8.37,15.44 7.46,14.54L10,12H4V18L6.05,15.95C7.32,17.22 9.07,18 11,18C12.55,18 14,17.5 15.14,16.64L20,21.5L21.5,20L16.64,15.14Z' /%3E%3C/svg%3E",
+                        },
+                    },
+                ],
+                menus: {
+                    [ContributableMenu.SearchResultsToolbar]: [{ action: REPLACE_ID }],
+                },
+            }),
+        })
+    )
+
+    return subscriptions
+}

```

</details>