### PR TITLE
prevent double-highlighting

### DIFF
--- a/shared/src/util/dom.tsx
+++ b/shared/src/util/dom.tsx
@@ -14,6 +14,12 @@ export function highlightNode(node: HTMLElement, start: number, length: number):
     if (length > node.textContent!.length - start) {
         return
     }
+
+    // Do not double-highlight.
+    if (node.querySelector('.selection-highlight')) {
+        return
+    }
+
     // We want to treat text nodes as walkable so they can be highlighted. Wrap these in a span and
     // replace them in the DOM.
     if (node.nodeType === Node.TEXT_NODE && node.textContent !== null) {


### PR DESCRIPTION
This fixed a bug I saw where rerenders of an ancestor component caused highlights to be applied multiple times. This resulted in the background color of the highlighted text getting darker and darker because it had multiple wrapping elements with partial opacity.

The `highlightNodeHelper` has a check to prevent this case, but it was not effective.

I am not able to reproduce the issue on our search results page anymore. Previously I could reproduce it by pressing <kbd>return</kbd> in the query input field. I will leave open this draft PR in case I or anyone else can repro it.

