### PR TITLE
repo-updater: Refactor Syncer to be created without constructor

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -124,8 +124,13 @@ func main() {
 	}
 
 	diffs := make(chan repos.Diff)
-	syncer := repos.NewSyncer(store, src, diffs, clock)
-	syncer.FailFullSync = envvar.SourcegraphDotComMode()
+	syncer := &repos.Syncer{
+		FailFullSync: envvar.SourcegraphDotComMode(),
+		Store:        store,
+		Sourcer:      src,
+		Diffs:        diffs,
+		Now:          clock,
+	}
 	server.Syncer = syncer
 
 	if !envvar.SourcegraphDotComMode() {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -37,23 +37,6 @@ type Syncer struct {
 	syncSignal signal
 }
 
-// NewSyncer returns a new Syncer that syncs stored repos with
-// the repos yielded by the configured sources, retrieved by the given sourcer.
-// Each completed sync results in a diff that is sent to the given diffs channel.
-func NewSyncer(
-	store Store,
-	sourcer Sourcer,
-	diffs chan Diff,
-	now func() time.Time,
-) *Syncer {
-	return &Syncer{
-		Store:   store,
-		Sourcer: sourcer,
-		Diffs:   diffs,
-		Now:     now,
-	}
-}
-
 // Run runs the Sync at the specified interval.
 func (s *Syncer) Run(ctx context.Context, interval time.Duration) error {
 	for ctx.Err() == nil {

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -69,7 +69,11 @@ func TestSyncer_Sync(t *testing.T) {
 			now := clock.Now
 			ctx := context.Background()
 
-			syncer := repos.NewSyncer(tc.store, tc.sourcer, nil, now)
+			syncer := &repos.Syncer{
+				Store:   tc.store,
+				Sourcer: tc.sourcer,
+				Now:     now,
+			}
 			_, err := syncer.Sync(ctx)
 
 			if have, want := fmt.Sprint(err), tc.err; have != want {
@@ -584,7 +588,11 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 					}
 				}
 
-				syncer := repos.NewSyncer(st, tc.sourcer, nil, now)
+				syncer := &repos.Syncer{
+					Store:   st,
+					Sourcer: tc.sourcer,
+					Now:     now,
+				}
 				diff, err := syncer.Sync(ctx)
 
 				if have, want := fmt.Sprint(err), tc.err; have != want {
@@ -735,7 +743,10 @@ func testSyncSubset(s repos.Store) func(*testing.T) {
 				}
 
 				clock := clock
-				syncer := repos.NewSyncer(st, nil, nil, clock.Now)
+				syncer := &repos.Syncer{
+					Store: st,
+					Now:   clock.Now,
+				}
 				_, err := syncer.SyncSubset(ctx, tc.sourced.Clone()...)
 				if err != nil {
 					t.Fatal(err)

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -681,13 +681,16 @@ func TestServer_StatusMessages(t *testing.T) {
 			}
 
 			clock := repos.NewFakeClock(time.Now(), 0)
-			syncer := repos.NewSyncer(store, nil, nil, clock.Now)
+			syncer := &repos.Syncer{
+				Store: store,
+				Now:   clock.Now,
+			}
 
 			if tc.sourcerErr != nil || tc.listRepoErr != nil {
 				store.ListReposError = tc.listRepoErr
 				sourcer := repos.NewFakeSourcer(tc.sourcerErr, repos.NewFakeSource(githubService, nil))
 				// Run Sync so that possibly `LastSyncErrors` is set
-				syncer = repos.NewSyncer(store, sourcer, nil, clock.Now)
+				syncer.Sourcer = sourcer
 				_, _ = syncer.Sync(ctx)
 			}
 
@@ -984,7 +987,10 @@ func TestRepoLookup(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			syncer := repos.NewSyncer(store, nil, nil, clock.Now)
+			syncer := &repos.Syncer{
+				Store: store,
+				Now:   clock.Now,
+			}
 			s := &Server{Syncer: syncer, Store: store}
 			if tc.githubDotComSource != nil {
 				s.GithubDotComSource = tc.githubDotComSource


### PR DESCRIPTION
This is a pure refactoring (no functionality change) to make it possible to create Syncer without a constructor. This is useful since in many test cases we set nil for values we don't care about, leading to quite an ugly constructor call. This will also facilitate introduction of more fields (such as what I am doing in https://github.com/sourcegraph/sourcegraph/pull/5645