### PR TITLE
add site admin page to easily export all config and settings

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2947,6 +2947,8 @@ type Site implements SettingsSubject {
     siteID: String!
     # The site's configuration. Only visible to site admins.
     configuration: SiteConfiguration!
+    # The site's critical configuration. Only visible to site admins.
+    criticalConfiguration: CriticalConfiguration!
     # The site's latest site-wide settings (which are the second-lowest-precedence
     # in the configuration cascade for a user).
     latestSettings: Settings
@@ -3052,6 +3054,14 @@ type SiteConfiguration {
     # This includes both JSON Schema validation problems and other messages that perform more advanced checks
     # on the configuration (that can't be expressed in the JSON Schema).
     validationMessages: [String!]!
+}
+
+# The critical configuration for a site.
+type CriticalConfiguration {
+    # The unique identifier of this site configuration version.
+    id: Int!
+    # The effective configuration JSON.
+    effectiveContents: String!
 }
 
 # Information about software updates for Sourcegraph.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2954,6 +2954,8 @@ type Site implements SettingsSubject {
     siteID: String!
     # The site's configuration. Only visible to site admins.
     configuration: SiteConfiguration!
+    # The site's critical configuration. Only visible to site admins.
+    criticalConfiguration: CriticalConfiguration!
     # The site's latest site-wide settings (which are the second-lowest-precedence
     # in the configuration cascade for a user).
     latestSettings: Settings
@@ -3059,6 +3061,14 @@ type SiteConfiguration {
     # This includes both JSON Schema validation problems and other messages that perform more advanced checks
     # on the configuration (that can't be expressed in the JSON Schema).
     validationMessages: [String!]!
+}
+
+# The critical configuration for a site.
+type CriticalConfiguration {
+    # The unique identifier of this site configuration version.
+    id: Int!
+    # The effective configuration JSON.
+    effectiveContents: String!
 }
 
 # Information about software updates for Sourcegraph.

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -69,6 +69,15 @@ func (r *siteResolver) Configuration(ctx context.Context) (*siteConfigurationRes
 	return &siteConfigurationResolver{}, nil
 }
 
+func (r *siteResolver) CriticalConfiguration(ctx context.Context) (*criticalConfigurationResolver, error) {
+	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
+	// so only admins may view it.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+	return &criticalConfigurationResolver{}, nil
+}
+
 func (r *siteResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err == backend.ErrMustBeSiteAdmin || err == backend.ErrNotAuthenticated {
 		return false, nil
@@ -204,4 +213,24 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 		return false, err
 	}
 	return globals.ConfigurationServerFrontendOnly.NeedServerRestart(), nil
+}
+
+type criticalConfigurationResolver struct{}
+
+func (r *criticalConfigurationResolver) ID(ctx context.Context) (int32, error) {
+	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
+	// so only admins may view it.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return 0, err
+	}
+	return 0, nil // TODO(slimsag): future: return the real ID here to prevent races
+}
+
+func (r *criticalConfigurationResolver) EffectiveContents(ctx context.Context) (string, error) {
+	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
+	// so only admins may view it.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return "", err
+	}
+	return globals.ConfigurationServerFrontendOnly.Raw().Critical, nil
 }

--- a/web/src/site-admin/SiteAdminExportConfigPage.tsx
+++ b/web/src/site-admin/SiteAdminExportConfigPage.tsx
@@ -127,8 +127,12 @@ export class SiteAdminExportConfigPage extends React.Component<Props, State> {
                 </div>
                 <p>
                     All configuration and settings, except critical site configuration (which must be accessed through
-                    the management console).
+                    the <a href="/help/admin/management_console ">management console</a>).
                 </p>
+                <div className="card-header alert alert-warning">
+                    Note: This editor is for export purposes only. You may edit the contents and use auto-complete, but
+                    changes will not be saved. Reloading the page will erase any of the changes you make in this editor.
+                </div>
                 <DynamicallyImportedMonacoSettingsEditor
                     value={this.state.allConfig ? JSON.stringify(this.state.allConfig, undefined, 2) : ''}
                     jsonSchema={allConfigSchema}
@@ -137,9 +141,6 @@ export class SiteAdminExportConfigPage extends React.Component<Props, State> {
                     isLightTheme={this.props.isLightTheme}
                     history={this.props.history}
                 />
-                <p className="form-text text-muted">
-                    <small>Note: Changes made in this editor will not be saved.</small>
-                </p>
             </div>
         )
     }

--- a/web/src/site-admin/SiteAdminExportConfigPage.tsx
+++ b/web/src/site-admin/SiteAdminExportConfigPage.tsx
@@ -83,46 +83,19 @@ const allConfigSchema = {
 
 interface Props extends RouteComponentProps {
     isLightTheme: boolean
-    authenticatedUser: GQL.IUser
 }
 
-const AuthenticatedSiteAdminExportConfigPage: React.FunctionComponent<Props> = ({
-    isLightTheme,
-    history,
-    authenticatedUser,
-}) => {
+export const SiteAdminExportConfigPage: React.FunctionComponent<Props> = ({ isLightTheme, history }) => {
     const allConfig = useObservable(useMemo(fetchAllConfigAndSettings, []))
     return (
         <div className="site-admin-export-config-page">
-            <PageTitle title="Export configuration - Admin" />
+            <PageTitle title="Debug info - Admin" />
             <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                <h2 className="mb-0">Export configuration and settings</h2>
+                <h2 className="mb-0">Debug information</h2>
             </div>
-            <p>
-                All configuration and settings, except critical site configuration (which must be accessed through the{' '}
-                <a href="/help/admin/management_console ">management console</a>).
-            </p>
+            <p>Debugging information that it is useful to share when reporting an issue.</p>
             <div className="card-header alert alert-warning">
-                <div>
-                    Note: This editor is read-only. To edit settings or configuration, visit the appropriate page:
-                </div>
-                <ul className="mb-0">
-                    <li>
-                        <Link to="/site-admin/configuration">Site configuration</Link>
-                    </li>
-                    <li>
-                        <Link to="/site-admin/external-services">External services</Link>
-                    </li>
-                    <li>
-                        <Link to="/site-admin/global-settings">Global settings</Link>
-                    </li>
-                    <li>
-                        <Link to="/site-admin/organizations">Organization settings</Link>
-                    </li>
-                    <li>
-                        <Link to={`/users/${authenticatedUser.username}/settings`}>User settings</Link>
-                    </li>
-                </ul>
+                <div>Please redact any secrets before sharing.</div>
             </div>
             <DynamicallyImportedMonacoSettingsEditor
                 value={allConfig ? JSON.stringify(allConfig, undefined, 2) : ''}
@@ -136,5 +109,3 @@ const AuthenticatedSiteAdminExportConfigPage: React.FunctionComponent<Props> = (
         </div>
     )
 }
-
-export const SiteAdminExportConfigPage = withAuthenticatedUser(AuthenticatedSiteAdminExportConfigPage)

--- a/web/src/site-admin/SiteAdminExportConfigPage.tsx
+++ b/web/src/site-admin/SiteAdminExportConfigPage.tsx
@@ -1,0 +1,146 @@
+import { RouteComponentProps } from 'react-router'
+import { AllConfig, fetchAllConfigAndSettings } from './backend'
+import React from 'react'
+import { Subscription } from 'rxjs'
+import { DynamicallyImportedMonacoSettingsEditor } from '../settings/DynamicallyImportedMonacoSettingsEditor'
+import awsCodeCommitJSON from '../../../schema/aws_codecommit.schema.json'
+import bitbucketCloudSchemaJSON from '../../../schema/bitbucket_cloud.schema.json'
+import bitbucketServerSchemaJSON from '../../../schema/bitbucket_server.schema.json'
+import githubSchemaJSON from '../../../schema/github.schema.json'
+import gitlabSchemaJSON from '../../../schema/gitlab.schema.json'
+import gitoliteSchemaJSON from '../../../schema/gitolite.schema.json'
+import otherExternalServiceSchemaJSON from '../../../schema/other_external_service.schema.json'
+import phabricatorSchemaJSON from '../../../schema/phabricator.schema.json'
+import settingsSchemaJSON from '../../../schema/settings.schema.json'
+import siteSchemaJSON from '../../../schema/site.schema.json'
+import { PageTitle } from '../components/PageTitle'
+import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
+
+/**
+ * Minimal shape of a JSON Schema. These values are treated as opaque, so more specific types are
+ * not needed.
+ */
+interface JSONSchema {
+    $id: string
+    definitions?: Record<string, { type: string }>
+}
+
+const externalServices: [ExternalServiceKind, JSONSchema][] = [
+    [ExternalServiceKind.AWSCODECOMMIT, awsCodeCommitJSON],
+    [ExternalServiceKind.BITBUCKETCLOUD, bitbucketCloudSchemaJSON],
+    [ExternalServiceKind.BITBUCKETSERVER, bitbucketServerSchemaJSON],
+    [ExternalServiceKind.GITHUB, githubSchemaJSON],
+    [ExternalServiceKind.GITLAB, gitlabSchemaJSON],
+    [ExternalServiceKind.GITOLITE, gitoliteSchemaJSON],
+    [ExternalServiceKind.OTHER, otherExternalServiceSchemaJSON],
+    [ExternalServiceKind.PHABRICATOR, phabricatorSchemaJSON],
+]
+
+const allConfigSchema = {
+    $id: 'all.schema.json#',
+    allowComments: true,
+    additionalProperties: false,
+    properties: {
+        site: siteSchemaJSON,
+        externalServices: {
+            type: 'object',
+            properties: externalServices.reduce<
+                Partial<{ [k in ExternalServiceKind]: { type: string; items: JSONSchema } }>
+            >((properties, [kind, schema]) => {
+                properties[kind] = {
+                    type: 'array',
+                    items: schema,
+                }
+                return properties
+            }, {}),
+        },
+        settings: {
+            type: 'object',
+            properties: {
+                subjects: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            __typename: {
+                                type: 'string',
+                            },
+                            settingsURL: {
+                                type: ['string', 'null'],
+                            },
+                            contents: {
+                                ...settingsSchemaJSON,
+                                type: ['object', 'null'],
+                            },
+                        },
+                    },
+                },
+                final: settingsSchemaJSON,
+            },
+        },
+    },
+    definitions: externalServices
+        .map(([, schema]) => schema.definitions)
+        .concat([siteSchemaJSON.definitions, settingsSchemaJSON.definitions])
+        .reduce(
+            (definitions, theseDefinitions) =>
+                theseDefinitions
+                    ? {
+                          ...definitions,
+                          ...theseDefinitions,
+                      }
+                    : definitions,
+            {}
+        ),
+}
+
+interface Props extends RouteComponentProps<any> {
+    isLightTheme: boolean
+}
+
+interface State {
+    allConfig?: AllConfig
+}
+
+export class SiteAdminExportConfigPage extends React.Component<Props, State> {
+    public state: State = {}
+    private subscriptions = new Subscription()
+
+    public componentDidMount(): void {
+        this.subscriptions.add(
+            fetchAllConfigAndSettings().subscribe(allConfig => {
+                this.setState({ allConfig })
+            })
+        )
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    public render(): JSX.Element | null {
+        return (
+            <div className="site-admin-export-config-page">
+                <PageTitle title="Export configuration - Admin" />
+                <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
+                    <h2 className="mb-0">Export configuration and settings</h2>
+                </div>
+                <p>
+                    All configuration and settings, except critical site configuration (which must be accessed through
+                    the management console).
+                </p>
+                <DynamicallyImportedMonacoSettingsEditor
+                    value={this.state.allConfig ? JSON.stringify(this.state.allConfig, undefined, 2) : ''}
+                    jsonSchema={allConfigSchema}
+                    canEdit={false}
+                    height={800}
+                    isLightTheme={this.props.isLightTheme}
+                    history={this.props.history}
+                />
+                <p className="form-text text-muted">
+                    <small>Note: Changes made in this editor will not be saved.</small>
+                </p>
+            </div>
+        )
+    }
+}

--- a/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -1,6 +1,5 @@
 import { RouteComponentProps } from 'react-router'
 import { fetchAllConfigAndSettings } from './backend'
-import * as GQL from '../../../shared/src/graphql/schema'
 import React, { useMemo } from 'react'
 import { DynamicallyImportedMonacoSettingsEditor } from '../settings/DynamicallyImportedMonacoSettingsEditor'
 import awsCodeCommitJSON from '../../../schema/aws_codecommit.schema.json'
@@ -17,8 +16,6 @@ import { PageTitle } from '../components/PageTitle'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { useObservable } from '../util/useObservable'
 import { mapValues, values } from 'lodash'
-import { Link } from '../../../shared/src/components/Link'
-import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
 
 /**
  * Minimal shape of a JSON Schema. These values are treated as opaque, so more specific types are
@@ -85,17 +82,31 @@ interface Props extends RouteComponentProps {
     isLightTheme: boolean
 }
 
-export const SiteAdminExportConfigPage: React.FunctionComponent<Props> = ({ isLightTheme, history }) => {
+export const SiteAdminReportBugPage: React.FunctionComponent<Props> = ({ isLightTheme, history }) => {
     const allConfig = useObservable(useMemo(fetchAllConfigAndSettings, []))
     return (
-        <div className="site-admin-export-config-page">
-            <PageTitle title="Debug info - Admin" />
+        <div>
+            <PageTitle title="Report a bug - Admin" />
             <div className="d-flex justify-content-between align-items-center mt-3 mb-1">
-                <h2 className="mb-0">Debug information</h2>
+                <h2 className="mb-0">Report a bug</h2>
             </div>
-            <p>Debugging information that it is useful to share when reporting an issue.</p>
+            <p>
+                Create an issue on the{' '}
+                <a target="_blank" rel="noopener noreferrer" href="https://github.com/sourcegraph/sourcegraph/issues">
+                    public issue tracker
+                </a>
+                , and include a description of the bug along with the info below (with secrets redacted). If the report
+                contains sensitive information that should not be public, email the report to{' '}
+                <a target="_blank" rel="noopener noreferrer" href="mailto:support@sourcegraph.com">
+                    support@sourcegraph.com
+                </a>
+                , instead.
+            </p>
             <div className="card-header alert alert-warning">
-                <div>Please redact any secrets before sharing.</div>
+                <div>
+                    Please redact any secrets before sharing, whether on the public issue tracker or with
+                    support@sourcegraph.com.
+                </div>
             </div>
             <DynamicallyImportedMonacoSettingsEditor
                 value={allConfig ? JSON.stringify(allConfig, undefined, 2) : ''}

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -5,9 +5,7 @@ import { createInvalidGraphQLMutationResponseError, dataOrThrowErrors, gql } fro
 import * as GQL from '../../../shared/src/graphql/schema'
 import { resetAllMemoizationCaches } from '../../../shared/src/util/memoizeObservable'
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
-import { SiteConfiguration } from '../schema/site.schema'
 import { Settings } from '../../../shared/src/settings/settings'
-import { CriticalConfiguration } from '../schema/critical.schema'
 
 /**
  * Fetches all users.

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -7,6 +7,7 @@ import { resetAllMemoizationCaches } from '../../../shared/src/util/memoizeObser
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 import { SiteConfiguration } from '../schema/site.schema'
 import { Settings } from '../../../shared/src/settings/settings'
+import { CriticalConfiguration } from '../schema/critical.schema'
 
 /**
  * Fetches all users.
@@ -321,7 +322,8 @@ type SettingsSubject = Pick<GQL.SettingsSubject, 'settingsURL' | '__typename'> &
  * must be fetched from management console
  */
 export interface AllConfig {
-    site: SiteConfiguration
+    site: GQL.ISiteConfiguration
+    critical: GQL.ICriticalConfiguration
     externalServices: Partial<Record<GQL.ExternalServiceKind, ExternalServiceConfig>>
     settings: {
         subjects: SettingsSubject[]
@@ -339,6 +341,10 @@ export function fetchAllConfigAndSettings(): Observable<AllConfig> {
                 site {
                     id
                     configuration {
+                        id
+                        effectiveContents
+                    }
+                    criticalConfiguration {
                         id
                         effectiveContents
                     }
@@ -412,6 +418,10 @@ export function fetchAllConfigAndSettings(): Observable<AllConfig> {
                     data.site.configuration &&
                     data.site.configuration.effectiveContents &&
                     parseJSONC(data.site.configuration.effectiveContents),
+                critical:
+                    data.site &&
+                    data.site.criticalConfiguration &&
+                    parseJSONC(data.site.criticalConfiguration.effectiveContents),
                 externalServices,
                 settings: {
                     subjects: settingsSubjects,

--- a/web/src/site-admin/routes.tsx
+++ b/web/src/site-admin/routes.tsx
@@ -87,9 +87,9 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
     },
     {
-        path: '/export-config',
+        path: '/report-bug',
         exact: true,
-        render: lazyComponent(() => import('./SiteAdminExportConfigPage'), 'SiteAdminExportConfigPage'),
+        render: lazyComponent(() => import('./SiteAdminReportBugPage'), 'SiteAdminReportBugPage'),
     },
     {
         path: '/surveys',

--- a/web/src/site-admin/routes.tsx
+++ b/web/src/site-admin/routes.tsx
@@ -87,6 +87,11 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
     },
     {
+        path: '/export-config',
+        exact: true,
+        render: lazyComponent(() => import('./SiteAdminExportConfigPage'), 'SiteAdminExportConfigPage'),
+    },
+    {
         path: '/surveys',
         exact: true,
         render: lazyComponent(() => import('./SiteAdminSurveyResponsesPage'), 'SiteAdminSurveyResponsesPage'),

--- a/web/src/site-admin/sidebaritems.ts
+++ b/web/src/site-admin/sidebaritems.ts
@@ -77,8 +77,8 @@ export const otherGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/pings',
         },
         {
-            label: 'Debug info',
-            to: '/site-admin/debug-info',
+            label: 'Report a bug',
+            to: '/site-admin/report-bug',
         },
     ],
 }

--- a/web/src/site-admin/sidebaritems.ts
+++ b/web/src/site-admin/sidebaritems.ts
@@ -76,6 +76,10 @@ export const otherGroup: SiteAdminSideBarGroup = {
             label: 'Pings',
             to: '/site-admin/pings',
         },
+        {
+            label: 'Export config',
+            to: '/site-admin/export-config',
+        },
     ],
 }
 

--- a/web/src/site-admin/sidebaritems.ts
+++ b/web/src/site-admin/sidebaritems.ts
@@ -77,8 +77,8 @@ export const otherGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/pings',
         },
         {
-            label: 'Export config',
-            to: '/site-admin/export-config',
+            label: 'Debug info',
+            to: '/site-admin/debug-info',
         },
     ],
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/3367.

Adds a site-admin page to easily export all config and settings at the URL `/site-admin/export-config`, accessible via the site admin sidebar:

![image](https://user-images.githubusercontent.com/1646931/66027430-b8a8f100-e4af-11e9-89dd-1de6bded22ec.png)
