### PR TITLE
repo-updater: Stream inserts

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -129,6 +129,7 @@ func main() {
 		Store:        store,
 		Sourcer:      src,
 		Synced:       synced,
+		Logger:       log15.Root(),
 		Now:          clock,
 	}
 	server.Syncer = syncer

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -141,12 +141,9 @@ func main() {
 		syncer.Synced = make(chan repos.Repos)
 		syncer.SubsetSynced = make(chan repos.Repos)
 		go watchSyncer(ctx, syncer, scheduler, gps)
-	}
-	server.Syncer = syncer
-
-	if !envvar.SourcegraphDotComMode() {
 		go func() { log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval())) }()
 	}
+	server.Syncer = syncer
 
 	go repos.RunPhabricatorRepositorySyncWorker(ctx, store)
 

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -254,6 +254,19 @@ func (s *updateScheduler) Update(rs ...*Repo) {
 	schedKnownRepos.Set(float64(known))
 }
 
+// Set updates the schedule with the given repos. However, rs is assumed to be
+// the known universe of repositories, rather than a subset.
+func (s *updateScheduler) Set(rs ...*Repo) {
+	s.Update(rs...)
+	known := 0
+	for _, r := range rs {
+		if !r.IsDeleted() {
+			known++
+		}
+	}
+	schedKnownRepos.Set(float64(known))
+}
+
 func (s *updateScheduler) upsert(r *Repo) {
 	repo := configuredRepo2FromRepo(r)
 

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -198,7 +198,7 @@ func group(srcs []Source) map[string]Sources {
 
 // listAll calls ListRepos on the given Source and collects the SourceResults
 // the Source sends over a channel into a slice of *Repo and a single error
-func listAll(ctx context.Context, src Source) ([]*Repo, error) {
+func listAll(ctx context.Context, src Source, observe ...func(*Repo)) ([]*Repo, error) {
 	results := make(chan SourceResult)
 
 	go func() {
@@ -217,6 +217,9 @@ func listAll(ctx context.Context, src Source) ([]*Repo, error) {
 				errs = multierror.Append(errs, &SourceError{Err: res.Err, ExtSvc: extSvc})
 			}
 			continue
+		}
+		for _, o := range observe {
+			o(res.Repo)
 		}
 		repos = append(repos, res.Repo)
 	}

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -22,6 +22,10 @@ type Syncer struct {
 	Store   Store
 	Sourcer Sourcer
 
+	// DisableStreaming if true will prevent the syncer from streaming in new
+	// sourced repositories into the store.
+	DisableStreaming bool
+
 	// FailFullSync prevents Sync from running. This should only be true for
 	// Sourcegraph.com
 	FailFullSync bool
@@ -352,6 +356,11 @@ func (s *Syncer) sourced(ctx context.Context, observe ...func(*Repo)) ([]*Repo, 
 }
 
 func (s *Syncer) streamingInsert(ctx context.Context) (func(*Repo), error) {
+	if s.DisableStreaming {
+		// Return noop
+		return func(*Repo) {}, nil
+	}
+
 	// syncSubset requires querying the store for related repositories, and
 	// will do nothing if there are any related repositories. Most
 	// repositories will already have related repos, so to avoid that cost we

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -30,7 +30,7 @@ type Syncer struct {
 	// Sourcegraph.com
 	FailFullSync bool
 
-	// Synced if non-nil is sent Repos synced by Sync.
+	// Synced is sent Repos that were synced by Sync (only if Synced is non-nil)
 	Synced chan Repos
 
 	// SubsetSynced if non-nil is sent Repos synced by SubsetSync.

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -19,24 +19,30 @@ import (
 // A Syncer periodically synchronizes available repositories from all its given Sources
 // with the stored Repositories in Sourcegraph.
 type Syncer struct {
+	Store   Store
+	Sourcer Sourcer
+
 	// FailFullSync prevents Sync from running. This should only be true for
 	// Sourcegraph.com
 	FailFullSync bool
 
+	// Synced if non-nil is sent Repos synced by Sync.
+	Synced chan Repos
+
 	// SubsetSynced if non-nil is sent Repos synced by SubsetSync.
 	SubsetSynced chan Repos
+
+	// Logger if non-nil is logged to.
+	Logger log15.Logger
+
+	// Now is time.Now. Can be set by tests to get deterministic output.
+	Now func() time.Time
 
 	// lastSyncErr contains the last error returned by the Sourcer in each
 	// Sync. It's reset with each Sync and if the sync produced no error, it's
 	// set to nil.
 	lastSyncErr   error
 	lastSyncErrMu sync.Mutex
-
-	Store   Store
-	Sourcer Sourcer
-	Synced  chan Repos
-	Logger  log15.Logger
-	Now     func() time.Time
 
 	syncSignal signal
 }

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -23,6 +23,9 @@ type Syncer struct {
 	// Sourcegraph.com
 	FailFullSync bool
 
+	// SubsetSynced if non-nil is sent Repos synced by SubsetSync.
+	SubsetSynced chan Repos
+
 	// lastSyncErr contains the last error returned by the Sourcer in each
 	// Sync. It's reset with each Sync and if the sync produced no error, it's
 	// set to nil.
@@ -142,8 +145,8 @@ func (s *Syncer) SyncSubset(ctx context.Context, sourcedSubset ...*Repo) (diff D
 		return Diff{}, errors.Wrap(err, "syncer.syncsubset.store.upsert-repos")
 	}
 
-	if s.Synced != nil {
-		s.Synced <- diff.Repos()
+	if s.SubsetSynced != nil {
+		s.SubsetSynced <- diff.Repos()
 	}
 
 	return diff, nil

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -33,7 +33,7 @@ type Syncer struct {
 	// Synced is sent Repos that were synced by Sync (only if Synced is non-nil)
 	Synced chan Repos
 
-	// SubsetSynced if non-nil is sent Repos synced by SubsetSync.
+	// SubsetSynced is sent Repos that were synced by SubsetSync (only if SubsetSynced is non-nil)
 	SubsetSynced chan Repos
 
 	// Logger if non-nil is logged to.

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -31,7 +31,7 @@ type Syncer struct {
 
 	Store   Store
 	Sourcer Sourcer
-	Diffs   chan Diff
+	Synced  chan Repos
 	Now     func() time.Time
 
 	syncSignal signal
@@ -96,8 +96,8 @@ func (s *Syncer) Sync(ctx context.Context) (diff Diff, err error) {
 		return Diff{}, errors.Wrap(err, "syncer.sync.store.upsert-repos")
 	}
 
-	if s.Diffs != nil {
-		s.Diffs <- diff
+	if s.Synced != nil {
+		s.Synced <- diff.Repos()
 	}
 
 	return diff, nil
@@ -141,8 +141,8 @@ func (s *Syncer) SyncSubset(ctx context.Context, sourcedSubset ...*Repo) (diff D
 		return Diff{}, errors.Wrap(err, "syncer.syncsubset.store.upsert-repos")
 	}
 
-	if s.Diffs != nil {
-		s.Diffs <- diff
+	if s.Synced != nil {
+		s.Synced <- diff.Repos()
 	}
 
 	return diff, nil

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -362,7 +362,7 @@ func (s *Syncer) streamingInsert(ctx context.Context) (func(*Repo), error) {
 	}
 
 	// syncSubset requires querying the store for related repositories, and
-	// will do nothing if there are any related repositories. Most
+	// will do nothing if `insertOnly` is set and there are any related repositories. Most
 	// repositories will already have related repos, so to avoid that cost we
 	// ask the store for all repositories and only do syncsubset if it might
 	// be an insert.

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -74,7 +74,7 @@ func TestSyncer_Sync(t *testing.T) {
 				Sourcer: tc.sourcer,
 				Now:     now,
 			}
-			_, err := syncer.Sync(ctx)
+			err := syncer.Sync(ctx)
 
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("have error %q, want %q", have, want)
@@ -593,7 +593,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					Sourcer: tc.sourcer,
 					Now:     now,
 				}
-				_, err := syncer.Sync(ctx)
+				err := syncer.Sync(ctx)
 
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("have error %q, want %q", have, want)
@@ -738,7 +738,7 @@ func testSyncSubset(s repos.Store) func(*testing.T) {
 					Store: st,
 					Now:   clock.Now,
 				}
-				_, err := syncer.SyncSubset(ctx, tc.sourced.Clone()...)
+				err := syncer.SyncSubset(ctx, tc.sourced.Clone()...)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -54,7 +54,7 @@ func TestSyncer_Sync(t *testing.T) {
 			name:    "store list error aborts sync",
 			sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource(&github, nil)),
 			store:   &repos.FakeStore{ListReposError: errors.New("boom")},
-			err:     "syncer.sync.store.list-repos: boom",
+			err:     "syncer.sync.streaming: syncer.storedExternalIDs: boom",
 		},
 		{
 			name:    "store upsert error aborts sync",
@@ -593,7 +593,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					Sourcer: tc.sourcer,
 					Now:     now,
 				}
-				diff, err := syncer.Sync(ctx)
+				_, err := syncer.Sync(ctx)
 
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("have error %q, want %q", have, want)
@@ -603,25 +603,16 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					return
 				}
 
-				for _, d := range []struct {
-					name       string
-					have, want repos.Repos
-				}{
-					{"added", diff.Added, tc.diff.Added},
-					{"deleted", diff.Deleted, tc.diff.Deleted},
-					{"modified", diff.Modified, tc.diff.Modified},
-					{"unmodified", diff.Unmodified, tc.diff.Unmodified},
-				} {
-					t.Logf("diff.%s", d.name)
-					repos.Assert.ReposEqual(d.want...)(t, d.have)
-				}
-
 				if st != nil {
-					var want repos.Repos
-					want.Concat(diff.Added, diff.Modified, diff.Unmodified)
-					sort.Sort(want)
+					var want, have repos.Repos
+					want.Concat(tc.diff.Added, tc.diff.Modified, tc.diff.Unmodified)
+					have, _ = st.ListRepos(ctx, repos.StoreListReposArgs{})
 
-					have, _ := st.ListRepos(ctx, repos.StoreListReposArgs{})
+					want = want.With(repos.Opt.RepoID(0))
+					have = have.With(repos.Opt.RepoID(0))
+					sort.Sort(want)
+					sort.Sort(have)
+
 					repos.Assert.ReposEqual(want...)(t, have)
 				}
 			}))

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -416,7 +416,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 			return nil, err
 		}
 
-		_, err = s.Syncer.SyncSubset(ctx, repo)
+		err = s.Syncer.SyncSubset(ctx, repo)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -655,7 +655,7 @@ func TestServer_StatusMessages(t *testing.T) {
 				Messages: []protocol.StatusMessage{
 					{
 						SyncError: &protocol.SyncError{
-							Message: "syncer.sync.store.list-repos: could not connect to database",
+							Message: "syncer.sync.streaming: syncer.storedExternalIDs: could not connect to database",
 						},
 					},
 				},

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -691,7 +691,7 @@ func TestServer_StatusMessages(t *testing.T) {
 				sourcer := repos.NewFakeSourcer(tc.sourcerErr, repos.NewFakeSource(githubService, nil))
 				// Run Sync so that possibly `LastSyncErrors` is set
 				syncer.Sourcer = sourcer
-				_, _ = syncer.Sync(ctx)
+				_ = syncer.Sync(ctx)
 			}
 
 			s := &Server{


### PR DESCRIPTION
Syncing requires fetching from all sources before it can update the database.
For large instances this leads to a long time (minutes) from the time an admin
makes a change to an external service to seeing the effects. The most common
complaint is adding repositories to the external service, and not seeing
them. This commit will eagerly add new repositories into the store before
running the full sync. This is a much smaller change than making the sync
engine fully stream based.

This is an alternative approach to making repo-updater completely stream based. The important observation is that users complain that they add a repository to an external service and don't see it. This change doesn't adjust how repo-updater's core sync algorithm works. Instead it will eagerly insert any repository from a source which is not already in the store.

Alternative to https://github.com/sourcegraph/sourcegraph/pull/5526

Fixes https://github.com/sourcegraph/sourcegraph/issues/5145