### PR TITLE
Fix disableExtension flag for native integrations

### DIFF
--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -866,28 +866,33 @@ export function injectCodeIntelligenceToCodeHost(
     subscriptions.add(extensionsController)
 
     let codeHostSubscription: Subscription
-    observeStorageKey('sync', 'disableExtension').subscribe(disableExtension => {
-        if (disableExtension) {
-            // We don't need to unsubscribe if the extension starts with disabled state.
-            if (codeHostSubscription) {
-                codeHostSubscription.unsubscribe()
-                subscriptions.remove(codeHostSubscription)
+    // In the browser extension, observe whether the `disableExtension` storage flag is set.
+    // In the native integration, this flag does not exist.
+    const extensionDisabled = isExtension ? observeStorageKey('sync', 'disableExtension') : of(false)
+    subscriptions.add(
+        extensionDisabled.subscribe(disableExtension => {
+            if (disableExtension) {
+                // We don't need to unsubscribe if the extension starts with disabled state.
+                if (codeHostSubscription) {
+                    codeHostSubscription.unsubscribe()
+                    subscriptions.remove(codeHostSubscription)
+                }
+                console.log('Browser extension is disabled')
+            } else {
+                codeHostSubscription = handleCodeHost({
+                    mutations,
+                    codeHost,
+                    extensionsController,
+                    platformContext,
+                    showGlobalDebug,
+                    sourcegraphURL,
+                    telemetryService,
+                    render: reactDOMRender,
+                })
+                subscriptions.add(codeHostSubscription)
+                console.log(`${isExtension ? 'Browser extension' : 'Native integration'} is enabled`)
             }
-            console.log('Browser extension is disabled')
-        } else {
-            codeHostSubscription = handleCodeHost({
-                mutations,
-                codeHost,
-                extensionsController,
-                platformContext,
-                showGlobalDebug,
-                sourcegraphURL,
-                telemetryService,
-                render: reactDOMRender,
-            })
-            subscriptions.add(codeHostSubscription)
-            console.log('Browser extension is enabled')
-        }
-    })
+        })
+    )
     return subscriptions
 }

--- a/browser/src/libs/code_intelligence/code_intelligence.tsx
+++ b/browser/src/libs/code_intelligence/code_intelligence.tsx
@@ -875,7 +875,6 @@ export function injectCodeIntelligenceToCodeHost(
                 // We don't need to unsubscribe if the extension starts with disabled state.
                 if (codeHostSubscription) {
                     codeHostSubscription.unsubscribe()
-                    subscriptions.remove(codeHostSubscription)
                 }
                 console.log('Browser extension is disabled')
             } else {


### PR DESCRIPTION
This flag should only be observed in the browser extension. Calling `observeStorageKey()` breaks native integrations.