### PR TITLE
fix handling of github "affiliated" repositoryQuery

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -452,6 +452,7 @@ func (s *GithubSource) listRepositoryQuery(ctx context.Context, query string, re
 		return
 	case "affiliated":
 		s.listAffiliated(ctx, results)
+		return
 	case "none":
 		// nothing
 		return


### PR DESCRIPTION
A `return` statement was omitted, so a repositoryQuery of `affiliated` would hit the GitHub list-user-repos API and then (erroneously) also hit the GitHub search API for the literal string query "affiliated". This string is present in many public GitHub repositories, so you'd see the following error:

```
00:11:34           repo-updater | ERROR Syncer, error: syncer.sync.sourced: 1 error occurred:
00:11:34           repo-updater | 	* repositoryQuery "affiliated" would return 1976 results. GitHub's Search API only returns up to 1000 results. Please adjust your repository query into multiple queries such that each returns less than 1000 results. For example: {"repositoryQuery": ["affiliated created:>=2019","affiliated created:2018","affiliated created:2016..2017","affiliated created:<2016"]}
```