### PR TITLE
Make handleRepoUpdate block when cloning

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -403,7 +403,7 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 		// optimistically, we assume that our cloning attempt might
 		// succeed.
 		resp.CloneInProgress = true
-		_, err := s.cloneRepo(ctx, req.Repo, req.URL, nil)
+		_, err := s.cloneRepo(ctx, req.Repo, req.URL, &cloneOptions{Block: true})
 		if err != nil {
 			log15.Warn("error cloning repo", "repo", req.Repo, "err", err)
 			resp.Error = err.Error()


### PR DESCRIPTION
[handleRepoUpdate](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/gitserver/server/server.go#L381-384) is documented to be synchronous but [the current behavior in the clone case](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/gitserver/server/server.go#L406) is non-blocking. This renders [the rate limiter in repoupdater](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/repo-updater/repos/scheduler.go#L224-226) ineffective when repos are being cloned. Fortunately, I don't think this has been causing many issues in practice because gitserver still enforces [GitMaxConcurrentClone _per replica_](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/gitserver/server/server.go#L211).

Consider this PR a bug report with a suggested fix, but I have not tested it and I don't want to own merging this.