### PR TITLE
update zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ require (
 )
 
 replace (
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20190819202617-014a202a7b3d
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20190821144538-4e4eef546d3e
 	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20180929065141-c790ffc3c46a
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.0.0-20190712190530-f05918046bab

--- a/go.sum
+++ b/go.sum
@@ -644,9 +644,8 @@ github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614 h1:MrlKMpoGse4bC
 github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/sourcegraph/zoekt v0.0.0-20190819202617-014a202a7b3d h1:gqd14PHERGyN1+j+vG0iJKVlYLupvVBqr+Q0I38B4NY=
-github.com/sourcegraph/zoekt v0.0.0-20190819202617-014a202a7b3d/go.mod h1:ktJjC94Qpag2sLp96e8uSc6KZ3hRoxz1pyN1yRKsOy4=
-github.com/sourcegraph/zoekt v0.0.0-20190821142101-b6bd1c5c5553/go.mod h1:ktJjC94Qpag2sLp96e8uSc6KZ3hRoxz1pyN1yRKsOy4=
+github.com/sourcegraph/zoekt v0.0.0-20190821144538-4e4eef546d3e h1:7W+71CvEPuD0Vi4G9Zdx6Wa/27jhpuTET6CwOKAvkLc=
+github.com/sourcegraph/zoekt v0.0.0-20190821144538-4e4eef546d3e/go.mod h1:ktJjC94Qpag2sLp96e8uSc6KZ3hRoxz1pyN1yRKsOy4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.0/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,7 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/zoekt v0.0.0-20190819202617-014a202a7b3d h1:gqd14PHERGyN1+j+vG0iJKVlYLupvVBqr+Q0I38B4NY=
 github.com/sourcegraph/zoekt v0.0.0-20190819202617-014a202a7b3d/go.mod h1:ktJjC94Qpag2sLp96e8uSc6KZ3hRoxz1pyN1yRKsOy4=
+github.com/sourcegraph/zoekt v0.0.0-20190821142101-b6bd1c5c5553/go.mod h1:ktJjC94Qpag2sLp96e8uSc6KZ3hRoxz1pyN1yRKsOy4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.0/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Includes changes:
- Support reading v15 indexes.
- Remove v15 indexes once v16 is built.
- Set HasSymbols to true if we ran ctags, not only if we have symbols.