### PR TITLE
Fix fetching private extensions from bext

### DIFF
--- a/browser/src/platform/worker.ts
+++ b/browser/src/platform/worker.ts
@@ -1,8 +1,11 @@
 import { ajax } from 'rxjs/ajax'
+import { DEFAULT_SOURCEGRAPH_URL } from '../shared/util/context'
 
 export async function createBlobURLForBundle(bundleURL: string): Promise<string> {
     const req = await ajax({
         url: bundleURL,
+        // Include credentials when fetching extensions from the private registry
+        withCredentials: new URL(bundleURL).origin !== DEFAULT_SOURCEGRAPH_URL,
         crossDomain: true,
         responseType: 'blob',
     }).toPromise()

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
@@ -62,9 +63,13 @@ func handleRegistryExtensionBundle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 
-	// Allow downstream Sourcegraph sites' clients to access this file directly.
-	w.Header().Del("Access-Control-Allow-Credentials") // credentials are not needed
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	// 🚨 SECURITY sourcegraph.com only: downstream Sourcegraph sites' clients to access this file directly.
+	// On private registries, requests to fetch extension  bundles are authenticated, and Access-Control headers
+	// should be preserved.
+	if envvar.SourcegraphDotComMode() {
+		w.Header().Del("Access-Control-Allow-Credentials") // credentials are not needed
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	}
 
 	// We want to cache forever because an extension release is immutable, except that if the
 	// database is reset and and the registry_extension_releases.id sequence starts over, we don't

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -64,7 +64,7 @@ func handleRegistryExtensionBundle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 
 	// 🚨 SECURITY sourcegraph.com only: downstream Sourcegraph sites' clients to access this file directly.
-	// On private registries, requests to fetch extension  bundles are authenticated, and Access-Control headers
+	// On private registries, requests to fetch extension bundles are authenticated, and Access-Control headers
 	// should be preserved.
 	if envvar.SourcegraphDotComMode() {
 		w.Header().Del("Access-Control-Allow-Credentials") // credentials are not needed


### PR DESCRIPTION
Fixes #5185

Fetching private registry extensions from the browser extension was broken. The fix is twofold:
- On the browser extension side, requests to fetch bundles from the private registry should include credentials. This fixed the 401 error that https://app.hubspot.com/contacts/2762526/company/768958849/ ran into...
- ...but replaced it with a CORS error. This is because in `extension_bundle.go`, `Access-Control` headers were set to allow cross-origin access to bundles hosted on sourcegraph.com. These lax headers caused no issues with same-origin requests made from the self-hosted sourcegraph webapp, but broke cross-origin requests from the browser extension: `The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.`. I fixed this by only downgrading these headers on sourcegraph.com.

Test plan:
- Published an extension to the private registry of my local dev instance and activated it
- Verified that the private extension bundle was correctly fetched from the browser extension on the code host.
- Verified that the private extension bundle was correctly fetched from the webapp.
- Verified that public extension bundles were correctly fetched from the browser extension & the webapp.
