### PR TITLE
Don't reference Bootstrap from HoverOverlay

### DIFF
--- a/browser/src/libs/bitbucket/code_intelligence.tsx
+++ b/browser/src/libs/bitbucket/code_intelligence.tsx
@@ -219,6 +219,7 @@ export const bitbucketServerCodeHost: CodeHost = {
         listItemClass: 'action-nav-item--bitbucket',
     },
     hoverOverlayClassProps: {
+        className: 'aui-dialog',
         actionItemClassName: 'aui-button hover-action-item--bitbucket-server',
         closeButtonClassName: 'aui-button',
     },

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -318,6 +318,7 @@ export const githubCodeHost: CodeHost = {
         listItemClassName: 'text-normal',
     },
     hoverOverlayClassProps: {
+        className: 'Box',
         actionItemClassName: 'btn btn-secondary',
         actionItemPressedClassName: 'active',
         closeButtonClassName: 'btn',

--- a/browser/src/libs/gitlab/code_intelligence.ts
+++ b/browser/src/libs/gitlab/code_intelligence.ts
@@ -113,6 +113,7 @@ export const gitlabCodeHost: CodeHost = {
         actionItemPressedClass: 'active',
     },
     hoverOverlayClassProps: {
+        className: 'card',
         actionItemClassName: 'btn btn-secondary action-item--gitlab',
         actionItemPressedClassName: 'active',
         closeButtonClassName: 'btn',

--- a/browser/src/libs/phabricator/code_intelligence.ts
+++ b/browser/src/libs/phabricator/code_intelligence.ts
@@ -185,7 +185,9 @@ export const phabricatorCodeHost: CodeHost = {
         actionItemIconClass: 'action-item__icon--phabricator',
     },
     hoverOverlayClassProps: {
+        className: 'aphront-dialog-view hover-overlay--phabricator',
         actionItemClassName: 'button grey hover-overlay-action-item--phabricator',
+        closeButtonClassName: 'button grey hover-overlay__close-button--phabricator',
     },
     codeViewsRequireTokenization: true,
 }

--- a/browser/src/libs/phabricator/style.scss
+++ b/browser/src/libs/phabricator/style.scss
@@ -1,3 +1,13 @@
+.hover-overlay--phabricator {
+    margin: 0;
+}
+
+.hover-overlay__close-button--phabricator {
+    // Fight Phabricator selector specificity
+    background: transparent !important;
+    border: none !important;
+}
+
 // Mimics Phabricator's font icon style
 .action-item__icon--phabricator {
     height: 14px;

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -130,7 +130,7 @@ export class HoverOverlay<A extends string> extends React.PureComponent<HoverOve
                               visibility: 'hidden',
                           }
                 }
-                className={`hover-overlay card ${className}`}
+                className={classNames('hover-overlay', className)}
                 ref={hoverRef}
             >
                 {showCloseButton && (

--- a/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`HoverOverlay actions and hover empty 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -20,7 +20,7 @@ exports[`HoverOverlay actions and hover empty 1`] = `
 
 exports[`HoverOverlay actions and hover error 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -51,7 +51,7 @@ exports[`HoverOverlay actions and hover error 1`] = `
 
 exports[`HoverOverlay actions and hover loading 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -77,7 +77,7 @@ exports[`HoverOverlay actions and hover loading 1`] = `
 
 exports[`HoverOverlay actions and hover present 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -148,7 +148,7 @@ exports[`HoverOverlay actions and hover undefined 1`] = `null`;
 
 exports[`HoverOverlay actions empty 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -168,7 +168,7 @@ exports[`HoverOverlay actions error 1`] = `null`;
 
 exports[`HoverOverlay actions error, hover present 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -196,7 +196,7 @@ exports[`HoverOverlay actions error, hover present 1`] = `
 
 exports[`HoverOverlay actions loading 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -214,7 +214,7 @@ exports[`HoverOverlay actions loading 1`] = `
 
 exports[`HoverOverlay actions present 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -274,7 +274,7 @@ exports[`HoverOverlay actions present 1`] = `
 
 exports[`HoverOverlay actions present, hover loading 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -341,7 +341,7 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
 
 exports[`HoverOverlay actions, hover and alert present 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -449,7 +449,7 @@ exports[`HoverOverlay hover empty 1`] = `null`;
 
 exports[`HoverOverlay hover error 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -480,7 +480,7 @@ exports[`HoverOverlay hover error 1`] = `
 
 exports[`HoverOverlay hover error, actions present 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -552,7 +552,7 @@ exports[`HoverOverlay hover error, actions present 1`] = `
 
 exports[`HoverOverlay hover loading 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -578,7 +578,7 @@ exports[`HoverOverlay hover loading 1`] = `
 
 exports[`HoverOverlay hover present 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -606,7 +606,7 @@ exports[`HoverOverlay hover present 1`] = `
 
 exports[`HoverOverlay hover present, actions loading 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",
@@ -634,7 +634,7 @@ exports[`HoverOverlay hover present, actions loading 1`] = `
 
 exports[`HoverOverlay multiple hovers present 1`] = `
 <div
-  className="hover-overlay card "
+  className="hover-overlay"
   style={
     Object {
       "left": "0px",

--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -11,7 +11,12 @@ import { HoverOverlay, HoverOverlayProps } from '../../../shared/src/hover/Hover
 // Components from shared with web-styling class names applied
 
 export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps<never>> = props => (
-    <HoverOverlay closeButtonClassName="btn btn-icon" actionItemClassName="btn btn-secondary" {...props} />
+    <HoverOverlay
+        {...props}
+        className="card"
+        closeButtonClassName="btn btn-icon"
+        actionItemClassName="btn btn-secondary"
+    />
 )
 WebHoverOverlay.displayName = 'WebHoverOverlay'
 


### PR DESCRIPTION
Use native code host styles for hover overlay instead of referencing Bootstrap which was removed from the browser extension CSS.
Makes them feel even more native.