### PR TITLE
authz: Introduce hard TTL in Bitbucket Server provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occuring before the update concludes.
+
 ### Fixed
 
 - Fixed an issue where search would sometimes crash with a panic due to a nil pointer. [#5246](https://github.com/sourcegraph/sourcegraph/issues/5246)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occuring before the update concludes.
+- A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occuring before the update concludes. If your previous `ttl` value is larger than the default of the new `hardTTL` setting (i.e. **3 days**), you must change the `ttl` to be smaller or, `hardTTL` to be larger.
 
 ### Fixed
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -165,11 +165,10 @@ Go to your Sourcegraph's external services page (i.e. `https://sourcegraph.examp
 
 ---
 
-Permissions for each user are cached for the configured `ttl` duration. When the `ttl` elapses, permissions will be refetched from Bitbucket Server again. A lower `ttl` makes Sourcegraph refresh permissions for each user more often. A higher `ttl` reduces the load on Bitbucket Server and improves user experience by using cached permissions on most requests (i.e. those that are issued within the `ttl` window). The more repos you have, the slower it is to fetch permissions.
+Permissions for each user are cached for the configured `ttl` duration (**3h** by default). When the `ttl` expires for a given user, during request that needs to be authorized, permissions will be refetched from Bitbucket Server again in the background, during which time the previously cached permissions will be used to authorize the user's actions. A lower `ttl` makes Sourcegraph refresh permissions for each user more often which increases load on Bitbucket Server, so have that in consideration when changing this value.
 
-Taking all of this into account, you may want to configure the `ttl` to something else than its default value of `3h`, depending on your requirements.
+The default `hardTTL` is **3 days**, after which a user's cached permissions must be updated before any user action can be authorized. While the update is happening an error is returned to the user. The default `hardTTL` value was chosen so that it reduces the chances of users being forced to wait for their permissions to be updated after a weekend of inactivity.
 
 ---
 
 Finally, **save the configuration**. You're done!
-

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -513,6 +513,12 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind:   "BITBUCKETSERVER",
+			desc:   "invalid authorization hardTTL",
+			config: `{"authorization": {"ttl": "3h", "hardTTL": "1h"}}`,
+			assert: includes(`authorization.hardTTL: must be larger than ttl`),
+		},
+		{
+			kind:   "BITBUCKETSERVER",
 			desc:   "valid authorization ttl 0",
 			config: `{"authorization": {"ttl": "0"}}`,
 			assert: excludes(`authorization.ttl: time: invalid duration 0`),

--- a/enterprise/cmd/frontend/internal/authz/authz_bitbucketserver.go
+++ b/enterprise/cmd/frontend/internal/authz/authz_bitbucketserver.go
@@ -60,6 +60,15 @@ func bitbucketServerProvider(
 		errs = multierror.Append(errs, err)
 	}
 
+	hardTTL, err := parseTTL(a.HardTTL)
+	if err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	if hardTTL < ttl {
+		errs = multierror.Append(errs, errors.Errorf("authorization.hardTTL: must be larger than ttl"))
+	}
+
 	baseURL, err := url.Parse(instanceURL)
 	if err != nil {
 		errs = multierror.Append(errs, err)
@@ -75,7 +84,7 @@ func bitbucketServerProvider(
 	var p authz.Provider
 	switch idp := a.IdentityProvider; {
 	case idp.Username != nil:
-		p = bbsauthz.NewProvider(cli, db, ttl)
+		p = bbsauthz.NewProvider(cli, db, ttl, hardTTL)
 	default:
 		errs = multierror.Append(errs, errors.Errorf("No identityProvider was specified"))
 	}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -34,12 +34,12 @@ var clock = func() time.Time { return time.Now().UTC().Truncate(time.Microsecond
 // the given bitbucketserver.Client to talk to a Bitbucket Server API that is
 // the source of truth for permissions. It assumes usernames of Sourcegraph accounts
 // match 1-1 with usernames of Bitbucket Server API users.
-func NewProvider(cli *bitbucketserver.Client, db *sql.DB, ttl time.Duration) *Provider {
+func NewProvider(cli *bitbucketserver.Client, db *sql.DB, ttl, hardTTL time.Duration) *Provider {
 	return &Provider{
 		client:   cli,
 		codeHost: extsvc.NewCodeHost(cli.URL, bitbucketserver.ServiceType),
 		pageSize: 1000,
-		store:    newStore(db, ttl, clock, newCache()),
+		store:    newStore(db, ttl, hardTTL, clock, newCache()),
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -459,7 +459,7 @@ func newClient(t *testing.T, name string) (*bitbucketserver.Client, func()) {
 }
 
 func newProvider(cli *bitbucketserver.Client, db *sql.DB, ttl time.Duration) *Provider {
-	p := NewProvider(cli, db, ttl)
+	p := NewProvider(cli, db, ttl, DefaultHardTTL)
 	p.pageSize = 1       // Exercise pagination
 	p.store.block = true // Wait for first update to complete.
 	return p

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -170,9 +170,14 @@
           }
         },
         "ttl": {
-          "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
+          "description": "Duration after which a user's cached permissions will be updated in the background (during which time the previously cached permissions will be used). This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
           "default": "3h"
+        },
+        "hardTTL": {
+          "description": "Duration after which a user's cached permissions must be updated before authorizing any user actions. This is 3 days by default.",
+          "type": "string",
+          "default": "72h"
         }
       }
     }

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -175,9 +175,14 @@ const BitbucketServerSchemaJSON = `{
           }
         },
         "ttl": {
-          "description": "The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
+          "description": "Duration after which a user's cached permissions will be updated in the background (during which time the previously cached permissions will be used). This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
           "type": "string",
           "default": "3h"
+        },
+        "hardTTL": {
+          "description": "Duration after which a user's cached permissions must be updated before authorizing any user actions. This is 3 days by default.",
+          "type": "string",
+          "default": "72h"
         }
       }
     }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -103,6 +103,7 @@ type BitbucketCloudConnection struct {
 
 // BitbucketServerAuthorization description: If non-null, enforces Bitbucket Server repository permissions.
 type BitbucketServerAuthorization struct {
+	HardTTL          string                          `json:"hardTTL,omitempty"`
 	IdentityProvider BitbucketServerIdentityProvider `json:"identityProvider"`
 	Oauth            BitbucketServerOAuth            `json:"oauth"`
 	Ttl              string                          `json:"ttl,omitempty"`

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -440,6 +440,7 @@ export const ALL_EXTERNAL_SERVICES: Record<GQL.ExternalServiceKind, ExternalServ
                             signingKey: '<signing key>',
                         },
                         ttl: '3h',
+                        hardTTL: '72h',
                     }
                     const comment =
                         '// Follow setup instructions in https://docs.sourcegraph.com/admin/repo/permissions#bitbucket_server'


### PR DESCRIPTION
This commit is the second chapter in #4812. It introduces the concept of
a hard TTL, which defines a duration after which a user's cached
permissions MUST be updated before any user action can be authorized.

This contrasts with the existing TTL setting which defines a duration
after which a user's cached permissions get updated in the background,
but the previously cached (and now stale) permissions can be used to
authorized user actions.


Test plan: go test