### PR TITLE
use consistent color for ext svc status messages icon in global navbar

### DIFF
--- a/web/src/global-styles/buttons.scss
+++ b/web/src/global-styles/buttons.scss
@@ -10,8 +10,8 @@
     }
 }
 
-// This class is meant for clickable icons
-// It is NOT meant for buttons with icons in it
+// This class is meant for clickable icons. It is NOT meant for buttons with icons in it or for nav
+// items.
 .btn-icon {
     margin: 0;
     padding: 0;

--- a/web/src/nav/StatusMessagesNavItem.tsx
+++ b/web/src/nav/StatusMessagesNavItem.tsx
@@ -209,7 +209,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                 toggle={this.toggleIsOpen}
                 className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
             >
-                <DropdownToggle caret={false} className="btn btn-icon" nav={true}>
+                <DropdownToggle caret={false} className="btn btn-link" nav={true}>
                     {this.renderIcon()}
                 </DropdownToggle>
 

--- a/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
   <a
     aria-expanded={false}
     aria-haspopup={true}
-    className="btn btn-icon nav-link"
+    className="btn btn-link nav-link"
     href="#"
     onClick={[Function]}
   >
@@ -67,7 +67,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
   <a
     aria-expanded={false}
     aria-haspopup={true}
-    className="btn btn-icon nav-link"
+    className="btn btn-link nav-link"
     href="#"
     onClick={[Function]}
   >
@@ -126,7 +126,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
   <a
     aria-expanded={false}
     aria-haspopup={true}
-    className="btn btn-icon nav-link"
+    className="btn btn-link nav-link"
     href="#"
     onClick={[Function]}
   >
@@ -195,7 +195,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site 
   <a
     aria-expanded={false}
     aria-haspopup={true}
-    className="btn btn-icon nav-link"
+    className="btn btn-link nav-link"
     href="#"
     onClick={[Function]}
   >
@@ -254,7 +254,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admi
   <a
     aria-expanded={false}
     aria-haspopup={true}
-    className="btn btn-icon nav-link"
+    className="btn btn-link nav-link"
     href="#"
     onClick={[Function]}
   >
@@ -323,7 +323,7 @@ exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
   <a
     aria-expanded={false}
     aria-haspopup={true}
-    className="btn btn-icon nav-link"
+    className="btn btn-link nav-link"
     href="#"
     onClick={[Function]}
   >
@@ -382,7 +382,7 @@ exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
   <a
     aria-expanded={false}
     aria-haspopup={true}
-    className="btn btn-icon nav-link"
+    className="btn btn-link nav-link"
     href="#"
     onClick={[Function]}
   >


### PR DESCRIPTION
Previously, the external services status messages nav item had the body text color, not the link color (as all other global navbar items have). This makes its color consistent with the other global navbar items.

## before
![sl1](https://user-images.githubusercontent.com/1976/64059820-4f645400-cb78-11e9-9033-b6f60ebdd940.png)

![s1](https://user-images.githubusercontent.com/1976/64059821-4f645400-cb78-11e9-9b41-059dccdb7ccd.png)

## after

![sl2](https://user-images.githubusercontent.com/1976/64059819-4f645400-cb78-11e9-8b02-ab999821dcc4.png)

![s2](https://user-images.githubusercontent.com/1976/64059822-4f645400-cb78-11e9-9f61-37f74e4a78e9.png)
