### PR TITLE
Add regression tests for onboarding flow

### DIFF
--- a/web/src/regression/onboarding.test.ts
+++ b/web/src/regression/onboarding.test.ts
@@ -1,0 +1,224 @@
+import * as GQL from '../../../shared/src/graphql/schema'
+import { Driver } from '../../../shared/src/e2e/driver'
+import { GraphQLClient } from './util/GraphQLClient'
+import { setTestDefaults, createAndInitializeDriver } from './util/init'
+import { Config, getConfig } from '../../../shared/src/e2e/config'
+import { ensureLoggedInOrCreateUser } from './util/helpers'
+import { ensureExternalService, waitForRepos } from './util/api'
+import { BoundingBox } from 'puppeteer'
+import { Key } from 'ts-key-enum'
+
+const testRepoSlugs = ['auth0/go-jwt-middleware', 'kyoshidajp/ghkw', 'PalmStoneGames/kube-cert-manager']
+
+interface ExpectedScreenshot {
+    screenshotFile: string
+    description: string
+}
+
+/**
+ * Utility class to verify screenshots match a particular description
+ */
+class ScreenshotVerifier {
+    public screenshots: ExpectedScreenshot[]
+    constructor(public driver: Driver) {
+        this.screenshots = []
+    }
+
+    public async verifyScreenshot({
+        filename,
+        description,
+        clip,
+    }: {
+        /**
+         * The filename to which to save the screenshot. It should be a decsriptive name that captures both
+         * what should be happening in the screenshot and the context around what's happening. E.g.,
+         * "progress-bar-after-initial-search-is-half-green.png"
+         */
+        filename: string
+
+        /**
+         * A short description of what should happen in the screenshot.
+         */
+        description: string
+        clip?: BoundingBox
+    }) {
+        await this.driver.page.screenshot({
+            path: filename,
+            clip,
+        })
+        this.screenshots.push({ screenshotFile: filename, description })
+    }
+
+    public async verifySelector(
+        filename: string,
+        description: string,
+        selector: string,
+        waitForSelectorToBeVisibleTimeout: number = 0
+    ) {
+        if (waitForSelectorToBeVisibleTimeout > 0) {
+            await this.driver.page.waitForFunction(
+                selector => {
+                    const element = document.querySelector(selector)
+                    if (!element) {
+                        return false
+                    }
+                    const { width, height } = element.getBoundingClientRect()
+                    return width > 0 && height > 0
+                },
+                { timeout: waitForSelectorToBeVisibleTimeout },
+                selector
+            )
+        }
+
+        const clip: BoundingBox | undefined = await this.driver.page.evaluate(selector => {
+            const element = document.querySelector(selector)
+            if (!element) {
+                throw new Error(`element with selector ${JSON.stringify(selector)} not found`)
+            }
+            const { left, top, width, height } = element.getBoundingClientRect()
+            return { x: left, y: top, width, height }
+        }, selector)
+        await this.verifyScreenshot({
+            filename,
+            description,
+            clip,
+        })
+    }
+
+    /**
+     * Returns instructions to manually verify each screenshot stored in the to-verify list.
+     */
+    public verificationInstructions(): string {
+        return `
+        @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+        @@@@ Manual verification steps required!!! @@@@
+        @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+        Please verify the following screenshots match the corresponding descriptions:
+
+        ${this.screenshots.map(s => `${s.screenshotFile}:\t${JSON.stringify(s.description)}`).join('\n        ')}
+
+        `
+        // TODO
+    }
+}
+
+describe('Onboarding', () => {
+    let config: Pick<Config, 'sudoToken' | 'sudoUsername' | 'gitHubToken' | 'sourcegraphBaseUrl'>
+    let driver: Driver
+    let gqlClient: GraphQLClient
+    let screenshots: ScreenshotVerifier
+
+    beforeAll(
+        async () => {
+            config = getConfig(['sudoToken', 'sudoUsername', 'gitHubToken', 'sourcegraphBaseUrl'])
+            driver = await createAndInitializeDriver(config.sourcegraphBaseUrl)
+            gqlClient = GraphQLClient.newForPuppeteerTest({
+                baseURL: config.sourcegraphBaseUrl,
+                sudoToken: config.sudoToken,
+                username: config.sudoUsername,
+            })
+            screenshots = new ScreenshotVerifier(driver)
+            setTestDefaults(driver)
+            await ensureLoggedInOrCreateUser({
+                driver,
+                gqlClient,
+                username: 'test-onboarding-regression-test-user',
+                password: 'test',
+                deleteIfExists: true,
+            })
+            await ensureExternalService(gqlClient, {
+                kind: GQL.ExternalServiceKind.GITHUB,
+                uniqueDisplayName: 'GitHub (search-regression-test)',
+                config: {
+                    url: 'https://github.com',
+                    token: config.gitHubToken,
+                    repos: testRepoSlugs,
+                    repositoryQuery: ['none'],
+                },
+            })
+            await waitForRepos(gqlClient, ['github.com/' + testRepoSlugs[testRepoSlugs.length - 1]])
+        },
+        20 * 1000 // wait 20s for cloning
+    )
+
+    afterAll(async () => {
+        if (driver) {
+            await driver.close()
+        }
+        console.log(screenshots.verificationInstructions())
+    })
+
+    test(
+        'Non-admin user onboarding',
+        async () => {
+            const statusBarSelector = '.activation-dropdown-button__progress-bar-container'
+
+            // Initial status indicator
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search')
+            await screenshots.verifySelector(
+                'initial-progress-bar-is-gray-circle.png',
+                'gray circle',
+                statusBarSelector,
+                2000
+            )
+
+            // Do a search
+            await driver.page.type('.e2e-query-input', 'asdf')
+            await driver.page.keyboard.press(Key.Enter)
+            await new Promise(resolve => setTimeout(resolve, 500)) // allow some time for confetti to play
+            await screenshots.verifyScreenshot({
+                filename: 'confetti-appears-after-first-search.png',
+                description: 'confetti',
+            })
+            await screenshots.verifySelector(
+                'progress-bar-after-initial-search-is-half-green.png',
+                '50% green circle',
+                statusBarSelector
+            )
+
+            // Do a find references
+            await driver.page.goto(
+                config.sourcegraphBaseUrl +
+                    '/ghe.sgdev.org/sourcegraph/gorillalabs-sparkling/-/blob/src/java/sparkling/function/FlatMapFunction.java#L10:12&tab=references'
+            )
+            const defTokenXPath = '//*[contains(@class, "blob-page__blob")]//span[./text()="FlatMapFunction"]'
+            await driver.page.waitForXPath(defTokenXPath)
+            const elems = await driver.page.$x(defTokenXPath)
+            await elems[0].click()
+            await Promise.all(elems.map(elem => elem.dispose()))
+            const findRefsSelector = '.e2e-tooltip-find-references'
+            await driver.page.waitForSelector(findRefsSelector)
+            await driver.page.click(findRefsSelector)
+            await driver.page.waitForSelector('.e2e-search-result')
+            await new Promise(resolve => setTimeout(resolve, 500)) // allow some time for confetti to play
+
+            await screenshots.verifyScreenshot({
+                filename: 'confetti-appears-after-find-refs.png',
+                description: 'confetti',
+            })
+            await screenshots.verifySelector(
+                'progress-bar-after-search-and-fnd-refs-is-full-green.png',
+                '100% green circle',
+                statusBarSelector
+            )
+
+            await driver.page.reload()
+
+            // Wait for status bar to appear but it should be invisible
+            await driver.page.waitForFunction(
+                statusBarSelector => {
+                    const element = document.querySelector(statusBarSelector)
+                    if (!element) {
+                        return false
+                    }
+                    const { width, height } = element.getBoundingClientRect()
+                    return width === 0 && height === 0
+                },
+                { timeout: 100000 },
+                statusBarSelector
+            )
+        },
+        30 * 1000
+    )
+})

--- a/web/src/regression/util/GraphQLClient.ts
+++ b/web/src/regression/util/GraphQLClient.ts
@@ -6,7 +6,24 @@ import { Observable } from 'rxjs'
  * A GraphQL client to be used from regression test scripts.
  */
 export class GraphQLClient {
-    constructor(public baseURL: string, public sudoToken: string, public username: string) {}
+    public static newForPuppeteerTest({
+        baseURL,
+        sudoToken,
+        username,
+    }: {
+        baseURL: string
+        sudoToken: string
+        username: string
+    }): GraphQLClient {
+        if (new URL(window.location.href).origin !== new URL(baseURL).origin) {
+            throw new Error(
+                `JSDOM URL "${window.location.href}" did not match Sourcegraph base URL "${baseURL}". Tests will fail with a same-origin violation. Try setting the environment variable SOURCEGRAPH_BASE_URL.`
+            )
+        }
+        return new GraphQLClient(baseURL, sudoToken, username)
+    }
+
+    private constructor(public baseURL: string, public sudoToken: string, public username: string) {}
 
     /**
      * mimics the `mutateGraphQL` function used by the Sourcegraph backend, but substitutes

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -154,11 +154,30 @@ export async function getUser(gqlClient: GraphQLClient, username: string): Promi
     return user
 }
 
-export async function deleteUser(gqlClient: GraphQLClient, username: string): Promise<void> {
-    const user = await getUser(gqlClient, username)
-    if (!user) {
-        throw new Error(`Fetched user ${username} was null`)
+export async function deleteUser(
+    gqlClient: GraphQLClient,
+    username: string,
+    mustAlreadyExist: boolean = true
+): Promise<void> {
+    let user: GQL.IUser | null
+    try {
+        user = await getUser(gqlClient, username)
+    } catch (err) {
+        if (mustAlreadyExist) {
+            throw err
+        } else {
+            return
+        }
     }
+
+    if (!user) {
+        if (mustAlreadyExist) {
+            throw new Error(`Fetched user ${username} was null`)
+        } else {
+            return
+        }
+    }
+
     await gqlClient
         .mutateGraphQL(
             gql`

--- a/web/src/regression/util/helpers.ts
+++ b/web/src/regression/util/helpers.ts
@@ -4,6 +4,7 @@ import { gql, dataOrThrowErrors } from '../../../../shared/src/graphql/graphql'
 import { catchError, map } from 'rxjs/operators'
 import { throwError } from 'rxjs'
 import { Key } from 'ts-key-enum'
+import { deleteUser } from './api'
 
 /**
  * Create the user with the specified password
@@ -13,20 +14,36 @@ export async function ensureLoggedInOrCreateUser({
     gqlClient,
     username,
     password,
+    deleteIfExists,
 }: {
     driver: Driver
     gqlClient: GraphQLClient
     username: string
     password: string
+    deleteIfExists?: boolean
 }): Promise<void> {
-    // Attempt to log in
-    try {
-        await driver.ensureLoggedIn({ username, password })
-        return
-    } catch (err) {
-        console.log(`Login failed (error: ${err.message}), will attempt to create user ${JSON.stringify(username)}`)
+    if (deleteIfExists) {
+        await deleteUser(gqlClient, username, false)
+    } else {
+        // Attempt to log in first
+        try {
+            await driver.ensureLoggedIn({ username, password })
+            return
+        } catch (err) {
+            console.log(`Login failed (error: ${err.message}), will attempt to create user ${JSON.stringify(username)}`)
+        }
     }
 
+    await createUser(driver, gqlClient, username, password)
+    await driver.ensureLoggedIn({ username, password })
+}
+
+export async function createUser(
+    driver: Driver,
+    gqlClient: GraphQLClient,
+    username: string,
+    password: string
+): Promise<void> {
     // If there's an error, try to create the user
     const passwordResetURL = await gqlClient
         .mutateGraphQL(
@@ -63,5 +80,4 @@ export async function ensureLoggedInOrCreateUser({
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await driver.page.waitForFunction(() => document.body.textContent!.includes('Your password was reset'))
-    await driver.ensureLoggedIn({ username, password })
 }

--- a/web/src/regression/util/init.ts
+++ b/web/src/regression/util/init.ts
@@ -1,6 +1,17 @@
 import { createDriverForTest, Driver } from '../../../../shared/src/e2e/driver'
+import { saveScreenshotsUponFailuresAndClosePage } from '../../../../shared/src/e2e/screenshotReporter'
+import * as path from 'path'
 
-export function regressionTestInit(): void {
+/**
+ * Sets default timeout and error handlers for regression tests. Includes:
+ * - Default Jest test timeout
+ * - Top-level rejection handlers
+ * - Screenshot on failure
+ *
+ * This should be called in the top-level `beforeAll` function of each regression test suite,
+ * after the driver is initailized.
+ */
+export function setTestDefaults(driver: Driver): void {
     // 10s test timeout. This must be greater than the Puppeteer navigation timeout (set to 5s
     // below) in order to get the stack trace to point to the Puppeteer command that failed instead
     // of a cryptic Jest test timeout location.
@@ -13,6 +24,13 @@ export function regressionTestInit(): void {
     process.on('rejectionHandled', error => {
         console.error('Caught rejectionHandled:', error)
     })
+
+    // Take a screenshot when a test fails.
+    saveScreenshotsUponFailuresAndClosePage(
+        path.resolve(__dirname, '..', '..', '..'),
+        path.resolve(__dirname, '..', '..', '..', 'puppeteer'),
+        () => driver.page
+    )
 }
 
 /**


### PR DESCRIPTION
Adds onboarding regression tests (`onboarding.test.ts`). These tests are a little bit different in that they print out manual verification steps at the very end:

```
              @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
              @@@@ Manual verification steps required!!! @@@@
              @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

              Please verify the following screenshots match the corresponding descriptions:

              initial-progress-bar-is-gray-circle.png:  "gray circle"
              confetti-appears-after-first-search.png:  "confetti"
              progress-bar-after-initial-search-is-half-green.png:      "50% green circle"
              confetti-appears-after-find-refs.png:     "confetti"
              progress-bar-after-search-and-fnd-refs-is-full-green.png: "100% green circle"
```

This is because there are certain visual things to verify that are hard to encode in logic, but easy for a human to eyeball.

*Side note: I considered using Percy, but image-diffing doesn't provide good signal here (consider the problem of diffing a screenshot of the confetti animation, which can vary based on exactly when you take the screenshot). It was easier just to take a screenshot and ask the human to verify at the end. I'm a little worried that the message will be ignored, so am considering whether to require an explicit "YES I verified this" prompt at the end of the test suite. Thoughts on that?*

There were a few other minor refactors such as renaming some utility functions, moving some error handling, and adding extra options to utility functions.

This only tests onboarding for non-admin users. I still need to add another tests for admin onboarding, which includes additional steps. It also does not add tests to verify that the onboarding status menu appears, which I'll do in a later PR.