### PR TITLE
gitserver: Use WARN log-level when cleaning up LRU repos

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -367,7 +367,7 @@ func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
 			return errors.Wrap(err, "finding the amount of space free on disk")
 		}
 		G := float64(1024 * 1024 * 1024)
-		log15.Info("cleanup: removed least recently used repo",
+		log15.Warn("cleanup: removed least recently used repo",
 			"repo", d,
 			"how old", time.Since(dirModTimes[d]),
 			"free space in GiB", float64(actualFreeBytes)/G,


### PR DESCRIPTION
Slack thread with context: https://sourcegraph.slack.com/archives/CHPC7UX16/p1566316586140100?thread_ts=1565708902.099900&cid=CHPC7UX16

We've had at least one customer run into `repo-updater`
seemingly cloning repositories in an endless loop. It turned out that
`gitserver` was at the same time cleaning up LRU repos because there was
not enough disk space.

The log message was not visible to the user in the default
configuration. With this change we make it visible.