### PR TITLE
a8n: Add updateCampaign mutation to GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -27,6 +27,14 @@ type CreateCampaignArgs struct {
 	}
 }
 
+type UpdateCampaignArgs struct {
+	Input struct {
+		ID          graphql.ID
+		Name        *string
+		Description *string
+	}
+}
+
 type CreateChangesetsArgs struct {
 	Input []struct {
 		Repository graphql.ID
@@ -35,14 +43,16 @@ type CreateChangesetsArgs struct {
 }
 
 type A8NResolver interface {
+	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
+	UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error)
 	CampaignByID(ctx context.Context, id graphql.ID) (CampaignResolver, error)
+	Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error)
+
+	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ChangesetResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
+	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ChangesetsConnectionResolver, error)
 
 	AddChangesetsToCampaign(ctx context.Context, args *AddChangesetsToCampaignArgs) (CampaignResolver, error)
-	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
-	Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error)
-	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ChangesetResolver, error)
-	Changesets(ctx context.Context, args *graphqlutil.ConnectionArgs) (ChangesetsConnectionResolver, error)
 }
 
 var onlyInEnterprise = errors.New("campaigns and changesets are only available in enterprise")
@@ -59,6 +69,13 @@ func (r *schemaResolver) CreateCampaign(ctx context.Context, args *CreateCampaig
 		return nil, onlyInEnterprise
 	}
 	return r.a8nResolver.CreateCampaign(ctx, args)
+}
+
+func (r *schemaResolver) UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error) {
+	if r.a8nResolver == nil {
+		return nil, onlyInEnterprise
+	}
+	return r.a8nResolver.UpdateCampaign(ctx, args)
 }
 
 func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -33,6 +33,8 @@ type Mutation {
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!
     # Create a campaign in a namespace. The newly created campaign is returned.
     createCampaign(input: CreateCampaignInput!): Campaign!
+    # Updates a campaign.
+    updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Updates the user profile information for the user with the given ID.
     #
     # Only the user and site admins may perform this mutation.
@@ -372,6 +374,18 @@ input CreateCampaignInput {
 
     # The description of the campaign as Markdown.
     description: String!
+}
+
+# Input arguments for updating a campaign.
+input UpdateCampaignInput {
+    # The ID of the campaign to update.
+    id: ID!
+
+    # The updated name of the campaign (if non-null).
+    name: String
+
+    # The updated description of the campaign as Markdown (if non-null).
+    description: String
 }
 
 # A collection of threads.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -35,6 +35,8 @@ type Mutation {
     addChangesetsToCampaign(campaign: ID!, changesets: [ID!]!): Campaign!
     # Create a campaign in a namespace. The newly created campaign is returned.
     createCampaign(input: CreateCampaignInput!): Campaign!
+    # Updates a campaign.
+    updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Updates the user profile information for the user with the given ID.
     #
     # Only the user and site admins may perform this mutation.
@@ -379,6 +381,18 @@ input CreateCampaignInput {
 
     # The description of the campaign as Markdown.
     description: String!
+}
+
+# Input arguments for updating a campaign.
+input UpdateCampaignInput {
+    # The ID of the campaign to update.
+    id: ID!
+
+    # The updated name of the campaign (if non-null).
+    name: String
+
+    # The updated description of the campaign as Markdown (if non-null).
+    description: String
 }
 
 # A collection of threads.


### PR DESCRIPTION
This adds a `updateCampaign` mutation to our API so that users can edit the name and the description of a previously created campaign.

Context: https://github.com/sourcegraph/sourcegraph/issues/5678

Test plan: `go test ./...`
