### PR TITLE
authz: Do not filter repo ids to cache in Bitbucket Server provider

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 
 		store = repos.NewObservedStore(
-			repos.NewDBStore(ctx, db, sql.TxOptions{Isolation: sql.LevelSerializable}),
+			repos.NewDBStore(db, sql.TxOptions{Isolation: sql.LevelSerializable}),
 			log15.Root(),
 			m,
 			trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -1,7 +1,6 @@
 package repos_test
 
 import (
-	"context"
 	"database/sql"
 	"flag"
 	"testing"
@@ -28,11 +27,10 @@ func TestIntegration(t *testing.T) {
 
 	t.Parallel()
 
-	ctx := context.Background()
 	db, cleanup := dbtest.NewDB(t, *dsn)
 	defer cleanup()
 
-	dbstore := repos.NewDBStore(ctx, db, sql.TxOptions{
+	dbstore := repos.NewDBStore(db, sql.TxOptions{
 		Isolation: sql.LevelSerializable,
 	})
 

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -88,7 +88,7 @@ type DBStore struct {
 }
 
 // NewDBStore instantiates and returns a new DBStore with prepared statements.
-func NewDBStore(ctx context.Context, db dbutil.DB, txOpts sql.TxOptions) *DBStore {
+func NewDBStore(db dbutil.DB, txOpts sql.TxOptions) *DBStore {
 	return &DBStore{db: db, txOpts: txOpts}
 }
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/bitbucketserver"
@@ -70,19 +71,34 @@ func testProviderRepoPerms(db *sql.DB) func(*testing.T) {
 
 		h := codeHost{CodeHost: p.codeHost}
 
-		repo := make(map[string]*types.Repo, len(f.repos))
-		repos := make([]*types.Repo, 0, len(f.repos))
+		stored := make([]*repos.Repo, 0, len(f.repos))
 		for _, r := range f.repos {
-			repo[r.Name] = &types.Repo{
-				ID:           api.RepoID(r.ID + 42), // Make them different
-				Name:         api.RepoName(r.Name),
+			stored = append(stored, &repos.Repo{
+				Name:         r.Name,
 				ExternalRepo: h.externalRepo(r),
-			}
-			repos = append(repos, repo[r.Name])
+				Sources:      map[string]*repos.SourceInfo{},
+			})
 		}
 
-		sort.Slice(repos, func(i, j int) bool {
-			return repos[i].Name <= repos[j].Name
+		ctx := context.Background()
+		err := repos.NewDBStore(nil, db, sql.TxOptions{}).UpsertRepos(ctx, stored...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		repo := make(map[string]*types.Repo, len(f.repos))
+		toverify := make([]*types.Repo, 0, len(f.repos))
+		for _, r := range stored {
+			repo[r.Name] = &types.Repo{
+				ID:           api.RepoID(r.ID),
+				Name:         api.RepoName(r.Name),
+				ExternalRepo: r.ExternalRepo,
+			}
+			toverify = append(toverify, repo[r.Name])
+		}
+
+		sort.Slice(toverify, func(i, j int) bool {
+			return toverify[i].Name <= toverify[j].Name
 		})
 
 		for i, tc := range []struct {
@@ -172,7 +188,7 @@ func testProviderRepoPerms(db *sql.DB) func(*testing.T) {
 					acct = h.externalAccount(int32(i), tc.user)
 				}
 
-				perms, err := p.RepoPerms(tc.ctx, acct, repos)
+				perms, err := p.RepoPerms(tc.ctx, acct, toverify)
 
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("error:\nhave: %q\nwant: %q", have, want)

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider_test.go
@@ -81,7 +81,7 @@ func testProviderRepoPerms(db *sql.DB) func(*testing.T) {
 		}
 
 		ctx := context.Background()
-		err := repos.NewDBStore(nil, db, sql.TxOptions{}).UpsertRepos(ctx, stored...)
+		err := repos.NewDBStore(db, sql.TxOptions{}).UpsertRepos(ctx, stored...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
 	"github.com/sourcegraph/sourcegraph/pkg/trace"
 	"gopkg.in/inconshreveable/log15.v2"
 )
@@ -82,15 +83,37 @@ func (p *Permissions) Authorized(repos []*types.Repo) []authz.RepoPerms {
 	return perms
 }
 
+func (p *Permissions) tracingFields() []otlog.Field {
+	fs := []otlog.Field{
+		otlog.Int32("Permissions.UserID", p.UserID),
+		otlog.String("Permissions.Perm", string(p.Perm)),
+		otlog.String("Permissions.Type", p.Type),
+	}
+
+	if p.IDs != nil {
+		fs = append(fs,
+			otlog.Uint64("Permissions.IDs.Count", p.IDs.GetCardinality()),
+			otlog.String("Permissions.UpdatedAt", p.UpdatedAt.String()),
+		)
+	}
+
+	return fs
+}
+
 // DefaultHardTTL is the default hard TTL used in the permissions store, after which
 // cached permissions for a given user MUST be updated, and previously cached permissions
 // can no longer be used, resulting in a call to LoadPermissions returning a StalePermissionsError.
 const DefaultHardTTL = 3 * 24 * time.Hour
 
 // PermissionsUpdateFunc fetches updated permissions from a source of truth,
-// returning the correspondent Sourcegraph ids (e.g. repo table ids) of those objects
-// for which the authenticated user has permissions for.
-type PermissionsUpdateFunc func(context.Context) (ids []uint32, err error)
+// returning the correspondent external ids of those objects for which the
+// authenticated user has permissions for, as well as the code host associated
+// with those objects.
+type PermissionsUpdateFunc func(context.Context) (
+	ids []uint32,
+	codeHost *extsvc.CodeHost,
+	err error,
+)
 
 // LoadPermissions loads stored permissions into p, calling the given update closure
 // to asynchronously fetch updated permissions when they expire. When there are no
@@ -109,7 +132,7 @@ func (s *store) LoadPermissions(
 	}
 
 	ctx, save := s.observe(ctx, "LoadPermissions", "")
-	defer func() { save(*p, &err) }()
+	defer func() { save(&err, (*p).tracingFields()...) }()
 
 	now := s.clock()
 
@@ -138,7 +161,7 @@ func (s *store) UpdatePermissions(
 	update PermissionsUpdateFunc,
 ) (err error) {
 	ctx, save := s.observe(ctx, "UpdatePermissions", "")
-	defer func() { save(p, &err) }()
+	defer func() { save(&err, p.tracingFields()...) }()
 
 	now := s.clock()
 	expired := *p
@@ -195,7 +218,7 @@ var errLockNotAvailable = errors.New("lock not available")
 // already held by another process will have errLockNotAvailable returned.
 func (s *store) lock(ctx context.Context, p *Permissions) (err error) {
 	ctx, save := s.observe(ctx, "lock", "")
-	defer save(p, &err)
+	defer func() { save(&err, p.tracingFields()...) }()
 
 	if _, ok := s.db.(*sql.Tx); !ok {
 		return errors.Errorf("store.lock must be called inside a transaction")
@@ -254,7 +277,7 @@ SELECT pg_try_advisory_xact_lock(%s, %s)
 
 func (s *store) load(ctx context.Context, p *Permissions) (err error) {
 	ctx, save := s.observe(ctx, "load", "")
-	defer save(p, &err)
+	defer func() { save(&err, p.tracingFields()...) }()
 
 	q := loadQuery(p)
 
@@ -284,6 +307,60 @@ func (s *store) load(ctx context.Context, p *Permissions) (err error) {
 	return p.IDs.UnmarshalBinary(ids)
 }
 
+func loadRepoIDsQuery(c *extsvc.CodeHost, externalIDs []uint32) *sqlf.Query {
+	ids := make([]*sqlf.Query, 0, len(externalIDs))
+	for _, eid := range externalIDs {
+		ids = append(ids, sqlf.Sprintf("%d", eid))
+	}
+	return sqlf.Sprintf(
+		loadRepoIDsQueryFmtStr,
+		c.ServiceType,
+		c.ServiceID,
+		sqlf.Join(ids, ","),
+	)
+}
+
+const loadRepoIDsQueryFmtStr = `
+-- source: enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go:store.loadRepoIDs
+SELECT id FROM repo
+WHERE external_service_type = %s AND external_service_id = %s AND external_id IN (%s)
+`
+
+func (s *store) loadRepoIDs(ctx context.Context, c *extsvc.CodeHost, externalIDs []uint32) (ids *roaring.Bitmap, err error) {
+	ctx, save := s.observe(ctx, "loadRepoIDs", "")
+	defer func() {
+		fs := []otlog.Field{otlog.Int("externalIDs.count", len(externalIDs))}
+		if ids != nil {
+			fs = append(fs, otlog.Uint64("repoIDs.count", ids.GetCardinality()))
+		}
+		save(&err, fs...)
+	}()
+
+	q := loadRepoIDsQuery(c, externalIDs)
+
+	var rows *sql.Rows
+	rows, err = s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return nil, err
+	}
+
+	ids = roaring.New()
+
+	for rows.Next() {
+		var id uint32
+		if err = rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids.Add(id)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return ids, rows.Close()
+}
+
 func loadQuery(p *Permissions) *sqlf.Query {
 	return sqlf.Sprintf(
 		loadQueryFmtStr,
@@ -302,7 +379,7 @@ WHERE user_id = %s AND permission = %s AND object_type = %s
 
 func (s *store) update(ctx context.Context, p *Permissions, update PermissionsUpdateFunc) (err error) {
 	ctx, save := s.observe(ctx, "update", "")
-	defer save(p, &err)
+	defer func() { save(&err, p.tracingFields()...) }()
 
 	// Set context to background without a request bound timeout,
 	// but let the above instrumentation use the original request's context.
@@ -354,13 +431,20 @@ func (s *store) update(ctx context.Context, p *Permissions, update PermissionsUp
 	}
 
 	// Slow cache update operation, talks to the code host.
-	var ids []uint32
-	if ids, err = update(ctx); err != nil {
+	var (
+		externalIDs []uint32
+		c           *extsvc.CodeHost
+	)
+
+	if externalIDs, c, err = update(ctx); err != nil {
 		return err
 	}
 
-	// Create a set of the given ids and update the timestamp.
-	p.IDs = roaring.BitmapOf(ids...)
+	p.IDs, err = s.loadRepoIDs(ctx, c, externalIDs)
+	if err != nil {
+		return err
+	}
+
 	p.UpdatedAt = now
 
 	// Write back the updated permissions to the database.
@@ -380,7 +464,7 @@ func (s *store) tx(ctx context.Context) (*sql.Tx, error) {
 
 func (s *store) upsert(ctx context.Context, p *Permissions) (err error) {
 	ctx, save := s.observe(ctx, "upsert", "")
-	defer save(p, &err)
+	defer func() { save(&err, p.tracingFields()...) }()
 
 	var q *sqlf.Query
 	if q, err = s.upsertQuery(p); err != nil {
@@ -429,29 +513,17 @@ DO UPDATE SET
   updated_at = excluded.updated_at
 `
 
-func (s *store) observe(ctx context.Context, family, title string) (context.Context, func(*Permissions, *error)) {
+func (s *store) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...otlog.Field)) {
 	began := s.clock()
 	tr, ctx := trace.New(ctx, "bitbucket.authz.store."+family, title)
 
-	return ctx, func(ps *Permissions, err *error) {
+	return ctx, func(err *error, fs ...otlog.Field) {
 		now := s.clock()
 		took := now.Sub(began)
 
-		fields := []otlog.Field{
-			otlog.String("Duration", took.String()),
-			otlog.Int32("Permissions.UserID", ps.UserID),
-			otlog.String("Permissions.Perm", string(ps.Perm)),
-			otlog.String("Permissions.Type", ps.Type),
-		}
+		fs = append(fs, otlog.String("Duration", took.String()))
 
-		if ps.IDs != nil {
-			fields = append(fields,
-				otlog.Uint64("Permissions.IDs.Count", ps.IDs.GetCardinality()),
-				otlog.String("Permissions.UpdatedAt", ps.UpdatedAt.String()),
-			)
-		}
-
-		tr.LogFields(fields...)
+		tr.LogFields(fs...)
 
 		success := err == nil || *err == nil
 		if !success {

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -135,7 +135,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 		}
 
 		ctx := context.Background()
-		err := repos.NewDBStore(nil, db, sql.TxOptions{}).UpsertRepos(ctx, rs...)
+		err := repos.NewDBStore(db, sql.TxOptions{}).UpsertRepos(ctx, rs...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -67,7 +67,7 @@ func BenchmarkStore(b *testing.B) {
 		s.block = true
 
 		ps := &Permissions{
-			UserID: 99,
+			UserID: 100,
 			Perm:   authz.Read,
 			Type:   "repos",
 		}
@@ -85,7 +85,7 @@ func BenchmarkStore(b *testing.B) {
 		s.block = true
 
 		ps := &Permissions{
-			UserID: 99,
+			UserID: 101,
 			Perm:   authz.Read,
 			Type:   "repos",
 		}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,7 +13,11 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
+	"github.com/sourcegraph/sourcegraph/pkg/extsvc/bitbucketserver"
 )
 
 func BenchmarkStore(b *testing.B) {
@@ -27,9 +32,14 @@ func BenchmarkStore(b *testing.B) {
 		ids[i] = uint32(i)
 	}
 
-	update := func(context.Context) ([]uint32, error) {
+	c := extsvc.CodeHost{
+		ServiceID:   "https://bitbucketserver.example.com",
+		ServiceType: bitbucketserver.ServiceType,
+	}
+
+	update := func(context.Context) ([]uint32, *extsvc.CodeHost, error) {
 		time.Sleep(2 * time.Second) // Emulate slow code host
-		return ids, nil
+		return ids, &c, nil
 	}
 
 	ctx := context.Background()
@@ -106,16 +116,38 @@ func testStore(db *sql.DB) func(*testing.T) {
 			return time.Unix(0, atomic.LoadInt64(&now)).Truncate(time.Microsecond)
 		}
 
+		codeHost := extsvc.CodeHost{
+			ServiceID:   "https://bitbucketserver.example.com",
+			ServiceType: bitbucketserver.ServiceType,
+		}
+
+		rs := make([]*repos.Repo, 0, 7)
+		for i := 1; i <= 7; i++ {
+			rs = append(rs, &repos.Repo{
+				Name: fmt.Sprintf("bitbucketserver.example.com/PROJ/%d", i),
+				ExternalRepo: api.ExternalRepoSpec{
+					ID:          strconv.Itoa(i),
+					ServiceType: codeHost.ServiceType,
+					ServiceID:   codeHost.ServiceID,
+				},
+				Sources: map[string]*repos.SourceInfo{},
+			})
+		}
+
+		ctx := context.Background()
+		err := repos.NewDBStore(nil, db, sql.TxOptions{}).UpsertRepos(ctx, rs...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		s := newStore(db, ttl, hardTTL, clock, newCache())
 		s.updates = make(chan *Permissions)
 
 		ids := []uint32{1, 2, 3}
 		e := error(nil)
-		update := func(context.Context) ([]uint32, error) {
-			return ids, e
+		update := func(context.Context) ([]uint32, *extsvc.CodeHost, error) {
+			return ids, &codeHost, e
 		}
-
-		ctx := context.Background()
 
 		ps := &Permissions{UserID: 42, Perm: authz.Read, Type: "repos"}
 		load := func(s *store) (*Permissions, error) {
@@ -201,9 +233,9 @@ func testStore(db *sql.DB) func(*testing.T) {
 			atomic.AddInt64(&now, int64(2*ttl))
 
 			delay := make(chan struct{})
-			update = func(context.Context) ([]uint32, error) {
+			update = func(context.Context) ([]uint32, *extsvc.CodeHost, error) {
 				<-delay
-				return ids, e
+				return ids, &codeHost, e
 			}
 
 			type op struct {

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -38,7 +38,6 @@ func BenchmarkStore(b *testing.B) {
 	}
 
 	update := func(context.Context) ([]uint32, *extsvc.CodeHost, error) {
-		time.Sleep(2 * time.Second) // Emulate slow code host
 		return ids, &c, nil
 	}
 


### PR DESCRIPTION
Up until now, the cached set of repository ids that a user is allowed to
see was dependent on the kind of request first done when there was no
cache (or it had expired). This commit changes the code so that we store
all authorized repository ids in the cache, not only those that were to
be verified when RepoPerms was called.

This bug would have resulted in false negatives (i.e. Sourcegraph refusing to show a repo to a user that is authorized to see it), but never in false positives.

Apart from those changes, this PR lays out the foundation to implement a GraphQL endpoint that can be called to update the permissions cache of a given user. The endpoint is not in this PR because there are still unknowns on how to reliably acquire the (dynamic) list of frontend instance addresses to call the endpoint on, concurrently.

Part of #4812 
