### PR TITLE
a8n/enterprise: Introduce ChangesetSyncer

### DIFF
--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -65,7 +65,11 @@ func main() {
 			HTTPFactory: repos.NewHTTPClientFactory(),
 		}
 
-		go syncer.Run(ctx)
+		go func() {
+			if err := syncer.Run(ctx); err != nil {
+				log15.Error("ChangesetSyncer.Run", "err", err)
+			}
+		}()
 	}
 
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -20,14 +21,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	iauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
+	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n/resolvers"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 	"gopkg.in/inconshreveable/log15.v2"
 )
@@ -54,6 +58,14 @@ func main() {
 			}
 		}()
 		go licensing.StartMaxUserCount(&usersStore{})
+
+		syncer := &a8n.ChangesetSyncer{
+			Store:       a8n.NewStore(dbconn.Global),
+			ReposStore:  repos.NewDBStore(dbconn.Global, sql.TxOptions{}),
+			HTTPFactory: repos.NewHTTPClientFactory(),
+		}
+
+		go syncer.Run(ctx, 2*time.Minute)
 	}
 
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -65,7 +65,7 @@ func main() {
 			HTTPFactory: repos.NewHTTPClientFactory(),
 		}
 
-		go syncer.Run(ctx, 2*time.Minute)
+		go syncer.Run(ctx)
 	}
 
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))

--- a/enterprise/pkg/a8n/resolvers/graphql.go
+++ b/enterprise/pkg/a8n/resolvers/graphql.go
@@ -368,58 +368,12 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	// We do this outside of a transaction.
 
 	store = repos.NewDBStore(r.store.DB(), sql.TxOptions{})
-	es, err := store.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{RepoIDs: repoIDs})
-	if err != nil {
-		return nil, err
+	syncer := ee.ChangesetSyncer{
+		ReposStore:  store,
+		Store:       r.store,
+		HTTPFactory: r.httpFactory,
 	}
-
-	byRepo := make(map[uint32]int64, len(rs))
-	for _, r := range rs {
-		eids := r.ExternalServiceIDs()
-		for _, id := range eids {
-			if _, ok := byRepo[r.ID]; !ok {
-				byRepo[r.ID] = id
-				break
-			}
-		}
-	}
-
-	type batch struct {
-		repos.ChangesetSource
-		Changesets []*repos.Changeset
-	}
-
-	batches := make(map[int64]*batch, len(es))
-	for _, e := range es {
-		src, err := repos.NewSource(e, r.httpFactory)
-		if err != nil {
-			return nil, err
-		}
-
-		css, ok := src.(repos.ChangesetSource)
-		if !ok {
-			return nil, errors.Errorf("unsupported repo type %q", e.Kind)
-		}
-
-		batches[e.ID] = &batch{ChangesetSource: css}
-	}
-
-	for _, c := range cs {
-		repoID := uint32(c.RepoID)
-		b := batches[byRepo[repoID]]
-		b.Changesets = append(b.Changesets, &repos.Changeset{
-			Changeset: c,
-			Repo:      repoSet[repoID],
-		})
-	}
-
-	for _, b := range batches {
-		if err = b.LoadChangesets(ctx, b.Changesets...); err != nil {
-			return nil, err
-		}
-	}
-
-	if err = r.store.UpdateChangesets(ctx, cs...); err != nil {
+	if err = syncer.Sync(ctx, cs...); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -291,6 +291,7 @@ func getChangesetQuery(opts *GetChangesetOpts) *sqlf.Query {
 // ListChangesetsOpts captures the query options needed for
 // listing changesets.
 type ListChangesetsOpts struct {
+	Cursor     int64
 	Limit      int
 	CampaignID int64
 	IDs        []int64
@@ -343,7 +344,10 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	}
 	opts.Limit++
 
-	var preds []*sqlf.Query
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("id >= %s", opts.Cursor),
+	}
+
 	if opts.CampaignID != 0 {
 		preds = append(preds, sqlf.Sprintf("campaign_ids ? %s", opts.CampaignID))
 	}
@@ -356,10 +360,6 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 			}
 		}
 		preds = append(preds, sqlf.Sprintf("id IN (%s)", sqlf.Join(ids, ",")))
-	}
-
-	if len(preds) == 0 {
-		preds = append(preds, sqlf.Sprintf("TRUE"))
 	}
 
 	return sqlf.Sprintf(
@@ -650,6 +650,7 @@ func getCampaignQuery(opts *GetCampaignOpts) *sqlf.Query {
 // listing campaigns.
 type ListCampaignsOpts struct {
 	ChangesetID int64
+	Cursor      int64
 	Limit       int
 }
 
@@ -699,13 +700,12 @@ func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
 	}
 	opts.Limit++
 
-	var preds []*sqlf.Query
-	if opts.ChangesetID != 0 {
-		preds = append(preds, sqlf.Sprintf("changeset_ids ? %s", opts.ChangesetID))
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("id >= %s", opts.Cursor),
 	}
 
-	if len(preds) == 0 {
-		preds = append(preds, sqlf.Sprintf("TRUE"))
+	if opts.ChangesetID != 0 {
+		preds = append(preds, sqlf.Sprintf("changeset_ids ? %s", opts.ChangesetID))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
-	"github.com/segmentio/fasthash/fnv1"
 	"github.com/sourcegraph/sourcegraph/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/pkg/extsvc/github"
@@ -715,61 +714,6 @@ func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
 		opts.Limit,
 	)
 }
-
-var errLockNotAvailable = errors.New("lock not available")
-
-// Lock uses Postgres advisory locks to acquire an exclusive lock.
-// Concurrent processes that call this method while a lock is
-// already held by another process will have errLockNotAvailable returned.
-func (s *Store) Lock(ctx context.Context, id string) (err error) {
-	if _, ok := s.db.(*sql.Tx); !ok {
-		return errors.Errorf("store.lock must be called inside a transaction")
-	}
-
-	q := lockQuery(id)
-
-	var rows *sql.Rows
-	rows, err = s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-	if err != nil {
-		return err
-	}
-
-	if !rows.Next() {
-		return rows.Err()
-	}
-
-	locked := false
-	if err = rows.Scan(&locked); err != nil {
-		return err
-	}
-
-	if err = rows.Close(); err != nil {
-		return err
-	}
-
-	if !locked {
-		return errLockNotAvailable
-	}
-
-	return nil
-}
-
-var lockNamespace = int32(fnv1.HashString32("a8n"))
-
-func lockQuery(id string) *sqlf.Query {
-	// Postgres advisory lock ids are a global namespace within one database.
-	lockID := int32(fnv1.HashString32(id))
-	return sqlf.Sprintf(
-		lockQueryFmtStr,
-		lockNamespace,
-		lockID,
-	)
-}
-
-const lockQueryFmtStr = `
--- source: enterprise/pkg/a8n/store.go:Lock
-SELECT pg_try_advisory_xact_lock(%s, %s)
-`
 
 func (s *Store) exec(ctx context.Context, q *sqlf.Query, sc scanFunc) error {
 	_, _, err := s.query(ctx, q, sc)

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -767,7 +767,7 @@ func lockQuery(id string) *sqlf.Query {
 }
 
 const lockQueryFmtStr = `
--- source: enterprise/cmd/frontend/internal/authz/bitbucketserver/store.go:store.lock
+-- source: enterprise/pkg/a8n/store.go:Lock
 SELECT pg_try_advisory_xact_lock(%s, %s)
 `
 

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -147,6 +147,24 @@ func TestStore(t *testing.T) {
 					}
 				}
 			}
+
+			{
+				var cursor int64
+				for i := 1; i <= len(campaigns); i++ {
+					opts := ListCampaignsOpts{Cursor: cursor, Limit: 1}
+					have, next, err := s.ListCampaigns(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					want := campaigns[i-1 : i]
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatalf("opts: %+v, diff: %s", opts, diff)
+					}
+
+					cursor = next
+				}
+			}
 		})
 
 		t.Run("Update", func(t *testing.T) {
@@ -387,6 +405,24 @@ func TestStore(t *testing.T) {
 				want := changesets
 				if diff := cmp.Diff(have, want); diff != "" {
 					t.Fatal(diff)
+				}
+			}
+
+			{
+				var cursor int64
+				for i := 1; i <= len(changesets); i++ {
+					opts := ListChangesetsOpts{Cursor: cursor, Limit: 1}
+					have, next, err := s.ListChangesets(ctx, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					want := changesets[i-1 : i]
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatalf("opts: %+v, diff: %s", opts, diff)
+					}
+
+					cursor = next
 				}
 			}
 		})

--- a/enterprise/pkg/a8n/syncer.go
+++ b/enterprise/pkg/a8n/syncer.go
@@ -22,17 +22,24 @@ type ChangesetSyncer struct {
 // Run runs the Sync at the specified interval.
 func (s *ChangesetSyncer) Run(ctx context.Context, interval time.Duration) error {
 	for ctx.Err() == nil {
-		log15.Warn("ChangesetSyncer running the sync")
-		if err := s.Sync(ctx); err != nil {
-			log15.Error("ChangesetSyncer", "error", err)
-		}
+		time.Sleep(interval)
 
-		select {
-		case <-time.After(interval):
-		}
+		s.syncAllChangesets(ctx)
 	}
 
 	return ctx.Err()
+}
+
+func (s *ChangesetSyncer) syncAllChangesets(ctx context.Context) {
+	cs, err := s.listAllChangesets(ctx)
+	if err != nil {
+		log15.Error("ChangesetSyncer.listAllChangesets", "error", err)
+		return
+	}
+
+	if err := s.Sync(ctx, cs...); err != nil {
+		log15.Error("ChangesetSyncer", "error", err)
+	}
 }
 
 // Sync refreshes the metadata of the specified changesets and updates them

--- a/enterprise/pkg/a8n/syncer.go
+++ b/enterprise/pkg/a8n/syncer.go
@@ -1,0 +1,127 @@
+package a8n
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/pkg/a8n"
+	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+// A ChangesetSyncer periodically sync the metadata of the changesets
+// saved in the database
+type ChangesetSyncer struct {
+	Store       *Store
+	ReposStore  repos.Store
+	HTTPFactory *httpcli.Factory
+}
+
+// Sync refreshes the metadata of the specified changesets and updates them
+// in the database
+func (s *ChangesetSyncer) Sync(ctx context.Context, cs ...*a8n.Changeset) (err error) {
+	if len(cs) == 0 {
+		return nil
+	}
+
+	var repoIDs []uint32
+	repoSet := map[uint32]*repos.Repo{}
+
+	for _, c := range cs {
+		id := uint32(c.RepoID)
+		if _, ok := repoSet[id]; !ok {
+			repoSet[id] = nil
+			repoIDs = append(repoIDs, id)
+		}
+	}
+
+	rs, err := s.ReposStore.ListRepos(ctx, repos.StoreListReposArgs{IDs: repoIDs})
+	if err != nil {
+		return err
+	}
+
+	for _, r := range rs {
+		repoSet[r.ID] = r
+	}
+
+	for _, c := range cs {
+		repo := repoSet[uint32(c.RepoID)]
+		if repo == nil {
+			log15.Warn("changeset not synced, repo not in database", "changeset_id", c.ID, "repo_id", c.RepoID)
+		}
+	}
+
+	es, err := s.ReposStore.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{RepoIDs: repoIDs})
+	if err != nil {
+		return err
+	}
+
+	byRepo := make(map[uint32]int64, len(rs))
+	for _, r := range rs {
+		eids := r.ExternalServiceIDs()
+		for _, id := range eids {
+			if _, ok := byRepo[r.ID]; !ok {
+				byRepo[r.ID] = id
+				break
+			}
+		}
+	}
+
+	type batch struct {
+		repos.ChangesetSource
+		Changesets []*repos.Changeset
+	}
+
+	batches := make(map[int64]*batch, len(es))
+	for _, e := range es {
+		src, err := repos.NewSource(e, s.HTTPFactory)
+		if err != nil {
+			return err
+		}
+
+		css, ok := src.(repos.ChangesetSource)
+		if !ok {
+			return errors.Errorf("unsupported repo type %q", e.Kind)
+		}
+
+		batches[e.ID] = &batch{ChangesetSource: css}
+	}
+
+	for _, c := range cs {
+		repoID := uint32(c.RepoID)
+		b := batches[byRepo[repoID]]
+		if b == nil {
+			continue
+		}
+		b.Changesets = append(b.Changesets, &repos.Changeset{
+			Changeset: c,
+			Repo:      repoSet[repoID],
+		})
+	}
+
+	for _, b := range batches {
+		if err = b.LoadChangesets(ctx, b.Changesets...); err != nil {
+			return err
+		}
+	}
+
+	if err = s.Store.UpdateChangesets(ctx, cs...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *ChangesetSyncer) listAllChangesets(ctx context.Context) (all []*a8n.Changeset, err error) {
+	for cursor := int64(-1); cursor != 0; {
+		opts := ListChangesetsOpts{Cursor: cursor, Limit: 1000}
+		cs, next, err := s.Store.ListChangesets(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		all, cursor = append(all, cs...), next
+	}
+
+	return all, err
+}

--- a/enterprise/pkg/a8n/syncer.go
+++ b/enterprise/pkg/a8n/syncer.go
@@ -2,6 +2,7 @@ package a8n
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/pkg/errors"
@@ -20,9 +21,10 @@ type ChangesetSyncer struct {
 }
 
 // Run runs the Sync at the specified interval.
-func (s *ChangesetSyncer) Run(ctx context.Context, interval time.Duration) error {
+func (s *ChangesetSyncer) Run(ctx context.Context) error {
 	for ctx.Err() == nil {
-		time.Sleep(interval)
+		seconds := 30 + rand.Intn(90)
+		time.Sleep(time.Duration(seconds) * time.Second)
 
 		s.syncAllChangesets(ctx)
 	}


### PR DESCRIPTION
(Previous, non-enterprise PR: https://github.com/sourcegraph/sourcegraph/pull/5648)

This PR moves the syncing part of the `CreateChangesets` resolver method to a `repos.ChangesetSyncer` with a `Sync` method.

This `Sync` method is then called in the resolver itself and in the background, in the original `Syncer`.

The reason we're calling it in the `Syncer` is that we don't want to have another, separate loop that would send requests to GitHub, possibly triggering their API abuse detection mechanism.

The `ChangesetSyncer.Sync` method is integration tested through the GraphQL tests for `CreateChangesets`, which call the same method. That it's periodically called in the background I tested manually with multiple changesets.

Do we need a feature flag? Not sure. Right now the changeset syncer does nothing if there are no changesets in the database.

What's missing? Depends on the level of polish we're going for. Some ideas:

- Maybe aeparate feature-flag-ENV-var. Currently the syncer calls the `ChangesetSyncer` on every run. If there are no changesets in the database (99% of our customers), then it does nothing. I'm not sure whether we need a flag in addition to that.
- Optimization: we're currently writing to the database with ever sync, even if nothing has changed. I think that is fine for now, but should be on top of the list regarding "improve syncing process" 
- The changeset sync currently gets triggered when we receive a trigger-sync-signal. That happens when a user saves an external service, for example. In that case, we probably don't want to sync changesets. But maybe we do want a "hard refresh" button for changesets somewhere in the UI?
- Refactor code so that the changeset syncer uses the `repos.Store` from the Syncer instead of constructing its own in the `Sync` method
- Maybe introduce a higher-level syncer that gets initialized with a ChangesetSyncer and a ReposSyncer. In its `Run` method this new syncer calls both syncers `Sync` method.
- Unit tests for the `ChangesetSyncer`