### PR TITLE
repo-updater: Correctly check if request is canceled in repo lookup

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -221,7 +221,7 @@ func (s *Server) handleRepoLookup(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.repoLookup(r.Context(), args)
 	if err != nil {
-		if err == context.Canceled {
+		if r.Context().Err() != nil {
 			http.Error(w, "request canceled", http.StatusGatewayTimeout)
 			return
 		}


### PR DESCRIPTION
We may return a wrapped error / pq doesn't return a context error if the
context is canceled.
