### PR TITLE
No longer preallocate repo slice in repohasfile filtering

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -52,7 +52,7 @@ func searchRepositories(ctx context.Context, args *search.Args, limit int32) (re
 
 	// Filter args.Repos by matching their names against the query pattern.
 	common = &searchResultsCommon{}
-	repos := make([]*search.RepositoryRevisions, 0, len(args.Repos))
+	var repos []*search.RepositoryRevisions
 	for _, r := range args.Repos {
 		if pattern.MatchString(string(r.Repo.Name)) {
 			repos = append(repos, r)


### PR DESCRIPTION
This follows up on a comment by @keegancsmith on a previous PR: https://github.com/sourcegraph/sourcegraph/pull/5189#discussion_r314038793, where he explained that preallocating is probably less memory efficient in the typical case for the line of code in question because usually the output slice is much smaller.

Test plan: relying on existing tests

