### PR TITLE
expose GitCommitConnection.totalCount in GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -86,6 +86,22 @@ func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*GitCommitRe
 	return resolvers, nil
 }
 
+func (r *gitCommitConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
+	if r.first != nil {
+		// Return indeterminate total count if the caller requested an incomplete list of commits
+		// (which means we'd need an extra and expensive Git operation to determine the total
+		// count). This is to avoid `totalCount` taking significantly longer than `nodes` to
+		// compute, which would be unexpected to many API clients.
+		return nil, nil
+	}
+	commits, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	n := int32(len(commits))
+	return &n, nil
+}
+
 func (r *gitCommitConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
 	commits, err := r.compute(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1748,6 +1748,11 @@ type PageInfo {
 type GitCommitConnection {
     # A list of Git commits.
     nodes: [GitCommit!]!
+    # The total number of Git commits in the connection. If the GitCommitConnection is paginated
+    # (e.g., because a "first" parameter was provided to the field that produced it), this field is
+    # null to avoid it taking unexpectedly long to compute the total count. Remove the pagination
+    # parameters to obtain a non-null value for this field.
+    totalCount: Int
     # Pagination information.
     pageInfo: PageInfo!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1755,6 +1755,11 @@ type PageInfo {
 type GitCommitConnection {
     # A list of Git commits.
     nodes: [GitCommit!]!
+    # The total number of Git commits in the connection. If the GitCommitConnection is paginated
+    # (e.g., because a "first" parameter was provided to the field that produced it), this field is
+    # null to avoid it taking unexpectedly long to compute the total count. Remove the pagination
+    # parameters to obtain a non-null value for this field.
+    totalCount: Int
     # Pagination information.
     pageInfo: PageInfo!
 }


### PR DESCRIPTION
If the GraphQL API is already computing the full (non-paginated) list of Git commits, it is nearly free to determine the totalCount. This is useful to some API consumers. The performance considerations and behavior are documented on the GraphQL API field.