### PR TITLE
e2e: Fix flaky search tabs test by waiting for element to be active

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1162,6 +1162,15 @@ describe('e2e test suite', () => {
             for (const searchType of ['diff', 'commit', 'symbol', 'repo']) {
                 await driver.page.waitForSelector(`.e2e-search-result-tab-${searchType}`)
                 await driver.page.click(`.e2e-search-result-tab-${searchType}`)
+                await driver.page.waitForFunction(
+                    (searchType: string) => {
+                        const el: HTMLElement | null = document.querySelector(`.e2e-search-result-tab-${searchType}`)
+                        return el && el.className.includes('e2e-search-result-tab--active')
+                    },
+                    {},
+                    searchType
+                )
+
                 await driver.assertWindowLocation(`/search?q=repo:%5Egithub.com/gorilla/mux%24+type:${searchType}`)
             }
         })


### PR DESCRIPTION
This test was still flaky, due to the check for the window location occurring before we arrive at the new URL. I added a `waitForFunction` to make sure the correct tab is already active. 