### PR TITLE
Ran dev/generate.sh against PostgreSQL 11.5

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -1,16 +1,16 @@
 # Table "public.access_tokens"
 ```
-     Column      |           Type           |                         Modifiers                          
------------------+--------------------------+------------------------------------------------------------
- id              | bigint                   | not null default nextval('access_tokens_id_seq'::regclass)
- subject_user_id | integer                  | not null
- value_sha256    | bytea                    | not null
- note            | text                     | not null
- created_at      | timestamp with time zone | not null default now()
- last_used_at    | timestamp with time zone | 
- deleted_at      | timestamp with time zone | 
- creator_user_id | integer                  | not null
- scopes          | text[]                   | not null
+     Column      |           Type           | Collation | Nullable |                  Default                  
+-----------------+--------------------------+-----------+----------+-------------------------------------------
+ id              | bigint                   |           | not null | nextval('access_tokens_id_seq'::regclass)
+ subject_user_id | integer                  |           | not null | 
+ value_sha256    | bytea                    |           | not null | 
+ note            | text                     |           | not null | 
+ created_at      | timestamp with time zone |           | not null | now()
+ last_used_at    | timestamp with time zone |           |          | 
+ deleted_at      | timestamp with time zone |           |          | 
+ creator_user_id | integer                  |           | not null | 
+ scopes          | text[]                   |           | not null | 
 Indexes:
     "access_tokens_pkey" PRIMARY KEY, btree (id)
     "access_tokens_value_sha256_key" UNIQUE CONSTRAINT, btree (value_sha256)
@@ -23,17 +23,17 @@ Foreign-key constraints:
 
 # Table "public.campaigns"
 ```
-      Column       |           Type           |                       Modifiers                        
--------------------+--------------------------+--------------------------------------------------------
- id                | bigint                   | not null default nextval('campaigns_id_seq'::regclass)
- name              | text                     | not null
- description       | text                     | 
- author_id         | integer                  | not null
- namespace_user_id | integer                  | 
- namespace_org_id  | integer                  | 
- created_at        | timestamp with time zone | not null default now()
- updated_at        | timestamp with time zone | not null default now()
- changeset_ids     | jsonb                    | not null default '{}'::jsonb
+      Column       |           Type           | Collation | Nullable |                Default                
+-------------------+--------------------------+-----------+----------+---------------------------------------
+ id                | bigint                   |           | not null | nextval('campaigns_id_seq'::regclass)
+ name              | text                     |           | not null | 
+ description       | text                     |           |          | 
+ author_id         | integer                  |           | not null | 
+ namespace_user_id | integer                  |           |          | 
+ namespace_org_id  | integer                  |           |          | 
+ created_at        | timestamp with time zone |           | not null | now()
+ updated_at        | timestamp with time zone |           | not null | now()
+ changeset_ids     | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
     "campaigns_pkey" PRIMARY KEY, btree (id)
     "campaigns_changeset_ids_gin_idx" gin (changeset_ids)
@@ -53,16 +53,16 @@ Triggers:
 
 # Table "public.changesets"
 ```
-        Column         |           Type           |                        Modifiers                        
------------------------+--------------------------+---------------------------------------------------------
- id                    | bigint                   | not null default nextval('changesets_id_seq'::regclass)
- campaign_ids          | jsonb                    | not null default '{}'::jsonb
- repo_id               | integer                  | not null
- created_at            | timestamp with time zone | not null default now()
- updated_at            | timestamp with time zone | not null default now()
- metadata              | jsonb                    | not null default '{}'::jsonb
- external_id           | text                     | not null
- external_service_type | text                     | not null
+        Column         |           Type           | Collation | Nullable |                Default                 
+-----------------------+--------------------------+-----------+----------+----------------------------------------
+ id                    | bigint                   |           | not null | nextval('changesets_id_seq'::regclass)
+ campaign_ids          | jsonb                    |           | not null | '{}'::jsonb
+ repo_id               | integer                  |           | not null | 
+ created_at            | timestamp with time zone |           | not null | now()
+ updated_at            | timestamp with time zone |           | not null | now()
+ metadata              | jsonb                    |           | not null | '{}'::jsonb
+ external_id           | text                     |           | not null | 
+ external_service_type | text                     |           | not null | 
 Indexes:
     "changesets_pkey" PRIMARY KEY, btree (id)
     "changesets_repo_external_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_id)
@@ -80,13 +80,13 @@ Triggers:
 
 # Table "public.critical_and_site_config"
 ```
-   Column   |           Type           |                               Modifiers                               
-------------+--------------------------+-----------------------------------------------------------------------
- id         | integer                  | not null default nextval('critical_and_site_config_id_seq'::regclass)
- type       | critical_or_site         | not null
- contents   | text                     | not null
- created_at | timestamp with time zone | not null default now()
- updated_at | timestamp with time zone | not null default now()
+   Column   |           Type           | Collation | Nullable |                       Default                        
+------------+--------------------------+-----------+----------+------------------------------------------------------
+ id         | integer                  |           | not null | nextval('critical_and_site_config_id_seq'::regclass)
+ type       | critical_or_site         |           | not null | 
+ contents   | text                     |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ updated_at | timestamp with time zone |           | not null | now()
 Indexes:
     "critical_and_site_config_pkey" PRIMARY KEY, btree (id)
     "critical_and_site_config_unique" UNIQUE, btree (id, type)
@@ -95,9 +95,9 @@ Indexes:
 
 # Table "public.default_repos"
 ```
- Column  |  Type   | Modifiers 
----------+---------+-----------
- repo_id | integer | not null
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ repo_id | integer |           | not null | 
 Indexes:
     "default_repos_pkey" PRIMARY KEY, btree (repo_id)
 Foreign-key constraints:
@@ -107,16 +107,16 @@ Foreign-key constraints:
 
 # Table "public.discussion_comments"
 ```
-     Column     |           Type           |                            Modifiers                             
-----------------+--------------------------+------------------------------------------------------------------
- id             | bigint                   | not null default nextval('discussion_comments_id_seq'::regclass)
- thread_id      | bigint                   | not null
- author_user_id | integer                  | not null
- contents       | text                     | not null
- created_at     | timestamp with time zone | not null default now()
- updated_at     | timestamp with time zone | not null default now()
- deleted_at     | timestamp with time zone | 
- reports        | text[]                   | not null default '{}'::text[]
+     Column     |           Type           | Collation | Nullable |                     Default                     
+----------------+--------------------------+-----------+----------+-------------------------------------------------
+ id             | bigint                   |           | not null | nextval('discussion_comments_id_seq'::regclass)
+ thread_id      | bigint                   |           | not null | 
+ author_user_id | integer                  |           | not null | 
+ contents       | text                     |           | not null | 
+ created_at     | timestamp with time zone |           | not null | now()
+ updated_at     | timestamp with time zone |           | not null | now()
+ deleted_at     | timestamp with time zone |           |          | 
+ reports        | text[]                   |           | not null | '{}'::text[]
 Indexes:
     "discussion_comments_pkey" PRIMARY KEY, btree (id)
     "discussion_comments_author_user_id_idx" btree (author_user_id)
@@ -130,12 +130,12 @@ Foreign-key constraints:
 
 # Table "public.discussion_mail_reply_tokens"
 ```
-   Column   |           Type           | Modifiers 
-------------+--------------------------+-----------
- token      | text                     | not null
- user_id    | integer                  | not null
- thread_id  | bigint                   | not null
- deleted_at | timestamp with time zone | 
+   Column   |           Type           | Collation | Nullable | Default 
+------------+--------------------------+-----------+----------+---------
+ token      | text                     |           | not null | 
+ user_id    | integer                  |           | not null | 
+ thread_id  | bigint                   |           | not null | 
+ deleted_at | timestamp with time zone |           |          | 
 Indexes:
     "discussion_mail_reply_tokens_pkey" PRIMARY KEY, btree (token)
     "discussion_mail_reply_tokens_token_idx" btree (token)
@@ -148,16 +148,16 @@ Foreign-key constraints:
 
 # Table "public.discussion_threads"
 ```
-     Column     |           Type           |                            Modifiers                            
-----------------+--------------------------+-----------------------------------------------------------------
- id             | bigint                   | not null default nextval('discussion_threads_id_seq'::regclass)
- author_user_id | integer                  | not null
- title          | text                     | 
- target_repo_id | bigint                   | 
- created_at     | timestamp with time zone | not null default now()
- archived_at    | timestamp with time zone | 
- updated_at     | timestamp with time zone | not null default now()
- deleted_at     | timestamp with time zone | 
+     Column     |           Type           | Collation | Nullable |                    Default                     
+----------------+--------------------------+-----------+----------+------------------------------------------------
+ id             | bigint                   |           | not null | nextval('discussion_threads_id_seq'::regclass)
+ author_user_id | integer                  |           | not null | 
+ title          | text                     |           |          | 
+ target_repo_id | bigint                   |           |          | 
+ created_at     | timestamp with time zone |           | not null | now()
+ archived_at    | timestamp with time zone |           |          | 
+ updated_at     | timestamp with time zone |           | not null | now()
+ deleted_at     | timestamp with time zone |           |          | 
 Indexes:
     "discussion_threads_pkey" PRIMARY KEY, btree (id)
     "discussion_threads_author_user_id_idx" btree (author_user_id)
@@ -174,21 +174,21 @@ Referenced by:
 
 # Table "public.discussion_threads_target_repo"
 ```
-     Column      |  Type   |                                  Modifiers                                  
------------------+---------+-----------------------------------------------------------------------------
- id              | bigint  | not null default nextval('discussion_threads_target_repo_id_seq'::regclass)
- thread_id       | bigint  | not null
- repo_id         | integer | not null
- path            | text    | 
- branch          | text    | 
- revision        | text    | 
- start_line      | integer | 
- end_line        | integer | 
- start_character | integer | 
- end_character   | integer | 
- lines_before    | text    | 
- lines           | text    | 
- lines_after     | text    | 
+     Column      |  Type   | Collation | Nullable |                          Default                           
+-----------------+---------+-----------+----------+------------------------------------------------------------
+ id              | bigint  |           | not null | nextval('discussion_threads_target_repo_id_seq'::regclass)
+ thread_id       | bigint  |           | not null | 
+ repo_id         | integer |           | not null | 
+ path            | text    |           |          | 
+ branch          | text    |           |          | 
+ revision        | text    |           |          | 
+ start_line      | integer |           |          | 
+ end_line        | integer |           |          | 
+ start_character | integer |           |          | 
+ end_character   | integer |           |          | 
+ lines_before    | text    |           |          | 
+ lines           | text    |           |          | 
+ lines_after     | text    |           |          | 
 Indexes:
     "discussion_threads_target_repo_pkey" PRIMARY KEY, btree (id)
     "discussion_threads_target_repo_repo_id_path_idx" btree (repo_id, path)
@@ -202,17 +202,17 @@ Referenced by:
 
 # Table "public.event_logs"
 ```
-      Column       |           Type           |                        Modifiers                        
--------------------+--------------------------+---------------------------------------------------------
- id                | bigint                   | not null default nextval('event_logs_id_seq'::regclass)
- name              | text                     | not null
- url               | text                     | not null
- user_id           | integer                  | not null
- anonymous_user_id | text                     | not null
- source            | text                     | not null
- argument          | text                     | not null
- version           | text                     | not null
- timestamp         | timestamp with time zone | not null default now()
+      Column       |           Type           | Collation | Nullable |                Default                 
+-------------------+--------------------------+-----------+----------+----------------------------------------
+ id                | bigint                   |           | not null | nextval('event_logs_id_seq'::regclass)
+ name              | text                     |           | not null | 
+ url               | text                     |           | not null | 
+ user_id           | integer                  |           | not null | 
+ anonymous_user_id | text                     |           | not null | 
+ source            | text                     |           | not null | 
+ argument          | text                     |           | not null | 
+ version           | text                     |           | not null | 
+ timestamp         | timestamp with time zone |           | not null | now()
 Indexes:
     "event_logs_pkey" PRIMARY KEY, btree (id)
     "event_logs_name" btree (name)
@@ -229,15 +229,15 @@ Check constraints:
 
 # Table "public.external_services"
 ```
-    Column    |           Type           |                           Modifiers                            
---------------+--------------------------+----------------------------------------------------------------
- id           | bigint                   | not null default nextval('external_services_id_seq'::regclass)
- kind         | text                     | not null
- display_name | text                     | not null
- config       | text                     | not null
- created_at   | timestamp with time zone | not null default now()
- updated_at   | timestamp with time zone | not null default now()
- deleted_at   | timestamp with time zone | 
+    Column    |           Type           | Collation | Nullable |                    Default                    
+--------------+--------------------------+-----------+----------+-----------------------------------------------
+ id           | bigint                   |           | not null | nextval('external_services_id_seq'::regclass)
+ kind         | text                     |           | not null | 
+ display_name | text                     |           | not null | 
+ config       | text                     |           | not null | 
+ created_at   | timestamp with time zone |           | not null | now()
+ updated_at   | timestamp with time zone |           | not null | now()
+ deleted_at   | timestamp with time zone |           |          | 
 Indexes:
     "external_services_pkey" PRIMARY KEY, btree (id)
 Check constraints:
@@ -247,12 +247,12 @@ Check constraints:
 
 # Table "public.global_state"
 ```
-         Column          |  Type   |         Modifiers         
--------------------------+---------+---------------------------
- site_id                 | uuid    | not null
- initialized             | boolean | not null default false
- mgmt_password_plaintext | text    | not null default ''::text
- mgmt_password_bcrypt    | text    | not null default ''::text
+         Column          |  Type   | Collation | Nullable | Default  
+-------------------------+---------+-----------+----------+----------
+ site_id                 | uuid    |           | not null | 
+ initialized             | boolean |           | not null | false
+ mgmt_password_plaintext | text    |           | not null | ''::text
+ mgmt_password_bcrypt    | text    |           | not null | ''::text
 Indexes:
     "global_state_pkey" PRIMARY KEY, btree (site_id)
 
@@ -260,11 +260,11 @@ Indexes:
 
 # Table "public.names"
 ```
- Column  |  Type   | Modifiers 
----------+---------+-----------
- name    | citext  | not null
- user_id | integer | 
- org_id  | integer | 
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ name    | citext  |           | not null | 
+ user_id | integer |           |          | 
+ org_id  | integer |           |          | 
 Indexes:
     "names_pkey" PRIMARY KEY, btree (name)
 Check constraints:
@@ -277,18 +277,18 @@ Foreign-key constraints:
 
 # Table "public.org_invitations"
 ```
-      Column       |           Type           |                          Modifiers                           
--------------------+--------------------------+--------------------------------------------------------------
- id                | bigint                   | not null default nextval('org_invitations_id_seq'::regclass)
- org_id            | integer                  | not null
- sender_user_id    | integer                  | not null
- recipient_user_id | integer                  | not null
- created_at        | timestamp with time zone | not null default now()
- notified_at       | timestamp with time zone | 
- responded_at      | timestamp with time zone | 
- response_type     | boolean                  | 
- revoked_at        | timestamp with time zone | 
- deleted_at        | timestamp with time zone | 
+      Column       |           Type           | Collation | Nullable |                   Default                   
+-------------------+--------------------------+-----------+----------+---------------------------------------------
+ id                | bigint                   |           | not null | nextval('org_invitations_id_seq'::regclass)
+ org_id            | integer                  |           | not null | 
+ sender_user_id    | integer                  |           | not null | 
+ recipient_user_id | integer                  |           | not null | 
+ created_at        | timestamp with time zone |           | not null | now()
+ notified_at       | timestamp with time zone |           |          | 
+ responded_at      | timestamp with time zone |           |          | 
+ response_type     | boolean                  |           |          | 
+ revoked_at        | timestamp with time zone |           |          | 
+ deleted_at        | timestamp with time zone |           |          | 
 Indexes:
     "org_invitations_pkey" PRIMARY KEY, btree (id)
     "org_invitations_singleflight" UNIQUE, btree (org_id, recipient_user_id) WHERE responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL
@@ -306,13 +306,13 @@ Foreign-key constraints:
 
 # Table "public.org_members"
 ```
-   Column   |           Type           |                        Modifiers                         
-------------+--------------------------+----------------------------------------------------------
- id         | integer                  | not null default nextval('org_members_id_seq'::regclass)
- org_id     | integer                  | not null
- created_at | timestamp with time zone | not null default now()
- updated_at | timestamp with time zone | not null default now()
- user_id    | integer                  | not null
+   Column   |           Type           | Collation | Nullable |                 Default                 
+------------+--------------------------+-----------+----------+-----------------------------------------
+ id         | integer                  |           | not null | nextval('org_members_id_seq'::regclass)
+ org_id     | integer                  |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ updated_at | timestamp with time zone |           | not null | now()
+ user_id    | integer                  |           | not null | 
 Indexes:
     "org_members_pkey" PRIMARY KEY, btree (id)
     "org_members_org_id_user_id_key" UNIQUE CONSTRAINT, btree (org_id, user_id)
@@ -324,28 +324,28 @@ Foreign-key constraints:
 
 # Table "public.org_members_bkup_1514536731"
 ```
-   Column    |           Type           | Modifiers 
--------------+--------------------------+-----------
- id          | integer                  | 
- org_id      | integer                  | 
- user_id_old | text                     | 
- created_at  | timestamp with time zone | 
- updated_at  | timestamp with time zone | 
- user_id     | integer                  | 
+   Column    |           Type           | Collation | Nullable | Default 
+-------------+--------------------------+-----------+----------+---------
+ id          | integer                  |           |          | 
+ org_id      | integer                  |           |          | 
+ user_id_old | text                     |           |          | 
+ created_at  | timestamp with time zone |           |          | 
+ updated_at  | timestamp with time zone |           |          | 
+ user_id     | integer                  |           |          | 
 
 ```
 
 # Table "public.orgs"
 ```
-      Column       |           Type           |                     Modifiers                     
--------------------+--------------------------+---------------------------------------------------
- id                | integer                  | not null default nextval('orgs_id_seq'::regclass)
- name              | citext                   | not null
- created_at        | timestamp with time zone | not null default now()
- updated_at        | timestamp with time zone | not null default now()
- display_name      | text                     | 
- slack_webhook_url | text                     | 
- deleted_at        | timestamp with time zone | 
+      Column       |           Type           | Collation | Nullable |             Default              
+-------------------+--------------------------+-----------+----------+----------------------------------
+ id                | integer                  |           | not null | nextval('orgs_id_seq'::regclass)
+ name              | citext                   |           | not null | 
+ created_at        | timestamp with time zone |           | not null | now()
+ updated_at        | timestamp with time zone |           | not null | now()
+ display_name      | text                     |           |          | 
+ slack_webhook_url | text                     |           |          | 
+ deleted_at        | timestamp with time zone |           |          | 
 Indexes:
     "orgs_pkey" PRIMARY KEY, btree (id)
     "orgs_name" UNIQUE, btree (name) WHERE deleted_at IS NULL
@@ -366,15 +366,15 @@ Referenced by:
 
 # Table "public.phabricator_repos"
 ```
-   Column   |           Type           |                           Modifiers                            
-------------+--------------------------+----------------------------------------------------------------
- id         | integer                  | not null default nextval('phabricator_repos_id_seq'::regclass)
- callsign   | citext                   | not null
- repo_name  | citext                   | not null
- created_at | timestamp with time zone | not null default now()
- updated_at | timestamp with time zone | not null default now()
- deleted_at | timestamp with time zone | 
- url        | text                     | not null default ''::text
+   Column   |           Type           | Collation | Nullable |                    Default                    
+------------+--------------------------+-----------+----------+-----------------------------------------------
+ id         | integer                  |           | not null | nextval('phabricator_repos_id_seq'::regclass)
+ callsign   | citext                   |           | not null | 
+ repo_name  | citext                   |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ updated_at | timestamp with time zone |           | not null | now()
+ deleted_at | timestamp with time zone |           |          | 
+ url        | text                     |           | not null | ''::text
 Indexes:
     "phabricator_repos_pkey" PRIMARY KEY, btree (id)
     "phabricator_repos_repo_name_key" UNIQUE CONSTRAINT, btree (repo_name)
@@ -383,12 +383,12 @@ Indexes:
 
 # Table "public.product_licenses"
 ```
-         Column          |           Type           |       Modifiers        
--------------------------+--------------------------+------------------------
- id                      | uuid                     | not null
- product_subscription_id | uuid                     | not null
- license_key             | text                     | not null
- created_at              | timestamp with time zone | not null default now()
+         Column          |           Type           | Collation | Nullable | Default 
+-------------------------+--------------------------+-----------+----------+---------
+ id                      | uuid                     |           | not null | 
+ product_subscription_id | uuid                     |           | not null | 
+ license_key             | text                     |           | not null | 
+ created_at              | timestamp with time zone |           | not null | now()
 Indexes:
     "product_licenses_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -398,14 +398,14 @@ Foreign-key constraints:
 
 # Table "public.product_subscriptions"
 ```
-         Column          |           Type           |       Modifiers        
--------------------------+--------------------------+------------------------
- id                      | uuid                     | not null
- user_id                 | integer                  | not null
- billing_subscription_id | text                     | 
- created_at              | timestamp with time zone | not null default now()
- updated_at              | timestamp with time zone | not null default now()
- archived_at             | timestamp with time zone | 
+         Column          |           Type           | Collation | Nullable | Default 
+-------------------------+--------------------------+-----------+----------+---------
+ id                      | uuid                     |           | not null | 
+ user_id                 | integer                  |           | not null | 
+ billing_subscription_id | text                     |           |          | 
+ created_at              | timestamp with time zone |           | not null | now()
+ updated_at              | timestamp with time zone |           | not null | now()
+ archived_at             | timestamp with time zone |           |          | 
 Indexes:
     "product_subscriptions_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -417,22 +417,22 @@ Referenced by:
 
 # Table "public.query_runner_state"
 ```
-      Column      |           Type           | Modifiers 
-------------------+--------------------------+-----------
- query            | text                     | 
- last_executed    | timestamp with time zone | 
- latest_result    | timestamp with time zone | 
- exec_duration_ns | bigint                   | 
+      Column      |           Type           | Collation | Nullable | Default 
+------------------+--------------------------+-----------+----------+---------
+ query            | text                     |           |          | 
+ last_executed    | timestamp with time zone |           |          | 
+ latest_result    | timestamp with time zone |           |          | 
+ exec_duration_ns | bigint                   |           |          | 
 
 ```
 
 # Table "public.recent_searches"
 ```
-   Column   |            Type             |                          Modifiers                           
-------------+-----------------------------+--------------------------------------------------------------
- id         | integer                     | not null default nextval('recent_searches_id_seq'::regclass)
- query      | text                        | not null
- created_at | timestamp without time zone | not null default now()
+   Column   |            Type             | Collation | Nullable |                   Default                   
+------------+-----------------------------+-----------+----------+---------------------------------------------
+ id         | integer                     |           | not null | nextval('recent_searches_id_seq'::regclass)
+ query      | text                        |           | not null | 
+ created_at | timestamp without time zone |           | not null | now()
 Indexes:
     "recent_searches_pkey" PRIMARY KEY, btree (id)
 
@@ -440,18 +440,18 @@ Indexes:
 
 # Table "public.registry_extension_releases"
 ```
-        Column         |           Type           |                                Modifiers                                 
------------------------+--------------------------+--------------------------------------------------------------------------
- id                    | bigint                   | not null default nextval('registry_extension_releases_id_seq'::regclass)
- registry_extension_id | integer                  | not null
- creator_user_id       | integer                  | not null
- release_version       | citext                   | 
- release_tag           | citext                   | not null
- manifest              | jsonb                    | not null
- bundle                | text                     | 
- created_at            | timestamp with time zone | not null default now()
- deleted_at            | timestamp with time zone | 
- source_map            | text                     | 
+        Column         |           Type           | Collation | Nullable |                         Default                         
+-----------------------+--------------------------+-----------+----------+---------------------------------------------------------
+ id                    | bigint                   |           | not null | nextval('registry_extension_releases_id_seq'::regclass)
+ registry_extension_id | integer                  |           | not null | 
+ creator_user_id       | integer                  |           | not null | 
+ release_version       | citext                   |           |          | 
+ release_tag           | citext                   |           | not null | 
+ manifest              | jsonb                    |           | not null | 
+ bundle                | text                     |           |          | 
+ created_at            | timestamp with time zone |           | not null | now()
+ deleted_at            | timestamp with time zone |           |          | 
+ source_map            | text                     |           |          | 
 Indexes:
     "registry_extension_releases_pkey" PRIMARY KEY, btree (id)
     "registry_extension_releases_version" UNIQUE, btree (registry_extension_id, release_version) WHERE release_version IS NOT NULL
@@ -464,20 +464,20 @@ Foreign-key constraints:
 
 # Table "public.registry_extensions"
 ```
-      Column       |           Type           |                            Modifiers                             
--------------------+--------------------------+------------------------------------------------------------------
- id                | integer                  | not null default nextval('registry_extensions_id_seq'::regclass)
- uuid              | uuid                     | not null
- publisher_user_id | integer                  | 
- publisher_org_id  | integer                  | 
- name              | citext                   | not null
- manifest          | text                     | 
- created_at        | timestamp with time zone | not null default now()
- updated_at        | timestamp with time zone | not null default now()
- deleted_at        | timestamp with time zone | 
+      Column       |           Type           | Collation | Nullable |                     Default                     
+-------------------+--------------------------+-----------+----------+-------------------------------------------------
+ id                | integer                  |           | not null | nextval('registry_extensions_id_seq'::regclass)
+ uuid              | uuid                     |           | not null | 
+ publisher_user_id | integer                  |           |          | 
+ publisher_org_id  | integer                  |           |          | 
+ name              | citext                   |           | not null | 
+ manifest          | text                     |           |          | 
+ created_at        | timestamp with time zone |           | not null | now()
+ updated_at        | timestamp with time zone |           | not null | now()
+ deleted_at        | timestamp with time zone |           |          | 
 Indexes:
     "registry_extensions_pkey" PRIMARY KEY, btree (id)
-    "registry_extensions_publisher_name" UNIQUE, btree ((COALESCE(publisher_user_id, 0)), (COALESCE(publisher_org_id, 0)), name) WHERE deleted_at IS NULL
+    "registry_extensions_publisher_name" UNIQUE, btree (COALESCE(publisher_user_id, 0), COALESCE(publisher_org_id, 0), name) WHERE deleted_at IS NULL
     "registry_extensions_uuid" UNIQUE, btree (uuid)
 Check constraints:
     "registry_extensions_name_length" CHECK (char_length(name::text) > 0 AND char_length(name::text) <= 128)
@@ -493,24 +493,24 @@ Referenced by:
 
 # Table "public.repo"
 ```
-        Column         |           Type           |                     Modifiers                     
------------------------+--------------------------+---------------------------------------------------
- id                    | integer                  | not null default nextval('repo_id_seq'::regclass)
- name                  | citext                   | not null
- description           | text                     | 
- language              | text                     | 
- fork                  | boolean                  | 
- created_at            | timestamp with time zone | not null default now()
- updated_at            | timestamp with time zone | 
- external_id           | text                     | 
- external_service_type | text                     | 
- external_service_id   | text                     | 
- enabled               | boolean                  | not null default true
- archived              | boolean                  | not null default false
- uri                   | citext                   | 
- deleted_at            | timestamp with time zone | 
- sources               | jsonb                    | not null default '{}'::jsonb
- metadata              | jsonb                    | not null default '{}'::jsonb
+        Column         |           Type           | Collation | Nullable |             Default              
+-----------------------+--------------------------+-----------+----------+----------------------------------
+ id                    | integer                  |           | not null | nextval('repo_id_seq'::regclass)
+ name                  | citext                   |           | not null | 
+ description           | text                     |           |          | 
+ language              | text                     |           |          | 
+ fork                  | boolean                  |           |          | 
+ created_at            | timestamp with time zone |           | not null | now()
+ updated_at            | timestamp with time zone |           |          | 
+ external_id           | text                     |           |          | 
+ external_service_type | text                     |           |          | 
+ external_service_id   | text                     |           |          | 
+ enabled               | boolean                  |           | not null | true
+ archived              | boolean                  |           | not null | false
+ uri                   | citext                   |           |          | 
+ deleted_at            | timestamp with time zone |           |          | 
+ sources               | jsonb                    |           | not null | '{}'::jsonb
+ metadata              | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
     "repo_pkey" PRIMARY KEY, btree (id)
     "repo_external_service_unique_idx" UNIQUE, btree (external_service_type, external_service_id, external_id) WHERE external_service_type IS NOT NULL AND external_service_id IS NOT NULL AND external_id IS NOT NULL
@@ -533,12 +533,12 @@ Referenced by:
 
 # Table "public.saved_queries"
 ```
-      Column      |           Type           | Modifiers 
-------------------+--------------------------+-----------
- query            | text                     | not null
- last_executed    | timestamp with time zone | not null
- latest_result    | timestamp with time zone | not null
- exec_duration_ns | bigint                   | not null
+      Column      |           Type           | Collation | Nullable | Default 
+------------------+--------------------------+-----------+----------+---------
+ query            | text                     |           | not null | 
+ last_executed    | timestamp with time zone |           | not null | 
+ latest_result    | timestamp with time zone |           | not null | 
+ exec_duration_ns | bigint                   |           | not null | 
 Indexes:
     "saved_queries_query_unique" UNIQUE, btree (query)
 
@@ -546,18 +546,18 @@ Indexes:
 
 # Table "public.saved_searches"
 ```
-      Column       |           Type           |                          Modifiers                          
--------------------+--------------------------+-------------------------------------------------------------
- id                | integer                  | not null default nextval('saved_searches_id_seq'::regclass)
- description       | text                     | not null
- query             | text                     | not null
- created_at        | timestamp with time zone | not null default now()
- updated_at        | timestamp with time zone | not null default now()
- notify_owner      | boolean                  | not null
- notify_slack      | boolean                  | not null
- user_id           | integer                  | 
- org_id            | integer                  | 
- slack_webhook_url | text                     | 
+      Column       |           Type           | Collation | Nullable |                  Default                   
+-------------------+--------------------------+-----------+----------+--------------------------------------------
+ id                | integer                  |           | not null | nextval('saved_searches_id_seq'::regclass)
+ description       | text                     |           | not null | 
+ query             | text                     |           | not null | 
+ created_at        | timestamp with time zone |           | not null | now()
+ updated_at        | timestamp with time zone |           | not null | now()
+ notify_owner      | boolean                  |           | not null | 
+ notify_slack      | boolean                  |           | not null | 
+ user_id           | integer                  |           |          | 
+ org_id            | integer                  |           |          | 
+ slack_webhook_url | text                     |           |          | 
 Indexes:
     "saved_searches_pkey" PRIMARY KEY, btree (id)
 Check constraints:
@@ -570,10 +570,10 @@ Foreign-key constraints:
 
 # Table "public.schema_migrations"
 ```
- Column  |  Type   | Modifiers 
----------+---------+-----------
- version | bigint  | not null
- dirty   | boolean | not null
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ version | bigint  |           | not null | 
+ dirty   | boolean |           | not null | 
 Indexes:
     "schema_migrations_pkey" PRIMARY KEY, btree (version)
 
@@ -581,14 +581,14 @@ Indexes:
 
 # Table "public.settings"
 ```
-     Column     |           Type           |                       Modifiers                       
-----------------+--------------------------+-------------------------------------------------------
- id             | integer                  | not null default nextval('settings_id_seq'::regclass)
- org_id         | integer                  | 
- contents       | text                     | 
- created_at     | timestamp with time zone | not null default now()
- user_id        | integer                  | 
- author_user_id | integer                  | 
+     Column     |           Type           | Collation | Nullable |               Default                
+----------------+--------------------------+-----------+----------+--------------------------------------
+ id             | integer                  |           | not null | nextval('settings_id_seq'::regclass)
+ org_id         | integer                  |           |          | 
+ contents       | text                     |           |          | 
+ created_at     | timestamp with time zone |           | not null | now()
+ user_id        | integer                  |           |          | 
+ author_user_id | integer                  |           |          | 
 Indexes:
     "settings_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -600,29 +600,29 @@ Foreign-key constraints:
 
 # Table "public.settings_bkup_1514702776"
 ```
-       Column       |           Type           | Modifiers 
---------------------+--------------------------+-----------
- id                 | integer                  | 
- org_id             | integer                  | 
- author_user_id_old | text                     | 
- contents           | text                     | 
- created_at         | timestamp with time zone | 
- user_id            | integer                  | 
- author_user_id     | integer                  | 
+       Column       |           Type           | Collation | Nullable | Default 
+--------------------+--------------------------+-----------+----------+---------
+ id                 | integer                  |           |          | 
+ org_id             | integer                  |           |          | 
+ author_user_id_old | text                     |           |          | 
+ contents           | text                     |           |          | 
+ created_at         | timestamp with time zone |           |          | 
+ user_id            | integer                  |           |          | 
+ author_user_id     | integer                  |           |          | 
 
 ```
 
 # Table "public.survey_responses"
 ```
-   Column   |           Type           |                           Modifiers                           
-------------+--------------------------+---------------------------------------------------------------
- id         | bigint                   | not null default nextval('survey_responses_id_seq'::regclass)
- user_id    | integer                  | 
- email      | text                     | 
- score      | integer                  | not null
- reason     | text                     | 
- better     | text                     | 
- created_at | timestamp with time zone | not null default now()
+   Column   |           Type           | Collation | Nullable |                   Default                    
+------------+--------------------------+-----------+----------+----------------------------------------------
+ id         | bigint                   |           | not null | nextval('survey_responses_id_seq'::regclass)
+ user_id    | integer                  |           |          | 
+ email      | text                     |           |          | 
+ score      | integer                  |           | not null | 
+ reason     | text                     |           |          | 
+ better     | text                     |           |          | 
+ created_at | timestamp with time zone |           | not null | now()
 Indexes:
     "survey_responses_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -632,13 +632,13 @@ Foreign-key constraints:
 
 # Table "public.user_emails"
 ```
-      Column       |           Type           |       Modifiers        
--------------------+--------------------------+------------------------
- user_id           | integer                  | not null
- email             | citext                   | not null
- created_at        | timestamp with time zone | not null default now()
- verification_code | text                     | 
- verified_at       | timestamp with time zone | 
+      Column       |           Type           | Collation | Nullable | Default 
+-------------------+--------------------------+-----------+----------+---------
+ user_id           | integer                  |           | not null | 
+ email             | citext                   |           | not null | 
+ created_at        | timestamp with time zone |           | not null | now()
+ verification_code | text                     |           |          | 
+ verified_at       | timestamp with time zone |           |          | 
 Indexes:
     "user_emails_no_duplicates_per_user" UNIQUE CONSTRAINT, btree (user_id, email)
     "user_emails_unique_verified_email" EXCLUDE USING btree (email WITH =) WHERE (verified_at IS NOT NULL)
@@ -649,19 +649,19 @@ Foreign-key constraints:
 
 # Table "public.user_external_accounts"
 ```
-    Column    |           Type           |                              Modifiers                              
---------------+--------------------------+---------------------------------------------------------------------
- id           | integer                  | not null default nextval('user_external_accounts_id_seq'::regclass)
- user_id      | integer                  | not null
- service_type | text                     | not null
- service_id   | text                     | not null
- account_id   | text                     | not null
- auth_data    | jsonb                    | 
- account_data | jsonb                    | 
- created_at   | timestamp with time zone | not null default now()
- updated_at   | timestamp with time zone | not null default now()
- deleted_at   | timestamp with time zone | 
- client_id    | text                     | not null
+    Column    |           Type           | Collation | Nullable |                      Default                       
+--------------+--------------------------+-----------+----------+----------------------------------------------------
+ id           | integer                  |           | not null | nextval('user_external_accounts_id_seq'::regclass)
+ user_id      | integer                  |           | not null | 
+ service_type | text                     |           | not null | 
+ service_id   | text                     |           | not null | 
+ account_id   | text                     |           | not null | 
+ auth_data    | jsonb                    |           |          | 
+ account_data | jsonb                    |           |          | 
+ created_at   | timestamp with time zone |           | not null | now()
+ updated_at   | timestamp with time zone |           | not null | now()
+ deleted_at   | timestamp with time zone |           |          | 
+ client_id    | text                     |           | not null | 
 Indexes:
     "user_external_accounts_pkey" PRIMARY KEY, btree (id)
     "user_external_accounts_account" UNIQUE, btree (service_type, service_id, client_id, account_id) WHERE deleted_at IS NULL
@@ -672,13 +672,13 @@ Foreign-key constraints:
 
 # Table "public.user_permissions"
 ```
-   Column    |           Type           | Modifiers 
--------------+--------------------------+-----------
- user_id     | integer                  | not null
- permission  | text                     | not null
- object_type | text                     | not null
- object_ids  | bytea                    | not null
- updated_at  | timestamp with time zone | not null
+   Column    |           Type           | Collation | Nullable | Default 
+-------------+--------------------------+-----------+----------+---------
+ user_id     | integer                  |           | not null | 
+ permission  | text                     |           | not null | 
+ object_type | text                     |           | not null | 
+ object_ids  | bytea                    |           | not null | 
+ updated_at  | timestamp with time zone |           | not null | 
 Indexes:
     "user_permissions_perm_object_unique" UNIQUE CONSTRAINT, btree (user_id, permission, object_type)
 
@@ -686,24 +686,24 @@ Indexes:
 
 # Table "public.users"
 ```
-       Column        |           Type           |                     Modifiers                      
----------------------+--------------------------+----------------------------------------------------
- id                  | integer                  | not null default nextval('users_id_seq'::regclass)
- username            | citext                   | not null
- display_name        | text                     | 
- avatar_url          | text                     | 
- created_at          | timestamp with time zone | not null default now()
- updated_at          | timestamp with time zone | not null default now()
- deleted_at          | timestamp with time zone | 
- invite_quota        | integer                  | not null default 15
- passwd              | text                     | 
- passwd_reset_code   | text                     | 
- passwd_reset_time   | timestamp with time zone | 
- site_admin          | boolean                  | not null default false
- page_views          | integer                  | not null default 0
- search_queries      | integer                  | not null default 0
- tags                | text[]                   | default '{}'::text[]
- billing_customer_id | text                     | 
+       Column        |           Type           | Collation | Nullable |              Default              
+---------------------+--------------------------+-----------+----------+-----------------------------------
+ id                  | integer                  |           | not null | nextval('users_id_seq'::regclass)
+ username            | citext                   |           | not null | 
+ display_name        | text                     |           |          | 
+ avatar_url          | text                     |           |          | 
+ created_at          | timestamp with time zone |           | not null | now()
+ updated_at          | timestamp with time zone |           | not null | now()
+ deleted_at          | timestamp with time zone |           |          | 
+ invite_quota        | integer                  |           | not null | 15
+ passwd              | text                     |           |          | 
+ passwd_reset_code   | text                     |           |          | 
+ passwd_reset_time   | timestamp with time zone |           |          | 
+ site_admin          | boolean                  |           | not null | false
+ page_views          | integer                  |           | not null | 0
+ search_queries      | integer                  |           | not null | 0
+ tags                | text[]                   |           |          | '{}'::text[]
+ billing_customer_id | text                     |           |          | 
 Indexes:
     "users_pkey" PRIMARY KEY, btree (id)
     "users_billing_customer_id" UNIQUE, btree (billing_customer_id) WHERE deleted_at IS NULL


### PR DESCRIPTION
The primary purpose of this PR is not to merge but raise discussion about the following:

I'm using PostgreSQL 11.5, and when I intended to run `./dev/generate.sh` to generate something else for me, I notice this diff in my `cmd/frontend/db/scheme.md`. I first guess is the new (11.5) psql returns more concrete column name (**Modifiers** vs **Collation | Nullable | Default**).
