### PR TITLE
hide quicklinks bar if empty

### DIFF
--- a/web/src/search/QuickLinks.tsx
+++ b/web/src/search/QuickLinks.tsx
@@ -4,22 +4,21 @@ import { Link } from '../../../shared/src/components/Link'
 import { QuickLink } from '../schema/settings.schema'
 
 interface Props {
-    quickLinks: QuickLink[]
+    quickLinks: QuickLink[] | undefined
+
+    className?: string
 }
 
-export class QuickLinks extends React.PureComponent<Props> {
-    public render(): JSX.Element | null {
-        return this.props.quickLinks.length > 0 ? (
-            <>
-                {this.props.quickLinks.map((quickLink, i) => (
-                    <small className="quicklink text-nowrap mr-2" key={i}>
-                        <Link to={quickLink.url} data-tooltip={quickLink.description}>
-                            <LinkIcon className="icon-inline pr-1" />
-                            {quickLink.name}
-                        </Link>
-                    </small>
-                ))}
-            </>
-        ) : null
-    }
-}
+export const QuickLinks: React.FunctionComponent<Props> = ({ quickLinks, className = '' }) =>
+    quickLinks && quickLinks.length > 0 ? (
+        <div className={className}>
+            {quickLinks.map((quickLink, i) => (
+                <small className="quicklink text-nowrap mr-2" key={i}>
+                    <Link to={quickLink.url} data-tooltip={quickLink.description}>
+                        <LinkIcon className="icon-inline pr-1" />
+                        {quickLink.name}
+                    </Link>
+                </small>
+            ))}
+        </div>
+    ) : null

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -94,11 +94,7 @@ export class SearchPage extends React.Component<Props, State> {
                                     isSourcegraphDotCom={this.props.isSourcegraphDotCom}
                                 />
                             </div>
-                            {quickLinks.length > 0 && (
-                                <div className="search-page__input-sub-container">
-                                    <QuickLinks quickLinks={quickLinks} />
-                                </div>
-                            )}
+                            <QuickLinks quickLinks={quickLinks} className="search-page__input-sub-container" />
                             <QueryBuilder
                                 onFieldsQueryChange={this.onBuilderQueryChange}
                                 isSourcegraphDotCom={window.context.sourcegraphDotComMode}
@@ -110,11 +106,7 @@ export class SearchPage extends React.Component<Props, State> {
                                 onFieldsQueryChange={this.onBuilderQueryChange}
                                 isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                             />
-                            {quickLinks.length > 0 && (
-                                <div className="search-page__input-sub-container">
-                                    <QuickLinks quickLinks={quickLinks} />
-                                </div>
-                            )}
+                            <QuickLinks quickLinks={quickLinks} className="search-page__input-sub-container" />
                             <div className="search-page__input-sub-container">
                                 <SearchFilterChips
                                     location={this.props.location}

--- a/web/src/search/results/SearchResultsFilterBars.scss
+++ b/web/src/search/results/SearchResultsFilterBars.scss
@@ -32,7 +32,8 @@
     }
 
     &__quicklinks {
-        margin: 0.25rem 0 0.25rem 0;
+        padding-top: map-get($spacers, 1);
+        padding-bottom: map-get($spacers, 1);
         display: flex;
         overflow-x: auto;
 

--- a/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/web/src/search/results/SearchResultsFilterBars.tsx
@@ -91,12 +91,9 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                 </div>
             </div>
         )}
-        {quickLinks && (
-            <div className="search-results-filter-bars__row" data-testid="quicklinks-bar">
-                <div className="search-results-filter-bars__quicklinks">
-                    <QuickLinks quickLinks={quickLinks} />
-                </div>
-            </div>
-        )}
+        <QuickLinks
+            quickLinks={quickLinks}
+            className="search-results-filter-bars__row search-results-filter-bars__quicklinks"
+        />
     </div>
 )


### PR DESCRIPTION
Fixes an issue where an empty horizontal bar would be shown on the search results page even if there were no quicklinks. Also simplifies the quicklinks component usage a bit so that callers need not check whether quicklinks are empty (this check was omitted on the search results page, which caused the bug).

## before, with quicklinks empty

![ql-empty](https://user-images.githubusercontent.com/1976/64059720-aec16480-cb76-11e9-9e8a-c1e027b2ae3a.png)

## after, with quicklinks empty

![ql-empty-post](https://user-images.githubusercontent.com/1976/64059722-b3861880-cb76-11e9-8687-d117692d2eea.png)

## after, with quicklinks non-empty

![ql-nonempty](https://user-images.githubusercontent.com/1976/64059723-b8e36300-cb76-11e9-9202-4d0eb45a2374.png)
