### PR TITLE
Language detection: .cxx is C++

### DIFF
--- a/shared/src/languages.ts
+++ b/shared/src/languages.ts
@@ -97,6 +97,7 @@ function getModeFromExtension(ext: string): string | undefined {
         case 'c':
         case 'cc':
         case 'cpp':
+        case 'cxx':
         case 'c++':
         case 'h++':
         case 'hh':


### PR DESCRIPTION
Makes `onLanguage:cpp` match `.cxx` files and makes https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/148 work.

Test plan: manual
