### PR TITLE
fix: update so usage of guest users is subject to a valid license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a new, _required_ `aws_codecommit.gitCredentials` setting to the [AWS CodeCommit external service config](https://docs.sourcegraph.com/admin/external_service/aws_codecommit#configuration). These Git credentials are required to create long-lived authenticated clone URLs for AWS CodeCommit repositories. For more information about Git credentials, see the AWS CodeCommit documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html#git-credentials-code-commit. For detailed instructions on how to create the credentials in IAM, see this page: https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html
 - Added support for specifying a URL formatted `gitolite.host` setting in [Gitolite external service config](https://docs.sourcegraph.com/admin/external_service/gitolite#configuration) (e.g. `ssh://git@gitolite.example.org:2222/`), in addition to the already supported SCP like format (e.g `git@gitolite.example.org`)
 - Added support for overriding critical, site, and external service configurations via files. Specify `CRITICAL_CONFIG_FILE=critical.json`, `SITE_CONFIG_FILE=site.json`, and/or `EXTSVC_CONFIG_FILE=extsvc.json` on the `frontend` container to do this.
+- Added enforcement of having a valid license for usage of unlimited guest (anonymous) users.
 
 ### Changed
 

--- a/enterprise/cmd/frontend/internal/dotcom/billing/plans.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/plans.go
@@ -13,8 +13,8 @@ import (
 // InfoForProductPlan returns the license key tags and min quantity that should be used for the
 // given product plan.
 //
-// License key tags indicate which product variant (e.g., Enterprise vs. Enterprise Starter), so
-// they are stored on the billing system in the metadata of the product plans.
+// License key tags indicate which product variant (e.g., Enterprise vs. Enterprise Plus vs.
+// Elite), so they are stored on the billing system in the metadata of the product plans.
 func InfoForProductPlan(ctx context.Context, planID string) (licenseTags []string, minQuantity *int32, err error) {
 	params := &stripe.PlanParams{Params: stripe.Params{Context: ctx}}
 	params.AddExpand("product")

--- a/enterprise/cmd/frontend/internal/dotcom/billing/plans.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/plans.go
@@ -13,8 +13,8 @@ import (
 // InfoForProductPlan returns the license key tags and min quantity that should be used for the
 // given product plan.
 //
-// License key tags indicate which product variant (e.g., Enterprise vs. Enterprise Plus vs.
-// Elite), so they are stored on the billing system in the metadata of the product plans.
+// License key tags indicate which product variant (e.g., Enterprise vs. Enterprise Starter), so
+// they are stored on the billing system in the metadata of the product plans.
 func InfoForProductPlan(ctx context.Context, planID string) (licenseTags []string, minQuantity *int32, err error) {
 	params := &stripe.PlanParams{Params: stripe.Params{Context: ctx}}
 	params.AddExpand("product")

--- a/enterprise/cmd/frontend/internal/licensing/features_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/features_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/pkg/license"
+	"github.com/sourcegraph/sourcegraph/pkg/conf"
 )
 
 func TestIsFeatureEnabled(t *testing.T) {
-	check := func(t *testing.T, feature Feature, licenseTags []string, wantEnabled bool) {
+	check := func(t *testing.T, feature conf.Feature, licenseTags []string, wantEnabled bool) {
 		t.Helper()
 		got := isFeatureEnabled(license.Info{Tags: licenseTags}, feature)
 		if got != wantEnabled {
@@ -15,14 +16,25 @@ func TestIsFeatureEnabled(t *testing.T) {
 		}
 	}
 
+	t.Run(string(conf.FeatureGuestUsers), func(t *testing.T) {
+		check(t, FeatureACLs, EnterpriseStarterTags, false)
+		check(t, FeatureACLs, EnterpriseTags, false)
+		check(t, FeatureACLs, EnterprisePlusTags, false)
+		check(t, FeatureACLs, EliteTags, true)
+	})
+
 	t.Run(string(FeatureACLs), func(t *testing.T) {
 		check(t, FeatureACLs, EnterpriseStarterTags, false)
 		check(t, FeatureACLs, EnterpriseTags, true)
+		check(t, FeatureACLs, EnterprisePlusTags, true)
+		check(t, FeatureACLs, EliteTags, true)
 	})
 
 	t.Run(string(FeatureExtensionRegistry), func(t *testing.T) {
 		check(t, FeatureExtensionRegistry, EnterpriseStarterTags, false)
-		check(t, FeatureExtensionRegistry, EnterpriseTags, true)
+		check(t, FeatureExtensionRegistry, EnterpriseTags, false)
+		check(t, FeatureExtensionRegistry, EnterprisePlusTags, false)
+		check(t, FeatureExtensionRegistry, EliteTags, true)
 		check(t, FeatureExtensionRegistry, []string{string(FeatureExtensionRegistry)}, true)
 	})
 }

--- a/enterprise/cmd/frontend/internal/licensing/features_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/features_test.go
@@ -17,10 +17,10 @@ func TestIsFeatureEnabled(t *testing.T) {
 	}
 
 	t.Run(string(conf.FeatureGuestUsers), func(t *testing.T) {
-		check(t, FeatureACLs, EnterpriseStarterTags, false)
-		check(t, FeatureACLs, EnterpriseTags, false)
-		check(t, FeatureACLs, EnterprisePlusTags, false)
-		check(t, FeatureACLs, EliteTags, true)
+		check(t, conf.FeatureGuestUsers, EnterpriseStarterTags, false)
+		check(t, conf.FeatureGuestUsers, EnterpriseTags, false)
+		check(t, conf.FeatureGuestUsers, EnterprisePlusTags, false)
+		check(t, conf.FeatureGuestUsers, EliteTags, true)
 	})
 
 	t.Run(string(FeatureACLs), func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/licensing/tags.go
+++ b/enterprise/cmd/frontend/internal/licensing/tags.go
@@ -7,6 +7,12 @@ const (
 	// of Enterprise features).
 	EnterpriseStarterTag = "starter"
 
+	// EnterprisePlusTag is the license tag for the Sourcegraph Enterprise Plus tier.
+	EnterprisePlusTag = "plus"
+
+	// EliteTag is the license tag for the Sourcegraph Elite tier.
+	EliteTag = "elite"
+
 	// TrueUpUserCountTag is the license tag that indicates that the licensed user count can be
 	// exceeded and will be charged later.
 	TrueUpUserCountTag = "true-up"
@@ -19,6 +25,12 @@ var (
 	// EnterpriseTags is the license tags for Enterprise (intentionally empty because it has no
 	// feature restrictions)
 	EnterpriseTags = []string{}
+
+	// EnterprisePlusTags is the license tags for Enterprise Plus.
+	EnterprisePlusTags = []string{EnterprisePlusTag}
+
+	// EliteTags is the license tags for Elite.
+	EliteTags = []string{EliteTag}
 )
 
 // ProductNameWithBrand returns the product name with brand (e.g., "Sourcegraph Enterprise") based
@@ -37,9 +49,18 @@ func ProductNameWithBrand(hasLicense bool, licenseTags []string) string {
 		return false
 	}
 
-	var name string
+	var name = " Enterprise"
+	// DEPRECATED: the Starter product is no longer available for new customers
 	if hasTag("starter") {
-		name = " Starter"
+		name = " Enterprise Starter"
+	}
+
+	if hasTag("plus") {
+		name = " Enterprise Plus"
+	}
+
+	if hasTag("elite") {
+		name = " Elite"
 	}
 
 	var misc []string
@@ -53,5 +74,5 @@ func ProductNameWithBrand(hasLicense bool, licenseTags []string) string {
 		name += " (" + strings.Join(misc, ", ") + ")"
 	}
 
-	return "Sourcegraph Enterprise" + name
+	return "Sourcegraph" + name
 }

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -71,6 +71,9 @@ func initLicensing() {
 	// proper product name.
 	graphqlbackend.GetProductNameWithBrand = licensing.ProductNameWithBrand
 
+	// Make the OSS conf.CheckFeature function use the proper license checks.
+	conf.CheckFeature = licensing.CheckFeature
+
 	// Make the Site.productSubscription.actualUserCount and Site.productSubscription.actualUserCountDate
 	// GraphQL fields return the proper max user count and timestamp on the current license.
 	graphqlbackend.ActualUserCount = licensing.ActualUserCount

--- a/pkg/conf/auth.go
+++ b/pkg/conf/auth.go
@@ -1,6 +1,8 @@
 package conf
 
-import "github.com/sourcegraph/sourcegraph/schema"
+import (
+	"github.com/sourcegraph/sourcegraph/schema"
+)
 
 // AuthProviderType returns the type string for the auth provider.
 func AuthProviderType(p schema.AuthProviders) string {
@@ -23,10 +25,15 @@ func AuthProviderType(p schema.AuthProviders) string {
 }
 
 // AuthPublic reports whether the site is public. Currently only the builtin auth provider allows
-// sites to be public. AuthPublic only returns true if auth.public (in site config) is true *and*
-// there is a builtin auth provider.
+// sites to be public. Public (guest) users is a paid feature. AuthPublic only returns true if
+// auth.public (in site config) is true *and* there is a builtin auth provider *and* there is a
+// valid license key.
 func AuthPublic() bool { return authPublic(Get()) }
 func authPublic(c *Unified) bool {
+	if err := CheckFeature(FeatureGuestUsers); err != nil {
+		return false
+	}
+
 	for _, p := range c.Critical.AuthProviders {
 		if p.Builtin != nil && c.Critical.AuthPublic {
 			return true

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -126,3 +126,18 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 // FormatOptions is the default format options that should be used for jsonx
 // edit computation.
 var FormatOptions = jsonx.FormatOptions{InsertSpaces: true, TabSize: 2, EOL: "\n"}
+
+// Feature is a product feature that is selectively activated based on the current license key.
+type Feature string
+
+const (
+	// FeatureGuestUsers is whether an instance is allowed to have unlimited guests (i.e., anonymous,
+	// with no user account).
+	FeatureGuestUsers Feature = "guests"
+)
+
+// CheckFeature checks whether the feature is activated based on the current license. Any feature
+// that exists to be checked in OSS code is automatically available to OSS builds.
+var CheckFeature = func(feature Feature) error {
+	return nil // feature is activated for current license
+}

--- a/schema/critical.schema.json
+++ b/schema/critical.schema.json
@@ -113,7 +113,7 @@
       "default": [{ "type": "builtin", "allowSignup": true }]
     },
     "auth.public": {
-      "description": "Allows anonymous visitors full read access to repositories, code files, search, and other data (except site configuration).\n\nSECURITY WARNING: If you enable this, you must ensure that only authorized users can access the server (using firewall rules or an external proxy, for example).\n\nRequires usage of the builtin authentication provider.",
+      "description": "Allows anonymous visitors full read access to repositories, code files, search, and other data (except site configuration).\n\nSECURITY WARNING: If you enable this, you must ensure that only authorized users can access the server (using firewall rules or an external proxy, for example).\n\nRequires usage of the builtin authentication provider\n\nNote: this is a paid feature and only available with a valid license key.",
       "type": "boolean",
       "default": false,
       "group": "Authentication"

--- a/schema/critical_stringdata.go
+++ b/schema/critical_stringdata.go
@@ -118,7 +118,7 @@ const CriticalSchemaJSON = `{
       "default": [{ "type": "builtin", "allowSignup": true }]
     },
     "auth.public": {
-      "description": "Allows anonymous visitors full read access to repositories, code files, search, and other data (except site configuration).\n\nSECURITY WARNING: If you enable this, you must ensure that only authorized users can access the server (using firewall rules or an external proxy, for example).\n\nRequires usage of the builtin authentication provider.",
+      "description": "Allows anonymous visitors full read access to repositories, code files, search, and other data (except site configuration).\n\nSECURITY WARNING: If you enable this, you must ensure that only authorized users can access the server (using firewall rules or an external proxy, for example).\n\nRequires usage of the builtin authentication provider\n\nNote: this is a paid feature and only available with a valid license key.",
       "type": "boolean",
       "default": false,
       "group": "Authentication"


### PR DESCRIPTION
Per Sourcegraph [pricing](https://about.sourcegraph.com/pricing/), having unlimited guest users requires a valid Sourcegraph Elite license key. This PR adds enforcement.

A few questions/downsides:

- Should the additions to conf.go go into a separate OSS package? Not sure the right home.
- Stripe billing and associated code still needs to be updated to match new product tiers.
- Several features that have been moved into higher tier plans (such as Enterprise Plus) are already in use by existing Enterprise customers (such as ACLs). It seems as though this is fixable via [the check on this line](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/frontend/internal/licensing/features.go#L34:2) but this will require re-issuing new license keys to all affected customers.
- My biggest concern: there's no way (that I can find?) to show an error in the management console to the admin who attempts to set `"auth.public" = true`... Instead, this will just silently fail. Any suggestions here? Do we have a good way to share errors during config updates, or alternatively, to show errors to admins asynchronously?

CC @juliasourceress 