### PR TITLE
searcher: don't copy regular expressions

### DIFF
--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -142,21 +142,6 @@ func compile(p *protocol.PatternInfo) (*readerGrep, error) {
 	}, nil
 }
 
-// Copy returns a copied version of rg that is safe to use from another
-// goroutine.
-func (rg *readerGrep) Copy() *readerGrep {
-	var reCopy *regexp.Regexp
-	if rg.re != nil {
-		reCopy = rg.re.Copy()
-	}
-	return &readerGrep{
-		re:               reCopy,
-		ignoreCase:       rg.ignoreCase,
-		matchPath:        rg.matchPath.Copy(),
-		literalSubstring: rg.literalSubstring,
-	}
-}
-
 // matchString returns whether rg's regexp pattern matches s. It is intended to be
 // used to match file paths.
 func (rg *readerGrep) matchString(s string) bool {
@@ -382,7 +367,7 @@ func concurrentFind(ctx context.Context, rg *readerGrep, zf *store.ZipFile, file
 	// Start workers. They read from files and write to matches.
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
-		go func(rg *readerGrep) {
+		go func() {
 			defer wg.Done()
 
 			for {
@@ -439,7 +424,7 @@ func concurrentFind(ctx context.Context, rg *readerGrep, zf *store.ZipFile, file
 					matchesmu.Unlock()
 				}
 			}
-		}(rg.Copy())
+		}()
 	}
 
 	wg.Wait()

--- a/cmd/searcher/search/matcher.go
+++ b/cmd/searcher/search/matcher.go
@@ -142,6 +142,17 @@ func compile(p *protocol.PatternInfo) (*readerGrep, error) {
 	}, nil
 }
 
+// Copy returns a copied version of rg that is safe to use from another
+// goroutine.
+func (rg *readerGrep) Copy() *readerGrep {
+	return &readerGrep{
+		re:               rg.re,
+		ignoreCase:       rg.ignoreCase,
+		matchPath:        rg.matchPath,
+		literalSubstring: rg.literalSubstring,
+	}
+}
+
 // matchString returns whether rg's regexp pattern matches s. It is intended to be
 // used to match file paths.
 func (rg *readerGrep) matchString(s string) bool {
@@ -158,10 +169,6 @@ func (rg *readerGrep) matchString(s string) bool {
 // LimitHit is true if some matches may not have been included in the result.
 // NOTE: This is not safe to use concurrently.
 func (rg *readerGrep) Find(zf *store.ZipFile, f *store.SrcFile) (matches []protocol.LineMatch, limitHit bool, err error) {
-	if rg.ignoreCase && rg.transformBuf == nil {
-		rg.transformBuf = make([]byte, zf.MaxLen)
-	}
-
 	// fileMatchBuf is what we run match on, fileBuf is the original
 	// data (for Preview).
 	fileBuf := zf.DataFor(f)
@@ -173,6 +180,9 @@ func (rg *readerGrep) Find(zf *store.ZipFile, f *store.SrcFile) (matches []proto
 	// trade some correctness for perf by using a non-utf8 aware
 	// lowercase function.
 	if rg.ignoreCase {
+		if rg.transformBuf == nil {
+			rg.transformBuf = make([]byte, zf.MaxLen)
+		}
 		fileMatchBuf = rg.transformBuf[:len(fileBuf)]
 		bytesToLowerASCII(fileMatchBuf, fileBuf)
 	}
@@ -367,7 +377,7 @@ func concurrentFind(ctx context.Context, rg *readerGrep, zf *store.ZipFile, file
 	// Start workers. They read from files and write to matches.
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
-		go func() {
+		go func(rg *readerGrep) {
 			defer wg.Done()
 
 			for {
@@ -424,7 +434,7 @@ func concurrentFind(ctx context.Context, rg *readerGrep, zf *store.ZipFile, file
 					matchesmu.Unlock()
 				}
 			}
-		}()
+		}(rg.Copy())
 	}
 
 	wg.Wait()

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -490,8 +490,12 @@ func diff(b1, b2 string) (string, error) {
 	defer os.Remove(f2.Name())
 	defer f2.Close()
 
-	f1.WriteString(b1)
-	f2.WriteString(b2)
+	if _, err := f1.WriteString(b1); err != nil {
+		return "", err
+	}
+	if _, err := f2.WriteString(b2); err != nil {
+		return "", err
+	}
 
 	data, err := exec.Command("diff", "-u", "--label=want", f1.Name(), "--label=got", f2.Name()).CombinedOutput()
 	if len(data) > 0 {

--- a/pkg/pathmatch/pathmatch_test.go
+++ b/pkg/pathmatch/pathmatch_test.go
@@ -32,10 +32,6 @@ func TestCompilePattern(t *testing.T) {
 				if got != want {
 					t.Errorf("path %q: got %v, want %v", path, got, want)
 				}
-
-				if got2 := match.Copy().MatchPath(path); got != got2 {
-					t.Errorf("path %q: after copy, got %v, want %v", path, got2, got)
-				}
 			}
 		})
 	}
@@ -56,10 +52,6 @@ func TestCompilePathPatterns(t *testing.T) {
 		if got != want {
 			t.Errorf("path %q: got %v, want %v", path, got, want)
 			continue
-		}
-
-		if got2 := match.Copy().MatchPath(path); got != got2 {
-			t.Errorf("path %q: after copy, got %v, want %v", path, got2, got)
 		}
 	}
 }


### PR DESCRIPTION
This is no longer necessary as of go 1.12 according to this staticcheck message:

> SA1019: rg.re.Copy is deprecated: In earlier releases, when using a Regexp in multiple goroutines, giving each goroutine its own copy helped to avoid lock contention. As of Go 1.12, using Copy is no longer necessary to avoid lock contention. Copy may still be appropriate if the reason for its use is to make two copies with different Longest settings.  (staticcheck)