### PR TITLE
e2e: wait for signup form before filling fields

### DIFF
--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -58,6 +58,7 @@ export class Driver {
         })
         const url = new URL(this.page.url())
         if (url.pathname === '/site-admin/init') {
+            await this.page.waitForSelector('.e2e-signup-form')
             if (email) {
                 await this.page.type('input[name=email]', email)
             }
@@ -66,6 +67,7 @@ export class Driver {
             await this.page.click('button[type=submit]')
             await this.page.waitForNavigation({ timeout: 5000 })
         } else if (url.pathname === '/sign-in') {
+            await this.page.waitForSelector('.e2e-signin-form')
             await this.page.type('input', username)
             await this.page.type('input[name=password]', password)
             await this.page.click('button[type=submit]')

--- a/web/src/auth/SignUpForm.tsx
+++ b/web/src/auth/SignUpForm.tsx
@@ -52,7 +52,7 @@ export class SignUpForm extends React.Component<SignUpFormProps, SignUpFormState
 
     public render(): JSX.Element | null {
         return (
-            <Form className="signin-signup-form signup-form" onSubmit={this.handleSubmit}>
+            <Form className="signin-signup-form signup-form e2e-signup-form" onSubmit={this.handleSubmit}>
                 {this.state.error && (
                     <div className="alert alert-danger my-2">Error: {upperFirst(this.state.error.message)}</div>
                 )}

--- a/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -35,7 +35,7 @@ export class UsernamePasswordSignInForm extends React.Component<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <Form className="signin-signup-form signin-form" onSubmit={this.handleSubmit}>
+            <Form className="signin-signup-form signin-form e2e-signin-form" onSubmit={this.handleSubmit}>
                 {window.context.allowSignup ? (
                     <Link className="signin-signup-form__mode" to={`/sign-up${this.props.location.search}`}>
                         Don't have an account? Sign up.


### PR DESCRIPTION
It appears that [this build](https://buildkite.com/sourcegraph/sourcegraph/builds/43598#a0be2ad6-0cab-4ff2-a443-2ea58b1edb09) failed because the email field didn't exist on the page when puppeteer attempted to fill it on `/site-admin/init`.

This ensures the signin/signup forms are present on the page before attempting to fill any fields.