### PR TITLE
search: handle repohascommitafter empty repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue that rendered the search filter `repohascommitafter` unusable in the presence of an empty repository.
+
 ### Removed
 
 ## 3.8.0

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -588,10 +588,14 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 			for _, rev := range revs.Revs {
 				ok, err := git.HasCommitAfter(ctx, revs.GitserverRepo(), after, rev.RevSpec)
 				if err != nil {
-					if ctx.Err() != nil {
-						run.Error(errors.New("timeout due to repohascommitafter: filter, please try setting a larger timeout: in your query (we are improving this, see https://github.com/sourcegraph/sourcegraph/issues/4614)"))
+					if gitserver.IsRevisionNotFound(err) {
 						continue
 					}
+
+					if ctx.Err() != nil {
+						err = errors.New("timeout due to repohascommitafter: filter, please try setting a larger timeout: in your query (we are improving this, see https://github.com/sourcegraph/sourcegraph/issues/4614)")
+					}
+
 					run.Error(err)
 					continue
 				}

--- a/pkg/vcs/git/commits.go
+++ b/pkg/vcs/git/commits.go
@@ -134,7 +134,7 @@ func HasCommitAfter(ctx context.Context, repo gitserver.Repo, date string, revsp
 	//  - CommitCount handles the case of opt.Range == "" by treating it as "HEAD"
 	//  - We are OK with not handling these bad repositories that contain HEAD branches.
 	//
-	commitid, err := ResolveRevision(ctx, repo, nil, revspec, nil)
+	commitid, err := ResolveRevision(ctx, repo, nil, revspec, &ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This addresses #5149. Empty repositories are ignored when using the `repohascommitafter` search filter.