### PR TITLE
Add browser extension e2e tests for Gitlab

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -136,6 +136,8 @@ It currently does not run in CI and is intended to be run manually for release t
 
 e2e/bitbucket.test.ts tests the browser extension on a Bitbucket Server instance.
 
+e2e/gitlab.test.ts tests the browser extension on gitlab.com (or a private Gitlab instance).
+
 ## Deploy
 
 Deployment the Chrome web store happen automatically in CI when the `bext/release` branch is updated.

--- a/browser/src/e2e/bitbucket.test.ts
+++ b/browser/src/e2e/bitbucket.test.ts
@@ -102,5 +102,6 @@ describe('Sourcegraph browser extension on Bitbucket Server', () => {
         url: `${BITBUCKET_BASE_URL}/projects/SOURCEGRAPH/repos/jsonrpc2/browse/call_opt.go?until=4fb7cd90793ee6ab445f466b900e6bffb9b63d78&untilPath=call_opt.go`,
         repoName: `${REPO_PATH_PREFIX}/SOURCEGRAPH/jsonrpc2`,
         sourcegraphBaseUrl,
+        lineSelector: '.line',
     })
 })

--- a/browser/src/e2e/bitbucket.test.ts
+++ b/browser/src/e2e/bitbucket.test.ts
@@ -3,6 +3,7 @@ import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e
 import { sourcegraphBaseUrl, createDriverForTest, Driver } from '../../../shared/src/e2e/driver'
 import { retry } from '../../../shared/src/e2e/e2e-test-utils'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
+import { testSingleFilePage } from './shared'
 
 // By default, these tests run against a local Bitbucket instance and a local Sourcegraph instance.
 // You can run them against other instances by setting the below env vars in addition to SOURCEGRAPH_BASE_URL.
@@ -96,42 +97,10 @@ describe('Sourcegraph browser extension on Bitbucket Server', () => {
         () => driver.page
     )
 
-    it('adds "View on Sourcegraph" buttons to files', async () => {
-        await driver.page.goto(
-            BITBUCKET_BASE_URL +
-                '/projects/SOURCEGRAPH/repos/jsonrpc2/browse/call_opt.go?until=4fb7cd90793ee6ab445f466b900e6bffb9b63d78&untilPath=call_opt.go'
-        )
-        await driver.page.waitForSelector('.code-view-toolbar .open-on-sourcegraph', { timeout: 10000 })
-        expect(await driver.page.$$('.code-view-toolbar .open-on-sourcegraph')).toHaveLength(1)
-        await Promise.all([
-            driver.page.waitForNavigation(),
-            driver.page.click('.code-view-toolbar .open-on-sourcegraph'),
-        ])
-        expect(driver.page.url()).toBe(
-            `${sourcegraphBaseUrl}/${REPO_PATH_PREFIX}/SOURCEGRAPH/jsonrpc2@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
-        )
-    })
-
-    it('shows hover tooltips when hovering a token', async () => {
-        await driver.page.goto(
-            BITBUCKET_BASE_URL +
-                '/projects/SOURCEGRAPH/repos/jsonrpc2/browse/call_opt.go?until=4fb7cd90793ee6ab445f466b900e6bffb9b63d78&untilPath=call_opt.go'
-        )
-        await driver.page.waitForSelector('.code-view-toolbar .open-on-sourcegraph')
-
-        // Pause to give codeintellify time to register listeners for
-        // tokenization (only necessary in CI, not sure why).
-        await driver.page.waitFor(1000)
-
-        // Trigger tokenization of the line.
-        const lineNumber = 16
-        const line = await driver.page.waitForSelector(`.line:nth-child(${lineNumber})`, { timeout: 10000 })
-        const [token] = await line.$x('//span[text()="CallOption"]')
-        await token.hover()
-        await driver.page.waitForSelector('.e2e-tooltip-go-to-definition')
-        await Promise.all([driver.page.waitForNavigation(), driver.page.click('.e2e-tooltip-go-to-definition')])
-        expect(await driver.page.evaluate(() => location.href)).toBe(
-            `${sourcegraphBaseUrl}/${REPO_PATH_PREFIX}/SOURCEGRAPH/jsonrpc2@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go#L5:6`
-        )
+    testSingleFilePage({
+        getDriver: () => driver,
+        url: `${BITBUCKET_BASE_URL}/projects/SOURCEGRAPH/repos/jsonrpc2/browse/call_opt.go?until=4fb7cd90793ee6ab445f466b900e6bffb9b63d78&untilPath=call_opt.go`,
+        repoName: `${REPO_PATH_PREFIX}/SOURCEGRAPH/jsonrpc2`,
+        sourcegraphBaseUrl,
     })
 })

--- a/browser/src/e2e/gitlab.test.ts
+++ b/browser/src/e2e/gitlab.test.ts
@@ -65,5 +65,6 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
         url: `${GITLAB_BASE_URL}/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go`,
         repoName: `${REPO_PATH_PREFIX}/sourcegraph/jsonrpc2`,
         sourcegraphBaseUrl,
+        lineSelector: '.line',
     })
 })

--- a/browser/src/e2e/gitlab.test.ts
+++ b/browser/src/e2e/gitlab.test.ts
@@ -1,0 +1,69 @@
+import * as path from 'path'
+import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e/screenshotReporter'
+import { sourcegraphBaseUrl, createDriverForTest, Driver } from '../../../shared/src/e2e/driver'
+import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
+import { testSingleFilePage } from './shared'
+
+// By default, these tests run against gitlab.com and a local Sourcegraph instance.
+// You can run them against other instances by setting the below env vars in addition to SOURCEGRAPH_BASE_URL.
+
+const GITLAB_BASE_URL = process.env.GITLAB_BASE_URL || 'https://gitlab.com'
+const GITLAB_TOKEN = process.env.GITLAB_TOKEN
+const REPO_PATH_PREFIX = new URL(GITLAB_BASE_URL).hostname
+
+// 1 minute test timeout. This must be greater than the default Puppeteer
+// command timeout of 30s in order to get the stack trace to point to the
+// Puppeteer command that failed instead of a cryptic Jest test timeout
+// location.
+jest.setTimeout(1000 * 60 * 1000)
+
+/**
+ * Runs initial setup for the Gitlab instance.
+ */
+async function init(driver: Driver): Promise<void> {
+    await driver.ensureLoggedIn()
+    await driver.setExtensionSourcegraphUrl()
+    await driver.ensureHasExternalService({
+        kind: ExternalServiceKind.GITLAB,
+        displayName: 'Gitlab',
+        config: JSON.stringify({
+            url: GITLAB_BASE_URL,
+            token: GITLAB_TOKEN,
+            projectQuery: ['groups/sourcegraph/projects?search=jsonrpc2'],
+        }),
+        ensureRepos: [REPO_PATH_PREFIX + '/sourcegraphs/jsonrpc2'],
+    })
+    await driver.ensureHasCORSOrigin({ corsOriginURL: GITLAB_BASE_URL })
+}
+
+describe('Sourcegraph browser extension on Gitlab Server', () => {
+    let driver: Driver
+
+    beforeAll(async () => {
+        try {
+            driver = await createDriverForTest({ loadExtension: true })
+            await init(driver)
+        } catch (err) {
+            console.error(err)
+            setTimeout(() => process.exit(1), 100)
+        }
+    }, 4 * 60 * 1000)
+
+    afterAll(async () => {
+        await driver.close()
+    })
+
+    // Take a screenshot when a test fails.
+    saveScreenshotsUponFailuresAndClosePage(
+        path.resolve(__dirname, '..', '..', '..', '..'),
+        path.resolve(__dirname, '..', '..', '..', '..', 'puppeteer'),
+        () => driver.page
+    )
+
+    testSingleFilePage({
+        getDriver: () => driver,
+        url: `${GITLAB_BASE_URL}/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go`,
+        repoName: `${REPO_PATH_PREFIX}/sourcegraph/jsonrpc2`,
+        sourcegraphBaseUrl,
+    })
+})

--- a/browser/src/e2e/shared.ts
+++ b/browser/src/e2e/shared.ts
@@ -1,0 +1,59 @@
+import { Driver } from '../../../shared/src/e2e/driver'
+
+/**
+ * Defines e2e tests for a single-file page of a code host.
+ */
+export function testSingleFilePage({
+    getDriver,
+    url,
+    sourcegraphBaseUrl,
+    repoName,
+}: {
+    /** Called to get the driver */
+    getDriver: () => Driver
+
+    /** The URL to sourcegraph/jsonrpc2 call_opt.go at commit 4fb7cd90793ee6ab445f466b900e6bffb9b63d78 on the code host */
+    url: string
+
+    /** The base URL of the sourcegraph instance */
+    sourcegraphBaseUrl: string
+
+    /** The repo name of sourcgraph/jsonrpc2 on the Sourcegraph instance */
+    repoName: string
+}): void {
+    it('adds "View on Sourcegraph" buttons to files', async () => {
+        await getDriver().page.goto(url)
+        await getDriver().page.waitForSelector('.code-view-toolbar .open-on-sourcegraph', { timeout: 10000 })
+        expect(await getDriver().page.$$('.code-view-toolbar .open-on-sourcegraph')).toHaveLength(1)
+        await Promise.all([
+            getDriver().page.waitForNavigation(),
+            getDriver().page.click('.code-view-toolbar .open-on-sourcegraph'),
+        ])
+        expect(getDriver().page.url()).toBe(
+            `${sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
+        )
+    })
+
+    it('shows hover tooltips when hovering a token', async () => {
+        await getDriver().page.goto(url)
+        await getDriver().page.waitForSelector('.code-view-toolbar .open-on-sourcegraph')
+
+        // Pause to give codeintellify time to register listeners for
+        // tokenization (only necessary in CI, not sure why).
+        await getDriver().page.waitFor(1000)
+
+        // Trigger tokenization of the line.
+        const lineNumber = 16
+        const line = await getDriver().page.waitForSelector(`.line:nth-child(${lineNumber})`, { timeout: 10000 })
+        const [token] = await line.$x('//span[text()="CallOption"]')
+        await token.hover()
+        await getDriver().page.waitForSelector('.e2e-tooltip-go-to-definition')
+        await Promise.all([
+            getDriver().page.waitForNavigation(),
+            getDriver().page.click('.e2e-tooltip-go-to-definition'),
+        ])
+        expect(await getDriver().page.evaluate(() => location.href)).toBe(
+            `${sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go#L5:6`
+        )
+    })
+}

--- a/browser/src/e2e/shared.ts
+++ b/browser/src/e2e/shared.ts
@@ -8,6 +8,7 @@ export function testSingleFilePage({
     url,
     sourcegraphBaseUrl,
     repoName,
+    lineSelector,
 }: {
     /** Called to get the driver */
     getDriver: () => Driver
@@ -20,6 +21,9 @@ export function testSingleFilePage({
 
     /** The repo name of sourcgraph/jsonrpc2 on the Sourcegraph instance */
     repoName: string
+
+    /** The CSS selector for a line in the code view */
+    lineSelector: string
 }): void {
     it('adds "View on Sourcegraph" buttons to files', async () => {
         await getDriver().page.goto(url)
@@ -44,7 +48,9 @@ export function testSingleFilePage({
 
         // Trigger tokenization of the line.
         const lineNumber = 16
-        const line = await getDriver().page.waitForSelector(`.line:nth-child(${lineNumber})`, { timeout: 10000 })
+        const line = await getDriver().page.waitForSelector(`${lineSelector}:nth-child(${lineNumber})`, {
+            timeout: 10000,
+        })
         const [token] = await line.$x('//span[text()="CallOption"]')
         await token.hover()
         await getDriver().page.waitForSelector('.e2e-tooltip-go-to-definition')

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -280,7 +280,12 @@ export class Driver {
         variables: {}
     }): Promise<GraphQLResult<T>> {
         const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
-        const xhrHeaders = await this.page.evaluate(() => (window as any).context.xhrHeaders)
+        const xhrHeaders =
+            (await this.page.evaluate(
+                sourcegraphBaseUrl =>
+                    location.href.startsWith(sourcegraphBaseUrl) && (window as any).context.xhrHeaders,
+                sourcegraphBaseUrl
+            )) || {}
         const response = await this.makeRequest<GraphQLResult<T>>({
             url: `${sourcegraphBaseUrl}/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`,
             init: {


### PR DESCRIPTION
Makes the e2e tests share implementation between Gitlab and Bitbucket.