### PR TITLE
a8n: Introduce the ChangesetSyncer to sync changeset metadata in background

### DIFF
--- a/cmd/repo-updater/repos/bitbucketcloud_test.go
+++ b/cmd/repo-updater/repos/bitbucketcloud_test.go
@@ -95,7 +95,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			repos, err := listAll(context.Background(), bbcSrc)
+			repos, err := listAllRepos(context.Background(), bbcSrc)
 
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)

--- a/cmd/repo-updater/repos/changeset_syncer.go
+++ b/cmd/repo-updater/repos/changeset_syncer.go
@@ -1,0 +1,126 @@
+package repos
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/pkg/a8n"
+	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+// A ChangesetSyncer periodically sync the metadata of the changesets
+// saved in the database
+type ChangesetSyncer struct {
+	A8NStore    *a8n.Store
+	ReposStore  Store
+	HTTPFactory *httpcli.Factory
+}
+
+// Sync refreshes the metadata of the specified changesets and updates them
+// in the database
+func (s *ChangesetSyncer) Sync(ctx context.Context, cs ...*a8n.Changeset) (err error) {
+	if len(cs) == 0 {
+		return nil
+	}
+
+	var repoIDs []uint32
+	repoSet := map[uint32]*Repo{}
+
+	for _, c := range cs {
+		id := uint32(c.RepoID)
+		if _, ok := repoSet[id]; !ok {
+			repoSet[id] = nil
+			repoIDs = append(repoIDs, id)
+		}
+	}
+
+	rs, err := s.ReposStore.ListRepos(ctx, StoreListReposArgs{IDs: repoIDs})
+	if err != nil {
+		return err
+	}
+
+	for _, r := range rs {
+		repoSet[r.ID] = r
+	}
+
+	for _, c := range cs {
+		repo := repoSet[uint32(c.RepoID)]
+		if repo == nil {
+			log15.Warn("changeset not synced, repo not in database", "changeset_id", c.ID, "repo_id", c.RepoID)
+		}
+	}
+
+	es, err := s.ReposStore.ListExternalServices(ctx, StoreListExternalServicesArgs{RepoIDs: repoIDs})
+	if err != nil {
+		return err
+	}
+
+	byRepo := make(map[uint32]int64, len(rs))
+	for _, r := range rs {
+		eids := r.ExternalServiceIDs()
+		for _, id := range eids {
+			if _, ok := byRepo[r.ID]; !ok {
+				byRepo[r.ID] = id
+				break
+			}
+		}
+	}
+
+	type batch struct {
+		ChangesetSource
+		Changesets []*Changeset
+	}
+
+	batches := make(map[int64]*batch, len(es))
+	for _, e := range es {
+		src, err := NewSource(e, s.HTTPFactory)
+		if err != nil {
+			return err
+		}
+
+		css, ok := src.(ChangesetSource)
+		if !ok {
+			return errors.Errorf("unsupported repo type %q", e.Kind)
+		}
+
+		batches[e.ID] = &batch{ChangesetSource: css}
+	}
+
+	for _, c := range cs {
+		repoID := uint32(c.RepoID)
+		b := batches[byRepo[repoID]]
+		if b == nil {
+			continue
+		}
+		b.Changesets = append(b.Changesets, &Changeset{
+			Changeset: c,
+			Repo:      repoSet[repoID],
+		})
+	}
+
+	for _, b := range batches {
+		if err = b.LoadChangesets(ctx, b.Changesets...); err != nil {
+			return err
+		}
+	}
+
+	if err = s.A8NStore.UpdateChangesets(ctx, cs...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *ChangesetSyncer) listAllChangesets(ctx context.Context) (all []*a8n.Changeset, err error) {
+	for cursor := int64(-1); cursor != 0; {
+		opts := a8n.ListChangesetsOpts{Cursor: cursor, Limit: 1000}
+		cs, next, err := s.A8NStore.ListChangesets(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		all, cursor = append(all, cs...), next
+	}
+
+	return all, err
+}

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -405,7 +405,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			repos, err := listAll(context.Background(), githubSrc)
+			repos, err := listAllRepos(context.Background(), githubSrc)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -198,7 +198,7 @@ func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
 				continue
 			}
 
-			repos, err := listAll(ctx, src)
+			repos, err := listAllRepos(ctx, src)
 			if err != nil {
 				log15.Error("Error fetching Phabricator repos", "err", err)
 				continue

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -196,9 +196,9 @@ func group(srcs []Source) map[string]Sources {
 	return groups
 }
 
-// listAll calls ListRepos on the given Source and collects the SourceResults
+// listAllRepos calls ListRepos on the given Source and collects the SourceResults
 // the Source sends over a channel into a slice of *Repo and a single error
-func listAll(ctx context.Context, src Source) ([]*Repo, error) {
+func listAllRepos(ctx context.Context, src Source) ([]*Repo, error) {
 	results := make(chan SourceResult)
 
 	go func() {

--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -750,7 +750,7 @@ func TestSources_ListRepos(t *testing.T) {
 					ctx = context.Background()
 				}
 
-				repos, err := listAll(ctx, srcs)
+				repos, err := listAllRepos(ctx, srcs)
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 				}

--- a/pkg/a8n/store.go
+++ b/pkg/a8n/store.go
@@ -291,6 +291,7 @@ func getChangesetQuery(opts *GetChangesetOpts) *sqlf.Query {
 // ListChangesetsOpts captures the query options needed for
 // listing changesets.
 type ListChangesetsOpts struct {
+	Cursor     int64
 	Limit      int
 	CampaignID int64
 	IDs        []int64
@@ -343,7 +344,10 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	}
 	opts.Limit++
 
-	var preds []*sqlf.Query
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("id >= %s", opts.Cursor),
+	}
+
 	if opts.CampaignID != 0 {
 		preds = append(preds, sqlf.Sprintf("campaign_ids ? %s", opts.CampaignID))
 	}
@@ -356,10 +360,6 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 			}
 		}
 		preds = append(preds, sqlf.Sprintf("id IN (%s)", sqlf.Join(ids, ",")))
-	}
-
-	if len(preds) == 0 {
-		preds = append(preds, sqlf.Sprintf("TRUE"))
 	}
 
 	return sqlf.Sprintf(
@@ -651,6 +651,7 @@ func getCampaignQuery(opts *GetCampaignOpts) *sqlf.Query {
 // listing campaigns.
 type ListCampaignsOpts struct {
 	ChangesetID int64
+	Cursor      int64
 	Limit       int
 }
 
@@ -660,7 +661,6 @@ func (s *Store) ListCampaigns(ctx context.Context, opts ListCampaignsOpts) (cs [
 
 	cs = make([]*Campaign, 0, opts.Limit)
 	_, _, err = s.query(ctx, q, func(sc scanner) (last, count int64, err error) {
-
 		var c Campaign
 		if err = scanCampaign(&c, sc); err != nil {
 			return 0, 0, err
@@ -701,13 +701,12 @@ func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
 	}
 	opts.Limit++
 
-	var preds []*sqlf.Query
-	if opts.ChangesetID != 0 {
-		preds = append(preds, sqlf.Sprintf("changeset_ids ? %s", opts.ChangesetID))
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("id >= %s", opts.Cursor),
 	}
 
-	if len(preds) == 0 {
-		preds = append(preds, sqlf.Sprintf("TRUE"))
+	if opts.ChangesetID != 0 {
+		preds = append(preds, sqlf.Sprintf("changeset_ids ? %s", opts.ChangesetID))
 	}
 
 	return sqlf.Sprintf(

--- a/pkg/a8n/store_test.go
+++ b/pkg/a8n/store_test.go
@@ -146,6 +146,24 @@ func TestStore(t *testing.T) {
 					}
 				}
 			}
+
+			{
+				var cursor int64
+				for i := 1; i <= len(campaigns); i++ {
+					opts := ListCampaignsOpts{Cursor: cursor, Limit: 1}
+					have, next, err := s.ListCampaigns(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					want := campaigns[i-1 : i]
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatalf("opts: %+v, diff: %s", opts, diff)
+					}
+
+					cursor = next
+				}
+			}
 		})
 
 		t.Run("Update", func(t *testing.T) {
@@ -386,6 +404,24 @@ func TestStore(t *testing.T) {
 				want := changesets
 				if diff := cmp.Diff(have, want); diff != "" {
 					t.Fatal(diff)
+				}
+			}
+
+			{
+				var cursor int64
+				for i := 1; i <= len(changesets); i++ {
+					opts := ListChangesetsOpts{Cursor: cursor, Limit: 1}
+					have, next, err := s.ListChangesets(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					want := changesets[i-1 : i]
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatalf("opts: %+v, diff: %s", opts, diff)
+					}
+
+					cursor = next
 				}
 			}
 		})


### PR DESCRIPTION
This PR moves the syncing part of the `CreateChangesets` resolver method to a `repos.ChangesetSyncer` with a `Sync` method.

This `Sync` method is then called in the resolver itself and in the background, in the original `Syncer`.

The reason we're calling it in the `Syncer` is that we don't want to have another, separate loop that would send requests to GitHub, possibly triggering their API abuse detection mechanism.

The `ChangesetSyncer.Sync` method is integration tested through the GraphQL tests for `CreateChangesets`, which call the same method. That it's periodically called in the background I tested manually with multiple changesets.

Do we need a feature flag? Not sure. Right now the changeset syncer does nothing if there are no changesets in the database.

What's missing? Depends on the level of polish we're going for. Some ideas:

- Maybe aeparate feature-flag-ENV-var. Currently the syncer calls the `ChangesetSyncer` on every run. If there are no changesets in the database (99% of our customers), then it does nothing. I'm not sure whether we need a flag in addition to that.
- Optimization: we're currently writing to the database with ever sync, even if nothing has changed. I think that is fine for now, but should be on top of the list regarding "improve syncing process" 
- The changeset sync currently gets triggered when we receive a trigger-sync-signal. That happens when a user saves an external service, for example. In that case, we probably don't want to sync changesets. But maybe we do want a "hard refresh" button for changesets somewhere in the UI?
- Refactor code so that the changeset syncer uses the `repos.Store` from the Syncer instead of constructing its own in the `Sync` method
- Maybe introduce a higher-level syncer that gets initialized with a ChangesetSyncer and a ReposSyncer. In its `Run` method this new syncer calls both syncers `Sync` method.
- Unit tests for the `ChangesetSyncer`