### PR TITLE
Regression test for site admin onboarding 

### DIFF
--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -12,15 +12,18 @@ export interface Config {
     includeAdminOnboarding: boolean
 }
 
-interface Field<T> {
+interface Field<T = string> {
     envVar: string
     description?: string
     defaultValue?: T
+}
+
+interface FieldParser<T = string> {
     parser: (rawValue: string) => T
 }
 
 type ConfigFields = {
-    [K in keyof Config]: Field<Config[K]>
+    [K in keyof Config]: Field<Config[K]> & (Config[K] extends string ? Partial<FieldParser> : FieldParser<Config[K]>)
 }
 
 const parseBool = (s: string): boolean => {
@@ -80,7 +83,7 @@ export function getConfig<T extends keyof Config>(required: T[]): Pick<Config, T
         }
         const envValue = process.env[field.envVar]
         if (envValue) {
-            config[fieldName] = field.parser(envValue)
+            config[fieldName] = field.parser ? field.parser(envValue) : envValue
         }
     }
 

--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -24,7 +24,7 @@ type ConfigFields = {
 }
 
 const parseBool = (s: string): boolean => {
-    if (['1', 't', 'T', 'TRUE', 'true', 'True'].some(v => v === s)) {
+    if (['1', 't', 'true'].some(v => v.toLowerCase() === s)) {
         return true
     }
     if (['0', 'f', 'F', 'FALSE', 'false', 'False'].some(v => v === s)) {

--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs'
 import { pick } from 'lodash'
 
 /**
@@ -10,58 +9,83 @@ export interface Config {
     sudoUsername: string
     gitHubToken: string
     sourcegraphBaseUrl: string
+    includeAdminOnboarding: boolean
 }
 
-export interface ConfigField {
+interface Field<T> {
     envVar: string
     description?: string
-    defaultValue?: string
+    defaultValue?: T
+    parser: (rawValue: string) => T
 }
 
-const configFields: { [K in keyof Config]: ConfigField } = {
+type ConfigFields = {
+    [K in keyof Config]: Field<Config[K]>
+}
+
+const parseBool = (s: string): boolean => {
+    if (['1', 't', 'T', 'TRUE', 'true', 'True'].some(v => v === s)) {
+        return true
+    }
+    if (['0', 'f', 'F', 'FALSE', 'false', 'False'].some(v => v === s)) {
+        return false
+    }
+    throw new Error(`could not parse string ${JSON.stringify(s)} to boolean`)
+}
+
+const configFields: ConfigFields = {
     sudoToken: {
         envVar: 'SOURCEGRAPH_SUDO_TOKEN',
+        parser: s => s,
         description:
             'An access token with "site-admin:sudo" permissions. This will be used to impersonate users in requests.',
     },
     sudoUsername: {
         envVar: 'SOURCEGRAPH_SUDO_USER',
+        parser: s => s,
         description: 'The site-admin-level username that will be impersonated with the sudo access token.',
     },
     gitHubToken: {
         envVar: 'GITHUB_TOKEN',
+        parser: s => s,
         description: 'A GitHub token that will be used to authenticate a GitHub external service.',
     },
     sourcegraphBaseUrl: {
         envVar: 'SOURCEGRAPH_BASE_URL',
+        parser: s => s,
         defaultValue: 'http://localhost:3080',
         description:
             'The base URL of the Sourcegraph instance, e.g., https://sourcegraph.sgdev.org or http://localhost:3080.',
     },
+    includeAdminOnboarding: {
+        envVar: 'INCLUDE_ADMIN_ONBOARDING',
+        parser: parseBool,
+        description:
+            'If true, include admin onboarding tests, which assume none of the admin onboarding steps have yet completed on the instance. If those steps have already been completed, this test will fail.',
+    },
 }
 
 /**
- * Reads e2e config from appropriate inputs: the config file defined by $CONFIG_FILE
- * and environment variables. The caller should specify the config fields that it
- * depends on. This method reads the config synchronously from disk.
+ * Reads e2e config from environment variables. The caller should specify the config fields that it
+ * depends on.
  */
 export function getConfig<T extends keyof Config>(required: T[]): Pick<Config, T> {
-    const configFile = process.env.CONFIG_FILE
-    // eslint-disable-next-line no-sync
-    const config = configFile ? JSON.parse(fs.readFileSync(configFile, 'utf-8')) : {}
-
-    // Set defaults and read env vars
-    for (const [fieldName, field] of Object.entries(configFields)) {
-        if (field.defaultValue && config[fieldName] === undefined) {
+    // Read config
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: { [key: string]: any } = {}
+    for (const fieldName of required) {
+        const field = configFields[fieldName]
+        if (field.defaultValue !== undefined) {
             config[fieldName] = field.defaultValue
         }
-        if (field.envVar && process.env[field.envVar]) {
-            config[fieldName] = process.env[field.envVar]
+        const envValue = process.env[field.envVar]
+        if (envValue) {
+            config[fieldName] = field.parser(envValue)
         }
     }
 
     // Check required fields for type safety
-    const missingKeys = required.filter(key => !config[key])
+    const missingKeys = required.filter(key => config[key] === undefined)
     if (missingKeys.length > 0) {
         const fieldInfo = (k: T): string => {
             const field = configFields[k]
@@ -79,11 +103,11 @@ export function getConfig<T extends keyof Config>(required: T[]): Pick<Config, T
         }
         throw new Error(`FAIL: Required config was not provided. These environment variables were missing:
 
-${missingKeys.map(k => `- ${fieldInfo(k)}`).join('\n')}
+            ${missingKeys.map(k => `- ${fieldInfo(k)}`).join('\n')}
 
-The recommended way to set them is to install direnv (https://direnv.net) and
-create a .envrc file at the root of this repository.
-`)
+            The recommended way to set them is to install direnv (https://direnv.net) and
+            create a .envrc file at the root of this repository.
+        `)
     }
 
     return pick(config, required)

--- a/shared/src/e2e/config.ts
+++ b/shared/src/e2e/config.ts
@@ -27,7 +27,7 @@ const parseBool = (s: string): boolean => {
     if (['1', 't', 'true'].some(v => v.toLowerCase() === s)) {
         return true
     }
-    if (['0', 'f', 'F', 'FALSE', 'false', 'False'].some(v => v === s)) {
+    if (['0', 'f', 'false'].some(v => v.toLowerCase() === s)) {
         return false
     }
     throw new Error(`could not parse string ${JSON.stringify(s)} to boolean`)

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -440,7 +440,7 @@ export class Driver {
      */
     public async clickElementWithText(
         text: string,
-        { tagName, log }: { tagName?: string; log?: boolean } = {}
+        { tagName, log }: { tagName?: keyof HTMLElementTagNameMap; log?: boolean } = {}
     ): Promise<void> {
         const handles = await this.findElementWithText(text, { tagName, log })
         await handles[0].click()

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -431,7 +431,7 @@ export class Driver {
                 return handles
             }
         }
-        throw new Error(`cannot click on non-existent element with text ${JSON.stringify(text)} and tag ${tag}`)
+        throw new Error(`Could not find element with text ${JSON.stringify(text)}${tag ? ' and tag ' + tag : ''}`)
     }
 
     /**

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -387,6 +387,69 @@ export class Driver {
             }
         }
     }
+
+    /**
+     * Finds the "best" element containing the text, where "best" is roughly defined as "what the
+     * user would click on if you told them to click on the text".
+     *
+     * Returns a list of elements when it is unsure how to pick among candidates. It generally tries
+     * to prefer elements that more tightly wrap the text. Throws an error when no elements could be
+     * found.
+     *
+     * The caller should call `dispose` on the returned JSHandles when done.
+     */
+    public async findElementWithText(
+        text: string,
+        {
+            tagName: selector,
+            log,
+        }: {
+            /**
+             * Filter candidate elements to those with the specified tag name
+             */
+            tagName?: string
+
+            /**
+             * Log the XPath quer(y|ies) used to find the element.
+             */
+            log?: boolean
+        } = {}
+    ): Promise<puppeteer.ElementHandle<Element>[]> {
+        const tag = selector || '*'
+        const queries = [
+            `//${tag}[text() = ${JSON.stringify(text)}]`,
+            `//${tag}[starts-with(text(), ${JSON.stringify(text)})]`,
+            `//${tag}[contains(text(), ${JSON.stringify(text)})]`,
+        ]
+
+        for (const query of queries) {
+            if (log) {
+                console.log(`locating xpath ${query}`)
+            }
+            const handles = await this.page.$x(query)
+            if (handles.length > 0) {
+                return handles
+            }
+        }
+        throw new Error(`cannot click on non-existent element with text ${JSON.stringify(text)} and tag ${tag}`)
+    }
+
+    /**
+     * Click the element containing the text. The element is discovered using the
+     * `findElementWithText` method.
+     */
+    public async clickElementWithText(
+        text: string,
+        { tagName, log }: { tagName?: string; log?: boolean } = {}
+    ): Promise<void> {
+        const handles = await this.findElementWithText(text, { tagName, log })
+        await handles[0].click()
+        await Promise.all(handles.map(handle => handle.dispose()))
+    }
+
+    public async waitUntilURL(url: string): Promise<void> {
+        await this.page.waitForFunction(url => document.location.href === url, {}, url)
+    }
 }
 
 function modifyJSONC(text: string, path: jsonc.JSONPath, f: (oldValue: jsonc.Node | undefined) => any): any {

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -407,7 +407,7 @@ export class Driver {
             /**
              * Filter candidate elements to those with the specified tag name
              */
-            tagName?: string
+            tagName?: keyof HTMLElementTagNameMap
 
             /**
              * Log the XPath quer(y|ies) used to find the element.

--- a/web/src/regression/onboarding.test.ts
+++ b/web/src/regression/onboarding.test.ts
@@ -6,142 +6,87 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { Driver } from '../../../shared/src/e2e/driver'
 import { GraphQLClient } from './util/GraphQLClient'
 import { setTestDefaults, createAndInitializeDriver } from './util/init'
-import { Config, getConfig } from '../../../shared/src/e2e/config'
+import { getConfig } from '../../../shared/src/e2e/config'
 import { ensureLoggedInOrCreateUser } from './util/helpers'
-import { ensureExternalService, waitForRepos } from './util/api'
-import { BoundingBox } from 'puppeteer'
+import {
+    ensureExternalService,
+    waitForRepos,
+    setUserSiteAdmin,
+    getUser,
+    deleteUser,
+    ensureNoExternalServices,
+    getExternalServices,
+} from './util/api'
 import { Key } from 'ts-key-enum'
+import { retry } from '../../../shared/src/e2e/e2e-test-utils'
+import { ScreenshotVerifier } from './util/ScreenshotVerifier'
 
-const testRepoSlugs = ['auth0/go-jwt-middleware', 'kyoshidajp/ghkw', 'PalmStoneGames/kube-cert-manager']
-
-interface ExpectedScreenshot {
-    screenshotFile: string
-    description: string
-}
+const activationNavBarSelector = '.e2e-activation-nav-item-toggle'
 
 /**
- * Utility class to verify screenshots match a particular description
+ * Gets the activation status for the current user from the GUI. There's no easy way to fetch this
+ * from the API, so we use a coarse method for extracting it from the GUI.
  */
-class ScreenshotVerifier {
-    public screenshots: ExpectedScreenshot[]
-    constructor(public driver: Driver) {
-        this.screenshots = []
-    }
-
-    public async verifyScreenshot({
-        filename,
-        description,
-        clip,
-    }: {
-        /**
-         * The filename to which to save the screenshot. It should be a decsriptive name that captures both
-         * what should be happening in the screenshot and the context around what's happening. E.g.,
-         * "progress-bar-after-initial-search-is-half-green.png"
-         */
-        filename: string
-
-        /**
-         * A short description of what should happen in the screenshot.
-         */
-        description: string
-        clip?: BoundingBox
-    }) {
-        await this.driver.page.screenshot({
-            path: filename,
-            clip,
-        })
-        this.screenshots.push({ screenshotFile: filename, description })
-    }
-
-    public async verifySelector(
-        filename: string,
-        description: string,
-        selector: string,
-        waitForSelectorToBeVisibleTimeout: number = 0
-    ) {
-        if (waitForSelectorToBeVisibleTimeout > 0) {
-            await this.driver.page.waitForFunction(
-                selector => {
-                    const element = document.querySelector(selector)
-                    if (!element) {
-                        return false
-                    }
-                    const { width, height } = element.getBoundingClientRect()
-                    return width > 0 && height > 0
-                },
-                { timeout: waitForSelectorToBeVisibleTimeout },
-                selector
-            )
+async function getActivationStatus(driver: Driver): Promise<{ complete: number; total: number }> {
+    await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+    await driver.page.waitForSelector(activationNavBarSelector)
+    await driver.page.click(activationNavBarSelector)
+    await new Promise(resolve => setTimeout(resolve, 2000)) // TODO: replace/delete
+    return driver.page.evaluate(() => {
+        const dropdownMenu = document.querySelector('.activation-dropdown')
+        if (!dropdownMenu) {
+            throw new Error('No activation status dropdown menu')
         }
-
-        const clip: BoundingBox | undefined = await this.driver.page.evaluate(selector => {
-            const element = document.querySelector(selector)
-            if (!element) {
-                throw new Error(`element with selector ${JSON.stringify(selector)} not found`)
-            }
-            const { left, top, width, height } = element.getBoundingClientRect()
-            return { x: left, y: top, width, height }
-        }, selector)
-        await this.verifyScreenshot({
-            filename,
-            description,
-            clip,
-        })
-    }
-
-    /**
-     * Returns instructions to manually verify each screenshot stored in the to-verify list.
-     */
-    public verificationInstructions(): string {
-        return `
-        @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-        @@@@ Manual verification steps required!!! @@@@
-        @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-
-        Please verify the following screenshots match the corresponding descriptions:
-
-        ${this.screenshots.map(s => `${s.screenshotFile}:\t${JSON.stringify(s.description)}`).join('\n        ')}
-
-        `
-        // TODO
-    }
+        const lineItems = Array.from(dropdownMenu.querySelectorAll('.activation-dropdown-item'))
+        const complete = lineItems.flatMap(el => Array.from(el.querySelectorAll('.mdi-icon.text-success'))).length
+        const incomplete = lineItems.flatMap(el => Array.from(el.querySelectorAll('.mdi-icon.text-muted'))).length
+        return {
+            complete,
+            total: complete + incomplete,
+        }
+    })
 }
 
 describe('Onboarding', () => {
-    let config: Pick<Config, 'sudoToken' | 'sudoUsername' | 'gitHubToken' | 'sourcegraphBaseUrl'>
+    const config = getConfig([
+        'sudoToken',
+        'sudoUsername',
+        'gitHubToken',
+        'sourcegraphBaseUrl',
+        'includeAdminOnboarding',
+    ])
+    const testExternalServiceConfig = {
+        kind: GQL.ExternalServiceKind.GITHUB,
+        uniqueDisplayName: 'GitHub (search-regression-test)',
+        config: {
+            url: 'https://github.com',
+            token: config.gitHubToken,
+            repos: ['auth0/go-jwt-middleware', 'kyoshidajp/ghkw', 'PalmStoneGames/kube-cert-manager'],
+            repositoryQuery: ['none'],
+        },
+    }
     let driver: Driver
     let gqlClient: GraphQLClient
     let screenshots: ScreenshotVerifier
+    const testUsername = 'test-onboarding-regression-test-user'
 
     beforeAll(
         async () => {
-            config = getConfig(['sudoToken', 'sudoUsername', 'gitHubToken', 'sourcegraphBaseUrl'])
             driver = await createAndInitializeDriver(config.sourcegraphBaseUrl)
+            setTestDefaults(driver)
             gqlClient = GraphQLClient.newForPuppeteerTest({
                 baseURL: config.sourcegraphBaseUrl,
                 sudoToken: config.sudoToken,
                 username: config.sudoUsername,
             })
             screenshots = new ScreenshotVerifier(driver)
-            setTestDefaults(driver)
             await ensureLoggedInOrCreateUser({
                 driver,
                 gqlClient,
-                username: 'test-onboarding-regression-test-user',
+                username: testUsername,
                 password: 'test',
                 deleteIfExists: true,
             })
-            await ensureExternalService(gqlClient, {
-                kind: GQL.ExternalServiceKind.GITHUB,
-                uniqueDisplayName: 'GitHub (search-regression-test)',
-                config: {
-                    url: 'https://github.com',
-                    token: config.gitHubToken,
-                    repos: testRepoSlugs,
-                    repositoryQuery: ['none'],
-                },
-            })
-            await waitForRepos(gqlClient, ['github.com/' + testRepoSlugs[testRepoSlugs.length - 1]])
         },
         20 * 1000 // wait 20s for cloning
     )
@@ -150,12 +95,79 @@ describe('Onboarding', () => {
         if (driver) {
             await driver.close()
         }
-        console.log(screenshots.verificationInstructions())
+        await deleteUser(gqlClient, testUsername, false)
+        if (screenshots.screenshots.length > 0) {
+            console.log(screenshots.verificationInstructions())
+        }
     })
+
+    /**
+     * Only run site-admin onboarding test if the appropriate environment variable is set.
+     * This test assumes an instance of Sourcegraph that does not yet have external services.
+     */
+    const testAdminOnboarding = config.includeAdminOnboarding ? test : test.skip
+    testAdminOnboarding(
+        'Site-admin onboarding',
+        async () => {
+            await ensureNoExternalServices(gqlClient, {
+                ...testExternalServiceConfig,
+                deleteIfExist: true,
+            })
+            if ((await getExternalServices(gqlClient)).length > 0) {
+                throw new Error(
+                    'other external services exist and this test should be run on an instance with no user-created external services'
+                )
+            }
+
+            const testUser = await getUser(gqlClient, 'test-onboarding-regression-test-user')
+            if (!testUser) {
+                throw new Error(`Could not obtain userID of user ${testUsername}`)
+            }
+            await setUserSiteAdmin(gqlClient, testUser.id, true)
+
+            const activationStatus = await getActivationStatus(driver)
+            if (activationStatus.total !== 4) {
+                throw new Error(`Expected 4 onboarding steps for site admins, but only found ${activationStatus.total}`)
+            }
+
+            // Verify add-external-service onboarding step
+            await driver.page.waitForSelector(activationNavBarSelector)
+            // Check that onboarding status menu contains menu item and it goes where it should
+            await retry(async () => {
+                // for some reason, first click doesn't work here
+                await driver.page.click(activationNavBarSelector)
+                await driver.page.click(activationNavBarSelector)
+                await driver.clickElementWithText('Connect your code host')
+            })
+            await driver.waitUntilURL(driver.sourcegraphBaseUrl + '/site-admin/external-services')
+            // Verify confetti plays
+            await driver.ensureHasExternalService({
+                kind: testExternalServiceConfig.kind,
+                displayName: testExternalServiceConfig.uniqueDisplayName,
+                config: JSON.stringify(testExternalServiceConfig.config),
+            })
+            await new Promise(resolve => setTimeout(resolve, 500)) // wait for confetti to play a bit
+            await screenshots.verifyScreenshot({
+                filename: 'confetti-appears-after-adding-first-external-service.png',
+                description: 'confetti coming out of "Setup" navbar item',
+            })
+        },
+        30 * 1000
+    )
 
     test(
         'Non-admin user onboarding',
         async () => {
+            await ensureExternalService(gqlClient, testExternalServiceConfig)
+            const repoSlugs = testExternalServiceConfig.config.repos
+            await waitForRepos(gqlClient, ['github.com/' + repoSlugs[repoSlugs.length - 1]])
+
+            const testUser = await getUser(gqlClient, testUsername)
+            if (!testUser) {
+                throw new Error(`Could not obtain userID of user ${testUsername}`)
+            }
+            await setUserSiteAdmin(gqlClient, testUser.id, false)
+
             const statusBarSelector = '.activation-dropdown-button__progress-bar-container'
 
             // Initial status indicator
@@ -173,7 +185,7 @@ describe('Onboarding', () => {
             await new Promise(resolve => setTimeout(resolve, 500)) // allow some time for confetti to play
             await screenshots.verifyScreenshot({
                 filename: 'confetti-appears-after-first-search.png',
-                description: 'confetti',
+                description: 'confetti coming out of "Setup" navbar item',
             })
             await screenshots.verifySelector(
                 'progress-bar-after-initial-search-is-half-green.png',
@@ -183,23 +195,24 @@ describe('Onboarding', () => {
 
             // Do a find references
             await driver.page.goto(
-                config.sourcegraphBaseUrl +
-                    '/ghe.sgdev.org/sourcegraph/gorillalabs-sparkling/-/blob/src/java/sparkling/function/FlatMapFunction.java#L10:12&tab=references'
+                config.sourcegraphBaseUrl + '/github.com/auth0/go-jwt-middleware/-/blob/jwtmiddleware.go'
             )
-            const defTokenXPath = '//*[contains(@class, "blob-page__blob")]//span[./text()="FlatMapFunction"]'
+            // await driver.page.mouse.move(100, 100)
+            const defTokenXPath =
+                '//*[contains(@class, "blob-page__blob")]//span[starts-with(text(), "TokenExtractor")]'
             await driver.page.waitForXPath(defTokenXPath)
             const elems = await driver.page.$x(defTokenXPath)
-            await elems[0].click()
+            await Promise.all(elems.map(e => e.click()))
             await Promise.all(elems.map(elem => elem.dispose()))
             const findRefsSelector = '.e2e-tooltip-find-references'
             await driver.page.waitForSelector(findRefsSelector)
             await driver.page.click(findRefsSelector)
             await driver.page.waitForSelector('.e2e-search-result')
-            await new Promise(resolve => setTimeout(resolve, 500)) // allow some time for confetti to play
 
+            await new Promise(resolve => setTimeout(resolve, 500)) // allow some time for confetti to play
             await screenshots.verifyScreenshot({
                 filename: 'confetti-appears-after-find-refs.png',
-                description: 'confetti',
+                description: 'confetti coming out of "Setup" navbar item',
             })
             await screenshots.verifySelector(
                 'progress-bar-after-search-and-fnd-refs-is-full-green.png',

--- a/web/src/regression/util/ScreenshotVerifier.ts
+++ b/web/src/regression/util/ScreenshotVerifier.ts
@@ -1,0 +1,97 @@
+import { Driver } from '../../../../shared/src/e2e/driver'
+import { BoundingBox } from 'puppeteer'
+
+interface ExpectedScreenshot {
+    screenshotFile: string
+    description: string
+}
+
+/**
+ * Utility class to verify screenshots match a particular description
+ */
+export class ScreenshotVerifier {
+    public screenshots: ExpectedScreenshot[]
+    constructor(public driver: Driver) {
+        this.screenshots = []
+    }
+
+    public async verifyScreenshot({
+        filename,
+        description,
+        clip,
+    }: {
+        /**
+         * The filename to which to save the screenshot. It should be a decsriptive name that captures both
+         * what should be happening in the screenshot and the context around what's happening. E.g.,
+         * "progress-bar-after-initial-search-is-half-green.png"
+         */
+        filename: string
+
+        /**
+         * A short description of what should happen in the screenshot.
+         */
+        description: string
+        clip?: BoundingBox
+    }): Promise<void> {
+        await this.driver.page.screenshot({
+            path: filename,
+            clip,
+        })
+        this.screenshots.push({ screenshotFile: filename, description })
+    }
+
+    public async verifySelector(
+        filename: string,
+        description: string,
+        selector: string,
+        waitForSelectorToBeVisibleTimeout: number = 0
+    ): Promise<void> {
+        if (waitForSelectorToBeVisibleTimeout > 0) {
+            await this.driver.page.waitForFunction(
+                selector => {
+                    const element = document.querySelector(selector)
+                    if (!element) {
+                        return false
+                    }
+                    const { width, height } = element.getBoundingClientRect()
+                    return width > 0 && height > 0
+                },
+                { timeout: waitForSelectorToBeVisibleTimeout },
+                selector
+            )
+        }
+
+        const clip: BoundingBox | undefined = await this.driver.page.evaluate(selector => {
+            const element = document.querySelector(selector)
+            if (!element) {
+                throw new Error(`element with selector ${JSON.stringify(selector)} not found`)
+            }
+            const { left, top, width, height } = element.getBoundingClientRect()
+            return { x: left, y: top, width, height }
+        }, selector)
+        await this.verifyScreenshot({
+            filename,
+            description,
+            clip,
+        })
+    }
+
+    /**
+     * Returns instructions to manually verify each screenshot stored in the to-verify list.
+     */
+    public verificationInstructions(): string {
+        return this.screenshots.length === 0
+            ? ''
+            : `
+
+        @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+        @@@@ Manual verification steps required!!! @@@@
+        @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+        Please verify the following screenshots match the corresponding descriptions:
+
+        ${this.screenshots.map(s => `${s.screenshotFile}:\t${JSON.stringify(s.description)}`).join('\n        ')}
+
+        `
+    }
+}

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -62,21 +62,58 @@ export async function waitForRepos(gqlClient: GraphQLClient, ensureRepos: string
     ).toPromise()
 }
 
-export async function ensureExternalService(
+export async function ensureNoExternalServices(
     gqlClient: GraphQLClient,
     options: {
         kind: GQL.ExternalServiceKind
         uniqueDisplayName: string
-        config: Record<string, any>
+        deleteIfExist?: boolean
     }
 ): Promise<void> {
-    const externalServices = await gqlClient
+    const externalServices = await getExternalServices(gqlClient, options)
+    if (externalServices.length === 0) {
+        return
+    }
+    if (!options.deleteIfExist) {
+        throw new Error('external services already exist, not deleting')
+    }
+
+    for (const externalService of externalServices) {
+        await gqlClient
+            .mutateGraphQL(
+                gql`
+                    mutation DeleteExternalService($externalService: ID!) {
+                        deleteExternalService(externalService: $externalService) {
+                            alwaysNil
+                        }
+                    }
+                `,
+                { externalService: externalService.id }
+            )
+            .toPromise()
+    }
+}
+
+export function getExternalServices(
+    gqlClient: GraphQLClient,
+    options: {
+        kind?: GQL.ExternalServiceKind
+        uniqueDisplayName?: string
+    } = {}
+): Promise<GQL.IExternalService[]> {
+    return gqlClient
         .queryGraphQL(
             gql`
                 query ExternalServices($first: Int) {
                     externalServices(first: $first) {
                         nodes {
+                            id
+                            kind
                             displayName
+                            config
+                            createdAt
+                            updatedAt
+                            warning
                         }
                     }
                 }
@@ -85,10 +122,27 @@ export async function ensureExternalService(
         )
         .pipe(
             map(dataOrThrowErrors),
-            map(({ externalServices }) => externalServices)
+            map(({ externalServices }) =>
+                externalServices.nodes.filter(
+                    ({ displayName, kind }) =>
+                        (options.uniqueDisplayName === undefined || options.uniqueDisplayName === displayName) &&
+                        (options.kind === undefined || options.kind === kind)
+                )
+            )
         )
         .toPromise()
-    if (externalServices.nodes.some(({ displayName }) => displayName === options.uniqueDisplayName)) {
+}
+
+export async function ensureExternalService(
+    gqlClient: GraphQLClient,
+    options: {
+        kind: GQL.ExternalServiceKind
+        uniqueDisplayName: string
+        config: Record<string, any>
+    }
+): Promise<void> {
+    const externalServices = await getExternalServices(gqlClient, options)
+    if (externalServices.length > 0) {
         return
     }
 
@@ -188,6 +242,21 @@ export async function deleteUser(
                 }
             `,
             { hard: false, user: user.id }
+        )
+        .toPromise()
+}
+
+export async function setUserSiteAdmin(gqlClient: GraphQLClient, userID: GQL.ID, siteAdmin: boolean): Promise<void> {
+    await gqlClient
+        .mutateGraphQL(
+            gql`
+                mutation SetUserIsSiteAdmin($userID: ID!, $siteAdmin: Boolean!) {
+                    setUserIsSiteAdmin(userID: $userID, siteAdmin: $siteAdmin) {
+                        alwaysNil
+                    }
+                }
+            `,
+            { userID, siteAdmin }
         )
         .toPromise()
 }


### PR DESCRIPTION
Add regression test for admin onboarding flow. It can be run by `cd`ing into the `web/` directory and running `yarn run test-regression -t 'Site-admin onboarding'`. Additional comments inline with code.