### PR TITLE
expose common namespaceName in GraphQL API for Namespace (User, Org)

### DIFF
--- a/cmd/frontend/graphqlbackend/namespaces.go
+++ b/cmd/frontend/graphqlbackend/namespaces.go
@@ -12,6 +12,7 @@ import (
 type Namespace interface {
 	ID() graphql.ID
 	URL() string
+	NamespaceName() string
 }
 
 func (r *schemaResolver) Namespace(ctx context.Context, args *struct{ ID graphql.ID }) (*namespaceResolver, error) {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -169,6 +169,8 @@ func (o *OrgResolver) ViewerIsMember(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+func (o *OrgResolver) NamespaceName() string { return o.org.Name }
+
 func (*schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	Name        string
 	DisplayName *string

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2129,6 +2129,10 @@ interface Namespace {
     # The globally unique ID of this namespace.
     id: ID!
 
+    # The name of this namespace's component. For a user, this is the username. For an organization,
+    # this is the organization name.
+    namespaceName: String!
+
     # The URL to this namespace.
     url: String!
 }
@@ -2238,6 +2242,9 @@ type User implements Node & SettingsSubject & Namespace {
     #
     # FOR INTERNAL USE ONLY.
     databaseID: Int!
+
+    # The name of this user namespace's component. For users, this is the username.
+    namespaceName: String!
 }
 
 # An access token that grants to the holder the privileges of the user who created it.
@@ -2427,6 +2434,9 @@ type Org implements Node & SettingsSubject & Namespace {
     url: String!
     # The URL to the organization's settings.
     settingsURL: String
+
+    # The name of this user namespace's component. For organizations, this is the organization's name.
+    namespaceName: String!
 }
 
 # The result of Mutation.inviteUserToOrganization.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2136,6 +2136,10 @@ interface Namespace {
     # The globally unique ID of this namespace.
     id: ID!
 
+    # The name of this namespace's component. For a user, this is the username. For an organization,
+    # this is the organization name.
+    namespaceName: String!
+
     # The URL to this namespace.
     url: String!
 }
@@ -2245,6 +2249,9 @@ type User implements Node & SettingsSubject & Namespace {
     #
     # FOR INTERNAL USE ONLY.
     databaseID: Int!
+
+    # The name of this user namespace's component. For users, this is the username.
+    namespaceName: String!
 }
 
 # An access token that grants to the holder the privileges of the user who created it.
@@ -2434,6 +2441,9 @@ type Org implements Node & SettingsSubject & Namespace {
     url: String!
     # The URL to the organization's settings.
     settingsURL: String
+
+    # The name of this user namespace's component. For organizations, this is the organization's name.
+    namespaceName: String!
 }
 
 # The result of Mutation.inviteUserToOrganization.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -275,6 +275,8 @@ func (r *UserResolver) URLForSiteAdminBilling(ctx context.Context) (*string, err
 	return UserURLForSiteAdminBilling(ctx, r.user.ID)
 }
 
+func (r *UserResolver) NamespaceName() string { return r.user.Username }
+
 func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 	OldPassword string
 	NewPassword string


### PR DESCRIPTION
Both User and Org in our GraphQL API implement Namespace, which is container for certain types of data and settings (currently only saved searches, but intended to be more for a8n).

The User and Org namespace is shared; i.e., a user and org can't have the same name. (This is enforced in the DB by using the `names` table.) API clients retrieving data from multiple namespaces (e.g., a list of all saved searches, or a8n campaigns in the future) can thus use the `namespaceName` as a unique name prefix for the data they retrieve.

Exposing the `namespaceName` as the same-named field on both User and Org makes this clearer. API clients could type-switch and use `User.username` or `Org.name`, but this is clearer.