### PR TITLE
Nick is catch-all owner for /doc/dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,8 +203,8 @@ Dockerfile @sourcegraph/distribution
 # Documentation and homepage
 README.md @sqs
 /doc/ @sqs @ryan-blunden
+/doc/dev/ @nicksnyder
 /doc/dev/product/ @christinaforney
-/doc/dev/teams.md @beyang @nicksnyder
 /web/src/enterprise/dotcom/welcome/ @sqs
 
 # Browser extensions


### PR DESCRIPTION
This prevents Quinn and Ryan from getting tagged on a lot of reviews that they don't need to be on.

teams.md also no longer exists.