### PR TITLE
go.mod: Remove original go1.13 replacement hacks

### DIFF
--- a/dev/tools.go
+++ b/dev/tools.go
@@ -3,16 +3,32 @@
 package main
 
 import (
+	// dev/go-install.sh has debug support
 	_ "github.com/go-delve/delve/cmd/dlv"
+
+	// dev/check/go-lint.sh
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+
+	// zoekt-* used in sourcegraph/server docker image build
 	_ "github.com/google/zoekt/cmd/zoekt-archive-index"
 	_ "github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver"
 	_ "github.com/google/zoekt/cmd/zoekt-webserver"
-	_ "github.com/kevinburke/differ"
+
+	// go-bindata is used in lots of our gen.go files
 	_ "github.com/kevinburke/go-bindata/go-bindata"
+
+	// goreman is used by our local dev environment
 	_ "github.com/mattn/goreman"
+
+	// vfsgendev is used by management console
 	_ "github.com/shurcooL/vfsgen/cmd/vfsgendev"
+
+	// use to build docs and in local dev env
 	_ "github.com/sourcegraph/docsite/cmd/docsite"
+
+	// used in schema pkg
 	_ "github.com/sourcegraph/go-jsonschema/cmd/go-jsonschema-compiler"
+
+	// used in many places
 	_ "golang.org/x/tools/cmd/stringer"
 )

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cosiner/argv v0.0.1 // indirect
 	github.com/crewjam/saml v0.0.0-20190521120225-344d075952c9
 	github.com/davecgh/go-spew v1.1.1
-	github.com/daviddengcn/go-colortext v0.0.0-20190211032704-186a3d44e920
+	github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920
 	github.com/dghubble/gologin v2.1.0+incompatible
 	github.com/dhui/dktest v0.3.1 // indirect
 	github.com/dlclark/regexp2 v1.2.0 // indirect
@@ -94,7 +94,7 @@ require (
 	github.com/karrick/tparse v2.4.2+incompatible
 	github.com/keegancsmith/sqlf v1.1.0
 	github.com/keegancsmith/tmpfriend v0.0.0-20180423180255-86e88902a513
-	github.com/kevinburke/differ v0.0.0-20181006040839-bdfd927653c8
+	github.com/kevinburke/differ v0.0.0-20180721181420-bdfd927653c8
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
 	github.com/klauspost/compress v1.8.3 // indirect
 	github.com/klauspost/cpuid v1.2.1 // indirect
@@ -157,7 +157,6 @@ require (
 	github.com/sqs/httpgzip v0.0.0-20180622165210-91da61ed4dff
 	github.com/src-d/enry/v2 v2.1.0
 	github.com/stripe/stripe-go v63.0.0+incompatible
-	github.com/stvp/tempredis v0.0.0-20190104202742-b82af8480203 // indirect
 	github.com/temoto/robotstxt v1.1.1
 	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/uber/gonduit v0.4.0
@@ -212,20 +211,3 @@ replace github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.2
 replace gopkg.in/russross/blackfriday.v2 v2.0.1 => github.com/russross/blackfriday/v2 v2.0.1
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190409202823-959b441ac422
-
-replace github.com/kevinburke/differ v0.0.0-20181006040839-bdfd927653c8 => github.com/kevinburke/differ v0.0.0-20180721181420-bdfd927653c8
-
-replace github.com/stvp/tempredis v0.0.0-20190104202742-b82af8480203 => github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203
-
-replace (
-	github.com/go-critic/go-critic v0.0.0-20181204210945-1df300866540 => github.com/go-critic/go-critic v0.3.5-0.20190526074819-1df300866540
-	github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6 => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
-	github.com/golangci/go-tools v0.0.0-20180109140146-af6baa5dc196 => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
-	github.com/golangci/gofmt v0.0.0-20181105071733-0b8337e80d98 => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
-	github.com/golangci/gosec v0.0.0-20180901114220-66fb7fc33547 => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
-	github.com/golangci/ineffassign v0.0.0-20180808204949-42439a7714cc => github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc
-	github.com/golangci/lint-1 v0.0.0-20180610141402-ee948d087217 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
-	mvdan.cc/unparam v0.0.0-20190124213536-fbb59629db34 => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34
-)
-
-replace github.com/daviddengcn/go-colortext v0.0.0-20190211032704-186a3d44e920 => github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,6 @@ require (
 	github.com/karrick/tparse v2.4.2+incompatible
 	github.com/keegancsmith/sqlf v1.1.0
 	github.com/keegancsmith/tmpfriend v0.0.0-20180423180255-86e88902a513
-	github.com/kevinburke/differ v0.0.0-20180721181420-bdfd927653c8
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
 	github.com/klauspost/compress v1.8.3 // indirect
 	github.com/klauspost/cpuid v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -462,8 +462,6 @@ github.com/keegancsmith/sqlf v1.1.0 h1:lQ2YFRqdEyjDZ/OHsh417gs/2Fz+Jc7qEM7kRrc3o
 github.com/keegancsmith/sqlf v1.1.0/go.mod h1:p1owj38vs/HG0UcZlyhFnXA57SgHejZiHGJBj6XWPxo=
 github.com/keegancsmith/tmpfriend v0.0.0-20180423180255-86e88902a513 h1:xa9SZfAid/jlS3kjwAvVDQFpe6t8SiS0Vl/H51BZYww=
 github.com/keegancsmith/tmpfriend v0.0.0-20180423180255-86e88902a513/go.mod h1:MhGoae1pr+JFXxDAYx3b0fMn1xtr1ly9dHa0+KHHon4=
-github.com/kevinburke/differ v0.0.0-20180721181420-bdfd927653c8 h1:enIcxGSgkyKGwZWjfgn/SPBOlDBocpPyRWZB9xAmp54=
-github.com/kevinburke/differ v0.0.0-20180721181420-bdfd927653c8/go.mod h1:I7eBHoOOU9N76qKli6iiqWZqh7iyxraK7SgR+kbDgW4=
 github.com/kevinburke/go-bindata v3.13.0+incompatible h1:hThDhUBH4KjTyhfXfOgacEPfFBNjltnzl/xzfLfrPoQ=
 github.com/kevinburke/go-bindata v3.13.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=


### PR DESCRIPTION
I noticed we didn't need this anymore. Additionally it lead to `go get` failing when I tried it out outside of the go path.