### PR TITLE
a8n: Support finding Campaigns/Changesets by ID in GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/changesets.go
+++ b/cmd/frontend/graphqlbackend/changesets.go
@@ -100,6 +100,25 @@ func (r *changesetsConnectionResolver) compute(ctx context.Context) ([]*a8n.Chan
 	return r.changesets, r.next, r.err
 }
 
+func changesetByID(ctx context.Context, s *a8n.Store, id graphql.ID) (*changesetResolver, error) {
+	// 🚨 SECURITY: Only site admins may access changesets for now.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	changesetID, err := unmarshalChangesetID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	changeset, err := s.GetChangeset(ctx, a8n.GetChangesetOpts{ID: changesetID})
+	if err != nil {
+		return nil, err
+	}
+
+	return &changesetResolver{store: s, Changeset: changeset}, nil
+}
+
 type changesetResolver struct {
 	store *a8n.Store
 	*a8n.Changeset

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -206,6 +206,8 @@ func NodeByID(ctx context.Context, s *a8n.Store, id graphql.ID) (Node, error) {
 		return accessTokenByID(ctx, id)
 	case "Campaign":
 		return campaignByID(ctx, s, id)
+	case "Changeset":
+		return changesetByID(ctx, s, id)
 	case "DiscussionComment":
 		return discussionCommentByID(ctx, id)
 	case "DiscussionThread":

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -193,17 +193,19 @@ func (r *schemaResolver) Root() *schemaResolver {
 }
 
 func (r *schemaResolver) Node(ctx context.Context, args *struct{ ID graphql.ID }) (*NodeResolver, error) {
-	n, err := NodeByID(ctx, args.ID)
+	n, err := NodeByID(ctx, r.A8NStore, args.ID)
 	if err != nil {
 		return nil, err
 	}
 	return &NodeResolver{n}, nil
 }
 
-func NodeByID(ctx context.Context, id graphql.ID) (Node, error) {
+func NodeByID(ctx context.Context, s *a8n.Store, id graphql.ID) (Node, error) {
 	switch relay.UnmarshalKind(id) {
 	case "AccessToken":
 		return accessTokenByID(ctx, id)
+	case "Campaign":
+		return campaignByID(ctx, s, id)
 	case "DiscussionComment":
 		return discussionCommentByID(ctx, id)
 	case "DiscussionThread":

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -43,7 +43,7 @@ type settingsMutation struct {
 func (r *schemaResolver) SettingsMutation(ctx context.Context, args *struct {
 	Input *settingsMutationGroupInput
 }) (*settingsMutation, error) {
-	subject, err := settingsSubjectByID(ctx, args.Input.Subject)
+	subject, err := settingsSubjectByID(ctx, r.A8NStore, args.Input.Subject)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -6,12 +6,13 @@ import (
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/pkg/api"
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
 )
 
-func (schemaResolver) SettingsSubject(ctx context.Context, args *struct{ ID graphql.ID }) (*settingsSubject, error) {
-	return settingsSubjectByID(ctx, args.ID)
+func (r *schemaResolver) SettingsSubject(ctx context.Context, args *struct{ ID graphql.ID }) (*settingsSubject, error) {
+	return settingsSubjectByID(ctx, r.A8NStore, args.ID)
 }
 
 var errUnknownSettingsSubject = errors.New("unknown settings subject")
@@ -26,8 +27,8 @@ type settingsSubject struct {
 
 // settingsSubjectByID fetches the settings subject with the given ID. If the ID refers to a node
 // that is not a valid settings subject, an error is returned.
-func settingsSubjectByID(ctx context.Context, id graphql.ID) (*settingsSubject, error) {
-	resolver, err := NodeByID(ctx, id)
+func settingsSubjectByID(ctx context.Context, s *a8n.Store, id graphql.ID) (*settingsSubject, error) {
+	resolver, err := NodeByID(ctx, s, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/tags.go
+++ b/cmd/frontend/graphqlbackend/tags.go
@@ -19,7 +19,7 @@ func (r *schemaResolver) SetTag(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	node, err := NodeByID(ctx, args.Node)
+	node, err := NodeByID(ctx, r.A8NStore, args.Node)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes the "invalid id" error reported by @felixfbecker on Slack.

Besides adding "Campaign" to the switch-statement in `NodeByID` this also changes `NodeByID` to pass on the `A8NStore` set on the `schemaResolver`.

We should probably rethink why `NodeByID` is exported at all (it's not used outside of `graphqlbackend`) and whether or not it should be a method on `*schemaResolver`.
