### PR TITLE
Allow running Phabricator e2e test with the browser extension

### DIFF
--- a/browser/src/e2e/phabricator.test.ts
+++ b/browser/src/e2e/phabricator.test.ts
@@ -11,6 +11,7 @@ import { isEqual } from 'lodash'
 const PHABRICATOR_BASE_URL = process.env.PHABRICATOR_BASE_URL || 'http://127.0.0.1'
 const PHABRICATOR_USERNAME = process.env.PHABRICATOR_USERNAME || 'admin'
 const PHABRICATOR_PASSWORD = process.env.PHABRICATOR_PASSWORD || 'sourcegraph'
+const TEST_NATIVE_INTEGRATION = Boolean(process.env.TEST_NATIVE_INTEGRATION)
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
 // command timeout of 30s in order to get the stack trace to point to the
@@ -104,7 +105,7 @@ async function configureSourcegraphIntegration(driver: Driver): Promise<void> {
     const callSignConfigStr = await driver.page.evaluate(() =>
         document.querySelector<HTMLTextAreaElement>('textarea[name="value"]')!.value.trim()
     )
-    const callSignConfig: PhabricatorMapping[] = callSignConfigStr && JSON.parse(callSignConfigStr)
+    const callSignConfig: PhabricatorMapping[] = (callSignConfigStr && JSON.parse(callSignConfigStr)) || []
     const jsonRpc2Mapping: PhabricatorMapping = {
         path: 'github.com/sourcegraph/jsonrpc2',
         callsign: 'JRPC',
@@ -143,7 +144,11 @@ async function init(driver: Driver): Promise<void> {
     await driver.ensureHasCORSOrigin({ corsOriginURL: PHABRICATOR_BASE_URL })
     await phabricatorLogin(driver)
     await addPhabricatorRepo(driver)
-    await configureSourcegraphIntegration(driver)
+    if (TEST_NATIVE_INTEGRATION) {
+        await configureSourcegraphIntegration(driver)
+    } else {
+        await driver.setExtensionSourcegraphUrl()
+    }
 }
 
 describe('Sourcegraph Phabricator extension', () => {
@@ -151,7 +156,7 @@ describe('Sourcegraph Phabricator extension', () => {
 
     beforeAll(async () => {
         try {
-            driver = await createDriverForTest()
+            driver = await createDriverForTest({ loadExtension: !TEST_NATIVE_INTEGRATION })
             await init(driver)
         } catch (err) {
             console.error(err)

--- a/browser/src/libs/phabricator/extension.tsx
+++ b/browser/src/libs/phabricator/extension.tsx
@@ -7,7 +7,6 @@ import { injectCodeIntelligence } from '../code_intelligence/inject'
 import { injectExtensionMarker } from '../sourcegraph/inject'
 import { getPhabricatorCSS, getSourcegraphURLFromConduit } from './backend'
 import { metaClickOverride } from './util'
-import { DEFAULT_ASSETS_URL } from '../../shared/util/context'
 
 // Just for informational purposes (see getPlatformContext())
 window.SOURCEGRAPH_PHABRICATOR_EXTENSION = true
@@ -37,7 +36,7 @@ async function init(): Promise<void> {
         window.localStorage.getItem('SOURCEGRAPH_URL') ||
         window.SOURCEGRAPH_URL ||
         (await getSourcegraphURLFromConduit())
-    const assetsURL = DEFAULT_ASSETS_URL
+    const assetsURL = new URL('/.assets/extension/', sourcegraphURL).href
 
     // Backwards compat: Support Legacy Phabricator extension. Check that the Phabricator integration
     // passed the bundle url. Legacy Phabricator extensions inject CSS via the loader.js script


### PR DESCRIPTION
This adds the option of running phabricator.e2e.ts with the browser extension as well as with the native integration.

