### PR TITLE
Omit credentials when fetching sideloaded bundles

### DIFF
--- a/browser/src/platform/worker.ts
+++ b/browser/src/platform/worker.ts
@@ -2,9 +2,11 @@ import { DEFAULT_SOURCEGRAPH_URL } from '../shared/util/context'
 import { checkOk } from '../../../shared/src/backend/fetch'
 
 export async function createBlobURLForBundle(bundleURL: string): Promise<string> {
+    const { origin, hostname } = new URL(bundleURL)
+    // Include credentials when fetching extensions from the private registry
+    const includeCredentials = origin !== DEFAULT_SOURCEGRAPH_URL && hostname !== 'localhost'
     const response = await fetch(bundleURL, {
-        // Include credentials when fetching extensions from the private registry
-        credentials: new URL(bundleURL).origin !== DEFAULT_SOURCEGRAPH_URL ? 'include' : 'omit',
+        credentials: includeCredentials ? 'include' : 'omit',
     })
     checkOk(response)
     const blob = await response.blob()


### PR DESCRIPTION
Without this, attempting to fetch a sideloaded extension bundle triggers a CORS error:

```
Access to fetch at 'http://localhost:1234/extension.js' from origin 'chrome-extension://bmfbcejdknlknpncfpeloejonjoledha' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.
```
