### PR TITLE
ci: push docker images to both docker hub and GCR

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -283,20 +283,21 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 		for _, image := range []string{dockerHubImage, gcrImage} {
 			if app != "server" || c.taggedRelease || c.patch || c.patchNoTest {
 				cmds = append(cmds,
+					bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s", baseImage, c.version, image, c.version)),
 					bk.Cmd(fmt.Sprintf("docker push %s:%s", image, c.version)),
 				)
 			}
 
 			if app == "server" && c.releaseBranch {
 				cmds = append(cmds,
-					bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s-insiders", image, c.version, image, c.branch)),
+					bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s-insiders", baseImage, c.version, image, c.branch)),
 					bk.Cmd(fmt.Sprintf("docker push %s:%s-insiders", image, c.branch)),
 				)
 			}
 
 			if insiders {
 				cmds = append(cmds,
-					bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:insiders", image, c.version, image)),
+					bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:insiders", baseImage, c.version, image)),
 					bk.Cmd(fmt.Sprintf("docker push %s:insiders", image)),
 				)
 			}

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -256,14 +256,14 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 			cmds = append(cmds, bk.Cmd(preBuildScript))
 		}
 
-		image := "sourcegraph/" + app
+		baseImage := "sourcegraph/" + app
 
 		getBuildScript := func() string {
 			buildScriptByApp := map[string]string{
 				"symbols": "env BUILD_TYPE=dist ./cmd/symbols/build.sh buildSymbolsDockerImage",
 
 				// The server image was built prior to e2e tests in a previous step.
-				"server": fmt.Sprintf("docker tag %s:%s_candidate %s:%s", image, c.version, image, c.version),
+				"server": fmt.Sprintf("docker tag %s:%s_candidate %s:%s", baseImage, c.version, baseImage, c.version),
 			}
 			if buildScript, ok := buildScriptByApp[app]; ok {
 				return buildScript
@@ -272,30 +272,36 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 		}
 
 		cmds = append(cmds,
-			bk.Env("IMAGE", image+":"+c.version),
+			bk.Env("IMAGE", baseImage+":"+c.version),
 			bk.Env("VERSION", c.version),
 			bk.Cmd(getBuildScript()),
 		)
 
-		if app != "server" || c.taggedRelease || c.patch || c.patchNoTest {
-			cmds = append(cmds,
-				bk.Cmd(fmt.Sprintf("docker push %s:%s", image, c.version)),
-			)
+		dockerHubImage := fmt.Sprintf("index.docker.io/%s", baseImage)
+		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
+
+		for _, image := range []string{dockerHubImage, gcrImage} {
+			if app != "server" || c.taggedRelease || c.patch || c.patchNoTest {
+				cmds = append(cmds,
+					bk.Cmd(fmt.Sprintf("docker push %s:%s", image, c.version)),
+				)
+			}
+
+			if app == "server" && c.releaseBranch {
+				cmds = append(cmds,
+					bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s-insiders", image, c.version, image, c.branch)),
+					bk.Cmd(fmt.Sprintf("docker push %s:%s-insiders", image, c.branch)),
+				)
+			}
+
+			if insiders {
+				cmds = append(cmds,
+					bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:insiders", image, c.version, image)),
+					bk.Cmd(fmt.Sprintf("docker push %s:insiders", image)),
+				)
+			}
 		}
 
-		if app == "server" && c.releaseBranch {
-			cmds = append(cmds,
-				bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s-insiders", image, c.version, image, c.branch)),
-				bk.Cmd(fmt.Sprintf("docker push %s:%s-insiders", image, c.branch)),
-			)
-		}
-
-		if insiders {
-			cmds = append(cmds,
-				bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:insiders", image, c.version, image)),
-				bk.Cmd(fmt.Sprintf("docker push %s:insiders", image)),
-			)
-		}
 		pipeline.AddStep(":docker:", cmds...)
 	}
 }


### PR DESCRIPTION
This PR changes our CI pipeline to push images to both hub.docker.io and [Google Container Registry (GCR)](https://cloud.google.com/container-registry/). GCR has a security scanning feature that we can use to perform checks on all of our published Docker images (we'll still tell our users to download the images from hub.docker.io)

cc @sourcegraph/distribution 