### PR TITLE
Regression tests refactor

### DIFF
--- a/browser/src/e2e/bitbucket.test.ts
+++ b/browser/src/e2e/bitbucket.test.ts
@@ -1,9 +1,10 @@
 import * as path from 'path'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e/screenshotReporter'
-import { sourcegraphBaseUrl, createDriverForTest, Driver } from '../../../shared/src/e2e/driver'
+import { createDriverForTest, Driver } from '../../../shared/src/e2e/driver'
 import { retry } from '../../../shared/src/e2e/e2e-test-utils'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { testSingleFilePage } from './shared'
+import { getConfig } from '../../../shared/src/e2e/config'
 
 // By default, these tests run against a local Bitbucket instance and a local Sourcegraph instance.
 // You can run them against other instances by setting the below env vars in addition to SOURCEGRAPH_BASE_URL.
@@ -15,6 +16,8 @@ const TEST_NATIVE_INTEGRATION = Boolean(process.env.TEST_NATIVE_INTEGRATION)
 const REPO_PATH_PREFIX = new URL(BITBUCKET_BASE_URL).hostname
 
 const BITBUCKET_INTEGRATION_JAR_URL = 'https://storage.googleapis.com/sourcegraph-for-bitbucket-server/latest.jar'
+
+const { sourcegraphBaseUrl } = getConfig(['sourcegraphBaseUrl'])
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
 // command timeout of 30s in order to get the stack trace to point to the
@@ -126,7 +129,7 @@ describe('Sourcegraph browser extension on Bitbucket Server', () => {
 
     beforeAll(async () => {
         try {
-            driver = await createDriverForTest({ loadExtension: !TEST_NATIVE_INTEGRATION })
+            driver = await createDriverForTest({ loadExtension: !TEST_NATIVE_INTEGRATION, sourcegraphBaseUrl })
             await init(driver)
         } catch (err) {
             console.error(err)

--- a/browser/src/e2e/gitlab.test.ts
+++ b/browser/src/e2e/gitlab.test.ts
@@ -1,8 +1,9 @@
 import * as path from 'path'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e/screenshotReporter'
-import { sourcegraphBaseUrl, createDriverForTest, Driver } from '../../../shared/src/e2e/driver'
+import { createDriverForTest, Driver } from '../../../shared/src/e2e/driver'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { testSingleFilePage } from './shared'
+import { getConfig } from '../../../shared/src/e2e/config'
 
 // By default, these tests run against gitlab.com and a local Sourcegraph instance.
 // You can run them against other instances by setting the below env vars in addition to SOURCEGRAPH_BASE_URL.
@@ -10,6 +11,8 @@ import { testSingleFilePage } from './shared'
 const GITLAB_BASE_URL = process.env.GITLAB_BASE_URL || 'https://gitlab.com'
 const GITLAB_TOKEN = process.env.GITLAB_TOKEN
 const REPO_PATH_PREFIX = new URL(GITLAB_BASE_URL).hostname
+
+const { sourcegraphBaseUrl } = getConfig(['sourcegraphBaseUrl'])
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
 // command timeout of 30s in order to get the stack trace to point to the
@@ -41,7 +44,7 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
 
     beforeAll(async () => {
         try {
-            driver = await createDriverForTest({ loadExtension: true })
+            driver = await createDriverForTest({ loadExtension: true, sourcegraphBaseUrl })
             await init(driver)
         } catch (err) {
             console.error(err)

--- a/browser/src/e2e/phabricator.test.ts
+++ b/browser/src/e2e/phabricator.test.ts
@@ -1,9 +1,10 @@
 import * as path from 'path'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e/screenshotReporter'
-import { sourcegraphBaseUrl, createDriverForTest, Driver, gitHubToken } from '../../../shared/src/e2e/driver'
+import { createDriverForTest, Driver } from '../../../shared/src/e2e/driver'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { PhabricatorMapping } from '../browser/types'
 import { isEqual } from 'lodash'
+import { getConfig } from '../../../shared/src/e2e/config'
 
 // By default, these tests run against a local Phabricator instance and a local Sourcegraph instance.
 // To run them against phabricator.sgdev.org and umami.sgdev.org, set the below env vars in addition to SOURCEGRAPH_BASE_URL.
@@ -14,6 +15,7 @@ const PHABRICATOR_PASSWORD = process.env.PHABRICATOR_PASSWORD || 'sourcegraph'
 const TEST_NATIVE_INTEGRATION = Boolean(
     process.env.TEST_NATIVE_INTEGRATION && JSON.parse(process.env.TEST_NATIVE_INTEGRATION)
 )
+const { gitHubToken, sourcegraphBaseUrl } = getConfig(['gitHubToken', 'sourcegraphBaseUrl'])
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
 // command timeout of 30s in order to get the stack trace to point to the
@@ -134,7 +136,7 @@ async function init(driver: Driver): Promise<void> {
     // TODO test with a Gitolite external service
     await driver.ensureHasExternalService({
         kind: ExternalServiceKind.GITHUB,
-        displayName: 'Github (phabricator)',
+        displayName: 'GitHub (phabricator)',
         config: JSON.stringify({
             url: 'https://github.com',
             token: gitHubToken,
@@ -158,7 +160,7 @@ describe('Sourcegraph Phabricator extension', () => {
 
     beforeAll(async () => {
         try {
-            driver = await createDriverForTest({ loadExtension: !TEST_NATIVE_INTEGRATION })
+            driver = await createDriverForTest({ loadExtension: !TEST_NATIVE_INTEGRATION, sourcegraphBaseUrl })
             await init(driver)
         } catch (err) {
             console.error(err)

--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -13,7 +13,7 @@ export interface Config {
 }
 
 export interface ConfigField {
-    envVar?: string
+    envVar: string
     description?: string
     defaultValue?: string
 }
@@ -62,25 +62,22 @@ export function getConfig<T extends keyof Config>(required: T[]): Pick<Config, T
             if (!field) {
                 return ''
             }
-            const info = []
-            if (field.envVar) {
-                info.push(`environment variable: ${field.envVar}`)
+            const info = [field.envVar]
+            if (field.defaultValue) {
+                info.push(`default value: ${field.defaultValue}`)
             }
             if (field.description) {
                 info.push(`description: ${field.description}`)
             }
-            if (field.defaultValue) {
-                info.push(`default value: ${field.defaultValue}`)
-            }
-            return `(${info.join(', ')})`
+            return `${info.join(', ')}`
         }
-        // const fieldInfo = k => `- ${k}`
-        throw new Error(`FAIL: Required config was not provided. The following keys were missing:
+        throw new Error(`FAIL: Required config was not provided. These environment variables were missing:
 
-${missingKeys.map(k => `- ${k} ${fieldInfo(k)}`).join('\n')}
+${missingKeys.map(k => `- ${fieldInfo(k)}`).join('\n')}
 
-Please set the appropriate environment variables or add these entries to the config file
-specified by the environment variable CONFIG_FILE`)
+The recommended way to set them is to install direnv (https://direnv.net) and
+create a .envrc file at the root of this repository.
+`)
     }
 
     return pick(config, required)

--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -7,7 +7,7 @@ import { pick } from 'lodash'
  */
 export interface Config {
     sudoToken: string
-    username: string
+    sudoUsername: string
     gitHubToken: string
     sourcegraphBaseUrl: string
 }
@@ -21,16 +21,22 @@ export interface ConfigField {
 const configFields: { [K in keyof Config]: ConfigField } = {
     sudoToken: {
         envVar: 'SOURCEGRAPH_SUDO_TOKEN',
+        description:
+            'An access token with "site-admin:sudo" permissions. This will be used to impersonate users in requests.',
     },
-    username: {
-        envVar: 'SOURCEGRAPH_USERNAME',
+    sudoUsername: {
+        envVar: 'SOURCEGRAPH_SUDO_USER',
+        description: 'The site-admin-level username that will be impersonated with the sudo access token.',
     },
     gitHubToken: {
         envVar: 'GITHUB_TOKEN',
+        description: 'A GitHub token that will be used to authenticate a GitHub external service.',
     },
     sourcegraphBaseUrl: {
         envVar: 'SOURCEGRAPH_BASE_URL',
         defaultValue: 'http://localhost:3080',
+        description:
+            'The base URL of the Sourcegraph instance, e.g., https://sourcegraph.sgdev.org or http://localhost:3080.',
     },
 }
 

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -8,7 +8,6 @@ import * as util from 'util'
 import { dataOrThrowErrors, gql, GraphQLResult } from '../graphql/graphql'
 import { IMutation, IQuery, ExternalServiceKind } from '../graphql/schema'
 import { readEnvBoolean, retry } from './e2e-test-utils'
-import { getConfig } from './config'
 import * as path from 'path'
 
 /**
@@ -20,11 +19,6 @@ export const oncePageEvent = <E extends keyof PageEventObj>(page: Page, eventNam
 export const percySnapshot = readEnvBoolean({ variable: 'PERCY_ON', defaultValue: false })
     ? realPercySnapshot
     : () => Promise.resolve()
-
-/**
- * Used in the external service configuration.
- */
-export const { gitHubToken, sourcegraphBaseUrl } = getConfig(['gitHubToken', 'sourcegraphBaseUrl'])
 
 export const BROWSER_EXTENSION_DEV_ID = 'bmfbcejdknlknpncfpeloejonjoledha'
 
@@ -45,7 +39,7 @@ type SelectTextMethod = 'selectall' | 'keyboard'
 type EnterTextMethod = 'type' | 'paste'
 
 export class Driver {
-    constructor(public browser: puppeteer.Browser, public page: puppeteer.Page) {}
+    constructor(public browser: puppeteer.Browser, public page: puppeteer.Page, public sourcegraphBaseUrl: string) {}
 
     public async ensureLoggedIn({
         username,
@@ -56,7 +50,7 @@ export class Driver {
         password: string
         email?: string
     }): Promise<void> {
-        await this.page.goto(sourcegraphBaseUrl)
+        await this.page.goto(this.sourcegraphBaseUrl)
         await this.page.evaluate(() => {
             localStorage.setItem('has-dismissed-browser-ext-toast', 'true')
             localStorage.setItem('has-dismissed-integrations-toast', 'true')
@@ -85,7 +79,7 @@ export class Driver {
     public async setExtensionSourcegraphUrl(): Promise<void> {
         await this.page.goto(`chrome-extension://${BROWSER_EXTENSION_DEV_ID}/options.html`)
         await this.page.waitForSelector('.e2e-sourcegraph-url')
-        await this.replaceText({ selector: '.e2e-sourcegraph-url', newText: sourcegraphBaseUrl })
+        await this.replaceText({ selector: '.e2e-sourcegraph-url', newText: this.sourcegraphBaseUrl })
         await this.page.keyboard.press(Key.Enter)
         await this.page.waitForFunction(
             () => {
@@ -171,7 +165,7 @@ export class Driver {
         config: string
         ensureRepos?: string[]
     }): Promise<void> {
-        await this.page.goto(sourcegraphBaseUrl + '/site-admin/external-services')
+        await this.page.goto(this.sourcegraphBaseUrl + '/site-admin/external-services')
         await this.page.waitFor('.e2e-filtered-connection')
         await this.page.waitForSelector('.e2e-filtered-connection__loader', { hidden: true })
 
@@ -203,10 +197,12 @@ export class Driver {
         if (ensureRepos) {
             // Clone the repositories
             for (const slug of ensureRepos) {
-                await this.page.goto(sourcegraphBaseUrl + `/site-admin/repositories?query=${encodeURIComponent(slug)}`)
+                await this.page.goto(
+                    this.sourcegraphBaseUrl + `/site-admin/repositories?query=${encodeURIComponent(slug)}`
+                )
                 await this.page.waitForSelector(`.repository-node[data-e2e-repository='${slug}']`, { visible: true })
                 // Workaround for https://github.com/sourcegraph/sourcegraph/issues/5286
-                await this.page.goto(`${sourcegraphBaseUrl}/${slug}`)
+                await this.page.goto(`${this.sourcegraphBaseUrl}/${slug}`)
             }
         }
     }
@@ -225,14 +221,14 @@ export class Driver {
     }
 
     public async assertWindowLocation(location: string, isAbsolute = false): Promise<any> {
-        const url = isAbsolute ? location : sourcegraphBaseUrl + location
+        const url = isAbsolute ? location : this.sourcegraphBaseUrl + location
         await retry(async () => {
             expect(await this.page.evaluate(() => window.location.href)).toEqual(url)
         })
     }
 
     public async assertWindowLocationPrefix(locationPrefix: string, isAbsolute = false): Promise<any> {
-        const prefix = isAbsolute ? locationPrefix : sourcegraphBaseUrl + locationPrefix
+        const prefix = isAbsolute ? locationPrefix : this.sourcegraphBaseUrl + locationPrefix
         await retry(async () => {
             const loc: string = await this.page.evaluate(() => window.location.href)
             expect(loc.startsWith(prefix)).toBeTruthy()
@@ -290,10 +286,10 @@ export class Driver {
             (await this.page.evaluate(
                 sourcegraphBaseUrl =>
                     location.href.startsWith(sourcegraphBaseUrl) && (window as any).context.xhrHeaders,
-                sourcegraphBaseUrl
+                this.sourcegraphBaseUrl
             )) || {}
         const response = await this.makeRequest<GraphQLResult<T>>({
-            url: `${sourcegraphBaseUrl}/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`,
+            url: `${this.sourcegraphBaseUrl}/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`,
             init: {
                 method: 'POST',
                 body: JSON.stringify({ query: request, variables }),
@@ -406,9 +402,11 @@ function modifyJSONC(text: string, path: jsonc.JSONPath, f: (oldValue: jsonc.Nod
 interface DriverOptions {
     /** If true, load the Sourcegraph browser extension. */
     loadExtension?: boolean
+
+    sourcegraphBaseUrl: string
 }
 
-export async function createDriverForTest({ loadExtension }: DriverOptions = {}): Promise<Driver> {
+export async function createDriverForTest({ loadExtension, sourcegraphBaseUrl }: DriverOptions): Promise<Driver> {
     const args = ['--window-size=1280,1024']
     if (process.getuid() === 0) {
         // TODO don't run as root in CI
@@ -440,5 +438,5 @@ export async function createDriverForTest({ loadExtension }: DriverOptions = {})
             util.inspect(message, { colors: true, depth: 2, breakLength: Infinity })
         )
     })
-    return new Driver(browser, page)
+    return new Driver(browser, page, sourcegraphBaseUrl)
 }

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -64,12 +64,12 @@ export class Driver {
             await this.page.type('input[name=username]', username)
             await this.page.type('input[name=password]', password)
             await this.page.click('button[type=submit]')
-            await this.page.waitForNavigation({ timeout: 1000 })
+            await this.page.waitForNavigation({ timeout: 5000 })
         } else if (url.pathname === '/sign-in') {
             await this.page.type('input', username)
             await this.page.type('input[name=password]', password)
             await this.page.click('button[type=submit]')
-            await this.page.waitForNavigation({ timeout: 1000 })
+            await this.page.waitForNavigation({ timeout: 5000 })
         }
     }
 

--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1,18 +1,15 @@
 import * as path from 'path'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e/screenshotReporter'
 import { retry } from '../../../shared/src/e2e/e2e-test-utils'
-import {
-    sourcegraphBaseUrl,
-    createDriverForTest,
-    Driver,
-    gitHubToken,
-    percySnapshot,
-} from '../../../shared/src/e2e/driver'
+import { createDriverForTest, Driver, percySnapshot } from '../../../shared/src/e2e/driver'
 import got from 'got'
 import { gql } from '../../../shared/src/graphql/graphql'
 import { random } from 'lodash'
 import MockDate from 'mockdate'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
+import { getConfig } from '../../../shared/src/e2e/config'
+
+const { gitHubToken, sourcegraphBaseUrl } = getConfig(['gitHubToken', 'sourcegraphBaseUrl'])
 
 // 1 minute test timeout. This must be greater than the default Puppeteer
 // command timeout of 30s in order to get the stack trace to point to the
@@ -67,7 +64,7 @@ describe('e2e test suite', () => {
             MockDate.reset()
 
             // Start browser.
-            driver = await createDriverForTest()
+            driver = await createDriverForTest({ sourcegraphBaseUrl })
             await init()
         },
         // Cloning the repositories takes ~1 minute, so give initialization 2

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -141,6 +141,7 @@ describe('Search regression test suite', () => {
         beforeAll(
             async () => {
                 driver = await createAndInitializeDriver()
+
                 gqlClient = new GraphQLClient(config.sourcegraphBaseUrl, config.sudoToken, config.username)
                 await ensureLoggedInOrCreateUser({ driver, gqlClient, username: 'test', password: 'test' })
                 await ensureExternalService(gqlClient, {

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e/screenshotReporter'
 import { Driver } from '../../../shared/src/e2e/driver'
-import { getConfig } from '../../../shared/src/e2e/config'
+import { getConfig, intro, Config } from '../../../shared/src/e2e/config'
 import { regressionTestInit, createAndInitializeDriver } from './util/init'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { GraphQLClient } from './util/GraphQLClient'
@@ -84,7 +84,9 @@ const testRepoSlugs = [
     'facebook/react',
 ]
 
-// Reads the number of results from the text at the top of the results page
+/**
+ * Reads the number of results from the text at the top of the results page
+ */
 function getNumResults() {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const matches = document.querySelector('body')!.textContent!.match(/([0-9]+)\+?\sresults?/)
@@ -119,11 +121,10 @@ function hasNoResultsOrError(): boolean {
 }
 
 describe('Search regression test suite', () => {
-    regressionTestInit()
-    const config = getConfig(['sudoToken', 'username', 'gitHubToken', 'sourcegraphBaseUrl'])
+    let config: Pick<Config, 'sudoToken' | 'username' | 'gitHubToken' | 'sourcegraphBaseUrl'>
     let driver: Driver
     let gqlClient: GraphQLClient
-
+    regressionTestInit()
     // Take a screenshot when a test fails.
     saveScreenshotsUponFailuresAndClosePage(
         path.resolve(__dirname, '..', '..', '..'),
@@ -131,16 +132,16 @@ describe('Search regression test suite', () => {
         () => driver.page
     )
 
-    if (new URL(window.location.href).origin !== new URL(config.sourcegraphBaseUrl).origin) {
-        throw new Error(
-            `JSDOM URL "${window.location.href}" did not match Sourcegraph base URL "${config.sourcegraphBaseUrl}". Tests will fail with a same-origin violation. Try setting the environment variable SOURCEGRAPH_BASE_URL.`
-        )
-    }
-
     describe('Search over a dozen repositories', () => {
         beforeAll(
             async () => {
-                driver = await createAndInitializeDriver()
+                config = getConfig(['sudoToken', 'username', 'gitHubToken', 'sourcegraphBaseUrl'])
+                if (new URL(window.location.href).origin !== new URL(config.sourcegraphBaseUrl).origin) {
+                    throw new Error(
+                        `JSDOM URL "${window.location.href}" did not match Sourcegraph base URL "${config.sourcegraphBaseUrl}". Tests will fail with a same-origin violation. Try setting the environment variable SOURCEGRAPH_BASE_URL.`
+                    )
+                }
+                driver = await createAndInitializeDriver(config.sourcegraphBaseUrl)
                 gqlClient = new GraphQLClient(config.sourcegraphBaseUrl, config.sudoToken, config.username)
                 await ensureLoggedInOrCreateUser({ driver, gqlClient, username: 'test', password: 'test' })
                 await ensureExternalService(gqlClient, {
@@ -160,7 +161,12 @@ describe('Search regression test suite', () => {
         )
 
         // Close browser.
-        afterAll(() => driver && driver.close())
+        afterAll(async () => {
+            if (driver) {
+                await driver.close()
+            }
+            console.log('You can limit the test run to specific tests by running `yarn run test-regression -t $QUERY`.')
+        })
 
         test('Global text search (alksdjflaksjdflkasjdf) with 0 results.', async () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=alksdjflaksjdflkasjdf')

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -135,7 +135,7 @@ describe('Search regression test suite', () => {
     describe('Search over a dozen repositories', () => {
         beforeAll(
             async () => {
-                config = getConfig(['sudoToken', 'username', 'gitHubToken', 'sourcegraphBaseUrl'])
+                config = getConfig(['sudoToken', 'sudoUsername', 'gitHubToken', 'sourcegraphBaseUrl'])
                 if (new URL(window.location.href).origin !== new URL(config.sourcegraphBaseUrl).origin) {
                     throw new Error(
                         `JSDOM URL "${window.location.href}" did not match Sourcegraph base URL "${config.sourcegraphBaseUrl}". Tests will fail with a same-origin violation. Try setting the environment variable SOURCEGRAPH_BASE_URL.`

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -141,7 +141,6 @@ describe('Search regression test suite', () => {
         beforeAll(
             async () => {
                 driver = await createAndInitializeDriver()
-
                 gqlClient = new GraphQLClient(config.sourcegraphBaseUrl, config.sudoToken, config.username)
                 await ensureLoggedInOrCreateUser({ driver, gqlClient, username: 'test', password: 'test' })
                 await ensureExternalService(gqlClient, {

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { saveScreenshotsUponFailuresAndClosePage } from '../../../shared/src/e2e/screenshotReporter'
 import { Driver } from '../../../shared/src/e2e/driver'
-import { getConfig, intro, Config } from '../../../shared/src/e2e/config'
+import { getConfig, Config } from '../../../shared/src/e2e/config'
 import { regressionTestInit, createAndInitializeDriver } from './util/init'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { GraphQLClient } from './util/GraphQLClient'

--- a/web/src/regression/search.test.ts
+++ b/web/src/regression/search.test.ts
@@ -121,7 +121,7 @@ function hasNoResultsOrError(): boolean {
 }
 
 describe('Search regression test suite', () => {
-    let config: Pick<Config, 'sudoToken' | 'username' | 'gitHubToken' | 'sourcegraphBaseUrl'>
+    let config: Pick<Config, 'sudoToken' | 'sudoUsername' | 'gitHubToken' | 'sourcegraphBaseUrl'>
     let driver: Driver
     let gqlClient: GraphQLClient
     regressionTestInit()
@@ -142,7 +142,7 @@ describe('Search regression test suite', () => {
                     )
                 }
                 driver = await createAndInitializeDriver(config.sourcegraphBaseUrl)
-                gqlClient = new GraphQLClient(config.sourcegraphBaseUrl, config.sudoToken, config.username)
+                gqlClient = new GraphQLClient(config.sourcegraphBaseUrl, config.sudoToken, config.sudoUsername)
                 await ensureLoggedInOrCreateUser({ driver, gqlClient, username: 'test', password: 'test' })
                 await ensureExternalService(gqlClient, {
                     kind: GQL.ExternalServiceKind.GITHUB,

--- a/web/src/regression/util/helpers.ts
+++ b/web/src/regression/util/helpers.ts
@@ -24,7 +24,7 @@ export async function ensureLoggedInOrCreateUser({
         await driver.ensureLoggedIn({ username, password })
         return
     } catch (err) {
-        console.log(`Login failed, will attempt to create user ${JSON.stringify(username)}`)
+        console.log(`Login failed (error: ${err.message}), will attempt to create user ${JSON.stringify(username)}`)
     }
 
     // If there's an error, try to create the user

--- a/web/src/regression/util/init.ts
+++ b/web/src/regression/util/init.ts
@@ -20,8 +20,8 @@ export function regressionTestInit(): void {
  * timeouts is under 5s. Otherwise, the timeout error will be a cryptic Jest timeout error, instead
  * of an error pointing to the timed-out Puppeteer command.
  */
-export async function createAndInitializeDriver(): Promise<Driver> {
-    const driver = await createDriverForTest()
+export async function createAndInitializeDriver(sourcegraphBaseUrl: string): Promise<Driver> {
+    const driver = await createDriverForTest({ sourcegraphBaseUrl })
     driver.page.setDefaultNavigationTimeout(5 * 1000) // 5s navigation timeout
     return driver
 }


### PR DESCRIPTION
* better config parsing error messsage
* pass sourcegraphBaseUrl and gitHubToken to Driver constructor, instead of reading globally from config