### PR TITLE
Search: make `type:` search filter singular

### DIFF
--- a/cmd/frontend/internal/pkg/search/query/searchquery.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery.go
@@ -50,7 +50,7 @@ var (
 			FieldFork:      {Literal: types.StringType, Quoted: types.StringType, Singular: true},
 			FieldArchived:  {Literal: types.StringType, Quoted: types.StringType, Singular: true},
 			FieldLang:      {Literal: types.StringType, Quoted: types.StringType, Negatable: true},
-			FieldType:      stringFieldType,
+			FieldType:      {Literal: types.StringType, Quoted: types.StringType, Singular: false},
 
 			FieldRepoHasFile:        regexpNegatableFieldType,
 			FieldRepoHasCommitAfter: {Literal: types.StringType, Quoted: types.StringType, Singular: true},

--- a/cmd/frontend/internal/pkg/search/query/searchquery.go
+++ b/cmd/frontend/internal/pkg/search/query/searchquery.go
@@ -50,7 +50,7 @@ var (
 			FieldFork:      {Literal: types.StringType, Quoted: types.StringType, Singular: true},
 			FieldArchived:  {Literal: types.StringType, Quoted: types.StringType, Singular: true},
 			FieldLang:      {Literal: types.StringType, Quoted: types.StringType, Negatable: true},
-			FieldType:      {Literal: types.StringType, Quoted: types.StringType, Singular: false},
+			FieldType:      {Literal: types.StringType, Quoted: types.StringType, Singular: true},
 
 			FieldRepoHasFile:        regexpNegatableFieldType,
 			FieldRepoHasCommitAfter: {Literal: types.StringType, Quoted: types.StringType, Singular: true},

--- a/web/src/search/helpers.test.tsx
+++ b/web/src/search/helpers.test.tsx
@@ -37,16 +37,12 @@ describe('search/helpers', () => {
             expect(getSearchTypeFromQuery('type:diff repo:^github.com/sourcegraph/sourcegraph test')).toEqual('diff')
         })
 
-        test('returns symbol when multiple search types, including symbol, are specified', () => {
-            // Edge case. If there are multiple type filters and `type:symbol` is one of them, symbol results always get returned.
-            expect(
-                getSearchTypeFromQuery('type:diff type:symbol repo:^github.com/sourcegraph/sourcegraph test')
-            ).toEqual('symbol')
-        })
-
         test('returns the first search type specified when multiple search types, not including symbol, are specified', () => {
             expect(
                 getSearchTypeFromQuery('type:diff type:commit repo:^github.com/sourcegraph/sourcegraph test')
+            ).toEqual('diff')
+            expect(
+                getSearchTypeFromQuery('type:diff type:symbol repo:^github.com/sourcegraph/sourcegraph test')
             ).toEqual('diff')
         })
     })

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -81,15 +81,6 @@ export function getSearchTypeFromQuery(query: string): SearchType {
     const matches = query.match(getTypeName)
 
     if (matches && matches.groups && matches.groups.type) {
-        // In an edge case where multiple `type:` filters are used, if
-        // `type:symbol` is included, symbol results be returned, regardless of order,
-        // so we must check for `type:symbol`. For other types,
-        // the first `type` filter appearing in the query is applied.
-        const symbolTypeRegex = /\btype:symbol\b/
-        const symbolMatches = query.match(symbolTypeRegex)
-        if (symbolMatches) {
-            return 'symbol'
-        }
         return matches.groups.type as SearchType
     }
 


### PR DESCRIPTION
Previously, we would not show an error if the `type:` field was entered into a query multiple times. Now, if multiple `type:` fields are in a query, we will display an error saying that you can only have one.