### PR TITLE
Lsif collapsed results

### DIFF
--- a/lsif/package.json
+++ b/lsif/package.json
@@ -5,11 +5,13 @@
   "license": "MIT",
   "version": "0.1.0",
   "dependencies": {
+    "@types/relateurl": "^0.2.28",
     "bloomfilter": "^0.0.18",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "lsif-protocol": "0.4.3",
     "mz": "^2.7.0",
+    "relateurl": "^0.2.7",
     "sqlite3": "^4.1.0",
     "typeorm": "^0.2.18",
     "vscode-languageserver": "^5.2.1",

--- a/lsif/src/database.ts
+++ b/lsif/src/database.ts
@@ -51,7 +51,7 @@ export class Database {
 
         const resultData = findResult(document.resultSets, document.definitionResults, range, 'definitionResult')
         if (resultData) {
-            return asLocations(document.ranges, document.orderedRanges, uri, resultData.values)
+            return asLocations(document.ranges, document.orderedRanges, path, resultData)
         }
 
         // TODO - vet this logic of finding the first result
@@ -87,8 +87,7 @@ export class Database {
 
         const result = []
         if (resultData) {
-            result.push(...asLocations(document.ranges, document.orderedRanges, uri, resultData.definitions))
-            result.push(...asLocations(document.ranges, document.orderedRanges, uri, resultData.references))
+            result.push(...asLocations(document.ranges, document.orderedRanges, path, resultData))
         } else {
             for (const moniker of monikers) {
                 result.push(...(await Database.monikerResults(this, RefModel, moniker, path => path)))

--- a/lsif/src/database.ts
+++ b/lsif/src/database.ts
@@ -118,7 +118,12 @@ export class Database {
         }
 
         // All hover contents should be contained in the document.
-        return findResult(document.resultSets, document.hovers, range, 'hoverResult')
+        const contents = findResult(document.resultSets, document.hovers, range, 'hoverResult')
+        if (!contents) {
+            return undefined
+        }
+
+        return { contents }
     }
 
     //

--- a/lsif/src/encoding.ts
+++ b/lsif/src/encoding.ts
@@ -3,7 +3,7 @@ import { BloomFilter } from 'bloomfilter'
 import { readEnvInt } from './util'
 
 // These parameters give us a 1 in 1.38x10^9 false positive rate if we assume
-// that the number of unique URIs referrable by an external package is of the
+// that the number of unique values referrable by an external package is of the
 // order of 10k (....but I have no idea if that is a reasonable estimate....).
 //
 // See the following link for a bloom calculator: https://hur.st/bloomfilter
@@ -22,12 +22,12 @@ const BLOOM_FILTER_NUM_HASH_FUNCTIONS = readEnvInt('BLOOM_FILTER_NUM_HASH_FUNCTI
  * Create a bloom filter containing the given values and return it as a base64
  * encoded gzipped string.
  *
- * @param uris The values to add to the bloom filter.
+ * @param values The values to add to the bloom filter.
  */
-export function createFilter(uris: string[]): Promise<string> {
+export function createFilter(values: string[]): Promise<string> {
     const filter = new BloomFilter(BLOOM_FILTER_BITS, BLOOM_FILTER_NUM_HASH_FUNCTIONS)
-    for (const uri of uris) {
-        filter.add(uri)
+    for (const value of values) {
+        filter.add(value)
     }
 
     // Need to shed the type of the array
@@ -40,16 +40,16 @@ export function createFilter(uris: string[]): Promise<string> {
 }
 
 /**
- * Decode `filter` as created by `createFilter` and determine if `uri` is a
+ * Decode `filter` as created by `createFilter` and determine if `value` is a
  * possible element. This may return a false positive (returning true if the
  * element is not actually a member), but will not return false negatives.
  *
  * @param filter The encoded filter.
- * @param uri The uri to test membership.
+ * @param value The value to test membership.
  */
-export async function testFilter(filter: string, uri: string): Promise<boolean> {
+export async function testFilter(filter: string, value: string): Promise<boolean> {
     const { numHashFunctions, buckets } = await decodeJSON(filter)
-    return new BloomFilter(buckets, numHashFunctions).test(uri)
+    return new BloomFilter(buckets, numHashFunctions).test(value)
 }
 
 /**

--- a/lsif/src/entities.ts
+++ b/lsif/src/entities.ts
@@ -1,5 +1,5 @@
-import { Id, MonikerKind } from 'lsif-protocol'
-import * as lsp from 'vscode-languageserver-protocol'
+import { Id, MonikerKind } from 'lsif-protocol';
+import { Position } from 'vscode-languageserver-protocol';
 
 /**
  * `DocumentData` stores data for a single document within an LSIF dump. The
@@ -104,12 +104,12 @@ export interface RangeData extends ResultObjectData {
     /**
      * `start` is the start position of the range.
      */
-    start: lsp.Position
+    start: Position
 
     /**
      * `end` is the end position of the range.
      */
-    end: lsp.Position
+    end: Position
 }
 
 /**
@@ -118,19 +118,6 @@ export interface RangeData extends ResultObjectData {
  * queried in the containing document.
  */
 export interface ResultSetData extends ResultObjectData {}
-
-/**
- * `HoverData` holds data used to answer a hover query.
- */
-export interface HoverData {
-    // TODO - normalize content
-    // TODO - used MarkupContent, MarkedString is deprecated
-
-    /**
-     * `contents` is the raw hover payload from the LSIf dump.
-     */
-    contents: lsp.MarkupContent | lsp.MarkedString | lsp.MarkedString[]
-}
 
 /**
  * `MonikerData` holds data about a moniker attached to a range or a result set.

--- a/lsif/src/entities.ts
+++ b/lsif/src/entities.ts
@@ -40,7 +40,7 @@ export interface DocumentData {
     /**
      * `hovers` map identifiers to a hover result.
      */
-    hovers: Map<Id, HoverData>
+    hovers: Map<Id, string>
 
     /**
      * `monikers` map identifiers to a moniker.

--- a/lsif/src/entities.ts
+++ b/lsif/src/entities.ts
@@ -26,14 +26,16 @@ export interface DocumentData {
     resultSets: Map<Id, ResultSetData>
 
     /**
-     * `definitionResults` map identifiers to a definition result.
+     * `definitionResults` map identifiers to set of range identifiers that compose
+     * the definition result.
      */
-    definitionResults: Map<Id, DefinitionResultData>
+    definitionResults: Map<Id, Id[]>
 
     /**
-     * `referenceResults` map identifiers to a reference result.
+     * `referenceResults` map identifiers to set of range identifiers that compose
+     * the definition result.
      */
-    referenceResults: Map<Id, ReferenceResultData>
+    referenceResults: Map<Id, Id[]>
 
     /**
      * `hovers` map identifiers to a hover result.
@@ -116,39 +118,6 @@ export interface RangeData extends ResultObjectData {
  * queried in the containing document.
  */
 export interface ResultSetData extends ResultObjectData {}
-
-/**
- * `DefinitionResultData` holds data used to answer a definitions query.
- */
-export interface DefinitionResultData {
-    /**
-     * `values` is a list of range identifiers that specify the definition. The
-     * range objects can be queried by their identifier within the containing
-     * document.
-     */
-    values: Id[]
-}
-
-/**
- * `ReferenceResultData` holds data used to answer a references query.
- */
-export interface ReferenceResultData {
-    // TODO - these can be collapsed, they're always merged in the API
-
-    /**
-     * `definitions` is a list of range identifiers that specify the definition of
-     * a target reference. The range objects can be queried by their identifier within
-     * the containing document.
-     */
-    definitions: Id[]
-
-    /**
-     * `references` is a list of range identifiers that specify the references of
-     * a target definition. The range objects can be queried by their identifier
-     * within the containing document.
-     */
-    references: Id[]
-}
 
 /**
  * `HoverData` holds data used to answer a hover query.

--- a/lsif/src/entities.ts
+++ b/lsif/src/entities.ts
@@ -1,5 +1,4 @@
 import { Id, MonikerKind } from 'lsif-protocol';
-import { Position } from 'vscode-languageserver-protocol';
 
 /**
  * `DocumentData` stores data for a single document within an LSIF dump. The
@@ -100,17 +99,7 @@ interface ResultObjectData {
  * It contains the same relevant edge data, which can be subsequently queried in
  * the containing document.
  */
-export interface RangeData extends ResultObjectData {
-    /**
-     * `start` is the start position of the range.
-     */
-    start: Position
-
-    /**
-     * `end` is the end position of the range.
-     */
-    end: Position
-}
+export interface RangeData extends ResultObjectData, FlattenedRange {}
 
 /**
  * `ResultSetData` is an internal representation of a result set vertex from an

--- a/lsif/src/importer.ts
+++ b/lsif/src/importer.ts
@@ -5,15 +5,7 @@ import { EntityManager } from 'typeorm'
 import { Hover, MarkupContent } from 'vscode-languageserver-types'
 import { Inserter } from './inserter'
 import { Package, SymbolReferences } from './xrepo'
-import {
-    MonikerData,
-    RangeData,
-    ResultSetData,
-    HoverData,
-    PackageInformationData,
-    DocumentData,
-    FlattenedRange,
-} from './entities'
+import { MonikerData, RangeData, ResultSetData, PackageInformationData, DocumentData, FlattenedRange } from './entities'
 import {
     Id,
     VertexLabels,
@@ -120,7 +112,7 @@ export class Importer {
     // Vertex data
     private definitionDatas: Map<Id, Map<Id, Id[]>> = new Map()
     private documents: Map<Id, string> = new Map()
-    private hoverDatas: Map<Id, HoverData> = new Map()
+    private hoverDatas: Map<Id, string> = new Map()
     private monikerDatas: Map<Id, MonikerData> = new Map()
     private packageInformationDatas: Map<Id, PackageInformationData> = new Map()
     private rangeDatas: Map<Id, RangeData> = new Map()
@@ -319,7 +311,7 @@ export class Importer {
 
     private handleDefinitionResult = this.setById(this.definitionDatas, () => new Map())
     private handleDocument = this.setById(this.documents, (e: Document) => e.uri)
-    private handleHover = this.setById(this.hoverDatas, (e: HoverResult) => e.result)
+    private handleHover = this.setById(this.hoverDatas, (e: HoverResult) => normalizeHover(e.result))
     private handleMoniker = this.setById(this.monikerDatas, convertMoniker)
     private handlePackageInformation = this.setById(this.packageInformationDatas, convertPackageInformation)
     private handleRange = this.setById(this.rangeDatas, (e: Range) => ({ ...e, monikers: [] }))
@@ -670,8 +662,7 @@ export class Importer {
 
         // Add hover to document, if it doesn't exist
         if (item.hoverResult && !document.hovers.has(item.hoverResult)) {
-            const hoverResult = assertDefined(item.hoverResult, 'hoverResult', this.hoverDatas)
-            document.hovers.set(item.hoverResult, normalizeHover(hoverResult))
+            document.hovers.set(item.hoverResult, assertDefined(item.hoverResult, 'hoverResult', this.hoverDatas))
         }
 
         // Attach definition and reference results results to the document.

--- a/lsif/src/importer.ts
+++ b/lsif/src/importer.ts
@@ -1,7 +1,10 @@
-import { EntityManager } from 'typeorm'
+import RelateUrl from 'relateurl'
 import { DefModel, DocumentModel, MetaModel, RefModel } from './models'
 import { encodeJSON } from './encoding'
+import { EntityManager } from 'typeorm'
+import { Hover, MarkupContent } from 'vscode-languageserver-types'
 import { Inserter } from './inserter'
+import { Package, SymbolReferences } from './xrepo'
 import {
     MonikerData,
     RangeData,
@@ -40,7 +43,6 @@ import {
     ElementTypes,
     Moniker,
 } from 'lsif-protocol'
-import { Package, SymbolReferences } from './xrepo'
 
 /**
  * The internal version of our SQLite databases. We need to keep this in case

--- a/lsif/src/models.ts
+++ b/lsif/src/models.ts
@@ -35,10 +35,10 @@ export class MetaModel {
 @Entity({ name: 'documents' })
 export class DocumentModel {
     /**
-     * `uri` is the root-relative path of the document.
+     * `path` is the root-relative path of the document.
      */
     @PrimaryColumn()
-    public uri!: string
+    public path!: string
 
     /**
      * `value` is the JSON-encoded document data.
@@ -71,10 +71,10 @@ class Symbols {
     public identifier!: string
 
     /**
-     * `documentUri` is the uri of the document to which this reference belongs.
+     * `documentPath` is the path of the document to which this reference belongs.
      */
     @Column()
-    public documentUri!: string
+    public documentPath!: string
 
     /**
      * `startLine` is the zero-indexed line describing the start of this range.

--- a/lsif/src/xrepo.ts
+++ b/lsif/src/xrepo.ts
@@ -95,18 +95,18 @@ export class XrepoDatabase {
     }
 
     /**
-     * Find all repository/commit pairs that reference `uri` in the given package. The
+     * Find all repository/commit pairs that reference `value` in the given package. The
      * returned results will include only repositories that have a dependency on the given
      * package. The returned results may (but is not likely to) include a repository/commit
-     * pair that does not reference `uri`. See cache.ts for configuration values that tune
+     * pair that does not reference `value`. See cache.ts for configuration values that tune
      * the bloom filter false positive rates.
      *
      * @param scheme The package manager scheme (e.g. npm, pip).
      * @param name The package name.
      * @param version The package version.
-     * @param uri The uri to test.
+     * @param value The value to test.
      */
-    public async getReferences(scheme: string, name: string, version: string, uri: string): Promise<ReferenceModel[]> {
+    public async getReferences(scheme: string, name: string, version: string, value: string): Promise<ReferenceModel[]> {
         return await this.withConnection(connection =>
             connection
                 .getRepository(ReferenceModel)
@@ -118,7 +118,7 @@ export class XrepoDatabase {
                     },
                 })
                 .then((results: ReferenceModel[]) =>
-                    results.filter(async result => await testFilter(result.filter, uri))
+                    results.filter(async result => await testFilter(result.filter, value))
                 )
         )
     }

--- a/lsif/yarn.lock
+++ b/lsif/yarn.lock
@@ -837,6 +837,11 @@
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/relateurl@^0.2.28":
+  version "0.2.28"
+  resolved "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz#6bda7db8653fa62643f5ee69e9f69c11a392e3a6"
+  integrity sha1-a9p9uGU/piZD9e5p6facEaOS46Y=
+
 "@types/serve-static@*":
   version "1.13.3"
   resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
@@ -4788,6 +4793,11 @@ regjsparser@^0.6.0:
   integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
   dependencies:
     jsesc "~0.5.0"
+
+relateurl@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
+  integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
This PR simplifies the blob format of a document:
- there is no longer a distinction between referenceResult/definition and referenceResult/reference as they both come back on reference requests
- definitionResults and referenceResults have been flattened from a class containing a list of identifiers to a list of identifiers
- flatten ranges when stored on disk (this can save some {, }, and " characters, and some pointer chasing)
- normalize hover data to a string so it's not a three-deep datastructure
- rename uri to path when talking about document locations within a project
- use relateUrl to get relative paths of a document