### PR TITLE
Phabricator: fix exception in getCodeElementFromTarget()

### DIFF
--- a/browser/src/libs/phabricator/dom_functions.ts
+++ b/browser/src/libs/phabricator/dom_functions.ts
@@ -79,15 +79,20 @@ export const diffDomFunctions: DOMFunctions = {
         }
 
         const td = target.closest('td')
-        if (
-            td &&
-            (td.classList.contains('show-more') ||
-                td.classList.contains('show-context') ||
-                !getLineNumberCellFromCodeElement(td))
-        ) {
+        if (!td) {
             return null
         }
-
+        if (td.classList.contains('show-more') || td.classList.contains('show-context')) {
+            // This element represents a collapsed part of the diff, it's not a code element.
+            return null
+        }
+        try {
+            getLineNumberCellFromCodeElement(td)
+        } catch (err) {
+            // The element has no associated line number cell: this can be the case when hovering
+            // 'empty' lines in the base part of a split diff that has added lines.
+            return null
+        }
         return td
     },
     getCodeElementFromLineNumber: getDiffCodeElementFromLineNumber,


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/5631/files#diff-8d890e341f1eb66bbf6768bc17c7acb2, `getLineNumberCellFromCodeElement()` was changed to always return `HTMLElement` (never `null`), and to throw when a line number cell could not be found.

However, this broke `getCodeElementFromTarget()` when hovering elements that legitimately do not have a line number cell (for instance 'empty' lines in the base part of a split diff that has added lines).

![image](https://user-images.githubusercontent.com/1741180/65514232-3338a600-dedd-11e9-9f4c-6109ccfbb89c.png)

