### PR TITLE
a8n: Inject the ChangesetSyncer from enterprise into repo-updater as sub syncer

### DIFF
--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	shared.Main()
+	shared.Main(nil)
 }

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -31,7 +31,7 @@ import (
 
 const port = "3182"
 
-func Main() {
+func Main(newSubSyncer repos.NewSubSyncer) {
 	streamingSyncer, _ := strconv.ParseBool(env.Get("SRC_STREAMING_SYNCER_ENABLED", "true", "Use the new, streaming repo metadata syncer."))
 
 	ctx := context.Background()
@@ -126,13 +126,20 @@ func Main() {
 
 	gps := repos.NewGitolitePhabricatorMetadataSyncer(store)
 
+	var subSyncer repos.SubSyncer
+	if newSubSyncer != nil {
+		subSyncer = newSubSyncer(db, store, cf)
+	}
+
 	syncer := &repos.Syncer{
 		Store:            store,
 		Sourcer:          src,
+		SubSyncer:        subSyncer,
 		DisableStreaming: !streamingSyncer,
 		Logger:           log15.Root(),
 		Now:              clock,
 	}
+
 	if envvar.SourcegraphDotComMode() {
 		syncer.FailFullSync = true
 	} else {

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -21,17 +20,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
-	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	iauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
-	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n/resolvers"
 	"github.com/sourcegraph/sourcegraph/pkg/conf"
-	"github.com/sourcegraph/sourcegraph/pkg/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/pkg/db/dbutil"
 	"gopkg.in/inconshreveable/log15.v2"
 )
@@ -58,18 +54,6 @@ func main() {
 			}
 		}()
 		go licensing.StartMaxUserCount(&usersStore{})
-
-		syncer := &a8n.ChangesetSyncer{
-			Store:       a8n.NewStore(dbconn.Global),
-			ReposStore:  repos.NewDBStore(dbconn.Global, sql.TxOptions{}),
-			HTTPFactory: repos.NewHTTPClientFactory(),
-		}
-
-		go func() {
-			if err := syncer.Run(ctx); err != nil {
-				log15.Error("ChangesetSyncer.Run", "err", err)
-			}
-		}()
 	}
 
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
+	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
 )
 
 func main() {
@@ -13,5 +14,5 @@ func main() {
 	if debug {
 		log.Println("enterprise edition")
 	}
-	shared.Main()
+	shared.Main(a8n.NewSubSyncer)
 }

--- a/enterprise/pkg/a8n/resolvers/graphql.go
+++ b/enterprise/pkg/a8n/resolvers/graphql.go
@@ -425,7 +425,7 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 		Store:       r.store,
 		HTTPFactory: r.httpFactory,
 	}
-	if err = syncer.Sync(ctx, cs...); err != nil {
+	if err = syncer.SyncChangesets(ctx, cs...); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/pkg/a8n/resolvers/graphql_test.go
+++ b/enterprise/pkg/a8n/resolvers/graphql_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
 	"github.com/sourcegraph/sourcegraph/pkg/httptestutil"
 	"github.com/sourcegraph/sourcegraph/pkg/jsonc"
+	"github.com/sourcegraph/sourcegraph/pkg/rcache"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -45,6 +46,7 @@ func TestCampaigns(t *testing.T) {
 
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
+	rcache.SetupForTest(t)
 
 	cf, save := newGithubClientFactory(t, "test-campaigns")
 	defer save()


### PR DESCRIPTION
This removes the `ChangesetSyncer` goroutine from `./enterprise/cmd/frontend` as planned in https://github.com/sourcegraph/sourcegraph/issues/5678

It does that by injecting a `SubSyncer` (something that gets run inside the `repos.Syncer`) constructor into the `shared.Main()` function both `repo-updater` binaries call.

This is a first idea of how we can "extend" the open-source version of `repo-updater` in `enterprise` without using global hooks.

I'm not entirely sure there's not a better solution possible, but I think this is also fine for a first step.

Happy about any feedback on this! 

---

Thoughts on the constraints and possible other solutions:

Since the complete runtime setup (database connections, http client factories, store, ...) still needs to happens in the open-source version of `repo-updater`, we cannot pull it out into the enterprise version and then pass things "down" into open-source, which needs to work standalone.

And since right now enterprise and open-source only differ in the "middle part" (how they construct the `Syncer`), it's hard to see a solution that doesn't inject something without duplicating either the "first" or "last" parts of the `Main()` function.
