### PR TITLE
Fallback to dockerized psql9.6 for schemadoc

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -575,7 +575,7 @@ Foreign-key constraints:
  deleted_at        | timestamp with time zone | 
 Indexes:
     "registry_extensions_pkey" PRIMARY KEY, btree (id)
-    "registry_extensions_publisher_name" UNIQUE, btree (COALESCE(publisher_user_id, 0), COALESCE(publisher_org_id, 0), name) WHERE deleted_at IS NULL
+    "registry_extensions_publisher_name" UNIQUE, btree ((COALESCE(publisher_user_id, 0)), (COALESCE(publisher_org_id, 0)), name) WHERE deleted_at IS NULL
     "registry_extensions_uuid" UNIQUE, btree (uuid)
 Check constraints:
     "registry_extensions_name_length" CHECK (char_length(name::text) > 0 AND char_length(name::text) <= 128)

--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -575,7 +575,7 @@ Foreign-key constraints:
  deleted_at        | timestamp with time zone | 
 Indexes:
     "registry_extensions_pkey" PRIMARY KEY, btree (id)
-    "registry_extensions_publisher_name" UNIQUE, btree ((COALESCE(publisher_user_id, 0)), (COALESCE(publisher_org_id, 0)), name) WHERE deleted_at IS NULL
+    "registry_extensions_publisher_name" UNIQUE, btree (COALESCE(publisher_user_id, 0), COALESCE(publisher_org_id, 0), name) WHERE deleted_at IS NULL
     "registry_extensions_uuid" UNIQUE, btree (uuid)
 Check constraints:
     "registry_extensions_name_length" CHECK (char_length(name::text) > 0 AND char_length(name::text) <= 128)

--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -58,7 +58,7 @@ func generate(log *log.Logger) (string, error) {
 			_ = server.Wait()
 		}()
 
-		dataSource = "postgres://postgres@localhost:5433/postgres?dbname=" + dbname
+		dataSource = "postgres://postgres@127.0.0.1:5433/postgres?dbname=" + dbname
 		run = func(cmd ...string) (string, error) {
 			cmd = append([]string{"exec", "-u", "postgres", dbname}, cmd...)
 			c := exec.Command("docker", cmd...)
@@ -70,7 +70,7 @@ func generate(log *log.Logger) (string, error) {
 		attempts := 0
 		for {
 			attempts++
-			if err := exec.Command("pg_isready", "-U", "postgres", "-d", dbname, "-h", "localhost", "-p", "5433").Run(); err == nil {
+			if err := exec.Command("pg_isready", "-U", "postgres", "-d", dbname, "-h", "127.0.0.1", "-p", "5433").Run(); err == nil {
 				break
 			} else if attempts > 30 {
 				return "", fmt.Errorf("gave up waiting after 30s attempt for pg_isready: %w", err)

--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -70,7 +70,7 @@ func generate(log *log.Logger) (string, error) {
 			if err := exec.Command("pg_isready", "-U", "postgres", "-d", dbname, "-h", "localhost", "-p", "5433").Run(); err == nil {
 				break
 			} else if attempts > 30 {
-				return "", fmt.Errorf("gave up waiting for pg_isready: %w", err)
+				return "", fmt.Errorf("gave up waiting after 30s attempt for pg_isready: %w", err)
 			}
 			time.Sleep(time.Second)
 		}

--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -29,7 +29,8 @@ func generate(log *log.Logger) (string, error) {
 		run        func(cmd ...string) (string, error)
 	)
 	// If we are using pg9.6 use it locally since it is faster (CI \o/)
-	if out, _ := exec.Command("pg_config", "--version").CombinedOutput(); bytes.Contains(out, []byte("PostgreSQL 9.6")) {
+	versionRe := regexp.MustCompile(fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta("9.6")))
+	if out, _ := exec.Command("psql", "--version").CombinedOutput(); versionRe.Match(out) {
 		dataSource = "dbname=" + dbname
 		run = func(cmd ...string) (string, error) {
 			c := exec.Command(cmd[0], cmd[1:]...)

--- a/cmd/frontend/db/schemadoc/main.go
+++ b/cmd/frontend/db/schemadoc/main.go
@@ -58,7 +58,6 @@ func generate(log *log.Logger) (string, error) {
 			_ = server.Wait()
 		}()
 
-		time.Sleep(1 * time.Second)
 		dataSource = "postgres://postgres@localhost:5433/postgres?dbname=" + dbname
 		run = func(cmd ...string) (string, error) {
 			cmd = append([]string{"exec", "-u", "postgres", dbname}, cmd...)

--- a/dev/update-schema-and-bindata.sh
+++ b/dev/update-schema-and-bindata.sh
@@ -1,19 +1,3 @@
 #!/usr/bin/env bash
 
-container="$(docker run -d --name some-postgres -p 5433:5432 postgres:9.6)"
-trap "docker rm -f $container" EXIT
-
-while ! env PGPORT=5433 pg_isready; do
-    echo "Sleeping 1s to wait for the postgres Docker container to start..."
-    sleep 1
-done
-
-go generate github.com/sourcegraph/sourcegraph/migrations
-env \
-  PATH="/usr/local/opt/postgresql@9.6/bin:$PATH" \
-  LOG_MIGRATE_TO_STDOUT=true \
-  PGPORT=5433 \
-  PGDATABASE=postgres \
-  PGUSER=postgres \
-  GO111MODULE=on \
-  go generate github.com/sourcegraph/sourcegraph/cmd/frontend/db
+go generate github.com/sourcegraph/sourcegraph/migrations github.com/sourcegraph/sourcegraph/cmd/frontend/db


### PR DESCRIPTION
Hack to use docker to ensure we always run schemadoc against the same version.