### PR TITLE
e2e tests: Automate 9.4 and 9.12 from the release testing grid

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -278,19 +278,15 @@ describe('e2e test suite', () => {
                         password: awsCodeCommitPassword,
                     },
                 }),
+                ensureRepos: ['aws/test'],
             })
-            await retry(async () => {
-                await driver.page.goto(sourcegraphBaseUrl + '/aws/test/-/blob/README')
-                const blob: string = await (await driver.page.waitFor(
-                    () => {
-                        const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
-                        return elem && elem.textContent
-                    },
-                    { timeout: 5000 } // Wait 5s for repos to be synced in the background
-                )).jsonValue()
+            await driver.page.goto(sourcegraphBaseUrl + '/aws/test/-/blob/README')
+            const blob: string = await (await driver.page.waitFor(() => {
+                const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
+                return elem && elem.textContent
+            })).jsonValue()
 
-                expect(blob).toBe('README\n\nchange')
-            })
+            expect(blob).toBe('README\n\nchange')
         })
 
         const bbsURL = process.env.BITBUCKET_SERVER_URL
@@ -310,21 +306,15 @@ describe('e2e test suite', () => {
                     repos: ['SOURCEGRAPH/jsonrpc2'],
                     repositoryPathPattern: 'bbs/{projectKey}/{repositorySlug}',
                 }),
+                ensureRepos: ['bbs/SOURCEGRAPH/jsonrpc2'],
             })
+            await driver.page.goto(sourcegraphBaseUrl + '/bbs/SOURCEGRAPH/jsonrpc2/-/blob/.travis.yml')
+            const blob: string = await (await driver.page.waitFor(() => {
+                const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
+                return elem && elem.textContent
+            })).jsonValue()
 
-            await retry(async () => {
-                await driver.page.goto(sourcegraphBaseUrl + '/bbs/SOURCEGRAPH/jsonrpc2/-/blob/.travis.yml')
-
-                const blob: string = await (await driver.page.waitFor(
-                    () => {
-                        const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
-                        return elem && elem.textContent
-                    },
-                    { timeout: 5000 } // Wait 5s for repos to be synced in the background
-                )).jsonValue()
-
-                expect(blob).toBe('language: go\ngo: \n - 1.x\n\nscript:\n - go test -race -v ./...')
-            })
+            expect(blob).toBe('language: go\ngo: \n - 1.x\n\nscript:\n - go test -race -v ./...')
         })
     })
 

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -279,13 +279,18 @@ describe('e2e test suite', () => {
                     },
                 }),
             })
-            await driver.page.goto(sourcegraphBaseUrl + '/aws/test/-/blob/README')
-            const blob: string = await (await driver.page.waitFor(() => {
-                const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
-                return elem && elem.textContent
-            })).jsonValue()
+            await retry(async () => {
+                await driver.page.goto(sourcegraphBaseUrl + '/aws/test/-/blob/README')
+                const blob: string = await (await driver.page.waitFor(
+                    () => {
+                        const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
+                        return elem && elem.textContent
+                    },
+                    { timeout: 5000 } // Wait 5s for repos to be synced in the background
+                )).jsonValue()
 
-            expect(blob).toBe('README\n\nchange')
+                expect(blob).toBe('README\n\nchange')
+            })
         })
 
         const bbsURL = process.env.BITBUCKET_SERVER_URL
@@ -306,13 +311,20 @@ describe('e2e test suite', () => {
                     repositoryPathPattern: 'bbs/{projectKey}/{repositorySlug}',
                 }),
             })
-            await driver.page.goto(sourcegraphBaseUrl + '/bbs/SOURCEGRAPH/jsonrpc2/-/blob/.travis.yml')
-            const blob: string = await (await driver.page.waitFor(() => {
-                const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
-                return elem && elem.textContent
-            })).jsonValue()
 
-            expect(blob).toBe('language: go\ngo: \n - 1.x\n\nscript:\n - go test -race -v ./...')
+            await retry(async () => {
+                await driver.page.goto(sourcegraphBaseUrl + '/bbs/SOURCEGRAPH/jsonrpc2/-/blob/.travis.yml')
+
+                const blob: string = await (await driver.page.waitFor(
+                    () => {
+                        const elem = document.querySelector<HTMLElement>('.e2e-repo-blob')
+                        return elem && elem.textContent
+                    },
+                    { timeout: 5000 } // Wait 5s for repos to be synced in the background
+                )).jsonValue()
+
+                expect(blob).toBe('language: go\ngo: \n - 1.x\n\nscript:\n - go test -race -v ./...')
+            })
         })
     })
 

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -55,7 +55,6 @@ describe('e2e test suite', () => {
                 url: 'https://github.com',
                 token: gitHubToken,
                 repos: repoSlugs,
-                repositoryQuery: ['none'],
             }),
             ensureRepos: repoSlugs.map(slug => `github.com/${slug}`),
         })


### PR DESCRIPTION
Let me quote the commit messages.

---

 e2e-tests: Add external service test for Bitbucket Server

This automates entry 9.4 from testing plan for 3.8. And it also
automates half of 9.12, by not using a `repositoryQuery` in the config.

Just like the test for AWS CodeCommit, it only runs if the environment
variables are set. I will do this for our buildkite configuration.
Locally the test already passes with the BBS config out of
`dev-private`.

---

 e2e-tests: Test that `repositoryQuery` is not needed if `repos` is set

This automates the second half of 9.12: by removing the
`repositoryQuery` here we test that the config is valid with `repos`
only. In other tests we test that `repositoryQuery` without `repos` is
valid.

The existing BitBucket Server test from f88f6a9 tests that this holds
true for BBS as well.