### PR TITLE
Catch Decoration Error

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -710,13 +710,17 @@ export function handleCodeHost({
             {
                 let decorationsByLine: DecorationMapByLine = new Map()
                 const update = (decorations?: TextDocumentDecoration[] | null): void => {
-                    decorationsByLine = applyDecorations(
-                        domFunctions,
-                        element,
-                        decorations || [],
-                        decorationsByLine,
-                        fileInfo.baseCommitID ? 'head' : undefined
-                    )
+                    try {
+                        decorationsByLine = applyDecorations(
+                            domFunctions,
+                            element,
+                            decorations || [],
+                            decorationsByLine,
+                            fileInfo.baseCommitID ? 'head' : undefined
+                        )
+                    } catch (err) {
+                        console.error('Could not apply head decorations to code view', codeViewEvent.element, err)
+                    }
                 }
                 codeViewEvent.subscriptions.add(
                     extensionsController.services.textDocumentDecoration
@@ -732,13 +736,17 @@ export function handleCodeHost({
             if (fileInfo.baseCommitID && fileInfo.baseFilePath) {
                 let decorationsByLine: DecorationMapByLine = new Map()
                 const update = (decorations?: TextDocumentDecoration[] | null): void => {
-                    decorationsByLine = applyDecorations(
-                        domFunctions,
-                        element,
-                        decorations || [],
-                        decorationsByLine,
-                        'base'
-                    )
+                    try {
+                        decorationsByLine = applyDecorations(
+                            domFunctions,
+                            element,
+                            decorations || [],
+                            decorationsByLine,
+                            'base'
+                        )
+                    } catch (err) {
+                        console.error('Could not apply base decorations to code view', codeViewEvent.element, err)
+                    }
                 }
                 codeViewEvent.subscriptions.add(
                     extensionsController.services.textDocumentDecoration

--- a/browser/src/libs/github/code_intelligence.ts
+++ b/browser/src/libs/github/code_intelligence.ts
@@ -203,10 +203,11 @@ const genericCodeViewResolver: ViewResolver<CodeView> = {
             return null
         }
 
-        const files = document.getElementsByClassName('file')
         const { pageType } = parseURL()
         const isSingleCodeFile =
-            files.length === 1 && pageType === 'blob' && document.getElementsByClassName('diff-view').length === 0
+            pageType === 'blob' &&
+            document.getElementsByClassName('file').length === 1 &&
+            document.getElementsByClassName('diff-view').length === 0
 
         if (isSingleCodeFile) {
             return { element: elem, ...singleFileCodeView }

--- a/browser/src/libs/github/dom_functions.ts
+++ b/browser/src/libs/github/dom_functions.ts
@@ -74,6 +74,10 @@ const getDiffCodeCellFromLineNumber = (
     line: number,
     part?: DiffPart
 ): HTMLTableCellElement | null => {
+    if (codeView.querySelector('.js-diff-load-container')) {
+        // Diff is collapsed
+        return null
+    }
     const isSplitDiff = isDomSplitDiff(codeView)
     const nthChild = getLineNumberElementIndex(part!, isSplitDiff) + 1 // nth-child() is 1-indexed
     const lineNumberCell = codeView.querySelector<HTMLTableCellElement>(


### PR DESCRIPTION
This avoids the errors in #5355, but does not solve the problem of applying decorations after uncollapsing the code view.