### PR TITLE
a8n: Setup rcache for tests

### DIFF
--- a/enterprise/pkg/a8n/resolvers/graphql_test.go
+++ b/enterprise/pkg/a8n/resolvers/graphql_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
 	"github.com/sourcegraph/sourcegraph/pkg/httptestutil"
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
+	"github.com/sourcegraph/sourcegraph/pkg/rcache"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -45,6 +46,7 @@ func TestCampaigns(t *testing.T) {
 
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
+	rcache.SetupForTest(t)
 
 	cf, save := newGithubClientFactory(t, "test-campaigns")
 	defer save()


### PR DESCRIPTION
We accidently relied on this being setup by another test when these
tests were still in the `graphqlbackend` package. Now that they've
moved, the `rcache` used by the `GitHubSource` was not setup for
testing.

The result was that the tests took ~16 seconds to run on CI until the
rcache connection times out (without an error, since it's a cache) and
90+ seconds on my machine.
