### PR TITLE
e2e: skip flaky search tabs test

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1134,7 +1134,7 @@ describe('e2e test suite', () => {
             expect(label).toEqual('Code')
         })
 
-        test('Clicking search results tabs updates query and URL', async () => {
+        test.skip('Clicking search results tabs updates query and URL', async () => {
             for (const searchType of ['diff', 'commit', 'symbol', 'repo']) {
                 await driver.page.click(`.e2e-search-result-tab-${searchType}`)
                 await driver.assertWindowLocation(`/search?q=repo:%5Egithub.com/gorilla/mux%24+type:${searchType}`)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/5593.

Disabling while finding cause of flakiness.
