### PR TITLE
LSIF: check for valid repository

### DIFF
--- a/cmd/frontend/internal/httpapi/lsif.go
+++ b/cmd/frontend/internal/httpapi/lsif.go
@@ -165,13 +165,13 @@ func lsifVerifyHandler(w http.ResponseWriter, r *http.Request) {
 
 func lsifUploadProxyHandler(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if conf.Get().LsifEnforceAuth {
-			repo, err := backend.Repos.GetByName(r.Context(), api.RepoName(r.URL.Query().Get("repository")))
-			if err != nil {
-				http.Error(w, "Unknown repository.", http.StatusUnauthorized)
-				return
-			}
+		repo, err := backend.Repos.GetByName(r.Context(), api.RepoName(r.URL.Query().Get("repository")))
+		if err != nil {
+			http.Error(w, "Unknown repository.", http.StatusUnauthorized)
+			return
+		}
 
+		if conf.Get().LsifEnforceAuth {
 			lsifUploadSecret, err := getLSIFUploadSecret()
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/5580, I accidentally dropped the sanity check on the existence of a repository when uploading LSIF data. This brings the check back.

Test plan: manual
