### PR TITLE
Configure lsif Renovate PRs to be owned by code-intel team

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["github>sourcegraph/renovate-config"],
   "semanticCommits": false,
-  "labels": ["bot"]
+  "labels": ["bot"],
+  "packageRules": [
+    {
+      "paths": ["lsif/"],
+      "reviewers": ["team:code-intel"]
+    }
+  ]
 }


### PR DESCRIPTION
This is in this repo and not in the [shared config](https://github.com/sourcegraph/renovate-config) because the path is specific to this repo.