### PR TITLE
add more GraphQL API examples

### DIFF
--- a/doc/_resources/assets/layout.css
+++ b/doc/_resources/assets/layout.css
@@ -21,7 +21,6 @@
     --loading-spinner-inner-color: #2b3750;
     --secondary: #e1e6ef;
     --border-color: #cad2e2;
-
     --body-bg: #ffffff;
     --text-muted: #{$color-light-text-2};
     --link-color: #566e9f;
@@ -665,7 +664,6 @@ li.content-nav-no-hover:hover {
 .content-nav-section-subsection {
     padding-top: 0;
     border-left: 1px solid #0d97ff;
-    margin-bottom: 1rem;
     background-color: none;
 }
 
@@ -1203,4 +1201,3 @@ li.content-nav-no-hover:hover {
 .version-dropdown .dropdown-item {
     padding: 0.5rem 1rem;
 }
-

--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -283,7 +283,12 @@
                     <li class="content-nav-no-hover">
                         <a class="content-nav-section-header" href="/api">Sourcegraph APIs</a>
                         <ul class="content-nav-section-group">
-                            <li><a href="/api/graphql">Sourcegraph GraphQL API</a></li>
+                            <li><a href="/api/graphql">GraphQL API</a></li>
+                            <li class="content-nav-no-hover">
+                                <ul class="content-nav-section-subsection">
+                                    <li><a href="/api/graphql/examples">Examples</a></li>
+                                </ul>
+                            </li>
                         </ul>
                     </li>
                 </ul>
@@ -510,11 +515,13 @@
 
 {{/* Define Page (Right Hand) Nav */}}
 {{define "index"}}
-    {{with (or (and (eq (len .Doc.Tree) 1) (index .Doc.Tree 0).Children) .Doc.Tree)}}
-        <h3 class="page-nav-title">On this page:</h3>
-        <ul>{{template "doc_nav" .}}</ul>
+    {{if gt (len .Doc.Tree) 0}}
+        {{with (or (and (eq (len .Doc.Tree) 1) (index .Doc.Tree 0).Children) .Doc.Tree)}}
+            <h3 class="page-nav-title">On this page:</h3>
+            <ul>{{template "doc_nav" .}}</ul>
+        {{end}}
+        <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">Edit this page on GitHub</a>
     {{end}}
-    <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">Edit this page on GitHub</a>
 {{end}}
 
 {{define "doc_nav"}}

--- a/doc/_resources/templates/doc.html
+++ b/doc/_resources/templates/doc.html
@@ -520,8 +520,8 @@
             <h3 class="page-nav-title">On this page:</h3>
             <ul>{{template "doc_nav" .}}</ul>
         {{end}}
-        <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">Edit this page on GitHub</a>
     {{end}}
+    <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">Edit this page on GitHub</a>
 {{end}}
 
 {{define "doc_nav"}}

--- a/doc/api/graphql/examples.md
+++ b/doc/api/graphql/examples.md
@@ -9,7 +9,7 @@ This page demonstrates a few example GraphQL queries for the [Sourcegraph GraphQ
 		<th>Example use case</th>
 	</tr>
 	<tr>
-  	<td>
+  	<td style="width:33%">
   		<a href="https://sourcegraph.com/api/console#%7B%22query%22%3A%22query%20%7B%5Cn%20%20repository(name%3A%20%5C%22github.com%2Fuber%2Freact-map-gl%5C%22)%20%7B%5Cn%20%20%20%20defaultBranch%20%7B%5Cn%20%20%20%20%20%20target%20%7B%5Cn%20%20%20%20%20%20%20%20commit%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20blob(path%3A%20%5C%22README.md%5C%22)%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20content%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D">Get the contents of a file on the default branch</a>
   	</td>
   	<td>Returns the file contents.</td>

--- a/doc/api/graphql/examples.md
+++ b/doc/api/graphql/examples.md
@@ -9,6 +9,13 @@ This page demonstrates a few example GraphQL queries for the [Sourcegraph GraphQ
 		<th>Example use case</th>
 	</tr>
 	<tr>
+  	<td>
+  		<a href="https://sourcegraph.com/api/console#%7B%22query%22%3A%22query%20%7B%5Cn%20%20repository(name%3A%20%5C%22github.com%2Fuber%2Freact-map-gl%5C%22)%20%7B%5Cn%20%20%20%20defaultBranch%20%7B%5Cn%20%20%20%20%20%20target%20%7B%5Cn%20%20%20%20%20%20%20%20commit%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20blob(path%3A%20%5C%22README.md%5C%22)%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20content%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D">Get the contents of a file on the default branch</a>
+  	</td>
+  	<td>Returns the file contents.</td>
+  	<td>Quickly fetch file contents without cloning a repository or hitting your code host API (which is usually slower or more rate-limited than Sourcegraph).</td>
+  </tr>
+	<tr>
 		<td>
 			<a href="https://sourcegraph.com/api/console#%7B%22query%22%3A%22query%20(%24query%3A%20String!)%20%7B%5Cn%20%20search(query%3A%20%24query)%20%7B%5Cn%20%20%20%20results%20%7B%5Cn%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20limitHit%5Cn%20%20%20%20%20%20resultCount%5Cn%20%20%20%20%20%20approximateResultCount%5Cn%20%20%20%20%20%20missing%20%7B%5Cn%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20cloning%20%7B%5Cn%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20timedout%20%7B%5Cn%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20indexUnavailable%5Cn%20%20%20%20%20%20results%20%7B%5Cn%20%20%20%20%20%20%20%20...%20on%20Repository%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20...%20on%20FileMatch%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20%20%20%20%20resource%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20...%20on%20CommitSearchResult%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20%20%20%20%20commit%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20oid%5Cn%20%20%20%20%20%20%20%20%20%20%20%20message%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%2C%22variables%22%3A%22%7B%5Cn%20%20%5C%22query%5C%22%3A%20%5C%22repo%3A%5Egithub.com%2Fgorilla%2Fmux%24%20Router%5C%22%5Cn%7D%22%7D">
 				Perform a search query and get results
@@ -21,14 +28,21 @@ This page demonstrates a few example GraphQL queries for the [Sourcegraph GraphQ
 			Search for a new framework or API that you are using (or have deprecated) and determine all of the repositories that haven't yet been migrated.
 		</td>
 	</tr>
+  <tr>
+  	<td>
+  		<a href="https://sourcegraph.com/api/console#%7B%22query%22%3A%22query%20%7B%5Cn%20%20repository(name%3A%20%5C%22github.com%2Fuber%2Freact-map-gl%5C%22)%20%7B%5Cn%20%20%20%20comparison(base%3A%20%5C%22be0e126b~3%5C%22%2C%20head%3A%20%5C%22be0e126b%5C%22)%20%7B%5Cn%20%20%20%20%20%20fileDiffs%20%7B%5Cn%20%20%20%20%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20oldPath%5Cn%20%20%20%20%20%20%20%20%20%20newPath%5Cn%20%20%20%20%20%20%20%20%20%20hunks%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20body%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D">Compare 2 commits</a>
+  	</td>
+  	<td>Returns a list of changes between 2 commits.</td>
+  	<td>Scan diffs between the old and new versions of a deployed service for changes that might indicate an incompatibility (e.g., in a service discovery manifest).</td>
+  </tr>
 	<tr>
 		<td>
 			<a href="https://sourcegraph.com/api/console#%7B%22query%22%3A%22%7B%5Cn%20%20repositories(first%3A%201000%2C%20enabled%3A%20true)%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20description%5Cn%20%20%20%20%20%20url%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%2C%22variables%22%3A%22%22%2C%22operationName%22%3Anull%7D">
-				List the first 1,000 enabled repositories
+				List the first 1,000 repositories
 			</a>
 		</td>
 		<td>
-			Returns the name, description, and URL of the first 1,000 repositories that are enabled on the Sourcegraph server (in order of their creation date).
+			Returns the name, description, and URL of the first 1,000 repositories on the Sourcegraph server (in order of their creation date).
 		</td>
 		<td>
 		</td>
@@ -43,7 +57,7 @@ This page demonstrates a few example GraphQL queries for the [Sourcegraph GraphQ
 			Returns every file in the repository, its path (relative to the repository root), whether or not it is a directory or plain file, and what the URL path to the file is.
 		</td>
 		<td>
-			List all of the files in each repository of your organization (when combined with the "List the first 1000 enabled repositories" example above) to determine which of your repositories are missing important files like READMEs, LICENSEs, and Dockerfiles.
+			List all of the files in each repository of your organization (when combined with the "List the first 1000 repositories" example above) to determine which of your repositories are missing important files like READMEs, LICENSEs, and Dockerfiles.
 		</td>
 	</tr>
 	<tr>
@@ -56,7 +70,7 @@ This page demonstrates a few example GraphQL queries for the [Sourcegraph GraphQ
 			Returns the primary language of the repository as well as a list of all the languages used in the repository.
 		</td>
 		<td>
-			List all of the languages in each repository of your organization (when combined with the "List the first 1000 enabled repositories" example above) to determine how many repos use each language across your entire organization.
+			List all of the languages in each repository of your organization (when combined with the "List the first 1000 repositories" example above) to determine how many repos use each language across your entire organization.
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
These examples were requested by a customer.

Also cleans up existing examples (to remove references to "enabled", which was removed as a concept).