### PR TITLE
gitserver: add `--` arg to prevent interpreting ref name in update-ref as arg

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -172,7 +172,7 @@ func (s *Server) handleCreateCommitFromPatch(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "update-ref", req.TargetRef, cmtHash)
+	cmd = exec.CommandContext(ctx, "git", "update-ref", "--", req.TargetRef, cmtHash)
 	cmd.Dir = repoGitDir
 
 	if out, err = run(cmd); err != nil {


### PR DESCRIPTION
If `req.TargetRef` was `-d`, this command would delete the ref whose name is the commit hash instead of updating it. This behavior would be unexpected. Because `cmtHash` is unlikely to collide with an actual ref name, this is extremely low risk, but it's good to fix anywya.