### PR TITLE
Fix: uneven padding on search result info bar

### DIFF
--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -52,7 +52,7 @@ interface SearchResultsInfoBarProps
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => (
-    <div className="search-results-info-bar px-2" data-testid="results-info-bar">
+    <div className="search-results-info-bar p-2" data-testid="results-info-bar">
         {(props.results.timedout.length > 0 ||
             props.results.cloning.length > 0 ||
             props.results.results.length > 0 ||


### PR DESCRIPTION
Evens out vertical padding of the search result info bar.

Before:
![image](https://user-images.githubusercontent.com/16265452/64736818-67a17080-d4a0-11e9-9ec0-886a96c0118f.png)

After:
![image](https://user-images.githubusercontent.com/16265452/64736782-53f60a00-d4a0-11e9-8862-6e9240ee7b69.png)