### PR TITLE
standardize generate.sh scripts

### DIFF
--- a/enterprise/dev/generate.sh
+++ b/enterprise/dev/generate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
+cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to enterprise/
 
 ../dev/generate.sh
 
-go list ./... | grep -v /vendor/ | xargs go generate -v
+go list ./... | xargs go generate -x


### PR DESCRIPTION
The enterprise generate.sh script had 3 minor problems:

- Its comment was inaccurate
- It needlessly passed packages through `grep -v /vendor/`, despite there being no vendor packages in enterprise. (There were in mid-2018.)
- It used `go generate -v` instead of `-x`, which differed from the main `/dev/generate.sh` script.