### PR TITLE
Prevent uncaught SecurityError in extensionHostFrame

### DIFF
--- a/browser/src/phabricator/extensionHostFrame.html
+++ b/browser/src/phabricator/extensionHostFrame.html
@@ -1,6 +1,12 @@
 <script type="text/javascript">
     // Create extension host worker
-    const assetsUrl = window.parent.SOURCEGRAPH_ASSETS_URL || '/.assets/extension/'
+    let assetsUrl = new URL('/.assets/extension/', window.location.origin).href
+    try {
+        assetsUrl = window.parent.SOURCEGRAPH_ASSETS_URL
+    } catch (e) {
+        // Catch SecurityErrors caused by accessing cross-origin iframes
+        // when the assets are not self-hosted by a code host.
+    }
     const hostWorker = new Worker(new URL('scripts/extensionHostWorker.bundle.js', assetsUrl).href)
     // Forward extension host worker init message,
     // making sur to transfer the endpoint MessagePort objects.


### PR DESCRIPTION
When the integration assets are self-hosted  by the code host, accessing `window.parent.SOURCEGRAPH_ASSETS_URL` is not an issue. However, when fetching  extensionHostFrame from the sourcegraph instance, `window.parent` is cross-origin, and accessing it will throw a SecurityError.
