### PR TITLE
pass-thru more HTMLTextAreaElement attributes on <EditorTextField>

### DIFF
--- a/shared/src/components/editorTextField/EditorTextField.tsx
+++ b/shared/src/components/editorTextField/EditorTextField.tsx
@@ -107,7 +107,7 @@ interface Props
     extends ExtensionsControllerProps,
         Pick<
             TextareaHTMLAttributes<HTMLTextAreaElement>,
-            'className' | 'placeholder' | 'autoFocus' | 'onKeyDown' | 'rows' | 'spellCheck'
+            'className' | 'placeholder' | 'autoFocus' | 'onKeyDown' | 'rows' | 'spellCheck' | 'disabled' | 'style'
         > {
     /**
      * The ID of the editor that this component is backed by.


### PR DESCRIPTION
This lets it behave more natively in our forms. This component is only used for experimental features right now.