### PR TITLE
Make searches default to index:only on sourcegraph.com

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -405,10 +405,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	}
 
 	var defaultRepos []*types.Repo
-	// TODO(ijt): make sure filters like file: don't prevent default repos from being used.
 	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 {
-		// TODO(ijt): check config like search.defaultRepos.enabled so installations not
-		// using default_repos won't have to pay the ~0.5 msec cost of this query.
 		defaultRepos, err = db.DefaultRepos.List(ctx)
 		if err != nil {
 			return nil, nil, false, err


### PR DESCRIPTION
Fixes #5301.

On sourcegraph.com, some default repos seem not to be showing up as indexed (see #5301 for evidence), so this restricts to only indexed repos when there are some and logs a few of the unindexed repos to help us track down the root of the problem.

Test plan: <!-- Required: What is the test plan for this change? -->
