### PR TITLE
Fall back on non-indexed search when indexed search returns an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occuring before the update concludes. If your previous `ttl` value is larger than the default of the new `hardTTL` setting (i.e. **3 days**), you must change the `ttl` to be smaller or, `hardTTL` to be larger.
+- Fall back to non-indexed search when indexed search is down. [#5351](https://github.com/sourcegraph/sourcegraph/issues/5351)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -941,6 +941,9 @@ func searchFilesInRepos(ctx context.Context, args *search.Args) (res []*fileMatc
 			}
 			common.indexUnavailable = true
 			err = nil
+			// Fall back on non-indexed search.
+			zoektRepos = nil
+			searcherRepos = args.Repos
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -350,14 +350,14 @@ func TestSearchFilesInRepos(t *testing.T) {
 		if !zoekt.Enabled() {
 			t.Fatal("zoekt object says it is not enabled")
 		}
-		wantRes := []*fileMatchResolver { { uri: repoName } }
+		wantRes := []*fileMatchResolver{{uri: repoName}}
 		if len(res) != 1 {
 			t.Errorf("got %d results, want 1", len(res))
 		}
 		if !reflect.DeepEqual(res, wantRes) {
 			t.Errorf("res is %s, want %s", spew.Sdump(res), spew.Sdump(wantRes))
 		}
-		wantRepos := []*types.Repo{ { Name: api.RepoName(repoName) } }
+		wantRepos := []*types.Repo{{Name: api.RepoName(repoName)}}
 		if !common.indexUnavailable {
 			t.Errorf("common.indexUnavailable is unexpectedly false. It should be true because zoekt is returning errors.")
 		}


### PR DESCRIPTION
Fixes #5351 

Searches were failing when indexed search was enabled but the indexed-search pod was down. This PR makes search fall back to searcher in that case.

Test plan: Added a unit test that appears to reproduce the problem.