### PR TITLE
remove manual URL construction from <GitCommitNode>, allow showing repository

### DIFF
--- a/web/src/repo/RepoRevSidebarCommits.tsx
+++ b/web/src/repo/RepoRevSidebarCommits.tsx
@@ -14,17 +14,15 @@ import { gitCommitFragment } from './commits/RepositoryCommitsPage'
 
 interface CommitNodeProps {
     node: GQL.IGitCommit
-    repoName: string
     location: H.Location
 }
 
-const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, repoName, location }) => (
+const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, location }) => (
     <li className="list-group-item p-0">
         <GitCommitNode
             compact={true}
             node={node}
             hideExpandCommitMessageBody={true}
-            repoName={repoName}
             afterElement={
                 <Link
                     to={replaceRevisionInURL(location.pathname + location.search + location.hash, node.oid as string)}
@@ -40,7 +38,6 @@ const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, repoName, 
 
 interface Props {
     repoID: GQL.ID
-    repoName: string
     rev: string | undefined
     filePath: string
     history: H.History
@@ -50,19 +47,14 @@ interface Props {
 export class RepoRevSidebarCommits extends React.PureComponent<Props> {
     public render(): JSX.Element | null {
         return (
-            <FilteredConnection<GQL.IGitCommit, Pick<CommitNodeProps, 'repoName' | 'location'>>
+            <FilteredConnection<GQL.IGitCommit, Pick<CommitNodeProps, 'location'>>
                 className="list-group list-group-flush"
                 compact={true}
                 noun="commit"
                 pluralNoun="commits"
                 queryConnection={this.fetchCommits}
                 nodeComponent={CommitNode}
-                nodeComponentProps={
-                    { repoName: this.props.repoName, location: this.props.location } as Pick<
-                        CommitNodeProps,
-                        'repoName' | 'location'
-                    >
-                }
+                nodeComponentProps={{ location: this.props.location } as Pick<CommitNodeProps, 'location'>}
                 defaultFirst={100}
                 hideSearch={true}
                 shouldUpdateURLQuery={false}

--- a/web/src/repo/TreePage.tsx
+++ b/web/src/repo/TreePage.tsx
@@ -331,10 +331,7 @@ export class TreePage extends React.PureComponent<Props, State> {
                             {/* eslint-enable react/jsx-no-bind */}
                             <div className="tree-page__section">
                                 <h3 className="tree-page__section-header">Changes</h3>
-                                <FilteredConnection<
-                                    GQL.IGitCommit,
-                                    Pick<GitCommitNodeProps, 'repoName' | 'className' | 'compact'>
-                                >
+                                <FilteredConnection<GQL.IGitCommit, Pick<GitCommitNodeProps, 'className' | 'compact'>>
                                     {...this.props}
                                     className="mt-2 tree-page__section--commits"
                                     listClassName="list-group list-group-flush"
@@ -343,7 +340,6 @@ export class TreePage extends React.PureComponent<Props, State> {
                                     queryConnection={this.queryCommits}
                                     nodeComponent={GitCommitNode}
                                     nodeComponentProps={{
-                                        repoName: this.props.repoName,
                                         className: 'list-group-item',
                                         compact: true,
                                     }}

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -169,7 +169,6 @@ export class BlobPanel extends React.PureComponent<Props> {
                                 reactElement: (
                                     <RepoRevSidebarCommits
                                         key="commits"
-                                        repoName={subject.repoName}
                                         repoID={this.props.repoID}
                                         rev={subject.rev}
                                         filePath={subject.filePath}

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -207,7 +207,6 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                             <div className="card-body">
                                 <GitCommitNode
                                     node={this.state.commitOrError}
-                                    repoName={this.props.repo.name}
                                     expandCommitMessageBody={true}
                                     showSHAAndParentsRow={true}
                                 />

--- a/web/src/repo/commits/GitCommitNode.tsx
+++ b/web/src/repo/commits/GitCommitNode.tsx
@@ -14,9 +14,6 @@ import { GitCommitNodeByline } from './GitCommitNodeByline'
 export interface GitCommitNodeProps {
     node: GQL.IGitCommit
 
-    /** The repository that contains this commit. */
-    repoName: string
-
     /** An optional additional CSS class name to apply to this element. */
     className?: string
 
@@ -121,7 +118,7 @@ export class GitCommitNode extends React.PureComponent<GitCommitNodeProps, State
                                                 this.state.flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'
                                             }
                                         >
-                                            <ContentCopyIcon className="icon-inline" />
+                                            <ContentCopyIcon className="icon-inline small" />
                                         </button>
                                     </div>
                                 )}
@@ -131,7 +128,7 @@ export class GitCommitNode extends React.PureComponent<GitCommitNodeProps, State
                                         to={this.props.node.tree.canonicalURL}
                                         data-tooltip="View files at this commit"
                                     >
-                                        <FileDocumentIcon className="icon-inline" />
+                                        <FileDocumentIcon className="icon-inline small" />
                                     </Link>
                                 )}
                             </div>
@@ -179,7 +176,7 @@ export class GitCommitNode extends React.PureComponent<GitCommitNodeProps, State
                                         <Link
                                             key={i}
                                             className="git-ref-tag-2 git-commit-node__sha-and-parents-parent"
-                                            to={`/${this.props.repoName}/-/commit/${parent.oid}`}
+                                            to={parent.url}
                                         >
                                             <code>{parent.abbreviatedOID}</code>
                                         </Link>

--- a/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -31,6 +31,7 @@ export const gitCommitFragment = gql`
         parents {
             oid
             abbreviatedOID
+            url
         }
         url
         canonicalURL
@@ -118,14 +119,14 @@ export class RepositoryCommitsPage extends React.PureComponent<Props> {
                     element={<RepoHeaderBreadcrumbNavItem key="commits">Commits</RepoHeaderBreadcrumbNavItem>}
                     repoHeaderContributionsLifecycleProps={this.props.repoHeaderContributionsLifecycleProps}
                 />
-                <FilteredConnection<GQL.IGitCommit, Pick<GitCommitNodeProps, 'repoName' | 'className' | 'compact'>>
+                <FilteredConnection<GQL.IGitCommit, Pick<GitCommitNodeProps, 'className' | 'compact'>>
                     className="repository-commits-page__content"
                     listClassName="list-group list-group-flush"
                     noun="commit"
                     pluralNoun="commits"
                     queryConnection={this.queryCommits}
                     nodeComponent={GitCommitNode}
-                    nodeComponentProps={{ repoName: this.props.repo.name, className: 'list-group-item' }}
+                    nodeComponentProps={{ className: 'list-group-item' }}
                     defaultFirst={20}
                     autoFocus={true}
                     history={this.props.history}

--- a/web/src/repo/compare/RepositoryCompareCommitsPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareCommitsPage.tsx
@@ -86,7 +86,7 @@ export class RepositoryCompareCommitsPage extends React.PureComponent<Props> {
             <div className="repository-compare-page">
                 <div className="card">
                     <div className="card-header">Commits</div>
-                    <FilteredConnection<GQL.IGitCommit, Pick<GitCommitNodeProps, 'repoName' | 'className' | 'compact'>>
+                    <FilteredConnection<GQL.IGitCommit, Pick<GitCommitNodeProps, 'className' | 'compact'>>
                         listClassName="list-group list-group-flush"
                         noun="commit"
                         pluralNoun="commits"
@@ -94,7 +94,6 @@ export class RepositoryCompareCommitsPage extends React.PureComponent<Props> {
                         queryConnection={this.queryCommits}
                         nodeComponent={GitCommitNode}
                         nodeComponentProps={{
-                            repoName: this.props.repo.name,
                             className: 'list-group-item',
                             compact: true,
                         }}


### PR DESCRIPTION
Previously, the `<GitCommitNode>` component accepted a `repoName` prop that it used to manually construct a URL. This is a bad practice; it should just use the URL from the `GitCommit` GraphQL value it receives.