### PR TITLE
ci: add gcloud docker configure command

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -277,6 +277,8 @@ func addDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 			bk.Cmd(getBuildScript()),
 		)
 
+		cmds = append(cmds, bk.Cmd("yes | gcloud auth configure-docker"))
+
 		dockerHubImage := fmt.Sprintf("index.docker.io/%s", baseImage)
 		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
 


### PR DESCRIPTION
After https://github.com/sourcegraph/sourcegraph/pull/5323, CI is currently failing with this error:

```
authorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```

After reading https://cloud.google.com/container-registry/docs/advanced-authentication#gcloud_as_a_docker_credential_helper, I believe `gcloud auth configure-docker` is what we need run in order to grant the credentials. 