### PR TITLE
run dev prometheus and grafana as current user

### DIFF
--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -33,6 +33,7 @@ docker run --rm  --cidfile ${CID_FILE} \
     --name=grafana \
     --cpus=1 \
     --memory=1g \
+    --user=$UID \
     -p 0.0.0.0:3000:3000 \
     -v ${GRAFANA_DISK}:/var/lib/grafana \
     -v ${DIR}/grafana/${CONFIG_SUB_DIR}:/sg_config_grafana/provisioning/datasources \
@@ -43,6 +44,7 @@ docker run --rm  --cidfile ${CID_FILE} \
     -e GF_USERS_AUTO_ASSIGN_ORG='true' \
     -e GF_USERS_AUTO_ASSIGN_ORG_ROLE=Editor \
     sourcegraph/grafana:6.3.3 >> ${GRAFANA_DISK}/logs/grafana.log 2>&1 &
+wait $!
 
 # Add the following lines above if you wish to use an auth proxy with Grafana:
 #

--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -34,6 +34,7 @@ docker run --rm ${NET_ARG} --cidfile ${CID_FILE} \
     --name=prometheus \
     --cpus=4 \
     --memory=4g \
+    --user=$UID \
     -p 0.0.0.0:9090:9090 \
     -v ${PROMETHEUS_DISK}:/prometheus \
     -v ${DIR}/prometheus/${CONFIG_SUB_DIR}:/sg_prometheus_add_ons \


### PR DESCRIPTION
Without this, if the Docker user can't write to the `$USER`'s `$PROMETHEUS_DISK` dir, then the container fails to start with the following error logs:

```
level=info ts=2019-09-10T01:57:57.823Z caller=main.go:293 msg="no time or size retention was set so using the default time retention" duration=15d
level=info ts=2019-09-10T01:57:57.823Z caller=main.go:329 msg="Starting Prometheus" version="(version=2.12.0, branch=HEAD, revision=43acd0e2e93f9f70c49b2267efa0124f1e759e86)"
level=info ts=2019-09-10T01:57:57.823Z caller=main.go:330 build_context="(go=go1.12.8, user=root@7a9dbdbe0cc7, date=20190818-13:53:16)"
level=info ts=2019-09-10T01:57:57.823Z caller=main.go:331 host_details="(Linux 4.18.0-25-generic #26-Ubuntu SMP Mon Jun 24 09:32:08 UTC 2019 x86_64 xq (none))"
level=info ts=2019-09-10T01:57:57.823Z caller=main.go:332 fd_limits="(soft=1048576, hard=1048576)"
level=info ts=2019-09-10T01:57:57.823Z caller=main.go:333 vm_limits="(soft=unlimited, hard=unlimited)"
level=error ts=2019-09-10T01:57:57.823Z caller=query_logger.go:82 component=activeQueryTracker msg="Error opening query log file" file=/prometheus/queries.active err="open /prometheus/queries.active: permission denied"
panic: Unable to create mmap-ed active query log

goroutine 1 [running]:
github.com/prometheus/prometheus/promql.NewActiveQueryTracker(0x7ffe372a1ef4, 0xb, 0x14, 0x2a6b7c0, 0xc0007be510, 0x2a6b7c0)
	/app/promql/query_logger.go:112 +0x4d2
main.main()
```

This causes the entire dev server goreman process to terminate.

(And same, in theory, would happen for the Grafana container, if it didn't have `wait $!`, so I added that.)