### PR TITLE
e2e: skip flaky search result tabs test

### DIFF
--- a/web/src/e2e/e2e.test.ts
+++ b/web/src/e2e/e2e.test.ts
@@ -1158,7 +1158,7 @@ describe('e2e test suite', () => {
             expect(label).toEqual('Code')
         })
 
-        test('Clicking search results tabs updates query and URL', async () => {
+        test.skip('Clicking search results tabs updates query and URL', async () => {
             for (const searchType of ['diff', 'commit', 'symbol', 'repo']) {
                 await driver.page.waitForSelector(`.e2e-search-result-tab-${searchType}`)
                 await driver.page.click(`.e2e-search-result-tab-${searchType}`)


### PR DESCRIPTION
My previous fix did not work so skipping again.