### PR TITLE
always use root-relative names in Git entries

### DIFF
--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -23,7 +23,7 @@ func (r *gitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	contents, err := git.ReadFile(ctx, *cachedRepo, api.CommitID(r.commit.OID()), r.path)
+	contents, err := git.ReadFile(ctx, *cachedRepo, api.CommitID(r.commit.OID()), r.Path())
 	if err != nil {
 		return "", err
 	}
@@ -32,7 +32,7 @@ func (r *gitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 }
 
 func (r *gitTreeEntryResolver) RichHTML(ctx context.Context) (string, error) {
-	switch path.Ext(r.path) {
+	switch path.Ext(r.Path()) {
 	case ".md", ".mdown", ".markdown", ".markdn":
 		break
 	default:
@@ -105,7 +105,7 @@ func (r *gitTreeEntryResolver) Highlight(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	content, err := git.ReadFile(ctx, *cachedRepo, api.CommitID(r.commit.OID()), r.path)
+	content, err := git.ReadFile(ctx, *cachedRepo, api.CommitID(r.commit.OID()), r.Path())
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (r *gitTreeEntryResolver) Highlight(ctx context.Context, args *struct {
 	simulateTimeout := r.commit.repo.repo.Name == "github.com/sourcegraph/AlwaysHighlightTimeoutTest"
 	html, result.aborted, err = highlight.Code(ctx, highlight.Params{
 		Content:         content,
-		Filepath:        r.path,
+		Filepath:        r.Path(),
 		DisableTimeout:  args.DisableTimeout,
 		IsLightTheme:    args.IsLightTheme,
 		SimulateTimeout: simulateTimeout,

--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -13,7 +13,7 @@ func (r *gitTreeEntryResolver) Blame(ctx context.Context,
 		StartLine int32
 		EndLine   int32
 	}) ([]*hunkResolver, error) {
-	hunks, err := git.BlameFile(ctx, gitserver.Repo{Name: r.commit.repo.repo.Name}, r.path, &git.BlameOptions{
+	hunks, err := git.BlameFile(ctx, gitserver.Repo{Name: r.commit.repo.repo.Name}, r.Path(), &git.BlameOptions{
 		NewestCommit: api.CommitID(r.commit.OID()),
 		StartLine:    int(args.StartLine),
 		EndLine:      int(args.EndLine),

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -138,7 +138,6 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	}
 	return &gitTreeEntryResolver{
 		commit:      r,
-		path:        args.Path,
 		stat:        stat,
 		isRecursive: args.Recursive,
 	}, nil
@@ -160,7 +159,6 @@ func (r *GitCommitResolver) Blob(ctx context.Context, args *struct {
 	}
 	return &gitTreeEntryResolver{
 		commit: r,
-		path:   args.Path,
 		stat:   stat,
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (r *gitTreeEntryResolver) IsRoot() bool {
-	path := path.Clean(r.path)
+	path := path.Clean(r.Path())
 	return path == "/" || path == "." || path == ""
 }
 
@@ -43,7 +43,7 @@ func (r *gitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 	if err != nil {
 		return nil, err
 	}
-	entries, err := git.ReadDir(ctx, *cachedRepo, api.CommitID(r.commit.OID()), r.path, r.isRecursive || args.Recursive)
+	entries, err := git.ReadDir(ctx, *cachedRepo, api.CommitID(r.commit.OID()), r.Path(), r.isRecursive || args.Recursive)
 	if err != nil {
 		if strings.Contains(err.Error(), "file does not exist") { // TODO proper error value
 			// empty tree is not an error
@@ -58,17 +58,11 @@ func (r *gitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 		entries = entries[:int(*args.First)]
 	}
 
-	var prefix string
-	if r.path != "" {
-		prefix = r.path + "/"
-	}
-
 	var l []*gitTreeEntryResolver
 	for _, entry := range entries {
 		if filter == nil || filter(entry) {
 			l = append(l, &gitTreeEntryResolver{
 				commit: r.commit,
-				path:   prefix + entry.Name(), // relies on git paths being cleaned already
 				stat:   entry,
 			})
 		}

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -30,20 +30,29 @@ func TestGitTree(t *testing.T) {
 	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &git.Commit{ID: exampleCommitSHA1})
 
 	git.Mocks.Stat = func(commit api.CommitID, path string) (os.FileInfo, error) {
-		if string(commit) != exampleCommitSHA1 || path != "foo bar" {
-			t.Error("wrong arguments to Stat")
+		if string(commit) != exampleCommitSHA1 {
+			t.Errorf("got commit %q, want %q", commit, exampleCommitSHA1)
 		}
-		return &util.FileInfo{Name_: "", Mode_: os.ModeDir}, nil
+		if want := "foo bar"; path != want {
+			t.Errorf("got path %q, want %q", path, want)
+		}
+		return &util.FileInfo{Name_: path, Mode_: os.ModeDir}, nil
 	}
 	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error) {
-		if string(commit) != exampleCommitSHA1 || name != "foo bar" || recurse {
-			t.Error("wrong arguments to RepoTree.Get")
+		if string(commit) != exampleCommitSHA1 {
+			t.Errorf("got commit %q, want %q", commit, exampleCommitSHA1)
+		}
+		if want := "foo bar"; name != want {
+			t.Errorf("got name %q, want %q", name, want)
+		}
+		if recurse {
+			t.Error("got recurse == false, want true")
 		}
 		return []os.FileInfo{
-			&util.FileInfo{Name_: "testDirectory", Mode_: os.ModeDir},
-			&util.FileInfo{Name_: "Geoffrey's random queries.32r242442bf", Mode_: os.ModeDir},
-			&util.FileInfo{Name_: "testFile", Mode_: 0},
-			&util.FileInfo{Name_: "% token.4288249258.sql", Mode_: 0},
+			&util.FileInfo{Name_: name + "/testDirectory", Mode_: os.ModeDir},
+			&util.FileInfo{Name_: name + "/Geoffrey's random queries.32r242442bf", Mode_: os.ModeDir},
+			&util.FileInfo{Name_: name + "/testFile", Mode_: 0},
+			&util.FileInfo{Name_: name + "/% token.4288249258.sql", Mode_: 0},
 		}, nil
 	}
 	defer git.ResetMocks()

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -293,7 +293,6 @@ func (r *fileDiffResolver) OldFile() *gitTreeEntryResolver {
 	}
 	return &gitTreeEntryResolver{
 		commit: r.cmp.base,
-		path:   r.fileDiff.OrigName,
 		stat:   createFileInfo(r.fileDiff.OrigName, false),
 	}
 }
@@ -304,7 +303,6 @@ func (r *fileDiffResolver) NewFile() *gitTreeEntryResolver {
 	}
 	return &gitTreeEntryResolver{
 		commit: r.cmp.head,
-		path:   r.fileDiff.NewName,
 		stat:   createFileInfo(r.fileDiff.NewName, false),
 	}
 }

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -746,7 +746,7 @@ func newSearchResultResolver(result interface{}, score int) *searchSuggestionRes
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.repo.Name), label: string(r.repo.Name)}
 
 	case *gitTreeEntryResolver:
-		return &searchSuggestionResolver{result: r, score: score, length: len(r.path), label: r.path}
+		return &searchSuggestionResolver{result: r, score: score, length: len(r.Path()), label: r.Path()}
 
 	case *searchSymbolResult:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.symbol.Name + " " + r.symbol.Parent), label: r.symbol.Name + " " + r.symbol.Parent}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -253,7 +253,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			// may cause duplicate suggestions when merging results from Zoekt and non-Zoekt sources
 			// (that do specify a commit ID), because their key k (i.e., k in seen[k]) will not
 			// equal.
-			k.file = s.path
+			k.file = s.Path()
 		case *searchSymbolResult:
 			k.repoName = s.commit.repo.repo.Name
 			k.symbol = s.symbol.Name + s.symbol.Parent

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -228,7 +228,7 @@ func testStringResult(result *searchSuggestionResolver) string {
 	case *RepositoryResolver:
 		name = "repo:" + string(r.repo.Name)
 	case *gitTreeEntryResolver:
-		name = "file:" + r.path
+		name = "file:" + r.Path()
 	default:
 		panic("never here")
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -97,7 +97,6 @@ func toSymbolResolver(symbol protocol.Symbol, baseURI *gituri.URI, lang string, 
 	resolver.location = &locationResolver{
 		resource: &gitTreeEntryResolver{
 			commit: commitResolver,
-			path:   resolver.uri.Fragment,
 			stat:   createFileInfo(resolver.uri.Fragment, false), // assume the path refers to a file (not dir)
 		},
 		lspRange: &symbolRange,

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -86,7 +86,6 @@ func (fm *fileMatchResolver) File() *gitTreeEntryResolver {
 			oid:      GitObjectID(fm.commitID),
 			inputRev: fm.inputRev,
 		},
-		path: fm.JPath,
 		stat: createFileInfo(fm.JPath, false),
 	}
 }

--- a/pkg/vcs/git/tree.go
+++ b/pkg/vcs/git/tree.go
@@ -202,7 +202,6 @@ func lsTreeUncached(ctx context.Context, repo gitserver.Repo, commit api.CommitI
 	}
 
 	trimPath := strings.TrimPrefix(path, "./")
-	prefixLen := strings.LastIndexByte(trimPath, '/') + 1
 	lines := strings.Split(string(out), "\x00")
 	fis := make([]os.FileInfo, len(lines)-1)
 	for i, line := range lines {
@@ -280,10 +279,7 @@ func lsTreeUncached(ctx context.Context, repo gitserver.Repo, commit api.CommitI
 		}
 
 		fis[i] = &util.FileInfo{
-			// This returns the full relative path (e.g. "path/to/file.go") when the path arg is "./"
-			// This behavior is necessary to construct the file tree.
-			// In all other cases, it returns the basename (e.g. "file.go").
-			Name_: name[prefixLen:],
+			Name_: name, // full path relative to root (not just basename)
 			Mode_: os.FileMode(mode),
 			Size_: size,
 			Sys_:  sys,

--- a/pkg/vcs/git/tree_test.go
+++ b/pkg/vcs/git/tree_test.go
@@ -189,8 +189,8 @@ func TestRepository_FileSystem(t *testing.T) {
 			continue
 		}
 		file1Info := dir1Entries[0]
-		if file1Info.Name() != "file1" {
-			t.Errorf("%s: got dir1 entry name == %q, want 'file1'", label, file1Info.Name())
+		if got, want := file1Info.Name(), "dir1/file1"; got != want {
+			t.Errorf("%s: got dir1 entry name == %q, want %q", label, got, want)
 		}
 		if want := int64(7); file1Info.Size() != want {
 			t.Errorf("%s: got dir1 entry size == %d, want %d", label, file1Info.Size(), want)
@@ -220,8 +220,8 @@ func TestRepository_FileSystem(t *testing.T) {
 		if !file1Info.Mode().IsRegular() {
 			t.Errorf("%s: file1 stat !IsRegular", label)
 		}
-		if name := file1Info.Name(); name != "file1" {
-			t.Errorf("%s: got file1 name %q, want 'file1'", label, name)
+		if got, want := file1Info.Name(), "dir1/file1"; got != want {
+			t.Errorf("%s: got file1 name %q, want %q", label, got, want)
 		}
 		if want := int64(7); file1Info.Size() != want {
 			t.Errorf("%s: got file1 size == %d, want %d", label, file1Info.Size(), want)
@@ -287,8 +287,8 @@ func TestRepository_FileSystem(t *testing.T) {
 			t.Errorf("%s: got %d dir1 entries, want 1", label, len(dir1Entries))
 			continue
 		}
-		if file1Info := dir1Entries[0]; file1Info.Name() != "file1" {
-			t.Errorf("%s: got dir1 entry name == %q, want 'file1'", label, file1Info.Name())
+		if got, want := dir1Entries[0].Name(), "dir1/file1"; got != want {
+			t.Errorf("%s: got dir1 entry name == %q, want %q", label, got, want)
 		}
 
 		// rootEntries should be empty for third commit


### PR DESCRIPTION
os.FileInfos representing Git objects now always return the full path relative to the repository root in the Name method. Previously the behavior depended on several complex factors, such as whether the entry was the root, whether the ReadDir traversal was recursive, etc.

This also lets us remove a field in gitTreeEntryResolver.

(Separated out from #5465, can be merged separately.)