### PR TITLE
repo-updater: Add feature-flagged `StreamingSync` method to `Syncer`

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -33,6 +34,8 @@ import (
 const port = "3182"
 
 func main() {
+	streamingSyncer, _ := strconv.ParseBool(env.Get("SRC_STREAMING_SYNCER_ENABLED", "false", "Use the new, streaming repo metadata syncer."))
+
 	ctx := context.Background()
 	env.Lock()
 	env.HandleHelpFlag()
@@ -129,7 +132,7 @@ func main() {
 	server.Syncer = syncer
 
 	if !envvar.SourcegraphDotComMode() {
-		go func() { log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval())) }()
+		go func() { log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval(), streamingSyncer)) }()
 	}
 
 	gps := repos.NewGitolitePhabricatorMetadataSyncer(store)

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -132,7 +132,13 @@ func main() {
 	server.Syncer = syncer
 
 	if !envvar.SourcegraphDotComMode() {
-		go func() { log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval(), streamingSyncer)) }()
+		go func() {
+			if streamingSyncer {
+				log.Fatal(syncer.StreamingRun(ctx, repos.GetUpdateInterval()))
+			} else {
+				log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval()))
+			}
+		}()
 	}
 
 	gps := repos.NewGitolitePhabricatorMetadataSyncer(store)

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -54,8 +54,9 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/UpsertRepos", testStoreUpsertRepos(store)},
 		{"DBStore/ListRepos", testStoreListRepos(store)},
 		{"DBStore/ListRepos/Pagination", testStoreListReposPagination(store)},
-		{"DBStore/Syncer/Sync", testSyncerSync(store)},
+		{"DBStore/Syncer/Sync", testSyncerSync(store, false)},
 		{"DBStore/Syncer/SyncSubset", testSyncSubset(store)},
+		{"DBStore/Syncer/StreamingSync", testSyncerSync(store, true)},
 	} {
 		t.Run(tc.name, tc.test)
 	}

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -27,6 +27,7 @@ type Store interface {
 
 	ListRepos(context.Context, StoreListReposArgs) ([]*Repo, error)
 	UpsertRepos(ctx context.Context, repos ...*Repo) error
+	DeleteReposExcept(ctx context.Context, ids ...uint32) error
 
 	ListAllRepoNames(context.Context) ([]api.RepoName, error)
 }
@@ -507,6 +508,38 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 		if err != nil {
 			return errors.Wrap(err, op.name)
 		}
+	}
+
+	return nil
+}
+
+func deleteReposExceptQuery(ids ...uint32) *sqlf.Query {
+	queryIDs := make([]*sqlf.Query, 0, len(ids))
+	for _, id := range ids {
+		if id != 0 {
+			queryIDs = append(queryIDs, sqlf.Sprintf("%d", id))
+		}
+	}
+	return sqlf.Sprintf("DELETE FROM repo WHERE id NOT in (%s)", sqlf.Join(queryIDs, ","))
+}
+
+// DeleteReposExcept deletes every repo in the repos table except the given repos
+func (s *DBStore) DeleteReposExcept(ctx context.Context, ids ...uint32) (err error) {
+	var q *sqlf.Query
+
+	if len(ids) == 0 {
+		q = sqlf.Sprintf("DELETE FROM repo")
+	} else {
+		q = deleteReposExceptQuery(ids...)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return errors.Wrap(err, "delete-repos-except")
+	}
+
+	if err = rows.Close(); err != nil {
+		return errors.Wrap(err, "delete-repos-except")
 	}
 
 	return nil

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -57,10 +57,16 @@ func NewSyncer(
 }
 
 // Run runs the Sync at the specified interval.
-func (s *Syncer) Run(ctx context.Context, interval time.Duration) error {
+func (s *Syncer) Run(ctx context.Context, interval time.Duration, useStreaming bool) error {
 	for ctx.Err() == nil {
-		if _, err := s.Sync(ctx); err != nil {
-			log15.Error("Syncer", "error", err)
+		if useStreaming {
+			if err := s.StreamingSync(ctx); err != nil {
+				log15.Error("Syncer", "error", err)
+			}
+		} else {
+			if _, err := s.Sync(ctx); err != nil {
+				log15.Error("Syncer", "error", err)
+			}
 		}
 
 		select {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -156,8 +156,8 @@ func (s *Syncer) StreamingSync(ctx context.Context) (err error) {
 		seenID:   make(map[api.ExternalRepoSpec]bool),
 		seenName: make(map[string]bool),
 	}
-	var errs *multierror.Error
 
+	var errs *multierror.Error
 	for result := range sourced {
 		if result.Err != nil {
 			for _, extSvc := range result.Source.ExternalServices() {
@@ -169,6 +169,9 @@ func (s *Syncer) StreamingSync(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
+	}
+	if err = errs.ErrorOrNil(); err != nil {
+		return errors.Wrap(err, "syncer.streaming-sync.sourcing")
 	}
 
 	// In `byID` are now all repositories that we want to keep in the database
@@ -189,7 +192,7 @@ func (s *Syncer) StreamingSync(ctx context.Context) (err error) {
 		return errors.Wrap(err, "syncer.streaming-sync.store.delete-repos-except")
 	}
 
-	return errs.ErrorOrNil()
+	return err
 }
 
 func (s *Syncer) syncSourcedRepo(ctx context.Context, state *syncRunState, r *Repo) (err error) {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	multierror "github.com/hashicorp/go-multierror"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
@@ -124,6 +125,207 @@ func (s *Syncer) Sync(ctx context.Context) (diff Diff, err error) {
 	return diff, nil
 }
 
+type syncRunState struct {
+	byID     map[api.ExternalRepoSpec]*Repo
+	byName   map[string]*Repo
+	seenID   map[api.ExternalRepoSpec]bool
+	seenName map[string]bool
+}
+
+// StreamingSync streams repositories when syncing
+func (s *Syncer) StreamingSync(ctx context.Context) (err error) {
+	ctx, save := s.observe(ctx, "Syncer.StreamingSync", "")
+	defer save(&Diff{}, &err)
+	defer s.setOrResetLastSyncErr(&err)
+
+	if s.FailFullSync {
+		return errors.New("Syncer is not enabled")
+	}
+
+	sourcedCtx, cancel := context.WithTimeout(ctx, sourceTimeout)
+	defer cancel()
+
+	sourced, err := s.asyncSourced(sourcedCtx)
+	if err != nil {
+		return errors.Wrap(err, "syncer.streaming-sync.async-sourced")
+	}
+
+	state := &syncRunState{
+		byID:     make(map[api.ExternalRepoSpec]*Repo),
+		byName:   make(map[string]*Repo),
+		seenID:   make(map[api.ExternalRepoSpec]bool),
+		seenName: make(map[string]bool),
+	}
+	var errs *multierror.Error
+
+	for result := range sourced {
+		if result.Err != nil {
+			for _, extSvc := range result.Source.ExternalServices() {
+				errs = multierror.Append(errs, &SourceError{Err: result.Err, ExtSvc: extSvc})
+			}
+			continue
+		}
+		err := s.syncSourcedRepo(ctx, state, result.Repo)
+		if err != nil {
+			return err
+		}
+	}
+
+	// In `byID` are now all repositories that we want to keep in the database
+	// We use `byID` for that instead of a separate slice, because when we come
+	// across repositories with the same, we choose a winner and discard the repo
+	// by deleting it from `byID`.
+	// We _could_ delete the discarded repo with a `DELETE` query directly,
+	// but this way, we only do a single `DELETE` at the end.
+	reposToKeep := make([]uint32, 0, len(state.byID))
+	for _, r := range state.byID {
+		if r.ID == 0 {
+			panic("repo has 0 id!")
+		}
+		reposToKeep = append(reposToKeep, r.ID)
+	}
+
+	if err = s.store.DeleteReposExcept(ctx, reposToKeep...); err != nil {
+		return errors.Wrap(err, "syncer.streaming-sync.store.delete-repos-except")
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func (s *Syncer) syncSourcedRepo(ctx context.Context, state *syncRunState, r *Repo) (err error) {
+	if !r.ExternalRepo.IsSet() {
+		panic(fmt.Errorf("%s has no valid external repo spec: %s", r.Name, r.ExternalRepo))
+	}
+
+	var (
+		txs              TxStore
+		closeTransaction = false
+		store            = s.store
+	)
+	if tr, ok := s.store.(Transactor); ok {
+		if txs, err = tr.Transact(ctx); err != nil {
+			return errors.Wrap(err, "syncer.syncsubset.transact")
+		}
+		closeTransaction = true
+		store = txs
+	}
+
+	merged := false
+	if old := state.byID[r.ExternalRepo]; old != nil {
+		// We use `Less` here in order to deterministically merge repos.
+		// e.g. with two repos that have the same name, one lower- one
+		// uppercase, the same one would always win
+		if r.Less(old) {
+			merge(r, old)
+		} else {
+			merge(old, r)
+		}
+		merged = true
+	}
+
+	// Ensure names are unique case-insensitively. We don't merge when finding
+	// a conflict on name, we deterministically pick which sourced repo to
+	// keep. Can't merge since they represent different repositories
+	// (different external ID).
+	k := strings.ToLower(r.Name)
+	if old := state.byName[k]; old == nil {
+		state.byName[k] = r
+	} else if !merged {
+		// Only discard repo if we didn't previously merge `r` with another
+		// one.
+
+		// If we previously merged, there _is_ going to be a naming
+		// confict, in which case we don't want to discard the merged
+		// repo.
+
+		keep, discard := pick(r, old)
+		state.byName[k] = keep
+		delete(state.byID, discard.ExternalRepo)
+	}
+
+	storedSubset, err := s.listMatchesForSourcedRepo(ctx, store, r)
+	if err != nil {
+		return errors.Wrap(err, "syncer.streaming-sync.store.list-repos")
+	}
+
+	diff := Diff{}
+	for _, old := range storedSubset {
+		var src *Repo
+		if r.ExternalRepo == old.ExternalRepo {
+			src = r
+		}
+
+		// We do not want a stored repository without an externalrepo to be set.
+		//
+		// We are unsure if customer repositories can have ExternalRepo unset. We
+		// know it can be unset for Sourcegraph.com. As such, we want to fallback
+		// to associating stored repositories by name with the sourced
+		// repositories.
+		// But only if we didn't previously associate the stored repo with
+		// another repo that we sourced.
+		if old.ExternalRepo.ID == "" && !state.seenName[old.Name] {
+			src = state.byName[strings.ToLower(old.Name)]
+		}
+
+		if src == nil {
+			diff.Deleted = append(diff.Deleted, old)
+			continue
+		}
+
+		if old.Update(src) {
+			diff.Modified = append(diff.Modified, old)
+		} else {
+			diff.Unmodified = append(diff.Unmodified, old)
+		}
+		state.seenID[old.ExternalRepo] = true
+		state.seenName[old.Name] = true
+	}
+
+	if !state.seenID[r.ExternalRepo] {
+		diff.Added = append(diff.Added, r)
+	}
+
+	if err = store.UpsertRepos(ctx, s.upserts(diff)...); err != nil {
+		return errors.Wrap(err, "syncer.streaming-sync.store.upsert-repos")
+	}
+
+	// Added, Unmodified, Modified are all repos that are in the database
+	// now.
+	// We keep track of them so we can `merge` them with the repos that
+	// will come over `results`.
+	// That allows us to
+	// (1) avoid duplicates (i.e. same repo from the same external service)
+	// (2) merge sources of same repo (i.e. same repo from different same external services)
+	for _, r := range diff.ReposExceptDeleted() {
+		state.byID[r.ExternalRepo] = r
+		state.byName[strings.ToLower(r.Name)] = r
+	}
+
+	if closeTransaction {
+		txs.Done(&err)
+	}
+
+	return nil
+}
+
+func (s *Syncer) listMatchesForSourcedRepo(ctx context.Context, store Store, r *Repo) (Repos, error) {
+	var storedSubset Repos
+	args := StoreListReposArgs{
+		Names:         []string{r.Name},
+		ExternalRepos: []api.ExternalRepoSpec{r.ExternalRepo},
+		UseOr:         true,
+	}
+
+	storedSubset, err := store.ListRepos(ctx, args)
+	if err != nil {
+		return storedSubset, err
+	}
+
+	sort.Stable(byExternalRepoSpecSet(storedSubset))
+
+	return storedSubset, nil
+}
+
 // SyncSubset runs the syncer on a subset of the stored repositories. It will
 // only sync the repositories with the same name or external service spec as
 // sourcedSubset repositories.
@@ -234,6 +436,19 @@ func (d Diff) Repos() Repos {
 	return all
 }
 
+// ReposExceptDeleted returns all repos in the Diff except the repos in Deleted.
+func (d Diff) ReposExceptDeleted() Repos {
+	all := make(Repos, 0, len(d.Added)+
+		len(d.Modified)+
+		len(d.Unmodified))
+
+	for _, rs := range []Repos{d.Added, d.Modified, d.Unmodified} {
+		all = append(all, rs...)
+	}
+
+	return all
+}
+
 // NewDiff returns a diff from the given sourced and stored repos.
 func NewDiff(sourced, stored []*Repo) (diff Diff) {
 	// Sort sourced so we merge determinstically
@@ -326,6 +541,27 @@ func (s *Syncer) sourced(ctx context.Context) ([]*Repo, error) {
 	defer cancel()
 
 	return listAll(ctx, srcs)
+}
+
+func (s *Syncer) asyncSourced(ctx context.Context) (chan SourceResult, error) {
+	svcs, err := s.store.ListExternalServices(ctx, StoreListExternalServicesArgs{})
+	if err != nil {
+		return nil, err
+	}
+
+	srcs, err := s.sourcer(svcs...)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(chan SourceResult)
+
+	go func() {
+		srcs.ListRepos(ctx, results)
+		close(results)
+	}()
+
+	return results, nil
 }
 
 func (s *Syncer) setOrResetLastSyncErr(perr *error) {

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -202,7 +202,7 @@ func (s *FakeStore) DeleteReposExcept(ctx context.Context, ids ...uint32) error 
 	}
 
 	deletes := []uint32{}
-	for id, _ := range s.repoByID {
+	for id := range s.repoByID {
 		if !seen[id] {
 			deletes = append(deletes, id)
 		}


### PR DESCRIPTION
(See bottom for context on this PR)

This PR adds a `StreamingSync` method to the `Syncer` in `repo-updater` that inserts/updates repositories one-by-one, while they're being fetched from the code hosts.

As you can see, there's not _that much_ code here: a helper method on the repos store called `DeleteReposExcept` and the rather (too?) long method called `StreamingSync`. I've annotated it with comments for my own understanding, but that might also give you context when reading through it.

I've also changed the existing Syncer tests to also run with this new `StreamingSync` method. The main difference is that when we do a streaming sync, we don't care about the "complete diff" (I don't think that's required, but if we _do_ want that, for debugging purposes, I think that's also possible) in the tests.

See #5145 and previous PR #5366 for more information on the goals/ideas behind this.

---

Since I've now switched to work on the higher-priority A8N RFC20 and RFC28, I thought that I could already gather feedback on this.

But this PR is complete, as in: tests are passing, it works, but the "only" thing missing is extensive testing/analyzing:
* Test this on k8s.sgdev.org
* Analyze the "intermediate phases" of a sync (i.e. do we delete and insert the same repos in a single sync? If so, how many useless writes do we do)
* It's probably wise to port the naming conflict tests from the `TestNewDiff` and `TestSyncSubset` tests to the streaming-sync tests
