### PR TITLE
a8n: Add deleteCampaign mutation to GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/a8n.go
+++ b/cmd/frontend/graphqlbackend/a8n.go
@@ -35,6 +35,10 @@ type UpdateCampaignArgs struct {
 	}
 }
 
+type DeleteCampaignArgs struct {
+	Campaign graphql.ID
+}
+
 type CreateChangesetsArgs struct {
 	Input []struct {
 		Repository graphql.ID
@@ -47,6 +51,7 @@ type A8NResolver interface {
 	UpdateCampaign(ctx context.Context, args *UpdateCampaignArgs) (CampaignResolver, error)
 	CampaignByID(ctx context.Context, id graphql.ID) (CampaignResolver, error)
 	Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error)
+	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
 
 	CreateChangesets(ctx context.Context, args *CreateChangesetsArgs) ([]ChangesetResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
@@ -76,6 +81,13 @@ func (r *schemaResolver) UpdateCampaign(ctx context.Context, args *UpdateCampaig
 		return nil, onlyInEnterprise
 	}
 	return r.a8nResolver.UpdateCampaign(ctx, args)
+}
+
+func (r *schemaResolver) DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error) {
+	if r.a8nResolver == nil {
+		return nil, onlyInEnterprise
+	}
+	return r.a8nResolver.DeleteCampaign(ctx, args)
 }
 
 func (r *schemaResolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (CampaignsConnectionResolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -35,6 +35,8 @@ type Mutation {
     createCampaign(input: CreateCampaignInput!): Campaign!
     # Updates a campaign.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
+    # Deletes a campaign.
+    deleteCampaign(campaign: ID!): EmptyResponse
     # Updates the user profile information for the user with the given ID.
     #
     # Only the user and site admins may perform this mutation.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -37,6 +37,8 @@ type Mutation {
     createCampaign(input: CreateCampaignInput!): Campaign!
     # Updates a campaign.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
+    # Deletes a campaign.
+    deleteCampaign(campaign: ID!): EmptyResponse
     # Updates the user profile information for the user with the given ID.
     #
     # Only the user and site admins may perform this mutation.

--- a/enterprise/pkg/a8n/resolvers/graphql.go
+++ b/enterprise/pkg/a8n/resolvers/graphql.go
@@ -206,6 +206,32 @@ func (r *Resolver) UpdateCampaign(ctx context.Context, args *graphqlbackend.Upda
 	return &campaignResolver{store: r.store, Campaign: campaign}, nil
 }
 
+func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.DeleteCampaignArgs) (*graphqlbackend.EmptyResponse, error) {
+	// 🚨 SECURITY: Only site admins may update campaigns for now
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	campaignID, err := unmarshalCampaignID(args.Campaign)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := r.store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer tx.Done(&err)
+
+	err = tx.DeleteCampaign(ctx, campaignID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &graphqlbackend.EmptyResponse{}, nil
+}
+
 func (r *Resolver) Campaigns(ctx context.Context, args *graphqlutil.ConnectionArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins may read campaigns for now
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {

--- a/enterprise/pkg/a8n/resolvers/graphql.go
+++ b/enterprise/pkg/a8n/resolvers/graphql.go
@@ -217,14 +217,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		return nil, err
 	}
 
-	tx, err := r.store.Transact(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	defer tx.Done(&err)
-
-	err = tx.DeleteCampaign(ctx, campaignID)
+	err = r.store.DeleteCampaign(ctx, campaignID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/pkg/a8n/resolvers/graphql_test.go
+++ b/enterprise/pkg/a8n/resolvers/graphql_test.go
@@ -455,6 +455,29 @@ func TestCampaigns(t *testing.T) {
 			t.Errorf("wrong campaign added to changeset. want=%v, have=%v", campaigns.Admin.ID, have)
 		}
 	}
+
+	deleteInput := map[string]interface{}{"id": campaigns.Admin.ID}
+	mustExec(ctx, t, s, deleteInput, &struct{}{}, `
+		mutation($id: ID!){
+			deleteCampaign(campaign: $id) { alwaysNil }
+		}
+	`)
+
+	var campaignsAfterDelete struct {
+		Campaigns struct {
+			TotalCount int
+		}
+	}
+
+	mustExec(ctx, t, s, nil, &campaignsAfterDelete, `
+		query { campaigns { totalCount } }
+	`)
+
+	haveCount := campaignsAfterDelete.Campaigns.TotalCount
+	wantCount := listed.All.TotalCount - 1
+	if haveCount != wantCount {
+		t.Errorf("wrong campaigns totalcount after delete. want=%d, have=%d", wantCount, haveCount)
+	}
 }
 
 func mustExec(

--- a/enterprise/pkg/a8n/store.go
+++ b/enterprise/pkg/a8n/store.go
@@ -557,6 +557,22 @@ func (s *Store) updateCampaignQuery(c *a8n.Campaign) (*sqlf.Query, error) {
 	), nil
 }
 
+// DeleteCampaign deletes the Campaign with the given ID.
+func (s *Store) DeleteCampaign(ctx context.Context, id int64) error {
+	q := sqlf.Sprintf(deleteCampaignQueryFmtstr, id)
+
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return err
+	}
+	return rows.Close()
+}
+
+var deleteCampaignQueryFmtstr = `
+-- source: pkg/a8n/store.go:DeleteCampaign
+DELETE FROM campaigns WHERE id = %s
+`
+
 // CountCampaignsOpts captures the query options needed for
 // counting campaigns.
 type CountCampaignsOpts struct {

--- a/enterprise/pkg/a8n/store_test.go
+++ b/enterprise/pkg/a8n/store_test.go
@@ -260,6 +260,24 @@ func TestStore(t *testing.T) {
 				}
 			})
 		})
+
+		t.Run("Delete", func(t *testing.T) {
+			for i := range campaigns {
+				err := s.DeleteCampaign(ctx, campaigns[i].ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				count, err := s.CountCampaigns(ctx, CountCampaignsOpts{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := count, int64(len(campaigns)-(i+1)); have != want {
+					t.Fatalf("have count: %d, want: %d", have, want)
+				}
+			}
+		})
 	})
 
 	t.Run("Changesets", func(t *testing.T) {


### PR DESCRIPTION
**Important:** This is based on https://github.com/sourcegraph/sourcegraph/pull/5698 and needs to be rebased after #5698 is merged.

This adds the `deleteCampaign` mutation to the GraphQL. It does a simple `DELETE FROM campaigns WHERE id = $id` in the database. The triggers we previously setup take care of cleaning up the `campaign_ids` column of changesets that were connected to the campaign.

---

What this *doesn't* do is clean up now-orphaned (not connected to a campaign) changesets. We cannot consistently do that, since we our changeset mutations — `createChangesets` and `addChangesetsToCampaign` — rely on being able to connect orphaned changesets to a campaign. If we now were to delete those changesets that were previously only connected to the now-deleted campaign, we'd say that "changesets without campaign is invalid", whereas it's totally valid to first call `createChangeset` and then `addChangesetsToCampaign`.

I'm still thinking about that, but any solution should be added in a follow-up PR.

Opinions welcome!