### PR TITLE
Fix various issues reported by golang-ci

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -62,7 +62,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 		if lookupByExternalErr == nil {
 			return uid, false, true, "", nil
 		}
-		if lookupByExternalErr != nil && !errcode.IsNotFound(lookupByExternalErr) {
+		if !errcode.IsNotFound(lookupByExternalErr) {
 			return 0, false, false, "Unexpected error looking up the Sourcegraph user account associated with the external account. Ask a site admin for help.", lookupByExternalErr
 		}
 

--- a/cmd/frontend/graphqlbackend/discussion_comments.go
+++ b/cmd/frontend/graphqlbackend/discussion_comments.go
@@ -88,7 +88,7 @@ func (r *discussionCommentResolver) HTML(ctx context.Context, args *struct{ Opti
 	if err != nil {
 		return "", err
 	}
-	return markdown.Render(contents, nil), nil
+	return markdown.Render(contents), nil
 }
 
 func (r *discussionCommentResolver) InlineURL(ctx context.Context) (*string, error) {

--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -42,7 +42,7 @@ func (r *gitTreeEntryResolver) RichHTML(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return markdown.Render(content, nil), nil
+	return markdown.Render(content), nil
 }
 
 type markdownOptions struct {
@@ -53,7 +53,7 @@ func (*schemaResolver) RenderMarkdown(args *struct {
 	Markdown string
 	Options  *markdownOptions
 }) string {
-	return markdown.Render(args.Markdown, nil)
+	return markdown.Render(args.Markdown)
 }
 
 func (*schemaResolver) HighlightCode(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -169,20 +169,6 @@ func (r *NodeResolver) ToSite() (*siteResolver, bool) {
 	return n, ok
 }
 
-// stringLogger describes something that can log strings, list them and also
-// clean up to make sure they don't use too much storage space.
-type stringLogger interface {
-	// Log stores the given string s.
-	Log(ctx context.Context, s string) error
-
-	// Top returns the top n most frequently occurring strings.
-	// The returns are parallel slices for the unique strings and their associated counts.
-	Top(ctx context.Context, n int32) ([]string, []int32, error)
-
-	// Cleanup removes old entries such that there are no more than limit remaining.
-	Cleanup(ctx context.Context, limit int) error
-}
-
 // schemaResolver handles all GraphQL queries for Sourcegraph.  To do this, it
 // uses subresolvers, some of which are globals and some of which are fields on
 // schemaResolver.

--- a/cmd/frontend/graphqlbackend/markdown.go
+++ b/cmd/frontend/graphqlbackend/markdown.go
@@ -11,5 +11,5 @@ func (m *markdownResolver) Text() string {
 }
 
 func (m *markdownResolver) HTML() string {
-	return markdown.Render(m.text, nil)
+	return markdown.Render(m.text)
 }

--- a/cmd/frontend/internal/app/assetsutil/handler.go
+++ b/cmd/frontend/internal/app/assetsutil/handler.go
@@ -73,8 +73,5 @@ func init() {
 }
 
 func isPhabricatorAsset(path string) bool {
-	if strings.Contains(path, "phabricator.bundle.js") {
-		return true
-	}
-	return false
+	return strings.Contains(path, "phabricator.bundle.js")
 }

--- a/cmd/frontend/internal/pkg/discussions/notify_mentions.go
+++ b/cmd/frontend/internal/pkg/discussions/notify_mentions.go
@@ -272,7 +272,7 @@ func (n *notifier) notifyUsername(ctx context.Context, username string) error {
 			ThreadTitle:           n.thread.Title,
 			CommentAuthorUsername: commentAuthor.Username,
 			CommentContents:       n.comment.Contents,
-			CommentContentsHTML:   template.HTML(markdown.Render(n.comment.Contents, nil)),
+			CommentContentsHTML:   template.HTML(markdown.Render(n.comment.Contents)),
 			URL:                   url.String(),
 			UniqueValue:           fmt.Sprint(n.comment.ID),
 			CanReply:              conf.CanReadEmail(),

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -427,14 +427,6 @@ func (s *updateScheduler) ScheduleInfo(id uint32) *protocol.RepoUpdateSchedulerI
 	return &result
 }
 
-func (s *updateScheduler) UpdateQueueLen() int {
-	s.updateQueue.mu.Lock()
-	queueLen := len(s.updateQueue.index)
-	s.updateQueue.mu.Unlock()
-
-	return queueLen
-}
-
 // updateQueue is a priority queue of repos to update.
 // A repo can't have more than one location in the queue.
 type updateQueue struct {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -31,7 +31,6 @@ type Server struct {
 		GetRepo(ctx context.Context, nameWithOwner string) (*repos.Repo, error)
 	}
 	Scheduler interface {
-		UpdateQueueLen() int
 		UpdateOnce(id uint32, name api.RepoName, url string)
 		ScheduleInfo(id uint32) *protocol.RepoUpdateSchedulerInfoResult
 	}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -1036,13 +1036,6 @@ type fakeScheduler struct {
 	queue repos.Repos
 }
 
-func (s *fakeScheduler) UpdateQueueLen() int {
-	if s.queue != nil {
-		return s.queue.Len()
-	}
-	return 0
-}
-
 func (s *fakeScheduler) UpdateOnce(_ uint32, _ api.RepoName, _ string) {}
 func (s *fakeScheduler) ScheduleInfo(id uint32) *protocol.RepoUpdateSchedulerInfoResult {
 	return &protocol.RepoUpdateSchedulerInfoResult{}

--- a/dev/fakehub/main.go
+++ b/dev/fakehub/main.go
@@ -168,33 +168,6 @@ func logger(h http.Handler) http.HandlerFunc {
 	})
 }
 
-// handleDefault shows the root page with links to config and repos.
-func handleDefault(tvars *templateVars, w http.ResponseWriter) {
-	t1 := `
-<p><a href="/config">config</a></p>
-{{if .Repos}}
-{{range .Repos}}
-<div><a href="{{.}}">{{.}}</a></div>{{end}}
-{{else}}
-<div>No git repos found.</div>
-{{end}}
-`
-	err := func() error {
-		t2, err := template.New("linkspage").Parse(t1)
-		if err != nil {
-			return errors.Wrap(err, "parsing template for links page")
-		}
-		if err := t2.Execute(w, tvars); err != nil {
-			return errors.Wrap(err, "executing links page template")
-		}
-		return nil
-	}()
-	if err != nil {
-		log.Println(err)
-		_, _ = w.Write([]byte(err.Error()))
-	}
-}
-
 // handleConfig shows the config for pasting into sourcegraph.
 func handleConfig(tvars *templateVars, w http.ResponseWriter) {
 	t1 := `// Paste this into Site admin | External services | Add external service | Single Git repositories:

--- a/pkg/gosrc/import_path.go
+++ b/pkg/gosrc/import_path.go
@@ -31,7 +31,7 @@ var errNoMatch = errors.New("no match")
 func ResolveImportPath(client *http.Client, importPath string) (*Directory, error) {
 	if d, err := resolveStaticImportPath(importPath); err == nil {
 		return d, nil
-	} else if err != nil && err != errNoMatch {
+	} else if err != errNoMatch {
 		return nil, err
 	}
 	return resolveDynamicImportPath(client, importPath)

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -7,21 +7,8 @@ import (
 	gfm "github.com/shurcooL/github_flavored_markdown"
 )
 
-// Options represents option for rendering Markdown content.
-type Options struct {
-	// TODO(slimsag): add option for controlling relative links here.
-}
-
-// DefaultOptions is the default options for rendering Markdown content.
-var DefaultOptions = Options{}
-
 // Render renders Markdown content into sanitized HTML that is safe to render anywhere.
-//
-// When nil, options will default to DefaultOptions.
-func Render(content string, options *Options) string {
-	if options == nil {
-		options = &DefaultOptions
-	}
+func Render(content string) string {
 	unsafeHTML := gfm.Markdown([]byte(content))
 
 	p := bluemonday.UGCPolicy()

--- a/pkg/vcs/git/exec.go
+++ b/pkg/vcs/git/exec.go
@@ -85,7 +85,7 @@ func readUntilTimeout(ctx context.Context, cmd *gitserver.Cmd) (data []byte, com
 		data, err = ioutil.ReadAll(sr)
 		if err == nil {
 			complete = true
-		} else if err != nil && err != context.DeadlineExceeded {
+		} else if err != context.DeadlineExceeded {
 			data = bytes.TrimSpace(data)
 			if isBadObjectErr(string(data), "") || isInvalidRevisionRangeError(string(data), "") {
 				return nil, true, &gitserver.RevisionNotFoundError{Repo: cmd.Repo.Name, Spec: "UNKNOWN"}


### PR DESCRIPTION
Removes some dead code and simplifies some expressions (see commits for details).

```
golangci-lint run --build-tags=dev -v ./...
```
