### PR TITLE
e2e-tests: Reset user settings at end of test

### DIFF
--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -331,10 +331,14 @@ export class Driver {
             `,
             variables: {},
         })
+
         const { currentUser } = dataOrThrowErrors(currentSettingsResponse)
+
         if (currentUser && currentUser.settingsCascade) {
-            const [userSettings] = currentUser.settingsCascade.subjects.slice(-1)
-            if (userSettings.latestSettings) {
+            const emptySettings = '{}'
+            const [{ latestSettings }] = currentUser.settingsCascade.subjects.slice(-1)
+
+            if (latestSettings && latestSettings.contents !== emptySettings) {
                 const updateConfigResponse = await this.makeGraphQLRequest<IMutation>({
                     request: gql`
                         mutation OverwriteSettings($subject: ID!, $lastID: Int, $contents: String!) {
@@ -348,9 +352,9 @@ export class Driver {
                         }
                     `,
                     variables: {
-                        contents: '{}',
+                        contents: emptySettings,
                         subject: currentUser.id,
-                        lastID: userSettings.latestSettings.id,
+                        lastID: latestSettings.id,
                     },
                 })
                 dataOrThrowErrors(updateConfigResponse)

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -117,6 +117,14 @@ describe('e2e test suite', () => {
                     throw new Error('Expected "' + message + '" message, but didn\'t find it')
                 }
             }, message)
+
+            await driver.replaceText({
+                selector: '.e2e-settings-file .monaco-editor',
+                newText: '{}',
+                selectMethod: 'keyboard',
+            })
+            await driver.page.click('.e2e-settings-file .e2e-save-toolbar-save')
+            await driver.page.waitFor(() => !document.querySelector('.e2e-global-alert .global-alerts__alert'))
         })
 
         test('Check access tokens work (create, use and delete)', async () => {

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -39,6 +39,7 @@ describe('e2e test suite', () => {
             'sourcegraph/sourcegraph-typescript',
         ]
         await driver.ensureLoggedIn()
+        await driver.resetUserSettings()
         await driver.ensureHasExternalService({
             kind: 'github',
             displayName: 'e2e-test-github',
@@ -78,12 +79,14 @@ describe('e2e test suite', () => {
         () => driver.page
     )
 
-    // Clear local storage to reset sidebar selection (files or tabs) for each test
     beforeEach(async () => {
         if (driver) {
+            // Clear local storage to reset sidebar selection (files or tabs) for each test
             await driver.page.evaluate(() => {
                 localStorage.setItem('repo-rev-sidebar-last-tab', 'files')
             })
+
+            await driver.resetUserSettings()
         }
     })
 
@@ -117,14 +120,6 @@ describe('e2e test suite', () => {
                     throw new Error('Expected "' + message + '" message, but didn\'t find it')
                 }
             }, message)
-
-            await driver.replaceText({
-                selector: '.e2e-settings-file .monaco-editor',
-                newText: '{}',
-                selectMethod: 'keyboard',
-            })
-            await driver.page.click('.e2e-settings-file .e2e-save-toolbar-save')
-            await driver.page.waitFor(() => !document.querySelector('.e2e-global-alert .global-alerts__alert'))
         })
 
         test('Check access tokens work (create, use and delete)', async () => {


### PR DESCRIPTION
This is a follow-up to #5210.

It makes sure that the notice banner is removed after the test. Otherwise it persists through multiple test runs on the same instance.