### PR TITLE
dbtesting: Reduce unintended sideeffects by not setting an actor

### DIFF
--- a/cmd/frontend/db/access_tokens_test.go
+++ b/cmd/frontend/db/access_tokens_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -10,7 +11,8 @@ import (
 // 🚨 SECURITY: This tests the routine that creates access tokens and returns the token secret value
 // to the user.
 func TestAccessTokens_Create(t *testing.T) {
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	subject, err := Users.Create(ctx, NewUser{
 		Email:                 "a@example.com",
@@ -84,7 +86,8 @@ func TestAccessTokens_List(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	subject1, err := Users.Create(ctx, NewUser{
 		Email:                 "a@example.com",
@@ -161,7 +164,8 @@ func TestAccessTokens_Lookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	subject, err := Users.Create(ctx, NewUser{
 		Email:                 "a@example.com",
@@ -228,7 +232,8 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	t.Run("subject", func(t *testing.T) {
 		subject, err := Users.Create(ctx, NewUser{

--- a/cmd/frontend/db/dbstore_db_test.go
+++ b/cmd/frontend/db/dbstore_db_test.go
@@ -13,8 +13,8 @@ func TestMigrations(t *testing.T) {
 		t.Skip()
 	}
 
-	// get testing context to ensure we can connect to the DB
-	_ = dbtesting.TestContext(t)
+	// Setup a global test database
+	dbtesting.SetupGlobalTestDB(t)
 
 	m := dbconn.NewMigrate(dbconn.Global)
 	// Run all down migrations then up migrations again to ensure there are no SQL errors.

--- a/cmd/frontend/db/default_repos_test.go
+++ b/cmd/frontend/db/default_repos_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -48,7 +49,8 @@ func Test_defaultRepos_List(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := dbtesting.TestContext(t)
+			dbtesting.SetupGlobalTestDB(t)
+			ctx := context.Background()
 			for _, r := range tc.repos {
 				if _, err := dbconn.Global.ExecContext(ctx, `INSERT INTO repo(id, name) VALUES ($1, $2)`, r.ID, r.Name); err != nil {
 					t.Fatal(err)
@@ -71,7 +73,8 @@ func Test_defaultRepos_List(t *testing.T) {
 }
 
 func BenchmarkDefaultRepos_List_Empty(b *testing.B) {
-	ctx := dbtesting.TestContext(b)
+	dbtesting.SetupGlobalTestDB(b)
+	ctx := context.Background()
 	select {
 	case <-ctx.Done():
 		b.Fatal("context already canceled")

--- a/cmd/frontend/db/discussion_comments_test.go
+++ b/cmd/frontend/db/discussion_comments_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -16,7 +17,8 @@ func TestDiscussionComments_Create(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",

--- a/cmd/frontend/db/discussion_threads_test.go
+++ b/cmd/frontend/db/discussion_threads_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -16,7 +17,8 @@ func TestDiscussionThreads_CreateGet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -76,7 +78,8 @@ func TestDiscussionThreads_Update(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -133,7 +136,8 @@ func TestDiscussionThreads_Count(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -197,7 +201,8 @@ func TestDiscussionThreads_List(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -261,7 +266,8 @@ func TestDiscussionThreads_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",

--- a/cmd/frontend/db/external_accounts_test.go
+++ b/cmd/frontend/db/external_accounts_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -13,7 +14,8 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	spec := extsvc.ExternalAccountSpec{
 		ServiceType: "xa",
@@ -39,7 +41,8 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{Username: "u"})
 	if err != nil {
@@ -75,7 +78,8 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	spec := extsvc.ExternalAccountSpec{
 		ServiceType: "xa",

--- a/cmd/frontend/db/org_invitations_test.go
+++ b/cmd/frontend/db/org_invitations_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -15,7 +16,8 @@ func TestOrgInvitations(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	sender, err := Users.Create(ctx, NewUser{
 		Email:                 "a1@example.com",

--- a/cmd/frontend/db/org_members_db_test.go
+++ b/cmd/frontend/db/org_members_db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -14,7 +15,8 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	// Create fixtures.
 	org1, err := Orgs.Create(ctx, "org1", nil)

--- a/cmd/frontend/db/orgs_test.go
+++ b/cmd/frontend/db/orgs_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -11,7 +12,8 @@ func TestOrgs_ValidNames(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	for _, test := range usernamesForTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -34,7 +36,8 @@ func TestOrgs_Count(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	org, err := Orgs.Create(ctx, "a", nil)
 	if err != nil {
@@ -62,7 +65,8 @@ func TestOrgs_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	org, err := Orgs.Create(ctx, "a", nil)
 	if err != nil {

--- a/cmd/frontend/db/recent_searches_test.go
+++ b/cmd/frontend/db/recent_searches_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -14,7 +15,8 @@ func TestRecentSearches_Log(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	q := fmt.Sprintf("fake query with random number %d", rand.Int())
 	rs := &RecentSearches{}
 	if err := rs.Log(ctx, q); err != nil {
@@ -38,13 +40,15 @@ func TestRecentSearches_Cleanup(t *testing.T) {
 	}
 	rs := &RecentSearches{}
 	t.Run("empty case", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
+		dbtesting.SetupGlobalTestDB(t)
+		ctx := context.Background()
 		if err := rs.Cleanup(ctx, 1); err != nil {
 			t.Error(err)
 		}
 	})
 	t.Run("single case", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
+		dbtesting.SetupGlobalTestDB(t)
+		ctx := context.Background()
 		q := "fake query"
 		if err := rs.Log(ctx, q); err != nil {
 			t.Fatal(err)
@@ -61,7 +65,8 @@ func TestRecentSearches_Cleanup(t *testing.T) {
 		}
 	})
 	t.Run("simple case", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
+		dbtesting.SetupGlobalTestDB(t)
+		ctx := context.Background()
 		limit := 10
 		for i := 1; i <= limit+1; i++ {
 			q := fmt.Sprintf("fake query for i = %d", i)
@@ -81,7 +86,8 @@ func TestRecentSearches_Cleanup(t *testing.T) {
 		}
 	})
 	t.Run("id gap", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
+		dbtesting.SetupGlobalTestDB(t)
+		ctx := context.Background()
 		addQueryWithRandomId := func(q string) {
 			insert := `INSERT INTO recent_searches (id, query) VALUES ((1e6*RANDOM())::int, $1)`
 			if _, err := dbconn.Global.ExecContext(ctx, insert, q); err != nil {
@@ -108,7 +114,8 @@ func TestRecentSearches_Cleanup(t *testing.T) {
 
 func BenchmarkRecentSearches_LogAndCleanup(b *testing.B) {
 	rs := &RecentSearches{}
-	ctx := dbtesting.TestContext(b)
+	dbtesting.SetupGlobalTestDB(b)
+	ctx := context.Background()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		q := fmt.Sprintf("fake query for i = %d", i)
@@ -177,7 +184,8 @@ func TestRecentSearches_Top(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs := &RecentSearches{}
-			ctx := dbtesting.TestContext(t)
+			dbtesting.SetupGlobalTestDB(t)
+			ctx := context.Background()
 			for _, q := range tt.queries {
 				if err := rs.Log(ctx, q); err != nil {
 					t.Fatal(err)

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -68,7 +68,8 @@ func TestRepos_Get(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	want := mustCreate(ctx, t, &types.Repo{
 		Name: "r",
@@ -99,7 +100,8 @@ func TestRepos_List(t *testing.T) {
 	}
 	defer func() { MockAuthzFilter = nil }()
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	want := mustCreate(ctx, t, &types.Repo{Name: "r"})
@@ -122,7 +124,8 @@ func TestRepos_List_fork(t *testing.T) {
 		return repos, nil
 	}
 	defer func() { MockAuthzFilter = nil }()
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	mine := mustCreate(ctx, t, &types.Repo{Name: "a/r", RepoFields: &types.RepoFields{Fork: false}})
@@ -167,7 +170,8 @@ func TestRepos_List_pagination(t *testing.T) {
 		return repos, nil
 	}
 	defer func() { MockAuthzFilter = nil }()
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -218,7 +222,8 @@ func TestRepos_List_query1(t *testing.T) {
 		return repos, nil
 	}
 	defer func() { MockAuthzFilter = nil }()
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -260,7 +265,8 @@ func TestRepos_List_query2(t *testing.T) {
 		return repos, nil
 	}
 	defer func() { MockAuthzFilter = nil }()
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -305,7 +311,8 @@ func TestRepos_List_sort(t *testing.T) {
 		return repos, nil
 	}
 	defer func() { MockAuthzFilter = nil }()
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -378,7 +385,8 @@ func TestRepos_List_patterns(t *testing.T) {
 		return repos, nil
 	}
 	defer func() { MockAuthzFilter = nil }()
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -435,7 +443,8 @@ func TestRepos_List_queryPattern(t *testing.T) {
 		return repos, nil
 	}
 	defer func() { MockAuthzFilter = nil }()
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{})
 
 	createdRepos := []*types.Repo{
@@ -586,7 +595,8 @@ func TestRepos_Create(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	// Add a repo.
 	createRepo(ctx, t, &types.Repo{
@@ -611,7 +621,8 @@ func TestRepos_Create_dupe(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	// Add a repo.
 	createRepo(ctx, t, &types.Repo{Name: "a/b"})

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -155,7 +155,8 @@ func Test_getBySQL_permissionsCheck(t *testing.T) {
 	}
 	defer func() { MockAuthzFilter = nil }()
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	allRepos := mustCreate(ctx, t,

--- a/cmd/frontend/db/repos_perm_test.go
+++ b/cmd/frontend/db/repos_perm_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc"
@@ -155,6 +156,7 @@ func Test_getBySQL_permissionsCheck(t *testing.T) {
 	defer func() { MockAuthzFilter = nil }()
 
 	ctx := dbtesting.TestContext(t)
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	allRepos := mustCreate(ctx, t,
 		&types.Repo{

--- a/cmd/frontend/db/repos_test.go
+++ b/cmd/frontend/db/repos_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -79,7 +80,8 @@ func TestRepos_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	if err := Repos.Upsert(ctx, api.InsertRepoOp{Name: "myrepo", Description: "", Fork: false, Enabled: true}); err != nil {
@@ -105,7 +107,8 @@ func TestRepos_Count(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	if count, err := Repos.Count(ctx, ReposListOptions{Enabled: true}); err != nil {
@@ -143,7 +146,8 @@ func TestRepos_Upsert(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	if _, err := Repos.GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {

--- a/cmd/frontend/db/repos_test.go
+++ b/cmd/frontend/db/repos_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/pkg/errcode"
@@ -79,6 +80,7 @@ func TestRepos_Delete(t *testing.T) {
 		t.Skip()
 	}
 	ctx := dbtesting.TestContext(t)
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	if err := Repos.Upsert(ctx, api.InsertRepoOp{Name: "myrepo", Description: "", Fork: false, Enabled: true}); err != nil {
 		t.Fatal(err)
@@ -104,6 +106,7 @@ func TestRepos_Count(t *testing.T) {
 		t.Skip()
 	}
 	ctx := dbtesting.TestContext(t)
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	if count, err := Repos.Count(ctx, ReposListOptions{Enabled: true}); err != nil {
 		t.Fatal(err)
@@ -141,6 +144,7 @@ func TestRepos_Upsert(t *testing.T) {
 		t.Skip()
 	}
 	ctx := dbtesting.TestContext(t)
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	if _, err := Repos.GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
 		if err == nil {

--- a/cmd/frontend/db/saved_searches_test.go
+++ b/cmd/frontend/db/saved_searches_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -14,7 +15,8 @@ func TestSavedSearchesIsEmpty(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	isEmpty, err := SavedSearches.IsEmpty(ctx)
 	if err != nil {
 		t.Fatal()
@@ -57,7 +59,8 @@ func TestSavedSearchesCreate(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
@@ -98,7 +101,8 @@ func TestSavedSearchesUpdate(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
@@ -142,7 +146,8 @@ func TestSavedSearchesDelete(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
@@ -181,7 +186,8 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
@@ -226,7 +232,8 @@ func TestSavedSearchesGetByID(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
@@ -272,7 +279,8 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)

--- a/cmd/frontend/db/settings_test.go
+++ b/cmd/frontend/db/settings_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -11,7 +12,8 @@ func TestSettings_ListAll(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user1, err := Users.Create(ctx, NewUser{Username: "u1"})
 	if err != nil {

--- a/cmd/frontend/db/survey_responses_test.go
+++ b/cmd/frontend/db/survey_responses_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
@@ -11,7 +12,8 @@ func TestSurveyResponses_Create_Count(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	count, err := SurveyResponses.Count(ctx)
 	if err != nil {

--- a/cmd/frontend/db/user_emails_test.go
+++ b/cmd/frontend/db/user_emails_test.go
@@ -16,7 +16,8 @@ func TestUserEmails_Get(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@example.com",
@@ -62,7 +63,8 @@ func TestUserEmails_GetPrimary(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@example.com",
@@ -115,7 +117,8 @@ func TestUserEmails_ListByUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@example.com",
@@ -161,7 +164,8 @@ func TestUserEmails_Add_Remove(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	const emailA = "a@example.com"
 	const emailB = "b@example.com"
@@ -223,7 +227,8 @@ func TestUserEmails_SetVerified(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	const email = "a@example.com"
 	user, err := Users.Create(ctx, NewUser{

--- a/cmd/frontend/db/user_tags_test.go
+++ b/cmd/frontend/db/user_tags_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -13,7 +14,8 @@ func TestUsers_SetTag(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	// Create user.
 	u, err := Users.Create(ctx, NewUser{Username: "u"})

--- a/cmd/frontend/db/users_builtin_auth_test.go
+++ b/cmd/frontend/db/users_builtin_auth_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
@@ -10,7 +11,8 @@ func TestUsers_BuiltinAuth(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	if _, err := Users.Create(ctx, NewUser{
 		Email:       "foo@bar.com",
@@ -90,7 +92,8 @@ func TestUsers_BuiltinAuth_VerifiedEmail(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:           "foo@bar.com",
@@ -115,7 +118,8 @@ func TestUsers_BuiltinAuthPasswordResetRateLimit(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	oldPasswordResetRateLimit := passwordResetRateLimit
 	defer func() {
@@ -153,7 +157,8 @@ func TestUsers_UpdatePassword(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	usr, err := Users.Create(ctx, NewUser{
 		Email:                 "foo@bar.com",

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbtesting"
@@ -391,6 +392,7 @@ func TestUsers_Delete(t *testing.T) {
 				t.Skip()
 			}
 			ctx := dbtesting.TestContext(t)
+			ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 			otherUser, err := Users.Create(ctx, NewUser{Username: "other"})
 			if err != nil {

--- a/cmd/frontend/db/users_test.go
+++ b/cmd/frontend/db/users_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -66,7 +67,8 @@ func TestUsers_ValidUsernames(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	for _, test := range usernamesForTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -90,7 +92,8 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	if _, err := globalstatedb.Get(ctx); err != nil {
 		t.Fatal(err)
@@ -176,7 +179,8 @@ func TestUsers_CheckAndDecrementInviteQuota(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -224,7 +228,8 @@ func TestUsers_ListCount(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -280,7 +285,8 @@ func TestUsers_Update(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -356,7 +362,8 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := Users.Create(ctx, NewUser{
 		Email:                 "a@a.com",
@@ -391,7 +398,8 @@ func TestUsers_Delete(t *testing.T) {
 			if testing.Short() {
 				t.Skip()
 			}
-			ctx := dbtesting.TestContext(t)
+			dbtesting.SetupGlobalTestDB(t)
+			ctx := context.Background()
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 			otherUser, err := Users.Create(ctx, NewUser{Username: "other"})

--- a/cmd/frontend/graphqlbackend/campaigns_test.go
+++ b/cmd/frontend/graphqlbackend/campaigns_test.go
@@ -1,6 +1,7 @@
 package graphqlbackend
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -21,7 +22,8 @@ func TestCampaigns(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	ctx = backend.WithAuthzBypass(ctx)
 
 	s := db.NewCampaignsStore(dbconn.Global)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -199,7 +199,8 @@ func BenchmarkSearchResults(b *testing.B) {
 }
 
 func BenchmarkIntegrationSearchResults(b *testing.B) {
-	ctx := dbtesting.TestContext(b)
+	dbtesting.SetupGlobalTestDB(b)
+	ctx := context.Background()
 
 	_, repos, zoektRepos := generateRepos(5000)
 	zoektFileMatches := generateZoektMatches(50)

--- a/cmd/frontend/internal/bg/migrate_saved_queries_to_db_test.go
+++ b/cmd/frontend/internal/bg/migrate_saved_queries_to_db_test.go
@@ -1,6 +1,7 @@
 package bg
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -15,7 +16,8 @@ func TestMigrateSavedQueriesAndSlackWebhookURLsFromSettingsToDatabase(t *testing
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	t.Run("migrate user saved query", func(t *testing.T) {
 		u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
@@ -80,7 +82,8 @@ func TestDoMigrateSavedQueriesAndSlackWebhookURLsFromSettingsToDatabase(t *testi
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	t.Run("valid", func(t *testing.T) {
 		u, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
@@ -163,7 +166,8 @@ func TestMigrateSavedQueryIntoDB(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	check := func(t *testing.T, settings *api.Settings, wantChanged bool) {
 		t.Helper()
@@ -218,7 +222,8 @@ func TestInsertSavedQueryIntoDB(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	t.Run("user saved search inserted into db table", func(t *testing.T) {
 		u, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
@@ -309,7 +314,8 @@ func TestMigrateSlackWebhookURL(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	t.Run("migrate user slack webhook URL", func(t *testing.T) {
 		u, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})

--- a/cmd/frontend/internal/bg/migrate_settings_motd_to_notices_test.go
+++ b/cmd/frontend/internal/bg/migrate_settings_motd_to_notices_test.go
@@ -14,7 +14,8 @@ func TestMigrateAllSettingsMOTDToNotices(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	// In TestMigrateSettingsMOTDToNotices below, we test the actual migration in more detail. Here
 	// we add 2 settings document that need migration (1 valid, 1 with an error). This makes this
@@ -70,7 +71,8 @@ func TestMigrateSettingsMOTDToNotices(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	check := func(t *testing.T, subject api.SettingsSubject, wantChanged bool, wantContents string) {
 		t.Helper()

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -56,7 +56,8 @@ func Test_serveReposList(t *testing.T) {
 	}
 
 	t.Run("all repos are returned for non-sourcegraph.com", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
+		dbtesting.SetupGlobalTestDB(t)
+		ctx := context.Background()
 		qs := []string{
 			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/alice/rabbitmq', 'github.com/alice/rabbitmq', '2015-01-01', '2016-01-01', '', '')`,
 			`INSERT INTO repo(uri, name, created_at, updated_at, description, language) VALUES ('github.com/bob/jabberd', 'github.com/bob/jabberd', '2001-01-01', '2019-01-01', '', '')`,
@@ -78,7 +79,8 @@ func Test_serveReposList(t *testing.T) {
 	})
 
 	t.Run("only default repos are returned for sourcegraph.com", func(t *testing.T) {
-		ctx := dbtesting.TestContext(t)
+		dbtesting.SetupGlobalTestDB(t)
+		ctx := context.Background()
 		qs := []string{
 			`INSERT INTO repo(id, name) VALUES (1, 'github.com/vim/vim')`,
 			`INSERT INTO repo(id, name) VALUES (2, 'github.com/torvalds/linux')`,

--- a/enterprise/cmd/frontend/internal/dotcom/billing/customers_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/customers_test.go
@@ -1,6 +1,7 @@
 package billing
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -9,7 +10,8 @@ import (
 )
 
 func TestGetOrAssignUserCustomerID(t *testing.T) {
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	c := 0
 	mockCreateCustomerID = func(userID int32) (string, error) {

--- a/enterprise/cmd/frontend/internal/dotcom/billing/db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/db_test.go
@@ -1,6 +1,7 @@
 package billing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
@@ -13,7 +14,8 @@ func init() {
 }
 
 func TestDBUsersBillingCustomerID(t *testing.T) {
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	t.Run("existing user", func(t *testing.T) {
 		u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -1,6 +1,7 @@
 package productsubscription
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
@@ -8,7 +9,8 @@ import (
 )
 
 func TestProductLicenses_Create(t *testing.T) {
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
@@ -60,7 +62,8 @@ func TestProductLicenses_List(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	u1, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
@@ -1,6 +1,7 @@
 package productsubscription
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -9,7 +10,8 @@ import (
 )
 
 func TestProductSubscriptions_Create(t *testing.T) {
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
@@ -56,7 +58,8 @@ func TestProductSubscriptions_List(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	u1, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
 	if err != nil {
@@ -118,7 +121,8 @@ func TestProductSubscriptions_List(t *testing.T) {
 }
 
 func TestProductSubscriptions_Update(t *testing.T) {
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -39,7 +40,8 @@ func TestRegistryExtensions_validNames(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
@@ -67,7 +69,8 @@ func TestRegistryExtensions(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	testGetByID := func(t *testing.T, id int32, want *dbExtension, wantPublisherName string) {
 		t.Helper()
@@ -334,7 +337,8 @@ func TestRegistryExtensions_ListCount(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	testList := func(t *testing.T, opt dbExtensionsListOptions, want []*dbExtension) {
 		t.Helper()

--- a/enterprise/cmd/frontend/internal/registry/releases_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -14,7 +15,8 @@ func TestRegistryExtensionReleases(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	user, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {

--- a/pkg/db/confdb/confdb_test.go
+++ b/pkg/db/confdb/confdb_test.go
@@ -1,6 +1,7 @@
 package confdb
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -12,7 +13,8 @@ func TestCriticalGetLatestDefault(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	latest, err := CriticalGetLatest(ctx)
 	if err != nil {
@@ -29,7 +31,8 @@ func TestCriticalCreate_RejectInvalidJSON(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	malformedJSON := "[This is malformed.}"
 
@@ -154,7 +157,8 @@ func TestCriticalCreateIfUpToDate(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := dbtesting.TestContext(t)
+			dbtesting.SetupGlobalTestDB(t)
+			ctx := context.Background()
 			for _, p := range test.sequence {
 				output, err := CriticalCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents)
 				if err != nil {

--- a/pkg/db/dbtesting/dbtesting.go
+++ b/pkg/db/dbtesting/dbtesting.go
@@ -2,7 +2,6 @@
 package dbtesting
 
 import (
-	"context"
 	"database/sql"
 	"hash/fnv"
 	"io"
@@ -37,7 +36,7 @@ func useFastPasswordMocks() {
 	}
 }
 
-// BeforeTest functions are called before each test is run (by TestContext).
+// BeforeTest functions are called before each test is run (by SetupGlobalTestDB).
 var BeforeTest []func()
 
 // DBNameSuffix must be set by DB test packages at init time to a value that is unique among all
@@ -50,13 +49,14 @@ var (
 	connectErr  error
 )
 
-// TestContext constructs a new context that holds a temporary test DB
-// handle and other test configuration.
+// SetupGlobalTestDB creates a temporary test DB handle, sets
+// `dbconn.Global` to it and setups other test configuration.
 //
-// Callers (other than github.com/sourcegraph/sourcegraph/cmd/frontend/db) must set a name in this
-// package's DBNameSuffix var that is unique among all other test packages that call TestContext, so
-// that each package's tests run in separate DBs and do not conflict.
-func TestContext(t testing.TB) context.Context {
+// Callers (other than github.com/sourcegraph/sourcegraph/cmd/frontend/db) must
+// set a name in this package's DBNameSuffix var that is unique among all other
+// test packages that call SetupGlobalTestDB, so that each package's
+// tests run in separate DBs and do not conflict.
+func SetupGlobalTestDB(t testing.TB) {
 	useFastPasswordMocks()
 
 	if testing.Short() {
@@ -74,15 +74,11 @@ func TestContext(t testing.TB) context.Context {
 		t.Fatal("Could not connect to DB", connectErr)
 	}
 
-	ctx := context.Background()
-
 	for _, f := range BeforeTest {
 		f()
 	}
 
 	emptyDBPreserveSchema(t, dbconn.Global)
-
-	return ctx
 }
 
 func emptyDBPreserveSchema(t testing.TB, d *sql.DB) {

--- a/pkg/db/dbtesting/dbtesting.go
+++ b/pkg/db/dbtesting/dbtesting.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 )
 
@@ -76,7 +75,6 @@ func TestContext(t testing.TB) context.Context {
 	}
 
 	ctx := context.Background()
-	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	for _, f := range BeforeTest {
 		f()

--- a/pkg/db/globalstatedb/globalstatedb_test.go
+++ b/pkg/db/globalstatedb/globalstatedb_test.go
@@ -1,6 +1,7 @@
 package globalstatedb
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -15,7 +16,8 @@ func TestGet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 	config, err := Get(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -71,7 +73,8 @@ func TestManagementConsoleState(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := dbtesting.TestContext(t)
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
 
 	// Site must be initialized to get mgmt console state.
 	mgmt, err := getManagementConsoleState(ctx)


### PR DESCRIPTION
We (@tsenart and I) ran into an issue where the user we created in our GraphQL test was automatically the `CurrentUser` in the resolver, even though we never set it.

Turns out that by it was the current user by _accident_ because the previous `dbtesting.TestContext` set an actor with the same UID on the context. Finding that took a long time.

So we decided to get rid of the side-effect and not set the actor in the function. Only 4 tests broke and we could easily fix those by setting an actor manually.

Then we realized that the `ctx` returned by `TestContext` doesn't have any test specific test information anymore and is just `context.Background()`, so we changed `TestContext` to not return a `ctx` anymore.

After that, the only thing `TestContext` did was (1) setup a test database and (2) set the global state so this test database is used. So we renamed it.

Testplan: `go test ./...`