### PR TITLE
Don't count fixtures into GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 cmd/frontend/graphqlbackend/schema.go linguist-generated=true
 cmd/repo-updater/repos/testdata/** linguist-generated=true
+**/__fixtures__/** linguist-generated=true
+**/bindata.go linguist-generated=true
 CHANGELOG.md merge=union


### PR DESCRIPTION
Currently our most used language according to GitHub is HTML. These are just copied DOM fixtures though and should not be counted.