### PR TITLE
repo-updater: Convert Sources to send results on channel instead of returning a slice of repos

### DIFF
--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
 	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/sourcegraph/sourcegraph/pkg/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
@@ -107,16 +106,8 @@ func newAWSCodeCommitSource(svc *ExternalService, c *schema.AWSCodeCommitConnect
 // ListRepos returns all AWS Code Commit repositories accessible to all
 // connections configured in Sourcegraph via the external services
 // configuration.
-func (s *AWSCodeCommitSource) ListRepos(ctx context.Context) (repos []*Repo, err error) {
-	rs, err := s.listAllRepositories(ctx)
-	for _, r := range rs {
-		awsRepo, err := s.makeRepo(r)
-		if err != nil {
-			return repos, err
-		}
-		repos = append(repos, awsRepo)
-	}
-	return repos, err
+func (s *AWSCodeCommitSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+	s.listAllRepositories(ctx, results)
 }
 
 // ExternalServices returns a singleton slice containing the external service.
@@ -162,21 +153,23 @@ func (s *AWSCodeCommitSource) authenticatedRemoteURL(repo *awscodecommit.Reposit
 	return u.String()
 }
 
-func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context) ([]*awscodecommit.Repository, error) {
-	repos := []*awscodecommit.Repository{}
-	errs := new(multierror.Error)
-
+func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context, results chan *SourceResult) {
 	var nextToken string
 	for {
 		batch, token, err := s.client.ListRepositories(ctx, nextToken)
 		if err != nil {
-			errs = multierror.Append(errs, err)
-			break
+			results <- &SourceResult{Source: s, Err: err}
+			return
 		}
 
 		for _, r := range batch {
 			if !s.excludes(r) {
-				repos = append(repos, r)
+				repo, err := s.makeRepo(r)
+				if err != nil {
+					results <- &SourceResult{Source: s, Err: err}
+					return
+				}
+				results <- &SourceResult{Source: s, Repo: repo}
 			}
 		}
 
@@ -186,8 +179,6 @@ func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context) ([]*awsco
 
 		nextToken = token
 	}
-
-	return repos, errs.ErrorOrNil()
 }
 
 func (s *AWSCodeCommitSource) excludes(r *awscodecommit.Repository) bool {

--- a/cmd/repo-updater/repos/awscodecommit.go
+++ b/cmd/repo-updater/repos/awscodecommit.go
@@ -106,7 +106,7 @@ func newAWSCodeCommitSource(svc *ExternalService, c *schema.AWSCodeCommitConnect
 // ListRepos returns all AWS Code Commit repositories accessible to all
 // connections configured in Sourcegraph via the external services
 // configuration.
-func (s *AWSCodeCommitSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s *AWSCodeCommitSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	s.listAllRepositories(ctx, results)
 }
 
@@ -153,12 +153,12 @@ func (s *AWSCodeCommitSource) authenticatedRemoteURL(repo *awscodecommit.Reposit
 	return u.String()
 }
 
-func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context, results chan *SourceResult) {
+func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context, results chan SourceResult) {
 	var nextToken string
 	for {
 		batch, token, err := s.client.ListRepositories(ctx, nextToken)
 		if err != nil {
-			results <- &SourceResult{Source: s, Err: err}
+			results <- SourceResult{Source: s, Err: err}
 			return
 		}
 
@@ -166,10 +166,10 @@ func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context, results c
 			if !s.excludes(r) {
 				repo, err := s.makeRepo(r)
 				if err != nil {
-					results <- &SourceResult{Source: s, Err: err}
+					results <- SourceResult{Source: s, Err: err}
 					return
 				}
-				results <- &SourceResult{Source: s, Repo: repo}
+				results <- SourceResult{Source: s, Repo: repo}
 			}
 		}
 

--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/conf/reposource"
@@ -58,12 +57,8 @@ func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConne
 
 // ListRepos returns all Bitbucket Cloud repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s BitbucketCloudSource) ListRepos(ctx context.Context) (repos []*Repo, err error) {
-	rs, err := s.listAllRepos(ctx)
-	for _, r := range rs {
-		repos = append(repos, s.makeRepo(r))
-	}
-	return repos, err
+func (s BitbucketCloudSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+	s.listAllRepos(ctx, results)
 }
 
 // ExternalServices returns a singleton slice containing the external service.
@@ -137,7 +132,7 @@ func (s *BitbucketCloudSource) authenticatedRemoteURL(repo *bitbucketcloud.Repo)
 	return u.String()
 }
 
-func (s *BitbucketCloudSource) listAllRepos(ctx context.Context) ([]*bitbucketcloud.Repo, error) {
+func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan *SourceResult) {
 	type batch struct {
 		repos []*bitbucketcloud.Repo
 		err   error
@@ -191,12 +186,10 @@ func (s *BitbucketCloudSource) listAllRepos(ctx context.Context) ([]*bitbucketcl
 	}()
 
 	seen := make(map[string]bool)
-	errs := new(multierror.Error)
-	var repos []*bitbucketcloud.Repo
-
 	for r := range ch {
 		if r.err != nil {
-			errs = multierror.Append(errs, r.err)
+			results <- &SourceResult{Source: s, Err: r.err}
+			continue
 		}
 
 		for _, repo := range r.repos {
@@ -206,11 +199,9 @@ func (s *BitbucketCloudSource) listAllRepos(ctx context.Context) ([]*bitbucketcl
 			}
 
 			if !seen[repo.UUID] {
-				repos = append(repos, repo)
+				results <- &SourceResult{Source: s, Repo: s.makeRepo(repo)}
 				seen[repo.UUID] = true
 			}
 		}
 	}
-
-	return repos, errs.ErrorOrNil()
 }

--- a/cmd/repo-updater/repos/bitbucketcloud.go
+++ b/cmd/repo-updater/repos/bitbucketcloud.go
@@ -57,7 +57,7 @@ func newBitbucketCloudSource(svc *ExternalService, c *schema.BitbucketCloudConne
 
 // ListRepos returns all Bitbucket Cloud repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s BitbucketCloudSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s BitbucketCloudSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	s.listAllRepos(ctx, results)
 }
 
@@ -132,7 +132,7 @@ func (s *BitbucketCloudSource) authenticatedRemoteURL(repo *bitbucketcloud.Repo)
 	return u.String()
 }
 
-func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan *SourceResult) {
+func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan SourceResult) {
 	type batch struct {
 		repos []*bitbucketcloud.Repo
 		err   error
@@ -188,7 +188,7 @@ func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan *S
 	seen := make(map[string]bool)
 	for r := range ch {
 		if r.err != nil {
-			results <- &SourceResult{Source: s, Err: r.err}
+			results <- SourceResult{Source: s, Err: r.err}
 			continue
 		}
 
@@ -199,7 +199,7 @@ func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan *S
 			}
 
 			if !seen[repo.UUID] {
-				results <- &SourceResult{Source: s, Repo: s.makeRepo(repo)}
+				results <- SourceResult{Source: s, Repo: s.makeRepo(repo)}
 				seen[repo.UUID] = true
 			}
 		}

--- a/cmd/repo-updater/repos/bitbucketcloud_test.go
+++ b/cmd/repo-updater/repos/bitbucketcloud_test.go
@@ -95,7 +95,8 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			repos, err := bbcSrc.ListRepos(context.Background())
+			repos, err := ListAll(context.Background(), bbcSrc)
+
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}

--- a/cmd/repo-updater/repos/bitbucketcloud_test.go
+++ b/cmd/repo-updater/repos/bitbucketcloud_test.go
@@ -95,7 +95,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			repos, err := ListAll(context.Background(), bbcSrc)
+			repos, err := listAll(context.Background(), bbcSrc)
 
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -100,7 +100,7 @@ func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerCon
 
 // ListRepos returns all BitbucketServer repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s BitbucketServerSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s BitbucketServerSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	s.listAllRepos(ctx, results)
 }
 
@@ -209,7 +209,7 @@ func (s *BitbucketServerSource) excludes(r *bitbucketserver.Repo) bool {
 	return false
 }
 
-func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan *SourceResult) {
+func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan SourceResult) {
 	type batch struct {
 		repos []*bitbucketserver.Repo
 		err   error
@@ -287,13 +287,13 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan *
 	seen := make(map[int]bool)
 	for r := range ch {
 		if r.err != nil {
-			results <- &SourceResult{Source: s, Err: r.err}
+			results <- SourceResult{Source: s, Err: r.err}
 			continue
 		}
 
 		for _, repo := range r.repos {
 			if !seen[repo.ID] && !s.excludes(repo) {
-				results <- &SourceResult{Source: s, Repo: s.makeRepo(repo)}
+				results <- SourceResult{Source: s, Repo: s.makeRepo(repo)}
 				seen[repo.ID] = true
 			}
 		}

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
@@ -114,14 +113,31 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 	}, nil
 }
 
+type githubResult struct {
+	err  error
+	repo *github.Repository
+}
+
 // ListRepos returns all Github repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s GithubSource) ListRepos(ctx context.Context) (repos []*Repo, err error) {
-	rs, err := s.listAllRepositories(ctx)
-	for _, r := range rs {
-		repos = append(repos, s.makeRepo(r))
+func (s GithubSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+	unfiltered := make(chan *githubResult)
+	go func() {
+		s.listAllRepositories(ctx, unfiltered)
+		close(unfiltered)
+	}()
+
+	seen := make(map[int64]bool)
+	for res := range unfiltered {
+		if res.err != nil {
+			results <- &SourceResult{Source: s, Err: res.err}
+			continue
+		}
+		if !seen[res.repo.DatabaseID] && !s.excludes(res.repo) {
+			results <- &SourceResult{Source: s, Repo: s.makeRepo(res.repo)}
+			seen[res.repo.DatabaseID] = true
+		}
 	}
-	return repos, err
 }
 
 // ExternalServices returns a singleton slice containing the external service.
@@ -210,13 +226,12 @@ type repositoryPager func(page int) (repos []*github.Repository, hasNext bool, c
 // paginate returns all the repositories from the given repositoryPager.
 // It repeatedly calls `pager` with incrementing page count until it
 // returns false for hasNext.
-func (s *GithubSource) paginate(ctx context.Context, pager repositoryPager) (map[int64]*github.Repository, error) {
-	set := make(map[int64]*github.Repository)
-
+func (s *GithubSource) paginate(ctx context.Context, results chan *githubResult, pager repositoryPager) {
 	hasNext := true
 	for page := 1; hasNext; page++ {
 		if err := ctx.Err(); err != nil {
-			return set, err
+			results <- &githubResult{err: err}
+			return
 		}
 
 		var pageRepos []*github.Repository
@@ -224,26 +239,25 @@ func (s *GithubSource) paginate(ctx context.Context, pager repositoryPager) (map
 		var err error
 		pageRepos, hasNext, cost, err = pager(page)
 		if err != nil {
-			return set, err
+			results <- &githubResult{err: err}
+			return
 		}
 
 		for _, r := range pageRepos {
-			set[r.DatabaseID] = r
+			results <- &githubResult{repo: r}
 		}
 
 		if hasNext && cost > 0 {
 			time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(cost))
 		}
 	}
-
-	return set, nil
 }
 
 // listOrg handles the `org` config option.
 // It returns all the repositories belonging to the given organization
 // by hitting the /orgs/:org/repos endpoint.
-func (s *GithubSource) listOrg(ctx context.Context, org string) (map[int64]*github.Repository, error) {
-	return s.paginate(ctx, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
+func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *githubResult) {
+	s.paginate(ctx, results, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
 		defer func() {
 			remaining, reset, retry, _ := s.client.RateLimit.Get()
 			log15.Debug(
@@ -262,10 +276,9 @@ func (s *GithubSource) listOrg(ctx context.Context, org string) (map[int64]*gith
 // listRepos returns the valid repositories from the given list of repository names.
 // This is done by hitting the /repos/:owner/:name endpoint for each of the given
 // repository names.
-func (s *GithubSource) listRepos(ctx context.Context, repos []string) (map[int64]*github.Repository, error) {
-	set := make(map[int64]*github.Repository)
-	if err := s.fetchAllRepositoriesInBatches(ctx, set); err == nil {
-		return set, nil
+func (s *GithubSource) listRepos(ctx context.Context, repos []string, results chan *githubResult) {
+	if err := s.fetchAllRepositoriesInBatches(ctx, results); err == nil {
+		return
 	} else {
 		// The way we fetch repositories in batches through the GraphQL API -
 		// using aliases to query multiple repositories in one query - is
@@ -278,12 +291,14 @@ func (s *GithubSource) listRepos(ctx context.Context, repos []string) (map[int64
 
 	for _, nameWithOwner := range repos {
 		if err := ctx.Err(); err != nil {
-			return set, err
+			results <- &githubResult{err: err}
+			return
 		}
 
 		owner, name, err := github.SplitRepositoryNameWithOwner(nameWithOwner)
 		if err != nil {
-			return set, errors.New("Invalid GitHub repository: nameWithOwner=" + nameWithOwner)
+			results <- &githubResult{err: errors.New("Invalid GitHub repository: nameWithOwner=" + nameWithOwner)}
+			return
 		}
 		var repo *github.Repository
 		repo, err = s.client.GetRepository(ctx, owner, name)
@@ -294,39 +309,43 @@ func (s *GithubSource) listRepos(ctx context.Context, repos []string) (map[int64
 				log15.Warn("skipping missing github.repos entry:", "name", nameWithOwner, "err", err)
 				continue
 			}
-			return set, errors.Wrapf(err, "Error getting GitHub repository: nameWithOwner=%s", nameWithOwner)
+
+			results <- &githubResult{err: errors.Wrapf(err, "Error getting GitHub repository: nameWithOwner=%s", nameWithOwner)}
+			break
 		}
 		log15.Debug("github sync: GetRepository", "repo", repo.NameWithOwner)
-		set[repo.DatabaseID] = repo
+
+		results <- &githubResult{repo: repo}
+
 		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
 	}
-
-	return set, nil
 }
 
 // listPublic handles the `public` keyword of the `repositoryQuery` config option.
 // It returns the public repositories listed on the /repositories endpoint.
-func (s *GithubSource) listPublic(ctx context.Context) (map[int64]*github.Repository, error) {
-	set := make(map[int64]*github.Repository)
+func (s *GithubSource) listPublic(ctx context.Context, results chan *githubResult) {
 	if s.githubDotCom {
-		return set, errors.New(`unsupported configuration "public" for "repositoryQuery" for github.com`)
+		results <- &githubResult{err: errors.New(`unsupported configuration "public" for "repositoryQuery" for github.com`)}
+		return
 	}
 	var sinceRepoID int64
 	for {
 		if err := ctx.Err(); err != nil {
-			return set, err
+			results <- &githubResult{err: err}
+			return
 		}
 
 		repos, err := s.client.ListPublicRepositories(ctx, sinceRepoID)
 		if err != nil {
-			return set, errors.Wrapf(err, "failed to list public repositories: sinceRepoID=%d", sinceRepoID)
+			results <- &githubResult{err: errors.Wrapf(err, "failed to list public repositories: sinceRepoID=%d", sinceRepoID)}
+			return
 		}
 		if len(repos) == 0 {
-			return set, nil
+			return
 		}
 		log15.Debug("github sync public", "repos", len(repos), "error", err)
 		for _, r := range repos {
-			set[r.DatabaseID] = r
+			results <- &githubResult{repo: r}
 			if sinceRepoID < r.DatabaseID {
 				sinceRepoID = r.DatabaseID
 			}
@@ -340,8 +359,8 @@ func (s *GithubSource) listPublic(ctx context.Context) (map[int64]*github.Reposi
 //
 // Affiliation is present if the user: (1) owns the repo, (2) is apart of an org that
 // the repo belongs to, or (3) is a collaborator.
-func (s *GithubSource) listAffiliated(ctx context.Context) (map[int64]*github.Repository, error) {
-	return s.paginate(ctx, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
+func (s *GithubSource) listAffiliated(ctx context.Context, results chan *githubResult) {
+	s.paginate(ctx, results, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
 		defer func() {
 			remaining, reset, retry, _ := s.client.RateLimit.Get()
 			log15.Debug(
@@ -360,8 +379,8 @@ func (s *GithubSource) listAffiliated(ctx context.Context) (map[int64]*github.Re
 // listSearch handles the `repositoryQuery` config option when a keyword is not present.
 // It returns the repositories resulting from from GitHub's advanced repository search
 // by hitting the /search/repositories endpoint.
-func (s *GithubSource) listSearch(ctx context.Context, query string) (map[int64]*github.Repository, error) {
-	return s.paginate(ctx, func(page int) ([]*github.Repository, bool, int, error) {
+func (s *GithubSource) listSearch(ctx context.Context, query string, results chan *githubResult) {
+	s.paginate(ctx, results, func(page int) ([]*github.Repository, bool, int, error) {
 		reposPage, err := s.searchClient.ListRepositoriesForSearch(ctx, query, page)
 		if err != nil {
 			return nil, false, 0, errors.Wrapf(err, "failed to list GitHub repositories for search: page=%d, searchString=%q", page, query)
@@ -426,15 +445,16 @@ func matchOrg(q string) string {
 // - `none`: disables `repositoryQuery`
 // Inputs other than these three keywords will be queried using
 // GitHub advanced repository search (endpoint: /search/repositories)
-func (s *GithubSource) listRepositoryQuery(ctx context.Context, query string) (map[int64]*github.Repository, error) {
+func (s *GithubSource) listRepositoryQuery(ctx context.Context, query string, results chan *githubResult) {
 	switch query {
 	case "public":
-		return s.listPublic(ctx)
+		s.listPublic(ctx, results)
+		return
 	case "affiliated":
-		return s.listAffiliated(ctx)
+		s.listAffiliated(ctx, results)
 	case "none":
 		// nothing
-		return nil, nil
+		return
 	}
 
 	// Special-casing for `org:<org-name>`
@@ -442,58 +462,27 @@ func (s *GithubSource) listRepositoryQuery(ctx context.Context, query string) (m
 	// list API instead of the limited
 	// search API.
 	if org := matchOrg(query); org != "" {
-		return s.listOrg(ctx, org)
+		s.listOrg(ctx, org, results)
+		return
 	}
 
 	// Run the query as a GitHub advanced repository search
 	// (https://github.com/search/advanced).
-	return s.listSearch(ctx, query)
+	s.listSearch(ctx, query, results)
 }
 
 // listAllRepositories returns the repositories from the given `orgs`, `repos`, and
 // `repositoryQuery` config options excluding the ones specified by `exclude`.
-func (s *GithubSource) listAllRepositories(ctx context.Context) ([]*github.Repository, error) {
-	set := make(map[int64]*github.Repository)
-	errs := new(multierror.Error)
+func (s *GithubSource) listAllRepositories(ctx context.Context, results chan *githubResult) {
+	s.listRepos(ctx, s.config.Repos, results)
 
 	for _, query := range s.config.RepositoryQuery {
-		list, err := s.listRepositoryQuery(ctx, query)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-			continue
-		}
-		for id, r := range list {
-			set[id] = r
-		}
-	}
-
-	list, err := s.listRepos(ctx, s.config.Repos)
-	if err != nil {
-		errs = multierror.Append(errs, err)
-	}
-	for id, r := range list {
-		set[id] = r
+		s.listRepositoryQuery(ctx, query, results)
 	}
 
 	for _, org := range s.config.Orgs {
-		list, err := s.listOrg(ctx, org)
-		if err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "failed to list organization %s repos", org))
-			continue
-		}
-		for id, r := range list {
-			set[id] = r
-		}
+		s.listOrg(ctx, org, results)
 	}
-
-	repos := make([]*github.Repository, 0, len(set))
-	for _, repo := range set {
-		if !s.excludes(repo) {
-			repos = append(repos, repo)
-		}
-	}
-
-	return repos, errs.ErrorOrNil()
 }
 
 func (s *GithubSource) getRepository(ctx context.Context, nameWithOwner string) (*github.Repository, error) {
@@ -512,7 +501,7 @@ func (s *GithubSource) getRepository(ctx context.Context, nameWithOwner string) 
 
 // fetchAllRepositoriesInBatches fetches the repositories configured in
 // config.Repos in batches and adds them to the supplied set
-func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, set map[int64]*github.Repository) error {
+func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, results chan *githubResult) error {
 	const batchSize = 30
 
 	for i := 0; i < len(s.config.Repos); i += batchSize {
@@ -534,7 +523,7 @@ func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, set ma
 
 		log15.Debug("github sync: GetGetReposByNameWithOwner", "repos", batch)
 		for _, r := range repos {
-			set[r.DatabaseID] = r
+			results <- &githubResult{repo: r}
 		}
 
 		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -120,7 +120,7 @@ type githubResult struct {
 
 // ListRepos returns all Github repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s GithubSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s GithubSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	unfiltered := make(chan *githubResult)
 	go func() {
 		s.listAllRepositories(ctx, unfiltered)
@@ -130,11 +130,11 @@ func (s GithubSource) ListRepos(ctx context.Context, results chan *SourceResult)
 	seen := make(map[int64]bool)
 	for res := range unfiltered {
 		if res.err != nil {
-			results <- &SourceResult{Source: s, Err: res.err}
+			results <- SourceResult{Source: s, Err: res.err}
 			continue
 		}
 		if !seen[res.repo.DatabaseID] && !s.excludes(res.repo) {
-			results <- &SourceResult{Source: s, Repo: s.makeRepo(res.repo)}
+			results <- SourceResult{Source: s, Repo: s.makeRepo(res.repo)}
 			seen[res.repo.DatabaseID] = true
 		}
 	}

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -306,7 +306,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			repos, err := githubSrc.ListRepos(context.Background())
+			repos, err := ListAll(context.Background(), githubSrc)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -306,7 +306,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			repos, err := ListAll(context.Background(), githubSrc)
+			repos, err := listAll(context.Background(), githubSrc)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/gitlab"
@@ -85,12 +84,8 @@ func newGitLabSource(svc *ExternalService, c *schema.GitLabConnection, cf *httpc
 
 // ListRepos returns all GitLab repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s GitLabSource) ListRepos(ctx context.Context) (repos []*Repo, err error) {
-	projs, err := s.listAllProjects(ctx)
-	for _, proj := range projs {
-		repos = append(repos, s.makeRepo(proj))
-	}
-	return repos, err
+func (s GitLabSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+	s.listAllProjects(ctx, results)
 }
 
 // ExternalServices returns a singleton slice containing the external service.
@@ -149,7 +144,7 @@ func (s *GitLabSource) excludes(p *gitlab.Project) bool {
 	return s.exclude[p.PathWithNamespace] || s.exclude[strconv.Itoa(p.ID)]
 }
 
-func (s *GitLabSource) listAllProjects(ctx context.Context) ([]*gitlab.Project, error) {
+func (s *GitLabSource) listAllProjects(ctx context.Context, results chan *SourceResult) {
 	type batch struct {
 		projs []*gitlab.Project
 		err   error
@@ -245,24 +240,19 @@ func (s *GitLabSource) listAllProjects(ctx context.Context) ([]*gitlab.Project, 
 	}()
 
 	seen := make(map[int]bool)
-	errs := new(multierror.Error)
-	var projects []*gitlab.Project
-
 	for b := range ch {
 		if b.err != nil {
-			errs = multierror.Append(errs, b.err)
+			results <- &SourceResult{Source: s, Err: b.err}
 			continue
 		}
 
 		for _, proj := range b.projs {
 			if !seen[proj.ID] && !s.excludes(proj) {
-				projects = append(projects, proj)
+				results <- &SourceResult{Source: s, Repo: s.makeRepo(proj)}
 				seen[proj.ID] = true
 			}
 		}
 	}
-
-	return projects, errs.ErrorOrNil()
 }
 
 var schemeOrHostNotEmptyErr = errors.New("scheme and host should be empty")

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -84,7 +84,7 @@ func newGitLabSource(svc *ExternalService, c *schema.GitLabConnection, cf *httpc
 
 // ListRepos returns all GitLab repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s GitLabSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s GitLabSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	s.listAllProjects(ctx, results)
 }
 
@@ -144,7 +144,7 @@ func (s *GitLabSource) excludes(p *gitlab.Project) bool {
 	return s.exclude[p.PathWithNamespace] || s.exclude[strconv.Itoa(p.ID)]
 }
 
-func (s *GitLabSource) listAllProjects(ctx context.Context, results chan *SourceResult) {
+func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceResult) {
 	type batch struct {
 		projs []*gitlab.Project
 		err   error
@@ -242,13 +242,13 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan *Source
 	seen := make(map[int]bool)
 	for b := range ch {
 		if b.err != nil {
-			results <- &SourceResult{Source: s, Err: b.err}
+			results <- SourceResult{Source: s, Err: b.err}
 			continue
 		}
 
 		for _, proj := range b.projs {
 			if !seen[proj.ID] && !s.excludes(proj) {
-				results <- &SourceResult{Source: s, Repo: s.makeRepo(proj)}
+				results <- SourceResult{Source: s, Repo: s.makeRepo(proj)}
 				seen[proj.ID] = true
 			}
 		}

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -72,21 +72,19 @@ func NewGitoliteSource(svc *ExternalService, cf *httpcli.Factory) (*GitoliteSour
 
 // ListRepos returns all Gitolite repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s *GitoliteSource) ListRepos(ctx context.Context) ([]*Repo, error) {
+func (s *GitoliteSource) ListRepos(ctx context.Context, results chan *SourceResult) {
 	all, err := s.cli.ListGitolite(ctx, s.conn.Host)
 	if err != nil {
-		return nil, err
+		results <- &SourceResult{Source: s, Err: err}
+		return
 	}
 
-	repos := make([]*Repo, 0, len(all))
 	for _, r := range all {
 		repo := s.makeRepo(r)
 		if !s.excludes(r, repo) {
-			repos = append(repos, repo)
+			results <- &SourceResult{Source: s, Repo: repo}
 		}
 	}
-
-	return repos, nil
 }
 
 // ExternalServices returns a singleton slice containing the external service.

--- a/cmd/repo-updater/repos/gitolite.go
+++ b/cmd/repo-updater/repos/gitolite.go
@@ -72,17 +72,17 @@ func NewGitoliteSource(svc *ExternalService, cf *httpcli.Factory) (*GitoliteSour
 
 // ListRepos returns all Gitolite repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s *GitoliteSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s *GitoliteSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	all, err := s.cli.ListGitolite(ctx, s.conn.Host)
 	if err != nil {
-		results <- &SourceResult{Source: s, Err: err}
+		results <- SourceResult{Source: s, Err: err}
 		return
 	}
 
 	for _, r := range all {
 		repo := s.makeRepo(r)
 		if !s.excludes(r, repo) {
-			results <- &SourceResult{Source: s, Repo: repo}
+			results <- SourceResult{Source: s, Repo: repo}
 		}
 	}
 }

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -117,7 +117,7 @@ func (o *observedSource) ListRepos(ctx context.Context, results chan SourceResul
 		close(uncounted)
 	}()
 
-	errs := new(multierror.Error)
+	var errs *multierror.Error
 	for res := range uncounted {
 		results <- res
 		if res.Err != nil {

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	multierror "github.com/hashicorp/go-multierror"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -98,14 +99,32 @@ func NewSourceMetrics() SourceMetrics {
 }
 
 // ListRepos calls into the inner Source registers the observed results.
-func (o *observedSource) ListRepos(ctx context.Context) (rs []*Repo, err error) {
+func (o *observedSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+	var (
+		err   error
+		count float64
+	)
+
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
-		count := float64(len(rs))
 		o.metrics.ListRepos.Observe(secs, count, &err)
 		log(o.log, "source.list-repos", &err)
 	}(time.Now())
-	return o.Source.ListRepos(ctx)
+
+	uncounted := make(chan *SourceResult)
+	go func() {
+		o.Source.ListRepos(ctx, uncounted)
+		close(uncounted)
+	}()
+
+	errs := new(multierror.Error)
+	for res := range uncounted {
+		results <- res
+		if res.Err != nil {
+			errs = multierror.Append(errs, res.Err)
+		}
+		count++
+	}
 }
 
 // NewObservedStore wraps the given Store with error logging,

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -99,7 +99,7 @@ func NewSourceMetrics() SourceMetrics {
 }
 
 // ListRepos calls into the inner Source registers the observed results.
-func (o *observedSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (o *observedSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	var (
 		err   error
 		count float64
@@ -111,7 +111,7 @@ func (o *observedSource) ListRepos(ctx context.Context, results chan *SourceResu
 		log(o.log, "source.list-repos", &err)
 	}(time.Now())
 
-	uncounted := make(chan *SourceResult)
+	uncounted := make(chan SourceResult)
 	go func() {
 		o.Source.ListRepos(ctx, uncounted)
 		close(uncounted)

--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -29,23 +29,22 @@ func NewOtherSource(svc *ExternalService) (*OtherSource, error) {
 
 // ListRepos returns all Other repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s OtherSource) ListRepos(ctx context.Context) ([]*Repo, error) {
+func (s OtherSource) ListRepos(ctx context.Context, results chan *SourceResult) {
 	urls, err := s.cloneURLs()
 	if err != nil {
-		return nil, err
+		results <- &SourceResult{Source: s, Err: err}
+		return
 	}
 
 	urn := s.svc.URN()
-	repos := make([]*Repo, 0, len(urls))
 	for _, u := range urls {
 		r, err := s.otherRepoFromCloneURL(urn, u)
 		if err != nil {
-			return nil, err
+			results <- &SourceResult{Source: s, Err: err}
+			return
 		}
-		repos = append(repos, r)
+		results <- &SourceResult{Source: s, Repo: r}
 	}
-
-	return repos, nil
 }
 
 // ExternalServices returns a singleton slice containing the external service.

--- a/cmd/repo-updater/repos/other.go
+++ b/cmd/repo-updater/repos/other.go
@@ -29,10 +29,10 @@ func NewOtherSource(svc *ExternalService) (*OtherSource, error) {
 
 // ListRepos returns all Other repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s OtherSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s OtherSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	urls, err := s.cloneURLs()
 	if err != nil {
-		results <- &SourceResult{Source: s, Err: err}
+		results <- SourceResult{Source: s, Err: err}
 		return
 	}
 
@@ -40,10 +40,10 @@ func (s OtherSource) ListRepos(ctx context.Context, results chan *SourceResult) 
 	for _, u := range urls {
 		r, err := s.otherRepoFromCloneURL(urn, u)
 		if err != nil {
-			results <- &SourceResult{Source: s, Err: err}
+			results <- SourceResult{Source: s, Err: err}
 			return
 		}
-		results <- &SourceResult{Source: s, Repo: r}
+		results <- SourceResult{Source: s, Repo: r}
 	}
 }
 

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -198,7 +198,7 @@ func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
 				continue
 			}
 
-			repos, err := ListAll(ctx, src)
+			repos, err := listAll(ctx, src)
 			if err != nil {
 				log15.Error("Error fetching Phabricator repos", "err", err)
 				continue

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -37,10 +37,10 @@ func NewPhabricatorSource(svc *ExternalService, cf *httpcli.Factory) (*Phabricat
 
 // ListRepos returns all Phabricator repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	cli, err := s.client(ctx)
 	if err != nil {
-		results <- &SourceResult{Source: s, Err: err}
+		results <- SourceResult{Source: s, Err: err}
 		return
 	}
 
@@ -49,7 +49,7 @@ func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan *SourceR
 		var page []*phabricator.Repo
 		page, cursor, err = cli.ListRepos(ctx, phabricator.ListReposArgs{Cursor: cursor})
 		if err != nil {
-			results <- &SourceResult{Source: s, Err: err}
+			results <- SourceResult{Source: s, Err: err}
 			return
 		}
 
@@ -60,10 +60,10 @@ func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan *SourceR
 
 			repo, err := s.makeRepo(r)
 			if err != nil {
-				results <- &SourceResult{Source: s, Err: err}
+				results <- SourceResult{Source: s, Err: err}
 				return
 			}
-			results <- &SourceResult{Source: s, Repo: repo}
+			results <- SourceResult{Source: s, Repo: repo}
 		}
 
 		if cursor.After == "" {

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -37,10 +37,11 @@ func NewPhabricatorSource(svc *ExternalService, cf *httpcli.Factory) (*Phabricat
 
 // ListRepos returns all Phabricator repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
-func (s *PhabricatorSource) ListRepos(ctx context.Context) (repos []*Repo, err error) {
+func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan *SourceResult) {
 	cli, err := s.client(ctx)
 	if err != nil {
-		return nil, err
+		results <- &SourceResult{Source: s, Err: err}
+		return
 	}
 
 	cursor := &phabricator.Cursor{Limit: 100, Order: "oldest"}
@@ -48,7 +49,8 @@ func (s *PhabricatorSource) ListRepos(ctx context.Context) (repos []*Repo, err e
 		var page []*phabricator.Repo
 		page, cursor, err = cli.ListRepos(ctx, phabricator.ListReposArgs{Cursor: cursor})
 		if err != nil {
-			return nil, err
+			results <- &SourceResult{Source: s, Err: err}
+			return
 		}
 
 		for _, r := range page {
@@ -58,17 +60,16 @@ func (s *PhabricatorSource) ListRepos(ctx context.Context) (repos []*Repo, err e
 
 			repo, err := s.makeRepo(r)
 			if err != nil {
-				return nil, err
+				results <- &SourceResult{Source: s, Err: err}
+				return
 			}
-			repos = append(repos, repo)
+			results <- &SourceResult{Source: s, Repo: repo}
 		}
 
 		if cursor.After == "" {
 			break
 		}
 	}
-
-	return repos, nil
 }
 
 // ExternalServices returns a singleton slice containing the external service.
@@ -197,7 +198,7 @@ func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
 				continue
 			}
 
-			repos, err := src.ListRepos(ctx)
+			repos, err := ListAll(ctx, src)
 			if err != nil {
 				log15.Error("Error fetching Phabricator repos", "err", err)
 				continue

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -82,7 +82,7 @@ const sourceTimeout = 30 * time.Minute
 type Source interface {
 	// ListRepos sends all the repos a source yields over the passed in channel
 	// as SourceResults
-	ListRepos(context.Context, chan *SourceResult)
+	ListRepos(context.Context, chan SourceResult)
 	// ExternalServices returns the ExternalServices for the Source.
 	ExternalServices() ExternalServices
 }
@@ -131,7 +131,7 @@ type Sources []Source
 
 // ListRepos lists all the repos of all the sources and returns the
 // aggregate result.
-func (srcs Sources) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (srcs Sources) ListRepos(ctx context.Context, results chan SourceResult) {
 	if len(srcs) == 0 {
 		return
 	}
@@ -194,7 +194,7 @@ func group(srcs []Source) map[string]Sources {
 // ListAll calls ListRepos on the given Source and collects the SourceResults
 // the Source sends over a channel into a slice of *Repo and a single error
 func ListAll(ctx context.Context, src Source) ([]*Repo, error) {
-	results := make(chan *SourceResult)
+	results := make(chan SourceResult)
 
 	go func() {
 		src.ListRepos(ctx, results)

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -80,10 +80,22 @@ const sourceTimeout = 30 * time.Minute
 // A Source yields repositories to be stored and analysed by Sourcegraph.
 // Successive calls to its ListRepos method may yield different results.
 type Source interface {
-	// ListRepos returns all the repos a source yields.
-	ListRepos(context.Context) ([]*Repo, error)
+	// ListRepos sends all the repos a source yields over the passed in channel
+	// as SourceResults
+	ListRepos(context.Context, chan *SourceResult)
 	// ExternalServices returns the ExternalServices for the Source.
 	ExternalServices() ExternalServices
+}
+
+// A SourceResult is sent by a Source over a channel for each repository it
+// yields when listing repositories
+type SourceResult struct {
+	// Source points to the Source that produced this result
+	Source Source
+	// Repo is the repository that was listed by the Source
+	Repo *Repo
+	// Err is only set in case the Source ran into an error when listing repositories
+	Err error
 }
 
 type SourceError struct {
@@ -145,15 +157,9 @@ type Sources []Source
 
 // ListRepos lists all the repos of all the sources and returns the
 // aggregate result.
-func (srcs Sources) ListRepos(ctx context.Context) ([]*Repo, error) {
+func (srcs Sources) ListRepos(ctx context.Context, results chan *SourceResult) {
 	if len(srcs) == 0 {
-		return nil, nil
-	}
-
-	type result struct {
-		src   Source
-		repos []*Repo
-		errs  []*SourceError
+		return
 	}
 
 	// Group sources by external service kind so that we execute requests
@@ -162,42 +168,17 @@ func (srcs Sources) ListRepos(ctx context.Context) ([]*Repo, error) {
 	// See https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)
 
 	var wg sync.WaitGroup
-	ch := make(chan result)
 	for _, sources := range group(srcs) {
 		wg.Add(1)
 		go func(sources Sources) {
 			defer wg.Done()
 			for _, src := range sources {
-				if repos, err := src.ListRepos(ctx); err != nil {
-					var errs []*SourceError
-					for _, extSvc := range src.ExternalServices() {
-						errs = append(errs, &SourceError{Err: err, ExtSvc: extSvc})
-					}
-					ch <- result{src: src, errs: errs}
-				} else {
-					ch <- result{src: src, repos: repos}
-				}
+				src.ListRepos(ctx, results)
 			}
 		}(sources)
 	}
 
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-
-	var repos []*Repo
-	errs := new(MultiSourceError)
-
-	for r := range ch {
-		if len(r.errs) != 0 {
-			errs.Append(r.errs...)
-		} else {
-			repos = append(repos, r.repos...)
-		}
-	}
-
-	return repos, errs.ErrorOrNil()
+	wg.Wait()
 }
 
 // ExternalServices returns the ExternalServices from the given Sources.
@@ -234,4 +215,29 @@ func group(srcs []Source) map[string]Sources {
 	}
 
 	return groups
+}
+
+// ListAll calls ListRepos on the given Source and collects the SourceResults
+// the Source sends over a channel into a slice of *Repo and a single error
+func ListAll(ctx context.Context, src Source) ([]*Repo, error) {
+	results := make(chan *SourceResult)
+
+	go func() {
+		src.ListRepos(ctx, results)
+		close(results)
+	}()
+
+	var repos []*Repo
+	errs := new(MultiSourceError)
+	for res := range results {
+		if res.Err != nil {
+			for _, extSvc := range res.Source.ExternalServices() {
+				errs.Append(&SourceError{Err: res.Err, ExtSvc: extSvc})
+			}
+			continue
+		}
+		repos = append(repos, res.Repo)
+	}
+
+	return repos, errs.ErrorOrNil()
 }

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -191,9 +191,9 @@ func group(srcs []Source) map[string]Sources {
 	return groups
 }
 
-// ListAll calls ListRepos on the given Source and collects the SourceResults
+// listAll calls ListRepos on the given Source and collects the SourceResults
 // the Source sends over a channel into a slice of *Repo and a single error
-func ListAll(ctx context.Context, src Source) ([]*Repo, error) {
+func listAll(ctx context.Context, src Source) ([]*Repo, error) {
 	results := make(chan SourceResult)
 
 	go func() {

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -26,7 +26,7 @@ type Sourcer func(...*ExternalService) (Sources, error)
 func NewSourcer(cf *httpcli.Factory, decs ...func(Source) Source) Sourcer {
 	return func(svcs ...*ExternalService) (Sources, error) {
 		srcs := make([]Source, 0, len(svcs))
-		errs := new(multierror.Error)
+		var errs *multierror.Error
 
 		for _, svc := range svcs {
 			if svc.IsDeleted() {
@@ -201,8 +201,11 @@ func ListAll(ctx context.Context, src Source) ([]*Repo, error) {
 		close(results)
 	}()
 
-	var repos []*Repo
-	errs := new(multierror.Error)
+	var (
+		repos []*Repo
+		errs  *multierror.Error
+	)
+
 	for res := range results {
 		if res.Err != nil {
 			for _, extSvc := range res.Source.ExternalServices() {

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -750,7 +750,7 @@ func TestSources_ListRepos(t *testing.T) {
 					ctx = context.Background()
 				}
 
-				repos, err := srcs.ListRepos(ctx)
+				repos, err := ListAll(ctx, srcs)
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 				}

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -750,7 +750,7 @@ func TestSources_ListRepos(t *testing.T) {
 					ctx = context.Background()
 				}
 
-				repos, err := ListAll(ctx, srcs)
+				repos, err := listAll(ctx, srcs)
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 				}

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -325,7 +325,7 @@ func (s *Syncer) sourced(ctx context.Context) ([]*Repo, error) {
 	ctx, cancel := context.WithTimeout(ctx, sourceTimeout)
 	defer cancel()
 
-	return ListAll(ctx, srcs)
+	return listAll(ctx, srcs)
 }
 
 func (s *Syncer) setOrResetLastSyncErr(perr *error) {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -331,6 +331,7 @@ func (s *Syncer) sourced(ctx context.Context) ([]*Repo, error) {
 func (s *Syncer) setOrResetLastSyncErr(perr *error) {
 	var err error
 	if perr != nil {
+		fmt.Printf("setOrResetLastSyncErr. *perr=%T, errors.Cause(*perr)=%T\n", *perr, errors.Cause(*perr))
 		err = *perr
 	}
 

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -325,7 +325,7 @@ func (s *Syncer) sourced(ctx context.Context) ([]*Repo, error) {
 	ctx, cancel := context.WithTimeout(ctx, sourceTimeout)
 	defer cancel()
 
-	return srcs.ListRepos(ctx)
+	return ListAll(ctx, srcs)
 }
 
 func (s *Syncer) setOrResetLastSyncErr(perr *error) {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -331,7 +331,6 @@ func (s *Syncer) sourced(ctx context.Context) ([]*Repo, error) {
 func (s *Syncer) setOrResetLastSyncErr(perr *error) {
 	var err error
 	if perr != nil {
-		fmt.Printf("setOrResetLastSyncErr. *perr=%T, errors.Cause(*perr)=%T\n", *perr, errors.Cause(*perr))
 		err = *perr
 	}
 

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -47,12 +47,15 @@ func NewFakeSource(svc *ExternalService, err error, rs ...*Repo) *FakeSource {
 
 // ListRepos returns the Repos that FakeSource was instantiated with
 // as well as the error, if any.
-func (s FakeSource) ListRepos(context.Context) ([]*Repo, error) {
-	repos := make([]*Repo, len(s.repos))
-	for i, r := range s.repos {
-		repos[i] = r.With(Opt.RepoSources(s.svc.URN()))
+func (s FakeSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+	if s.err != nil {
+		results <- &SourceResult{Source: s, Err: s.err}
+		return
 	}
-	return repos, s.err
+
+	for _, r := range s.repos {
+		results <- &SourceResult{Source: s, Repo: r.With(Opt.RepoSources(s.svc.URN()))}
+	}
 }
 
 // ExternalServices returns a singleton slice containing the external service.

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 )
@@ -17,14 +18,14 @@ import (
 // ignoring the given external services.
 func NewFakeSourcer(err error, srcs ...Source) Sourcer {
 	return func(svcs ...*ExternalService) (Sources, error) {
-		errs := new(MultiSourceError)
+		errs := new(multierror.Error)
 
 		if err != nil {
 			for _, svc := range svcs {
-				errs.Append(&SourceError{Err: err, ExtSvc: svc})
+				errs = multierror.Append(errs, &SourceError{Err: err, ExtSvc: svc})
 			}
 			if len(svcs) == 0 {
-				errs.Append(&SourceError{Err: err, ExtSvc: nil})
+				errs = multierror.Append(errs, &SourceError{Err: err, ExtSvc: nil})
 			}
 		}
 

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -48,14 +48,14 @@ func NewFakeSource(svc *ExternalService, err error, rs ...*Repo) *FakeSource {
 
 // ListRepos returns the Repos that FakeSource was instantiated with
 // as well as the error, if any.
-func (s FakeSource) ListRepos(ctx context.Context, results chan *SourceResult) {
+func (s FakeSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	if s.err != nil {
-		results <- &SourceResult{Source: s, Err: s.err}
+		results <- SourceResult{Source: s, Err: s.err}
 		return
 	}
 
 	for _, r := range s.repos {
-		results <- &SourceResult{Source: s, Repo: r.With(Opt.RepoSources(s.svc.URN()))}
+		results <- SourceResult{Source: s, Repo: r.With(Opt.RepoSources(s.svc.URN()))}
 	}
 }
 

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -18,7 +18,7 @@ import (
 // ignoring the given external services.
 func NewFakeSourcer(err error, srcs ...Source) Sourcer {
 	return func(svcs ...*ExternalService) (Sources, error) {
-		errs := new(multierror.Error)
+		var errs *multierror.Error
 
 		if err != nil {
 			for _, svc := range svcs {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -311,7 +311,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		_, err = src.ListRepos(ctx)
+		_, err = repos.ListAll(ctx, src)
 		if err != nil && ctx.Err() != nil {
 			// ignore if we took too long
 			err = nil

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -451,20 +452,24 @@ func (s *Server) handleStatusMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if e := s.Syncer.LastSyncError(); e != nil {
-		if multiSourceErr, ok := errors.Cause(e).(*repos.MultiSourceError); ok {
-			for _, sourceErr := range multiSourceErr.Errors {
-				resp.Messages = append(resp.Messages, protocol.StatusMessage{
-					ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-						Message:           sourceErr.Err.Error(),
-						ExternalServiceId: sourceErr.ExtSvc.ID,
-					},
-				})
+		if multiErr, ok := errors.Cause(e).(*multierror.Error); ok {
+			for _, e := range multiErr.Errors {
+				if sourceErr, ok := e.(*repos.SourceError); ok {
+					resp.Messages = append(resp.Messages, protocol.StatusMessage{
+						ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
+							Message:           sourceErr.Err.Error(),
+							ExternalServiceId: sourceErr.ExtSvc.ID,
+						},
+					})
+				} else {
+					resp.Messages = append(resp.Messages, protocol.StatusMessage{
+						SyncError: &protocol.SyncError{Message: e.Error()},
+					})
+				}
 			}
 		} else {
 			resp.Messages = append(resp.Messages, protocol.StatusMessage{
-				SyncError: &protocol.SyncError{
-					Message: e.Error(),
-				},
+				SyncError: &protocol.SyncError{Message: e.Error()},
 			})
 		}
 	}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -323,6 +323,12 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		for res := range results {
 			if res.Err != nil {
 				err = res.Err
+				// Send error to user before waiting for all results, but drain
+				// the rest of the results to not leak a blocked goroutine
+				go func() {
+					for res = range results {
+					}
+				}()
 				break
 			}
 		}


### PR DESCRIPTION
This is the preparation for solving https://github.com/sourcegraph/sourcegraph/issues/5145.

It converts the interface of all existing `Source`s to send results on a channel. It keeps the existing behavior in the separate Sources regarding error handling: some accumulate errors and some return early.

The next step is then to use the channel in the syncer.

For ease of reviewing I think it makes sense to merge this here first.