### PR TITLE
LSIF: add docs

### DIFF
--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -91,6 +91,12 @@
                         <a class="content-nav-section-header" href="/user">User documentation</a>
                         <ul class="content-nav-section-group">
                             <li><a href="/user/code_intelligence">Code intelligence overview</a></li>
+                            <li class="content-nav-no-hover">
+                                <ul class="content-nav-section-subsection">
+                                    <li><a href="/user/code_intelligence/lsif">LSIF</a></li>
+                                    <li><a href="/user/code_intelligence/language_servers">Language servers</a></li>
+                                </ul>
+                            </li>
                             <li><a href="/user/search">Code search overview</a></li>
                             <li class="content-nav-no-hover">
                                 <ul class="content-nav-section-subsection">

--- a/doc/user/code_intelligence/index.md
+++ b/doc/user/code_intelligence/index.md
@@ -12,7 +12,7 @@ Code intelligence works out of the box with all of the most popular [programming
 There are two ways to get more precise code intelligence:
 
 - **Recommended**: [upload LSIF code intelligence data](./lsif.md)
-- Not recommended: [deploy a language server](./lsif.md)
+- Not recommended: [deploy a language server](./language_servers.md)
 
 Code intelligence is provided by [Sourcegraph extensions](../../extensions/index.md).
 

--- a/doc/user/code_intelligence/index.md
+++ b/doc/user/code_intelligence/index.md
@@ -9,14 +9,12 @@ Code intelligence provides advanced code navigation and cross-references for you
 
 Code intelligence works out of the box with all of the most popular [programming language extensions](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22).
 
-You can get more accurate (but usually slower) code intelligence by enabling a dedicated language extension and setting up the corresponding language server:
+There are two ways to get more precise code intelligence:
 
-- [Go](https://sourcegraph.com/extensions/sourcegraph/go)
-- [TypeScript](https://sourcegraph.com/extensions/sourcegraph/typescript)
-- [Python](https://sourcegraph.com/extensions/sourcegraph/python)
-- Check the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22) for more
+- **Recommended**: [upload LSIF code intelligence data](./lsif.md)
+- Not recommended: [deploy a language server](./lsif.md)
 
-Code intelligence is provided by [Sourcegraph extensions](../../extensions/index.md) and language servers that run securely in your self-hosted Sourcegraph instance. The extensions (and associated language servers) perform advanced, scalable code analysis and are derived from our popular open-source language servers in use by hundreds of thousands of developers in editors and on Sourcegraph.com.
+Code intelligence is provided by [Sourcegraph extensions](../../extensions/index.md).
 
 By spinning up Sourcegraph, you can get code intelligence:
 
@@ -25,19 +23,19 @@ By spinning up Sourcegraph, you can get code intelligence:
 - On diffs in your code review tool, via our [integrations](../../integration/index.md)
 - Via the Sourcegraph API (for programmatic access)
 
-**Hover tooltips with documentation and type signatures**
+**Hover tooltips with documentation and type signatures (using a language server)**
 
 <img src="img/hover-tooltip.png" width="500"/>
 
-**Go to definition**
+**Go to definition (using a language server)**
 
 <img src="img/go-to-def.gif" width="500"/>
 
-**Find references**
+**Find references (using a language server)**
 
 <img src="img/find-refs.gif" width="450"/>
 
-**GitHub pull request and file integration**
+**GitHub pull request and file integration (using a language server)**
 
 <img src="img/CodeReview.gif" width="450" style="margin-left:0;margin-right:0;"/>
 
@@ -48,20 +46,6 @@ By spinning up Sourcegraph, you can get code intelligence:
 **Symbol sidebar**
 
 <img src="img/SymbolSidebar.png" width="500"/>
-
-## Language server deployment
-
-Most Sourcegraph extensions that provide code intelligence require a server component, called a language server. These language servers are usually deployed alongside other Sourcegraph services in another Docker container or within the same Kubernetes cluster. Check the corresponding extension documentation for deployment instructions.
-
----
-
-### Open standards
-
-Code intelligence is powered by [Sourcegraph extensions](../index.md) and language servers based on the open-standard Language Server Protocol (published by Microsoft, with participation from Facebook, Google, Sourcegraph, GitHub, RedHat, Twitter, Salesforce, Eclipse, and others).
-
-Hundreds of thousands of developers already use Sourcegraph's language servers in their editor or while browsing public code on [Sourcegraph.com](https://sourcegraph.com). Microsoft's [Visual Studio Code](https://code.visualstudio.com) and GitHub's [Atom](https://atom.io) editors both use Sourcegraph language servers in official editor extensions. The language servers used for code intelligence on Sourcegraph are based on our widely used language servers, with extensive improvements for performance, cross-repository definitions and references, security, isolation, type/build inference, and robustness.
-
-For more information about the Language Server Protocol (LSP), visit [Microsoft's official LSP site](https://microsoft.github.io/language-server-protocol/). For a more detailed list of existing language servers, visit [langserver.org](https://langserver.org) (maintained by Sourcegraph).
 
 ---
 

--- a/doc/user/code_intelligence/language_servers.md
+++ b/doc/user/code_intelligence/language_servers.md
@@ -1,4 +1,4 @@
-# LSP and language servers
+# Language servers
 
 > Language servers are not recommended. We recommend using [LSIF](./lsif.md) to get precise code intelligence.
 

--- a/doc/user/code_intelligence/language_servers.md
+++ b/doc/user/code_intelligence/language_servers.md
@@ -9,7 +9,7 @@ Language servers provide more precise code intelligence than the out-of-the-box 
 - [Python](https://sourcegraph.com/extensions/sourcegraph/python)
 - More can be found in the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22)
 
-Language servers that run securely in your self-hosted Sourcegraph instance. The extensions (and associated language servers) perform advanced, scalable code analysis and are derived from our popular open-source language servers in use by hundreds of thousands of developers in editors and on Sourcegraph.com.
+Language servers run securely in your self-hosted Sourcegraph instance. The extensions (and associated language servers) perform advanced, scalable code analysis and are derived from our popular open-source language servers in use by hundreds of thousands of developers in editors and on Sourcegraph.com.
 
 ## Language server deployment
 

--- a/doc/user/code_intelligence/language_servers.md
+++ b/doc/user/code_intelligence/language_servers.md
@@ -1,6 +1,6 @@
 # Language servers
 
-> Language servers are not recommended. We recommend using [LSIF](./lsif.md) to get precise code intelligence.
+> Language servers are not recommended because they are complex to configure, require separate deployment, and are slow to initialize. Instead, we recommend using [LSIF](./lsif.md) to get precise code intelligence.
 
 Language servers provide more precise code intelligence than the out-of-the-box experience. There are language servers for the following languages:
 

--- a/doc/user/code_intelligence/language_servers.md
+++ b/doc/user/code_intelligence/language_servers.md
@@ -7,7 +7,7 @@ Language servers provide more precise code intelligence than the out-of-the-box 
 - [Go](https://sourcegraph.com/extensions/sourcegraph/go)
 - [TypeScript](https://sourcegraph.com/extensions/sourcegraph/typescript)
 - [Python](https://sourcegraph.com/extensions/sourcegraph/python)
-- Check the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22) for more
+- More can be found in the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22)
 
 Language servers that run securely in your self-hosted Sourcegraph instance. The extensions (and associated language servers) perform advanced, scalable code analysis and are derived from our popular open-source language servers in use by hundreds of thousands of developers in editors and on Sourcegraph.com.
 

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -1,0 +1,74 @@
+# LSIF
+
+LSIF is a file format for precomputed code intelligence data. It's fast and precise, but needs to be periodically generated and uploaded to your Sourcegraph instance.
+
+> LSIF is supported in Sourcegraph 3.8 and up.
+
+## Language support
+
+- [TypeScript](https://github.com/Microsoft/lsif-node/tree/master/tsc)
+- [Go](https://github.com/sourcegraph/lsif-go)
+- [Python](https://github.com/sourcegraph/lsif-py), [C/C++](https://github.com/sourcegraph/lsif-cpp), and [OCaml](https://github.com/sourcegraph/merlin-to-coif) are early stage
+- LSIF indexers for more languages coming soon!
+
+## Setting up LSIF code intelligence
+
+TODO overview of how indexers work (the general pipeline of generating + moniker generation)
+
+Install the LSIF indexer for your language (e.g. Go):
+
+```
+$ go get github.com/sourcegraph/lsif-go/cmd/lsif-go
+```
+
+Generate `data.lsif` in your project root:
+
+TODO what's required in the CI environment
+
+```
+some-project-dir$ lsif-go --noContents --out=data.lsif
+```
+
+Get the LSIF bash uploader:
+
+```
+some-project-dir$ curl -O https://raw.githubusercontent.com/sourcegraph/sourcegraph/master/lsif/upload.sh
+```
+
+Upload `data.lsif` to your Sourcegraph instance:
+
+```
+some-project-dir$ env \
+  SRC_ENDPOINT=https://sourcegraph.example.com \
+  REPOSITORY=github.com/<user>/<reponame> \
+  COMMIT=<40 char hash> \
+  bash upload.sh data.lsif
+```
+
+If the upload is accepted, the response will be `null`.
+
+Now, when you visit a file in that repository on your Sourcegraph instance, the code intelligence should be more precise than it was out-of-the-box.
+
+## Troubleshooting
+
+When uploading:
+
+- `REPOSITORY` must match the name of the repository on your Sourcegraph instance
+- `COMMIT` must be the full 40 character hash
+- Set http or https to whichever you use when visiting your Sourcegraph instance in your browser
+
+## Stale code intelligence
+
+LSIF code intelligence will be out-of-sync when you're viewing a file that has changed since the LSIF data was uploaded. You can fix this by setting up a periodic job that generates and uploads LSIF for the tip of your default branch (e.g. master) daily. Improvements to this are slated for Sourcegraph 3.9.
+
+TODO mention how basic code intel falls back
+
+TODO recommend against mixing LSIF and LSP
+
+## More about LSIF
+
+To learn more, check out our lightning talk about LSIF from GopherCon 2019 or the [introductory blog post](https://about.sourcegraph.com/blog/code-intelligence-with-lsif):
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/fMIRKRj_A88" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+TODO comparison with LSP

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -1,10 +1,16 @@
 # LSIF
 
-LSIF is a file format for precomputed code intelligence data. It's fast and precise, but needs to be periodically generated and uploaded to your Sourcegraph instance.
+[LSIF](https://github.com/Microsoft/language-server-protocol/blob/master/indexFormat/specification.md) is a file format for precomputed code intelligence data. It provides fast and precise code intelligence, but needs to be periodically generated and uploaded to your Sourcegraph instance. LSIF is opt-in: repositories for which you have not uploaded LSIF data will continue to use the out-of-the-box code intelligence.
 
 > LSIF is supported in Sourcegraph 3.8 and up.
 
-## Language support
+> For users who have a language server deployed, LSIF will take priority over the language server when LSIF data exists for a repository.
+
+## LSIF indexers
+
+An LSIF indexer is a command line tool that analyzes your project's source code and generates a file in LSIF format containing all the definitions, references, and hover documentation in your project. That LSIF file is later uploaded to Sourcegraph to provide code intelligence.
+
+Several languages are currently supported:
 
 - [TypeScript](https://github.com/Microsoft/lsif-node/tree/master/tsc)
 - [Go](https://github.com/sourcegraph/lsif-go)
@@ -13,17 +19,13 @@ LSIF is a file format for precomputed code intelligence data. It's fast and prec
 
 ## Setting up LSIF code intelligence
 
-TODO overview of how indexers work (the general pipeline of generating + moniker generation)
-
 Install the LSIF indexer for your language (e.g. Go):
 
 ```
 $ go get github.com/sourcegraph/lsif-go/cmd/lsif-go
 ```
 
-Generate `data.lsif` in your project root:
-
-TODO what's required in the CI environment
+Generate `data.lsif` in your project root (most LSIF indexers require a proper build environment: dependencies have been fetched, environment variables are set, etc.):
 
 ```
 some-project-dir$ lsif-go --noContents --out=data.lsif
@@ -59,16 +61,10 @@ When uploading:
 
 ## Stale code intelligence
 
-LSIF code intelligence will be out-of-sync when you're viewing a file that has changed since the LSIF data was uploaded. You can fix this by setting up a periodic job that generates and uploads LSIF for the tip of your default branch (e.g. master) daily. Improvements to this are slated for Sourcegraph 3.9.
-
-TODO mention how basic code intel falls back
-
-TODO recommend against mixing LSIF and LSP
+LSIF code intelligence will be out-of-sync when you're viewing a file that has changed since the LSIF data was uploaded. You can mitigate this by setting up a periodic job that generates and uploads LSIF for the tip of your default branch (e.g. master) daily. Improvements to this are planned for Sourcegraph 3.9.
 
 ## More about LSIF
 
 To learn more, check out our lightning talk about LSIF from GopherCon 2019 or the [introductory blog post](https://about.sourcegraph.com/blog/code-intelligence-with-lsif):
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/fMIRKRj_A88" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-TODO comparison with LSP

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -59,6 +59,8 @@ When uploading:
 - `COMMIT` must be the full 40 character hash
 - Set http or https to whichever you use when visiting your Sourcegraph instance in your browser
 
+When LSIF data does not exist for a particular file in a repository, Sourcegraph will fall back to out-of-the-box code intelligence.
+
 ## Stale code intelligence
 
 LSIF code intelligence will be out-of-sync when you're viewing a file that has changed since the LSIF data was uploaded. You can mitigate this by setting up a periodic job that generates and uploads LSIF for the tip of your default branch (e.g. master) daily. Improvements to this are planned for Sourcegraph 3.9.

--- a/doc/user/code_intelligence/lsif.md
+++ b/doc/user/code_intelligence/lsif.md
@@ -43,21 +43,17 @@ Upload `data.lsif` to your Sourcegraph instance:
 some-project-dir$ env \
   SRC_ENDPOINT=https://sourcegraph.example.com \
   REPOSITORY=github.com/<user>/<reponame> \
-  COMMIT=<40 char hash> \
+  COMMIT=$(git rev-parse HEAD | tr -d "\n") \
   bash upload.sh data.lsif
 ```
 
-If the upload is accepted, the response will be `null`.
-
-Now, when you visit a file in that repository on your Sourcegraph instance, the code intelligence should be more precise than it was out-of-the-box.
-
-## Troubleshooting
-
-When uploading:
-
+- `SRC_ENDPOINT` is the URL to your Sourcegraph instance
 - `REPOSITORY` must match the name of the repository on your Sourcegraph instance
 - `COMMIT` must be the full 40 character hash
-- Set http or https to whichever you use when visiting your Sourcegraph instance in your browser
+
+If the upload is accepted, the response will be `null`. If an error occurred, you'll see it in the response.
+
+After uploading LSIF files, your Sourcegraph instance will use these files to power code intelligence so that when you visit a file in that repository on your Sourcegraph instance, the code intelligence should be more precise than it was out-of-the-box.
 
 When LSIF data does not exist for a particular file in a repository, Sourcegraph will fall back to out-of-the-box code intelligence.
 

--- a/doc/user/code_intelligence/lsp.md
+++ b/doc/user/code_intelligence/lsp.md
@@ -1,0 +1,24 @@
+# LSP and language servers
+
+> Language servers are not recommended. We recommend using [LSIF](./lsif.md) to get precise code intelligence.
+
+Language servers provide more precise code intelligence than the out-of-the-box experience. There are language servers for the following languages:
+
+- [Go](https://sourcegraph.com/extensions/sourcegraph/go)
+- [TypeScript](https://sourcegraph.com/extensions/sourcegraph/typescript)
+- [Python](https://sourcegraph.com/extensions/sourcegraph/python)
+- Check the [extension registry](https://sourcegraph.com/extensions?query=category%3A%22Programming+languages%22) for more
+
+Language servers that run securely in your self-hosted Sourcegraph instance. The extensions (and associated language servers) perform advanced, scalable code analysis and are derived from our popular open-source language servers in use by hundreds of thousands of developers in editors and on Sourcegraph.com.
+
+## Language server deployment
+
+Most Sourcegraph extensions that provide code intelligence require a server component, called a language server. These language servers are usually deployed alongside other Sourcegraph services in another Docker container or within the same Kubernetes cluster. Check the corresponding extension documentation for deployment instructions.
+
+### Open standards
+
+Code intelligence is powered by [Sourcegraph extensions](../index.md) and language servers based on the open-standard Language Server Protocol (published by Microsoft, with participation from Facebook, Google, Sourcegraph, GitHub, RedHat, Twitter, Salesforce, Eclipse, and others).
+
+Hundreds of thousands of developers already use Sourcegraph's language servers in their editor or while browsing public code on [Sourcegraph.com](https://sourcegraph.com). Microsoft's [Visual Studio Code](https://code.visualstudio.com) and GitHub's [Atom](https://atom.io) editors both use Sourcegraph language servers in official editor extensions. The language servers used for code intelligence on Sourcegraph are based on our widely used language servers, with extensive improvements for performance, cross-repository definitions and references, security, isolation, type/build inference, and robustness.
+
+For more information about the Language Server Protocol (LSP), visit [Microsoft's official LSP site](https://microsoft.github.io/language-server-protocol/). For a more detailed list of existing language servers, visit [langserver.org](https://langserver.org) (maintained by Sourcegraph).


### PR DESCRIPTION
This adds a docs page for LSIF from a customer's perspective: what's LSIF, how to upload, how to use, etc.

Am I missing any important sections? Did I skip any steps (because it's obvious to me but might not be obvious to a user)?

I'm working through the TODOs. They'll be gone by merge time.