### PR TITLE
LSIF: dockerignore node_modules

### DIFF
--- a/lsif/.dockerignore
+++ b/lsif/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lsif/.dockerignore
+++ b/lsif/.dockerignore
@@ -1,1 +1,4 @@
 node_modules
+Dockerfile
+.dockerignore
+out

--- a/lsif/Dockerfile
+++ b/lsif/Dockerfile
@@ -3,11 +3,8 @@ FROM alpine:3.10@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529
 RUN apk add --no-cache nodejs-current=12.4.0-r0 nodejs-npm=10.16.3-r0
 RUN npm install -g yarn@1.17.3
 
-COPY package.json yarn.lock /lsif/
+COPY . /lsif/
 RUN yarn --cwd /lsif
-
-COPY tsconfig.json /lsif
-COPY src /lsif/src
 RUN yarn --cwd /lsif run build
 
 FROM alpine:3.9@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb


### PR DESCRIPTION
It's not necessary to copy node_modules, so adding them to dockerignore saves a bit of time on each build.

Test plan: CI
