### PR TITLE
Use UNSAFE_componentWillReceiveProps in BlobPage.tsx

### DIFF
--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -113,6 +113,7 @@ interface State {
     blobOrError?: GQL.IGitBlob | ErrorLike
 }
 
+// eslint-disable-next-line react/no-unsafe
 export class BlobPage extends React.PureComponent<Props, State> {
     private propsUpdates = new Subject<Props>()
     private extendHighlightingTimeoutClicks = new Subject<void>()
@@ -171,14 +172,16 @@ export class BlobPage extends React.PureComponent<Props, State> {
         this.propsUpdates.next(this.props)
     }
 
-    public componentDidUpdate(prevProps: Props): void {
-        this.propsUpdates.next(this.props)
+    // Use UNSAFE_componentWillReceiveProps to avoid this.state.blobOrError being out of sync
+    // with props (see https://github.com/sourcegraph/sourcegraph/issues/5575).
+    public UNSAFE_componentWillReceiveProps(nextProps: Props): void {
+        this.propsUpdates.next(nextProps)
         if (
-            this.props.repoName !== prevProps.repoName ||
-            this.props.commitID !== prevProps.commitID ||
-            this.props.filePath !== prevProps.filePath ||
+            this.props.repoName !== nextProps.repoName ||
+            this.props.commitID !== nextProps.commitID ||
+            this.props.filePath !== nextProps.filePath ||
             ToggleRenderedFileMode.getModeFromURL(this.props.location) !==
-                ToggleRenderedFileMode.getModeFromURL(prevProps.location)
+                ToggleRenderedFileMode.getModeFromURL(nextProps.location)
         ) {
             this.logViewEvent()
         }


### PR DESCRIPTION
Fixes #5575

The switch to `componentDidUpdate()` in the [eslint refactor](https://github.com/sourcegraph/sourcegraph/pull/5072) introduced a bug whereby invalid props could be passed down to `Blob.tsx`, with `AbsoluteRepoFile` props being out of sync with the file content.

`Blob.tsx` would then call `addModel()` with the out-of-sync data and. Upon receiving the correct file content, the invalid state would remain since a model with the given URI already existed.

This fixes the bug topically by reverting to using `UNSAFE_componentWillReceiveProps`. As a follow-up, we should look into simplifying the complex update logic in `BlobPage.tsx` and `Blob.tsx`.
