### PR TITLE
status-indicator: Display all syncing errors from repo-updater

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -826,7 +826,7 @@ type Query {
     #
     # FOR INTERNAL USE ONLY.
     dotcom: DotcomQuery!
-    # Lists all status messages
+    # FOR INTERNAL USE ONLY: Lists all status messages
     statusMessages: [StatusMessage!]!
 
     # Look up a namespace by ID.
@@ -3712,14 +3712,15 @@ type ProductSubscriptionEvent {
     url: String
 }
 
-# A status message produced when repositories are being cloned
+# FOR INTERNAL USE ONLY: A status message produced when repositories are being
+# cloned
 type CloningProgress {
     # The message of this status message
     message: String!
 }
 
-# A status message produced when repositories could not be synced from an
-# external service
+# FOR INTERNAL USE ONLY: A status message produced when repositories could not
+# be synced from an external service
 type ExternalServiceSyncError {
     # The message of this status message
     message: String!
@@ -3727,13 +3728,14 @@ type ExternalServiceSyncError {
     externalService: ExternalService!
 }
 
-# A status message produced when repositories could not be synced
+# FOR INTERNAL USE ONLY: A status message produced when repositories could not
+# be synced
 type SyncError {
     # The message of this status message
     message: String!
 }
 
-# A status message
+# FOR INTERNAL USE ONLY: A status message
 union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 # An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3712,23 +3712,29 @@ type ProductSubscriptionEvent {
     url: String
 }
 
-# An status message produced when repositories are being cloned
-type CloningStatusMessage {
+# A status message produced when repositories are being cloned
+type CloningProgress {
     # The message of this status message
     message: String!
 }
 
-# An status message produced when repositories could not be synced from code
-# hosts
-type SyncErrorStatusMessage {
+# A status message produced when repositories could not be synced from an
+# external service
+type ExternalServiceSyncError {
     # The message of this status message
     message: String!
     # The external service that failed to sync
     externalService: ExternalService!
 }
 
+# A status message produced when repositories could not be synced
+type SyncError {
+    # The message of this status message
+    message: String!
+}
+
 # A status message
-union StatusMessage = CloningStatusMessage | SyncErrorStatusMessage
+union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 # An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
 # JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3719,23 +3719,29 @@ type ProductSubscriptionEvent {
     url: String
 }
 
-# An status message produced when repositories are being cloned
-type CloningStatusMessage {
+# A status message produced when repositories are being cloned
+type CloningProgress {
     # The message of this status message
     message: String!
 }
 
-# An status message produced when repositories could not be synced from code
-# hosts
-type SyncErrorStatusMessage {
+# A status message produced when repositories could not be synced from an
+# external service
+type ExternalServiceSyncError {
     # The message of this status message
     message: String!
     # The external service that failed to sync
     externalService: ExternalService!
 }
 
+# A status message produced when repositories could not be synced
+type SyncError {
+    # The message of this status message
+    message: String!
+}
+
 # A status message
-union StatusMessage = CloningStatusMessage | SyncErrorStatusMessage
+union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 # An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
 # JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -833,7 +833,7 @@ type Query {
     #
     # FOR INTERNAL USE ONLY.
     dotcom: DotcomQuery!
-    # Lists all status messages
+    # FOR INTERNAL USE ONLY: Lists all status messages
     statusMessages: [StatusMessage!]!
 
     # Look up a namespace by ID.
@@ -3719,14 +3719,15 @@ type ProductSubscriptionEvent {
     url: String
 }
 
-# A status message produced when repositories are being cloned
+# FOR INTERNAL USE ONLY: A status message produced when repositories are being
+# cloned
 type CloningProgress {
     # The message of this status message
     message: String!
 }
 
-# A status message produced when repositories could not be synced from an
-# external service
+# FOR INTERNAL USE ONLY: A status message produced when repositories could not
+# be synced from an external service
 type ExternalServiceSyncError {
     # The message of this status message
     message: String!
@@ -3734,13 +3735,14 @@ type ExternalServiceSyncError {
     externalService: ExternalService!
 }
 
-# A status message produced when repositories could not be synced
+# FOR INTERNAL USE ONLY: A status message produced when repositories could not
+# be synced
 type SyncError {
     # The message of this status message
     message: String!
 }
 
-# A status message
+# FOR INTERNAL USE ONLY: A status message
 union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 # An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -34,17 +34,24 @@ type statusMessageResolver struct {
 	message protocol.StatusMessage
 }
 
-func (r *statusMessageResolver) ToCloningStatusMessage() (*statusMessageResolver, bool) {
+func (r *statusMessageResolver) ToCloningProgress() (*statusMessageResolver, bool) {
 	return r, r.message.Cloning != nil
 }
 
-func (r *statusMessageResolver) ToSyncErrorStatusMessage() (*statusMessageResolver, bool) {
+func (r *statusMessageResolver) ToExternalServiceSyncError() (*statusMessageResolver, bool) {
+	return r, r.message.ExternalServiceSyncError != nil
+}
+
+func (r *statusMessageResolver) ToSyncError() (*statusMessageResolver, bool) {
 	return r, r.message.SyncError != nil
 }
 
 func (r *statusMessageResolver) Message() (string, error) {
 	if r.message.Cloning != nil {
 		return r.message.Cloning.Message, nil
+	}
+	if r.message.ExternalServiceSyncError != nil {
+		return r.message.ExternalServiceSyncError.Message, nil
 	}
 	if r.message.SyncError != nil {
 		return r.message.SyncError.Message, nil
@@ -53,7 +60,8 @@ func (r *statusMessageResolver) Message() (string, error) {
 }
 
 func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {
-	externalService, err := db.ExternalServices.GetByID(ctx, r.message.SyncError.ExternalServiceId)
+	id := r.message.ExternalServiceSyncError.ExternalServiceId
+	externalService, err := db.ExternalServices.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -18,11 +18,15 @@ func TestStatusMessages(t *testing.T) {
 			statusMessages {
 				__typename
 
-				... on CloningStatusMessage {
+				... on CloningProgress {
 					message
 				}
 
-				... on SyncErrorStatusMessage {
+				... on SyncError {
+					message
+				}
+
+				... on ExternalServiceSyncError {
 					message
 					externalService {
 						id
@@ -98,14 +102,19 @@ func TestStatusMessages(t *testing.T) {
 		repoupdater.MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
 			res := &protocol.StatusMessagesResponse{Messages: []protocol.StatusMessage{
 				{
-					Cloning: &protocol.CloningStatusMessage{
+					Cloning: &protocol.CloningProgress{
 						Message: "Currently cloning 5 repositories in parallel...",
 					},
 				},
 				{
-					SyncError: &protocol.SyncErrorStatusMessage{
+					ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
 						Message:           "Authentication failed. Please check credentials.",
 						ExternalServiceId: 1,
+					},
+				},
+				{
+					SyncError: &protocol.SyncError{
+						Message: "Could not save to database",
 					},
 				},
 			}}
@@ -121,16 +130,20 @@ func TestStatusMessages(t *testing.T) {
 					{
 						"statusMessages": [
 							{
-								"__typename": "CloningStatusMessage",
+								"__typename": "CloningProgress",
 								"message": "Currently cloning 5 repositories in parallel..."
 							},
 							{
-								"__typename": "SyncErrorStatusMessage",
+								"__typename": "ExternalServiceSyncError",
 								"externalService": {
 									"displayName": "GitHub.com testing",
 									"id": "RXh0ZXJuYWxTZXJ2aWNlOjE="
 								},
 								"message": "Authentication failed. Please check credentials."
+							},
+							{
+								"__typename": "SyncError",
+								"message": "Could not save to database"
 							}
 						]
 					}

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -23,11 +23,11 @@ type Syncer struct {
 	// Sourcegraph.com
 	FailFullSync bool
 
-	// multiSourceErr contains the last error returned by the Sourcer in each
-	// Sync. It's reset with each Sync and if the Sourcer produced no error,
-	// it's set to nil.
-	multiSourceErr   *MultiSourceError
-	multiSourceErrMu sync.Mutex
+	// lastSyncErr contains the last error returned by the Sourcer in each
+	// Sync. It's reset with each Sync and if the sync produced no error, it's
+	// set to nil.
+	lastSyncErr   error
+	lastSyncErrMu sync.Mutex
 
 	store   Store
 	sourcer Sourcer
@@ -84,6 +84,7 @@ func (s *Syncer) TriggerSync() {
 func (s *Syncer) Sync(ctx context.Context) (diff Diff, err error) {
 	ctx, save := s.observe(ctx, "Syncer.Sync", "")
 	defer save(&diff, &err)
+	defer s.setOrResetLastSyncErr(&err)
 
 	if s.FailFullSync {
 		return Diff{}, errors.New("Syncer is not enabled")
@@ -318,47 +319,34 @@ func (s *Syncer) sourced(ctx context.Context) ([]*Repo, error) {
 
 	srcs, err := s.sourcer(svcs...)
 	if err != nil {
-		// Only reset source error if it was non-nil. Because if `ListRepos`
-		// produces an error through multiple syncs, the state of
-		// multiSourceErr would flip-flop between here and the `ListRepos` call
-		// further down.
-		s.setOrResetMultiSourceErr(err)
 		return nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, sourceTimeout)
 	defer cancel()
 
-	repos, err := srcs.ListRepos(ctx)
-	s.setOrResetMultiSourceErr(err)
-
-	return repos, err
+	return srcs.ListRepos(ctx)
 }
 
-func (s *Syncer) setOrResetMultiSourceErr(err error) {
-	s.multiSourceErrMu.Lock()
+func (s *Syncer) setOrResetLastSyncErr(err *error) {
+	s.lastSyncErrMu.Lock()
+	defer s.lastSyncErrMu.Unlock()
 
-	if multiSourceErr, ok := err.(*MultiSourceError); ok {
-		s.multiSourceErr = multiSourceErr
-	} else {
-		s.multiSourceErr = nil
+	if err != nil {
+		s.lastSyncErr = *err
+		return
 	}
 
-	s.multiSourceErrMu.Unlock()
+	s.lastSyncErr = nil
 }
 
-// LastSyncErrors returns the SourceErrors that were produced in the last Sync
-// run. If the slice is empty, the last sync run didn't produce any errors.
-func (s *Syncer) LastSyncErrors() []*SourceError {
-	s.multiSourceErrMu.Lock()
-	defer s.multiSourceErrMu.Unlock()
+// LastSyncError returns the error that was produced in the last Sync run. If
+// no error was produced, this returns nil.
+func (s *Syncer) LastSyncError() error {
+	s.lastSyncErrMu.Lock()
+	defer s.lastSyncErrMu.Unlock()
 
-	var errors []*SourceError
-	if s.multiSourceErr != nil {
-		errors = s.multiSourceErr.Errors
-	}
-
-	return errors
+	return s.lastSyncErr
 }
 
 func (s *Syncer) observe(ctx context.Context, family, title string) (context.Context, func(*Diff, *error)) {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -328,16 +328,15 @@ func (s *Syncer) sourced(ctx context.Context) ([]*Repo, error) {
 	return srcs.ListRepos(ctx)
 }
 
-func (s *Syncer) setOrResetLastSyncErr(err *error) {
-	s.lastSyncErrMu.Lock()
-	defer s.lastSyncErrMu.Unlock()
-
-	if err != nil {
-		s.lastSyncErr = *err
-		return
+func (s *Syncer) setOrResetLastSyncErr(perr *error) {
+	var err error
+	if perr != nil {
+		err = *perr
 	}
 
-	s.lastSyncErr = nil
+	s.lastSyncErrMu.Lock()
+	s.lastSyncErr = err
+	s.lastSyncErrMu.Unlock()
 }
 
 // LastSyncError returns the error that was produced in the last Sync run. If

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -30,18 +30,16 @@ func TestSyncer_Sync(t *testing.T) {
 	gitlab := repos.ExternalService{ID: 2, Kind: "gitlab"}
 
 	for _, tc := range []struct {
-		name           string
-		sourcer        repos.Sourcer
-		store          repos.Store
-		err            string
-		lastSyncErrors string
+		name    string
+		sourcer repos.Sourcer
+		store   repos.Store
+		err     string
 	}{
 		{
-			name:           "sourcer error aborts sync",
-			sourcer:        repos.NewFakeSourcer(errors.New("boom")),
-			store:          new(repos.FakeStore),
-			err:            "syncer.sync.sourced: 1 error occurred:\n\t* boom\n\n",
-			lastSyncErrors: "boom",
+			name:    "sourcer error aborts sync",
+			sourcer: repos.NewFakeSourcer(errors.New("boom")),
+			store:   new(repos.FakeStore),
+			err:     "syncer.sync.sourced: 1 error occurred:\n\t* boom\n\n",
 		},
 		{
 			name: "sources partial errors aborts sync",
@@ -49,9 +47,8 @@ func TestSyncer_Sync(t *testing.T) {
 				repos.NewFakeSource(&github, nil),
 				repos.NewFakeSource(&gitlab, errors.New("boom")),
 			),
-			store:          new(repos.FakeStore),
-			err:            "syncer.sync.sourced: 1 error occurred:\n\t* boom\n\n",
-			lastSyncErrors: "boom",
+			store: new(repos.FakeStore),
+			err:   "syncer.sync.sourced: 1 error occurred:\n\t* boom\n\n",
 		},
 		{
 			name:    "store list error aborts sync",
@@ -79,12 +76,8 @@ func TestSyncer_Sync(t *testing.T) {
 				t.Errorf("have error %q, want %q", have, want)
 			}
 
-			haveErrs := make([]string, 0, len(syncer.LastSyncErrors()))
-			for _, e := range syncer.LastSyncErrors() {
-				haveErrs = append(haveErrs, fmt.Sprint(e))
-			}
-			if have, want := strings.Join(haveErrs, ","), tc.lastSyncErrors; have != want {
-				t.Errorf("have error %q, want %q", have, want)
+			if have, want := fmt.Sprint(syncer.LastSyncError()), tc.err; have != want {
+				t.Errorf("have LastSyncError %q, want %q", have, want)
 			}
 		})
 	}

--- a/pkg/repoupdater/protocol/repoupdater.go
+++ b/pkg/repoupdater/protocol/repoupdater.go
@@ -174,18 +174,23 @@ type ExternalServiceSyncResult struct {
 	Error           string
 }
 
-type CloningStatusMessage struct {
+type CloningProgress struct {
 	Message string
 }
 
-type SyncErrorStatusMessage struct {
+type ExternalServiceSyncError struct {
 	Message           string
 	ExternalServiceId int64
 }
 
+type SyncError struct {
+	Message string
+}
+
 type StatusMessage struct {
-	Cloning   *CloningStatusMessage   `json:"cloning"`
-	SyncError *SyncErrorStatusMessage `json:"sync_error"`
+	Cloning                  *CloningProgress          `json:"cloning"`
+	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
+	SyncError                *SyncError                `json:"sync_error"`
 }
 
 type StatusMessagesResponse struct {

--- a/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -16,9 +16,9 @@ describe('StatusMessagesNavItem', () => {
         ).toMatchSnapshot()
     })
 
-    describe('one CLONING message', () => {
+    describe('one CloningProgress message', () => {
         const message: GQL.StatusMessage = {
-            __typename: 'CloningStatusMessage',
+            __typename: 'CloningProgress',
             message: 'Currently cloning repositories...',
         }
 
@@ -46,9 +46,9 @@ describe('StatusMessagesNavItem', () => {
         })
     })
 
-    describe('one SYNCERROR message', () => {
+    describe('one ExternalServiceSyncError message', () => {
         const message: GQL.StatusMessage = {
-            __typename: 'SyncErrorStatusMessage',
+            __typename: 'ExternalServiceSyncError',
             message: 'failed to list organization kubernetes repos: request returned status 404: Not Found',
             externalService: {
                 __typename: 'ExternalService',
@@ -60,6 +60,36 @@ describe('StatusMessagesNavItem', () => {
                 updatedAt: new Date(),
                 warning: '',
             },
+        }
+
+        const fetchMessages = () => of([message])
+        test('as non-site admin', () => {
+            expect(
+                renderer
+                    .create(<StatusMessagesNavItem scheduler={queueScheduler} fetchMessages={fetchMessages} />)
+                    .toJSON()
+            ).toMatchSnapshot()
+        })
+
+        test('as site admin', () => {
+            expect(
+                renderer
+                    .create(
+                        <StatusMessagesNavItem
+                            scheduler={queueScheduler}
+                            fetchMessages={fetchMessages}
+                            isSiteAdmin={true}
+                        />
+                    )
+                    .toJSON()
+            ).toMatchSnapshot()
+        })
+    })
+
+    describe('one SyncError message', () => {
+        const message: GQL.StatusMessage = {
+            __typename: 'SyncError',
+            message: 'syncer.sync.store.upsert-repos: pg: unique constraint foobar',
         }
 
         const fetchMessages = () => of([message])

--- a/web/src/nav/StatusMessagesNavItem.tsx
+++ b/web/src/nav/StatusMessagesNavItem.tsx
@@ -20,11 +20,15 @@ export function fetchAllStatusMessages(): Observable<GQL.StatusMessage[]> {
                 statusMessages {
                     __typename
 
-                    ... on CloningStatusMessage {
+                    ... on CloningProgress {
                         message
                     }
 
-                    ... on SyncErrorStatusMessage {
+                    ... on SyncError {
+                        message
+                    }
+
+                    ... on ExternalServiceSyncError {
                         message
                         externalService {
                             id
@@ -128,7 +132,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
 
     private renderMessage(message: GQL.StatusMessage): JSX.Element | null {
         switch (message.__typename) {
-            case 'CloningStatusMessage':
+            case 'CloningProgress':
                 return (
                     <StatusMessagesNavItemEntry
                         key={message.message}
@@ -141,7 +145,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                         entryType="progress"
                     />
                 )
-            case 'SyncErrorStatusMessage':
+            case 'ExternalServiceSyncError':
                 return (
                     <StatusMessagesNavItemEntry
                         key={message.message}
@@ -154,6 +158,19 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                         entryType="warning"
                     />
                 )
+            case 'SyncError':
+                return (
+                    <StatusMessagesNavItemEntry
+                        key={message.message}
+                        title="Syncing repositories failed:"
+                        text={message.message}
+                        showLink={this.props.isSiteAdmin}
+                        linkTo="/site-admin/external-services"
+                        linkText="Configure external services"
+                        linkOnClick={this.toggleIsOpen}
+                        entryType="warning"
+                    />
+                )
         }
     }
 
@@ -161,7 +178,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         if (isErrorLike(this.state.messagesOrError)) {
             return <CloudAlertIcon className="icon-inline" />
         }
-        if (this.state.messagesOrError.some(({ __typename }) => __typename === 'SyncErrorStatusMessage')) {
+        if (this.state.messagesOrError.some(({ __typename }) => __typename === 'ExternalServiceSyncError')) {
             return (
                 <CloudAlertIcon
                     className="icon-inline"
@@ -169,7 +186,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                 />
             )
         }
-        if (this.state.messagesOrError.some(({ __typename }) => __typename === 'CloningStatusMessage')) {
+        if (this.state.messagesOrError.some(({ __typename }) => __typename === 'CloningProgress')) {
             return (
                 <CloudSyncIcon
                     className="icon-inline"

--- a/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
 </div>
 `;
 
-exports[`StatusMessagesNavItem one CLONING message as non-site admin 1`] = `
+exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`] = `
 <div
   className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
   onKeyDown={[Function]}
@@ -118,7 +118,7 @@ exports[`StatusMessagesNavItem one CLONING message as non-site admin 1`] = `
 </div>
 `;
 
-exports[`StatusMessagesNavItem one CLONING message as site admin 1`] = `
+exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
 <div
   className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
   onKeyDown={[Function]}
@@ -187,7 +187,7 @@ exports[`StatusMessagesNavItem one CLONING message as site admin 1`] = `
 </div>
 `;
 
-exports[`StatusMessagesNavItem one SYNCERROR message as non-site admin 1`] = `
+exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site admin 1`] = `
 <div
   className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
   onKeyDown={[Function]}
@@ -246,7 +246,7 @@ exports[`StatusMessagesNavItem one SYNCERROR message as non-site admin 1`] = `
 </div>
 `;
 
-exports[`StatusMessagesNavItem one SYNCERROR message as site admin 1`] = `
+exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admin 1`] = `
 <div
   className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
   onKeyDown={[Function]}
@@ -308,6 +308,134 @@ exports[`StatusMessagesNavItem one SYNCERROR message as site admin 1`] = `
           to="/site-admin/external-services/abcd"
         >
           Edit "GitHub.com"
+        </a>
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
+<div
+  className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+  onKeyDown={[Function]}
+>
+  <a
+    aria-expanded={false}
+    aria-haspopup={true}
+    className="btn btn-icon nav-link"
+    href="#"
+    onClick={[Function]}
+  >
+    <svg
+      className="mdi-icon icon-inline"
+      data-tooltip="Repositories up to date"
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M10,17L6.5,13.5L7.91,12.08L10,14.17L15.18,9L16.59,10.41M19.35,10.03C18.67,6.59 15.64,4 12,4C9.11,4 6.6,5.64 5.35,8.03C2.34,8.36 0,10.9 0,14C0,17.31 2.69,20 6,20H19C21.76,20 24,17.76 24,15C24,12.36 21.95,10.22 19.35,10.03Z"
+      />
+    </svg>
+  </a>
+  <div
+    aria-hidden={true}
+    className="status-messages-nav-item__dropdown-menu dropdown-menu dropdown-menu-right"
+    role="menu"
+    tabIndex="-1"
+  >
+    <h3>
+      External Service Status
+    </h3>
+    <div
+      className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-warning"
+    >
+      <h4>
+        <svg
+          className="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19,20H6C2.71,20 0,17.29 0,14C0,10.9 2.34,8.36 5.35,8.03C6.6,5.64 9.11,4 12,4C15.64,4 18.67,6.59 19.35,10.03C21.95,10.22 24,12.36 24,15C24,17.74 21.74,20 19,20M11,15V17H13V15H11M11,13H13V8H11V13Z"
+          />
+        </svg>
+        Syncing repositories failed:
+      </h4>
+      <p>
+        syncer.sync.store.upsert-repos: pg: unique constraint foobar
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
+<div
+  className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+  onKeyDown={[Function]}
+>
+  <a
+    aria-expanded={false}
+    aria-haspopup={true}
+    className="btn btn-icon nav-link"
+    href="#"
+    onClick={[Function]}
+  >
+    <svg
+      className="mdi-icon icon-inline"
+      data-tooltip="Repositories up to date"
+      fill="currentColor"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M10,17L6.5,13.5L7.91,12.08L10,14.17L15.18,9L16.59,10.41M19.35,10.03C18.67,6.59 15.64,4 12,4C9.11,4 6.6,5.64 5.35,8.03C2.34,8.36 0,10.9 0,14C0,17.31 2.69,20 6,20H19C21.76,20 24,17.76 24,15C24,12.36 21.95,10.22 19.35,10.03Z"
+      />
+    </svg>
+  </a>
+  <div
+    aria-hidden={true}
+    className="status-messages-nav-item__dropdown-menu dropdown-menu dropdown-menu-right"
+    role="menu"
+    tabIndex="-1"
+  >
+    <h3>
+      External Service Status
+    </h3>
+    <div
+      className="status-messages-nav-item__entry mb-3 status-messages-nav-item__entry--border-warning"
+    >
+      <h4>
+        <svg
+          className="mdi-icon icon-inline mr-1"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19,20H6C2.71,20 0,17.29 0,14C0,10.9 2.34,8.36 5.35,8.03C6.6,5.64 9.11,4 12,4C15.64,4 18.67,6.59 19.35,10.03C21.95,10.22 24,12.36 24,15C24,17.74 21.74,20 19,20M11,15V17H13V15H11M11,13H13V8H11V13Z"
+          />
+        </svg>
+        Syncing repositories failed:
+      </h4>
+      <p>
+        syncer.sync.store.upsert-repos: pg: unique constraint foobar
+      </p>
+      <p
+        className="status-messages-nav-item__entry-link"
+      >
+        <a
+          onClick={[Function]}
+          to="/site-admin/external-services"
+        >
+          Configure external services
         </a>
       </p>
     </div>


### PR DESCRIPTION
This is a follow-up to #5319 and implements the improved error reporting as described in this comment: https://github.com/sourcegraph/sourcegraph/pull/5319#discussion_r316627988

The user visible changes:

* The types of `StatusMessage`s have been changed so that there is now an `ExternalServiceSyncError` to which an external service is attached and the new `SyncError` without an external service
* The `SyncError` will now be produced whenever the syncing process in repo-updater fails, even if that doesn't involve an external service. That means we now, for example, display errors that originate in the database. That's something customer's ran into in the past but that was never visible.

Test plan: manual testing, `go test`, `cd web && yarn test --runInBand StatusMessagesNavItem.test.tsx`
