### PR TITLE
fix accidental omission of alert CSS class

### DIFF
--- a/web/src/site-admin/SiteAdminManagementConsolePassword.tsx
+++ b/web/src/site-admin/SiteAdminManagementConsolePassword.tsx
@@ -77,7 +77,7 @@ export class SiteAdminManagementConsolePassword extends React.Component<Props, S
         return (
             <>
                 <div className="card">
-                    <div className="card-header alert-warning">
+                    <div className="card-header alert alert-warning">
                         <KeyVariantIcon /> Critical configuration is set in the{' '}
                         <a href="/help/admin/management_console ">management console</a>.
                     </div>


### PR DESCRIPTION
Bootstrap alerts need `.alert` and `.alert-VARIANT` classes, not just `.alert-VARIANT`.