### PR TITLE
repo-updater: Replace SubSyncer with PreSync function

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -31,7 +31,7 @@ import (
 
 const port = "3182"
 
-func Main(newSubSyncer repos.NewSubSyncer) {
+func Main(newPreSync repos.NewPreSync) {
 	streamingSyncer, _ := strconv.ParseBool(env.Get("SRC_STREAMING_SYNCER_ENABLED", "true", "Use the new, streaming repo metadata syncer."))
 
 	ctx := context.Background()
@@ -126,18 +126,16 @@ func Main(newSubSyncer repos.NewSubSyncer) {
 
 	gps := repos.NewGitolitePhabricatorMetadataSyncer(store)
 
-	var subSyncer repos.SubSyncer
-	if newSubSyncer != nil {
-		subSyncer = newSubSyncer(db, store, cf)
-	}
-
 	syncer := &repos.Syncer{
 		Store:            store,
 		Sourcer:          src,
-		SubSyncer:        subSyncer,
 		DisableStreaming: !streamingSyncer,
 		Logger:           log15.Root(),
 		Now:              clock,
+	}
+
+	if newPreSync != nil {
+		syncer.PreSync = newPreSync(db, store, cf)
 	}
 
 	if envvar.SourcegraphDotComMode() {

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"log"
 	"os"
 	"strconv"
 
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/pkg/a8n"
+	"github.com/sourcegraph/sourcegraph/pkg/httpcli"
 )
 
 func main() {
@@ -14,5 +18,14 @@ func main() {
 	if debug {
 		log.Println("enterprise edition")
 	}
-	shared.Main(a8n.NewSubSyncer)
+
+	shared.Main(func(db *sql.DB, rs repos.Store, cf *httpcli.Factory) func(context.Context) error {
+		syncer := &a8n.ChangesetSyncer{
+			Store:       a8n.NewStore(db),
+			ReposStore:  rs,
+			HTTPFactory: cf,
+		}
+
+		return syncer.Sync
+	})
 }

--- a/enterprise/pkg/a8n/syncer.go
+++ b/enterprise/pkg/a8n/syncer.go
@@ -2,7 +2,6 @@ package a8n
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -17,14 +16,6 @@ type ChangesetSyncer struct {
 	Store       *Store
 	ReposStore  repos.Store
 	HTTPFactory *httpcli.Factory
-}
-
-func NewSubSyncer(db *sql.DB, store repos.Store, cf *httpcli.Factory) repos.SubSyncer {
-	return &ChangesetSyncer{
-		Store:       NewStore(db),
-		ReposStore:  store,
-		HTTPFactory: cf,
-	}
 }
 
 // Sync refreshes the metadata of all changesets and updates them in the


### PR DESCRIPTION
Inspired by [@tsenart's comment here](https://github.com/sourcegraph/sourcegraph/pull/5755#discussion_r329129423) I took another stab at this.

I like this version a lot more. I feel that there's less coupling between `a8n` and `repos` now and it allows us to keep the enterprise-specific initialization in the `enterprise` `main()` function.

What do you think?
