### PR TITLE
Remove CODEOWNERS again for package.json files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -258,13 +258,11 @@ README.md @sqs
 /pkg/hubspot/ @dadlerj
 /pkg/highlight/ @slimsag
 
-# These can also be configured by package through Renovate config (see renovate.json)
-**/package.json @sourcegraph/web
-**/yarn.lock @sourcegraph/web
-
-# Code intel team owns LSIF server
-/lsif/package.json @sourcegraph/code-intel
-/lsif/yarn.lock @sourcegraph/code-intel
+# These are configured through Renovate config.
+# See ../renovate.json and https://github.com/sourcegraph/renovate-config/blob/master/renovate.json
+# This is so that automerged PRs do not trigger email notification spam.
+**/package.json
+**/yarn.lock
 
 /go.sum @sourcegraph/core-services
 /go.mod @sourcegraph/core-services

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["github>sourcegraph/renovate-config"],
   "semanticCommits": false,
-  "labels": ["bot"],
   "packageRules": [
     {
       "paths": ["lsif/"],


### PR DESCRIPTION
I re-configured this in renovate.json and the team reviewers issue was fixed by granting additional permissions.