### PR TITLE
LSIF: only store one LSIF dump for all commits

### DIFF
--- a/lsif/src/backend.ts
+++ b/lsif/src/backend.ts
@@ -114,7 +114,7 @@ export class Backend {
  * @param commit The repository commit.
  */
 export function makeFilename(storageRoot: string, repository: string, commit: string): string {
-    return path.join(storageRoot, `${encodeURIComponent(repository)}@${commit}.lsif.db`)
+    return path.join(storageRoot, `${encodeURIComponent(repository)}.lsif.db`)
 }
 
 /**

--- a/lsif/upload.sh
+++ b/lsif/upload.sh
@@ -17,12 +17,19 @@ usage() {
     echo "  bash upload-lsif.sh <file.lsif>"
 }
 
-if [[ -z "$SRC_LSIF_UPLOAD_TOKEN" || -z "$REPOSITORY" || -z "$COMMIT" || -z "$file" ]]; then
+if [[ -z "$REPOSITORY" || -z "$COMMIT" || -z "$file" ]]; then
     usage
     exit 1
 fi
 
-curl \
+URL="$SRC_ENDPOINT/.api/lsif/upload?"
+URL="${URL}repository=$(urlencode "$REPOSITORY")"
+URL="${URL}&commit=$(urlencode "$COMMIT")"
+if [ -n "$SRC_LSIF_UPLOAD_TOKEN" ]; then
+    URL="${URL}&upload_token=$(urlencode "$SRC_LSIF_UPLOAD_TOKEN")"
+fi
+
+cat "$file" | gzip | curl \
     -H "Content-Type: application/x-ndjson+lsif" \
-    "$SRC_ENDPOINT/.api/lsif/upload?repository=$(urlencode "$REPOSITORY")&commit=$(urlencode "$COMMIT")&upload_token=$(urlencode "$SRC_LSIF_UPLOAD_TOKEN")" \
-    --data-binary "@$file"
+    "$URL" \
+    --data-binary @-


### PR DESCRIPTION
Prior to this change, an LSIF dump was associated with specific repo@commit. That means you would only get code intel powered by LSIF when you were on an exact commit that had LSIF data, but it was always correct.

After this change, an LSIF dump is only associated with a repo. That means you'll get LSIF code intel on any commit on the repo, but it will be incorrect when there's a diff between your current commit and the commit at which the LSIF data was generated. The failure mode is pretty confusing:

![2019-09-13 23 25 07](https://user-images.githubusercontent.com/1387653/64903860-059e6200-d67e-11e9-8af4-e50e3b3fde84.gif)

There's no indicator that I've "fallen off a cliff", so to speak, where the rest of the document's lines are out of sync with the LSIF dump.

There are several ways to mitigate that problem down the road:

- Keep track of which commit the LSIF dump was generated on and indicate to the user when the current file has been modified since the LSIF dump
- Set a threshold number of commits after which the LSIF data is considered "stale" and don't show it at all
- Support multiple LSIF dumps per repo and pick the nearest (see the [nearest commit RFC](https://docs.google.com/document/d/16g_S9ViSgsCvwJqbpeo734WwHPem6Fpl40dpdaRaXdQ/edit))

Test plan: already covered
