### PR TITLE
globalstatedb: Skip Bcrypt test if -short

### DIFF
--- a/pkg/db/globalstatedb/globalstatedb_test.go
+++ b/pkg/db/globalstatedb/globalstatedb_test.go
@@ -44,6 +44,10 @@ func TestGenerateRandomPassword(t *testing.T) {
 }
 
 func TestBcryptHashTime(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	plaintext, err := generateRandomPassword()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Bcrypt test is quite CPU intensive. On my laptop I have observed the
`globalstatedb` tests take 6s when I run `go test -short ./...`. This is the
only test which is this slow in short mode.

Test Plan: Ran all tests and then manually checked nothing was slow

```bash
go test -count=1 -short ./... | tee test.txt
cat test.txt | grep ^ok | sort -n -k 3
```
