### PR TITLE
Adapt code for TypeScript 3.7

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
   "jest.pathToJest": "yarn -s test",
   "jest.showCoverageOnLoad": false,
   "jest.autoEnable": false, // until we confirm people like it
+  "typescript.format.semicolons": "remove",
   "eslint.autoFixOnSave": true,
   "eslint.validate": [
     "javascript",

--- a/browser/scripts/build.ts
+++ b/browser/scripts/build.ts
@@ -18,7 +18,6 @@ compiler.run((err, stats) => {
     if (stats.hasErrors()) {
         signale.error('Webpack compilation error')
         process.exit(1)
-        return
     }
     signale.success('Webpack compilation done')
 

--- a/browser/src/libs/code_intelligence/extensions.tsx
+++ b/browser/src/libs/code_intelligence/extensions.tsx
@@ -97,7 +97,7 @@ export const renderGlobalDebug = ({
 const IS_LIGHT_THEME = true // assume all code hosts have a light theme (correct for now)
 
 const cleanupDecorationsForCodeElement = (codeElement: HTMLElement, part: DiffPart | undefined): void => {
-    codeElement.style.backgroundColor = null
+    codeElement.style.backgroundColor = ''
     const previousAttachments = codeElement.querySelectorAll(`.line-decoration-attachment[data-part=${part}]`)
     for (const attachment of previousAttachments) {
         attachment.remove()
@@ -105,7 +105,7 @@ const cleanupDecorationsForCodeElement = (codeElement: HTMLElement, part: DiffPa
 }
 
 const cleanupDecorationsForLineElement = (lineElement: HTMLElement): void => {
-    lineElement.style.backgroundColor = null
+    lineElement.style.backgroundColor = ''
 }
 
 /**
@@ -191,14 +191,14 @@ export const applyDecorations = (
                     // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
                     link.setAttribute('rel', 'noreferrer noopener')
 
-                    link.style.color = style.color || null
+                    link.style.color = style.color || ''
                     link.appendChild(e)
                     return link
                 }
 
                 const after = document.createElement('span')
-                after.style.color = style.color || null
-                after.style.backgroundColor = style.backgroundColor || null
+                after.style.color = style.color || ''
+                after.style.backgroundColor = style.backgroundColor || ''
                 after.textContent = decoration.after.contentText || null
                 if (decoration.after.hoverMessage) {
                     after.title = decoration.after.hoverMessage

--- a/web/src/repo/blob/Blob.tsx
+++ b/web/src/repo/blob/Blob.tsx
@@ -381,10 +381,10 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                     if (decoratedElements) {
                         // Clear previous decorations.
                         for (const element of decoratedElements) {
-                            element.style.backgroundColor = null
-                            element.style.border = null
-                            element.style.borderColor = null
-                            element.style.borderWidth = null
+                            element.style.backgroundColor = ''
+                            element.style.border = ''
+                            element.style.borderColor = ''
+                            element.style.borderWidth = ''
                         }
                     }
 


### PR DESCRIPTION
Migrate code to work with TS 3.7. This means if the build fails for our nightly upgrade Renovate PR, it is a compiler bug.