### PR TITLE
LSIF: add a config setting to control checking of LSIF upload tokens

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -516,6 +516,7 @@ type SiteConfiguration struct {
 	GitMaxConcurrentClones            int                         `json:"gitMaxConcurrentClones,omitempty"`
 	GithubClientID                    string                      `json:"githubClientID,omitempty"`
 	GithubClientSecret                string                      `json:"githubClientSecret,omitempty"`
+	LsifEnforceAuth                   bool                        `json:"lsifEnforceAuth,omitempty"`
 	LsifUploadSecret                  string                      `json:"lsifUploadSecret,omitempty"`
 	LsifVerificationGithubToken       string                      `json:"lsifVerificationGithubToken,omitempty"`
 	MaxReposToSearch                  int                         `json:"maxReposToSearch,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -76,6 +76,12 @@
       "type": "string",
       "group": "Security"
     },
+    "lsifEnforceAuth": {
+      "description": "Whether or not LSIF uploads will be blocked unless a valid LSIF upload token is provided.",
+      "type": "boolean",
+      "default": false,
+      "group": "Security"
+    },
     "disableAutoGitUpdates": {
       "description": "Disable periodically fetching git contents for existing repositories.",
       "type": "boolean",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -81,6 +81,12 @@ const SiteSchemaJSON = `{
       "type": "string",
       "group": "Security"
     },
+    "lsifEnforceAuth": {
+      "description": "Whether or not LSIF uploads will be blocked unless a valid LSIF upload token is provided.",
+      "type": "boolean",
+      "default": false,
+      "group": "Security"
+    },
     "disableAutoGitUpdates": {
       "description": "Disable periodically fetching git contents for existing repositories.",
       "type": "boolean",


### PR DESCRIPTION
Prior to this PR, the LSIF upload token validation could not be bypassed, even through site config. This made it impossible to upload LSIF for non-GitHub repositories (there's no supported way to prove repository ownership).

After this PR, LSIF upload token validation can be toggled by the boolean site config `lsifEnforceAuth`. By default, all LSIF uploads will be allowed. Sourcegraph.com will have this set to true, meaning LSIF upload tokens are required. This makes it much easier for customers to try out LSIF on their own instances.

Resolves https://github.com/sourcegraph/sourcegraph/issues/5516

Test plan: manual while LSIF support is in alpha
