### PR TITLE
Change NodeByID to a method to make dependency injection easier

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -175,27 +175,27 @@ func (r *schemaResolver) Root() *schemaResolver {
 }
 
 func (r *schemaResolver) Node(ctx context.Context, args *struct{ ID graphql.ID }) (*NodeResolver, error) {
-	n, err := NodeByID(ctx, r.a8nResolver, args.ID)
+	n, err := r.nodeByID(ctx, args.ID)
 	if err != nil {
 		return nil, err
 	}
 	return &NodeResolver{n}, nil
 }
 
-func NodeByID(ctx context.Context, a8n A8NResolver, id graphql.ID) (Node, error) {
+func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, error) {
 	switch relay.UnmarshalKind(id) {
 	case "AccessToken":
 		return accessTokenByID(ctx, id)
 	case "Campaign":
-		if a8n == nil {
+		if r.a8nResolver == nil {
 			return nil, onlyInEnterprise
 		}
-		return a8n.CampaignByID(ctx, id)
+		return r.a8nResolver.CampaignByID(ctx, id)
 	case "Changeset":
-		if a8n == nil {
+		if r.a8nResolver == nil {
 			return nil, onlyInEnterprise
 		}
-		return a8n.ChangesetByID(ctx, id)
+		return r.a8nResolver.ChangesetByID(ctx, id)
 	case "DiscussionComment":
 		return discussionCommentByID(ctx, id)
 	case "DiscussionThread":

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -43,7 +43,12 @@ type settingsMutation struct {
 func (r *schemaResolver) SettingsMutation(ctx context.Context, args *struct {
 	Input *settingsMutationGroupInput
 }) (*settingsMutation, error) {
-	subject, err := settingsSubjectByID(ctx, r.a8nResolver, args.Input.Subject)
+	n, err := NodeByID(ctx, r.a8nResolver, args.Input.Subject)
+	if err != nil {
+		return nil, err
+	}
+
+	subject, err := settingsSubjectForNode(ctx, n)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -43,7 +43,7 @@ type settingsMutation struct {
 func (r *schemaResolver) SettingsMutation(ctx context.Context, args *struct {
 	Input *settingsMutationGroupInput
 }) (*settingsMutation, error) {
-	n, err := NodeByID(ctx, r.a8nResolver, args.Input.Subject)
+	n, err := r.nodeByID(ctx, args.Input.Subject)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (r *schemaResolver) SettingsSubject(ctx context.Context, args *struct{ ID graphql.ID }) (*settingsSubject, error) {
-	n, err := NodeByID(ctx, r.a8nResolver, args.ID)
+	n, err := r.nodeByID(ctx, args.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -11,7 +11,12 @@ import (
 )
 
 func (r *schemaResolver) SettingsSubject(ctx context.Context, args *struct{ ID graphql.ID }) (*settingsSubject, error) {
-	return settingsSubjectByID(ctx, r.a8nResolver, args.ID)
+	n, err := NodeByID(ctx, r.a8nResolver, args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return settingsSubjectForNode(ctx, n)
 }
 
 var errUnknownSettingsSubject = errors.New("unknown settings subject")
@@ -24,15 +29,10 @@ type settingsSubject struct {
 	user            *UserResolver
 }
 
-// settingsSubjectByID fetches the settings subject with the given ID. If the ID refers to a node
-// that is not a valid settings subject, an error is returned.
-func settingsSubjectByID(ctx context.Context, a8n A8NResolver, id graphql.ID) (*settingsSubject, error) {
-	resolver, err := NodeByID(ctx, a8n, id)
-	if err != nil {
-		return nil, err
-	}
-
-	switch s := resolver.(type) {
+// settingsSubjectForNode fetches the settings subject for the given Node. If
+// the node is not a valid settings subject, an error is returned.
+func settingsSubjectForNode(ctx context.Context, n Node) (*settingsSubject, error) {
+	switch s := n.(type) {
 	case *siteResolver:
 		return &settingsSubject{site: s}, nil
 

--- a/cmd/frontend/graphqlbackend/tags.go
+++ b/cmd/frontend/graphqlbackend/tags.go
@@ -19,7 +19,7 @@ func (r *schemaResolver) SetTag(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	node, err := NodeByID(ctx, r.a8nResolver, args.Node)
+	node, err := r.nodeByID(ctx, args.Node)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We talked about this little refactoring yesterday.

While `NodeByID` was exported, it wasn't used outside the `graphqlbackend` package. And now that we've added dependencies to `schemaResolver` it's cumbersome to pass them to `NodeByID` which then passes them on again.
