### PR TITLE
Symbols: bump ctags

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache add --virtual build-deps curl jansson-dev \
     libseccomp-dev linux-headers autoconf pkgconfig make automake \
     gcc g++ binutils
 
-ENV CTAGS_VERSION=1a94658c2cb47304d0e9811d49e0a5f48bdb3a0a
+ENV CTAGS_VERSION=03f933a96d3ef87adbf9d167462d45ce69577edb
 
 # hadolint ignore=DL3003
 RUN curl -fsSL -o ctags.tar.gz "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" && \

--- a/cmd/symbols/internal/pkg/ctags/Dockerfile
+++ b/cmd/symbols/internal/pkg/ctags/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9@sha256:644fcb1a676b5165371437feaa922943aaf7afcfa8bfee4472f6860aad1ef2a0 AS ctags
 
-ENV CTAGS_VERSION=1a94658c2cb47304d0e9811d49e0a5f48bdb3a0a
+ENV CTAGS_VERSION=03f933a96d3ef87adbf9d167462d45ce69577edb
 
 # hadolint ignore=DL3003,DL3018,DL4006
 RUN apk --no-cache add --virtual build-deps curl jansson-dev libseccomp-dev linux-headers autoconf pkgconfig make automake gcc g++ binutils && \

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -573,7 +573,7 @@ describe('e2e test suite', () => {
                         'toAxiosCancelToken',
                         'source',
                     ],
-                    symbolTypes: ['constant', 'constant', 'constant', 'function', 'function', 'function', 'constant'],
+                    symbolTypes: ['constant', 'constant', 'function', 'function', 'function', 'constant'],
                 },
                 {
                     name: 'lists symbols in file for Java',

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -567,7 +567,6 @@ describe('e2e test suite', () => {
                         '/github.com/sourcegraph/sourcegraph-typescript@a7b7a61e31af76dad3543adec359fa68737a58a1/-/blob/server/src/cancellation.ts',
                     symbolNames: [
                         'createAbortError',
-                        'Object',
                         'isAbortError',
                         'throwIfCancelled',
                         'tryCancel',
@@ -704,7 +703,7 @@ describe('e2e test suite', () => {
                     name: 'highlights correct line for Typescript',
                     filePath:
                         '/github.com/sourcegraph/sourcegraph-typescript@a7b7a61e31af76dad3543adec359fa68737a58a1/-/blob/server/src/cancellation.ts',
-                    index: 3,
+                    index: 2,
                     line: 17,
                 },
             ]


### PR DESCRIPTION
This pulls in https://github.com/universal-ctags/ctags/commit/03f933a96d3ef87adbf9d167462d45ce69577edb which fixes a TypeScript bug https://github.com/universal-ctags/ctags/issues/2176 that was causing incorrect symbols to appear in the symbols sidebar.

Before:

![image](https://user-images.githubusercontent.com/1387653/65007100-4f778a00-d8c2-11e9-9c02-85c970b72df0.png)

After:

![image](https://user-images.githubusercontent.com/1387653/65007144-72a23980-d8c2-11e9-8b84-a18bcef78fed.png)

Original discussion https://sourcegraph.slack.com/archives/CHXHX7XAS/p1568659354011300

Test plan: manual
