### PR TITLE
migrate Sourcegraph.com telemetry pipeline to gcloud

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -94,7 +94,6 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 		if args.Argument != nil {
 			argument = *args.Argument
 		}
-		var event []byte
 		event, err := json.Marshal(bigQueryEvent{
 			EventName:       args.Event,
 			UserID:          int(actor.UID),

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -18,7 +18,7 @@ import (
 )
 
 // PubSubDotComEventsTopicID is the topic ID of the topic that forwards messages to Sourcegraph.com events' pub/sub subscribers.
-var PubSubDotComEventsTopicID = env.Get("PUBSUB_EVENTS_TOPIC_ID", "", "Pub/sub dotcom events topic ID is the pub/sub topic id where Sourcegraph.com events are published.")
+var PubSubDotComEventsTopicID = env.Get("PUBSUB_DOTCOM_EVENTS_TOPIC_ID", "", "Pub/sub dotcom events topic ID is the pub/sub topic id where Sourcegraph.com events are published.")
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
 	if envvar.SourcegraphDotComMode() {

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -83,7 +83,7 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 	Source       string
 	Argument     *string
 }) (*EmptyResponse, error) {
-	if !conf.EventLoggingEnabled() {
+	if !conf.EventLoggingEnabled() || pubSubDotComEventsTopicID == "" {
 		return nil, nil
 	}
 	actor := actor.FromContext(ctx)

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -17,8 +17,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/version"
 )
 
-// PubSubDotComEventsTopicID is the topic ID of the topic that forwards messages to Sourcegraph.com events' pub/sub subscribers.
-var PubSubDotComEventsTopicID = env.Get("PUBSUB_DOTCOM_EVENTS_TOPIC_ID", "", "Pub/sub dotcom events topic ID is the pub/sub topic id where Sourcegraph.com events are published.")
+// pubSubDotComEventsTopicID is the topic ID of the topic that forwards messages to Sourcegraph.com events' pub/sub subscribers.
+var pubSubDotComEventsTopicID = env.Get("PUBSUB_DOTCOM_EVENTS_TOPIC_ID", "", "Pub/sub dotcom events topic ID is the pub/sub topic id where Sourcegraph.com events are published.")
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
 	if envvar.SourcegraphDotComMode() {
@@ -108,7 +108,7 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 		}); err != nil {
 			return nil, err
 		}
-		return nil, pubsubutil.Publish(PubSubDotComEventsTopicID, buf.String())
+		return nil, pubsubutil.Publish(pubSubDotComEventsTopicID, buf.String())
 	}
 
 	return nil, usagestats.LogEvent(

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -1,7 +1,9 @@
 package graphqlbackend
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -10,7 +12,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/pkg/actor"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/env"
+	"github.com/sourcegraph/sourcegraph/pkg/pubsub/pubsubutil"
+	"github.com/sourcegraph/sourcegraph/pkg/version"
 )
+
+// PubSubDotComEventsTopicID is the topic ID of the topic that forwards messages to Sourcegraph.com events' pub/sub subscribers.
+var PubSubDotComEventsTopicID = env.Get("PUBSUB_EVENTS_TOPIC_ID", "", "Pub/sub dotcom events topic ID is the pub/sub topic id where Sourcegraph.com events are published.")
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
 	if envvar.SourcegraphDotComMode() {
@@ -76,11 +84,33 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 	Source       string
 	Argument     *string
 }) (*EmptyResponse, error) {
-	if envvar.SourcegraphDotComMode() || !conf.EventLoggingEnabled() {
+	if !conf.EventLoggingEnabled() {
 		return nil, nil
 	}
-
 	actor := actor.FromContext(ctx)
+
+	// On Sourcegraph.com, log events to BigQuery instead of the internal Postgres table.
+	if envvar.SourcegraphDotComMode() {
+		var argument string
+		if args.Argument != nil {
+			argument = *args.Argument
+		}
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(bigQueryEvent{
+			EventName:       args.Event,
+			UserID:          int(actor.UID),
+			AnonymousUserID: args.UserCookieID,
+			URL:             args.URL,
+			Source:          args.Source,
+			Argument:        argument,
+			Timestamp:       time.Now().UTC().Format(time.RFC3339),
+			Version:         version.Version(),
+		}); err != nil {
+			return nil, err
+		}
+		return nil, pubsubutil.Publish(PubSubDotComEventsTopicID, buf.String())
+	}
+
 	return nil, usagestats.LogEvent(
 		ctx,
 		args.Event,
@@ -90,4 +120,15 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 		args.Source,
 		args.Argument,
 	)
+}
+
+type bigQueryEvent struct {
+	EventName       string `json:"name"`
+	AnonymousUserID string `json:"anonymous_user_id"`
+	UserID          int    `json:"user_id"`
+	URL             string `json:"url"`
+	Source          string `json:"source"`
+	Argument        string `json:"argument,omitempty"`
+	Timestamp       string `json:"timestamp"`
+	Version         string `json:"version"`
 }

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -21,7 +21,7 @@ import (
 )
 
 // PubSubPingsTopicID is the topic ID of the topic that forwards messages to Pings' pub/sub subscribers.
-var PubSubPingsTopicID = env.Get("PUBSUB_PINGS_TOPIC_ID", "", "Pub/sub pings topic ID is the pub/sub topic id where pings are published.")
+var PubSubPingsTopicID = env.Get("PUBSUB_TOPIC_ID", "", "Pub/sub pings topic ID is the pub/sub topic id where pings are published.")
 
 var (
 	// latestReleaseDockerServerImageBuild is only used by sourcegraph.com to tell existing

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -20,8 +20,8 @@ import (
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
 
-// PubSubPingsTopicID is the topic ID of the topic that forwards messages to Pings' pub/sub subscribers.
-var PubSubPingsTopicID = env.Get("PUBSUB_TOPIC_ID", "", "Pub/sub pings topic ID is the pub/sub topic id where pings are published.")
+// pubSubPingsTopicID is the topic ID of the topic that forwards messages to Pings' pub/sub subscribers.
+var pubSubPingsTopicID = env.Get("PUBSUB_TOPIC_ID", "", "Pub/sub pings topic ID is the pub/sub topic id where pings are published.")
 
 var (
 	// latestReleaseDockerServerImageBuild is only used by sourcegraph.com to tell existing
@@ -214,7 +214,7 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 	eventlogger.LogEvent(0, "", "ServerUpdateCheck", json.RawMessage(message))
 
 	if pubsubutil.Enabled() {
-		err := pubsubutil.Publish(PubSubPingsTopicID, message)
+		err := pubsubutil.Publish(pubSubPingsTopicID, message)
 		if err != nil {
 			log15.Warn("pubsubutil.Publish: failed to Publish", "message", message, "error", err)
 		}

--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -13,11 +13,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/tracking"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
+	"github.com/sourcegraph/sourcegraph/pkg/env"
 	"github.com/sourcegraph/sourcegraph/pkg/eventlogger"
 	"github.com/sourcegraph/sourcegraph/pkg/hubspot"
 	"github.com/sourcegraph/sourcegraph/pkg/pubsub/pubsubutil"
 	log15 "gopkg.in/inconshreveable/log15.v2"
 )
+
+// PubSubPingsTopicID is the topic ID of the topic that forwards messages to Pings' pub/sub subscribers.
+var PubSubPingsTopicID = env.Get("PUBSUB_PINGS_TOPIC_ID", "", "Pub/sub pings topic ID is the pub/sub topic id where pings are published.")
 
 var (
 	// latestReleaseDockerServerImageBuild is only used by sourcegraph.com to tell existing
@@ -210,7 +214,7 @@ func logPing(r *http.Request, clientVersionString string, hasUpdate bool) {
 	eventlogger.LogEvent(0, "", "ServerUpdateCheck", json.RawMessage(message))
 
 	if pubsubutil.Enabled() {
-		err := pubsubutil.Publish(pubsubutil.PubSubTopicID, message)
+		err := pubsubutil.Publish(PubSubPingsTopicID, message)
 		if err != nil {
 			log15.Warn("pubsubutil.Publish: failed to Publish", "message", message, "error", err)
 		}

--- a/pkg/pubsub/pubsubutil/pubsubutil.go
+++ b/pkg/pubsub/pubsubutil/pubsubutil.go
@@ -14,9 +14,6 @@ import (
 // PubSubProjectID is used to create a new pubsub client.
 var PubSubProjectID = env.Get("PUBSUB_PROJECT_ID", "", "Pub/sub project ID is the id of the pubsub project.")
 
-// PubSubTopicID is the topic ID of the topic that forwards messages from publishers to subscribers.
-var PubSubTopicID = env.Get("PUBSUB_TOPIC_ID", "", "Pub/sub topic ID is the pub/sub topic id where messages are published.")
-
 var client *pubsub.Client
 
 // Enabled returns true if pubsub has been configured to run.

--- a/web/src/user/settings/backend.tsx
+++ b/web/src/user/settings/backend.tsx
@@ -125,10 +125,6 @@ export function logUserEvent(event: GQL.UserEvent): void {
  * Not used at all for public/sourcegraph.com usage.
  */
 export function logEvent(event: string): void {
-    if (window.context && window.context.sourcegraphDotComMode) {
-        return
-    }
-
     mutateGraphQL(
         gql`
             mutation logEvent($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/5128

Depends on https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/1356

A follow-up PR will be created to eliminate all residuals from the old telemetry tooling.