### PR TITLE
Display commit email in tooltip, and Sourcegraph username with display name

### DIFF
--- a/web/src/repo/GitRef.tsx
+++ b/web/src/repo/GitRef.tsx
@@ -85,6 +85,9 @@ export const gitRefFragment = gql`
     fragment SignatureFields on Signature {
         person {
             displayName
+            user {
+                username
+            }
         }
         date
     }

--- a/web/src/repo/commits/GitCommitNodeByline.test.tsx
+++ b/web/src/repo/commits/GitCommitNodeByline.test.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import * as GQL from '../../../../shared/src/graphql/schema'
-import { GitCommitNodeByline } from './GitCommitNodeByline'
+import { GitCommitNodeByline, Signature } from './GitCommitNodeByline'
 
-const FIXTURE_SIGNATURE_1: GQL.ISignature = {
-    __typename: 'Signature',
+const FIXTURE_SIGNATURE_1: Signature = {
     date: '1990-01-01',
     person: {
-        __typename: 'Person',
         name: 'Alice Zhao',
         displayName: 'Alice Zhao',
         email: 'alice@example.com',
@@ -16,16 +13,16 @@ const FIXTURE_SIGNATURE_1: GQL.ISignature = {
     },
 }
 
-const FIXTURE_SIGNATURE_2: GQL.ISignature = {
-    __typename: 'Signature',
+const FIXTURE_SIGNATURE_2: Signature = {
     date: '1991-01-01',
     person: {
-        __typename: 'Person',
         name: 'Bob Yang',
         displayName: 'Bob Yang',
         email: 'bob@example.com',
         avatarURL: 'http://example.com/bob.png',
-        user: null,
+        user: {
+            username: 'bYang',
+        },
     },
 }
 
@@ -68,14 +65,15 @@ describe('GitCommitNodeByline', () => {
                     <GitCommitNodeByline
                         author={FIXTURE_SIGNATURE_1}
                         committer={{
-                            __typename: 'Signature',
                             date: '1992-01-01',
                             person: {
-                                __typename: 'Person',
                                 name: 'GitHub',
                                 email: 'noreply@github.com',
                                 displayName: 'GitHub',
                                 avatarURL: 'http://example.com/github.png',
+                                user: {
+                                    username: 'gitUserName',
+                                },
                             },
                         }}
                     />

--- a/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -7,9 +7,24 @@ import { UserAvatar } from '../../user/UserAvatar'
  * The subset of {@link GQL.ISignature} information needed by {@link GitCommitNodeByline}. Using the
  * minimal subset makes testing easier.
  */
-interface Signature extends Pick<GQL.ISignature, 'date'> {
-    person: Pick<GQL.IPerson, 'email' | 'name' | 'displayName' | 'avatarURL'>
+export interface Signature extends Pick<GQL.ISignature, 'date'> {
+    person: {
+        user: Pick<GQL.IUser, 'username'> | null
+    } & Pick<GQL.IPerson, 'email' | 'name' | 'displayName' | 'avatarURL'>
 }
+
+/**
+ * Formats person names to: "username (Display Name)" or "Display Name"
+ */
+const formatPersonNames = ({ user, displayName }: Signature['person']): string =>
+    user ? `${user.username} (${displayName})` : displayName
+
+/**
+ * Formats person names with {@link formatPersonNames}, and shows tooltip with user email.
+ */
+const PersonNames: React.FC<{ person: Signature['person'] }> = ({ person }) => (
+    <strong data-tooltip={person.email}>{formatPersonNames(person)}</strong>
+)
 
 /**
  * Displays a Git commit's author and committer (with avatars if available) and the dates.
@@ -37,15 +52,15 @@ export const GitCommitNodeByline: React.FunctionComponent<{
                 <UserAvatar
                     className="icon-inline"
                     user={author.person}
-                    data-tooltip={`${author.person.displayName} (author)`}
+                    data-tooltip={`${formatPersonNames(author.person)} (author)`}
                 />{' '}
                 <UserAvatar
                     className="icon-inline mr-1"
                     user={committer.person}
-                    data-tooltip={`${committer.person.displayName} (committer)`}
+                    data-tooltip={`${formatPersonNames(committer.person)} (committer)`}
                 />{' '}
-                <strong>{author.person.displayName}</strong> {!compact && 'authored'} and{' '}
-                <strong>{committer.person.displayName}</strong>{' '}
+                <PersonNames person={author.person} /> {!compact && 'authored'} and{' '}
+                <PersonNames person={committer.person} />{' '}
                 {!compact && (
                     <>
                         committed <Timestamp date={committer.date} />
@@ -57,8 +72,12 @@ export const GitCommitNodeByline: React.FunctionComponent<{
 
     return (
         <small className={`git-commit-node-byline git-commit-node-byline--no-committer ${className}`}>
-            <UserAvatar className="icon-inline mr-1" user={author.person} data-tooltip={author.person.displayName} />{' '}
-            <strong>{author.person.displayName}</strong>{' '}
+            <UserAvatar
+                className="icon-inline mr-1"
+                user={author.person}
+                data-tooltip={formatPersonNames(author.person)}
+            />{' '}
+            <PersonNames person={author.person} />{' '}
             {!compact && (
                 <>
                     committed <Timestamp date={author.date} />

--- a/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -22,7 +22,7 @@ const formatPersonNames = ({ user, displayName }: Signature['person']): string =
 /**
  * Formats person names with {@link formatPersonNames}, and shows tooltip with user email.
  */
-const PersonNames: React.FC<{ person: Signature['person'] }> = ({ person }) => (
+const PersonNames: React.FunctionComponent<{ person: Signature['person'] }> = ({ person }) => (
     <strong data-tooltip={person.email}>{formatPersonNames(person)}</strong>
 )
 

--- a/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -50,6 +50,9 @@ export const gitCommitFragment = gql`
             name
             email
             displayName
+            user {
+                username
+            }
         }
         date
     }

--- a/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -10,7 +10,9 @@ exports[`GitCommitNodeByline author (compact) 1`] = `
     src="http://example.com/alice.png"
   />
    
-  <strong>
+  <strong
+    data-tooltip="alice@example.com"
+  >
     Alice Zhao
   </strong>
    
@@ -34,7 +36,9 @@ exports[`GitCommitNodeByline author 1`] = `
     src="http://example.com/alice.png"
   />
    
-  <strong>
+  <strong
+    data-tooltip="alice@example.com"
+  >
     Alice Zhao
   </strong>
    
@@ -60,19 +64,23 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
    
   <img
     className="user-avatar icon-inline mr-1"
-    data-tooltip="Bob Yang (committer)"
+    data-tooltip="bYang (Bob Yang) (committer)"
     src="http://example.com/bob.png"
   />
    
-  <strong>
+  <strong
+    data-tooltip="alice@example.com"
+  >
     Alice Zhao
   </strong>
    
   authored
    and
    
-  <strong>
-    Bob Yang
+  <strong
+    data-tooltip="bob@example.com"
+  >
+    bYang (Bob Yang)
   </strong>
    
   committed 
@@ -97,19 +105,23 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
    
   <img
     className="user-avatar icon-inline mr-1"
-    data-tooltip="Bob Yang (committer)"
+    data-tooltip="bYang (Bob Yang) (committer)"
     src="http://example.com/bob.png"
   />
    
-  <strong>
+  <strong
+    data-tooltip="alice@example.com"
+  >
     Alice Zhao
   </strong>
    
   authored
    and
    
-  <strong>
-    Bob Yang
+  <strong
+    data-tooltip="bob@example.com"
+  >
+    bYang (Bob Yang)
   </strong>
    
   committed 
@@ -132,7 +144,9 @@ exports[`GitCommitNodeByline omit GitHub committer 1`] = `
     src="http://example.com/alice.png"
   />
    
-  <strong>
+  <strong
+    data-tooltip="alice@example.com"
+  >
     Alice Zhao
   </strong>
    
@@ -156,7 +170,9 @@ exports[`GitCommitNodeByline same author and committer 1`] = `
     src="http://example.com/alice.png"
   />
    
-  <strong>
+  <strong
+    data-tooltip="alice@example.com"
+  >
     Alice Zhao
   </strong>
    


### PR DESCRIPTION
- closes #2777
- If person has username, display `username (Display Name)`, else `Display Name`
- Always display commit email in tooltip
- Updates everywhere git commit nodes are rendered

**Before**

![Screenshot from 2019-09-20 19-23-34](https://user-images.githubusercontent.com/1495145/65350176-0898d580-dbdd-11e9-9aaa-b8109464d16f.png)

**After**

![Screenshot from 2019-09-20 19-22-51](https://user-images.githubusercontent.com/1495145/65350167-033b8b00-dbdd-11e9-97e2-45bb26385ca8.png)
