### PR TITLE
add React hook for scrolling to location anchor

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -12,6 +12,7 @@ import { SettingsCascadeProps } from '../../shared/src/settings/settings'
 import { ErrorLike } from '../../shared/src/util/errors'
 import { parseHash } from '../../shared/src/util/url'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { useScrollToLocationHash } from './components/useScrollToLocationHash'
 import { GlobalContributions } from './contributions'
 import { ExploreSectionDescriptor } from './explore/ExploreArea'
 import { ExtensionAreaRoute } from './extensions/extension/ExtensionArea'
@@ -100,6 +101,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const needsSiteInit = window.context.showOnboarding
     const isSiteInit = props.location.pathname === '/site-admin/init'
 
+    useScrollToLocationHash(props.location)
     // Remove trailing slash (which is never valid in any of our URLs).
     if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {
         return <Redirect to={{ ...props.location, pathname: props.location.pathname.slice(0, -1) }} />

--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -21,7 +21,6 @@ import {
 import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { pluralize } from '../../../shared/src/util/strings'
-import { parseHash } from '../../../shared/src/util/url'
 import { Form } from './Form'
 import { RadioButtons } from './RadioButtons'
 
@@ -130,21 +129,6 @@ interface ConnectionNodesProps<C extends Connection<N>, N, NP = {}>
 }
 
 class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureComponent<ConnectionNodesProps<C, N, NP>> {
-    public componentDidMount(): void {
-        // Scroll to hash. But if the hash is a line number in a blob (or any viewState), then do not scroll,
-        // because the hash is handled separately by the Blob component.
-        if (this.props.location.hash && !parseHash(this.props.location.hash).viewState) {
-            this.scrollToHash(this.props.location.hash)
-        }
-    }
-
-    public componentDidUpdate(prevProps: ConnectionNodesProps<C, N, NP>): void {
-        if (prevProps.connection !== this.props.connection || prevProps.location.hash !== this.props.location.hash) {
-            // Try scrolling when either the content or the hash changed.
-            this.scrollToHash(this.props.location.hash)
-        }
-    }
-
     public render(): JSX.Element | null {
         const NodeComponent = this.props.nodeComponent
         const ListComponent: any = this.props.listComponent || 'ul' // TODO: remove cast when https://github.com/Microsoft/TypeScript/issues/28768 is fixed
@@ -250,25 +234,6 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
     }
 
     private onClickShowMore = () => this.props.onShowMore()
-
-    /** Scroll to the anchor in the page identified by the location fragment (e.g., #my-section). */
-    private scrollToHash(hash: string): void {
-        if (!hash) {
-            return
-        }
-
-        // This does not cause a page navigation (because window.location.hash === hash already), but it does cause
-        // the page to scroll to the hash. This is simpler than using scrollTo, scrollIntoView, etc. Also assigning
-        // window.location.hash does not trigger a navigation when `window.location.hash === hash`, so we can't
-        // just use that.
-        //
-        // Finally, ensure that hash begins with a "#" so that this can't be used to redirect to arbitrary URLs (as
-        // an open redirect vulnerability). This should always be true, but just be safe and document this
-        // assertion in code.
-        if (hash.startsWith('#')) {
-            window.location.href = hash
-        }
-    }
 }
 
 /**

--- a/web/src/components/useScrollToLocationHash.ts
+++ b/web/src/components/useScrollToLocationHash.ts
@@ -1,0 +1,36 @@
+import H from 'history'
+import { useEffect, useState } from 'react'
+
+/**
+ * A React hook that scrolls the viewport to the element identified in the location hash (e.g., the
+ * element with ID or name "foo" for the URL "https://example.com/a/b/#foo").
+ *
+ * This is needed because the browser's standard scroll-to-hash behavior doesn't work when using
+ * react-router.
+ *
+ * If a React component needs the browser to scroll to elements that it renders asynchronously, the
+ * React component must use this hook in such a way that it is invoked on each render. It is OK if
+ * multiple components in a render tree use this hook.
+ */
+export const useScrollToLocationHash = (location: H.Location): void => {
+    // Run on each render, because the element we need to scroll to might be derived from
+    // asynchronously fetched data and not be present on the first render. But once we've found and
+    // scrolled to an element for the location hash, don't keep trying to scroll to that element on
+    // each render.
+    const [scrolledTo, setScrolledTo] = useState<string>()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => {
+        if (location.hash) {
+            const idOrName = location.hash.slice(1)
+            if (idOrName !== scrolledTo) {
+                const element = document.getElementById(idOrName) || document.getElementsByName(idOrName).item(0)
+                if (element) {
+                    element.scrollIntoView()
+                    setScrolledTo(idOrName)
+                } else {
+                    setScrolledTo(undefined)
+                }
+            }
+        }
+    })
+}

--- a/web/src/repo/blob/RenderedFile.tsx
+++ b/web/src/repo/blob/RenderedFile.tsx
@@ -1,6 +1,7 @@
-import * as H from 'history'
 import * as React from 'react'
+import H from 'history'
 import { Markdown } from '../../../../shared/src/components/Markdown'
+import { useScrollToLocationHash } from '../../components/useScrollToLocationHash'
 
 interface Props {
     /**
@@ -14,49 +15,13 @@ interface Props {
 /**
  * Displays a file whose contents are rendered to HTML, such as a Markdown file.
  */
-export class RenderedFile extends React.PureComponent<Props> {
-    public componentDidMount(): void {
-        if (this.props.dangerousInnerHTML && this.props.location.hash) {
-            this.scrollToHash(this.props.location.hash)
-        }
-    }
-
-    public componentDidUpdate(prevProps: Props): void {
-        if (
-            prevProps.dangerousInnerHTML !== this.props.dangerousInnerHTML ||
-            prevProps.location.hash !== this.props.location.hash
-        ) {
-            // Try scrolling when either the content or the hash changed.
-            this.scrollToHash(this.props.location.hash)
-        }
-    }
-
-    public render(): JSX.Element | null {
-        return (
-            <div className="rendered-file">
-                <div className="rendered-file__container">
-                    <Markdown dangerousInnerHTML={this.props.dangerousInnerHTML} />
-                </div>
+export const RenderedFile: React.FunctionComponent<Props> = ({ dangerousInnerHTML, location }) => {
+    useScrollToLocationHash(location)
+    return (
+        <div className="rendered-file">
+            <div className="rendered-file__container">
+                <Markdown dangerousInnerHTML={dangerousInnerHTML} />
             </div>
-        )
-    }
-
-    /** Scroll to the anchor in the page identified by the location fragment (e.g., #my-section). */
-    private scrollToHash(hash: string): void {
-        if (!hash) {
-            return
-        }
-
-        // This does not cause a page navigation (because window.location.hash === hash already), but it does cause
-        // the page to scroll to the hash. This is simpler than using scrollTo, scrollIntoView, etc. Also assigning
-        // window.location.hash does not trigger a navigation when `window.location.hash === hash`, so we can't
-        // just use that.
-        //
-        // Finally, ensure that hash begins with a "#" so that this can't be used to redirect to arbitrary URLs (as
-        // an open redirect vulnerability). This should always be true, but just be safe and document this
-        // assertion in code.
-        if (hash.startsWith('#')) {
-            window.location.href = hash
-        }
-    }
+        </div>
+    )
 }


### PR DESCRIPTION
This logic was previously implemented in a couple places separately and in an incomplete manner. Now there is a React hook that is well documented and comprehensive.

Test plan:

1. Go to http://localhost:3080/github.com/auth0/express-jwt/-/blob/README.md#revoked-tokens and ensure the browser scrolls down to the "Revoked tokens" section header automatically (even though that README's file content is loaded asynchronously).
1. Click on other section headers `#` links on that same document and ensure those are scrolled to.