### PR TITLE
a8n: Add externalURL to Changeset

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns_test.go
+++ b/cmd/frontend/graphqlbackend/campaigns_test.go
@@ -248,14 +248,18 @@ func TestCampaigns(t *testing.T) {
 	graphqlRepoID := string(marshalRepositoryID(api.RepoID(repo.ID)))
 
 	type Changeset struct {
-		ID         string
-		Repository struct{ ID string }
-		Campaigns  CampaignConnection
-		CreatedAt  string
-		UpdatedAt  string
-		Title      string
-		Body       string
-		State      string
+		ID          string
+		Repository  struct{ ID string }
+		Campaigns   CampaignConnection
+		CreatedAt   string
+		UpdatedAt   string
+		Title       string
+		Body        string
+		State       string
+		ExternalURL struct {
+			URL         string
+			ServiceType string
+		}
 	}
 
 	var result struct {
@@ -276,6 +280,10 @@ func TestCampaigns(t *testing.T) {
 			title
 			body
 			state
+			externalURL {
+				url
+				serviceType
+			}
 		}
 		mutation($repository: ID!, $externalID: String!) {
 			changeset: createChangeset(repository: $repository, externalID: $externalID) {
@@ -292,6 +300,10 @@ func TestCampaigns(t *testing.T) {
 			Title:      "add extension filter to filter bar",
 			Body:       "Enables adding extension filters to the filter bar by rendering the extension filter as filter chips inside the filter bar.\r\nWIP for https://github.com/sourcegraph/sourcegraph/issues/962\r\n\r\n> This PR updates the CHANGELOG.md file to describe any user-facing changes.\r\n.\r\n",
 			State:      "MERGED",
+			ExternalURL: struct{ URL, ServiceType string }{
+				URL:         "https://github.com/sourcegraph/sourcegraph/pull/999",
+				ServiceType: "github",
+			},
 		}
 
 		have := result.Changeset

--- a/cmd/frontend/graphqlbackend/changesets.go
+++ b/cmd/frontend/graphqlbackend/changesets.go
@@ -9,6 +9,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/pkg/a8n"
@@ -223,4 +224,12 @@ func (r *changesetResolver) Body() (string, error) {
 
 func (r *changesetResolver) State() (a8n.ChangesetState, error) {
 	return r.Changeset.State()
+}
+
+func (r *changesetResolver) ExternalURL() (*externallink.Resolver, error) {
+	url, err := r.Changeset.URL()
+	if err != nil {
+		return nil, err
+	}
+	return externallink.NewResolver(url, r.Changeset.ExternalServiceType), nil
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -435,6 +435,9 @@ type Changeset implements Node {
 
     # The state of the changeset
     state: ChangesetState!
+
+    # The external URL of the changeset on the code host
+    externalURL: ExternalLink!
 }
 
 # A list of changesets.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -442,6 +442,9 @@ type Changeset implements Node {
 
     # The state of the changeset
     state: ChangesetState!
+
+    # The external URL of the changeset on the code host
+    externalURL: ExternalLink!
 }
 
 # A list of changesets.

--- a/pkg/a8n/types.go
+++ b/pkg/a8n/types.go
@@ -104,3 +104,13 @@ func (t *Changeset) State() (s ChangesetState, err error) {
 
 	return s, nil
 }
+
+// URL of a Changeset.
+func (t *Changeset) URL() (s string, err error) {
+	switch m := t.Metadata.(type) {
+	case *github.PullRequest:
+		return m.URL, nil
+	default:
+		return "", errors.New("unknown changeset type")
+	}
+}

--- a/pkg/a8n/types_test.go
+++ b/pkg/a8n/types_test.go
@@ -22,6 +22,7 @@ func TestChangesetMetadata(t *testing.T) {
 		Body:         "This fixes a bunch of bugs",
 		URL:          "https://github.com/sourcegraph/sourcegraph/pull/12345",
 		Number:       12345,
+		State:        "MERGED",
 		Author:       githubActor,
 		Participants: []github.Actor{githubActor},
 		CreatedAt:    now,
@@ -54,5 +55,23 @@ func TestChangesetMetadata(t *testing.T) {
 
 	if want, have := githubPR.Body, body; want != have {
 		t.Errorf("changeset body wrong. want=%q, have=%q", want, have)
+	}
+
+	state, err := changeset.State()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, have := ChangesetStateMerged, state; want != have {
+		t.Errorf("changeset state wrong. want=%q, have=%q", want, have)
+	}
+
+	url, err := changeset.URL()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, have := githubPR.URL, url; want != have {
+		t.Errorf("changeset url wrong. want=%q, have=%q", want, have)
 	}
 }


### PR DESCRIPTION
This commit adds the `externalURL`, an `ExternalLink`, to the `Changeset` in the GraphQL API.