### PR TITLE
Wrap up overflowing code snippets in docs, fixes 5533

### DIFF
--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -383,6 +383,7 @@ a:hover {
     border-width: 1px;
     border-style: solid;
     border-radius: 3px;
+    overflow: auto;
 }
 .markdown-body aside > :first-child {
     margin-top: 0;

--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -383,7 +383,6 @@ a:hover {
     border-width: 1px;
     border-style: solid;
     border-radius: 3px;
-    overflow: auto;
 }
 .markdown-body aside > :first-child {
     margin-top: 0;
@@ -527,6 +526,7 @@ a:hover {
     font-size: 85%;
     background-color: rgba(27, 31, 35, 0.05);
     border-radius: 3px;
+    white-space: pre-wrap;
 }
 .markdown-body pre {
     word-wrap: normal;

--- a/doc/index.md
+++ b/doc/index.md
@@ -29,10 +29,16 @@ For next steps and further configuration options, visit the [site administration
 
 > NOTE: If you get stuck or need help, [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new?&title=Improve+Sourcegraph+quickstart+guide), [tweet (@srcgraph)](https://twitter.com/srcgraph) or [email](mailto:support@sourcegraph.com?subject=Sourcegraph%20quickstart%20guide).
 
-> NOTE: If you run Docker on an OS such as RHEL, Fedora, or CentOS with SELinux enabled, sVirt doesn't allow the Docker process
-to access `~/.sourcegraph/config` and `~/.sourcegraph/data`. In that case, you will see the following message: `Failed to setup nginx:failed to generate nginx configuration to /etc/sourcegraph: open /etc/sourcegraph/nginx.conf: permission denied`. 
+<span class="virtual-br"></span>
 
-> To fix this, run: `mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chcon -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
+> NOTE: If you run Docker on an OS such as RHEL, Fedora, or CentOS with SELinux enabled, sVirt doesn't allow the Docker process
+to access `~/.sourcegraph/config` and `~/.sourcegraph/data`. In that case, you will see the following message:
+
+> `Failed to setup nginx:failed to generate nginx configuration to /etc/sourcegraph: open /etc/sourcegraph/nginx.conf: permission denied`.
+
+> To fix this, run:
+
+> `mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chcon -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
 
 ## Upgrading Sourcegraph
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -30,7 +30,9 @@ For next steps and further configuration options, visit the [site administration
 > NOTE: If you get stuck or need help, [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new?&title=Improve+Sourcegraph+quickstart+guide), [tweet (@srcgraph)](https://twitter.com/srcgraph) or [email](mailto:support@sourcegraph.com?subject=Sourcegraph%20quickstart%20guide).
 
 > NOTE: If you run Docker on an OS such as RHEL, Fedora, or CentOS with SELinux enabled, sVirt doesn't allow the Docker process
-to access `~/.sourcegraph/config` and `~/.sourcegraph/data`. In that case, you will see the following message: `Failed to setup nginx:failed to generate nginx configuration to /etc/sourcegraph: open /etc/sourcegraph/nginx.conf: permission denied`. To fix this, run: `mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chcon -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
+to access `~/.sourcegraph/config` and `~/.sourcegraph/data`. In that case, you will see the following message: `Failed to setup nginx:failed to generate nginx configuration to /etc/sourcegraph: open /etc/sourcegraph/nginx.conf: permission denied`. 
+
+> To fix this, run: `mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chcon -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
 
 ## Upgrading Sourcegraph
 


### PR DESCRIPTION
Add scrolling to note paragraphs that overflow in the docs. Fixes: https://github.com/sourcegraph/sourcegraph/issues/5533

Before:

![image](https://user-images.githubusercontent.com/9110008/64643838-2046b180-d3c6-11e9-8341-dc1ead1aacff.png)

After: 
![image](https://user-images.githubusercontent.com/9110008/64643804-12912c00-d3c6-11e9-92b5-91ab807e19f1.png)



