### PR TITLE
dev: Do not trap EXIT signal when starting grafana container

### DIFF
--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -12,20 +12,7 @@ GRAFANA_DISK="${HOME}/.sourcegraph-dev/data/grafana"
 IMAGE=sourcegraph/grafana:10.0.0
 CONTAINER=grafana
 
-CID_FILE="${GRAFANA_DISK}/grafana.cid"
-
 mkdir -p ${GRAFANA_DISK}/logs
-rm -f ${CID_FILE}
-
-function finish {
-  if test -f ${CID_FILE}; then
-      echo 'trapped CTRL-C: stopping docker grafana container'
-      docker stop $(cat ${CID_FILE})
-      rm -f  ${CID_FILE}
-  fi
-  docker rm -f $CONTAINER
-}
-trap finish EXIT
 
 CONFIG_SUB_DIR="all"
 
@@ -34,7 +21,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 fi
 
 docker inspect $CONTAINER > /dev/null 2>&1 && docker rm -f $CONTAINER
-docker run --rm  --cidfile ${CID_FILE} \
+docker run --rm \
     --name=grafana \
     --cpus=1 \
     --memory=1g \


### PR DESCRIPTION
Without this change, when I stop the dev server or `./dev/grafana.sh`
with Ctrl-C I get something like this:

    $ ./dev/grafana.sh
    ^Ctrapped CTRL-C: stopping docker grafana container
    eeb46861c179752a8b7b5d7aaaf990b38ccbfdd5ee491eef0800b1799a1f40e0
    Error: No such container: grafana

That happens every time, without fail.

I don't know why and why it's different from the Prometheus container,
but it looks to me like the Grafana container handles Ctrl-C.

With the changes in this PR applied, when I hit Ctrl-C I get this:

    $ ./dev/grafana.sh
    ^C%                                                                                                                                                                       ~/work/sourcegraph dev/grafana-exit X λ docker ps | grep grafna                                                                                                     -129-

And the container is cleaned up:

    $ docker ps | grep grafana
    [no output]

Do with this what you will: take it as a fix or as a bug report that's
looking for a proper solution :)