### PR TITLE
e2e-tests: Help debugging by adding date to access token name

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -122,7 +122,8 @@ describe('e2e test suite', () => {
             await driver.page.goto(baseURL + '/users/test/settings/tokens/new')
             await driver.page.waitForSelector('.e2e-create-access-token-description')
 
-            const name = 'E2E Test ' + random(1, 1e7)
+            const now = await driver.page.evaluate(() => new Date().toISOString())
+            const name = 'E2E Test ' + now + ' ' + random(1, 1e7)
 
             await driver.replaceText({
                 selector: '.e2e-create-access-token-description',


### PR DESCRIPTION
This addresses the post-merge feedback by @keegancsmith on https://github.com/sourcegraph/sourcegraph/pull/5241 and adds the current date to the access token name to help future debugging