### PR TITLE
Adding sidenav links to retrospectives and RFC doc

### DIFF
--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -326,6 +326,7 @@
                             <li><a href="/dev/postgresql">PostgreSQL storage tips</a></li>
                             <li><a href="/dev/phabricator_gitolite">Print info from Gitolite</a></li>
                             <li><a href="/dev/product">Product</a></li>
+                            <li><a href="/dev/rfcs">RFCs</a></li>
                             <li><a href="/dev/releases">Releases</a></li>
                             <li><a href="/dev/retrospectives">Retrospectives</a></li>
                             <li class="content-nav-no-hover">
@@ -336,6 +337,10 @@
                                     <li><a href="/dev/retrospectives/3_3">3.3 retrospective</a></li>
                                     <li><a href="/dev/retrospectives/customer_license_expiration">Customer license expiration P0 retrospective</a></li>
                                     <li><a href="/dev/retrospectives/postgresql_upgrade">Tomás’ notes on the PostgreSQL upgrade</a></li>
+                                    <li><a href="/dev/retrospectives/3_4">3.4 retrospective</a></li>
+                                    <li><a href="/dev/retrospectives/3_5">3.5 retrospective</a></li>
+                                    <li><a href="/dev/retrospectives/3_6">3.6 retrospective</a></li>
+                                    <li><a href="/dev/retrospectives/3_7">3.7 retrospective</a></li>
                                 </ul>
                             </li>
                             <li><a href="/dev/architecture">Sourcegraph Architecture Overview</a></li>

--- a/doc/dev/release_issue_template.md
+++ b/doc/dev/release_issue_template.md
@@ -132,3 +132,10 @@ Run a find replace on:
 - [ ] Close the milestone.
 - [ ] Notify the next release captain that they are on duty for the next release. Include a link to this release issue template.
 - [ ] Remind the team that they should submit [retrospective feedback](retrospectives/index.md) 24 hours before the scheduled retrospective meeting.
+
+## After the Retrospective
+
+- [ ] Scrub the retrospective Google doc for any priviledged customer data.
+- [ ] [Convert to Markdown](https://gsuite.google.com/marketplace/app/docs_to_markdown/700168918607).
+- [ ] Add a new retrospective page in `sourcegraph/doc/dev/retrospectives`.
+- [ ] Add a link to it on `retrospectives/index.md` and in the left nav (`sourcegraph/doc/_resources/templates/doc.html`)

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -1,5 +1,9 @@
 # RFCs
 
+<div class="alert alert-success">
+  See <a href="https://drive.google.com/drive/folders/1bip_pMeWePyNNdCEETRzoyMdLtntcNKR">Sourcegraph RFCs in Google Drive</a>.
+</div>
+
 We value writing down plans so that we can asynchronously communicate to and solicit feedback from our remote-first team. A good plan communicates what problem is being solved, why that problem is being prioritized now, and what the plan is to solve the identified problem.
 
 This document describes how we operationalize written planning through our RFC process. This process is designed to be lightweight so that it can be used for many purposes (e.g. product specs, policy decisions, technical discussion), and it is optimized for facilitating collaboration and feedback. In contrast, GitHub issues are best for tracking concrete bug reports or work that has already been scoped and planned (i.e. there isn't much remaining to discuss).
@@ -81,7 +85,7 @@ The precise format is not as important as the content itself. Ultimately RFCs ar
 
 [We value openness](https://docs.sourcegraph.com/dev/open_source_open_company). Transparency helps us communicate with and gather feedback from our customers, and it holds everyone accountable to a higher quality bar.
 
-The default sharing state of documents in our Google Drive's RFCs folder will allow everyone to publically read/comment, and all Sourcegraph teammates to edit.
+The default sharing state of documents in our [Google Drive's RFCs](https://drive.google.com/drive/folders/1bip_pMeWePyNNdCEETRzoyMdLtntcNKR) folder will allow everyone to publically read/comment, and all Sourcegraph teammates to edit.
 
 ![Google link sharing settings](link-sharing.png)
 

--- a/doc/dev/rfcs/index.md
+++ b/doc/dev/rfcs/index.md
@@ -85,7 +85,7 @@ The precise format is not as important as the content itself. Ultimately RFCs ar
 
 [We value openness](https://docs.sourcegraph.com/dev/open_source_open_company). Transparency helps us communicate with and gather feedback from our customers, and it holds everyone accountable to a higher quality bar.
 
-The default sharing state of documents in our [Google Drive's RFCs](https://drive.google.com/drive/folders/1bip_pMeWePyNNdCEETRzoyMdLtntcNKR) folder will allow everyone to publically read/comment, and all Sourcegraph teammates to edit.
+The default sharing state of documents in our [Google Drive's RFCs](https://drive.google.com/drive/folders/1bip_pMeWePyNNdCEETRzoyMdLtntcNKR) folder will allow everyone to publicly read/comment, and all Sourcegraph teammates to edit.
 
 ![Google link sharing settings](link-sharing.png)
 


### PR DESCRIPTION
- Added missing left nav links
- Linked to RFC Google Drive folder
- Updated release template to add retrospective to docs
