### PR TITLE
e2e: fix flaky search results type tabs test

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1134,8 +1134,9 @@ describe('e2e test suite', () => {
             expect(label).toEqual('Code')
         })
 
-        test.skip('Clicking search results tabs updates query and URL', async () => {
+        test('Clicking search results tabs updates query and URL', async () => {
             for (const searchType of ['diff', 'commit', 'symbol', 'repo']) {
+                await driver.page.waitForSelector(`.e2e-search-result-tab-${searchType}`)
                 await driver.page.click(`.e2e-search-result-tab-${searchType}`)
                 await driver.assertWindowLocation(`/search?q=repo:%5Egithub.com/gorilla/mux%24+type:${searchType}`)
             }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/pull/5606. 

I believe the cause of flakiness previously was that we did not wait for the tab to appear before trying to click on it.