### PR TITLE
authz: Remove in-memory cache from Bitbucket Server permissions store

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -108,7 +108,7 @@ func (p *Provider) RepoPerms(ctx context.Context, acct *extsvc.ExternalAccount, 
 		Type:   "repos",
 	}
 
-	err = p.store.LoadPermissions(ctx, &ps, p.update(userName))
+	err = p.store.LoadPermissions(ctx, ps, p.update(userName))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/provider.go
@@ -39,7 +39,7 @@ func NewProvider(cli *bitbucketserver.Client, db *sql.DB, ttl, hardTTL time.Dura
 		client:   cli,
 		codeHost: extsvc.NewCodeHost(cli.URL, bitbucketserver.ServiceType),
 		pageSize: 1000,
-		store:    newStore(db, ttl, hardTTL, clock, newCache()),
+		store:    newStore(db, ttl, hardTTL, clock),
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/store_test.go
@@ -54,7 +54,7 @@ func BenchmarkStore(b *testing.B) {
 		}
 
 		for i := 0; i < b.N; i++ {
-			err := s.LoadPermissions(ctx, &ps, update)
+			err := s.LoadPermissions(ctx, ps, update)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -72,7 +72,7 @@ func BenchmarkStore(b *testing.B) {
 		}
 
 		for i := 0; i < b.N; i++ {
-			err := s.LoadPermissions(ctx, &ps, update)
+			err := s.LoadPermissions(ctx, ps, update)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -133,8 +133,7 @@ func testStore(db *sql.DB) func(*testing.T) {
 		ps := &Permissions{UserID: 42, Perm: authz.Read, Type: "repos"}
 		load := func(s *store) (*Permissions, error) {
 			ps := *ps
-			p := &ps
-			return p, s.LoadPermissions(ctx, &p, update)
+			return &ps, s.LoadPermissions(ctx, &ps, update)
 		}
 
 		array := func(ids *roaring.Bitmap) []uint32 {


### PR DESCRIPTION
This commit removes the in-memory caching layer from the permissions store used
by the Bitbucket Server authz provider.

This reduces performance of authzFilter slightly. As indicated by the
existing benchmarks, we go from single digit microseconds to single digit milliseconds,
since now all authorization requests must incur the cost of a network roundtrip to Postgres
and the correspondent serialization and deserialization.

However, this allows us to easily invalidate any user's cached
permissions by simply deleting a row in the `user_permissions` table,
which is an operational requirement surfaced by one of our customers.

Eventually, such cache invalidation ought to be more easily triggered
via our UI, but for now, we enable admins to do so with a simple
playbook:

```sql
WITH batch AS (
  SELECT id FROM users
  WHERE username IN (
    'foo',
    'bar',
    'baz'
  )
)

DELETE FROM user_permissions USING batch
WHERE user_permissions.user_id = batch.id;
```

Part of #4812
