### PR TITLE
make <GitRefTag onMouseDown> optional

### DIFF
--- a/web/src/repo/GitRefTag.tsx
+++ b/web/src/repo/GitRefTag.tsx
@@ -10,7 +10,7 @@ interface Props {
     /**
      * Called when the mousedown event is triggered on the element.
      */
-    onMouseDown: () => void
+    onMouseDown?: () => void
 }
 
 export const GitRefTag: React.FunctionComponent<Props> = ({ gitRef, onMouseDown }: Props) => {


### PR DESCRIPTION
There was no need for it to be required.