### PR TITLE
web: Render external service form errors/warnings as Markdown

### DIFF
--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -31,13 +31,13 @@ export class SiteAdminExternalServiceForm extends React.Component<Props, {}> {
                 {this.props.error && (
                     <div className="alert alert-danger">
                         <p>Error saving configuration:</p>
-                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.error.message)} />
+                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.error.message.replace(/\t/g, ''))} />
                     </div>
                 )}
                 {this.props.warning && (
                     <div className="alert alert-warning">
                         <h4>Warning</h4>
-                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.warning)} />
+                        <Markdown dangerousInnerHTML={renderMarkdown(this.props.warning.replace(/\t/g, ''))} />
                     </div>
                 )}
                 <div className="form-group">


### PR DESCRIPTION
This is a really simple first fix for #4842, as suggested by @felixbecker.

The _proper_ solution would probably be to make the errors themselves more readable & easier to parse, but that's a lot more work than this fix here.

Until we find the time/muse to do that, this here already improves on the current sate.

It now looks like this:

<img width="968" alt="Screen Shot 2019-08-27 at 09 59 16" src="https://user-images.githubusercontent.com/1185253/63752575-c61bfb80-c8b1-11e9-9816-75e629d64db1.png">
