### PR TITLE
No longer do tracing within searcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occuring before the update concludes. If your previous `ttl` value is larger than the default of the new `hardTTL` setting (i.e. **3 days**), you must change the `ttl` to be smaller or, `hardTTL` to be larger.
+- Searcher no longer makes spans, to lighten the load on Lightstep so its traces can be viewed. [#5303](https://github.com/sourcegraph/sourcegraph/pull/5303)
 
 ### Fixed
 

--- a/cmd/searcher/search/eval.go
+++ b/cmd/searcher/search/eval.go
@@ -32,7 +32,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/search/matchtree"
 	"github.com/sourcegraph/sourcegraph/pkg/search/query"
 	"github.com/sourcegraph/sourcegraph/pkg/store"
-	"golang.org/x/net/trace"
 )
 
 // This file adapts zoekt's matchtree to work on content without any indexes.
@@ -68,22 +67,12 @@ func (s *StoreSearcher) Search(ctx context.Context, q query.Q, opts *api.Options
 	repo := api.Repository{Name: opts.Repositories[0]}
 	status := api.RepositoryStatusSearched
 
-	tr := trace.New("search", repo.String())
-	tr.LazyPrintf("query: %s", q)
-	tr.LazyPrintf("opts:  %+v", opts)
 	defer func() {
-		if sr != nil {
-			tr.LazyPrintf("num files: %d", len(sr.Files))
-		}
 		if err != nil {
 			if status == api.RepositoryStatusSearched {
 				status = api.RepositoryStatusError
 			}
-			tr.LazyPrintf("error: %v", err)
-			tr.SetError()
 		}
-		tr.LazyPrintf("status: %s", status)
-		tr.Finish()
 		if err != nil {
 			err = errors.Wrapf(err, "failed to search %s for %s", repo, q)
 		}
@@ -117,7 +106,6 @@ func (s *StoreSearcher) Search(ctx context.Context, q query.Q, opts *api.Options
 	if err != nil {
 		return nil, err
 	}
-	tr.LazyPrintf("matchtree: %s", mt)
 
 	// Fetch/Open the zip file
 	prepareCtx := ctx


### PR DESCRIPTION
This is meant to help with #5215.

These traces apparently happen for every repo being searched, but there can be thousands of repos and that would overwhelm lightstep.

<!-- Reminder: Have you updated the changelog and relevant docs ? -->

Test plan: run this within an instance with say 10k repositories and see if the lightstep traces are usable.

