### PR TITLE
status-indicator: Remove feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
+- The `statusIndicator` feature flag has been removed from the site configuration's `experimentalFeatures` section. The status indicator has been enabled by default since 3.6.0 and you can now safely remove the feature flag from your configuration.
+
 ## 3.7.1
 
 ### Fixed

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -78,8 +78,6 @@ type JSContext struct {
 	AuthProviders []authProviderInfo `json:"authProviders"`
 
 	Branding *schema.Branding `json:"branding"`
-
-	ShowStatusIndicator bool `json:"showStatusIndicator"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -174,8 +172,6 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		AuthProviders: authProviders,
 
 		Branding: conf.Branding(),
-
-		ShowStatusIndicator: conf.ShowStatusIndicator(),
 	}
 }
 

--- a/pkg/conf/computed.go
+++ b/pkg/conf/computed.go
@@ -301,14 +301,6 @@ func BrandName() string {
 	return branding.BrandName
 }
 
-func ShowStatusIndicator() bool {
-	val := Get().ExperimentalFeatures.StatusIndicator
-	if val == "" {
-		return true
-	}
-	return val == "enabled"
-}
-
 // SearchSymbolsParallelism returns 20, or the site config
 // "debug.search.symbolsParallelism" value if configured.
 func SearchSymbolsParallelism() int {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -237,8 +237,7 @@ type ExcludedGitoliteRepo struct {
 
 // ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 type ExperimentalFeatures struct {
-	Discussions     string `json:"discussions,omitempty"`
-	StatusIndicator string `json:"statusIndicator,omitempty"`
+	Discussions string `json:"discussions,omitempty"`
 }
 
 // Extensions description: Configures Sourcegraph extensions.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -54,12 +54,6 @@
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
-        },
-        "statusIndicator": {
-          "description": "Enables the external service status indicator in the navigation bar.",
-          "type": "string",
-          "enum": ["enabled", "disabled"],
-          "default": "enabled"
         }
       },
       "group": "Experimental",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -59,12 +59,6 @@ const SiteSchemaJSON = `{
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "disabled"
-        },
-        "statusIndicator": {
-          "description": "Enables the external service status indicator in the navigation bar.",
-          "type": "string",
-          "enum": ["enabled", "disabled"],
-          "default": "enabled"
         }
       },
       "group": "Experimental",

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -126,9 +126,6 @@ interface SourcegraphContext {
 
         brandName: string
     }
-
-    /** Whether new external service status indicator is shown in navbar or not. */
-    showStatusIndicator?: boolean
 }
 
 interface BrandAssets {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -123,13 +123,7 @@ export class GlobalNavbar extends React.PureComponent<Props, State> {
                         )}
                     </>
                 )}
-                {!this.state.authRequired && (
-                    <NavLinks
-                        {...this.props}
-                        showStatusIndicator={!!window.context.showStatusIndicator}
-                        showDotComMarketing={showDotComMarketing}
-                    />
-                )}
+                {!this.state.authRequired && <NavLinks {...this.props} showDotComMarketing={showDotComMarketing} />}
             </div>
         )
     }

--- a/web/src/nav/NavLinks.test.tsx
+++ b/web/src/nav/NavLinks.test.tsx
@@ -62,7 +62,6 @@ describe('NavLinks', () => {
         settingsCascade: SETTINGS_CASCADE,
         history,
         isSourcegraphDotCom: false,
-        showStatusIndicator: false,
     }
 
     // The 3 main props that affect the desired contents of NavLinks are whether the user is signed

--- a/web/src/nav/NavLinks.tsx
+++ b/web/src/nav/NavLinks.tsx
@@ -35,7 +35,6 @@ interface Props
     authenticatedUser: GQL.IUser | null
     showDotComMarketing: boolean
     isSourcegraphDotCom: boolean
-    showStatusIndicator: boolean
 }
 
 export class NavLinks extends React.PureComponent<Props> {
@@ -98,7 +97,6 @@ export class NavLinks extends React.PureComponent<Props> {
                     </>
                 )}
                 {!this.props.isSourcegraphDotCom &&
-                    this.props.showStatusIndicator &&
                     this.props.authenticatedUser &&
                     this.props.authenticatedUser.siteAdmin && (
                         <li className="nav-item">


### PR DESCRIPTION
The status indicator has been enabled by default since 3.6.0 and this removes the feature flag.

This fixes #5493