### PR TITLE
e2e-tests: Minor fixes and follow-ups

### DIFF
--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -24,11 +24,6 @@ export const percySnapshot = readEnvBoolean({ variable: 'PERCY_ON', defaultValue
  */
 export const gitHubToken = readEnvString({ variable: 'GITHUB_TOKEN' })
 
-export const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
-export const awsAccessKeyID = process.env.AWS_ACCESS_KEY_ID
-export const awsCodeCommitGitUsername = process.env.AWS_CODE_COMMIT_GIT_USERNAME
-export const awsCodeCommitGitPassword = process.env.AWS_CODE_COMMIT_GIT_PASSWORD
-
 export const baseURL = readEnvString({ variable: 'SOURCEGRAPH_BASE_URL', defaultValue: 'http://localhost:3080' })
 
 /**

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -272,7 +272,7 @@ describe('e2e test suite', () => {
             })
             await driver.page.goto(baseURL + '/aws/test/-/blob/README')
             const blob: string = await (await driver.page.waitFor(() => {
-                const elem = document.querySelector<HTMLInputElement>('.e2e-repo-blob')
+                const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
                 return elem && elem.textContent
             })).jsonValue()
 

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -6,6 +6,7 @@ import { baseURL, createDriverForTest, Driver, gitHubToken, percySnapshot } from
 import got from 'got'
 import { gql } from '../../../shared/src/graphql/graphql'
 import { random } from 'lodash'
+import MockDate from 'mockdate'
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
 // command timeout of 30s in order to get the stack trace to point to the
@@ -52,9 +53,12 @@ describe('e2e test suite', () => {
         })
     }
 
-    // Start browser.
     beforeAll(
         async () => {
+            // Reset date mocking
+            MockDate.reset()
+
+            // Start browser.
             driver = await createDriverForTest()
             await init()
         },
@@ -123,8 +127,7 @@ describe('e2e test suite', () => {
             await driver.page.goto(baseURL + '/users/test/settings/tokens/new')
             await driver.page.waitForSelector('.e2e-create-access-token-description')
 
-            const now = await driver.page.evaluate(() => new Date().toISOString())
-            const name = 'E2E Test ' + now + ' ' + random(1, 1e7)
+            const name = 'E2E Test ' + new Date().toISOString() + ' ' + random(1, 1e7)
 
             await driver.replaceText({
                 selector: '.e2e-create-access-token-description',

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -253,10 +253,9 @@ describe('e2e test suite', () => {
                 : test.skip.bind(test)
 
         testIfAwsCredentialsSet('AWS CodeCommit', async () => {
-            const displayName = 'e2e-aws-code-commit-' + random(1, 1e7)
             await driver.ensureHasExternalService({
                 kind: 'awscodecommit',
-                displayName,
+                displayName: 'e2e-aws-code-commit',
                 config: JSON.stringify({
                     region: 'us-west-1',
                     accessKeyID: awsAccessKeyID,


### PR DESCRIPTION
This is a follow up to #5242 and contains

* single name for AWS CodeCommit service so it gets cleaned up by `ensureHasExternalService`
* removal of unused variables

