### PR TITLE
E2E: only dump logs once

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -52,7 +52,6 @@ if [ $? -ne 0 ]; then
     echo "^^^ +++"
     echo "$URL was not accessible within 60s. Here's the output of docker inspect and docker logs:"
     docker inspect "$CONTAINER"
-    docker logs --timestamps "$CONTAINER"
     exit 1
 fi
 set -e


### PR DESCRIPTION
I believe dumping logs twice was accidentally caused by https://github.com/sourcegraph/sourcegraph/pull/2896

Noticed in https://github.com/sourcegraph/sourcegraph/issues/5722#issuecomment-534925269